### PR TITLE
Fix highlighting of "Consultations" in main navigation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
     when "publications"
       publications_path
     when "consultations", "consultation_responses"
-      open_consultations_path
+      consultations_path
     when "ministerial_roles"
       ministerial_roles_path
     when "organisations"

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -113,11 +113,11 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "consultation-related pages should be related to consulatations main navigation" do
-    assert_equal open_consultations_path, current_main_navigation_path(controller: "consultations", action: "index")
-    assert_equal open_consultations_path, current_main_navigation_path(controller: "consultations", action: "open")
-    assert_equal open_consultations_path, current_main_navigation_path(controller: "consultations", action: "closed")
-    assert_equal open_consultations_path, current_main_navigation_path(controller: "consultations", action: "show")
-    assert_equal open_consultations_path, current_main_navigation_path(controller: "consultation_responses", action: "show")
+    assert_equal consultations_path, current_main_navigation_path(controller: "consultations", action: "index")
+    assert_equal consultations_path, current_main_navigation_path(controller: "consultations", action: "open")
+    assert_equal consultations_path, current_main_navigation_path(controller: "consultations", action: "closed")
+    assert_equal consultations_path, current_main_navigation_path(controller: "consultations", action: "show")
+    assert_equal consultations_path, current_main_navigation_path(controller: "consultation_responses", action: "show")
   end
 
   test "minister-related pages should be related to ministers main navigation" do


### PR DESCRIPTION
Broken by 4b5f57045a90b5957794a4dcef917a8c63ca137a.

This is a band-aid over the underlying problem that there are no tests keeping `current_main_navigation_path` in sync with the contents of the `#global-nav` element in `website.html.erb`.

I haven't fixed that here since it requires a decision about whether to simply write such tests against the current code, or rewrite that code to remove duplication between `#global-nav` and the helper (e.g. use params instead of named route helpers in the `main_navigation_link_to` calls in `#global-nav`), or both.
