### PR TITLE
An interrupt exception (Ctrl-C) should stop the tests running.

### DIFF
--- a/lib/patches/allow_interrupt_during_minitest_run.rb
+++ b/lib/patches/allow_interrupt_during_minitest_run.rb
@@ -1,0 +1,31 @@
+require 'rails/test_help'
+
+if ActiveSupport::VERSION::STRING == "3.1.3" && MiniTest::Unit::VERSION == "2.5.1"
+  module ActiveSupport::Testing::SetupAndTeardown::ForMiniTest
+    PASSTHROUGH_EXCEPTIONS = MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
+
+    def run(runner)
+      result = '.'
+      begin
+        run_callbacks :setup do
+          result = super
+        end
+      rescue *PASSTHROUGH_EXCEPTIONS
+        raise
+      rescue Exception => e
+        result = runner.puke(self.class, method_name, e)
+      ensure
+        begin
+          run_callbacks :teardown
+        rescue *PASSTHROUGH_EXCEPTIONS
+          raise
+        rescue Exception => e
+          result = runner.puke(self.class, method_name, e)
+        end
+      end
+      result
+    end
+  end
+else
+  warn "Ignoring 'allow interrupt during MiniTest run' patch since it has not been tested with this version of ActiveSupport & MiniTest and it monkey-patches ForMiniTest#run which in turn monkey-patches MiniTest::Unit::TestCase#run and the relevant code may have changed."
+end


### PR DESCRIPTION
The monkey-patch in ActiveSupport for MiniTest is out-of-date (at least
for the version of Ruby I am running). This means that currently when
you try to interrupt a test, the current test is marked as having an
error, but execution continues.

Given this patch is a monkey-patch on top of a monkey-patch, it's clearly
not a great solution, but it solves my immediate problem for now and
it would be a fair bit of work to sort out what should happen for all
the combinations of MiniTest & ActiveSupport versions.

I would eventually like to submit a patch to ActiveSupport, but don't want
to get distracted for now.
