### PR TITLE
Rename DocumentImageUploader to EditionImageUploader.

### DIFF
--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -1,7 +1,7 @@
 class ImageData < ActiveRecord::Base
   has_many :images
 
-  mount_uploader :file, DocumentImageUploader, mount_on: :carrierwave_image
+  mount_uploader :file, EditionImageUploader, mount_on: :carrierwave_image
 
   validates :file, presence: true
 end

--- a/app/uploaders/edition_image_uploader.rb
+++ b/app/uploaders/edition_image_uploader.rb
@@ -1,4 +1,4 @@
-class DocumentImageUploader < CarrierWave::Uploader::Base
+class EditionImageUploader < CarrierWave::Uploader::Base
   def store_dir
     "system/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/test/unit/edition_image_uploader_test.rb
+++ b/test/unit/edition_image_uploader_test.rb
@@ -1,14 +1,14 @@
 require 'test_helper'
 
-class DocumentImageUploaderTest < ActiveSupport::TestCase
+class EditionImageUploaderTest < ActiveSupport::TestCase
   test "should only allow JPG JPEG GIF or PNG images" do
-    uploader = DocumentImageUploader.new
+    uploader = EditionImageUploader.new
     assert_equal %w(jpg jpeg gif png), uploader.extension_white_list
   end
 
   test "should store uploads in a directory that persists across deploys" do
     model = stub("AR Model", id: 1)
-    uploader = DocumentImageUploader.new(model, "mounted-as")
+    uploader = EditionImageUploader.new(model, "mounted-as")
     assert_match /^system/, uploader.store_dir
   end
 end


### PR DESCRIPTION
I don't think this should affect the storage path which is based on the associated model name and not the uploader class name, but I'd quite like someone to double-check for me.
