### PR TITLE
`Role#to_s` shouldn't know anything about the current person.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,9 +49,25 @@ module ApplicationHelper
     end
   end
 
+  def role_appointment(appointment, link=false)
+    role_text = (link ? link_to(appointment.role.name, appointment.role) : appointment.role.name)
+    if appointment.current?
+      role_text.html_safe
+    else
+      ended = appointment.ended_at ? l(appointment.ended_at.to_date) : 'present'
+      "as #{role_text} (#{l(appointment.started_at.to_date)} to #{ended})".html_safe
+    end
+  end
+
   def ministerial_appointment_options
     RoleAppointment.for_ministerial_roles.alphabetical_by_person.map do |appointment|
-      [appointment.id, appointment.to_s]
+      [appointment.id, "#{appointment.person.name}, #{role_appointment(appointment)}, in #{appointment.role.organisations.to_sentence}"]
+    end
+  end
+
+  def ministerial_role_options
+    MinisterialRole.alphabetical_by_person.map do |role|
+      [role.id, "#{role.name}, in #{role.organisations.to_sentence} (#{role.current_person_name})"]
     end
   end
 

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -6,7 +6,7 @@ class MinisterialRole < Role
   has_many :editions, through: :edition_ministerial_roles
   has_many :speeches, through: :current_role_appointments
 
-  searchable title: :to_s, link: :search_link, content: :current_person_biography, format: 'minister'
+  searchable title: :search_title, link: :search_link, content: :current_person_biography, format: 'minister'
 
   def self.cabinet
     name = arel_table[:name]
@@ -22,6 +22,10 @@ class MinisterialRole < Role
 
   def destroyable?
     super && editions.empty?
+  end
+
+  def search_title
+    current_person ? "#{current_person.name} (#{to_s})" : to_s
   end
 
   def search_link

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -171,6 +171,10 @@ class Organisation < ActiveRecord::Base
     child_organisations.none? && organisation_roles.none? && !new_record?
   end
 
+  def to_s
+    name
+  end
+
   private
 
   def contact_and_contact_numbers_are_blank(attributes)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -34,7 +34,11 @@ class Person < ActiveRecord::Base
   end
 
   def name
-    [title, forename, surname, letters].compact.join(' ')
+    [title, forename, surname, letters].reject(&:blank?).join(' ')
+  end
+
+  def to_s
+    name
   end
 
   def previous_role_appointments

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -62,16 +62,12 @@ class Role < ActiveRecord::Base
     organisations.map(&:name).join(' and ')
   end
 
-  def name_and_organisations
+  def to_s
     if organisations.any?
       "#{name}, #{organisation_names}"
     else
       name
     end
-  end
-
-  def to_s
-    current_person ? "#{current_person.name} (#{name_and_organisations})" : name_and_organisations
   end
 
   def destroyable?

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -99,11 +99,6 @@ class RoleAppointment < ActiveRecord::Base
     end
   end
 
-  def to_s
-    ended = ended_at ? ended_at.to_date : 'present'
-    "#{person.name} (#{role.name_and_organisations}, #{started_at.to_date} - #{ended})"
-  end
-
   private
 
   def make_other_current_appointments_non_current

--- a/app/views/admin/editions/_minister_fields.html.erb
+++ b/app/views/admin/editions/_minister_fields.html.erb
@@ -1,2 +1,2 @@
-<%= form.label :ministerial_role_ids, 'Ministers' %>
-<%= form.select :ministerial_role_ids, options_from_collection_for_select(MinisterialRole.alphabetical_by_person, 'id', 'to_s', edition.ministerial_role_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose ministers..."} %>
+<%= form.label :ministerial_role_ids, 'Ministerial roles' %>
+<%= form.select :ministerial_role_ids, options_from_collection_for_select(ministerial_role_options, :first, :last, edition.ministerial_role_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose ministers..."} %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -48,8 +48,11 @@
     <p class="details">
       <span class="type"><%= @edition.speech_type.name %></span>
       for speech delivered by
-      <span class="ministerial_role">
-        <%= link_to @edition.role_appointment, @edition.role_appointment.role %>
+      <span class="role_appointment">
+        <span class="person"><%= link_to @edition.role_appointment.person, @edition.role_appointment.person %></span>
+        <span class="role"><%= role_appointment(@edition.role_appointment, true) %></span>
+        in
+        <span class="organisations"><%= @edition.role.organisations.map {|o| link_to(o.name, o)}.to_sentence %></span>
       </span>
       on
       <span class="delivered_on"><%= @edition.delivered_on.to_s(:long_ordinal) %></span>

--- a/app/views/ministerial_roles/_list.html.erb
+++ b/app/views/ministerial_roles/_list.html.erb
@@ -1,3 +1,3 @@
 <%= render_list_of_ministerial_roles(ministerial_roles) do |ministerial_role| %>
-  <%= link_to ministerial_role, ministerial_role %>
+  <%= link_to ministerial_role.name, ministerial_role %> (<%= link_to ministerial_role.current_person_name, ministerial_role.current_person %>)
 <% end %>

--- a/app/views/speeches/_document_contextual.html.erb
+++ b/app/views/speeches/_document_contextual.html.erb
@@ -3,7 +3,12 @@
     <li>
       <h1>Who</h1>
       <div class="img"><%= image_for_person @document.person %></div>
-      <span class="role_appointment"><%= link_to @document.role_appointment, @document.role %></span>
+      <span class="role_appointment">
+        <span class="person"><%= link_to @document.role_appointment.person, @document.role_appointment.person %></span>
+        <span class="role"><%= role_appointment(@document.role_appointment, true) %></span>
+        in
+        <span class="organisations"><%= @document.role.organisations.map {|o| link_to(o.name, o)}.to_sentence %></span>
+      </span>
     </li>
     <li class="delivered_on">
       <h1>When</h1>

--- a/features/editing-draft-policies.feature
+++ b/features/editing-draft-policies.feature
@@ -25,8 +25,8 @@ Scenario: Creating a new draft policy that's the responsibility of multiple mini
     | Ministerial Role    | Person     |
     | Minister of Finance | John Smith |
     | Treasury Secretary  | Jane Doe   |
-  When I draft a new policy "Pinch more pennies" associated with "John Smith" and "Jane Doe"
-  Then I should see in the preview that "Pinch more pennies" is associated with "John Smith" and "Jane Doe"
+  When I draft a new policy "Pinch more pennies" associated with "Minister of Finance" and "Treasury Secretary"
+  Then I should see in the preview that "Pinch more pennies" is associated with "Minister of Finance" and "Treasury Secretary"
 
 Scenario: Creating a new draft policy that applies to multiple nations
   When I draft a new policy "Outlaw Moustaches" that does not apply to the nations:

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -147,8 +147,8 @@ end
 
 When /^I draft a new policy "([^"]*)" associated with "([^"]*)" and "([^"]*)"$/ do |title, minister_1, minister_2|
   begin_drafting_policy title: title
-  select minister_1, from: "Ministers"
-  select minister_2, from: "Ministers"
+  select minister_1, from: "Ministerial roles"
+  select minister_2, from: "Ministerial roles"
   click_button "Save"
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -33,7 +33,7 @@ module DocumentHelper
     speech_type = SpeechType::Transcript
     begin_drafting_document options.merge(type: 'speech')
     select speech_type.name, from: "Type"
-    select "Colonel Mustard (Attorney General, 2010-01-01 - present)", from: "Delivered by"
+    select "Colonel Mustard, Attorney General", from: "Delivered by"
     select_date "Delivered on", with: 1.day.ago.to_s
     fill_in "Location", with: "The Drawing Room"
     fill_in "Summary", with: "Some summary of the content"

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -80,10 +80,16 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
 
     get :show, id: draft_speech
 
-    assert_select ".details .type", "Transcript"
-    assert_select ".details .ministerial_role", "Theresa May (Secretary of State, Home Office, 2011-01-01 - present)"
-    assert_select ".details .delivered_on", "1 June 2011"
-    assert_select ".details .location", "The Guidhall"
+    assert_select ".details" do
+      assert_select ".type", "Transcript"
+      assert_select ".role_appointment" do
+        assert_select ".person", "Theresa May"
+        assert_select ".role", "Secretary of State"
+        assert_select ".organisations", "Home Office"
+      end
+      assert_select ".delivered_on", "1 June 2011"
+      assert_select ".location", "The Guidhall"
+    end
   end
 
   private

--- a/test/functional/speeches_controller_test.rb
+++ b/test/functional/speeches_controller_test.rb
@@ -19,7 +19,7 @@ class SpeechesControllerTest < ActionController::TestCase
 
     get :show, id: published_speech.document
 
-    assert_select ".details .role_appointment", /Theresa May .+Secretary of State, Home Office/
+    assert_select ".details .role_appointment .person", "Theresa May" # \s* as \s* Secretary of State \s* in \s* Home Office/
     assert_select ".details .delivered_on", /1 June 2011/
     assert_select ".details .location", /The Guidhall/
   end
@@ -35,7 +35,7 @@ class SpeechesControllerTest < ActionController::TestCase
 
     get :show, id: published_speech.document
 
-    assert_select ".details .role_appointment", /Theresa May .+Secretary of State, Home Office/
+    assert_select ".details .role_appointment .person", "Theresa May"
   end
 
   test "should display details about a transcript" do

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -16,9 +16,9 @@ class ApplicationHelperTest < ActionView::TestCase
     options = ministerial_appointment_options
 
     assert_equal 3, options.length
-    assert options.include? [philip_hammond_appointment.id, "Philip Hammond (Secretary of State, Ministry of Defence, 2011-01-01 - present)"]
-    assert options.include? [philip_hammond_home_secretary_appointment.id, "Philip Hammond (Secretary of State, Home Office, 2010-01-01 - 2011-01-01)"]
-    assert options.include? [theresa_may_appointment.id, "Theresa May (Secretary of State, Home Office, 2011-01-01 - present)"]
+    assert options.include? [philip_hammond_appointment.id, "Philip Hammond, Secretary of State, in Ministry of Defence"]
+    assert options.include? [philip_hammond_home_secretary_appointment.id, "Philip Hammond, as Secretary of State (01 January 2010 to 01 January 2011), in Home Office"]
+    assert options.include? [theresa_may_appointment.id, "Theresa May, Secretary of State, in Home Office"]
   end
 
   test "should not include non-ministerial appointments" do

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -344,11 +344,4 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     assert_same_elements [first_pm_appt, deputy_pm_appt, second_pm_appt], RoleAppointment.for_ministerial_roles
   end
-
-  test "to_s should include the person, role and dates" do
-    role = build(:role, name: "Minister of Silly", organisations: [build(:organisation, name: "Ministry of Fun")])
-    person = build(:person, forename: "Jeremy", surname: "Chumfatty")
-    appt = build(:role_appointment, role: role, person: person, started_at: Date.parse("2012-05-23"))
-    assert_equal "Jeremy Chumfatty (Minister of Silly, Ministry of Fun, 2012-05-23 - present)", appt.to_s
-  end
 end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -6,39 +6,13 @@ class RoleTest < ActiveSupport::TestCase
     refute role.valid?
   end
 
-  test "should return the person, role and all organisation names" do
-    frank = create(:person, forename: "Frank")
-    role = create(:role, name: "Treasury secretary",
-                   organisations: [
-                    create(:organisation, name: "Department of Health"),
-                    create(:organisation, name: "Department for Education")])
-    create(:role_appointment, role: role, person: frank)
-    assert_equal "Frank (Treasury secretary, Department of Health and Department for Education)", role.to_s
-  end
-
-  test "should return the person, role and organisation names" do
-    frank = create(:person, forename: "Frank")
-    role = create(:role, name: "Treasury secretary",
-                   organisations: [create(:organisation, name: "Department of Health")])
-    create(:role_appointment, role: role, person: frank)
-    assert_equal "Frank (Treasury secretary, Department of Health)", role.to_s
-  end
-
-  test "should return the person and role names when there are no organisations" do
-    frank = create(:person, forename: "Frank")
-    role = create(:role, name: "Treasury secretary",
-                   organisations: [])
-    create(:role_appointment, role: role, person: frank)
-    assert_equal "Frank (Treasury secretary)", role.to_s
-  end
-
-  test "should return the role and organisation names when person is missing" do
+  test "should return the role and organisation name" do
     role = create(:role, name: "Treasury secretary", people: [],
                    organisations: [create(:organisation, name: "Department of Health")])
     assert_equal "Treasury secretary, Department of Health", role.to_s
   end
 
-  test "should return the role and all organisation names when person is missing" do
+  test "should return the role and all organisation names" do
     role = create(:role, name: "Treasury secretary", people: [],
                    organisations: [
                      create(:organisation, name: "Department of Health"),
@@ -46,7 +20,7 @@ class RoleTest < ActiveSupport::TestCase
     assert_equal "Treasury secretary, Department of Health and Department for Education", role.to_s
   end
 
-  test "should return the role name when person and organisations are missing" do
+  test "should return the role name when organisations are missing" do
     role = create(:role, name: "Treasury secretary", people: [], organisations: [])
     assert_equal "Treasury secretary", role.to_s
   end


### PR DESCRIPTION
Using a default `to_s` method from `Role` everywhere that a minister was used was, I believe, muddying the distinction between Role, RoleAppointment and Person, and made it harder to sensibly construct strings and links to each which included just the right amount of context to be useful.

I have extracted the `current_person` usage out of the Role (except for the search_index, although perhaps that's a pointer that we should really be indexing appointments, or people, or some other combination of information?).

I've made this a pull request partly to get a second pair of eyes on it, and partly because it touches quite a few files.

I know that I've introduced some duplication in this commit, but I feel that it's better to have HTML that's constructed independently than be constrained by a string generated in the model. Perhaps there is a sensible helper that can be extracted.
