### PR TITLE
Automatically re-write /government/admin URLs in GovSpeak

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -120,10 +120,15 @@ module GovspeakHelper
       return false
     end
 
-    return false unless %w(http https).include?(uri.scheme)
-    truncated_link_uri = [normalise_host(uri.host), uri.path.split("/")[1,2]].join("/")
-    truncated_host_uri = [normalise_host(request.host) + Whitehall.router_prefix, "admin"].join("/")
-    truncated_link_uri == truncated_host_uri
+    admin_path = [Whitehall.router_prefix, "admin"].join("/")
+
+    if %w(http https).include?(uri.scheme)
+      truncated_link_uri = [normalise_host(uri.host), uri.path.split("/")[1,2]].join("/")
+      truncated_host_uri = [normalise_host(request.host) + admin_path].join("/")
+      truncated_link_uri == truncated_host_uri
+    else
+      uri.path.start_with?(admin_path)
+    end
   end
 
   def find_edition_and_supporting_page_from_uri(uri)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -160,6 +160,12 @@ class GovspeakHelperTest < ActionView::TestCase
       html = govspeak_to_html("this and [that](http://test.host#{admin_edition_path(edition)}) yeah?")
       assert_select_within_html html, "a[href=?]", public_document_url(edition), text: "that"
     end
+
+    test "should rewrite relative links to admin previews of published #{edition_class.name} as their public document" do
+      edition = create(:"published_#{edition_class.name.underscore}")
+      html = govspeak_to_html("this and [that](#{admin_edition_path(edition)}) yeah?")
+      assert_select_within_html html, "a[href=?]", public_document_url(edition), text: "that"
+    end
   end
 
   test "should rewrite absolute links to admin previews of published Speeches as their public document" do


### PR DESCRIPTION
Previously we were only looking at the hostname to figure out if we need to
rewrite the URLs to the non-admin versions. This changes the functionality to
include relative URLs beginning with /government/admin in the link munger.
