### PR TITLE
Search requests should be able to respond with results in JSON format.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,7 +3,10 @@ class SearchController < PublicFacingController
     @search_term = params[:q]
     if @search_term.present?
       @results = Whitehall.search_client.search(@search_term)
-      render action: :results
+      respond_to do |format|
+        format.html { render action: :results }
+        format.json { render json: @results }
+      end
     end
   end
 

--- a/app/controllers/specialist_guides_controller.rb
+++ b/app/controllers/specialist_guides_controller.rb
@@ -23,6 +23,10 @@ class SpecialistGuidesController < DocumentsController
     @more_mainstream_results = mainstream_results.length > 5
     @results = Whitehall.search_client.search(@search_term, 'specialist_guidance').take(50 - @mainstream_results.length)
     @total_results = @results.length + @mainstream_results.length
+    respond_to do |format|
+      format.html
+      format.json { render json: @results }
+    end
   end
 
   def autocomplete

--- a/test/functional/search_controller_test.rb
+++ b/test/functional/search_controller_test.rb
@@ -64,6 +64,18 @@ class SearchControllerTest < ActionController::TestCase
     assert_select ".search_results .publication"
   end
 
+  test "should be capable of responding with JSON results" do
+    results = [
+      {"title" => "document-title-1", "link" => "/document-slug-1"},
+      {"title" => "document-title-2", "link" => "/document-slug-2"}
+    ]
+    client = stub("search", search: results)
+    Whitehall.stubs(:search_client).returns(client)
+    get :index, q: "search-term", format: :json
+    data = JSON.parse(response.body)
+    assert_equal results, data
+  end
+
   test "should return the response from autocomplete as a string" do
     client = stub("search")
     Whitehall.stubs(:search_client).returns(client)

--- a/test/functional/specialist_guides_controller_test.rb
+++ b/test/functional/specialist_guides_controller_test.rb
@@ -294,6 +294,18 @@ some more content
     assert_select ".search-results .thing .meta", "Bits and Bobs"
   end
 
+  test "should be capable of responding with JSON results" do
+    results = [
+      {"title" => "document-title-1", "link" => "/document-slug-1"},
+      {"title" => "document-title-2", "link" => "/document-slug-2"}
+    ]
+    Whitehall.search_client.stubs(:search).returns(results)
+    Whitehall.mainstream_search_client.stubs(:search).returns([])
+    get :search, q: "search-term", format: :json
+    data = JSON.parse(response.body)
+    assert_equal results, data
+  end
+
   test "autocomplete returns the response from autocomplete as a string" do
     search_client = stub('search_client')
     raw_rummager_response = "rummager-response-body-json"


### PR DESCRIPTION
- This brings whitehall and specialist guidance search into line with
  mainstream search. The JSON format should be very similar to
  mainstream in both cases i.e. an array of hashes with each hash
  representing a single search result.
- Note that we are currently not including the mainstream results which
  _are_ included in the HTML version of the results for specialist
  guidance.
- If we want to include the mainstream results for specialist guidance in
  the JSON, we'd need to think about what is the best way to structure the
  JSON. This would in turn mean we might need to change the structure of
  mainstream JSON to keep everything consistent.
- Given that before this commit, a 500 error was occurring, it seems
  as if this change is a significant improvement and we can always
  iterate towards a better solution.
