### PR TITLE
Change instances of `publications_organisation_path` to filter page

### DIFF
--- a/app/controllers/document_series_controller.rb
+++ b/app/controllers/document_series_controller.rb
@@ -2,7 +2,7 @@ class DocumentSeriesController < PublicFacingController
   before_filter :load_organisation
 
   def index
-    redirect_to publications_organisation_path(@organisation)
+    redirect_to publications_path(departments: [@organisation])
   end
 
   def show

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,7 +1,7 @@
 class OrganisationsController < PublicFacingController
   before_filter :load_organisation,
     only: [:show, :about, :contact_details, :announcements, :consultations,
-           :ministers, :management_team, :policies, :publications,
+           :ministers, :management_team, :policies,
            :agencies_and_partners, :chiefs_of_staff]
 
   def index
@@ -44,10 +44,6 @@ class OrganisationsController < PublicFacingController
     @ministerial_roles = @organisation.ministerial_roles.order("organisation_roles.ordering").map do |role|
       RolePresenter.new(role)
     end
-  end
-
-  def publications
-    @publications = Publication.published.in_organisation(@organisation).order("publication_date DESC")
   end
 
   def management_team

--- a/app/views/organisations/_navigation.html.erb
+++ b/app/views/organisations/_navigation.html.erb
@@ -5,7 +5,7 @@
     <% if organisation.department? %>
       <li><%= organisation_navigation_link_to 'News & speeches', announcements_organisation_path(organisation) %></li>
       <li><%= organisation_navigation_link_to 'Policies', policies_organisation_path(organisation) %></li>
-      <li><%= organisation_navigation_link_to 'Publications', publications_organisation_path(organisation) %></li>
+      <li><%= link_to 'Publications', publications_path(departments: [organisation.slug]) %></li>
       <li><%= organisation_navigation_link_to 'Consultations', consultations_organisation_path(organisation) %></li>
       <li><%= organisation_navigation_link_to 'Agencies & partners', agencies_and_partners_organisation_path(organisation) %></li>
       <li><%= organisation_navigation_link_to 'Ministers', ministers_organisation_path(organisation) %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,6 @@ Whitehall::Application.routes.draw do
         get :chiefs_of_staff, path: 'chiefs-of-staff'
         get :agencies_and_partners, path: 'agencies-and-partners'
         get :policies
-        get :publications
       end
     end
     resources :ministerial_roles, path: 'ministers', only: [:index, :show]

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -160,7 +160,6 @@ Then /^I should see the "([^"]*)" organisation's (.*) page$/ do |organisation_na
     when 'news'     then "News"
     when 'home'     then organisation_name
     when 'policies' then  "Policies"
-    when 'publications' then "Publications"
     end
 
   assert page.has_css?('title', text: title)

--- a/features/viewing-organisations.feature
+++ b/features/viewing-organisations.feature
@@ -38,9 +38,6 @@ Scenario: Navigating between pages for an organisation
   When I navigate to the "Cabinet Office" organisation's Policies page
   Then I should see the "Cabinet Office" organisation's policies page
   And I should see the organisation navigation
-  When I navigate to the "Cabinet Office" organisation's Publications page
-  Then I should see the "Cabinet Office" organisation's publications page
-  And I should see the organisation navigation
   When I navigate to the "Cabinet Office" organisation's Home page
   Then I should see the "Cabinet Office" organisation's home page
   When I navigate to the "Cabinet Office" organisation's Agencies & partners page

--- a/test/functional/document_series_controller_test.rb
+++ b/test/functional/document_series_controller_test.rb
@@ -8,7 +8,7 @@ class DocumentSeriesControllerTest < ActionController::TestCase
 
     get :index, organisation_id: organisation
 
-    assert_redirected_to publications_organisation_path(organisation)
+    assert_redirected_to publications_path(departments: [organisation])
   end
 
   test 'show should display published documents within a series' do

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class OrganisationsControllerTest < ActionController::TestCase
 
-  SUBPAGE_ACTIONS = [:about, :agencies_and_partners, :announcements, :consultations, :contact_details, :management_team, :ministers, :policies, :publications]
+  SUBPAGE_ACTIONS = [:about, :agencies_and_partners, :announcements, :consultations, :contact_details, :management_team, :ministers, :policies]
 
   should_be_a_public_facing_controller
 
@@ -73,7 +73,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "nav" do
       refute_select "a[href=?]", announcements_organisation_path(organisation)
       refute_select "a[href=?]", policies_organisation_path(organisation)
-      refute_select "a[href=?]", publications_organisation_path(organisation)
+      refute_select "a[href=?]", publications_path(departments: [organisation])
       refute_select "a[href=?]", consultations_organisation_path(organisation)
       refute_select "a[href=?]", ministers_organisation_path(organisation)
     end
@@ -341,30 +341,6 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_equal [later_consultation, earlier_consultation], assigns(:consultations)
   end
 
-  test "should display all published corporate and non-corporate publications for the organisation" do
-    organisation = create(:organisation)
-    published_publication = create(:published_publication, organisations: [organisation])
-    draft_publication = create(:draft_publication, organisations: [organisation])
-    published_corporate_publication = create(:published_corporate_publication, organisations: [organisation])
-
-    get :publications, id: organisation
-
-    assert_equal [published_publication, published_corporate_publication].to_set, assigns(:publications).to_set
-  end
-
-  test "should order publications by publication date" do
-    organisation = create(:organisation)
-    older_publication = create(:published_publication, title: "older", publication_date: 3.days.ago, organisations: [organisation])
-    newest_publication = create(:published_publication, title: "newest", publication_date: 1.day.ago, organisations: [organisation])
-    oldest_publication = create(:published_publication, title: "oldest", publication_date: 4.days.ago, organisations: [organisation])
-
-    get :publications, id: organisation
-
-    assert_select "#publications" do
-      assert_select "#{record_css_selector(newest_publication)}+#{record_css_selector(older_publication)}+#{record_css_selector(oldest_publication)}"
-    end
-  end
-
   test "should display an about-us page for the organisation" do
     organisation = create(:organisation,
       name: "unformatted & name",
@@ -600,7 +576,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     ministerial_department = create(:organisation_type, name: "Ministerial Department")
     organisation = create(:organisation, organisation_type: ministerial_department)
 
-    [:show, :about, :consultations, :contact_details, :management_team, :ministers, :policies, :publications].each do |page|
+    [:show, :about, :consultations, :contact_details, :management_team, :ministers, :policies].each do |page|
       get page, id: organisation
       assert_select "##{dom_id(organisation)}.#{organisation.slug}.ministerial-department"
     end


### PR DESCRIPTION
This replaces the old pointers at the organisation specific page with a link to the filtered publications view.

The old controllers and URL configuration have now been removed.

https://www.pivotaltracker.com/story/show/32773349
