### PR TITLE
Add postal address to consultation participation

### DIFF
--- a/app/helpers/consultations_helper.rb
+++ b/app/helpers/consultations_helper.rb
@@ -56,7 +56,24 @@ module ConsultationsHelper
     if consultation_participation.has_link?
       options << content_tag(:p, link_to(consultation_participation.link_text, consultation_participation.link_url), class: "online")
     end
-    if consultation_participation.has_email?
+    if consultation_participation.has_email? || consultation_participation.has_postal_address?
+      respond_by = ""
+      if consultation_participation.has_email?
+        respond_by << content_tag(:dl, "email")
+        respond_by << content_tag(:dd, mail_to(consultation_participation.email), class: "email")
+      end
+      if consultation_participation.has_postal_address?
+        respond_by << content_tag(:dl, "post")
+        respond_by << content_tag(:dd, format_with_html_line_breaks(consultation_participation.postal_address), class: "postal-address")
+      end
+      if consultation_participation.has_response_form?
+        header = "Return the form to us by#{consultation_participation.has_postal_address? && consultation_participation.has_email? ? ' either': ''}:"
+      else
+        header = "Contact us by#{consultation_participation.has_postal_address? && consultation_participation.has_email? ? ' either': ''}:"
+      end
+      respond_by = content_tag(:dl,
+        respond_by.html_safe
+      )
       if consultation_participation.has_response_form?
         options << content_tag(:ol,
           content_tag(:li, content_tag(:p,
@@ -65,15 +82,13 @@ module ConsultationsHelper
                     consultation_participation.consultation_response_form.file.url)
           ) +
           content_tag(:li,
-            content_tag(:p, "Return the form to us by:") +
-            content_tag(:dl,
-              content_tag(:dt, "email") +
-              content_tag(:dd, mail_to(consultation_participation.email), class: "email")
-            )
+                      content_tag(:p, header) +
+            respond_by
           )
         )
       else
-        options << content_tag(:p, ("Contact us by email at: " + content_tag(:span, mail_to(consultation_participation.email))).html_safe, class: "email")
+        options << content_tag(:div,
+                               content_tag(:p, header) + respond_by)
       end
     end
     options.join(content_tag(:p, "or", class: "or")).html_safe

--- a/app/models/consultation_participation.rb
+++ b/app/models/consultation_participation.rb
@@ -19,6 +19,10 @@ class ConsultationParticipation < ActiveRecord::Base
     consultation_response_form.present?
   end
 
+  def has_postal_address?
+    postal_address.present?
+  end
+
   after_destroy :destroy_form_if_required
 
   private

--- a/app/views/admin/consultations/_additional_significant_fields.html.erb
+++ b/app/views/admin/consultations/_additional_significant_fields.html.erb
@@ -11,6 +11,7 @@
     <%= participation_fields.text_field :link_url, label_text: 'Link URL' %>
     <%= participation_fields.text_field :link_text %>
     <%= participation_fields.text_field :email %>
+    <%= participation_fields.text_area :postal_address, rows: "4", style: "width: auto" %>
     <%= participation_fields.fields_for :consultation_response_form, participation_fields.object.consultation_response_form || participation_fields.object.build_consultation_response_form do |response_form_fields| %>
       <%= response_form_fields.text_field :title, label_text: "Downloadable response form title" %>
       <%= response_form_fields.file_field :file %>

--- a/app/views/admin/consultations/_edition.html.erb
+++ b/app/views/admin/consultations/_edition.html.erb
@@ -22,6 +22,11 @@
           <%= mail_to_consultation_participation(edition) %>
         </p>
       <% end %>
+      <% if edition.consultation_participation.has_postal_address? %>
+        <div class="postal-address">
+          <%= format_with_html_line_breaks(edition.consultation_participation.postal_address) %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </article>

--- a/db/migrate/20120903132914_add_postal_address_to_consultation_participation.rb
+++ b/db/migrate/20120903132914_add_postal_address_to_consultation_participation.rb
@@ -1,0 +1,5 @@
+class AddPostalAddressToConsultationParticipation < ActiveRecord::Migration
+  def change
+    add_column :consultation_participations, :postal_address, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(:version => 20120904144149) do
     t.datetime "updated_at"
     t.string   "email"
     t.integer  "consultation_response_form_id"
+    t.text     "postal_address"
   end
 
   create_table "consultation_response_forms", :force => true do |t|

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -147,6 +147,17 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     end
   end
 
+  test "show displays consultation postal address" do
+    consultation_participation = create(:consultation_participation,
+      postal_address: "Test street"
+    )
+    consultation = create(:consultation, consultation_participation: consultation_participation)
+    get :show, id: consultation
+    assert_select '.participation' do
+      assert_select '.postal-address', text: 'Test street'
+    end
+  end
+
   test "edit displays consultation fields" do
     response_form = create(:consultation_response_form)
     participation = create(:consultation_participation, consultation_response_form: response_form)
@@ -161,6 +172,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_url]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_text]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
+      assert_select "textarea[name='edition[consultation_participation_attributes][postal_address]']"
       assert_select "input[type='hidden'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][id]'][value=?]", response_form.id
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][title]']"
       assert_select "input[type='file'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][file]']"

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -283,4 +283,18 @@ class ConsultationsControllerTest < ActionController::TestCase
     refute_select ".participation .online"
     refute_select ".participation .email"
   end
+
+  test 'show displays the postal address for participation' do
+    address = %q{123 Example Street
+London N123}
+    consultation_participation = create(:consultation_participation,
+                                        postal_address: address
+                                        )
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
+    get :show, id: published_consultation.document
+
+    assert_select ".participation" do
+      assert_select ".postal-address", html: "123 Example Street<br />London N123"
+    end
+  end
 end


### PR DESCRIPTION
This adds a simple text field for submitting a postal address for consultation participation. The address is displayed with newlines converted to hard HTML breaks to conserve address formatting.
