### PR TITLE
Make session cookie HTTPS only in !dev/test environments

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-Whitehall::Application.config.session_store :cookie_store, key: '_whitehall_session'
+Whitehall::Application.config.session_store :cookie_store, key: '_whitehall_session',
+                                                           secure: !(Rails.env.test? || Rails.env.development?)
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
One of the outcomes of security auditing was that our session cookie is  vulnerable to man in the middle/session replay attacks because it's not HTTPS only. This change makes the session initializer (sic) enable HTTPS-only cookies in non test/dev situations.
