### PR TITLE
Add series information to publication index

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -2,7 +2,8 @@
  browser: true,
  white: true,
  plusplus: true,
- vars: true */
+ vars: true,
+ nomen: true */
 /*global jQuery */
 
 
@@ -37,11 +38,16 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
     progressSpan: function(current, total) {
       return '<span>' + current + " of " + total + '</span>';
     },
+    importantAttributes: ["id", "title", "url", "type"],
     importantAttribute: function(attribute) {
-      return ($.inArray(attribute, ["id", "title", "url", "type"]) < 0);
+      return ($.inArray(attribute, documentFilter.importantAttributes) < 0);
     },
     capitalize: function(attribute) {
       return attribute.replace(/_/, " ").replace(/(^|\s)([a-z])/g, function(_,a,b){ return a+b.toUpperCase(); });
+    },
+    drawTableCell: function(attributeName, attributeValue) {
+      var inner = attributeValue;
+      return '<td class="' + attributeName + ' attribute">' + inner + '</td>';
     },
     drawTableRows: function(results) {
       var $tBody = $('<tbody />'), i,l;
@@ -57,7 +63,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         $tableRow.append($th);
         for(var attribute in row) {
           if (documentFilter.importantAttribute(attribute)) {
-            $tableRow.append($('<td class="' + attribute + ' attribute">' + row[attribute] + '</td>'));
+            $tableRow.append($(documentFilter.drawTableCell(attribute, row[attribute])));
           }
         }
         $tBody.append($tableRow);
@@ -148,11 +154,11 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         selected: $.map(documentFilter.$form.find('select'), function(n) {
           var $n = $(n);
           return {id: $n.attr('id'), value: $n.val()};
-        }), 
+        }),
         text: $.map(documentFilter.$form.find('input[type=text]'), function(n) {
           var $n = $(n);
           return {id: $n.attr('id'), value: $n.val()};
-        }), 
+        }),
         checked: $.map(documentFilter.$form.find('input[type=radio]:checked'), function(n) {
           return $(n).attr('id');
         })

--- a/app/presenters/publication_filter_json_presenter.rb
+++ b/app/presenters/publication_filter_json_presenter.rb
@@ -4,11 +4,18 @@ class PublicationFilterJsonPresenter < DocumentFilterJsonPresenter
   end
 
   def document_hash(document)
-    super.merge(
+    to_merge = {
       publication_date: h.render_datetime_microformat(document, :publication_date) {
         document.publication_date.to_s(:long_ordinal)
       }.html_safe,
-      publication_type: document.publication_type.singular_name
-    )
+      publication_type: document.publication_type.singular_name,
+      publication_series: ""
+    }
+    if document.part_of_series?
+      link = h.link_to(document.document_series.name, h.organisation_document_series_path(document.document_series.organisation, document.document_series))
+      to_merge[:publication_series] = "Part of a series: #{link}".html_safe
+    end
+
+    super.merge(to_merge)
   end
 end

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -27,8 +27,10 @@
         <thead class="visuallyhidden">
           <tr>
             <th scope="col">Title</th>
+            <th scope="col">Publication Organisations</th>
             <th scope="col">Publication Date</th>
             <th scope="col">Publication Type</th>
+            <th scope="col">Publication Series</th>
           </tr>
         </thead>
         <tbody>
@@ -49,6 +51,11 @@
             </td>
             <td class="publication_type attribute">
               <%= publication.publication_type.singular_name %>
+            </td>
+            <td class="publication_series attribute">
+              <% if publication.part_of_series? %>
+                Part of a series: <%= link_to publication.document_series.name, organisation_document_series_path(publication.document_series.organisation, publication.document_series) %>
+              <% end %>
             </td>
           <% end %>
         <% end %>

--- a/features/filtering-publications.feature
+++ b/features/filtering-publications.feature
@@ -32,3 +32,12 @@ Scenario: The list should load more when I scroll to the end
   Then I should see 20 documents
   And I scroll to the bottom of the page
   Then I should see 40 documents
+
+@javascript
+Scenario: Publication series are included in publication list
+  Given a series "Test Series" for the organisation "Acme"
+    And a published publication "May 2012 update" in the series "Test Series"
+    And 25 published publications for the organisation "Big co."
+  When I visit the list of publications
+    And I filter to only those from the "Acme" department
+  Then I should see the publication "May 2012 Update" belongs to the "Test Series" series

--- a/features/step_definitions/document_series_steps.rb
+++ b/features/step_definitions/document_series_steps.rb
@@ -41,3 +41,21 @@ end
 Then /^I should see the series from "([^"]*)" first in the series list$/ do |organisation_name|
   assert page.has_css?("select optgroup:nth-child(1)[label='#{organisation_name}']")
 end
+
+Given /^a series "([^"]*)" for the organisation "([^"]*)"$/ do |series_name, organisation_name|
+  organisation = create(:organisation, name: organisation_name)
+  series = create(:document_series, name: series_name, organisation: organisation)
+end
+
+Given /^a published publication "([^"]*)" in the series "([^"]*)"$/ do |publication_name, series_name|
+  series = DocumentSeries.find_by_name(series_name)
+  publication = create(:published_publication, title: publication_name, document_series: series, organisations: [series.organisation])
+end
+
+Then /^I should see the publication "([^"]*)" belongs to the "([^"]*)" series$/ do |publication_name, series_name|
+  publication = Publication.find_by_title(publication_name)
+  series = DocumentSeries.find_by_name(series_name)
+  within record_css_selector(publication) do
+    assert page.has_css? "a[href='#{organisation_document_series_path(series.organisation, series)}']", text: series.name
+  end
+end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -340,6 +340,32 @@ class PublicationsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'index should show relevant document series information' do
+    organisation = create(:organisation)
+    series = create(:document_series, organisation: organisation)
+    publication = create(:published_publication, document_series: series)
+
+    get :index
+
+    assert_select_object(publication) do
+      assert_select ".publication_series a[href=?]", organisation_document_series_path(organisation, series)
+    end
+  end
+
+  test 'index requested as JSON includes document series information' do
+    organisation = create(:organisation)
+    series = create(:document_series, organisation: organisation)
+    publication = create(:published_publication, document_series: series)
+
+    get :index, format: :json
+
+    json = ActiveSupport::JSON.decode(response.body)
+
+    result = json['results'].first
+
+    assert_equal "Part of a series: <a href=\"#{organisation_document_series_path(organisation, series)}\">#{series.name}</a>", result['publication_series']
+  end
+
   test "show displays the ISBN of the attached document" do
     attachment = create(:attachment, isbn: '0099532816')
     edition = create("published_publication", :with_attachment, body: "!@1", attachments: [attachment])


### PR DESCRIPTION
This displays the information of a series the document is in in the index and via the Ajax updating mechanism.

The Javascript to present this information is getting a bit hairy and led to the decision to send back the text as a string rather than URL/name pairs in a JSON object, but since Neil wanted to try it out quickly I did the simplest thing.
