### PR TITLE
Use the HTML validation from Govspeak to defend aganist XSS.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'carrierwave'
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '~> 0.8.18'
+  gem 'govspeak', '~> 1.0.1'
 end
 gem 'kramdown', git: 'https://github.com/alphagov/kramdown.git', branch: "add-gemspec"
 gem 'validates_email_format_of'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,9 +152,10 @@ GEM
       warden (~> 1.2)
     gherkin (2.4.21)
       json (>= 1.4.6)
-    govspeak (0.8.18)
+    govspeak (1.0.1)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
+      sanitize (= 2.0.3)
     haml (3.1.6)
     hash_syntax (1.0.0)
       object_regex (~> 1.0.1)
@@ -282,6 +283,8 @@ GEM
     ruby_parser (2.3.1)
       sexp_processor (~> 3.0)
     rubyzip (0.9.4)
+    sanitize (2.0.3)
+      nokogiri (>= 1.4.4, < 1.6)
     sass (3.2.1)
     sass-rails (3.1.4)
       actionpack (~> 3.1.0)
@@ -368,7 +371,7 @@ DEPENDENCIES
   fog
   friendly_id (= 4.0.0.beta14)
   gds-sso (~> 1.2.2)
-  govspeak (~> 0.8.18)
+  govspeak (~> 1.0.1)
   hash_syntax
   isbn_validation
   jquery-rails

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -9,6 +9,7 @@ class Country < ActiveRecord::Base
   has_many :editions, through: :edition_countries
   has_many :featured_news_articles, through: :edition_countries, class_name: "NewsArticle", source: :edition, conditions: { "edition_countries.featured" => true, "editions.state" => "published" }
 
+  validates_with SafeHtmlValidator
   validates :name, presence: true
 
   extend FriendlyId

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -19,6 +19,7 @@ class Edition < ActiveRecord::Base
   has_many :edition_authors, dependent: :destroy
   has_many :authors, through: :edition_authors, source: :user
 
+  validates_with SafeHtmlValidator
   validates :title, :creator, presence: true
   validates :body, presence: true, if: :body_required?
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -103,6 +103,7 @@ class Organisation < ActiveRecord::Base
   accepts_nested_attributes_for :organisation_roles
   accepts_nested_attributes_for :edition_organisations
 
+  validates_with SafeHtmlValidator
   validates :name, presence: true, uniqueness: true
   validates :organisation_type_id, presence: true
   validates :logo_formatted_name, presence: true

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,6 +19,7 @@ class Person < ActiveRecord::Base
   has_many :organisations, through: :organisation_roles
 
   validates :name, presence: true
+  validates_with SafeHtmlValidator
 
   extend FriendlyId
   friendly_id :slug_name, use: :slugged

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -13,6 +13,7 @@ class Role < ActiveRecord::Base
   scope :ministerial, where(type: 'MinisterialRole')
 
   validates :name, presence: true
+  validates_with SafeHtmlValidator
 
   before_destroy :prevent_destruction_unless_destroyable
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -37,6 +37,7 @@ class Topic < ActiveRecord::Base
     TopicRelation.relation_for(pa.id, rpa.id).destroy_inverse_relation
   }
 
+  validates_with SafeHtmlValidator
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true
 

--- a/app/validators/safe_html_validator.rb
+++ b/app/validators/safe_html_validator.rb
@@ -1,0 +1,24 @@
+class SafeHtmlValidator < ActiveModel::Validator
+  def validate(record)
+    record.changes.each do |field_name, (old_value, new_value)|
+      check_struct(record, field_name, new_value)
+    end
+  end
+
+  def check_struct(record, field_name, value)
+    if value.respond_to?(:values) # e.g. Hash
+      value.values.each { |entry| check_struct(record, field_name, entry) }
+    elsif value.respond_to?(:each) # e.g. Array
+      value.each { |entry| check_struct(record, field_name, entry) }
+    elsif value.is_a?(String)
+      check_string(record, field_name, value)
+    end
+  end
+
+  def check_string(record, field_name, string)
+    unless Govspeak::HtmlValidator.new(string).valid?
+      error = "cannot include invalid Govspeak or JavaScript"
+      record.errors.add(field_name, error)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Whitehall
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/presenters)
+    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/presenters #{config.root}/app/validators)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/test/support/govspeak_validation_test_helper.rb
+++ b/test/support/govspeak_validation_test_helper.rb
@@ -1,0 +1,11 @@
+module GovspeakValidationTestHelper
+  def should_protect_against_xss_and_content_attacks_on(*attributes)
+    attributes.each do |attribute|
+      test "should protect against XSS and content attacks via #{attribute}" do
+        object = build(factory_name_from_test, attribute => "<script>badThings();</script>")
+        refute object.valid?, "should not be valid with unsafe content"
+        assert object.errors[attribute].include?("cannot include invalid Govspeak or JavaScript"), "didn't add validation errors to #{attribute} attribute"
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ class ActiveSupport::TestCase
   include Factory::Syntax::Methods
   include ModelStubbingHelpers
   include HtmlAssertions
+  extend GovspeakValidationTestHelper
 
   setup do
     Timecop.freeze(2011, 11, 11, 11, 11, 11)
@@ -70,10 +71,18 @@ class ActiveSupport::TestCase
     def edition_class_from_test_name
       name.sub(/Test$/, '').constantize
     end
+
+    def factory_name_from_test
+      name.sub(/Test$/, '').underscore.to_sym
+    end
   end
 
   def edition_class_from_test_name
     self.class.edition_class_from_test_name
+  end
+
+  def factory_name_from_test
+    self.class.factory_name_from_test
   end
 end
 

--- a/test/unit/case_study_test.rb
+++ b/test/unit/case_study_test.rb
@@ -6,6 +6,7 @@ class CaseStudyTest < EditionTestCase
   should_allow_image_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :body
 
   test "should be able to relate to policies" do
     article = build(:case_study)

--- a/test/unit/consultation_response_test.rb
+++ b/test/unit/consultation_response_test.rb
@@ -6,6 +6,7 @@ class ConsultationResponseTest < EditionTestCase
   should_not_allow_inline_attachments
   should_allow_a_summary_to_be_written
   should_not_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test "should not be valid without an associated consultation" do
     consultation_response = build(:consultation_response, consultation: nil)

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -6,6 +6,7 @@ class ConsultationTest < EditionTestCase
   should_allow_inline_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test "should not be valid without an opening on date" do
     consultation = build(:consultation, opening_on: nil)

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CountryTest < ActiveSupport::TestCase
+  should_protect_against_xss_and_content_attacks_on :name, :about
+
   test 'should be invalid without a name' do
     country = build(:country, name: nil)
     refute country.valid?

--- a/test/unit/international_priority_test.rb
+++ b/test/unit/international_priority_test.rb
@@ -4,4 +4,5 @@ class InternationalPriorityTest < EditionTestCase
   should_allow_image_attachments
   should_not_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -6,6 +6,7 @@ class NewsArticleTest < EditionTestCase
   should_allow_image_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note, :notes_to_editors
 
   test "should be able to relate to other editions" do
     article = build(:news_article)

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class OrganisationTest < ActiveSupport::TestCase
+  should_protect_against_xss_and_content_attacks_on :name, :about_us, :description
+
   test 'should be invalid without a name' do
     organisation = build(:organisation, name: nil)
     refute organisation.valid?

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class PersonTest < ActiveSupport::TestCase
+  should_protect_against_xss_and_content_attacks_on :biography
+
   test "should be invalid without a name" do
     person = build(:person, title: nil, forename: nil, surname: nil, letters: nil)
     refute person.valid?

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -4,6 +4,7 @@ class PolicyTest < EditionTestCase
   should_allow_image_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :body
 
   test "does not allow attachment" do
     refute build(:policy).allows_attachments?

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -6,6 +6,7 @@ class PublicationTest < EditionTestCase
   should_not_allow_inline_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test 'should be invalid without a publication date' do
     publication = build(:publication, publication_date: nil)
@@ -13,7 +14,7 @@ class PublicationTest < EditionTestCase
   end
 
   test "should build a draft copy of the existing publication" do
-    published_publication = create(:published_publication, 
+    published_publication = create(:published_publication,
       :with_attachment,
       publication_date: Date.parse("2010-01-01"),
       publication_type_id: PublicationType::ResearchAndAnalysis.id

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class RoleTest < ActiveSupport::TestCase
+  should_protect_against_xss_and_content_attacks_on :responsibilities
+
   test "should be invalid without a name" do
     role = build(:role, name: nil)
     refute role.valid?

--- a/test/unit/specialist_guide_test.rb
+++ b/test/unit/specialist_guide_test.rb
@@ -6,6 +6,7 @@ class SpecialistGuideTest < EditionTestCase
   should_allow_inline_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test "should allow body to be paginated" do
     article = build(:specialist_guide)

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -4,6 +4,7 @@ class SpeechTest < EditionTestCase
   should_allow_image_attachments
   should_allow_a_summary_to_be_written
   should_allow_a_body_to_be_written
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test "should be able to relate to other editions" do
     article = build(:speech)

--- a/test/unit/topic_test.rb
+++ b/test/unit/topic_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class TopicTest < ActiveSupport::TestCase
+  should_protect_against_xss_and_content_attacks_on :name, :description
+
   test "should default to the 'current' state" do
     topic = Topic.new
     assert topic.current?


### PR DESCRIPTION
When a model includes `validates_with SafeHtmlValidator`, every
field that is changed on that model will be passed through HTML
validation to ensure that no script tags or other errant HTML is
present.

I've also added tests for the key fields we are concerned with; I
suppose technically we could add tests for every class and every
field, but that felt like overkill.
