### PR TITLE
Change policies view to use Ajax filtering

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -3,9 +3,13 @@ class PoliciesController < DocumentsController
 
   respond_to :html
   respond_to :atom, only: :activity
+  respond_to :json, only: :index
 
   def index
-    @policies = Policy.published.includes(:document).by_published_at
+    params[:page] ||= 1
+    params[:direction] ||= "alphabetical"
+    @filter = Whitehall::DocumentFilter.new(policies, params)
+    respond_with PolicyFilterJsonPresenter.new(@filter)
   end
 
   def show
@@ -27,5 +31,9 @@ class PoliciesController < DocumentsController
 
   def document_class
     Policy
+  end
+
+  def policies
+    Policy.published.includes(:document)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -60,6 +60,11 @@ class Organisation < ActiveRecord::Base
             class_name: "Announcement",
             conditions: { "editions.state" => "published"},
             source: :edition
+  has_many :published_policies,
+            through: :edition_organisations,
+            class_name: "Policy",
+            conditions: { "editions.state" => "published"},
+            source: :edition
 
   has_many :document_series
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -69,6 +69,10 @@ class Topic < ActiveRecord::Base
     includes(:published_policies).select { |t| t.published_policies.map(&:published_related_publication_count).sum > 0 }
   end
 
+  def self.with_related_policies
+    joins(:published_policies).group(arel_table[:id])
+  end
+
   scope :alphabetical, order("name ASC")
 
   scope :featured, where(featured: true)

--- a/app/presenters/policy_filter_json_presenter.rb
+++ b/app/presenters/policy_filter_json_presenter.rb
@@ -1,0 +1,10 @@
+class PolicyFilterJsonPresenter < DocumentFilterJsonPresenter
+
+  def document_hash(document)
+    super.merge(
+      first_published_at: h.render_datetime_microformat(document, :first_published_at) {
+        document.first_published_at.to_s(:long_ordinal)
+      }.html_safe
+    )
+  end
+end

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -10,9 +10,49 @@
   </div>
 </div>
 
-
 <div class="block-2">
   <div class="inner-block">
-    <%= render partial: "grouped_list", locals: {policies: @policies} %>
+    <%= render partial: "documents/filter_form", locals: {document_type: :policy} %>
+  </div>
+</div>
+
+<div class="block-3">
+  <div class="inner-block filter-results" aria-live="polite">
+    <% if @filter.documents.any? %>
+      <table class="document-list emphasise-recent" id="document-list">
+        <thead class="visuallyhidden">
+          <tr>
+            <th scope="col">Title</th>
+            <th scope="col">Orgnisations</th>
+            <th scope="col">First published at</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @filter.documents.each_with_index do |policy, i| %>
+            <%= content_tag_for(:tr, policy, class: "document-row#{i < 3 ? ' recent' : ''}") do %>
+              <th scope="row" class="title attribute">
+                <%= link_to policy.title, public_document_path(policy),
+                    title: "View #{policy.title}" %>
+              </th>
+              <td class="attribute organisations">
+                <%= policy.organisations.map { |o|
+                      organisation_display_name(o) }.to_sentence.html_safe %>
+              </td>
+              <td class="attribute first_published_at">
+                <%= render_datetime_microformat(policy, :first_published_at) {
+                    policy.first_published_at.to_s(:long_ordinal)
+              }%>
+              </td>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+      <%= paginate @filter.documents %>
+    <% else %>
+      <div class="no-results">
+        <h2>There are no matching policies.</h2>
+        <p>Try making your search broader and try again.</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/features/filtering-policies.feature
+++ b/features/filtering-policies.feature
@@ -1,0 +1,44 @@
+Feature: Filtering published policies
+
+@javascript
+Scenario: The list should only display policies matching the organisation filter
+  Given a published policy "One man went to mow" for the organisation "Big co."
+  And a published policy "Standard Beard Lengths" for the organisation "Acme"
+  When I visit the list of policies
+  And I filter to only those from the "Acme" department
+  Then I should see the policy "Standard Beard Lengths"
+  And I should not see the policy "One man went to mow"
+
+@javascript
+Scenario: The list should only display policies matching the topic filter
+  Given two topics "Gardening" and "Formalities" exist
+  And a published policy "Improved methods of lawn cultivation" exists in the "Gardening" topic
+  And a published policy "Dress codes" exists in the "Formalities" topic
+  When I visit the list of policies
+  And I filter to only those from the "Formalities" topic
+  Then I should see the policy "Dress codes"
+  And I should not see the policy "Improved methods of lawn cultivation"
+
+@javascript
+Scenario: The list should add pagination
+  Given 25 published policies for the organisation "Big co."
+  When I visit the list of policies
+  And I filter to only those from the "Big co." department
+  Then I should see a link to the next page of documents
+
+@javascript
+Scenario: The list should tell me how far I am from the end
+  Given 25 published policies for the organisation "Big co."
+  And 20 published policies for the organisation "Acme"
+  When I visit the list of policies
+  And I filter to only those from the "Big co." department
+  Then I should see that the next page is 2 of 2
+
+@javascript
+Scenario: The list should load more when I scroll to the end
+  Given 41 published policies for the organisation "Big co."
+  When I visit the list of policies
+  And I filter to only those from the "Big co." department
+  Then I should see 20 documents
+  And I scroll to the bottom of the page
+  Then I should see 40 documents

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -358,6 +358,20 @@ Given /^a published policy "([^"]*)" with a link "([^"]*)" in the body$/ do |tit
   create(:published_policy, title: title, body: body)
 end
 
+Given /^a published policy "([^"]*)" for the organisation "([^"]*)"$/ do |title, organisation|
+  org = create(:organisation, name: organisation)
+  create(:published_policy, title: title, organisations: [org])
+end
+
 Then /^I should see that the policy "([^"]*)" includes an embedded media player$/ do |arg1|
   assert_video_player_exists
+end
+
+When /^I visit the list of policies$/ do
+  visit "/government/policies"
+end
+
+Given /^(\d+) published policies for the organisation "([^"]+)"$/ do |count, organisation|
+  organisation = create(:organisation, name: organisation)
+  count.to_i.times { |i| create(:published_policy, title: "keyword-#{i}", organisations: [organisation]) }
 end

--- a/lib/whitehall/document_filter.rb
+++ b/lib/whitehall/document_filter.rb
@@ -27,11 +27,13 @@ class Whitehall::DocumentFilter
       Topic.with_related_specialist_guides.order(:name)
     when :announcement
       Topic.with_related_announcements.order(:name)
+    when :policy
+      Topic.with_related_policies.order(:name)
     end
   end
 
   def all_organisations_with(type)
-    Organisation.joins(:"published_#{type}s").group(:name).ordered_by_name_ignoring_prefix
+    Organisation.joins(:"published_#{type.to_s.pluralize}").group(:name).ordered_by_name_ignoring_prefix
   end
 
   def selected_topics

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -4,7 +4,7 @@ class PoliciesControllerTest < ActionController::TestCase
   include DocumentViewAssertions
 
   should_be_a_public_facing_controller
-  should_render_a_list_of :policies
+
   should_show_the_countries_associated_with :policy
   should_display_inline_images_for :policy
   should_not_display_lead_image_for :policy
@@ -13,6 +13,7 @@ class PoliciesControllerTest < ActionController::TestCase
   should_show_change_notes_on_action :policy, :show do |policy|
     get :show, id: policy.document
   end
+  should_return_json_suitable_for_the_document_filter :policy
 
   test "show displays the date that the policy was updated" do
     policy = create(:published_policy)


### PR DESCRIPTION
This changes the policies homepage from an A-Z grouped set to one of the new Ajax filter pages.

https://www.pivotaltracker.com/story/show/35187489
