### PR TITLE
Move responsibility for role management to the SSO server.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,10 @@ class User < ActiveRecord::Base
     departmental_editor? ? "Departmental Editor" : "Policy Writer"
   end
 
+  def departmental_editor?
+    has_permission?(GDS::SSO::Config.default_scope, 'Editor')
+  end
+
   def organisation_name
     organisation ? organisation.name : nil
   end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,9 +9,6 @@
     <%= form.label :organisation_id, 'Organisation' %>
     <%= form.select :organisation_id, options_from_collection_for_select(Organisation.all, 'id', 'name', form.object.organisation_id), {}, class: 'chzn-select', data: { placeholder: "Choose your organisation" } %>
 
-    <%= form.label :departmental_editor %>
-    <%= form.check_box :departmental_editor %>
-
     <%= form.save_or_cancel cancel: admin_user_path %>
   <% end %>
 </section>

--- a/db/migrate/20120917134544_remove_editor_flag_from_users.rb
+++ b/db/migrate/20120917134544_remove_editor_flag_from_users.rb
@@ -1,0 +1,18 @@
+class RemoveEditorFlagFromUsers < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+    serialize :permissions, Hash
+  end
+
+  def up
+    User.all.each do |user|
+      if user.departmental_editor?
+        permissions = user.permissions['Whitehall']
+        if permissions && !permissions.include?('Editor')
+          user.permissions['Whitehall'] = (permissions << 'Editor')
+          user.save!
+        end
+      end
+    end
+    remove_column :users, :departmental_editor
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -503,7 +503,6 @@ ActiveRecord::Schema.define(:version => 20120919074734) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "departmental_editor", :default => false
     t.string   "email"
     t.integer  "organisation_id"
     t.string   "uid"

--- a/features/user_administration.feature
+++ b/features/user_administration.feature
@@ -22,11 +22,6 @@ Scenario: Logged in users should be able to set their organisation
   When I set the organisation for "John Smith" to "Department of Beards"
   Then I should see my organisation is "Department of Beards"
 
-Scenario: Logged in users should be able to set their role
-  Given I am a writer called "John Smith"
-  When I set the role for "John Smith" to departmental editor
-  Then I should see that I am a departmental editor
-
 Scenario: Logged in users should be able to see other users' contact details
   Given I am a writer
   And there is a user called "John Smith" with email address "johnsmith@example.com"

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -14,10 +14,9 @@ FactoryGirl.define do
   end
 
   factory :policy_writer, parent: :user, aliases: [:author, :creator, :fact_check_requestor] do
-    departmental_editor false
   end
 
   factory :departmental_editor, parent: :user do
-    departmental_editor true
+    permissions { Hash[GDS::SSO::Config.default_scope => ["signin", "Editor"]] }
   end
 end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -32,7 +32,6 @@ class Admin::UsersControllerTest < ActionController::TestCase
     assert_select "form[action='#{admin_user_path}']" do
       assert_select "input[name='user[email]'][type='text'][value='user@example.com']"
       assert_select "select[name='user[organisation_id]']"
-      assert_select "input[type='checkbox'][name='user[departmental_editor]']"
       assert_select "input[type='submit'][value='Save']"
     end
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -15,4 +15,14 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, email: nil)
     assert user.valid?
   end
+
+  test 'should be a departmental editor if has whitehall Editor role' do
+    user = build(:user, email: nil, permissions: {'Whitehall' => ['Editor']})
+    assert user.departmental_editor?
+  end
+
+  test 'should not be a departmental editor if does not have has whitehall Editor role' do
+    user = build(:user, email: nil, permissions: {'Whitehall' => []})
+    refute user.departmental_editor?
+  end
 end


### PR DESCRIPTION
For this to work, an 'Editor' permission needs to be added to
the whitehall app in signonotron2.  A related change has been made
to the signonotron2 project[1] which needs to be applied and deployed
before this commit.

[1] https://github.com/alphagov/signonotron2/pull/19
