### PR TITLE
Move exception_notifier config into an initializer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,10 +74,5 @@ Whitehall::Application.configure do
 
   config.action_mailer.delivery_method = :ses
 
-  config.middleware.use ExceptionNotifier,
-    email_prefix: "[Whitehall exception] ",
-    sender_address: %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-    exception_recipients: %w{govuk-exceptions@digital.cabinet-office.gov.uk govuk@gofreerange.com}
-
   config.slimmer.use_cache = true
 end

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,6 @@
+unless Rails.env.development? or Rails.env.test?
+  Rails.application.config.middleware.use ExceptionNotifier,
+    email_prefix: "[#{Rails.application.class.name.split('::').first} (#{Plek.current.environment})] ",
+    sender_address: %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
+    exception_recipients: %w{govuk-exceptions@digital.cabinet-office.gov.uk}
+end


### PR DESCRIPTION
This is so that it can be overridden in staging by the deploy scripts.

Staging excpetions will be sent to a different extension address so that we can differentiate them from production.
