### PR TITLE
Let a person to be honorific

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -280,9 +280,9 @@
   #topics {
     .topic {
       list-style: none;
-      counter-increment: headings 1;  
+      counter-increment: headings 1;
       h2:before {
-        content: counter(headings, decimal-leading-zero) "."; 
+        content: counter(headings, decimal-leading-zero) ".";
         display: block;
       }
       
@@ -492,9 +492,7 @@
       }
       
       .current-appointee {
-        @include core-19;
         padding-top: 0;
-        
         a {
           &:hover,
           &:focus,
@@ -510,16 +508,21 @@
         span {
           display: block;
           @include core-14;
+          padding-bottom: 0;
           color: $low-contrast;
-          margin-bottom: ($gutter-one-sixth*-1)
+        }
+        strong {
+          display: block;
+          @include core-19;
+        }
+        &.privy_counsellor strong {
+          padding-top: 0;
         }
       }
-      
       .role {
         @include core-14;
         padding-top: 2px;
         padding-top: 0.2rem;
-        
         a {
           color: $body-text;
         }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,7 +41,7 @@ class Person < ActiveRecord::Base
   end
 
   def name
-    [title, forename, surname, letters].compact.join(' ')
+    [("The Rt Hon" if privy_counsellor?), title, forename, surname, letters].compact.join(' ')
   end
 
   def previous_role_appointments

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -34,8 +34,8 @@ class PersonPresenter < Draper::Base
 
   def link
     name = ""
-    name << "<span class='person-title'>#{title}</span> " if title
-    name << "<strong>#{forename} #{surname} #{letters}</strong>"
+    name << "<span class='person-title'>The Rt Hon</span> " if privy_counsellor?
+    name << "<strong>#{title} #{forename} #{surname} #{letters}</strong>"
     h.link_to name.html_safe, path
   end
 

--- a/app/presenters/role_presenter.rb
+++ b/app/presenters/role_presenter.rb
@@ -11,8 +11,8 @@ class RolePresenter < Draper::Base
 
   def announcements
     return [] unless ministerial?
-    announcements = 
-      SpeechPresenter.decorate(model.published_speeches.limit(10)).to_a + 
+    announcements =
+      SpeechPresenter.decorate(model.published_speeches.limit(10)).to_a +
       NewsArticlePresenter.decorate(model.published_news_articles.limit(10)).to_a
     announcements.sort_by { |a| a.display_date.to_datetime }.reverse[0..9]
   end
@@ -58,6 +58,10 @@ class RolePresenter < Draper::Base
 
     def image_url
       "blank-person.png"
+    end
+
+    def privy_counsellor?
+      false
     end
   end
 end

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -2,6 +2,7 @@
   <%= person_form.errors %>
 
   <fieldset>
+    <%= person_form.check_box :privy_counsellor, label_text: 'Rt Hon?' %>
     <%= person_form.text_field :title %>
     <%= person_form.text_field :forename %>
     <%= person_form.text_field :surname %>

--- a/app/views/ministerial_roles/_role.html.erb
+++ b/app/views/ministerial_roles/_role.html.erb
@@ -3,7 +3,7 @@
     <div class="image_holder">
       <%= link_to person.image, person %>
     </div>
-    <<%= hlevel %> class="current-appointee"><%= link_to "<span>#{person.title}</span> <strong>#{person.forename} #{person.surname} #{person.letters}</strong>".html_safe, person.path %></<%= hlevel %>>
+    <<%= hlevel %> class="current-appointee"><%= person.link %></<%= hlevel %>>
     <p class="role">
       <%= roles.map { |role| role.link }.join(", ").html_safe %>
     </p>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -116,7 +116,9 @@
                     <div class="image_holder">
                       <%= minister.current_person_image %>
                     </div>
-                    <h3 class="current-appointee"><%= minister.current_person_link %></h3>
+                    <h3 class="current-appointee<%= " privy_counsellor" if minister.current_person.privy_counsellor? %>">
+                      <%= minister.current_person_link %>
+                    </h3>
                     <p class="role"><%= minister.link %></p>
                   </div>
                 <% end %>

--- a/db/migrate/20121019110948_add_privy_counsellor_to_people.rb
+++ b/db/migrate/20121019110948_add_privy_counsellor_to_people.rb
@@ -1,0 +1,6 @@
+class AddPrivyCounsellorToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :privy_counsellor, :boolean, default: false
+    remove_column :people, :privy_councillor
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121017134138) do
+ActiveRecord::Schema.define(:version => 20121019110948) do
 
   create_table "attachments", :force => true do |t|
     t.string   "carrierwave_file"
@@ -399,10 +399,10 @@ ActiveRecord::Schema.define(:version => 20121017134138) do
     t.string   "letters"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "privy_councillor",  :default => false
     t.string   "carrierwave_image"
     t.text     "biography"
     t.string   "slug"
+    t.boolean  "privy_counsellor",  :default => false
   end
 
   add_index "people", ["slug"], :name => "index_people_on_slug", :unique => true

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -11,6 +11,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     get :new
 
     assert_select "form[action='#{admin_people_path}']" do
+      assert_select "input[name='person[privy_counsellor]'][type=checkbox]"
       assert_select "input[name='person[title]'][type=text]"
       assert_select "input[name='person[forename]'][type=text]"
       assert_select "input[name='person[surname]'][type=text]"


### PR DESCRIPTION
For styling reasons we require 'The Rt Hon' to be separate from the rest
of a persons title. This creates a boolean value which will add 'The Rt
Hon' to the front of a persons name when displayed.
