### PR TITLE
Only show featured dcoument on org page if image has been virus checked.

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -10,7 +10,7 @@ class OrganisationsController < PublicFacingController
   def show
     @recently_updated = @organisation.published_editions.by_published_at.limit(3)
     if @organisation.live?
-      @featured_editions = FeaturedEditionPresenter.decorate(@organisation.featured_edition_organisations.limit(6))
+      @featured_editions = FeaturedEditionPresenter.decorate(@organisation.featured_edition_organisations.select(&:image_ready?)[0..5])
       @top_military_role = @organisation.top_military_role && RolePresenter.decorate(@organisation.top_military_role)
       @policies = PolicyPresenter.decorate(@organisation.published_policies.by_published_at.limit(3))
       @topics = @organisation.topics_with_content

--- a/app/models/edition_organisation.rb
+++ b/app/models/edition_organisation.rb
@@ -7,4 +7,8 @@ class EditionOrganisation < ActiveRecord::Base
 
   validates :edition, :organisation, presence: true
   validates :image, :alt_text, presence: true, if: :featured?
+
+  def image_ready?
+    image.virus_checked?
+  end
 end

--- a/app/models/edition_organisation_image_data.rb
+++ b/app/models/edition_organisation_image_data.rb
@@ -4,6 +4,10 @@ class EditionOrganisationImageData < ActiveRecord::Base
 
   validate :image_must_be_960px_by_640px, if: :image_changed?
 
+  def virus_checked?
+    file.present? && File.exist?(file.path)
+  end
+
   private
 
   def image_changed?

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -63,6 +63,23 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_equal [policy, news_article], assigns(:featured_editions).collect(&:model)
   end
 
+  test "only shows featured editions whose images have been virus checked" do
+    organisation = build(:organisation, id: 123)
+    Organisation.stubs(:find).returns(organisation)
+
+    with_quarantined_image = build(:featured_edition_organisation)
+    with_quarantined_image.stubs(image_ready?: false)
+
+    with_virus_checked_image = build(:featured_edition_organisation)
+    with_virus_checked_image.stubs(image_ready?: true)
+
+    organisation.stubs(:featured_edition_organisations).returns([with_quarantined_image, with_virus_checked_image])
+
+    get :show, id: organisation
+
+    assert_equal [with_virus_checked_image.edition], assigns(:featured_editions).collect(&:model)
+  end
+
   test "shows a maximum of 6 featured editions" do
     organisation = create(:organisation)
     editions = []

--- a/test/unit/edition_organisation_image_data_test.rb
+++ b/test/unit/edition_organisation_image_data_test.rb
@@ -16,4 +16,21 @@ class EditionOrganisationImageDataTest < ActiveSupport::TestCase
     image_data.save(validate: false)
     assert image_data.reload.valid?
   end
+
+  test "should indicate that image has been virus checked if file exists" do
+    image_data = build(:edition_organisation_image_data)
+    File.stubs(:exist?).with(image_data.file.path).returns(true)
+    assert image_data.virus_checked?
+  end
+
+  test "should indicate that image has not been virus checked if file does not exist" do
+    image_data = build(:edition_organisation_image_data)
+    File.stubs(:exist?).with(image_data.file.path).returns(false)
+    refute image_data.virus_checked?
+  end
+
+  test "should indicate that image has not been virus checked if file not set" do
+    image_data = build(:edition_organisation_image_data, file: nil)
+    refute image_data.virus_checked?
+  end
 end

--- a/test/unit/edition_organisation_test.rb
+++ b/test/unit/edition_organisation_test.rb
@@ -48,4 +48,18 @@ class EditionOrganisationTest < ActiveSupport::TestCase
 
     assert_nil edition_organisation.image
   end
+
+  test "should indicate that image is ready if image is not quarantined" do
+    clean_image = stub("clean-image", virus_checked?: true)
+    edition_organisation = build(:edition_organisation)
+    edition_organisation.stubs(:image).returns(clean_image)
+    assert edition_organisation.image_ready?
+  end
+
+  test "should indicate that image is not ready if image is still quarantined" do
+    quarantined_image = stub("quarantined-image", virus_checked?: false)
+    edition_organisation = build(:edition_organisation)
+    edition_organisation.stubs(:image).returns(quarantined_image)
+    refute edition_organisation.image_ready?
+  end
 end


### PR DESCRIPTION
This is to avoid displaying the placeholder image in such a prominent
position. See https://www.pivotaltracker.com/story/show/38484895.

We use the fact that the file path for the image is the path where the
image will be placed once it has been removed from the virus scanning
quarantine to determine whether the image is ready to display.
