### PR TITLE
Format headers for policy, news, detailed_guidance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,8 @@ class ApplicationController < ActionController::Base
   def set_slimmer_organisations_header(organisations)
     set_slimmer_headers(organisations: "<#{organisations.map(&:analytics_identifier).join('><')}>")
   end
+
+  def set_slimmer_format_header(format_name)
+    set_slimmer_headers(format: format_name)
+  end
 end

--- a/app/controllers/detailed_guides_controller.rb
+++ b/app/controllers/detailed_guides_controller.rb
@@ -1,4 +1,6 @@
 class DetailedGuidesController < DocumentsController
+  FORMAT_NAME = "detailed_guidance"
+
   layout "detailed-guidance"
   skip_before_filter :set_search_path
   before_filter :set_search_index
@@ -10,6 +12,7 @@ class DetailedGuidesController < DocumentsController
   def show
     @categories = @document.mainstream_categories
     @topics = @document.topics
+    set_slimmer_format_header(FORMAT_NAME)
     render action: "show"
   end
 

--- a/app/controllers/news_articles_controller.rb
+++ b/app/controllers/news_articles_controller.rb
@@ -1,4 +1,6 @@
 class NewsArticlesController < DocumentsController
+  FORMAT_NAME = "news"
+
   def index
     @news_articles = NewsArticle.published.by_first_published_at
   end
@@ -7,6 +9,7 @@ class NewsArticlesController < DocumentsController
     @related_policies = @document.published_related_policies
     @document = NewsArticlePresenter.decorate(@document)
     set_slimmer_organisations_header(@document.organisations)
+    set_slimmer_format_header(FORMAT_NAME)
   end
 
   private

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,5 +1,6 @@
 class PoliciesController < DocumentsController
   include CacheControlHelper
+  FORMAT_NAME = "policy"
 
   before_filter :find_document, only: [:show, :activity]
 
@@ -20,6 +21,7 @@ class PoliciesController < DocumentsController
     @recently_changed_documents = Edition.published.related_to(@policy).in_reverse_chronological_order
     @show_navigation = (@policy.supporting_pages.any? or @recently_changed_documents.any?)
     set_slimmer_organisations_header(@policy.organisations)
+    set_slimmer_format_header(FORMAT_NAME)
   end
 
   def activity

--- a/test/functional/application_controller_analytics_test.rb
+++ b/test/functional/application_controller_analytics_test.rb
@@ -11,6 +11,11 @@ class ApplicationControllerAnalyticsTest < ActionController::TestCase
       set_slimmer_organisations_header(orgs)
       render text: "ok"
     end
+
+    def test_format
+      set_slimmer_format_header("format_name")
+      render text: "ok"
+    end
   end
 
   tests TestController
@@ -34,5 +39,15 @@ class ApplicationControllerAnalyticsTest < ActionController::TestCase
       get :test_organisations
     end
     assert_equal "<D1><D2>", response.headers["X-Slimmer-Organisations"]
+  end
+
+  test "sets format header for google analytics" do
+    with_routing do |map|
+      map.draw do
+        match '/test_format', to: 'application_controller_analytics_test/test#test_format'
+      end
+      get :test_format
+    end
+    assert_equal "format_name", response.headers["X-Slimmer-Format"]
   end
 end

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -105,6 +105,14 @@ That's all
     assert_select "link[rel=alternate][href=?]", api_detailed_guide_url(detailed_guide.document)
   end
 
+  test "the format name is being set to 'detailed_guidance'" do
+    guide = create(:published_detailed_guide)
+
+    get :show, id: guide.document
+
+    assert_equal "detailed_guidance", response.headers["X-Slimmer-Format"]
+  end
+
   private
 
   def given_two_detailed_guides_in_two_organisations

--- a/test/functional/news_articles_controller_test.rb
+++ b/test/functional/news_articles_controller_test.rb
@@ -59,4 +59,12 @@ class NewsArticlesControllerTest < ActionController::TestCase
       assert_select ".published-at[title='#{updated_news_article.published_at.iso8601}']"
     end
   end
+
+  test "the format name is being set to news" do
+    news_article = create(:published_news_article)
+
+    get :show, id: news_article.document
+
+    assert_equal "news", response.headers["X-Slimmer-Format"]
+  end
 end

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -425,4 +425,12 @@ That's all
       end
     end
   end
+
+  test "the format name is being set to policy" do
+    policy = create(:published_policy)
+
+    get :show, id: policy.document
+
+    assert_equal "policy", response.headers["X-Slimmer-Format"]
+  end
 end


### PR DESCRIPTION
Add format headers for policy, news, detailed_guidance. This is required for success tracking.

@pbadenski
@gtrogers
