### PR TITLE
Avoid exception when org-related admin links appear in govspeak text.

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -172,8 +172,11 @@ module GovspeakHelper
   end
 
   def find_organisation_from_uri(uri)
-    slug = uri.split("/").last
-    Organisation.find(slug)
+    organisation_id = nil
+    if uri[%r{/admin/organisations/([\w-]+)$}]
+      organisation_id = $1
+    end
+    Organisation.where(slug: organisation_id).first
   end
 
   def rewritten_href_for_edition(edition, supporting_page)

--- a/test/unit/helpers/govspeak_helper_link_rewriting_test.rb
+++ b/test/unit/helpers/govspeak_helper_link_rewriting_test.rb
@@ -39,6 +39,47 @@ class GovspeakHelperLinkRewritingTest < ActionView::TestCase
     assert_rewrites_link(from: admin_supporting_page_url(supporting_page_2), to: public_supporting_page_url(policy_2, supporting_page_2))
   end
 
+  test "should rewrite link to an admin page for an organisation as a link to its public page" do
+    organisation = create(:organisation)
+    assert_rewrites_link(from: admin_organisation_url(organisation), to: organisation_url(organisation))
+  end
+
+  test "should not raise exception when link to an admin page for an organisation corporate information is present" do
+    organisation = create(:organisation, name: "department-for-communities-and-local-government")
+    page = create(:corporate_information_page, organisation: organisation)
+    path = admin_organisation_corporate_information_page_path(organisation, page)
+    assert_nothing_raised do
+      govspeak_to_html("[text](#{path})")
+    end
+  end
+
+  test "should not raise exception when link to an admin edit page for an organisation corporate information is present" do
+    organisation = create(:organisation, name: "department-for-communities-and-local-government")
+    page = create(:corporate_information_page, organisation: organisation)
+    path = edit_admin_organisation_corporate_information_page_path(organisation, page)
+    assert_nothing_raised do
+      govspeak_to_html("[text](#{path})")
+    end
+  end
+
+  test "should not raise exception when link to an admin page for an organisation document series is present" do
+    organisation = create(:organisation, name: "department-for-communities-and-local-government")
+    document_series = create(:document_series, organisation: organisation)
+    path = admin_organisation_document_series_path(organisation, document_series)
+    assert_nothing_raised do
+      govspeak_to_html("[text](#{path})")
+    end
+  end
+
+  test "should not raise exception when link to an admin edit page for an organisation document series is present" do
+    organisation = create(:organisation, name: "department-for-communities-and-local-government")
+    document_series = create(:document_series, organisation: organisation)
+    path = edit_admin_organisation_document_series_path(organisation, document_series)
+    assert_nothing_raised do
+      govspeak_to_html("[text](#{path})")
+    end
+  end
+
   test 'should rewrite admin link to an archived edition as a link to its published edition' do
     archived_edition, published_edition = create_archived_policy_with_published_edition
     assert_rewrites_link(from: admin_edition_url(archived_edition), to: public_document_url(published_edition))

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -182,14 +182,6 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".govspeak .attachment.embedded a[href^='https://some.cdn.com/']"
   end
 
-  test "rewrites organisation links" do
-    organisation = create(:organisation)
-    url = admin_organisation_url(organisation)
-    govspeak = "this and [that](#{url}) yeah?"
-    html = govspeak_to_html(govspeak)
-    assert_select_within_html html, "a[href='#{organisation_url(organisation)}']"
-  end
-
   private
 
   def internal_preview_host


### PR DESCRIPTION
- The change in 2a236d623e391f8e927dd0c767a2e65cb2bdd80e was too naïve.
  There are other admin organisation-related paths which it cannot
  handle. In particular, people have understandably linked to admin
  organisation corporate information pages and admin organisation
  document series pages (both their "show" and "edit" versions).
- This commit does not actually fix the re-writing to work how it
  probably ought to, but it does avoid raising an
  `ActiveRecord::RecordNotFound` exception, which in turn causes the
  page to respond with a 404.
- I've taken the liberty of moving the organisation admin link
  re-writing test into the test where it's siblings live.
- I've tried to follow similar conventions in
  `GovspeakHelperTest#find_organisation_from_uri` as are used in
  `GovspeakHelper#find_edition_and_supporting_page_from_uri` to make
  things more consistent.
