### PR TITLE
Don't link to homepage from homepage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -228,6 +228,12 @@ module ApplicationHelper
     end
   end
 
+  def progress_bar_link
+    unless params[:controller] == "home" && params[:action] == "home"
+      link_to "More will join soon", root_path
+    end
+  end
+
   def featured_grid_class(count=0)
     case count
     when 1

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -46,7 +46,10 @@
         <div id="content"></div>
         <div class="progress-bar js-progress-bar" id="progress-bar" data-join-count="2">
           <div class="bar"><div class="joined"></div></div>
-          <p>2 of 24  ministerial departments have moved their corporate websites to GOV.UK. <%= link_to "More will join soon", root_path %></p>
+          <p>
+            2 of 24  ministerial departments have moved their corporate websites to GOV.UK.
+            <%= progress_bar_link %>
+          </p>
         </div>
         <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
           <%= yield %>

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -57,6 +57,18 @@ class HomeControllerTest < ActionController::TestCase
     end
   end
 
+  test "home page doeesn't link to iself in the progress bar" do
+    get :home
+
+    refute_select ".progress-bar a[href=#{root_path}]"
+  end
+
+  test "non home page page doeesn't link to iself in the progress bar" do
+    get "how-government-works".to_sym
+
+    assert_select ".progress-bar a[href=#{root_path}]"
+  end
+
   private
 
   def create_published_documents


### PR DESCRIPTION
The link to the homepage in the progress bar shouldn't be there on the
homepage but should otherwise.
