### PR TITLE
Remove missing mainstream category/associations

### DIFF
--- a/db/migrate/20121123155149_remove_deleted_mainstream_category.rb
+++ b/db/migrate/20121123155149_remove_deleted_mainstream_category.rb
@@ -2,13 +2,19 @@ class RemoveDeletedMainstreamCategory < ActiveRecord::Migration
   class EditionMainstreamCategory < ActiveRecord::Base
     belongs_to :mainstream_category
   end
+  class MainstreamCategory < ActiveRecord::Base
+  end
 
   def up
     puts "Removing all edition associations with the tax-and-legislation-for-corporations category"
-    EditionMainstreamCategory.where(mainstream_category_id: 46).destroy_all
+    category_to_delete = MainstreamCategory.where(slug: 'tax-and-legislation-for-corporations').first
 
-    puts "Remove the tax-and-legislation-for-corporations mainstream sub-category"
-    execute "DELETE FROM mainstream_categories WHERE id = 46"
+    if category_to_delete
+      EditionMainstreamCategory.where(mainstream_category_id: category_to_delete).destroy_all
+
+      puts "Remove the tax-and-legislation-for-corporations mainstream sub-category"
+      category_to_delete.destroy
+    end
   end
 
   def down


### PR DESCRIPTION
This commit ensures that there are no edition links to the old deleted
category and then removes it.

As I'm not that familiar with how the mainstream categories work, and this is a destructive change, I've popped it up as a pull request to ensure there aren't any unintended side effects to removing this category. Better that just pushing it to master last thing on a Friday :)

See this ticket[1] for rationale. 

[1] https://www.pivotaltracker.com/story/show/38787469
