### PR TITLE
Use opening date as first published date

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -67,6 +67,10 @@ class Consultation < Publicationesque
     response.published_on_or_default
   end
 
+  def first_published_date
+    opening_on.to_date
+  end
+
   def last_significantly_changed_on
     ((response_published? && response_published_on) || (closed? && closing_on) || (open? && opening_on) || first_published_at).to_date
   end
@@ -100,6 +104,14 @@ class Consultation < Publicationesque
   def hash_with_blank_values?(hash)
     hash.values.inject(true) do |result, value|
       result && (value.is_a?(Hash) ? hash_with_blank_values?(value) : value.blank?)
+    end
+  end
+
+  def set_timestamp_for_sorting
+    if first_published_version?
+      self.timestamp_for_sorting = opening_on
+    else
+      self.timestamp_for_sorting = published_at
     end
   end
 

--- a/app/presenters/publicationesque_presenter.rb
+++ b/app/presenters/publicationesque_presenter.rb
@@ -9,7 +9,7 @@ class PublicationesquePresenter < Draper::Base
     when Publication
       :publication_date
     when Consultation
-      :first_published_at
+      :timestamp_for_sorting
     when StatisticalDataSet
       :first_published_at
     else

--- a/db/migrate/20121203111348_update_timestamp_for_sorting_on_consultations.rb
+++ b/db/migrate/20121203111348_update_timestamp_for_sorting_on_consultations.rb
@@ -1,0 +1,13 @@
+class UpdateTimestampForSortingOnConsultations < ActiveRecord::Migration
+  def up
+    execute %{
+      UPDATE editions
+      SET timestamp_for_sorting=opening_on
+      WHERE type='Consultation' and published_major_version='1'
+    }
+  end
+
+  def down
+    # No down as this there are no schema changes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121130142956) do
+ActiveRecord::Schema.define(:version => 20121203111348) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -319,8 +319,8 @@ ActiveRecord::Schema.define(:version => 20121130142956) do
     t.integer  "published_related_publication_count",                             :default => 0,       :null => false
     t.datetime "timestamp_for_sorting"
     t.integer  "primary_mainstream_category_id"
-    t.boolean  "replaces_businesslink",                                           :default => false
     t.datetime "scheduled_publication"
+    t.boolean  "replaces_businesslink",                                           :default => false
     t.boolean  "access_limited"
     t.integer  "published_major_version"
     t.integer  "published_minor_version"

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -87,7 +87,7 @@ class HomeControllerTest < ActionController::TestCase
       create(:published_news_article, first_published_at: x.days.ago + 2.hours)
       create(:published_speech, delivered_on: x.days.ago + 3.hours)
       create(:published_publication, publication_date: x.days.ago + 4.hours)
-      create(:published_consultation, first_published_at: x.days.ago + 5.hours)
+      create(:published_consultation, opening_on: x.days.ago + 5.hours)
     end
   end
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -328,7 +328,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "should display the organisation's publications with content" do
     organisation = create(:organisation)
     publication = create(:published_publication, organisations: [organisation], publication_type: PublicationType::PolicyPaper, publication_date: Date.parse("2012-01-01"))
-    consultation = create(:published_consultation, organisations: [organisation], first_published_at: Time.zone.parse("2012-01-01 01:01:01"))
+    consultation = create(:published_consultation, organisations: [organisation], opening_on: 3.days.ago)
 
     get :show, id: organisation
 
@@ -338,7 +338,7 @@ class OrganisationsControllerTest < ActionController::TestCase
         assert_select '.document-type', "Policy paper"
       end
       assert_select_object consultation do
-        assert_select '.publication-date abbr[title=?]', Time.zone.parse("2012-01-01 01:01:01").iso8601
+        assert_select '.publication-date abbr[title=?]', 3.days.ago.iso8601
         assert_select '.document-type', "Open consultation"
       end
     end

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -409,10 +409,10 @@ That's all
 
   test 'activity atom feed shows activity documents' do
     policy = create(:published_policy)
-    publication = create(:published_publication, published_at: 1.day.ago, publication_date: 4.weeks.ago, related_policies: [policy])
-    consultation = create(:published_consultation, published_at: 1.weeks.ago, related_policies: [policy])
+    publication = create(:published_publication, publication_date: 4.weeks.ago, related_policies: [policy])
+    consultation = create(:published_consultation, opening_on: 1.weeks.ago, related_policies: [policy])
     news_article = create(:published_news_article, published_at: 3.weeks.ago, related_policies: [policy])
-    speech = create(:published_speech, published_at: 2.days.ago, delivered_on: 2.weeks.ago, related_policies: [policy])
+    speech = create(:published_speech, delivered_on: 2.weeks.ago, related_policies: [policy])
 
     get :activity, id: policy.document, format: "atom"
 

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -258,4 +258,16 @@ class ConsultationTest < EditionTestCase
 
     assert_equal today, consultation.response_published_on
   end
+
+  test "first published date is the date of consultation opening" do
+    consultation = create(:published_consultation, opening_on: 4.days.ago)
+
+    assert_equal 4.days.ago.to_date, consultation.first_published_date
+  end
+
+  test "sets inital timestamp for sorting as opening date" do
+    consultation = create(:published_consultation, opening_on: 4.days.ago)
+
+    assert_equal 4.days.ago, consultation.timestamp_for_sorting
+  end
 end


### PR DESCRIPTION
Consultations should use the opening date as their initial date. This
will set the sorting date to be the opening date on the first edition
(untill there is a major change). It also goes through and updates all
the consulations in the system to use this date.
