### PR TITLE
Don't specify a search index to slimmer

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -1,17 +1,12 @@
 class PublicFacingController < ApplicationController
   helper :all
   before_filter :set_cache_control_headers
-  before_filter :set_search_index
   before_filter :restrict_request_formats
 
   private
 
   def set_cache_control_headers
     expires_in Whitehall.default_cache_max_age, public: true
-  end
-
-  def set_search_index
-    response.headers[Slimmer::Headers::SEARCH_INDEX_HEADER] = 'government'
   end
 
   def error(status_code)

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -23,13 +23,6 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
   end
 
-  test "all public facing requests should use the inside government search" do
-    with_routing_to_test_action do
-      get :test
-      assert_equal 'government', response.headers["X-Slimmer-Search-Index"]
-    end
-  end
-
   test "all public facing requests without a format parameter should respond with html" do
     mime_types = ["text/html", "application/xhtml+xml", "application/json", "application/xml", "application/atom+xml"]
 


### PR DESCRIPTION
With changes to how search works on gov.uk this header is no longer necessary. The slimmer processor to handle this will be removed in due course.
