### PR TITLE
Remove `form_for` tag in favour of a html `form`.

### DIFF
--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -1,6 +1,6 @@
 <div class="filter-block">
   <h2>You can use the filters to show only results that match your interests</h2>
-  <%= form_tag send(:"#{document_type.to_s.pluralize}_path"), method: :get, id: "document-filter", class: 'js-document-filter' do %>
+  <form method="get" action="<%= send(:"#{document_type.to_s.pluralize}_path") %>" id="document-filter" class="js-document-filter">
     <fieldset>
       <legend class="visuallyhidden">Filter <%= document_type.to_s.pluralize %></legend>
 
@@ -56,5 +56,5 @@
         </div>
       </div>
     </fieldset>
-  <% end %>
+  </form>
 </div>


### PR DESCRIPTION
The only difference I can see between this and the `form_for` tag is
that it will no longer spit out the utf8 fixing field which adds `utf8=✓` 
to the url. Seeing this is a GET request the utf8 fix isn't even needed.
