### PR TITLE
Reset all NewsArticle and FatalityNotice documents

### DIFF
--- a/db/data_migration/20121213100857_fix_mod_news_versions.rb
+++ b/db/data_migration/20121213100857_fix_mod_news_versions.rb
@@ -15,7 +15,9 @@ Document.find_by_sql("SELECT d.* FROM documents d left join editions e on d.id =
     #   change minor version to be i
     edition.update_column(:published_minor_version, i)
     #   change minor_change to true
-    edition.update_column(:minor_change, true)
+    if i > 0
+      edition.update_column(:minor_change, true)
+    end
     #   call edition.set_timestamp_for_sorting
     edition.update_column(:timestamp_for_sorting, edition.first_published_at)
     #  end for


### PR DESCRIPTION
There are some erroneously versioned announcements on production that need to be rolled up to be minor changes. This migration finds all documents that match those criteria and resets all their editions to the same minor version. This has the effect of removing the change notes from the frontend and resetting the display/sort date to a sensible and useful value.

https://www.pivotaltracker.com/story/show/41154745
