### PR TITLE
Use GOVUK_ASSET_ROOT variable for static config in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ will email the new user and prompt them to create their account.
 
 ## Using local assets
 
-* Set `GOVUK_ASSET_HOST` to point to your local instance of the `static` app
-  when running the `whitehall` app e.g. `STATIC_DEV=http://static.dev`, this is set
+* Set `GOVUK_ASSET_ROOT` to point to your local instance of the `static` app
+  when running the `whitehall` app e.g. `GOVUK_ASSET_ROOT=http://static.dev`, this is set
   for you within the development VM.
 
 ## Getting search running locally

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Whitehall::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.slimmer.asset_host = ENV['GOVUK_ASSET_HOST'] || "https://static.preview.alphagov.co.uk"
+  config.slimmer.asset_host = ENV['GOVUK_ASSET_ROOT'] || "https://static.preview.alphagov.co.uk"
 
   if ENV['SHOW_PRODUCTION_IMAGES']
     orig_host = config.asset_host


### PR DESCRIPTION
This is so it picks up the correct value within the VM. Kept the old
default value so people outside the vm will see no change.
