### PR TITLE
CSV of GOV.UK exempt websites

### DIFF
--- a/doc/govuk-exemption-list.csv
+++ b/doc/govuk-exemption-list.csv
@@ -1,0 +1,149 @@
+Name,URL,Notes
+"Crown Prosecution Service",http://www.cps.gov.uk
+"HM Crown Prosecution Service Inspectorate",http://www.hmcpsi.gov.uk
+"Serious Fraud Office",http://www.sfo.gov.uk
+"Advisory Conciliation and Arbitration Service (ACAS)",http://www.acas.org.uk
+"Arts & Humanities Research Council",http://www.ahrc.ac.uk
+"Biotechnology and Biological Sciences Research Council",http://www.bbsrc.ac.uk
+"Economic and Social Research Council",http://www.esrc.ac.uk
+"Engineering and Physical Sciences Research Council",http://www.epsrc.ac.uk
+"Higher Education Funding Council for England (HEFCE)",http://www.hefce.ac.uk
+"Medical Research Council",http://www.mrc.ac.uk
+"Met Office",http://www.metoffice.gov.uk
+"Natural Environment Research Council",http://www.nerc.ac.uk
+"Office for Fair Access (OFFA)",http://www.offa.org.uk
+"Ordnance Survey",http://www.ordnancesurvey.co.uk
+"Research Councils UK",http://www.rcuk.ac.uk
+"Science & Technology Facilities Council",http://www.stfc.ac.uk
+"Student Loans Company",http://www.slc.co.uk
+"Student Loans Company",http://www.studentloanrepayment.co.uk
+"The Takeover Panel",http://www.thetakeoverpanel.org.uk
+"UK Trade & Investment (UKTI)",http://www.techcityuk.com
+"UK Trade & Investment (UKTI)",http://www.opentoexport.com
+"Prince of Wales",http://www.princeofwales.gov.uk
+"Royal",http://www.royal.gov.uk
+"Independent",http://www.independent.gov.uk
+"Architects Registration Board",http://www.arb.org.uk/
+"Audit Commission",http://www.audit-commission.gov.uk/Pages/default.aspx
+"Fire Service College",http://www.fireservicecollege.ac.uk/
+"Independent Housing Ombudsman",http://www.housing-ombudsman.org.uk/
+"Local Government Ombudsman",http://www.lgo.org.uk/
+"London Thames Gateway UDC",http://ltgdc.org.uk/
+"Queen Elizabeth II Conference Centre",http://www.qeiicc.co.uk/
+"Valuation Tribunal for England / Valuation Tribunal Service",http://www.valuationtribunal.gov.uk/Home.aspx
+"West Northants UDC",http://www.wndc.org.uk/
+"Arts Council England",http://www.artscouncil.org.uk
+"BBC",http://www.bbc.co.uk
+"British Film Institute",http://www.bfi.org.uk
+"British Film Institute",http://industry.bfi.org.uk
+"Channel 4",http://www.channel4.com
+"English Heritage",http://www.english-heritage.org.uk/
+"Gambling Commission",http://www.gamblingcommission.gov.uk
+"Heritage Lottery Fund",http://www.hlf.org.uk
+"Historic Royal Palaces",http://www.hrp.org.uk/
+"Horserace Betting Levy Board",http://www.hblb.org.uk
+"National Lottery Commission",http://www.natlotcomm.gov.uk
+"Ofcom",http://www.ofcom.org.uk
+"Public Lending Right",http://www.plr.uk.com/
+"S4C",http://www.s4c.co.uk
+"Sport England",http://www.sportengland.org
+"Sports Ground Safety Authority",http://www.safetyatsportsgrounds.org.uk
+"The Royal Parks",http://www.royalparks.org.uk
+"UK Anti-Doping",http://www.ukad.org.uk
+"UK Sport",http://www.uksport.gov.uk
+"Visit Britain",http://www.visitbritain.com
+"Visit England",http://www.visitengland.com
+"Committee on Climate Change",http://www.theccc.org.uk
+"Nuclear Decommissioning Authority",http://www.nda.gov.uk
+"Ofgem",http://www.ofgem.gov.uk
+"Agriculture and Horticulture Development board (AHDB)",http://www.ahdb.org.uk
+"Agriculture and Horticulture Development board (AHDB)",http://www.bpex.org.uk
+"AHVLA Scientific",http://www.ahvlascientific.com
+"Animal Health & Veterinary Laboratories Agency - EU Research Projects",http://www.flu-lab-net.eu
+"Animal Health & Veterinary Laboratories Agency - EU Research Projects",http://www.esnip3.eu
+"Centre for Environment, Fisheries and Aquaculture Science (Cefas)",http://www.cefas.defra.gov.uk
+"Drinking Water Inspectorate",http://www.dwi.defra.gov.uk
+"Forestry Commission",http://www.forestry.gov.uk
+"National Forest Company",http://www.nationalforest.org
+"National Parks",http://www.nationalparks.gov.uk
+"Ofwat",http://www.ofwat.gov.uk
+"Seafish Industry Authority",http://www.seafish.org,"(additionally www.fishandchipsawards.com is being merged into the Seafish.org site this summer)"
+"The Food and Environment Research Agency (Fera)",http://www.fera.defra.gov.uk
+"Waste and Resources Action Programme (WRAP)",http://www.recyclenow.com
+"Waste and Resources Action Programme (WRAP)",http://www.wrap.org.uk
+"Joint Nature Conservation Committee",http://jncc.defra.gov.uk/
+"Consumer Council for Water (CCWater)",http://www.ccwater.org.uk/
+"Cafcass",http://www.cafcass.gov.uk
+"Examinations Appeals Board",http://www.theeab.org.uk
+"Independent Commission for Aid Impact",http://www.independent.gov.uk/icai
+"Directly Operated Railways",http://www.directlyoperatedrailways.co.uk
+"Office of Rail Regulation",http://www.rail-reg.gov.uk
+"Passenger Focus",http://www.passengerfocus.org.uk
+"British Pharmacopoeia (BP)",http://pharmacopoeia.mhra.gov.uk
+"Care Quality Commission (CQC)",http://www.cqc.org.uk
+"Healthwatch England",http://www.healthwatchengland.org.uk
+"Healthwatch England",http://www.healthwatch.co.uk
+"Human Fertilisation and Embryology Authority",http://www.hfea.gov.uk/
+"Human Tissue Authority",http://www.hta.gov.uk
+"National Institute for Biological Standards and Control (NIBSC)",http://www.nibsc.ac.uk
+"National Institute for Health and Clinical Excellence (NICE)",http://www.nice.org.uk/
+"NHS",http://www.nhs.uk,"and all subdomains"
+"Child Maintenance and Enforcement Commission",http://www.cmoptions.org
+"Health & Safety Laboratory (HSL)",http://www.hsl.gov.uk
+"Health and Safety Executive",http://www.hse.gov.uk
+"Pension Protection Fund Ombudsman (PPFO)",http://www.ppfo.org.uk
+"Pensions Ombudsman",http://www.pensions-ombudsman.org.uk
+"The Pensions Advisory Service",http://www.pensionsadvisoryservice.org.uk
+"The Pensions Regulator",http://www.thepensionsregulator.gov.uk
+"British Council",http://www.britishcouncil.org/
+"FCO Services",http://www.fcoservices.gov.uk/
+"Great Britain China Centre (GBCC)",http://www.gbcc.org.uk/
+"Marshall Aid Commissions",http://www.marshallscholarship.org/
+"Westminster Foundation for Democracy",http://www.wfd.org
+"Wilton Park",http://www.wiltonpark.org.uk
+"Food Standards Agency (FSA)",http://www.food.gov.uk/
+"The Adjudicator’s Office",http://www.adjudicatorsoffice.gov.uk
+"The Adjudicator’s Office",http://www.adjudicators.gov.uk
+"National Savings and Investments",http://www.nsandi.com
+"Child Exploitation & Online Protection Agency (CEOP)",http://www.ceop.police.uk
+"Equality and Human Rights Commission (EHRC)",http://www.equalityhumanrights.com/
+"Her Majesty’s Inspectorate of Constabulary (HMIC)",http://www.hmic.gov.uk
+"Hillsborough Independent Panel",http://hillsborough.independent.gov.uk/index.html,"(currently in operation)"
+"Hillsborough Independent Panel",http://panel.hillsborough.independent.gov.uk/index.html,"(to be temporarily created one week before go live)"
+"Independent Police Complaints Commission (IPCC)",http://www.ipcc.gov.uk
+"Independent Reviewer of Terrorist Legislation",http://www.independent.gov.uk/terrorism-legislation-reviewer
+"National Crime Agency",,"To be published"
+"Office of Surveillance Commissioners",http://www.surveillancecommissioners.independent.gov.uk
+"Security Industry Authority (SIA)",http://www.sia.homeoffice.gov.uk/
+"Security Industry Authority (SIA)",https://portal.the-sia.org.uk/web/start.swe
+"Security Industry Authority (SIA)",http://www.assessment.sia.homeoffice.gov.uk/home/acs/members/acslogin.htm
+"Serious Organised Crime Agency (SOCA)",http://www.soca.gov.uk
+"The Investigatory Powers Tribunal",http://www.ipt-uk.com
+"British Forces Germany (BFGNet)",http://www.bfgnet.de
+"Defence Academy (DA)",http://www.da.mod.uk
+"Defence Advisory Notice System (DNotice) (Defence, Press and Broadcasting Advisory Committee)",http://www.dnotice.org.uk
+"Defence Sixth Form College (DSFC)",http://www.dsfc.ac.uk
+"Defence Support Group (DSG)",http://www.dsg.mod.uk
+"Proud to Serve",http://www.proud2serve.net
+"Service Complaints Commissioner (SCC)",http://armedforcescomplaints.independent.gov.uk
+"Service Prosecuting Authority (SPA)",http://spa.independent.gov.uk
+"Sovereign Base Area Cyprus (SBA)",http://www.sba.mod.uk
+"UK Hydrographic Office (UKHO)",http://www.ukho.gov.uk
+"HM Inspectorate of Prisons",http://www.justice.gov.uk/about/hmi-prisons
+"HM Inspectorate of Probation",http://www.justice.gov.uk/about/hmi-probation
+"Independent Monitoring Board",http://www.justice.gov.uk/about/imb
+"Information Commissioner's Office (ICO)",http://www.ico.gov.uk
+"Judicial Appointments Commission",http://jac.judiciary.gov.uk
+"Judiciary",http://www.judiciary.gov.uk
+"Legal Services Board",http://www.legalservicesboard.org.uk
+"Legal Services Board",http://www.legalservicesconsumerpanel.org.uk
+"Legislation.gov.uk",http://www.legislation.gov.uk
+"Office of Judicial Complaints",http://judicialcomplaints.judiciary.gov.uk/
+"Prisons and Probation Ombudsman",http://www.ppo.gov.uk
+"Sentencing Council's",http://sentencingcouncil.judiciary.gov.uk
+"The Judicial Committee of the Privy Council",http://www.jcpc.gov.uk
+"The Legal Ombudsman",http://www.legalombudsman.org.uk/
+"The Supreme Court of the United Kingdom",http://www.supremecourt.gov.uk
+"TNA",http://www.nationalarchives.gov.uk
+"UK Statistics Authority",http://www.statisticsauthority.gov.uk/
+"Office National Statistics",http://www.ons.gov.uk


### PR DESCRIPTION
We are publishing a CSV containing the list of
websites that are exempt from GOV.UK (list 
accurate as of 2012-12-17).

This file is not intended to be publicly exposed
on GOV.UK but will be linked to from the GDS blog
post announcing the publication of the list.

This is a temporary location for this file
(agreed with @jystewart). It was felt that the
whitehall repo was the most appropriate place for
it.
