### PR TITLE
Display organisations grouped by type

### DIFF
--- a/app/assets/javascripts/application/hide-department-children.js
+++ b/app/assets/javascripts/application/hide-department-children.js
@@ -11,7 +11,7 @@
 
       $departments.each(function(i, el){
         var $department = $(el),
-            $childOrganisations = $department.find('.child-organisations'),
+            $childOrganisations = $department.find('.organisations-box'),
             $viewAll = $('<a href="#" class="view-all">view all</a>');
 
         if($department.find(windowHash).length === 0){

--- a/app/assets/javascripts/application/on_ready.js
+++ b/app/assets/javascripts/application/on_ready.js
@@ -13,6 +13,7 @@ jQuery(function($) {
   $('.js-toggle-change-notes').toggler();
   $('.js-toggle-accessibility-warning').toggler({header: ".toggler", content: ".help-block"})
   $('.js-toggle-nav').toggler({header: ".toggler", content: ".content", showArrow: false, actLikeLightbox: true})
+  $('.js-toggle-org-list').toggler({actLikeLightbox: true})
 
   $(".js-document-filter").enableDocumentFilter();
 

--- a/app/assets/stylesheets/frontend/helpers/_document-page-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document-page-header.scss
@@ -69,10 +69,6 @@
         li {
           margin-left: 0;
 
-          @include media(tablet) {
-            margin-left: 7px;
-          }
-
           &.hm-government {
             margin-bottom: $gutter-one-sixth;
           }
@@ -82,11 +78,6 @@
           padding-bottom: ($gutter*0.25);
           @include media(tablet){
             margin-left: $gutter-half;
-          }
-        }
-        .show-other-content {
-          @include media(tablet) {
-            margin-left: $gutter-two-thirds;
           }
         }
       }

--- a/app/assets/stylesheets/frontend/helpers/_organisations.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisations.scss
@@ -1,10 +1,90 @@
+.organisations-box {
+  background: $panel-colour;
+
+  .organisations-box-inner {
+    padding: $gutter-half;
+  }
+
+  h3 {
+    @include ig-core-14;
+    border-bottom: 1px solid $border-colour;
+  }
+  p {
+    padding-bottom: $gutter-half;
+  }
+  ol {
+    overflow: hidden;
+    margin: 0 (-$gutter-one-third) $gutter-one-third;
+    li {
+      @include ig-core-16;
+      display: block;
+
+      @include media(desktop){
+        width: 33.33%;
+        float: left;
+      }
+
+      &:nth-child(3n+1) {
+        clear: left;
+      }
+
+      a {
+        display: block;
+        padding: 0 $gutter-one-third;
+      }
+    }
+  }
+}
 
 .organisations-icon-list {
+  position: relative;
+
+  .show-other-content {
+    padding: 0;
+    color: $link-colour;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+      outline: none;
+      cursor: pointer;
+    }
+    &:after {
+      display: inline-block;
+      font-size: 8px;
+      height: 10px;
+      padding-left: 5px;
+      vertical-align: middle;
+      content: " \25BC";
+    }
+  }
+  &.open {
+    .show-other-content:after {
+      content: " \25B2";
+    }
+  }
+
   .organisation {
     overflow: hidden;
     list-style: none;
-    padding-bottom: $gutter-one-third;
-  // stops descenders being cropped off
+    padding-bottom: $gutter-one-third; // stops descenders being cropped off
+  }
+
+  .organisations-box {
+    @include media(tablet){
+      position: absolute;
+      width: 200%;
+      right: 0;
+      z-index: 10;
+    }
+
+    ol {
+      li {
+        @include media(tablet){
+          width: 100%;
+        }
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -92,48 +92,15 @@
           content: " \25BC";
         }
 
-        .child-organisations {
+        .organisations-box {
           display: none;
 
         }
       }
     }
-    .child-organisations {
+    .organisations-box {
       clear: both;
       margin: 0 (-15px);
-      background: $panel-colour;
-      p{
-        padding-bottom:$gutter-half;
-
-      }
-      .child-inner {
-        padding: $gutter-half;
-      }
-      h3 {
-        @include ig-core-14;
-        border-bottom: 1px solid $border-colour;
-      }
-      ol {
-        overflow: hidden;
-        margin: 0 (-$gutter-one-third) $gutter-one-third;
-        li {
-          @include ig-core-16;
-          display: block;
-          @include media(desktop){
-            width: 33.33%;
-            float: left;
-          }
-
-          &:nth-child(3n+1) {
-            clear: left;
-          }
-
-          a {
-            display: block;
-            padding: 0 $gutter-one-third;
-          }
-        }
-      }
     }
     .index-list {
       li {

--- a/app/assets/stylesheets/frontend/views/_topic.scss
+++ b/app/assets/stylesheets/frontend/views/_topic.scss
@@ -49,7 +49,7 @@
         @include bold;
       }
     }
-    .meta {      
+    .meta {
       margin-top: $gutter;
 
       @include media(tablet) {
@@ -59,9 +59,6 @@
 
         .organisations-icon-list {
           margin-left: $gutter-half;
-        }
-        .show-other-content {
-          margin-left: $gutter-two-thirds;
         }
       }
     }

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -95,4 +95,8 @@ module OrganisationHelper
       @organisation.military_roles.any? ||
       @traffic_commissioner_roles.any?
   end
+
+  def organisations_grouped_by_type(organisations)
+    organisations.group_by(&:organisation_type).sort_by { |type,department| type.listing_order }
+  end
 end

--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -44,11 +44,7 @@
     <div class="inner-block" id="responsibilities">
       <%= content_tag_for :section, @ministerial_role, class: "responsibilities" do %>
         <%= render  partial: 'organisations/organisations_logo_list',
-                    locals: {
-                      organisations: @ministerial_role.organisations,
-                      external_links: false,
-                      remove_line_breaks: false
-                    } %>
+                    locals: { organisations: @ministerial_role.organisations } %>
 
         <h1>Responsibilities</h1>
         <%= @ministerial_role.responsibilities %>

--- a/app/views/organisations/_organisations_logo_list.html.erb
+++ b/app/views/organisations/_organisations_logo_list.html.erb
@@ -1,38 +1,49 @@
 <%
-  extra_class ||= ""
-  external_links ||= false
-  remove_line_breaks ||= false
   lead_organisations ||= []
   organisations ||= []
+  all_organisations = lead_organisations + organisations
+  show_hm_government = lead_organisations.length == 0
 %>
-
-<ul class="organisations-icon-list<%= " multiple-orgs" if organisations.length > 1 %> js-hide-extra-rows-<%= 1 + lead_organisations.size %>">
-
-  <% if organisations.length > 1 %>
-    <li class="organisation hm-government">
-      <span class="organisation-logo organisation-logo-stacked-single-identity">
-        <span><%= remove_line_breaks ? "HM Government" : "HM Government".html_safe %></span>
-      </span>
-    </li>
-  <% end %>
-
-  <% lead_organisations.each do |organisation| %>
-    <%= content_tag_for(:li, organisation, class: organisation.slug) do %>
-      <%= link_to organisation_path(organisation),
-            title: organisation.logo_formatted_name,
-            class: organisation_logo_classes(organisation, {stacked: true, use_identity: (organisations.length == 1)}) do %>
-        <span><%= remove_line_breaks ? organisation.logo_formatted_name : format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+<div class="organisations-icon-list js-toggle-org-list">
+  <% if all_organisations.length > 1 %>
+    <% if show_hm_government %>
+      <h3 class="organisation hm-government">
+        <span class="organisation-logo organisation-logo-stacked-single-identity">
+          <span>HM Government</span>
+        </span>
+      </h3>
+    <% end %>
+    <ul>
+      <% lead_organisations.each do |organisation| %>
+        <%= content_tag_for :li, organisation, class:  organisation.slug do %>
+          <%= link_to organisation_path(organisation),
+                      class: organisation_logo_classes(organisation, {stacked: !show_hm_government, use_identity: !show_hm_government}) do %>
+            <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </ul>
+    <span class="toggle show-other-content">+ others</span>
+    <div class="organisations-box overlay js-hidden"><div class="organisations-box-inner">
+      <% organisations_grouped_by_type(organisations).each do |type, organisations| %>
+        <h3><%= type.name.pluralize %></h3>
+        <ol>
+          <% organisations.each do |organisation| %>
+            <%= content_tag_for :li, organisation, prefix: 'by-type' do %>
+              <%= link_to organisation.name, organisation_path(organisation) %>
+            <% end %>
+          <% end %>
+        </ol>
+      <% end %>
+    </div></div>
+  <% else %>
+    <% all_organisations.each do |organisation| %>
+      <%= content_tag_for(:div, organisation, class: organisation.slug) do %>
+        <%= link_to organisation_path(organisation),
+              class: organisation_logo_classes(organisation, {stacked: true, use_identity: true}) do %>
+          <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
-
-  <% (organisations - lead_organisations).each do |organisation| %>
-    <%= content_tag_for(:li, organisation, class: organisation.slug) do %>
-      <%= link_to organisation_path(organisation),
-            title: organisation.logo_formatted_name,
-            class: organisation_logo_classes(organisation, {stacked: true, use_identity: (organisations.length == 1)}) do %>
-        <span><%= remove_line_breaks ? organisation.logo_formatted_name : format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
-      <% end %>
-    <% end %>
-  <% end %>
-</ul>
+</div>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -26,7 +26,7 @@
                 </h2>
                 <% if ministerial_department.agencies_and_public_bodies.any? %>
                   <p class="works-with">Works with <%= ministerial_department.agencies_and_public_bodies.count %> agencies &amp; public bodies</p>
-                  <div class="child-organisations js-hidden"><div class="child-inner">
+                  <div class="organisations-box js-hidden"><div class="organisations-box-inner">
                     <p><%= link_to "#{ministerial_department.name} homepage", organisation_path(ministerial_department) %></p>
                     <% ministerial_department.agencies_and_public_bodies_by_type.each do |type,departments| %>
                       <h3><%= type.name %></h3>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -58,11 +58,7 @@
         <% @person.current_role_appointments.each do |appointment| %>
           <%= content_tag_for :section, appointment, class: "role" do %>
             <%= render  partial: 'organisations/organisations_logo_list',
-                        locals: {
-                          organisations: appointment.role.organisations,
-                          external_links: false,
-                          remove_line_breaks: false
-                        } %>
+                        locals: { organisations: appointment.role.organisations } %>
             
             <h1 id="<%= appointment.role.name.parameterize%>"><%= appointment.role.name %></h1>
 

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -5,10 +5,10 @@ end
 Given /^"([^"]*)" is a minister with a history$/ do |name|
   person = create_person(name)
   role = create(:ministerial_role)
-  create(:organisation, ministerial_roles: [role])
+  create(:ministerial_department, ministerial_roles: [role])
   create(:role_appointment, role: role, person: person, started_at: 2.years.ago, ended_at: 1.year.ago)
   role = create(:ministerial_role)
-  create(:organisation, ministerial_roles: [role])
+  create(:ministerial_department, ministerial_roles: [role])
   create(:role_appointment, role: role, person: person, started_at: 1.year.ago, ended_at: nil)
 end
 

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -102,17 +102,17 @@ class PoliciesControllerTest < ActionController::TestCase
   end
 
   test "should link to organisations related to the policy" do
-    first_org = create(:organisation, logo_formatted_name: "first")
-    second_org = create(:organisation, logo_formatted_name: "second")
+    first_org = create(:organisation)
+    second_org = create(:organisation)
     edition = create(:published_policy, organisations: [first_org, second_org])
 
     get :show, id: edition.document
 
     assert_select_object first_org do
-      assert_select "a[href='#{organisation_path(first_org)}']", first_org.logo_formatted_name
+      assert_select "a[href='#{organisation_path(first_org)}']"
     end
     assert_select_object second_org do
-      assert_select "a[href='#{organisation_path(second_org)}']", second_org.logo_formatted_name
+      assert_select "a[href='#{organisation_path(second_org)}']"
     end
   end
 

--- a/test/functional/supporting_pages_controller_test.rb
+++ b/test/functional/supporting_pages_controller_test.rb
@@ -136,18 +136,18 @@ class SupportingPagesControllerTest < ActionController::TestCase
   end
 
   test "should link to organisations from within the metadata navigation" do
-    first_org = create(:organisation, logo_formatted_name: "first")
-    second_org = create(:organisation, logo_formatted_name: "second")
+    first_org = create(:organisation)
+    second_org = create(:organisation)
     policy = create(:published_policy, organisations: [first_org, second_org])
     supporting_page = create(:supporting_page, edition: policy)
 
     get :show, policy_id: policy.document, id: supporting_page
 
     assert_select_object first_org do
-      assert_select "a[href='#{organisation_path(first_org)}']", first_org.logo_formatted_name
+      assert_select "a[href='#{organisation_path(first_org)}']"
     end
     assert_select_object second_org do
-      assert_select "a[href='#{organisation_path(second_org)}']", second_org.logo_formatted_name
+      assert_select "a[href='#{organisation_path(second_org)}']"
     end
   end
 


### PR DESCRIPTION
On topics and documents we want the organisations to be in a box grouped
by type. This makes it clearer as to the structure of departments and
how they fit together.

This probably wants to wait till after the document organisation logo branch has been merged and then rebased for that so it can use lead orgs with then.
