### PR TITLE
Run cucumber so the tests aren't in transactions

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -30,11 +30,12 @@ Capybara.default_selector = :css
 # recommended as it will mask a lot of errors for you!
 #
 ActionController::Base.allow_rescue = false
+Cucumber::Rails::World.use_transactional_fixtures = false
 
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
-  DatabaseCleaner.strategy = :transaction
+  DatabaseCleaner.strategy = :truncation
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end


### PR DESCRIPTION
It's generally better to run cucumber so that the tests aren't wrapped in a transaction, because we're testing the full stack and that's not really how it works in reality.

On my machine the transactional cukes ran in 4m34s, the non-transactional ones ran in 4m14s.  I doubt that's a truly significant measure, but it does mean there was no negative effecting.
