### PR TITLE
Switch font mixins from `core` to `ig-core`

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -42,17 +42,17 @@ $thumbnail-width: 99px;
   
   .attachment-details {
     h1, h2, h3 {
-      @include core-27;
+      @include ig-core-27;
       margin: 0;
     }
     
     .extra-description {
-      @include core-19;
+      @include ig-core-19;
       margin: 0;
     }
     
     .metadata {
-      @include core-14;
+      @include ig-core-14;
       margin: 0;
       .changed,
       .references {
@@ -63,7 +63,7 @@ $thumbnail-width: 99px;
   
   .accessibility-warning {
     h3 {
-      @include core-14;
+      @include ig-core-14;
       margin: 0;
       color: $text-colour;
     }
@@ -92,7 +92,7 @@ $thumbnail-width: 99px;
   }
   
   h2.supporting-documents-title {
-    @include core-16;
+    @include ig-core-16;
     margin-top: $gutter;
     color: $text-colour;
   }

--- a/app/assets/stylesheets/frontend/helpers/_change-notes.scss
+++ b/app/assets/stylesheets/frontend/helpers/_change-notes.scss
@@ -1,7 +1,7 @@
 .change-notes {
   display: inline-block;
   position: relative;
-  // @include core-14;
+  // @include ig-core-14;
   min-width: 160px;
   padding: 0;
 
@@ -55,7 +55,7 @@
     dt, dd {
       width: auto;
       float: none;
-      @include core-14;
+      @include ig-core-14;
       padding: 0 $gutter-one-third;
     }
     dd {

--- a/app/assets/stylesheets/frontend/helpers/_collection_list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_collection_list.scss
@@ -2,7 +2,7 @@
   @extend %contain-floats;
 
   .collection-item {
-    @include core-19;
+    @include ig-core-19;
     list-style: none;
 
     .summary a {

--- a/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
+++ b/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
@@ -3,7 +3,7 @@
   position: relative;
   clear: both;
   padding-bottom: $gutter-two-thirds;
-  @include core-16;
+  @include ig-core-16;
   
   h1 {
     @include bold;
@@ -44,6 +44,6 @@
     vertical-align: top;
   }
   p {
-    @include core-16;
+    @include ig-core-16;
   }
 }

--- a/app/assets/stylesheets/frontend/helpers/_corporate-information.scss
+++ b/app/assets/stylesheets/frontend/helpers/_corporate-information.scss
@@ -1,6 +1,6 @@
 .corporate-information {
   h1 {
-    @include core-27;
+    @include ig-core-27;
     margin: $gutter 0 $gutter-half 0;
   }
   .corporate-information-block {
@@ -15,7 +15,7 @@
       width: 100%;
     }
     h2 {
-      @include core-19;
+      @include ig-core-19;
       @include bold;
     }
   }

--- a/app/assets/stylesheets/frontend/helpers/_document-page-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document-page-header.scss
@@ -3,7 +3,7 @@
   padding-bottom: ($gutter-two-thirds + $gutter-one-sixth);
 
   h1 {
-    @include core-36;
+    @include ig-core-36;
     margin-top: ($gutter-two-thirds);
     @include media(tablet){
       margin-bottom: ($gutter + $gutter-one-third - 3px);
@@ -35,7 +35,7 @@
     
     dl {
       display: inline;
-      @include core-14;
+      @include ig-core-14;
 
       dt {
         @include bold;

--- a/app/assets/stylesheets/frontend/helpers/_document.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document.scss
@@ -3,7 +3,7 @@
     p {
       margin-top: $gutter-one-third*-1;
       margin-bottom: $gutter-half;
-      @include core-19;
+      @include ig-core-19;
     }
   }
 
@@ -11,11 +11,11 @@
     padding-top: $gutter-one-third;
   
     h1 {
-      @include core-19;
+      @include ig-core-19;
     }
     
     li {
-      @include core-16;
+      @include ig-core-16;
     }
   }
 }

--- a/app/assets/stylesheets/frontend/helpers/_document_list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_list.scss
@@ -14,7 +14,7 @@
   }
 
   th {
-    @include core-19;
+    @include ig-core-19;
     text-align: left;
     float: left;
     display: inline;
@@ -29,7 +29,7 @@
   }
 
   td {
-    @include core-14;
+    @include ig-core-14;
     text-align: left;
     float: left;
     display: inline;
@@ -40,13 +40,13 @@
   
   .document-row:first-child {
     th {
-      @include core-27;
+      @include ig-core-27;
       @include bold;
     }
   }
   .document-row:nth-child(2) {
     th {
-      @include core-24;
+      @include ig-core-24;
       @include bold;
     }
   }

--- a/app/assets/stylesheets/frontend/helpers/_filter.scss
+++ b/app/assets/stylesheets/frontend/helpers/_filter.scss
@@ -1,6 +1,6 @@
 .filter-block {
   h2 {
-    @include core-19;
+    @include ig-core-19;
   }
 
   form {
@@ -21,15 +21,15 @@
   }
 
   label {
-    @include core-19;
+    @include ig-core-19;
 
     &.sub-title {
-      @include core-19;
+      @include ig-core-19;
     }
   }
 
   input {
-    @include core-14;
+    @include ig-core-14;
     background: $white;
     width: 100%;
     margin: 0;
@@ -42,7 +42,7 @@
   }
 
   select {
-    @include core-14;
+    @include ig-core-14;
     background: #fff;
     line-height: 1.3;
     width: 100%;
@@ -78,13 +78,13 @@
     padding-bottom: $gutter-one-third;
 
     h3 {
-      @include core-14;
+      @include ig-core-14;
       display: inline;
       padding-right: $gutter-half;
     }
 
     label {
-      @include core-14;
+      @include ig-core-14;
       padding-right: $gutter-one-third;
     }
   }
@@ -104,7 +104,7 @@
     margin: 0 auto;
     color: $white;
     @include button($mellow-red);
-    @include core-19;
+    @include ig-core-19;
     padding-bottom: 7px;
     padding-bottom: 0.7rem;
   }
@@ -129,10 +129,10 @@
     padding: $gutter 0 $gutter-half;
     border-bottom: 1px solid $border-colour;
     h2 {
-      @include core-27;
+      @include ig-core-27;
     }
     p {
-      @include core-19;
+      @include ig-core-19;
     }
   }
 }
@@ -143,14 +143,14 @@
   }
 
   .selections {
-    @include core-19;
+    @include ig-core-19;
   }
 
   .chosen {
     margin-bottom: $gutter-one-third;
 
     span {
-    //  @include core-24;
+    //  @include ig-core-24;
       @include bold;
       color: $link-colour;
 
@@ -166,7 +166,7 @@
       a {
         position: relative;
         top: 2px;
-        @include core-19;
+        @include ig-core-19;
         line-height: 0;
         text-decoration: none;
       }

--- a/app/assets/stylesheets/frontend/helpers/_global-nav.scss
+++ b/app/assets/stylesheets/frontend/helpers/_global-nav.scss
@@ -24,7 +24,7 @@
 
   a,
   .toggler {
-    @include core-16;
+    @include ig-core-16;
     display: block;
     padding: $gutter-one-third 8px;
     text-decoration: none;
@@ -173,7 +173,7 @@
   }
   
   p {
-    @include core-16;
+    @include ig-core-16;
   }
 
   .close-button {

--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -7,7 +7,7 @@
   }
 
   h2 {
-    @include core-27;
+    @include ig-core-27;
     color: lighten($text-colour, 20%);
     margin-top: $gutter;
     @media (max-width: 640px) {
@@ -15,7 +15,7 @@
     }
   }
   h3 {
-    @include core-24;
+    @include ig-core-24;
     color: lighten($text-colour, 20%);
     margin-top: $gutter;
     @media (max-width: 640px) {
@@ -25,7 +25,7 @@
   h4,
   h5,
   h6 {
-    @include core-19;
+    @include ig-core-19;
     color: lighten($text-colour, 20%);
     margin-top: $gutter;
     @media (max-width: 640px) {
@@ -37,7 +37,7 @@
   }
 
   p {
-    @include core-19;
+    @include ig-core-19;
     margin: $gutter-half 0;
     @media (max-width: 640px) {
       margin: $gutter-one-sixth 0;
@@ -61,7 +61,7 @@
   }
 
   li {
-    @include core-19;
+    @include ig-core-19;
     margin-left: $gutter*1.2;
 
     li {
@@ -96,7 +96,7 @@
     &:before {
       content: "\201C";
       float: left;
-      @include core-48;
+      @include ig-core-48;
       padding-top: 0;
     }
     p {
@@ -135,7 +135,7 @@
     }
 
     figcaption {
-      @include core-14;
+      @include ig-core-14;
     }
   }
 
@@ -177,7 +177,7 @@
     border-spacing: 0;
     margin: $gutter -1em $gutter -1em;
     width: 100%;
-    @include core-19;
+    @include ig-core-19;
 
     caption {
       text-align:left;

--- a/app/assets/stylesheets/frontend/helpers/_heading-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_heading-block.scss
@@ -4,7 +4,7 @@
   @extend %contain-floats;
 
   h1 {
-    @include core-27;
+    @include ig-core-27;
 
     @include media(tablet){
       float: left;
@@ -36,12 +36,12 @@
 
         h2 a {
           display: block;
-          @include core-19;
+          @include ig-core-19;
           @include bold;
         }
 
         p, .metadata {
-          @include core-14;
+          @include ig-core-14;
           padding-top: 1px;
         }
 
@@ -52,7 +52,7 @@
       }
     }
     .see-all {
-      @include core-19;
+      @include ig-core-19;
 
       @include media(desktop) {
         padding-left: $gutter-half;

--- a/app/assets/stylesheets/frontend/helpers/_holding.scss
+++ b/app/assets/stylesheets/frontend/helpers/_holding.scss
@@ -5,9 +5,9 @@
   }
 
   h1 {
-    @include core-48;
+    @include ig-core-48;
   }
   p {
-    @include core-24;
+    @include ig-core-24;
   }
 }

--- a/app/assets/stylesheets/frontend/helpers/_index-list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_index-list.scss
@@ -1,7 +1,7 @@
 .index-list-page {
 
   .page-header {
-    @include core-48;
+    @include ig-core-48;
     padding: $gutter-half 0;
 
     .title {
@@ -27,7 +27,7 @@
   margin-left: 33.333%;
   
   h3 {
-    @include core-19;
+    @include ig-core-19;
   }
 }
 
@@ -35,6 +35,6 @@
   li {
     list-style: none;
     border-bottom: 1px solid $border-colour;
-    @include core-19;
+    @include ig-core-19;
   }
 }

--- a/app/assets/stylesheets/frontend/helpers/_js-list-items.scss
+++ b/app/assets/stylesheets/frontend/helpers/_js-list-items.scss
@@ -8,6 +8,6 @@
   }
 
   p {
-    @include core-19;
+    @include ig-core-19;
   }
 }

--- a/app/assets/stylesheets/frontend/helpers/_page-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_page-header.scss
@@ -5,7 +5,7 @@
   background-position: 0 8px;
 
   h1 {
-    @include core-48;
+    @include ig-core-48;
     .label {
       display: block;
     }
@@ -13,7 +13,7 @@
 
   .explanation {
     margin-top: $gutter-two-thirds*-1;
-    @include core-19;
+    @include ig-core-19;
   }
 
   .ministers .minister {
@@ -29,7 +29,7 @@
     .show-other-content {
       float: left;
       margin-left: $gutter-half;
-      @include core-14;
+      @include ig-core-14;
       padding: 3px 6px 0 4px;
     }
   }
@@ -55,7 +55,7 @@
   }
 }
 .show-other-content {
-  @include core-14;
+  @include ig-core-14;
   margin-left: 0.3em;
   white-space: nowrap;
 }

--- a/app/assets/stylesheets/frontend/helpers/_pagination.scss
+++ b/app/assets/stylesheets/frontend/helpers/_pagination.scss
@@ -6,7 +6,7 @@
   width: 100%;
 
   li {
-    @include core-27;
+    @include ig-core-27;
     display: block;
     padding: 0;
     margin: 0;
@@ -52,7 +52,7 @@
 
       span {
         display: block;
-        @include core-14;
+        @include ig-core-14;
       }
       &:focus span,
       &:hover span {

--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -75,20 +75,20 @@
 
   span {
     display: block;
-    @include core-14;
+    @include ig-core-14;
     padding-bottom: 0;
     color: $secondary-text-colour;
   }
   strong {
     display: block;
-    @include core-19;
+    @include ig-core-19;
   }
   &.privy_counsellor strong {
     padding-top: 0;
   }
 
   .role {
-    @include core-14;
+    @include ig-core-14;
     padding-top: 2px;
     padding-top: 0.2rem;
     a {

--- a/app/assets/stylesheets/frontend/helpers/_print.scss
+++ b/app/assets/stylesheets/frontend/helpers/_print.scss
@@ -1,15 +1,15 @@
 h1 {
-  @include core-27;
+  @include ig-core-27;
   margin: $gutter 0;
 }
 h2 {
-  @include core-24;
+  @include ig-core-24;
   margin: $gutter 0 0;
 }
 h3,
 h4,
 h5 {
-  @include core-19;
+  @include ig-core-19;
   margin: $gutter 0 0;
 }
 h4 {
@@ -19,7 +19,7 @@ h5 {
   margin: 0;
 }
 p {
-  @include core-14;
+  @include ig-core-14;
   margin: $gutter-half 0;
 }
 ol {
@@ -31,7 +31,7 @@ ul {
   list-style-position: outside;
 }
 li {
-  @include core-14;
+  @include ig-core-14;
   margin-left: $gutter*1.2;
   
   li {
@@ -68,7 +68,7 @@ figure {
     max-width: 100%;
   }
   figcaption {
-    @include core-14;
+    @include ig-core-14;
   }
 }
 .player-container {

--- a/app/assets/stylesheets/frontend/helpers/_simple-alphabetical-list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_simple-alphabetical-list.scss
@@ -24,7 +24,7 @@
       width: 50px;
       margin-left: -50px;
       text-align: center;
-      @include core-48;
+      @include ig-core-48;
       color: $secondary-text-colour;
       top: -3px;
 
@@ -46,11 +46,11 @@
       }
 
       li {
-        @include core-19;
+        @include ig-core-19;
         padding-bottom: $gutter-one-third;
         
         .role {
-          @include core-14;
+          @include ig-core-14;
         }
       }
     }

--- a/app/assets/stylesheets/frontend/helpers/_sub-navigation.scss
+++ b/app/assets/stylesheets/frontend/helpers/_sub-navigation.scss
@@ -1,6 +1,6 @@
 .sub_navigation {
   li {
-    @include core-19;
+    @include ig-core-19;
     @media (min-width: 1px ){ // target modern browsers
       list-style: none;
       padding-left: $gutter-half;

--- a/app/assets/stylesheets/frontend/styleguide/_typography.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_typography.scss
@@ -51,7 +51,7 @@
 // CORE FONTS - NEW TRANSPORT
 
 // Display size used for infographics and pull-quotes/splashes
-@mixin core-80($line-height: (80 / 80), $line-height-640: (55 / 53)) {
+@mixin ig-core-80($line-height: (80 / 80), $line-height-640: (55 / 53)) {
   font-family: $NTA-Light;
   @if $is-print == false {
     font-size: 80px;
@@ -69,7 +69,7 @@
 }
 
 // Suitable for page headings
-@mixin core-48 {
+@mixin ig-core-48 {
   font-family: $NTA-Light;
   font-size: 48px;
   font-size: 4.8rem;
@@ -89,7 +89,7 @@
 }
 
 // Suitable for page headings
-@mixin core-36 {
+@mixin ig-core-36 {
   font-family: $NTA-Light;
   font-size: 36px;
   font-size: 3.6rem;
@@ -109,7 +109,7 @@
 }
 
 // Suitable for body headings
-@mixin core-27 {
+@mixin ig-core-27 {
   font-family: $NTA-Light;
   font-size: 27px;
   font-size: 2.7rem;
@@ -129,7 +129,7 @@
 }
 
 // Suitable for short body copy
-@mixin core-24 {
+@mixin ig-core-24 {
   font-family: $NTA-Light;
   font-size: 24px;
   font-size: 2.4rem;
@@ -149,7 +149,7 @@
 }
 
 // Suitable for long body copy
-@mixin core-19 {
+@mixin ig-core-19 {
   font-family: $NTA-Light;
   font-size: 19px;
   font-size: 1.9rem;
@@ -169,7 +169,7 @@
 }
 
 // Suitable body pullouts and asides
-@mixin core-16 {
+@mixin ig-core-16 {
   font-family: $NTA-Light;
   font-size: 16px;
   font-size: 1.6rem;
@@ -189,7 +189,7 @@
 }
 
 // Suitable for captions, buttons etc
-@mixin core-14 {
+@mixin ig-core-14 {
   font-family: $NTA-Light;
   font-size: 14px;
   font-size: 1.4rem;

--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -85,12 +85,12 @@ nav.consultations_scope {
       padding: $gutter-one-third 0;
 
       h2, .jump {
-        @include core-27;
+        @include ig-core-27;
         padding: 0 $gutter-one-third;
       }
       abbr {
         display: block;
-        @include core-48;
+        @include ig-core-48;
         padding: 0;
         margin: 0;
       }
@@ -111,7 +111,7 @@ nav.consultations_scope {
         padding: 0 $gutter-half;
 
         h2, .jump {
-          @include core-19;
+          @include ig-core-19;
           padding: $gutter-half 0;
         }
         h2 {
@@ -138,11 +138,11 @@ nav.consultations_scope {
       padding: $gutter-two-thirds $gutter-half;
       
       p {
-        @include core-19;
+        @include ig-core-19;
       }
 
       h2 {
-        @include core-48;
+        @include ig-core-48;
         padding-top: 8px;
       }
 
@@ -155,7 +155,7 @@ nav.consultations_scope {
       h2 {
       }
       .run-time {
-        @include core-24;
+        @include ig-core-24;
         padding: $gutter-half;
         .dates {
           white-space: nowrap;
@@ -171,7 +171,7 @@ nav.consultations_scope {
   }
   .participation {
     background: $panel-colour;
-    @include core-19;
+    @include ig-core-19;
     margin: ($gutter*-1) ($gutter-half*-1) 0;
     @include media(tablet){
       margin: ($gutter*-1) 0 0 0;
@@ -187,14 +187,14 @@ nav.consultations_scope {
       text-decoration: underline;
     }
     h2, .online {
-      @include core-24;
+      @include ig-core-24;
     }
     h2 {
       @include bold;
     }
     dl {
       dt {
-        @include core-16;
+        @include ig-core-16;
       }
       dd {
         margin-bottom: $gutter-one-third;

--- a/app/assets/stylesheets/frontend/views/_countries.scss
+++ b/app/assets/stylesheets/frontend/views/_countries.scss
@@ -26,7 +26,7 @@
   }
   .article_section {
     h1 {
-      @include core-16;
+      @include ig-core-16;
     }
   }
   @media (max-width: 768px) {

--- a/app/assets/stylesheets/frontend/views/_detailed_guides.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides.scss
@@ -20,7 +20,7 @@
     }
     .button {
       @include button($detailed-guidance-brand);
-      @include core-19;
+      @include ig-core-19;
       padding-bottom: 7px;
       padding-bottom: 0.7rem;
     }
@@ -101,12 +101,12 @@
         float: left;
         padding-left: $gutter-one-third;
         padding-right: $gutter-one-third;
-        @include core-14;
+        @include ig-core-14;
       }
     }
 
     .label {
-      @include core-14;
+      @include ig-core-14;
       margin-bottom: 0;
       max-width: 33em;
       a {
@@ -118,7 +118,7 @@
       padding-top: 0;
     }
     .page-meta {
-      @include core-19;
+      @include ig-core-19;
       max-width: 33em;
       p {
         display: inline;
@@ -138,7 +138,7 @@
     }
 
     .replaces-businesslink {
-      @include core-16;
+      @include ig-core-16;
       padding-top: 10px;
 
       @include media(desktop){
@@ -157,7 +157,7 @@
   }
 
   .meta {
-    @include core-14;
+    @include ig-core-14;
     @include media(desktop) {
       float: right;
     }
@@ -167,12 +167,12 @@
     padding-top: $gutter-one-sixth;
 
     h1 {
-      @include core-19;
+      @include ig-core-19;
     }
 
     ol {
       border-top: 1px solid $border-colour;
-      @include core-16;
+      @include ig-core-16;
       padding: 0;
       margin: 0;
 
@@ -215,10 +215,10 @@
 
   .in-page-navigation {
     h3 {
-      @include core-16;
+      @include ig-core-16;
     }
     li {
-      @include core-16;
+      @include ig-core-16;
       padding: 0;
       list-style: disc;
     }
@@ -260,7 +260,7 @@
     margin: 0 -$gutter;
 
     h1 {
-      @include core-27;
+      @include ig-core-27;
       background: $detailed-guidance-brand;
       color: $white;
       margin: $gutter;
@@ -278,11 +278,11 @@
       }
 
       h2 {
-        @include core-27;
+        @include ig-core-27;
       }
 
       ul {
-        @include core-19;
+        @include ig-core-19;
         color: $detailed-guidance-brand;
 
         li {
@@ -302,12 +302,12 @@
       }
 
       h2 {
-        @include core-19;
+        @include ig-core-19;
         color: $text-colour;
       }
 
       ul {
-        @include core-16;
+        @include ig-core-16;
       }
     }
 
@@ -395,7 +395,7 @@
 
   .filters {
     li a {
-      @include core-16;
+      @include ig-core-16;
       display: block;
       padding: 3px 3px 3px 6px;
       width: 100%;
@@ -420,7 +420,7 @@
   }
   .result-block {
     h2 {
-      @include core-24;
+      @include ig-core-24;
       padding-top: 0;
       margin-bottom: $gutter-half;
     }
@@ -440,7 +440,7 @@
         margin-bottom: $gutter-one-third;
       }
       .meta {
-        @include core-16;
+        @include ig-core-16;
       }
       .meta {
         display: block;

--- a/app/assets/stylesheets/frontend/views/_detailed_guides_print.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides_print.scss
@@ -1,14 +1,14 @@
 .detailed-guides-show {
   .change-notes {
     h1 {
-      @include core-14;
+      @include ig-core-14;
     }
     .overlay {
       display: none;
     }
   }
   .metadata {
-    @include core-14;
+    @include ig-core-14;
   }
   .page-header {
     padding-bottom: $gutter*2;

--- a/app/assets/stylesheets/frontend/views/_document-page.scss
+++ b/app/assets/stylesheets/frontend/views/_document-page.scss
@@ -50,13 +50,13 @@
 
       li {
         float: none;
-        @include core-16;
+        @include ig-core-16;
       }
     }
   }
 
   .notice p {
-    @include core-16;
+    @include ig-core-16;
     padding: $gutter-one-third;
     margin-bottom: $gutter;
     background: yellow;

--- a/app/assets/stylesheets/frontend/views/_document-series.scss
+++ b/app/assets/stylesheets/frontend/views/_document-series.scss
@@ -1,11 +1,11 @@
 .document-series-page {
 
   h2 {
-    @include core-27;
+    @include ig-core-27;
   }
 
   .page_title {
-    @include core-36;
+    @include ig-core-36;
   }
 
   .document-series-page .description {

--- a/app/assets/stylesheets/frontend/views/_home.scss
+++ b/app/assets/stylesheets/frontend/views/_home.scss
@@ -2,7 +2,7 @@
 .inside_gov_sunset {
 
   h1 {
-    @include core-48;
+    @include ig-core-48;
     margin: 0 0 $gutter;
     @include media(desktop) {
       margin-top: 0;
@@ -20,7 +20,7 @@
   .block-1 {
 
     p {
-      @include core-19;
+      @include ig-core-19;
       margin-bottom: $gutter-half;
       &:nth-child(2) {
         margin-bottom: $gutter;
@@ -28,7 +28,7 @@
     }
 
     p.intro {
-      @include core-27;
+      @include ig-core-27;
     }
 
   }
@@ -65,7 +65,7 @@
   // typography
 
   h2 {
-    @include core-27;
+    @include ig-core-27;
     @include bold;
 
     border-bottom: 5px solid $black;
@@ -73,7 +73,7 @@
   }
 
   h3 {
-    @include core-27;
+    @include ig-core-27;
     @include bold;
   }
 
@@ -93,7 +93,7 @@
     }
 
     p.intro {
-      @include core-27;
+      @include ig-core-27;
     }
 
     @include media(tablet) {
@@ -121,21 +121,21 @@
     margin-top: ($gutter*2);
 
     .live-count {
-      @include core-27;
+      @include ig-core-27;
       margin-bottom: $gutter;
     }
 
     .organisation-count {
-      @include core-80;
+      @include ig-core-80;
       @include bold;
       display: block;
 
       @include media(tablet) {
-        @include core-48;
+        @include ig-core-48;
       }
 
       @include media(desktop) {
-        @include core-80;
+        @include ig-core-80;
       }
     }
 
@@ -162,10 +162,10 @@
       padding-top: $gutter;
 
       h3 {
-        @include core-19;
+        @include ig-core-19;
       }
       p {
-        @include core-16;
+        @include ig-core-16;
       }
     }
 
@@ -210,7 +210,7 @@
     a { color: $fuschia; }
 
     p {
-      @include core-16;
+      @include ig-core-16;
     }
 
     @include media(tablet) {

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -4,7 +4,7 @@
   }
 
   p, li{
-    @include core-19;
+    @include ig-core-19;
     a {
       text-decoration: underline;
     }
@@ -122,7 +122,7 @@
       }
     }
     .caption {
-      @include core-16;
+      @include ig-core-16;
     }
   }
   .civil-pie {
@@ -167,7 +167,7 @@
   }
   
   .feature-caption {
-    @include core-16;
+    @include ig-core-16;
     display: block;
     padding-bottom: $gutter;
   }
@@ -176,7 +176,7 @@
     p {
       text-align: center;
       color: #999;
-      @include core-48;
+      @include ig-core-48;
       padding: $gutter-half 0 $gutter;
     }
 
@@ -224,7 +224,7 @@
 
       span{
         color:black;
-        @include core-16;
+        @include ig-core-16;
         display: block;
         padding: 0;
         margin: 0;
@@ -249,7 +249,7 @@
   .policy-count {
     text-align: center;
     p {
-      @include core-16;
+      @include ig-core-16;
     }
     
     p.circle{
@@ -289,7 +289,7 @@
   }
   
   h1 {
-    @include core-48;
+    @include ig-core-48;
     @include bold;
     margin: 0 0 $gutter;
     @include media(desktop) {
@@ -298,7 +298,7 @@
   }
 
   h2 {
-    @include core-36;
+    @include ig-core-36;
     border-bottom: 5px solid $inside-gov-brand;
     margin: $gutter 0 $gutter;
     clear:both;
@@ -309,7 +309,7 @@
   }
 
   h3 {
-    @include core-27;
+    @include ig-core-27;
     @include bold;
     margin: 0 0 $gutter-half;
     width:100%;
@@ -323,7 +323,7 @@
   .depts-cont,
   .gov-types {
     h3 {
-      @include core-24;
+      @include ig-core-24;
       @include bold;
       margin-bottom: 0;
     }
@@ -343,7 +343,7 @@
   }
 
   h4 {
-    @include core-24;
+    @include ig-core-24;
     @include bold;
     &.with-gutter {
       margin-top: $gutter-half;
@@ -357,12 +357,12 @@
   }
    
   p.intro {
-    @include core-27;
+    @include ig-core-27;
     margin-bottom:$gutter*2;
     max-width: 26em;
   }
   p.small-print {
-    @include core-14;
+    @include ig-core-14;
   }
   h2.coalition {
     border-color: $coalition-green;
@@ -434,7 +434,7 @@
       span.circle .caption {
         position: relative;
         top: -5px;
-        @include core-14;
+        @include ig-core-14;
       }
     }
   }
@@ -450,7 +450,7 @@
       span.circle .caption {
         position: relative;
         top: -5px;
-        @include core-14;
+        @include ig-core-14;
       }
     }
   }
@@ -466,7 +466,7 @@
       span.circle .caption {
         position: relative;
         top: -5px;
-        @include core-14;
+        @include ig-core-14;
       }
     }
   }

--- a/app/assets/stylesheets/frontend/views/_mainstream-category.scss
+++ b/app/assets/stylesheets/frontend/views/_mainstream-category.scss
@@ -20,7 +20,7 @@
     padding-top: $gutter-half;
 
     h1 {
-      @include core-36;
+      @include ig-core-36;
     }
   }
 
@@ -30,7 +30,7 @@
     list-style: none;
 
     .guide {
-      @include core-19;
+      @include ig-core-19;
       margin-bottom: $gutter-half;
     }
   }

--- a/app/assets/stylesheets/frontend/views/_ministerial-roles.scss
+++ b/app/assets/stylesheets/frontend/views/_ministerial-roles.scss
@@ -24,7 +24,7 @@
   
   .block-2 {
     h1.label {
-      @include core-48;
+      @include ig-core-48;
       @include bold;
       padding-top: 0;
     }
@@ -41,7 +41,7 @@
     padding-top: ($gutter*2);
   
     h1.label {
-      @include core-48;
+      @include ig-core-48;
       @include bold;
     }
     

--- a/app/assets/stylesheets/frontend/views/_new-document-page.scss
+++ b/app/assets/stylesheets/frontend/views/_new-document-page.scss
@@ -16,7 +16,7 @@
     margin-top: $gutter;
 
     p {
-      @include core-24;
+      @include ig-core-24;
     }
   }
 
@@ -24,7 +24,7 @@
     padding-top: $gutter+$gutter-one-third;
 
     p {
-      @include core-16;
+      @include ig-core-16;
     }
   }
 

--- a/app/assets/stylesheets/frontend/views/_operational-field.scss
+++ b/app/assets/stylesheets/frontend/views/_operational-field.scss
@@ -10,7 +10,7 @@
       padding-bottom: 0;
     }
     .label {
-      @include core-48;
+      @include ig-core-48;
       @include bold;
       padding-top: 0;
     }
@@ -30,11 +30,11 @@
   }
 
   h2 {
-    @include core-27;
+    @include ig-core-27;
   }
 
   .page_title {
-    @include core-36;
+    @include ig-core-36;
   }
 
   .meta {
@@ -52,7 +52,7 @@
   .fatalities {
     ul {
       list-style: none;
-      @include core-16;
+      @include ig-core-16;
 
       .fatality-notice {
         margin: $gutter 0 $gutter-half;

--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -26,7 +26,7 @@
 
     .filter-list-form {
       label {
-        @include core-19;
+        @include ig-core-19;
         color: $secondary-text-colour;
         display: inline-block;
       }
@@ -60,7 +60,7 @@
       .view-all {
         display: block;
         float: left;
-        @include core-16;
+        @include ig-core-16;
       }
       .works-with {
         @include media(desktop){
@@ -106,14 +106,14 @@
         padding: $gutter-half;
       }
       h3 {
-        @include core-14;
+        @include ig-core-14;
         border-bottom: 1px solid $border-colour;
       }
       ol {
         overflow: hidden;
         margin: 0 (-$gutter-one-third) $gutter-one-third;
         li {
-          @include core-16;
+          @include ig-core-16;
           display: block;
           @include media(desktop){
             width: 33.33%;
@@ -135,7 +135,7 @@
       li {
         list-style: none;
         border-bottom: 1px solid $border-colour;
-        @include core-19;
+        @include ig-core-19;
       }
     }
   }
@@ -185,7 +185,7 @@
 
   h1.label,
   .topic h2 {
-    @include core-27;
+    @include ig-core-27;
     margin-bottom: $gutter-two-thirds;
   }
 
@@ -227,7 +227,7 @@
       }
 
       h4 {
-        @include core-19;
+        @include ig-core-19;
 
         @include media(tablet){
           position: absolute;
@@ -243,7 +243,7 @@
         }
 
         li {
-          @include core-16;
+          @include ig-core-16;
           @include media(tablet){
             padding-bottom: 0;
           }
@@ -263,7 +263,7 @@
       width: 66.66%;
 
       h2 {
-        @include core-48;
+        @include ig-core-48;
         padding-left: $gutter-one-third;
         margin-top: $gutter;
       }
@@ -296,16 +296,16 @@
           display: block;
         }
         .meta {
-          @include core-14;
+          @include ig-core-14;
           color: $secondary-text-colour;
           padding-bottom: 0;
         }
         h2 {
-          @include core-19;
+          @include ig-core-19;
           padding-top: 0;
         }
         .summary {
-          @include core-16;
+          @include ig-core-16;
         }
       }
 
@@ -339,10 +339,10 @@
               }
             }
             h2 {
-              @include core-24;
+              @include ig-core-24;
             }
             .summary {
-              @include core-19;
+              @include ig-core-19;
             }
           }
         }
@@ -395,10 +395,10 @@
         }
       }
       h2 {
-        @include core-19;
+        @include ig-core-19;
       }
       .summary {
-        @include core-16;
+        @include ig-core-16;
       }
     }
 
@@ -450,11 +450,11 @@
     margin: 0;
 
     .document-row {
-      @include core-14;
+      @include ig-core-14;
       border-bottom: none;
 
       th {
-        @include core-14;
+        @include ig-core-14;
         margin: $gutter-one-third 0 0 0;
         padding: 0;
       }
@@ -485,13 +485,13 @@
       padding: $gutter-half;
     }
     h2 {
-      @include core-24;
+      @include ig-core-24;
     }
   }
 
   .what-we-do {
     p {
-      @include core-19;
+      @include ig-core-19;
     }
 
     .parent_organisations {
@@ -581,7 +581,7 @@
   #org-contacts {
 
     h2 {
-      @include core-24;
+      @include ig-core-24;
     }
 
     .organisation_contact h2 {
@@ -695,7 +695,7 @@
       clear: both;
       overflow: hidden;
       margin: $gutter-half 0;
-      @include core-16;
+      @include ig-core-16;
       padding: 0;
       line-height: ($gutter-two-thirds+$gutter-one-sixth);
     }
@@ -796,14 +796,14 @@
 
     .sub-organisation-name {
       h2 {
-        @include core-36;
+        @include ig-core-36;
         padding-left: 0;
         margin-top: $gutter-half;
         a {
           color: #000;
         }
         @include media(desktop) {
-          @include core-48;
+          @include ig-core-48;
         }
       }
       @include media(desktop) {
@@ -820,7 +820,7 @@
 
   .description {
     p {
-      @include core-19;
+      @include ig-core-19;
     }
 
     margin-bottom: $gutter;
@@ -839,7 +839,7 @@
     }
   }
   .information-block {
-    @include core-19;
+    @include ig-core-19;
     padding: $gutter-two-thirds 33.33% $gutter-two-thirds 0;
     margin-top: 0;
     margin-bottom: $gutter;
@@ -901,7 +901,7 @@
 
     .sub-organisation-name {
       h2 {
-        @include core-36;
+        @include ig-core-36;
         padding-top: $gutter;
         a {
           color: #000;
@@ -911,7 +911,7 @@
   }
 
   nav {
-    @include core-16;
+    @include ig-core-16;
     padding: ($gutter - $gutter-one-third) 0 $gutter;
     h1 {
       @include bold;
@@ -936,14 +936,14 @@
     }
   }
   .main {
-    @include core-48;
+    @include ig-core-48;
 
     @include media(desktop){
       margin: ($gutter*3 + $gutter-half) 0 $gutter-half;
     }
   }
   .description {
-    @include core-27;
+    @include ig-core-27;
   }
   .body {
     h2 {
@@ -956,7 +956,7 @@
   }
   .corporate-publications {
     h1 {
-      @include core-27;
+      @include ig-core-27;
       margin: $gutter 0 $gutter-half 0;
     }
     ul {
@@ -966,11 +966,11 @@
         padding: $gutter-one-sixth 0;
 
         h3 {
-          @include core-19;
+          @include ig-core-19;
           padding: 0;
         }
         .metadata {
-          @include core-14;
+          @include ig-core-14;
           padding: 0;
         }
         a {
@@ -980,7 +980,7 @@
     }
     .transparency {
       a {
-        @include core-19;
+        @include ig-core-19;
         @include bold;
       }
     }

--- a/app/assets/stylesheets/frontend/views/_people.scss
+++ b/app/assets/stylesheets/frontend/views/_people.scss
@@ -10,7 +10,7 @@
       padding-bottom: 0;
     }
     .label {
-      @include core-48;
+      @include ig-core-48;
       @include bold;
       padding-top: 0;
     }
@@ -31,7 +31,7 @@
     
     ul li {
       list-style: none;
-      @include core-27;
+      @include ig-core-27;
       @include light;
     }
 
@@ -90,12 +90,12 @@
     section {
       margin: $gutter 0 $gutter*2;
       h1 {
-        @include core-27;
+        @include ig-core-27;
         margin: 0;
       }
 
       .read-more {
-        @include core-19;
+        @include ig-core-19;
       }
     }
 

--- a/app/assets/stylesheets/frontend/views/_policies.scss
+++ b/app/assets/stylesheets/frontend/views/_policies.scss
@@ -63,7 +63,7 @@
 
 
   .supporting-page-title {
-    @include core-27;
+    @include ig-core-27;
     margin-bottom: $gutter;
   }
 
@@ -140,7 +140,7 @@
 
       &:before { display: none; }
 
-      @include core-19;
+      @include ig-core-19;
       line-height: (45/16);
 
       @include media(tablet) {
@@ -207,7 +207,7 @@
 
       a {
         display: block;
-        @include core-24;
+        @include ig-core-24;
         padding: $gutter-half 0 $gutter-half ($gutter-half + 2px);
         margin: 0 2px;
         background: $panel-colour;
@@ -224,7 +224,7 @@
         &.current {
           position: relative;
           margin-bottom: -1px;
-          @include core-24;
+          @include ig-core-24;
           padding: $gutter-half 0 ($gutter-half + 4px) ($gutter-half + 1px);
           border: 1px solid $border-colour;
           border-bottom: none;
@@ -241,7 +241,7 @@
   #case-studies {
     h1 {
       // from _document.scss h2
-      @include core-27;
+      @include ig-core-27;
       color: lighten($text-colour, 50%);
       margin-top: $gutter;
       @media (max-width: 640px) {
@@ -251,7 +251,7 @@
     li {
       // from _document.scss li
       width: 90%;
-      @include core-19;
+      @include ig-core-19;
       margin-left: $gutter*1.2;
 
       li {

--- a/app/assets/stylesheets/frontend/views/_policy_teams.scss
+++ b/app/assets/stylesheets/frontend/views/_policy_teams.scss
@@ -33,7 +33,7 @@
     }
   }
   h2 {
-    @include core-27;
+    @include ig-core-27;
     color: lighten($text-colour, 20%);
     margin-top: $gutter;
     @include media(tablet) {
@@ -44,18 +44,18 @@
   .description {
     padding-bottom: $gutter-half;
     .govspeak p:first-child {
-      @include core-24;
+      @include ig-core-24;
     }
   }
 
   .policy {
-    @include core-19;
+    @include ig-core-19;
     list-style: none;
     border-bottom: 1px solid $border-colour;
     @include bold;
   }
 
   .email {
-    @include core-19;
+    @include ig-core-19;
   }
 }

--- a/app/assets/stylesheets/frontend/views/_site-index.scss
+++ b/app/assets/stylesheets/frontend/views/_site-index.scss
@@ -27,11 +27,11 @@
   
   .block-2 {
     .introduction {
-      @include core-24;
+      @include ig-core-24;
     }
     
     .beta-site {
-      @include core-16;
+      @include ig-core-16;
     }
   }
   

--- a/app/assets/stylesheets/frontend/views/_topic.scss
+++ b/app/assets/stylesheets/frontend/views/_topic.scss
@@ -72,7 +72,7 @@
       @extend %contain-floats;
 
       h1 {
-        @include core-27;
+        @include ig-core-27;
         float: left;
       }
       .subscribe {
@@ -86,11 +86,11 @@
       clear: both;
 
       .document-row {
-        @include core-14;
+        @include ig-core-14;
         border-bottom: none;
 
         th {
-          @include core-14;
+          @include ig-core-14;
           margin: $gutter-one-third 0 0 0;
           padding: 0;
         }
@@ -107,14 +107,14 @@
   .policies,
   .elsewhere {
     h1 {
-      @include core-27;
+      @include ig-core-27;
     }
   }
 
   .what {
     .govspeak {
       p {
-        @include core-24;
+        @include ig-core-24;
         margin: 0;
       }
     }
@@ -123,7 +123,7 @@
   .collection-list {
     padding-top: $gutter-two-thirds;
     .collection-item h2 {
-      @include core-24;
+      @include ig-core-24;
       margin-bottom: $gutter-one-sixth;
     }
   }
@@ -153,7 +153,7 @@
 
         li {
           list-style: none;
-          @include core-16;
+          @include ig-core-16;
         }
       }
     }


### PR DESCRIPTION
This is the first step in switching to the new frontend toolkit fonts.
In the toolkit there are a different set of fonts mixins which use the
core name. This will let us continue to use our cores while we migrate
each page to the new stuff. Eventually we should be left with no
references to `ig-core` and at that point we can remove them entirely.
