### PR TITLE
Hide joining bar with count in JavaScript not Ruby

### DIFF
--- a/app/assets/javascripts/application/joining-message.js
+++ b/app/assets/javascripts/application/joining-message.js
@@ -13,14 +13,18 @@
       if(joining.$progressBar.length === 1){
         var joiningCookie = root.GOVUK.cookie(joining.cookieName);
 
-        if(""+ joining.$progressBar.data('join-count') === joiningCookie){
-          joining.hideBar();
+        if(""+ joining.$progressBar.data('join-count') !== joiningCookie){
+          joining.showBar();
         }
+
         joining.addCloseButton();
       }
     },
+    showBar: function(){
+      joining.$progressBar.removeClass('js-hidden');
+    },
     hideBar: function(){
-      joining.$progressBar.hide();
+      joining.$progressBar.addClass('js-hidden');
     },
     closeBar: function(){
       root.GOVUK.cookie(joining.cookieName, joining.$progressBar.data('join-count'), 30);

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -44,16 +44,14 @@
           </div>
         </div>
         <div id="content"></div>
-        <% unless cookies['inside-gov-joining'] == joined_ministerial_department_count.to_s %>
-          <div class="progress-bar js-progress-bar" id="progress-bar" data-join-count="<%= joined_ministerial_department_count %>">
-            <div class="bar"><div class="joined" style="width: <%= joined_ministerial_department_percent %>"></div></div>
-            <p>
-              <%= joined_ministerial_department_count %> of <%= ministerial_department_count %>
-              ministerial departments have moved their corporate websites to GOV.UK.
-              <%= progress_bar_link %>
-            </p>
-          </div>
-        <% end %>
+        <div class="progress-bar js-progress-bar js-hidden" id="progress-bar" data-join-count="<%= joined_ministerial_department_count %>">
+          <div class="bar"><div class="joined" style="width: <%= joined_ministerial_department_percent %>"></div></div>
+          <p>
+            <%= joined_ministerial_department_count %> of <%= ministerial_department_count %>
+            ministerial departments have moved their corporate websites to GOV.UK.
+            <%= progress_bar_link %>
+          </p>
+        </div>
         <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
           <%= yield %>
         </div>

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -110,15 +110,6 @@ class HomeControllerTest < ActionController::TestCase
     assert_select '.progress-bar', /1 of 2/
   end
 
-  test "progress bar does not show if you have suppressed it" do
-    @request.cookies['inside-gov-joining'] = '1'
-    org = create(:ministerial_department)
-
-    get :home
-
-    refute_select '.progress-bar'
-  end
-
   test "how government works page shows a count of published policies" do
     create(:published_policy)
     create(:draft_policy)

--- a/test/javascripts/unit/joining-message_test.js
+++ b/test/javascripts/unit/joining-message_test.js
@@ -1,6 +1,6 @@
 module("display joining message", {
   setup: function() {
-    this.$message = $('<div class="js-progress-bar" data-join-count="2"></div>');
+    this.$message = $('<div class="js-progress-bar js-hidden" data-join-count="2"></div>');
     $('#qunit-fixture').append(this.$message);
 
     this.cookieStub = sinon.stub(GOVUK, "cookie").returns('cookie value');
@@ -10,20 +10,12 @@ module("display joining message", {
   }
 });
 
-test('hides progress bar', function(){
-  GOVUK.joiningMessage.init();
-
-  ok(this.$message.is(':visible'));
-  GOVUK.joiningMessage.hideBar();
-  ok(!this.$message.is(':visible'));
-});
-
 test('closes bar and sets a cookie' , function(){
   GOVUK.joiningMessage.init();
 
-  ok(this.$message.is(':visible'));
+  ok(!this.$message.hasClass('js-hidden'));
   GOVUK.joiningMessage.closeBar();
-  ok(!this.$message.is(':visible'));
+  ok(this.$message.hasClass('js-hidden'));
 
   var cookieCallArgs = this.cookieStub.getCall(this.cookieStub.callCount-1).args
   var expectedArgs = ["inside-gov-joining", 2, 30]
@@ -45,10 +37,18 @@ test('closes bar when clicking close', function(){
   closeStub.restore();
 });
 
+test('shows bar if cookie does not match data value', function(){
+  this.$message.data('join-count', 'not the cookie value');
+
+  ok(this.$message.hasClass('js-hidden'));
+  GOVUK.joiningMessage.init();
+  ok(!this.$message.hasClass('js-hidden'));
+});
+
 test('hides bar if cookie matches data value', function(){
   this.$message.data('join-count', 'cookie value');
 
-  ok(this.$message.is(':visible'));
+  ok(this.$message.hasClass('js-hidden'));
   GOVUK.joiningMessage.init();
-  ok(!this.$message.is(':visible'));
+  ok(this.$message.hasClass('js-hidden'));
 });


### PR DESCRIPTION
Due to the caching that we have in production the bar would always
be hidden if the first person that visits the page in a cache window had
already dissmissed the bar.

Moved the logic into the frontend so it should never be effected by
the cache. Also used the `.js-hidden` class so that you will never see
the flash of content if you have already dismissed the bar and it will
instead just get shown to people who have not dismissed the bar.
