### PR TITLE
Migration to remove old users without email or uid

### DIFF
--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -12,6 +12,8 @@ module Admin::AuditTrailHelper
     html << " ".html_safe
     if actor
       html << content_tag(:span, class: "actor") { linked_author(actor) }
+    else
+      html << "User (removed)"
     end
     html << " ".html_safe
     html << relative_time(entry.created_at, class: "created_at")

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -84,7 +84,11 @@ module Edition::AuditTrail
     end
 
     def actor
-      version.whodunnit && User.find(version.whodunnit)
+      if User.exists?(version.whodunnit)
+        User.find(version.whodunnit)
+      else
+        nil # for deleted users
+      end
     end
 
     private

--- a/db/migrate/20121217131213_remove_old_users.rb
+++ b/db/migrate/20121217131213_remove_old_users.rb
@@ -1,0 +1,15 @@
+class RemoveOldUsers < ActiveRecord::Migration
+  def up
+    users_to_keep = Edition.includes(:authors).all.map(&:authors).flatten.uniq
+    users_to_keep << User.find_by_name!("GDS Inside Government Team")
+    users_to_keep << User.find_by_name!("Automatic Data Importer")
+    users_to_keep << User.find_by_name!("Scheduled Publishing Robot")
+    users = User.arel_table
+    users_to_destroy = User.where(users[:uid].eq(nil).or(users[:email].eq(nil)).or(users[:permissions].eq(nil))) - users_to_keep
+    users_to_destroy.map(&:destroy)
+  end
+
+  def down
+    #noop
+  end
+end


### PR DESCRIPTION
Keeps users who have editions published/pending/archived.

Keep important bot users

Also removing users with nil permissions

Could not just use sso email list as some users are duplicated (clean up would be needed) and some users are bots, but by checking on the uid we should be clearing most old users.
