### PR TITLE
Removing notes_to_editors and moving content to body

### DIFF
--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -8,9 +8,6 @@
       <% if @edition.change_note_required? %>
         <li><a href="#change-note" data-toggle="tab">Change note</a></li>
       <% end %>
-      <% if @edition.notes_to_editors.present? %>
-        <li><a href="#notes_to_editors" data-toggle="tab">Notes to editors</a></li>
-      <% end %>
       <% if @edition.allows_supporting_pages? %>
         <li><a href="#supporting_pages" data-toggle="tab">Supporting pages <span class="badge"><%= @edition.supporting_pages.count %></span></a></li>
       <% end %>
@@ -54,12 +51,6 @@
           <% else %>
               <%= @edition.change_note %>
           <% end %></p>
-        </section>
-      <% end %>
-      <% if @edition.notes_to_editors.present? %>
-        <section class="tab-pane" id="notes_to_editors">
-          <h1>Notes to editors</h1>
-          <%= govspeak_to_html @edition.notes_to_editors %>
         </section>
       <% end %>
       <% if @edition.allows_supporting_pages? %>

--- a/app/views/admin/fact_check_requests/edit.html.erb
+++ b/app/views/admin/fact_check_requests/edit.html.erb
@@ -5,9 +5,6 @@
     <ul class="nav nav-tabs">
       <li><p class="guidance">Please review all content:</p></li>
       <li class="active"><a href="#document" data-toggle="tab">Document</a></li>
-      <% if @edition.notes_to_editors.present? %>
-        <li><a href="#notes_to_editors" data-toggle="tab">Notes to editors</a></li>
-      <% end %>
       <% if @edition.allows_supporting_pages? && @edition.supporting_pages.any? %>
         <li><a href="#supporting_pages" data-toggle="tab">Supporting pages</a></li>
       <% end %>
@@ -16,12 +13,6 @@
       <section class="document_page tab-pane active" id="document">
         <%= render partial: 'admin/editions/edition', locals: { edition: @edition } %>
       </section>
-      <% if @edition.notes_to_editors.present? %>
-        <section class="tab-pane" id="notes_to_editors">
-          <h1>Notes to editors</h1>
-          <%= govspeak_to_html @edition.notes_to_editors %>
-        </section>
-      <% end %>
       <% if @edition.allows_supporting_pages? && @edition.supporting_pages.any? %>
         <section class="tab-pane supporting_pages" id="supporting_pages">
           <h1>Supporting pages</h1>

--- a/app/views/detailed_guides/_document_content.html.erb
+++ b/app/views/detailed_guides/_document_content.html.erb
@@ -2,12 +2,4 @@
   <div class="body">
     <%= govspeak_edition_to_html @document %>
   </div>
-  <% if @document.notes_to_editors.present? %>
-    <section id="notes_to_editors">
-      <h1>Notes to editors</h1>
-      <div class="notes_to_editors">
-        <%= govspeak_to_html @document.notes_to_editors %>
-      </div>
-    </section>
-  <% end %>
 </article>

--- a/db/migrate/20130102171246_migrate_notes_to_editors_on_edition.rb
+++ b/db/migrate/20130102171246_migrate_notes_to_editors_on_edition.rb
@@ -1,0 +1,12 @@
+class MigrateNotesToEditorsOnEdition < ActiveRecord::Migration
+  def up
+    Edition.where('notes_to_editors !=""').each do |edition| 
+      edition.update_attribute :body, "\n##Notes to editors\n\n#{edition.notes_to_editors}"
+    end
+    remove_column :editions, :notes_to_editors
+  end
+
+  def down
+    add_column :editions, :notes_to_editors
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121224115459) do
+ActiveRecord::Schema.define(:version => 20130102171246) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -344,7 +344,6 @@ ActiveRecord::Schema.define(:version => 20121224115459) do
     t.datetime "published_at"
     t.datetime "first_published_at"
     t.date     "publication_date"
-    t.text     "notes_to_editors"
     t.text     "summary"
     t.integer  "speech_type_id"
     t.boolean  "stub",                                                            :default => false

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -4,10 +4,6 @@ Given /^a published news article "([^"]*)" with related published policies "([^"
   create(:published_news_article, title: news_article_title, related_policies: [policy_1, policy_2])
 end
 
-Given /^a published news article "([^"]*)" with notes to editors "([^"]*)"$/ do |title, notes_to_editors|
-  create(:published_news_article, title: title, notes_to_editors: notes_to_editors)
-end
-
 Given /^a published news article "([^"]*)" for the organisation "([^"]*)"$/ do |title, organisation|
   organisation = create(:organisation, name: organisation)
   create(:published_news_article, title: title, organisations: [organisation])
@@ -40,10 +36,6 @@ When /^I draft a new news article "([^"]*)" relating it to "([^"]*)" and "([^"]*
   select first_policy, from: "Related policies"
   select second_policy, from: "Related policies"
   click_button "Save"
-end
-
-Then /^I should see the notes to editors "([^"]*)" for the news article$/ do |notes_to_editors|
-  assert has_css?("#{notes_to_editors_selector}", text: notes_to_editors)
 end
 
 When /^I publish a news article "([^"]*)" associated with "([^"]*)"$/ do |title, person_name|

--- a/features/viewing-published-news-articles.feature
+++ b/features/viewing-published-news-articles.feature
@@ -4,8 +4,3 @@ Scenario: Viewing a published news article with related policies
   Given a published news article "News 1" with related published policies "Policy 1" and "Policy 2"
   When I visit the news article "News 1"
   Then I can see links to the related published policies "Policy 1" and "Policy 2"
-
-#Scenario: Viewing a published news article with notes to editors
-#  Given a published news article "News 1" with notes to editors "Notes to editors"
-#  When I visit the news article "News 1"
-#  Then I should see the notes to editors "Notes to editors" for the news article

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -30,7 +30,6 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
   should_prevent_modification_of_unmodifiable :news_article
   should_allow_overriding_of_first_published_at_for :news_article
   should_have_summary :news_article
-  should_have_notes_to_editors :news_article
   should_allow_scheduled_publication_of :news_article
 
   test "new displays news article fields" do
@@ -47,18 +46,4 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
     assert_select ".summary", text: "a-simple-summary"
   end
 
-  test "should render the notes to editors using govspeak markup" do
-    news_article = create(:news_article, notes_to_editors: "notes-to-editors-in-govspeak")
-    govspeak_transformation_fixture default: "\n", "notes-to-editors-in-govspeak" => "notes-to-editors-in-html" do
-      get :show, id: news_article
-    end
-
-    assert_select "#{notes_to_editors_selector}", text: /notes-to-editors-in-html/
-  end
-
-  test "should exclude the notes to editors section if there are not any" do
-    news_article = create(:news_article, notes_to_editors: "")
-    get :show, id: news_article
-    refute_select "#{notes_to_editors_selector}"
-  end
 end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -53,32 +53,6 @@ module AdminEditionControllerTestHelpers
       end
     end
 
-    def should_have_notes_to_editors(edition_type)
-      edition_class = edition_class_for(edition_type)
-
-      test "create should create a new #{edition_type} with notes to editors" do
-        attributes = controller_attributes_for(edition_type)
-
-        post :create, edition: attributes.merge(
-          notes_to_editors: "notes-to-editors"
-        )
-
-        created_edition = edition_class.last
-        assert_equal "notes-to-editors", created_edition.notes_to_editors
-      end
-
-      test "update should save modified #{edition_type} notes to editors" do
-        edition = create(edition_type)
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition,
-          notes_to_editors: "new-notes-to-editors"
-        )
-
-        saved_edition = edition.reload
-        assert_equal "new-notes-to-editors", saved_edition.notes_to_editors
-      end
-    end
-
     def should_allow_unpublishing_for(edition_type)
       edition_class = edition_class_for(edition_type)
 

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -41,10 +41,6 @@ module CssSelectors
     ".inapplicable-nations"
   end
 
-  def notes_to_editors_selector
-    "#notes_to_editors"
-  end
-
   def parent_organisations_list_selector
     "select[name='organisation[parent_organisation_ids][]']"
   end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -6,7 +6,7 @@ class NewsArticleTest < EditionTestCase
   should_allow_image_attachments
   should_have_first_image_pulled_out
   should_allow_a_summary_to_be_written
-  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note, :notes_to_editors
+  should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
   test "should be able to relate to other editions" do
     article = build(:news_article)


### PR DESCRIPTION
Move data from notes_to_editors to body
Remove references of notes_to_editors and drop column

https://www.pivotaltracker.com/story/show/37669869
