### PR TITLE
Add inline attachment style

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -12,6 +12,13 @@ $thumbnail-width: 99px;
     padding: $gutter-half 0 0 ($thumbnail-width + $gutter);
   }
   
+  &.inline {
+    background: transparent;
+    position: static;
+    padding: 0;
+    margin: 0;
+  }
+
   .attachment-thumb {
     position: relative;
     float: left;

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -114,4 +114,12 @@ Details of document required:
     prefix = references.size == 1 ? "and its reference" : "and its references"
     references.any? ? ", #{prefix} (" + references.join(", ") + ")" : ""
   end
+
+  def attachment_attributes(attachment)
+    attributes = []
+    attributes << content_tag(:span, humanized_content_type(attachment.file_extension), class: 'type')
+    attributes << content_tag(:span, number_to_human_size(attachment.file_size), class: 'file-size')
+    attributes << content_tag(:span, pluralize(attachment.number_of_pages, "page") , class: 'page-length') if attachment.number_of_pages.present?
+    attributes.join(', ').html_safe
+  end
 end

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -94,11 +94,18 @@ module GovspeakHelper
   end
 
   def govspeak_with_attachments_and_alt_format_information(govspeak, attachments = [], alternative_format_contact_email = nil)
-    govspeak.gsub(/\n{0,2}^!@([0-9]+)\s*/) do
+    govspeak = govspeak.gsub(/\n{0,2}^!@([0-9]+)\s*/) do
       if attachment = attachments[$1.to_i - 1]
         "\n\n" + render(partial: "documents/attachment.html.erb", object: attachment, locals: {alternative_format_contact_email: alternative_format_contact_email}) + "\n\n"
       else
         "\n\n"
+      end
+    end
+    govspeak.gsub(/\[InlineAttachment:([0-9]+)\]/) do
+      if attachment = attachments[$1.to_i - 1]
+        render(partial: "documents/inline_attachment.html.erb", object: attachment)
+      else
+        ""
       end
     end
   end

--- a/app/views/admin/editions/_attachment_fields.html.erb
+++ b/app/views/admin/editions/_attachment_fields.html.erb
@@ -29,28 +29,31 @@
         <% end %>
       </div>
     <% else %>
-      <%= edition_attachments_fields.fields_for :attachment do |attachment_fields| %>
-        <%= attachment_fields.text_field :title %>
-        <% if edition.allows_attachment_references? %>
-          <%= attachment_fields.text_field :isbn, label_text: 'ISBN' %>
-          <%= attachment_fields.text_field :unique_reference %>
-          <%= attachment_fields.text_field :command_paper_number %>
-          <%= attachment_fields.text_field :order_url, label_text: 'Order URL' %>
-          <%= attachment_fields.text_field :price, label_text: "Price in £s" %>
-        <% end %>
-        <%= attachment_fields.check_box :accessible, label_text: "Attachment is accessible" %>
+      <div class="well">
+        <%= edition_attachments_fields.fields_for :attachment do |attachment_fields| %>
+          <%= attachment_fields.text_field :title %>
+          <% if edition.allows_attachment_references? %>
+            <%= attachment_fields.text_field :isbn, label_text: 'ISBN' %>
+            <%= attachment_fields.text_field :unique_reference %>
+            <%= attachment_fields.text_field :command_paper_number %>
+            <%= attachment_fields.text_field :order_url, label_text: 'Order URL' %>
+            <%= attachment_fields.text_field :price, label_text: "Price in £s" %>
+          <% end %>
+          <%= attachment_fields.check_box :accessible, label_text: "Attachment is accessible" %>
 
-        <div class="attachment">
-          <p>Current data: <%= link_to_attachment(edition_attachments_fields.object.attachment) %></p>
-          <p>Actions: <%= attachment_action_fields(attachment_fields) %></p>
-          <%= replacement_attachment_data_fields(attachment_fields) %>
-        </div>
-      <% end %>
-      <% if show_inline_attachment_help %>
-        <p>Markdown to use:
+          <div class="attachment">
+            <p>Current data: <%= link_to_attachment(edition_attachments_fields.object.attachment) %></p>
+            <p>Actions: <%= attachment_action_fields(attachment_fields) %></p>
+            <%= replacement_attachment_data_fields(attachment_fields) %>
+          </div>
+        <% end %>
+        <% if show_inline_attachment_help %>
+          <p>Markdown to use:</p>
           <input type="text" readonly="readonly" value="!@<%= i += 1 %>" />
-        </p>
-      <% end %>
+          <p>or</p>
+          <input type="text" readonly="readonly" value="[InlineAttachment:<%= i %>]" />
+        <% end %>
+      </div>
     <% end %>
   <% end %>
 </fieldset>

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -26,9 +26,7 @@
       <% unless published_on.blank? %>
         <span class="changed">Published: <%= absolute_date(published_on) %></span>
       <% end %>
-      <span class="type"><%= humanized_content_type(attachment.file_extension) %></span>,
-      <span class="file-size"><%= number_to_human_size(attachment.file_size) %></span><% if attachment.number_of_pages.present? %>,
-        <span class="page-length"><%= pluralize(attachment.number_of_pages, "page") %></span><% end %>
+      <%= attachment_attributes(attachment) %>
     </p>
     <% if attachment.order_url.present? %>
       <p>

--- a/app/views/documents/_inline_attachment.html.erb
+++ b/app/views/documents/_inline_attachment.html.erb
@@ -1,0 +1,4 @@
+<%= content_tag_for(:span, attachment, class: "inline") do %>
+  <%= link_to attachment.title, attachment.url %>
+  [<%= attachment_attributes(attachment) %>]
+<% end %>


### PR DESCRIPTION
Add an option to parse attachments in the form
`[InlineAttachment:([0-9]+)]`.

Also added a `well` around each attachment in the admin to make it
easier to work out which attribute set fits with which attachment.
