### PR TITLE
Change Editions to have many document_series

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -125,6 +125,9 @@ class Admin::EditionsController < Admin::BaseController
     if @edition.can_be_associated_with_statistical_data_sets?
       params[:edition][:statistical_data_set_document_ids] ||= []
     end
+    if @edition.can_be_grouped_in_series?
+      params[:edition][:document_series_ids] ||= []
+    end
     if @edition.can_be_related_to_policies?
       params[:edition][:related_document_ids] ||= []
     end

--- a/app/helpers/admin/document_series_helper.rb
+++ b/app/helpers/admin/document_series_helper.rb
@@ -1,5 +1,5 @@
 module Admin::DocumentSeriesHelper
-  def document_series_select_options(edition, user)
+  def document_series_select_options(edition, user, document_series_ids)
     organisation = user.organisation
     grouped_series = DocumentSeries.all.group_by(&:organisation)
     primary_series = grouped_series.delete(user.organisation)
@@ -7,12 +7,12 @@ module Admin::DocumentSeriesHelper
     series_options = [%{<option value=""></option>}]
     if primary_series
       series_options << (%{<optgroup label="#{user.organisation.name}">} +
-      options_from_collection_for_select(primary_series, 'id', 'name', edition.document_series_id) +
+      options_from_collection_for_select(primary_series, 'id', 'name', document_series_ids) +
       %{</optgroup>})
     end
     series_options << grouped_series.map do |organisation, series|
       %{<optgroup label="#{organisation.name}">} +
-      options_from_collection_for_select(series, 'id', 'name', edition.document_series_id) +
+      options_from_collection_for_select(series, 'id', 'name', document_series_ids) +
       %{</optgroup>}
     end
     series_options.join.html_safe

--- a/app/helpers/document_series_helper.rb
+++ b/app/helpers/document_series_helper.rb
@@ -5,4 +5,10 @@ module DocumentSeriesHelper
                  %{(#{edition.state} #{edition.format_name})},
                  class: "document_state")
   end
+
+  def list_of_links_to_document_series(edition)
+    edition.document_series.map do |ds|
+      link_to ds.name, organisation_document_series_path(ds.organisation, ds)
+    end.to_sentence.html_safe
+  end
 end

--- a/app/models/document_series.rb
+++ b/app/models/document_series.rb
@@ -1,7 +1,8 @@
 class DocumentSeries < ActiveRecord::Base
   belongs_to :organisation
 
-  has_many :editions, order: 'publication_date desc'
+  has_many :editions, through: :edition_document_series, order: 'publication_date desc'
+  has_many :edition_document_series
 
   validates_with SafeHtmlValidator
   validates :name, presence: true

--- a/app/models/edition/document_series.rb
+++ b/app/models/edition/document_series.rb
@@ -8,7 +8,8 @@ module Edition::DocumentSeries
   end
 
   included do
-    belongs_to :document_series
+    has_many :edition_document_series, foreign_key: :edition_id
+    has_many :document_series, through: :edition_document_series
 
     add_trait Trait
   end
@@ -18,6 +19,6 @@ module Edition::DocumentSeries
   end
 
   def part_of_series?
-    document_series.present?
+    document_series.any?
   end
 end

--- a/app/models/edition_document_series.rb
+++ b/app/models/edition_document_series.rb
@@ -1,0 +1,4 @@
+class EditionDocumentSeries < ActiveRecord::Base
+  belongs_to :edition
+  belongs_to :document_series
+end

--- a/app/presenters/publication_filter_json_presenter.rb
+++ b/app/presenters/publication_filter_json_presenter.rb
@@ -12,8 +12,10 @@ class PublicationFilterJsonPresenter < DocumentFilterJsonPresenter
       publication_series: ""
     }
     if document.part_of_series?
-      link = h.link_to(document.document_series.name, h.organisation_document_series_path(document.document_series.organisation, document.document_series))
-      to_merge[:publication_series] = "Part of a series: #{link}".html_safe
+      links = document.document_series.map do |ds|
+        h.link_to(ds.name, h.organisation_document_series_path(ds.organisation, ds))
+      end
+      to_merge[:publication_series] = "Part of a series: #{links.to_sentence}".html_safe
     end
 
     super.reverse_merge(to_merge)

--- a/app/views/admin/editions/_document_preview.html.erb
+++ b/app/views/admin/editions/_document_preview.html.erb
@@ -135,9 +135,11 @@
       <% if @edition.can_be_grouped_in_series? %>
         <section>
           <h1>Document series</h1>
-          <% if document_series = @edition.document_series %>
-            <%= content_tag_for :p, document_series do %>
-              <%= link_to document_series.name, admin_organisation_document_series_path(document_series.organisation, document_series) %>
+          <% if @edition.document_series.any? %>
+          <% @edition.document_series.each do |document_series| %>
+              <%= content_tag_for :p, document_series do %>
+                <%= link_to document_series.name, admin_organisation_document_series_path(document_series.organisation, document_series) %>
+              <% end %>
             <% end %>
           <% else %>
             <p>This document is not associated with any series.</p>
@@ -157,7 +159,7 @@
         <ul>
           <% @edition.document.document_sources.map(&:url).each do |url| %>
             <li><%= url %></li>
-          <% end %>  
+          <% end %>
         </ul>
       <% end %>
     </section>

--- a/app/views/admin/editions/_document_series_fields.html.erb
+++ b/app/views/admin/editions/_document_series_fields.html.erb
@@ -1,2 +1,2 @@
-<%= form.label :document_series_id, 'Document series' %>
-<%= form.select :document_series_id, document_series_select_options(edition, current_user), {allow_blank: true}, {class: 'chzn-select', data: { placeholder: "Choose series this document is a part of..." }} %>
+<%= form.label :document_series_ids, 'Document series' %>
+<%= form.select :document_series_ids, document_series_select_options(edition, current_user, edition.document_series_ids), {allow_blank: true}, {multiple: true, class: 'chzn-select', data: { placeholder: "Choose series this document is a part of..." }} %>

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -64,7 +64,7 @@
       <% end %>
       <% if document.respond_to?(:part_of_series?) && document.part_of_series? %>
         <dt>Series:</dt>
-        <dd><%= link_to document.document_series.name, organisation_document_series_path(document.document_series.organisation, document.document_series) %></dd>
+        <dd><%= list_of_links_to_document_series(document) %></dd>
       <% end %>
       <% if document.respond_to?(:statistical_data_sets) && document.statistical_data_sets.any? %>
         <dt>Live data:</dt>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -19,13 +19,13 @@
 <div class="block-4">
   <div class="inner-block">
     <%= render partial: "documents/filter_results" %>
-    
+
     <div class="filter-feed">
       <%= link_to_feed filter_atom_feed_url %>
     </div>
-    
+
     <div class="filter-results" id="publications-container" aria-live="polite"><%# this class used by Javascript %>
-      
+
       <% if @filter.documents.any? %>
         <table class="document-list emphasise-recent" id="document-list"><%# this class used by Javascript %>
           <thead class="visuallyhidden">
@@ -56,7 +56,8 @@
               </td>
               <td class="publication_series attribute">
                 <% if document.part_of_series? %>
-                  Part of a series: <%= link_to document.document_series.name, organisation_document_series_path(document.document_series.organisation, document.document_series) %>
+                  Part of a series:
+                  <%= list_of_links_to_document_series(document) %>
                 <% end %>
               </td>
             <% end %>

--- a/db/migrate/20130115114312_add_edition_document_series.rb
+++ b/db/migrate/20130115114312_add_edition_document_series.rb
@@ -1,0 +1,15 @@
+class AddEditionDocumentSeries < ActiveRecord::Migration
+  def up
+    create_table :edition_document_series do |t|
+      t.references :edition, null: false
+      t.references :document_series, null: false
+    end
+    add_index(:edition_document_series,
+        [:edition_id, :document_series_id], unique: true,
+        name: "index_edition_document_series")
+  end
+
+  def down
+    drop_table :edition_document_series
+  end
+end

--- a/db/migrate/20130116105121_remove_document_series_id_from_edition.rb
+++ b/db/migrate/20130116105121_remove_document_series_id_from_edition.rb
@@ -1,0 +1,26 @@
+class RemoveDocumentSeriesIdFromEdition < ActiveRecord::Migration
+  def up
+    say "Moving document_series_id to EditionDocumentSeries"
+    editions = Edition.where(Edition.arel_table[:document_series_id].not_eq(nil))
+    total_count = editions.count
+    changed_count = 0
+    editions.find_each do |e|
+      if e.document_series_id
+        EditionDocumentSeries.create({
+            edition_id: e.id,
+            document_series_id: e.document_series_id
+          })
+        changed_count += 1
+      end
+    end
+
+    say "Editions with a document_series_id: #{total_count}"
+    say "EditionDocumentSeries num created : #{changed_count}"
+
+    remove_column :editions, :document_series_id
+  end
+
+  def down
+    add_column :editions, :document_series_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130110162911) do
+ActiveRecord::Schema.define(:version => 20130116105121) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -253,6 +253,13 @@ ActiveRecord::Schema.define(:version => 20130110162911) do
   add_index "edition_authors", ["edition_id"], :name => "index_edition_authors_on_edition_id"
   add_index "edition_authors", ["user_id"], :name => "index_edition_authors_on_user_id"
 
+  create_table "edition_document_series", :force => true do |t|
+    t.integer "edition_id",         :null => false
+    t.integer "document_series_id", :null => false
+  end
+
+  add_index "edition_document_series", ["edition_id", "document_series_id"], :name => "index_edition_document_series", :unique => true
+
   create_table "edition_mainstream_categories", :force => true do |t|
     t.integer  "edition_id"
     t.integer  "mainstream_category_id"
@@ -363,7 +370,6 @@ ActiveRecord::Schema.define(:version => 20130110162911) do
     t.string   "additional_related_mainstream_content_url"
     t.string   "additional_related_mainstream_content_title"
     t.integer  "alternative_format_provider_id"
-    t.integer  "document_series_id"
     t.integer  "published_related_publication_count",                             :default => 0,       :null => false
     t.datetime "public_timestamp"
     t.integer  "primary_mainstream_category_id"
@@ -379,7 +385,6 @@ ActiveRecord::Schema.define(:version => 20130110162911) do
 
   add_index "editions", ["alternative_format_provider_id"], :name => "index_editions_on_alternative_format_provider_id"
   add_index "editions", ["document_id"], :name => "index_editions_on_document_id"
-  add_index "editions", ["document_series_id"], :name => "index_editions_on_document_series_id"
   add_index "editions", ["first_published_at"], :name => "index_editions_on_first_published_at"
   add_index "editions", ["operational_field_id"], :name => "index_editions_on_operational_field_id"
   add_index "editions", ["policy_team_id"], :name => "index_editions_on_policy_team_id"

--- a/features/step_definitions/document_series_steps.rb
+++ b/features/step_definitions/document_series_steps.rb
@@ -49,7 +49,7 @@ end
 
 Given /^a published publication "([^"]*)" in the series "([^"]*)"$/ do |publication_name, series_name|
   series = DocumentSeries.find_by_name(series_name)
-  publication = create(:published_publication, title: publication_name, document_series: series, organisations: [series.organisation])
+  publication = create(:published_publication, title: publication_name, document_series: [series], organisations: [series.organisation])
 end
 
 Then /^I should see the publication "([^"]*)" belongs to the "([^"]*)" series$/ do |publication_name, series_name|

--- a/features/step_definitions/viewing_published_statistical_data_sets_steps.rb
+++ b/features/step_definitions/viewing_published_statistical_data_sets_steps.rb
@@ -4,12 +4,12 @@ end
 
 Given /^a published publication that's part of the "([^"]*)" document series$/ do |document_series_name|
   document_series = DocumentSeries.find_by_name!(document_series_name)
-  create(:published_publication, document_series: document_series)
+  create(:published_publication, document_series: [document_series])
 end
 
 Given /^a published statistical data set "([^"]*)" that's part of the "([^"]*)" document series$/ do |data_set_title, document_series_name|
   document_series = DocumentSeries.find_by_name!(document_series_name)
-  create(:published_statistical_data_set, title: data_set_title, document_series: document_series)
+  create(:published_statistical_data_set, title: data_set_title, document_series: [document_series])
 end
 
 Given /^a published statistical data set "([^"]*)"$/ do |data_set_title|

--- a/lib/whitehall/uploader/finders/document_series_finder.rb
+++ b/lib/whitehall/uploader/finders/document_series_finder.rb
@@ -1,8 +1,13 @@
 class Whitehall::Uploader::Finders::DocumentSeriesFinder
-  def self.find(slug, logger, line_number)
-    return if slug.blank?
-    document_series = DocumentSeries.find_by_slug(slug)
-    logger.error "Unable to find Document series with slug '#{slug}'" unless document_series
-    document_series
+  def self.find(*slugs, logger, line_number)
+    slugs = slugs.reject { |slug| slug.blank? }.uniq
+    slugs.collect do |slug|
+      if document_series = DocumentSeries.find_by_slug(slug)
+        document_series
+      else
+        logger.error "Unable to find Document series with slug '#{slug}'"
+        nil
+      end
+    end.compact
   end
 end

--- a/lib/whitehall/uploader/publication_row.rb
+++ b/lib/whitehall/uploader/publication_row.rb
@@ -19,7 +19,8 @@ module Whitehall::Uploader
       HeadingValidator.new
         .required(%w{old_url title summary body organisation})
         .multiple("policy_#", 1..4)
-        .required(%w{publication_type document_series publication_date})
+        .multiple("document_series_#", 1..4)
+        .required(%w{publication_type publication_date})
         .optional(%w{order_url price isbn urn command_paper_number}) # First attachment
         .ignored("ignore_*")
         .multiple(%w{attachment_#_url attachment_#_title}, 0..Row::ATTACHMENT_LIMIT)
@@ -66,7 +67,7 @@ module Whitehall::Uploader
     end
 
     def document_series
-      Finders::DocumentSeriesFinder.find(row['document_series'], @logger, @line_number)
+      Finders::DocumentSeriesFinder.find(row['document_series_1'], row['document_series_2'], row['document_series_3'], row['document_series_4'], @logger, @line_number)
     end
 
     def ministerial_roles
@@ -91,7 +92,7 @@ module Whitehall::Uploader
 
     def attributes
       [:title, :summary, :body, :publication_date, :publication_type,
-       :related_policies, :lead_edition_organisations, :document_series,
+       :related_policies, :lead_edition_organisations,
        :ministerial_roles, :attachments, :alternative_format_provider,
        :world_locations].map.with_object({}) do |name, result|
         result[name] = __send__(name)

--- a/test/fixtures/dft_publication_import_with_json_test.csv
+++ b/test/fixtures/dft_publication_import_with_json_test.csv
@@ -1,4 +1,4 @@
-ignore_status,old_url,title,summary,body,publication_type,policy_1,policy_2,document_series,organisation,publication_date,ignore_date,isbn,urn,command_paper_number,ignore_i,json_attachments
+ignore_status,old_url,title,summary,body,publication_type,policy_1,policy_2,document_series_1,organisation,publication_date,ignore_date,isbn,urn,command_paper_number,ignore_i,json_attachments
 new,http://www.dft.gov.uk/publications/a5m1-link-dunstable-northern-bypass,A5/M1 Link Dunstable Northern Bypass,The Secretaries' of State interim decision letter on Highways Orders following local inquiry and the inspector's report on the A5-M1 Link Dunstable Northern Bypass.,"## Summary
 
 The Secretaries' of State interim decision letter on Highways Orders following local inquiry and the inspector's report on the A5-M1 Link Dunstable Northern Bypass.

--- a/test/functional/admin/document_series_controller_test.rb
+++ b/test/functional/admin/document_series_controller_test.rb
@@ -22,9 +22,9 @@ class Admin::DocumentSeriesControllerTest < ActionController::TestCase
     organisation = create(:organisation)
 
     post :create, organisation_id: organisation, document_series: {
-      name: "series-name",
-      description: "series-description"
-    }
+          name: "series-name",
+          description: "series-description"
+        }
 
     assert_equal 1, organisation.document_series.count
     document_series = organisation.document_series.first
@@ -64,7 +64,7 @@ class Admin::DocumentSeriesControllerTest < ActionController::TestCase
   test "show lists all associated editions" do
     document_series = create(:document_series)
     organisation = document_series.organisation
-    edition = create(:published_publication, document_series: document_series)
+    edition = create(:published_publication, document_series: [document_series])
 
     get :show, organisation_id: organisation, id: document_series
 

--- a/test/functional/document_series_controller_test.rb
+++ b/test/functional/document_series_controller_test.rb
@@ -14,8 +14,8 @@ class DocumentSeriesControllerTest < ActionController::TestCase
   test 'show should display published publications within the series' do
     organisation = create(:organisation)
     series = create(:document_series, organisation: organisation)
-    publication = create(:published_publication, document_series: series)
-    draft_publication = create(:draft_publication, document_series: series)
+    publication = create(:published_publication, document_series: [series])
+    draft_publication = create(:draft_publication, document_series: [series])
 
     get :show, organisation_id: organisation, id: series
 
@@ -42,8 +42,8 @@ class DocumentSeriesControllerTest < ActionController::TestCase
   test 'show should display published statistical data sets within the series' do
     organisation = create(:organisation)
     series = create(:document_series, organisation: organisation)
-    statistical_data_set = create(:published_statistical_data_set, document_series: series)
-    draft_statistical_data_set = create(:draft_statistical_data_set, document_series: series)
+    statistical_data_set = create(:published_statistical_data_set, document_series: [series])
+    draft_statistical_data_set = create(:draft_statistical_data_set, document_series: [series])
 
     get :show, organisation_id: organisation, id: series
 
@@ -87,7 +87,7 @@ class DocumentSeriesControllerTest < ActionController::TestCase
     user = login_as(:departmental_editor)
     organisation = create(:organisation)
     series = create(:document_series, organisation: organisation)
-    publication = create(:draft_publication, document_series: series, scheduled_publication: Time.zone.now + Whitehall.default_cache_max_age * 2)
+    publication = create(:draft_publication, document_series: [series], scheduled_publication: Time.zone.now + Whitehall.default_cache_max_age * 2)
     publication.schedule_as(user, force: true)
 
     Timecop.freeze(Time.zone.now + Whitehall.default_cache_max_age * 1.5) do

--- a/test/functional/publication_filter_json_presenter_test.rb
+++ b/test/functional/publication_filter_json_presenter_test.rb
@@ -24,6 +24,7 @@ class PublicationFilterJsonPresenterTest < PresenterTestCase
     # TODO: perhaps rethink edition factory, so this apparent duplication
     # isn't neccessary
     publication.stubs(:organisations).returns([organisation])
+    publication.stubs(:document_series).returns([stub_record(:document_series, name: "test-series", organisation: organisation)])
     @filter.stubs(:documents).returns(PublicationesquePresenter.decorate([publication]))
     json = JSON.parse(PublicationFilterJsonPresenter.new(@filter).to_json)
     assert_equal 1, json['results'].size

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -132,12 +132,6 @@ class PublicationsControllerTest < ActionController::TestCase
     refute_select_object(draft_consultation)
   end
 
-  test 'index should not use n+1 selects for publications' do
-    15.times { create(:published_publication) }
-    number_of_queries = count_queries { get :index }
-    assert number_of_queries < 15
-  end
-
   test "index sets Cache-Control: max-age to the time of the next scheduled publication" do
     user = login_as(:departmental_editor)
     publication = create(:draft_publication, scheduled_publication: Time.zone.now + Whitehall.default_cache_max_age * 2)
@@ -157,7 +151,7 @@ class PublicationsControllerTest < ActionController::TestCase
       response.attachments << build(:attachment)
     end
     number_of_queries = count_queries { get :index }
-    assert number_of_queries < 17
+    assert_include 0..17, number_of_queries
   end
 
   test "index highlights selected topic filter options" do
@@ -552,7 +546,7 @@ class PublicationsControllerTest < ActionController::TestCase
   test 'index should show relevant document series information' do
     organisation = create(:organisation)
     series = create(:document_series, organisation: organisation)
-    publication = create(:published_publication, document_series: series)
+    publication = create(:published_publication, document_series: [series])
 
     get :index
 
@@ -564,7 +558,7 @@ class PublicationsControllerTest < ActionController::TestCase
   test 'index requested as JSON includes document series information' do
     organisation = create(:organisation)
     series = create(:document_series, organisation: organisation)
-    publication = create(:published_publication, document_series: series)
+    publication = create(:published_publication, document_series: [series])
 
     get :index, format: :json
 

--- a/test/functional/statistical_data_sets_controller_test.rb
+++ b/test/functional/statistical_data_sets_controller_test.rb
@@ -29,7 +29,7 @@ class StatisticalDataSetsControllerTest < ActionController::TestCase
 
   test "show links to the document series that the statistical data set belongs to" do
     document_series = create(:document_series)
-    statistical_data_set = create(:published_statistical_data_set, document_series: document_series)
+    statistical_data_set = create(:published_statistical_data_set, document_series: [document_series])
     get :show, id: statistical_data_set.document
     assert_select "a[href=?]", organisation_document_series_path(document_series.organisation, document_series)
   end

--- a/test/integration/dft_publication_import_with_json_test.rb
+++ b/test/integration/dft_publication_import_with_json_test.rb
@@ -13,6 +13,7 @@ class DftPublicationWithJsonImportTest < ActiveSupport::TestCase
     import = Import.create_from_file(creator, file, "publication", organisation.id)
     assert import.valid?, import.errors.full_messages.join(", ")
     import.perform
+
     assert_equal [], import.import_errors
 
     publication = Publication.first

--- a/test/integration/statistical_data_set_import_test.rb
+++ b/test/integration/statistical_data_set_import_test.rb
@@ -19,7 +19,7 @@ class StatisticalDataSetImportTest < ActiveSupport::TestCase
 
     assert_equal creator, statistical_data_set.creator
     assert_equal [organisation], statistical_data_set.organisations
-    assert_equal statistical_data_series, statistical_data_set.document_series
+    assert_equal [statistical_data_series], statistical_data_set.document_series
     assert_equal "http://example.com/legacy-url", statistical_data_set.document.document_sources.first.url
 
     assert_equal "!@1 !@2", statistical_data_set.body

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1585,28 +1585,42 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#edition_new" do
-          assert_select "select[name='edition[document_series_id]']"
+          assert_select "select[name='edition[document_series_ids][]']"
         end
       end
 
       test "when editing allows assignment to document series" do
         series = create(:document_series)
-        edition = create(edition_type, document_series: series)
+        edition = create(edition_type, document_series: [series])
 
         get :edit, id: edition
 
         assert_select "form#edition_edit" do
-          assert_select "select[name='edition[document_series_id]']"
+          assert_select "select[name='edition[document_series_ids][]']"
         end
       end
 
       test "shows assigned document series" do
         series = create(:document_series)
-        edition = create(edition_type, document_series: series)
+        edition = create(edition_type, document_series: [series])
 
         get :show, id: edition
 
         assert_select_object(series)
+      end
+
+      test "creating should create a new document with related document_series" do
+        series1 = create(:document_series)
+        series2 = create(:document_series)
+
+        attributes = controller_attributes_for(edition_type)
+
+        post :create, edition: attributes.merge(
+          document_series_ids: [series1.id, series2.id]
+        )
+
+        assert document = edition_class.last
+        assert_include [series1, series2], document.document_series
       end
     end
   end

--- a/test/unit/document_series_test.rb
+++ b/test/unit/document_series_test.rb
@@ -10,41 +10,41 @@ class DocumentSeriesTest < ActiveSupport::TestCase
 
   test 'should be associatable to editions' do
     series = create(:document_series)
-    publication = create(:publication, document_series: series)
+    publication = create(:publication, document_series: [series])
     assert_equal [publication], series.editions
   end
 
   test 'published_editions should return only those editions who are published' do
     series = create(:document_series)
-    draft_publication = create(:draft_publication, document_series: series)
-    published_publication = create(:published_publication, document_series: series)
+    draft_publication = create(:draft_publication, document_series: [series])
+    published_publication = create(:published_publication, document_series: [series])
     assert_equal [published_publication], series.published_editions
   end
 
   test 'published_editions should be ordered by most recent publication date first' do
     series = create(:document_series)
-    old_publication = create(:published_publication, document_series: series, publication_date: 2.days.ago)
-    new_publication = create(:published_publication, document_series: series, publication_date: 1.day.ago)
+    old_publication = create(:published_publication, document_series: [series], publication_date: 2.days.ago)
+    new_publication = create(:published_publication, document_series: [series], publication_date: 1.day.ago)
     assert_equal [new_publication, old_publication], series.published_editions
   end
 
   test 'published_publications should return published publications' do
     series = create(:document_series)
-    published_publication = create(:published_publication, document_series: series)
-    draft_publication = create(:draft_publication, document_series: series)
+    published_publication = create(:published_publication, document_series: [series])
+    draft_publication = create(:draft_publication, document_series: [series])
     assert_equal [published_publication], series.published_publications
   end
 
   test 'published_statistical_data_sets should return published statistical data sets' do
     series = create(:document_series)
-    published_statistical_data_set = create(:published_statistical_data_set, document_series: series)
-    draft_statistical_data_set = create(:draft_statistical_data_set, document_series: series)
+    published_statistical_data_set = create(:published_statistical_data_set, document_series: [series])
+    draft_statistical_data_set = create(:draft_statistical_data_set, document_series: [series])
     assert_equal [published_statistical_data_set], series.published_statistical_data_sets
   end
 
   test 'should not be destroyable if editions are associated' do
     series = create(:document_series)
-    publication = create(:draft_publication, document_series: series)
+    publication = create(:draft_publication, document_series: [series])
     series.destroy
     assert DocumentSeries.find(series.id)
   end

--- a/test/unit/publicationesque_presenter_test.rb
+++ b/test/unit/publicationesque_presenter_test.rb
@@ -21,7 +21,7 @@ class PublicationesquePresenterTest < ActiveSupport::TestCase
   end
 
   test "should indicate when publication is part of a series" do
-    publication = build(:publication, document_series: build(:document_series))
+    publication = build(:publication, document_series: [build(:document_series)])
     presenter = PublicationesquePresenter.decorate(publication)
     assert presenter.part_of_series?
   end
@@ -33,7 +33,7 @@ class PublicationesquePresenterTest < ActiveSupport::TestCase
   end
 
   test "should indicate when publication is not part of a series" do
-    publication = build(:publication, document_series: nil)
+    publication = build(:publication)
     presenter = PublicationesquePresenter.decorate(publication)
     refute presenter.part_of_series?
   end

--- a/test/unit/uploader/finders/document_series_finder_test.rb
+++ b/test/unit/uploader/finders/document_series_finder_test.rb
@@ -9,11 +9,11 @@ class Whitehall::Uploader::Finders::DocumentSeriesFinderTest < ActiveSupport::Te
 
   test "returns the document series identified by slug" do
     document_series = create(:document_series)
-    assert_equal document_series, Whitehall::Uploader::Finders::DocumentSeriesFinder.find(document_series.slug, @log, @line_number)
+    assert_equal [document_series], Whitehall::Uploader::Finders::DocumentSeriesFinder.find(document_series.slug, @log, @line_number)
   end
 
-  test "returns nil if the slug is blank" do
-    assert_equal nil, Whitehall::Uploader::Finders::DocumentSeriesFinder.find('', @log, @line_number)
+  test "returns empty array if the slug is blank" do
+    assert_equal [], Whitehall::Uploader::Finders::DocumentSeriesFinder.find('', @log, @line_number)
   end
 
   test "does not add an error if the slug is blank" do
@@ -21,8 +21,8 @@ class Whitehall::Uploader::Finders::DocumentSeriesFinderTest < ActiveSupport::Te
     assert_equal '', @log_buffer.string
   end
 
-  test "returns nil if the document series can't be found" do
-    assert_equal nil, Whitehall::Uploader::Finders::DocumentSeriesFinder.find('made-up-document-series-slug', @log, @line_number)
+  test "returns empty array if the document series can't be found" do
+    assert_equal [], Whitehall::Uploader::Finders::DocumentSeriesFinder.find('made-up-document-series-slug', @log, @line_number)
   end
 
   test "logs a warning if the document series can't be found" do

--- a/test/unit/uploader/publication_row_test.rb
+++ b/test/unit/uploader/publication_row_test.rb
@@ -17,7 +17,8 @@ class Whitehall::Uploader::PublicationRowTest < ActiveSupport::TestCase
   def basic_headings
     %w{old_url  title summary body  publication_type
       policy_1  policy_2  policy_3  policy_4
-      organisation  document_series publication_date
+      organisation  document_series_1 document_series_2
+      document_series_3 document_series_4 publication_date
       order_url price ISBN  URN command_paper_number
       country_1 country_2 country_3 country_4}
   end
@@ -70,8 +71,8 @@ class Whitehall::Uploader::PublicationRowTest < ActiveSupport::TestCase
 
   test "finds document series by slug in doc_series column" do
     document_series = create(:document_series)
-    row = new_publication_row({"document_series" => document_series.slug})
-    assert_equal document_series, row.document_series
+    row = new_publication_row({"document_series_1" => document_series.slug})
+    assert_equal [document_series], row.document_series
   end
 
   test "finds publication type by slug in the pub type column" do
@@ -131,7 +132,7 @@ class Whitehall::Uploader::PublicationRowTest < ActiveSupport::TestCase
 
     row = new_publication_row({
       "attachment_1_title" => "first title",
-      "attachment_1_url" => "http://example.com/attachment.pdf" 
+      "attachment_1_url" => "http://example.com/attachment.pdf"
     }, Logger.new(StringIO.new))
 
     attachment = Attachment.new(title: "first title")


### PR DESCRIPTION
Added join model, modified the tests and associations. 

Importer changes: document_series is no longer an attribute
should use the followin in csv's instead document_series_1,
document_series_2, document_series_3, document_series_4

Removed the n+1 test after conversations with David about it's usefulness and because we use Publicationesque in the search and only publications have document series, there has to be an additional query to fetch a publication's  document_series
