### PR TITLE
Override default whenever Rake/Runner task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,11 @@
 $: << '.'
 require File.dirname(__FILE__) + "/initializers/scheduled_publishing"
 
+# We need Rake to use our own environment
+job_type :rake, "cd :path && govuk_setenv whitehall bundle exec rake :task --silent :output"
+# We need Rails to use our own environment
+job_type :runner, "cd :path && govuk_setenv whitehall script/rails runner -e :environment ':task' :output"
+
 # Run every SCHEDULED_PUBLISHING_PRECISION_IN_MINUTES minutes, 2 minutes before the due moment
 # this allows the the ruby process (and rails) time to boot up. The scheduler then sleeps until
 # the edition is due


### PR DESCRIPTION
We need the environment to be set up the way the apps have it, i.e via `govuk_setenv`. This overrides the default Rake and Runner tasks within the schedule.rb itself - it may be better to do this in an initialiser so we can vary based on deploy.
