### PR TITLE
Add `first_published_at` field to detailed guides

### DIFF
--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -26,4 +26,6 @@
   </fieldset>
 
   <%= render partial: 'nation_fields', locals: { form: form, edition: edition } %>
+
+  <%= render partial: 'first_published_at', locals: { form: form, edition: edition } %>
 <% end %>

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -34,6 +34,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_association_with_related_mainstream_content :detailed_guide
   should_allow_alternative_format_provider_for :detailed_guide
   should_allow_scheduled_publication_of :detailed_guide
+  should_allow_overriding_of_first_published_at_for :detailed_guide
 
   test "new allows selection of mainstream categories" do
     funk = create(:mainstream_category,


### PR DESCRIPTION
This will let users edit the first published at date. This will stop detailed guides showing up in the latest box on an org. 

https://www.pivotaltracker.com/story/show/41218399
