### PR TITLE
Set the correct PATH for whenever cronjobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,7 @@
 $: << '.'
 require File.dirname(__FILE__) + "/initializers/scheduled_publishing"
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
 
 # We need Rake to use our own environment
 job_type :rake, "cd :path && govuk_setenv whitehall bundle exec rake :task --silent :output"


### PR DESCRIPTION
The default path for cron is `/usr/bin:/bin` so it cannot find scripts in `/usr/local/bin` which is unfortunately where govuk_setenv lives. This change (as per https://gist.github.com/950975) sets PATH for whevener in schedule.rb
