### PR TITLE
Atom feed entries should have consistent IDs

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -13,10 +13,29 @@ module FeedHelper
     builder.updated feed_updated_timestamp
 
     documents.each do |document|
-      builder.entry(document, url: public_document_url(document), published: document.first_public_at, updated: document.public_timestamp) do |entry|
+      builder.entry(document, id: document_id(document, builder), url: public_document_url(document), published: document.first_public_at, updated: document.public_timestamp) do |entry|
         document_as_feed_entry(document, builder, govdelivery_version)
       end
     end
+  end
+
+  def document_id(record, builder)
+    # This slightly clunky logic is to give entries a consistent ID -
+    # the default `record.id` is the latest edition, which means the
+    # entries would get a new ID for each version, which breaks the
+    # spec.
+    # The interpolation logic is straight out of:
+    # http://api.rubyonrails.org/classes/ActionView/Helpers/AtomFeedHelper/AtomFeedBuilder.html#method-i-entry
+    id = record.document ? record.document.id : record.id
+    "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
+  end
+
+  def schema_date(builder)
+    builder.instance_variable_get(:@feed_options)[:schema_date]
+  end
+
+  def host
+    request.host
   end
 
   def document_as_feed_entry(document, builder, govdelivery_version = false)

--- a/test/unit/helpers/feed_helper_test.rb
+++ b/test/unit/helpers/feed_helper_test.rb
@@ -5,6 +5,14 @@ class FeedHelperTest < ActionView::TestCase
   # include this just so public_document_url can be stubbed later
   include PublicDocumentRoutesHelper
 
+  def host
+    "test.dev.gov.uk"
+  end
+
+  def schema_date(_)
+    '2005'
+  end
+
   test 'feed_wants_govdelivery_version? is false when there is no govdelivery_version param' do
     stubs(:params).returns({})
     refute feed_wants_govdelivery_version?
@@ -47,8 +55,8 @@ class FeedHelperTest < ActionView::TestCase
     builder = mock('builder')
     entries = sequence('entries')
     builder.stubs(:updated)
-    builder.expects(:entry).with(d2, url: '/policy_url', published: 2.weeks.ago, updated: 13.days.ago).yields(builder).in_sequence(entries)
-    builder.expects(:entry).with(d1, url: '/publication_url', published: 1.week.ago, updated: 3.days.ago).yields(builder).in_sequence(entries)
+    builder.expects(:entry).with(d2, id: 'tag:test.dev.gov.uk,2005:Policy/14', url: '/policy_url', published: 2.weeks.ago, updated: 13.days.ago).yields(builder).in_sequence(entries)
+    builder.expects(:entry).with(d1, id: 'tag:test.dev.gov.uk,2005:Publication/12', url: '/publication_url', published: 1.week.ago, updated: 3.days.ago).yields(builder).in_sequence(entries)
     feed_entry = sequence('feed_entry')
     expects(:document_as_feed_entry).with(d2, builder, false).in_sequence(feed_entry)
     expects(:document_as_feed_entry).with(d1, builder, false).in_sequence(feed_entry)
@@ -108,5 +116,15 @@ class FeedHelperTest < ActionView::TestCase
     builder.stubs(:summary)
     builder.stubs(:content)
     document_as_feed_entry(document, builder, true)
+  end
+
+  test 'document_id sets ID as the original document ID when available' do
+    d = Publication.new
+    d.stubs(:id).returns('4')
+    doc = Document.new
+    doc.stubs(:id).returns('33')
+    d.stubs(:document).returns(doc)
+
+    assert_equal document_id(d, nil), 'tag:test.dev.gov.uk,2005:Publication/33'
   end
 end


### PR DESCRIPTION
Because of the way we provide and sort objects for Atom feeds, the
Edition is what turns up in the builder. This provides an inconsistent
atom:id as it's based on the record's primary key, which will obviously
change from version to version.

These changes should keep the atom:id stable across new versions.
