### PR TITLE
Make feeds validate and add change note to entries

### DIFF
--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -202,12 +202,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index, format: :atom, departments: [org.to_param]
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 1 do |entries|
-        entries.zip([news]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.body}/
-        end
-      end
+      assert_select_atom_entries([news])
     end
   end
 
@@ -220,12 +215,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index, format: :atom, departments: [org.to_param], govdelivery_version: 'on'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 1 do |entries|
-        entries.zip([news]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: document.summary
-        end
-      end
+      assert_select_atom_entries([news], :summary)
     end
   end
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -20,12 +20,7 @@ class HomeControllerTest < ActionController::TestCase
       assert_select 'feed > link[rel=?][type=?][href=?]', 'self', 'application/atom+xml', atom_feed_url(format: :atom), 1
       assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', root_url, 1
 
-      assert_select 'feed > entry' do |entries|
-        entries.each do |entry|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', 1
-        end
-      end
+      assert_select_atom_entries([document])
     end
   end
 
@@ -42,12 +37,7 @@ class HomeControllerTest < ActionController::TestCase
     assert_select_atom_feed do
       assert_select 'feed > updated', text: recent_documents.first.public_timestamp.iso8601
 
-      assert_select 'feed > entry' do |entries|
-        entries.zip(recent_documents) do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.body}/
-        end
-      end
+      assert_select_atom_entries(recent_documents)
     end
   end
 
@@ -64,12 +54,7 @@ class HomeControllerTest < ActionController::TestCase
     assert_select_atom_feed do
       assert_select 'feed > updated', text: recent_documents.first.public_timestamp.iso8601
 
-      assert_select 'feed > entry' do |entries|
-        entries.zip(recent_documents) do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: document.summary
-        end
-      end
+      assert_select_atom_entries(recent_documents, :summary)
     end
   end
 

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -119,12 +119,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     get :show, format: :atom, id: ministerial_role
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |actual_entries|
-        expected_entries.zip(actual_entries).each do |expected, actual_entry|
-          assert_select_atom_entry actual_entry, expected
-          assert_select actual_entry, 'entry > content[type=?]', 'html', count: 1, text: /#{expected.body}/
-        end
-      end
+      assert_select_atom_entries(expected_entries)
     end
   end
 
@@ -139,12 +134,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     get :show, format: :atom, id: ministerial_role, govdelivery_version: 'true'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |actual_entries|
-        expected_entries.zip(actual_entries).each do |expected, actual_entry|
-          assert_select_atom_entry actual_entry, expected
-          assert_select actual_entry, 'entry > content[type=?]', 'text', count: 1, text: expected.summary
-        end
-      end
+      assert_select_atom_entries(expected_entries, :summary)
     end
   end
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -499,12 +499,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     get :show, id: organisation, format: :atom
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([pol, pub]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.body}/
-        end
-      end
+      assert_select_atom_entries([pol, pub])
     end
   end
 
@@ -516,12 +511,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     get :show, id: organisation, format: :atom, govdelivery_version: 'true'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([pol, pub]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: document.summary
-        end
-      end
+      assert_select_atom_entries([pol, pub], :summary)
     end
   end
 

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -158,12 +158,7 @@ class PeopleControllerAtomFeedTest < ActionController::TestCase
     get :show, format: :atom, id: person
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |actual_entries|
-        expected_entries.zip(actual_entries).each do |expected, entry|
-          assert_select_atom_entry entry, expected
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{expected.body}/
-        end
-      end
+      assert_select_atom_entries(expected_entries)
     end
   end
 
@@ -178,12 +173,7 @@ class PeopleControllerAtomFeedTest < ActionController::TestCase
     get :show, format: :atom, id: person, govdelivery_version: '1'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |actual_entries|
-        expected_entries.zip(actual_entries).each do |expected, entry|
-          assert_select_atom_entry entry, expected
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: expected.summary
-        end
-      end
+      assert_select_atom_entries(expected_entries, :summary)
     end
   end
 end

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -429,12 +429,7 @@ That's all
       assert_select 'feed > updated', consultation.public_timestamp.iso8601
       assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', activity_policy_url(policy.document), 1
 
-      assert_select 'feed > entry' do |entries|
-        entries.zip([consultation, speech, news_article, publication]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content', text: Builder::XChar.encode(@controller.view_context.govspeak_edition_to_html(document))
-        end
-      end
+      assert_select_atom_entries([consultation, speech, news_article, publication])
     end
   end
 
@@ -453,12 +448,7 @@ That's all
       assert_select 'feed > updated', consultation.public_timestamp.iso8601
       assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', activity_policy_url(policy.document), 1
 
-      assert_select 'feed > entry' do |entries|
-        entries.zip([consultation, speech, news_article, publication]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content', text: document.summary
-        end
-      end
+      assert_select_atom_entries([consultation, speech, news_article, publication], :summary)
     end
   end
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -413,12 +413,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index, format: :atom, departments: [org.to_param]
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([c1, p1]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.body}/
-        end
-      end
+      assert_select_atom_entries([c1, p1])
     end
   end
 
@@ -432,12 +427,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index, format: :atom, departments: [org.to_param], govdelivery_version: 'yes'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([c1, p1]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: document.summary
-        end
-      end
+      assert_select_atom_entries([c1, p1], :summary)
     end
   end
 
@@ -450,12 +440,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index, format: :atom, departments: [org.to_param]
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 1 do |entries|
-        entries.each do |entry|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', 1
-        end
-      end
+      assert_select_atom_entries([document])
     end
   end
 

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -65,12 +65,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     get :show, id: world_location, format: :atom
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([pol, pub]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.body}/
-        end
-      end
+      assert_select_atom_entries([pol, pub])
     end
   end
 
@@ -82,12 +77,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     get :show, id: world_location, format: :atom, govdelivery_version: 'on'
 
     assert_select_atom_feed do
-      assert_select 'feed > entry', count: 2 do |entries|
-        entries.zip([pol, pub]).each do |entry, document|
-          assert_select_atom_entry entry, document
-          assert_select entry, 'entry > content[type=?]', 'text', count: 1, text: document.summary
-        end
-      end
+      assert_select_atom_entries([pol, pub], :summary)
     end
   end
 

--- a/test/support/atom_test_helpers.rb
+++ b/test/support/atom_test_helpers.rb
@@ -7,14 +7,19 @@ module AtomTestHelpers
     assert_select 'head > link[rel=?][type=?][href=?]', 'alternate', 'application/atom+xml', ERB::Util.html_escape(url)
   end
 
-  def assert_select_atom_entry(entry, document)
-    assert_select entry, 'entry > id', 1
-    assert_select entry, 'entry > published', count: 1, text: document.first_public_at.iso8601
-    assert_select entry, 'entry > updated', count: 1, text: document.public_timestamp.iso8601
-    assert_select entry, 'entry > link[rel=?][type=?][href=?]', 'alternate', 'text/html', public_document_url(document)
-    assert_select entry, 'entry > title', count: 1, text: "#{document.display_type}: #{document.title}"
-    assert_select entry, 'entry > summary', count: 1, text: document.summary
-    assert_select entry, 'entry > category', count: 1, text: document.display_type
+  def assert_select_atom_entries(documents, content_attribute = :body)
+    assert_select 'feed > entry', count: documents.length do |entries|
+      entries.zip(documents).each do |entry, document|
+        assert_select entry, 'entry > id', 1
+        assert_select entry, 'entry > published', count: 1, text: document.first_public_at.iso8601
+        assert_select entry, 'entry > updated', count: 1, text: document.public_timestamp.iso8601
+        assert_select entry, 'entry > link[rel=?][type=?][href=?]', 'alternate', 'text/html', public_document_url(document)
+        assert_select entry, 'entry > title', count: 1, text: "#{document.display_type}: #{document.title}"
+        assert_select entry, 'entry > summary', count: 1, text: document.summary
+        assert_select entry, 'entry > category', count: 1, label: document.display_type, term: document.display_type
+        assert_select entry, 'entry > content[type=?]', 'html', count: 1, text: /#{document.send(content_attribute)}/
+      end
+    end
   end
 
 end


### PR DESCRIPTION
- Feeds were not valdating due to us incorrectly sending categories with
  entries. The correct way is to use an attribute on a category element
  not put the value in the element.
- Add a change note if there is one to the entry body. For this it was
  needed to send the govdelivery version as html rather than text as the
  atom spec lets parsers remove whitespace in the content tag.
- Having the content always go as HTML enabled reducing the test logic
  in each of the tests and moving more into the helper method. This
  makes the tests slightly cleaner to look at.
