### PR TITLE
Add Org acronyms to select drop downs in admin

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -76,7 +76,7 @@ module Admin::EditionsHelper
     def edition_organisations_fields(edition_organisations, lead = true)
       field_identifier = lead ? 'lead' : 'supporting'
       edition_organisations.map.with_index do |eo, idx|
-        select_options = @template.options_from_collection_for_select(Organisation.all, 'id', 'name', eo.organisation_id)
+        select_options = @template.options_from_collection_for_select(Organisation.all, 'id', 'select_name', eo.organisation_id)
         @template.label_tag "edition_edition_organisations_attributes_organisation_id_#{field_identifier}_#{idx}" do
           [
             "Organisation #{idx + 1}",

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -213,6 +213,10 @@ class Organisation < ActiveRecord::Base
     [acronym, name].find { |s| s.present? }
   end
 
+  def select_name
+    [name, ("(#{acronym})" if acronym.present?)].compact.join(' ')
+  end
+
   def search_link
     # This should be organisation_path(self), but we can't use that because friendly_id's #to_param returns
     # the old value of the slug (e.g. nil for a new record) if the record is dirty, and apparently the record

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -41,7 +41,7 @@
 
           <li class="organisation-filter <%= (params[:organisation] && params[:organisation] != current_user.organisation_id) ? 'active' : nil %>">
             <%= form_tag("", method: :get) do %>
-              <%= select_tag :organisation, options_from_collection_for_select(Organisation.all - [current_user.organisation], 'id', 'name', params[:organisation]), class: 'chzn-select', include_blank: true, data: { placeholder: "Other organisations..." } %>
+              <%= select_tag :organisation, options_from_collection_for_select(Organisation.all - [current_user.organisation], 'id', 'select_name', params[:organisation]), class: 'chzn-select', include_blank: true, data: { placeholder: "Other organisations..." } %>
               <%= hidden_field_tag :type, params[:type] if params[:type] %>
               <%= hidden_field_tag :state, params[:state] if params[:state] %>
               <%= submit_tag "Go", class: "btn" %>

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -446,6 +446,11 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal 'Blah blah', build(:organisation, acronym: '', name: 'Blah blah').display_name
   end
 
+  test 'select_name should use full name and acronym if present or not if not' do
+    assert_equal 'Name (Blah)', build(:organisation, acronym: 'Blah', name: 'Name').select_name
+    assert_equal 'Name', build(:organisation, acronym: '', name: 'Name').select_name
+  end
+
   test "should be destroyable when there are no associated people/child orgs/roles" do
     organisation = create(:organisation)
     assert organisation.destroyable?


### PR DESCRIPTION
This will make the chosen interface much more usable as you can type
'MOD' rather the full name.
