### PR TITLE
Bump gds-api-adapters for pagination and redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'lograge'
 gem 'unicorn'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '4.1.3'
+gem 'gds-api-adapters', '4.3.0'
 gem 'whenever', '0.7.3', require: false
 gem 'mini_magick'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,10 +132,12 @@ GEM
       ruby-hmac
     formatador (0.2.1)
     friendly_id (4.0.0.beta14)
-    gds-api-adapters (4.1.3)
+    gds-api-adapters (4.3.0)
+      link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rest-client (~> 1.6.3)
     gds-sso (3.0.0)
       omniauth-gds (= 0.0.3)
       rack-accept (~> 0.4.4)
@@ -180,6 +182,7 @@ GEM
     libwebsocket (0.1.7.1)
       addressable
       websocket
+    link_header (0.0.5)
     lograge (0.0.6)
       actionpack
       activesupport
@@ -386,7 +389,7 @@ DEPENDENCIES
   faker
   fog
   friendly_id (= 4.0.0.beta14)
-  gds-api-adapters (= 4.1.3)
+  gds-api-adapters (= 4.3.0)
   gds-sso (= 3.0.0)
   govspeak (~> 1.2.3)
   govuk_frontend_toolkit (= 0.12.1)


### PR DESCRIPTION
Two main new features: the ability to traverse paginated responses in the content API and the ability to follow redirect responses from services, so we can change URLs in services without needing an immediate version bump in every application.

See [the GitHub comparison](https://github.com/alphagov/gds-api-adapters/compare/v4.1.3...v4.3.0) for full changes.
