### PR TITLE
Remove about field from world locations

### DIFF
--- a/app/views/world_locations/about.html.erb
+++ b/app/views/world_locations/about.html.erb
@@ -24,18 +24,4 @@
       </div>
     </div>
   </div>
-
-  <div class="block-3">
-    <div class="inner-block">
-      <div class="document_page">
-        <div class="document_view">
-          <article class="document">
-            <div class="body">
-              <%= govspeak_to_html @world_location.about %>
-            </div>
-          </article>
-        </div>
-      </div>
-    </div>
-  </div>
 <% end %>

--- a/db/migrate/20130204133738_remove_about_from_world_location.rb
+++ b/db/migrate/20130204133738_remove_about_from_world_location.rb
@@ -1,0 +1,9 @@
+class RemoveAboutFromWorldLocation < ActiveRecord::Migration
+  def up
+    remove_column :world_locations, :about
+  end
+
+  def down
+    add_column :world_locations, :about, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130131111958) do
+ActiveRecord::Schema.define(:version => 20130204133738) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -788,7 +788,6 @@ ActiveRecord::Schema.define(:version => 20130131111958) do
     t.string   "embassy_email"
     t.string   "slug"
     t.text     "description"
-    t.text     "about"
     t.boolean  "active",                 :default => false, :null => false
     t.integer  "world_location_type_id",                    :null => false
   end

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -20,10 +20,9 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
   test 'updating should modify the world location' do
     world_location = create(:world_location)
 
-    put :update, id: world_location, world_location: { description: 'country-description', about: 'country-about' }
+    put :update, id: world_location, world_location: { description: 'country-description' }
 
     world_location.reload
     assert_equal 'country-description', world_location.description
-    assert_equal 'country-about', world_location.about
   end
 end

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -70,26 +70,13 @@ class WorldLocationsControllerTest < ActionController::TestCase
   test "should display an about page for the world location" do
     world_location = create(:world_location,
       name: "country-name",
-      about: "country-about"
+      description: "country-about"
     )
 
     get :about, id: world_location
 
     assert_select ".page_title", text: "country-name"
-    assert_select ".body", text: "country-about"
-  end
-
-  test "should render the about content using govspeak markup" do
-    world_location = create(:world_location,
-      name: "country-name",
-      about: "body-in-govspeak"
-    )
-
-    govspeak_transformation_fixture "body-in-govspeak" => "body-in-html" do
-      get :about, id: world_location
-    end
-
-    assert_select ".body", text: "body-in-html"
+    assert_select ".description", text: "country-about"
   end
 
   test "shows featured items in defined order" do

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class WorldLocationTest < ActiveSupport::TestCase
-  should_protect_against_xss_and_content_attacks_on :name, :about
+  should_protect_against_xss_and_content_attacks_on :name
 
   test 'should be invalid without a name' do
     world_location = build(:world_location, name: nil)


### PR DESCRIPTION
Left the location/about page intact as it was not part of the story.
