### PR TITLE
Rename world location description => mission statement.

### DIFF
--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_for([:admin, @world_location]) do |form| %>
       <%= form.label :world_location_type_id, 'Type' %>
       <%= form.select :world_location_type_id, options_from_collection_for_select(WorldLocationType.all, :id, :name, form.object.world_location_type_id) %>
-      <%= form.text_area :description %>
+      <%= form.text_area :mission_statement %>
 
       <%= form.check_box :active,
                 label_text: "Active (can visitors click through from the world location list?)" %>

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -39,7 +39,7 @@
       <section class="article-section">
         <h1 class="keyline-header">Our mission</h1>
         <p>
-          <span class="description"><%= format_with_html_line_breaks(@world_location.description) %></span>
+          <span class="mission_statement"><%= format_with_html_line_breaks(@world_location.mission_statement) %></span>
         </p>
       </section>
     </div>

--- a/db/migrate/20130207090657_rename_world_location_description_to_mission_statement.rb
+++ b/db/migrate/20130207090657_rename_world_location_description_to_mission_statement.rb
@@ -1,0 +1,5 @@
+class RenameWorldLocationDescriptionToMissionStatement < ActiveRecord::Migration
+  def change
+    rename_column :world_locations, :description, :mission_statement
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130204133738) do
+ActiveRecord::Schema.define(:version => 20130207090657) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -798,7 +798,7 @@ ActiveRecord::Schema.define(:version => 20130204133738) do
     t.string   "embassy_telephone"
     t.string   "embassy_email"
     t.string   "slug"
-    t.text     "description"
+    t.text     "mission_statement"
     t.boolean  "active",                              :default => false, :null => false
     t.integer  "world_location_type_id",                                 :null => false
     t.string   "iso2",                   :limit => 2

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -23,16 +23,16 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
     get :edit, id: world_location
 
     assert_template 'world_locations/edit'
-    assert_select "textarea[name='world_location[description]']"
+    assert_select "textarea[name='world_location[mission_statement]']"
     assert_select '#govspeak_help'
   end
 
   test 'updating should modify the world location' do
     world_location = create(:world_location)
 
-    put :update, id: world_location, world_location: { description: 'country-description' }
+    put :update, id: world_location, world_location: { mission_statement: 'country-mission-statement' }
 
     world_location.reload
-    assert_equal 'country-description', world_location.description
+    assert_equal 'country-mission-statement', world_location.mission_statement
   end
 end

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -21,22 +21,22 @@ class WorldLocationsControllerTest < ActionController::TestCase
     end
   end
 
-  test "should display world location name and description" do
+  test "should display world location name and mission-statement" do
     world_location = create(:world_location,
       name: "country-name",
-      description: "country-description"
+      mission_statement: "country-mission-statement"
     )
     get :show, id: world_location
     assert_select ".name", text: "UK and country-name"
-    assert_select ".description", text: "country-description"
+    assert_select ".mission_statement", text: "country-mission-statement"
   end
 
-  test "should use html line breaks when displaying the description" do
-    world_location = create(:world_location, description: "Line 1\nLine 2")
+  test "should use html line breaks when displaying the mission_statement" do
+    world_location = create(:world_location, mission_statement: "Line 1\nLine 2")
     get :show, id: world_location
-    assert_select ".description", /Line 1/
-    assert_select ".description", /Line 2/
-    assert_select ".description br", count: 1
+    assert_select ".mission_statement", /Line 1/
+    assert_select ".mission_statement", /Line 2/
+    assert_select ".mission_statement br", count: 1
   end
 
   test 'show has atom feed autodiscovery link' do

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class WorldLocationTest < ActiveSupport::TestCase
-  should_protect_against_xss_and_content_attacks_on :name
+  should_protect_against_xss_and_content_attacks_on :name, :mission_statement
 
   test 'should be invalid without a name' do
     world_location = build(:world_location, name: nil)


### PR DESCRIPTION
In the public interface, the information is presented under the
title 'Our Mission'.  Calling it the description in the admin
interface and model is inconsistent.

I went with mission statement as a name, because that's what
Ross had called it in an email to me.

Bonus feature: Added xss protection to the mission statement
