### PR TITLE
Remove whitespace between link and full stop on organisation pages

### DIFF
--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -48,10 +48,10 @@
                 supported by
                 <% agencies_and_public_bodies_count = @organisation.agencies_and_public_bodies.count %>
                 <% if agencies_and_public_bodies_count == 1 %>
-                  <%= link_to "#{agencies_and_public_bodies_count} public body", organisations_path(anchor: @organisation.slug) %>
+                  <%= link_to "#{agencies_and_public_bodies_count} public body", organisations_path(anchor: @organisation.slug) %>.
                 <% else %>
-                  <%= link_to "#{agencies_and_public_bodies_count} agencies and public bodies", organisations_path(anchor: @organisation.slug) %>
-                <% end %><% end %>.
+                  <%= link_to "#{agencies_and_public_bodies_count} agencies and public bodies", organisations_path(anchor: @organisation.slug) %>.
+                <% end %><% end %>
             </p>
             <p><%= link_to "Read more about what we do", about_organisation_path(@organisation) %></p>
           <% end %>


### PR DESCRIPTION
With the right (wrong) spacing and line length, this full stop can end
up on a separate line, right in the middle of the organisation page. For example, on the [BIS organisation page](https://www.gov.uk/government/organisations/department-for-business-innovation-skills):

![Screen Shot 2013-02-12 at 16 00 30](https://f.cloud.github.com/assets/32775/152336/2c53ae58-75c0-11e2-843c-1e18dd9b3359.png)
