### PR TITLE
Force all requests to appear remote in production

### DIFF
--- a/config/initializers/all_requests_remote.rb
+++ b/config/initializers/all_requests_remote.rb
@@ -1,0 +1,16 @@
+# Rails <3.2.0 will render debug pages in production to requests it considers local.
+# Our production stack makes all requests appear local.
+# This monkeypatch forces all requests to appear remote.
+# 
+# The relevant problem code is here (we want it to use "rescue_action_in_public",
+# but instead it uses "rescue_action_locally"):
+# https://github.com/rails/rails/blob/v3.1.11/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L68
+if Rails.env.production?
+  module ActionDispatch
+    class Request
+      def local?
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
We discovered some time ago that Whitehall was serving up debug pages for errors in production.

@nickstenning addressed this by having nginx rewrite response bodies for 4xx/5xx responses. This isn't ideal because it means any semantic 4xx/5xx response body is lost.

This change removes the need for that.
