### PR TITLE
Moved validation for first_published_at for news

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -425,6 +425,7 @@ class Edition < ActiveRecord::Base
   def errors_as_draft
     if imported?
       begin
+        self.apply_any_extra_validations_when_converting_from_imported_to_draft
         self.try_draft
         return valid? ? [] : errors
       ensure
@@ -433,6 +434,9 @@ class Edition < ActiveRecord::Base
     else
       valid? ? [] : errors
     end
+  end
+
+  def apply_any_extra_validations_when_converting_from_imported_to_draft
   end
 
   def set_public_timestamp

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -3,7 +3,6 @@ class NewsArticle < Announcement
   include Edition::FactCheckable
   include Edition::FirstImagePulledOut
 
-  validates :first_published_at, presence: true, unless: ->(edition) { edition.can_have_some_invalid_data? }
   validates :news_article_type_id, presence: true
   validate :only_news_article_allowed_invalid_data_can_be_awaiting_type
 
@@ -29,6 +28,12 @@ class NewsArticle < Announcement
 
   def can_apply_to_local_government?
     true
+  end
+
+  def apply_any_extra_validations_when_converting_from_imported_to_draft
+    class << self
+      validates :first_published_at, presence: true
+    end
   end
 
   private

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -90,7 +90,6 @@ module DocumentHelper
 
   def fill_in_news_article_fields
     select "News story", from: "News article type"
-    select_date "First published at", with: '2010-01-01'
   end
 
   def fill_in_publication_fields

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     summary "news-summary"
     body  "news-body"
     news_article_type {NewsArticleType::PressRelease}
-    first_published_at { 1.day.ago }
   end
 
   factory :imported_news_article, parent: :news_article, traits: [:imported]

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -65,14 +65,14 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert news_article.valid?
   end
 
+  test 'imported news article are not valid_as_draft? when the first_published_at is blank, but draft articles are' do
+    refute build(:news_article, state: 'imported', first_published_at: nil).valid_as_draft?
+    assert build(:news_article, state: 'draft', first_published_at: nil).valid_as_draft?
+  end
+
   [:draft, :scheduled, :published, :archived, :submitted, :rejected].each do |state|
     test "#{state} news article is not valid when the news article type is 'imported-awaiting-type'" do
       news_article = build(:news_article, state: state, news_article_type: NewsArticleType.find_by_slug('imported-awaiting-type'))
-      refute news_article.valid?
-    end
-
-    test "#{state} news article is not valid when the first_published_at is blank" do
-      news_article = build(:news_article, state: state, first_published_at: nil)
       refute news_article.valid?
     end
   end


### PR DESCRIPTION
Instead of requiring first_published_at for draft news articles, we now
no longer require it, but make it a requirement for imported news
articles before they go to draft, using a new set of validations which
are only used for this step.

This allows us to support two parallel workflows (importing news, and
creating brand new news) which have slightly different validation
semantics.

Story: https://www.pivotaltracker.com/story/show/44021041
