### PR TITLE
Add a whip check method on ministerial_role.rb

### DIFF
--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -6,6 +6,8 @@ class MinisterialRolesController < PublicFacingController
     }
     ministerial_department_type = OrganisationType.find_by_name('Ministerial department')
 
+    @whip_organisations = Whitehall::WhipOrganisation.all.map{|wo| [ wo, [] ]}
+
     @ministerial_roles_by_organisation = Organisation.includes(ministerial_role_appointments: [:role, :person]).merge(RoleAppointment.current).where(organisation_type_id: ministerial_department_type).map do |organisation|
       [
         organisation,
@@ -13,12 +15,24 @@ class MinisterialRolesController < PublicFacingController
           # This select is needed due to ActiveRecord not adding a `where type`
           # to the role query. Rejecting the extra objects seems nicer than
           # suffereing from n+1 queries to load in the people and roles.
-          appointment.role.is_a? MinisterialRole
+          if appointment.role.is_a?(MinisterialRole) && !Whitehall::WhipOrganisation.role_is_a_whip?(appointment.role)
+            appointment
+          elsif Whitehall::WhipOrganisation.role_is_a_whip?(appointment.role)
+            @whip_organisations.each_with_index do |wo, i|
+               if Whitehall::WhipOrganisation.whip_org_for_role(appointment.role).include?(wo[0])
+                @whip_organisations[i][1] << RoleAppointmentPresenter.decorate(appointment)
+              end
+            end
+            nil
+          end
         }.map { |appointment|
           RoleAppointmentPresenter.decorate(appointment)
         }.sort_by {|role_appointment| role_appointment.role.seniority }
       ]
     end
+
+    @ministerial_roles_by_whip_organisations = @whip_organisations.map {|wo| [wo[0], wo[1].sort_by {|role_appointment| role_appointment.role.seniority }]}
+    @ministerial_roles_by_organisation += @ministerial_roles_by_whip_organisations
   end
 
   def show

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -34,11 +34,17 @@
     <h1>Ministers by organisation</h1>
     <% @ministerial_roles_by_organisation.each do |organisation, ministers| %>
       <%= content_tag_for :section, organisation do %>
-        <h2>
-          <%= link_to organisation_path(organisation), class: logo_classes(class_name: organisation.organisation_logo_type.class_name,  size: 'medium', stacked: true) do %>
-            <span><%= format_with_html_line_breaks(organisation.logo_formatted_name) %></span>
-          <% end %>
-        </h2>
+        <% if organisation.is_a?(Whitehall::WhipOrganisation) %>
+          <h2>
+            <span><%= format_with_html_line_breaks(organisation.name) %></span>
+          </h2>
+        <% else %>
+          <h2>
+            <%= link_to organisation_path(organisation), class: logo_classes(class_name: organisation.organisation_logo_type.class_name,  size: 'medium', stacked: true) do %>
+              <span><%= format_with_html_line_breaks(organisation.logo_formatted_name) %></span>
+            <% end %>
+          </h2>
+        <% end %>
         <ul class="minister-list">
           <% ministers.each.with_index do |role_appointment, i| %>
             <%= render partial: "people/person",

--- a/lib/active_record_like_interface.rb
+++ b/lib/active_record_like_interface.rb
@@ -1,4 +1,5 @@
 module ActiveRecordLikeInterface
+  include ActiveModel::Conversion
   module ClassMethods
     def primary_key
       :id
@@ -19,6 +20,10 @@ module ActiveRecordLikeInterface
     def create(*args)
       new(*args).save
     end
+
+    def model_name
+      ActiveModel::Name.new self
+    end
   end
 
   def initialize(options={})
@@ -37,6 +42,10 @@ module ActiveRecordLikeInterface
 
   def save
     self.class.repository[id] = self
+  end
+
+  def persisted?
+    true
   end
 
   def destroyed?

--- a/lib/whitehall/whip_organisation.rb
+++ b/lib/whitehall/whip_organisation.rb
@@ -1,0 +1,51 @@
+module Whitehall
+  class WhipOrganisation
+    include ActiveRecordLikeInterface
+
+    attr_accessor :id, :label, :selection_criteria
+
+    def slug
+      label.downcase.gsub(/[^a-z]+/, "-")
+    end
+
+    alias :name :label
+
+    def self.find_by_slug(slug)
+      all.find { |wo| wo.slug == slug }
+    end
+
+    def self.whip_org_for_role(role)
+      all.select{|wo| wo.selection_criteria.match(role.name) }
+    end
+
+    def self.role_is_a_whip?(role)
+      whip_org_for_role(role).any?
+    end
+
+    WHIPSHOUSEOFCOMMONS = Regexp.new(
+      [
+        /^Chief Whip and Parliamentary Secretary to the Treasury/,
+        /^Deputy Chief Whip, Comptroller of HM Household/,
+        /^Deputy Chief Whip, Treasurer of HM Household/,
+        /^Government Whip, Vice Chamberlain of HM Household/,
+      ].join("|")
+    )
+    WHIPSHOUSEOFLORDS = Regexp.new(
+      [
+        /^Government Deputy Chief Whip and Captain of the Queen's Bodyguard of the Yeomen of the Guard/,
+        /^Lords Chief Whip and Captain of the Honourable Corps of Gentlemen at Arms/
+      ].join("|"))
+    JUNIORLORDSOFTHETREASURY = /^Government Whip, Lord Commissioner of HM Treasury/
+    ASSISTANTWHIPS = /^Assistant Whip/
+    BARONESSANDLORDSINWAITING = Regexp.new(
+      [
+        /^Government Whip, Baroness in Waiting/,
+        /^Government Whip, Lord in Waiting/
+      ].join("|"))
+    WhipsHouseOfCommons = create(id: 1, label: "Whips - House of Commons", selection_criteria: WHIPSHOUSEOFCOMMONS)
+    WhipsHouseofLords = create(id: 2, label: "Whips - House of Lords", selection_criteria: WHIPSHOUSEOFLORDS)
+    JuniorLordsoftheTreasury = create(id: 3, label: "Junior Lords of the Treasury", selection_criteria: JUNIORLORDSOFTHETREASURY)
+    AssistantWhips = create(id: 4, label: "Assistant Whips", selection_criteria: ASSISTANTWHIPS)
+    BaronessAndLordsInWaiting = create(id: 5, label: "Baroness and Lords in Waiting", selection_criteria: BARONESSANDLORDSINWAITING)
+  end
+end

--- a/test/unit/whitehall/whip_organisation_test.rb
+++ b/test/unit/whitehall/whip_organisation_test.rb
@@ -1,0 +1,48 @@
+# encoding: UTF-8
+require "test_helper"
+
+module Whitehall
+  class WhipOrganisationTest < ActiveSupport::TestCase
+
+    test "whip_org_for_role returns WhipsHouseOfCommons matching roles" do
+      role1 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury")
+      role2 = create(:ministerial_role, name: "Deputy Chief Whip, Comptroller of HM Household")
+      role3 = create(:ministerial_role, name: "Deputy Chief Whip, Treasurer of HM Household")
+      role4 = create(:ministerial_role, name: "Government Whip, Vice Chamberlain of HM Household")
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(1)], Whitehall::WhipOrganisation.whip_org_for_role(role1)
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(1)], Whitehall::WhipOrganisation.whip_org_for_role(role2)
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(1)], Whitehall::WhipOrganisation.whip_org_for_role(role3)
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(1)], Whitehall::WhipOrganisation.whip_org_for_role(role4)
+    end
+    test "whip_org_for_role returns WhipsHouseofLords matching roles" do
+      role1 = create(:ministerial_role, name: "Government Deputy Chief Whip and Captain of the Queen's Bodyguard of the Yeomen of the Guard")
+      role2 = create(:ministerial_role, name: "Lords Chief Whip and Captain of the Honourable Corps of Gentlemen at Arms")
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(2)], Whitehall::WhipOrganisation.whip_org_for_role(role1)
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(2)], Whitehall::WhipOrganisation.whip_org_for_role(role2)
+    end
+    test "whip_org_for_role returns JuniorLordsoftheTreasury matching roles" do
+      role = create(:ministerial_role, name: "Government Whip, Lord Commissioner of HM Treasury")
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(3)], Whitehall::WhipOrganisation.whip_org_for_role(role)
+    end
+    test "whip_org_for_role returns AssistantWhips matching roles" do
+      role = create(:ministerial_role, name: "Assistant Whip")
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(4)], Whitehall::WhipOrganisation.whip_org_for_role(role)
+    end
+    test "whip_org_for_role returns BaronessAndLordsInWaiting matching roles" do
+      role1 = create(:ministerial_role, name: "Government Whip, Baroness in Waiting")
+      role2 = create(:ministerial_role, name: "Government Whip, Lord in Waiting")
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(5)], Whitehall::WhipOrganisation.whip_org_for_role(role1)
+      assert_equal [Whitehall::WhipOrganisation.find_by_id(5)], Whitehall::WhipOrganisation.whip_org_for_role(role2)
+    end
+
+    test "role_is_a_whip? returns true if a given role is a whip role" do
+      role = create(:ministerial_role, name: "Assistant Whip")
+      assert_equal true, Whitehall::WhipOrganisation.role_is_a_whip?(role)
+    end
+
+    test "role_is_a_whip? returns false if a given role is not a whip role" do
+      role = create(:ministerial_role, name: "Prime Minister")
+      assert_equal false, Whitehall::WhipOrganisation.role_is_a_whip?(role)
+    end
+  end
+end


### PR DESCRIPTION
`Whitehall::WhipOrganisation` is used to define the Regex's that are
used to find whips for each psudo org.

We then extract the whip appointments and append them to the orgs list
grouped by whip_organisations sorted by seniority.

ActiveRecordLikeInterface now includes ActiveModel::Conversion and
implments model_name so that content_tag_for method works.
