### PR TITLE
Editable world location titles in English.

### DIFF
--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -6,6 +6,9 @@
     <%= form_for([:admin, @world_location]) do |form| %>
       <%= form.label :world_location_type_id, 'Type' %>
       <%= form.select :world_location_type_id, options_from_collection_for_select(WorldLocationType.all, :id, :name, form.object.world_location_type_id) %>
+
+      <%= form.text_field :title %>
+
       <%= form.text_area :mission_statement %>
 
       <%= form.check_box :active,

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -23,6 +23,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
     get :edit, id: world_location
 
     assert_template 'world_locations/edit'
+    assert_select "input[name='world_location[title]']"
     assert_select "textarea[name='world_location[mission_statement]']"
     assert_select '#govspeak_help'
   end


### PR DESCRIPTION
We'll need to be able to change these in English, as well as in
any translations. I didn't spot that I hadn't added the field to
the normal form as well as the translation.

https://www.pivotaltracker.com/story/show/44462901
