### PR TITLE
Move locale selection from form into translation index.

### DIFF
--- a/app/controllers/admin/world_location_translations_controller.rb
+++ b/app/controllers/admin/world_location_translations_controller.rb
@@ -3,18 +3,12 @@ class Admin::WorldLocationTranslationsController < Admin::BaseController
   helper_method :translation_locale
 
   def index
-    @locales = (world_location.translated_locales - [:en]).map {|l| Locale.new(l)}
-  end
-
-  def new
+    @translated_locales = (world_location.translated_locales - [:en]).map {|l| Locale.new(l)}
+    @missing_locales = Locale.non_english - @translated_locales
   end
 
   def create
-    if @translated_world_location.update_attributes(params[:world_location])
-      redirect_to admin_world_location_translations_path(@translated_world_location)
-    else
-      render action: 'new'
-    end
+    redirect_to edit_admin_world_location_translation_path(world_location, id: translation_locale)
   end
 
   def edit
@@ -31,12 +25,12 @@ class Admin::WorldLocationTranslationsController < Admin::BaseController
   private
 
   def load_translated_and_english_world_locations
-    @translated_world_location = LocalisedModel.new(world_location, translation_locale)
+    @translated_world_location = LocalisedModel.new(world_location, translation_locale.code)
     @english_world_location = LocalisedModel.new(world_location, :en)
   end
 
   def translation_locale
-    @translation_locale ||= params[:translation_locale] || params[:id]
+    @translation_locale ||= Locale.new(params[:translation_locale] || params[:id])
   end
 
   def world_location

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -1,7 +1,9 @@
 module LocaleHelper
-  def options_for_non_english_locales
-    Locale.non_english.map do |l|
-      ["#{l.native_language_name} (#{l.english_language_name})" , l.code]
-    end
+  def select_locale(attribute, locales, options = {})
+    select_tag attribute, options_for_select(options_for_locales(locales)), options
+  end
+
+  def options_for_locales(locales)
+    locales.map {|l| ["#{l.native_language_name} (#{l.english_language_name})", l.code.to_s] }
   end
 end

--- a/app/views/admin/world_location_translations/_fields.html.erb
+++ b/app/views/admin/world_location_translations/_fields.html.erb
@@ -1,8 +1,5 @@
 <%= form.errors %>
 
-<%= label_tag "translation_locale", "Locale" %>
-<%= select_tag :translation_locale, options_for_select(options_for_non_english_locales, translation_locale), disabled: editing_translation %>
-
 <fieldset>
 <%= form.text_field :name %>
 <p class="english-name original-translation">English: <%= english_location.name %></p>

--- a/app/views/admin/world_location_translations/edit.html.erb
+++ b/app/views/admin/world_location_translations/edit.html.erb
@@ -1,7 +1,23 @@
 <% page_title "Edit translation for: #{@english_world_location.name}" %>
 
-<h1>Edit translation for: <%= @english_world_location.name %></h1>
+<h1>Edit '<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)' translation for: <%= @english_world_location.name %></h1>
 
 <%= form_for @translated_world_location, url: admin_world_location_translation_path(@translated_world_location, translation_locale), method: :put do |form| %>
-  <%= render partial: "fields", locals: {form: form, editing_translation: true, english_location: @english_world_location} %>
+  <%= form.errors %>
+
+  <fieldset>
+  <%= form.text_field :name %>
+  <p class="english-name original-translation">English: <%= @english_world_location.name %></p>
+  </fieldset>
+
+  <fieldset>
+  <%= form.text_field :title %>
+  <p class="english-title original-translation">English: <%= @english_world_location.title %></p>
+  </fieldset>
+
+  <fieldset>
+  <%= form.text_area :mission_statement %>
+  <p class="english-mission-statement original-translation">English: <%= @english_world_location.mission_statement %></p>
+  </fieldset>
+  <%= form.save_or_cancel cancel: admin_world_location_translations_path(@english_world_location) %>
 <% end %>

--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -1,7 +1,13 @@
 <% page_title @world_location.name + " translations" %>
 <section>
   <nav class="actions">
-    <%= link_to "Create Translation", new_admin_world_location_translation_path(@world_location), class: "btn new_resource", title: "Create Translation" %>
+    <% if @missing_locales.any? %>
+      <%= form_tag admin_world_location_translations_path(@world_location) do %>
+        <%= label_tag :translation_locale, 'Locale' %>
+        <%= select_locale :translation_locale, @missing_locales %>
+        <%= submit_tag "Create translation" %>
+      <% end %>
+    <% end %>
   </nav>
 </section>
 
@@ -13,7 +19,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @locales.each do |locale| %>
+    <% @translated_locales.each do |locale| %>
       <tr>
         <td class="locale">
           <%= link_to locale.native_language_name, edit_admin_world_location_translation_path(@world_location, locale.code) %> (<%= link_to "view", world_location_path(@world_location, locale: locale) %>)

--- a/app/views/admin/world_location_translations/new.html.erb
+++ b/app/views/admin/world_location_translations/new.html.erb
@@ -1,7 +1,0 @@
-<% page_title "New translation for: #{@english_world_location.name}" %>
-
-<h1>New translation for: <%= @english_world_location.name %></h1>
-
-<%= form_for @translated_world_location, url: admin_world_location_translations_path(@translated_world_location), method: :post do |form| %>
-  <%= render partial: "fields", locals: {form: form, editing_translation: false, english_location: @english_world_location} %>
-<% end %>

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -5,8 +5,8 @@ def add_translation_to_world_location(location, translation)
     click_link "manage translations"
   end
 
-  click_link "Create Translation"
   select translation["locale"], from: "Locale"
+  click_on "Create translation"
   fill_in "Name", with: translation["name"]
   fill_in "Title", with: translation["title"]
   fill_in "Mission statement", with: translation["mission_statement"]
@@ -94,13 +94,11 @@ When /^I edit the "([^"]*)" translation for "([^"]*)" setting:$/ do |locale, nam
     click_link "manage translations"
   end
   click_link locale
-  select translation["locale"], from: "Locale"
   fill_in "Name", with: translation["name"]
   fill_in "Title", with: translation["title"]
   fill_in "Mission statement", with: translation["mission_statement"]
   click_on "Save"
 end
-
 
 Then /^I should see the featured items of the (?:country|overseas territory|international delegation) "([^"]*)" are:$/ do |name, expected_table|
   world_location = WorldLocation.find_by_name!(name)


### PR DESCRIPTION
By selecting a locale before inputting a translation we can reduce
the number of views, remove duplication in controller, and fix the
bug in pivotal[1] where the select input has to be disabled when
editing an existing translation.

[1] https://www.pivotaltracker.com/story/show/44462687
