### PR TITLE
Remove translated attributes from editions table

### DIFF
--- a/db/migrate/20130218162129_remove_title_and_summary_and_body_from_editions.rb
+++ b/db/migrate/20130218162129_remove_title_and_summary_and_body_from_editions.rb
@@ -1,0 +1,13 @@
+class RemoveTitleAndSummaryAndBodyFromEditions < ActiveRecord::Migration
+  def up
+    remove_column :editions, :title
+    remove_column :editions, :summary
+    remove_column :editions, :body
+  end
+
+  def self.down
+    add_column :editions, :body, :text, limit: 16.megabytes - 1
+    add_column :editions, :summary, :text
+    add_column :editions, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130218120402) do
+ActiveRecord::Schema.define(:version => 20130218162129) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -399,9 +399,9 @@ ActiveRecord::Schema.define(:version => 20130218120402) do
   create_table "editions", :force => true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version",                                                    :default => 0
+    t.integer  "lock_version",                                :default => 0
     t.integer  "document_id"
-    t.string   "state",                                                           :default => "draft", :null => false
+    t.string   "state",                                       :default => "draft", :null => false
     t.string   "type"
     t.integer  "role_appointment_id"
     t.string   "location"
@@ -412,32 +412,29 @@ ActiveRecord::Schema.define(:version => 20130218120402) do
     t.datetime "first_published_at"
     t.date     "publication_date"
     t.integer  "speech_type_id"
-    t.boolean  "stub",                                                            :default => false
+    t.boolean  "stub",                                        :default => false
     t.text     "change_note"
     t.boolean  "force_published"
-    t.boolean  "minor_change",                                                    :default => false
+    t.boolean  "minor_change",                                :default => false
     t.integer  "publication_type_id"
     t.string   "related_mainstream_content_url"
     t.string   "related_mainstream_content_title"
     t.string   "additional_related_mainstream_content_url"
     t.string   "additional_related_mainstream_content_title"
     t.integer  "alternative_format_provider_id"
-    t.integer  "published_related_publication_count",                             :default => 0,       :null => false
+    t.integer  "published_related_publication_count",         :default => 0,       :null => false
     t.datetime "public_timestamp"
     t.integer  "primary_mainstream_category_id"
     t.datetime "scheduled_publication"
-    t.boolean  "replaces_businesslink",                                           :default => false
-    t.boolean  "access_limited",                                                                       :null => false
+    t.boolean  "replaces_businesslink",                       :default => false
+    t.boolean  "access_limited",                                                   :null => false
     t.integer  "published_major_version"
     t.integer  "published_minor_version"
     t.integer  "operational_field_id"
     t.text     "roll_call_introduction"
     t.text     "govdelivery_url"
     t.integer  "news_article_type_id"
-    t.boolean  "relevant_to_local_government",                                    :default => false
-    t.string   "title"
-    t.text     "summary"
-    t.text     "body",                                        :limit => 16777215
+    t.boolean  "relevant_to_local_government",                :default => false
   end
 
   add_index "editions", ["alternative_format_provider_id"], :name => "index_editions_on_alternative_format_provider_id"


### PR DESCRIPTION
These were initially removed in 77f82bb28a061ce8188245a37c5c515d8798d755, when
we introduced the edition_translations table. Unfortunately, that commit
prevented us from deploying: The removal of the columns would've resulted in
broken pages for people hitting the old processes that were running the code
that expected those columns to exist.

We amended that migration in 8b26d249637255f71b0f633d2920c5b2273d116c so that
it didn't remove the columns from the editions table, after verifying that
Globalize3 was still going to behave correctly.

Now that those changes have all been deployed to production we can finally
tidy up after ourselves.

This relates to https://www.pivotaltracker.com/story/show/43568447.
