### PR TITLE
Split out Organisation#show into #documents

### DIFF
--- a/app/assets/javascripts/admin/on_ready.js
+++ b/app/assets/javascripts/admin/on_ready.js
@@ -42,4 +42,11 @@ jQuery(document).ready(function($) {
     window.location.hash = $(this).data('target');
     window.scrollTo(before_shown_scroll_y, before_shown_scroll_y);
   });
+
+  if (window.location.hash && $('.tab-content').length > 0) {
+    // we may need to preload the tabs
+    var hash = window.location.hash.substring(1);
+    // ... if it's not already selected.
+    $('a[href$=#' + hash + '][data-toggle=tab]:not(.active)').tab('show');
+  }
 })

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrganisationsController < Admin::BaseController
   before_filter :build_organisation, only: [:new]
   before_filter :build_organisation_roles, only: [:new]
-  before_filter :load_organisation, only: [:show, :edit, :update, :destroy]
+  before_filter :load_organisation, only: [:show, :edit, :update, :destroy, :documents]
   before_filter :build_organisation_classifications, only: [:new, :edit]
   before_filter :delete_absent_organisation_classifications, only: [:update]
   before_filter :build_organisation_mainstream_links, only: [:new, :edit]
@@ -32,7 +32,15 @@ class Admin::OrganisationsController < Admin::BaseController
   end
 
   def show
+  end
+
+  def documents
+    @featured_editions = @organisation.featured_edition_organisations.collect { |e| e.edition }
     @editions = Edition.accessible_to(current_user).published.in_organisation(@organisation).in_reverse_chronological_order
+    if @featured_editions.any?
+      @editions = @editions.where(Edition.arel_table[:id].not_in @featured_editions.map(&:id))
+    end
+    @editions = @editions.page(params[:page]).per(20)
   end
 
   def edit

--- a/app/views/admin/organisations/_organisation_editions.html.erb
+++ b/app/views/admin/organisations/_organisation_editions.html.erb
@@ -1,0 +1,32 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>Title</th>
+      <th>Published</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% editions.each do |edition| %>
+    <%= content_tag_for :tr, edition do %>
+    <td class="type"><%= edition.type.titleize %></td>
+    <td><%= link_to edition.title, admin_edition_path(edition) %></td>
+    <td><%=l edition.major_change_published_at.to_date %></td>
+    <% association = edition.association_with_organisation(organisation) %>
+    <td><%= "Featured" if association.featured? %></td>
+    <td>
+      <% if association.featured? %>
+      <%= form_for([:admin, association], html: {class: "button_to"}) do |f| %>
+      <%= f.hidden_field :featured, value: false %>
+      <%= f.submit "Unfeature", class: "btn btn-danger" %>
+      <% end %>
+      <% else %>
+      <%= link_to "Feature", edit_admin_edition_organisation_path(association), class: "btn" %>
+      <% end %>
+    </td>
+    <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/organisations/documents.html.erb
+++ b/app/views/admin/organisations/documents.html.erb
@@ -1,0 +1,20 @@
+<% page_title @organisation.name %>
+<div class="row-fluid organisation-header">
+  <div class="span8">
+    <h1><%= @organisation.name %></h1>
+    <%= link_to "View on website", organisation_path(@organisation) %>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span12 organisation-details">
+    <section>
+      <div class="tabbable">
+        <%= render partial: "admin/organisations/tabs/navigation", locals: { organisation: @organisation, documents_page: true } %>
+        <div class="tab-content">
+          <%= render partial: "admin/organisations/tabs/documents", locals: {show: true} %>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -10,17 +10,7 @@
   <div class="span12 organisation-details">
     <section>
       <div class="tabbable">
-        <ul class="nav nav-tabs">
-          <li class="active"><a href="#details" data-toggle="tab">Details</a></li>
-          <li><a href="#contacts" data-toggle="tab">Contacts</a></li>
-          <li><a href="#social_media_accounts" data-toggle="tab">Social Media Accounts</a></li>
-          <li><a href="#about-us" data-toggle="tab">About Us</a></li>
-          <li><a href="#groups" data-toggle="tab">Governance groups</a></li>
-          <li><a href="#people" data-toggle="tab">People</a></li>
-          <li><a href="#documents" data-toggle="tab">Featured documents</a></li>
-          <li><a href="#document_series" data-toggle="tab">Document Series</a></li>
-          <li><a href="#corporate_information_pages" data-toggle="tab">Corporate Information Pages</a></li>
-        </ul>
+        <%= render partial: "admin/organisations/tabs/navigation", locals: {organisation: @organisation}  %>
         <div class="tab-content">
           <%= render partial: "admin/organisations/tabs/details" %>
           <%= render partial: "admin/organisations/tabs/contacts" %>
@@ -28,7 +18,6 @@
           <%= render partial: "admin/organisations/tabs/about_us" %>
           <%= render partial: "admin/organisations/tabs/groups" %>
           <%= render partial: "admin/organisations/tabs/people" %>
-          <%= render partial: "admin/organisations/tabs/documents" %>
           <%= render partial: "admin/organisations/tabs/document_series" %>
           <%= render partial: "admin/organisations/tabs/corporate_information_pages" %>
         </div>

--- a/app/views/admin/organisations/tabs/_documents.html.erb
+++ b/app/views/admin/organisations/tabs/_documents.html.erb
@@ -1,4 +1,5 @@
-<div class="tab-pane" id="documents">
+<% show ||= false %>
+<div class="tab-pane<% if show %> active<% end %>" id="documents">
   <% if @organisation.featured_edition_organisations.any? %>
     <h2>Featured documents</h2>
     <%= form_for [:admin, @organisation], as: :organisation do |form| %>
@@ -13,37 +14,16 @@
     <% end %>
   <% end %>
 
-  <h2>Published documents (<%= link_to "View all", admin_editions_path(organisation: @organisation.slug, state: :active)%>)</h2>
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Title</th>
-        <th>Published</th>
-        <th></th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @editions.each do |edition| %>
-        <%= content_tag_for :tr, edition do %>
-          <td class="type"><%= edition.type.titleize %></td>
-          <td><%= link_to edition.title, admin_edition_path(edition) %></td>
-          <td><%=l edition.major_change_published_at.to_date %></td>
-          <% association = edition.association_with_organisation(@organisation) %>
-          <td><%= "Featured" if association.featured? %></td>
-          <td>
-            <% if association.featured? %>
-              <%= form_for([:admin, association], html: {class: "button_to"}) do |f| %>
-                <%= f.hidden_field :featured, value: false %>
-                <%= f.submit "Unfeature", class: "btn btn-danger" %>
-              <% end %>
-            <% else %>
-              <%= link_to "Feature", edit_admin_edition_organisation_path(association), class: "btn" %>
-            <% end %>
-          </td>
-        <% end %>
-      <% end %>
-    </tbody>
-  </table>
+  <% if @featured_editions.any? %>
+    <h2>Featured documents</h2>
+    <%= render partial: 'organisation_editions',
+               locals: { editions: @featured_editions, organisation: @organisation } %>
+  <% end %>
+  <% if @editions.any? %>
+    <h2>Published documents (<%= link_to "View all", admin_editions_path(organisation: @organisation.slug, state: :active)%>)</h2>
+    <%= paginate @editions, theme: 'twitter-bootstrap' %>
+    <%= render partial: 'organisation_editions',
+               locals: { editions: @editions, organisation: @organisation  } %>
+    <%= paginate @editions, theme: 'twitter-bootstrap' %>
+  <% end %>
 </div>

--- a/app/views/admin/organisations/tabs/_navigation.html.erb
+++ b/app/views/admin/organisations/tabs/_navigation.html.erb
@@ -1,0 +1,14 @@
+<%
+  documents_page ||= false
+%>
+<ul class="nav nav-tabs">
+  <li<% unless documents_page %> class="active"<% end %>><a href="<%= admin_organisation_path(organisation) %>#details"<% unless documents_page %> data-toggle="tab"<% end %>>Details</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#contacts"<% unless documents_page %> data-toggle="tab"<% end %>>Contacts</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#social_media_accounts"<% unless documents_page %> data-toggle="tab"<% end %>>Social Media Accounts</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#about-us"<% unless documents_page %> data-toggle="tab"<% end %>>About Us</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#groups"<% unless documents_page %> data-toggle="tab"<% end %>>Governance groups</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#people"<% unless documents_page %> data-toggle="tab"<% end %>>People</a></li>
+  <li<% if documents_page %> class="active"<% end %>><a href="<%= admin_organisation_path(organisation) %>/documents">Featured documents</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#document_series"<% unless documents_page %> data-toggle="tab"<% end %>>Document Series</a></li>
+  <li><a href="<%= admin_organisation_path(organisation) %>#corporate_information_pages"<% unless documents_page %> data-toggle="tab"<% end %>>Corporate Information Pages</a></li>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,9 @@ Whitehall::Application.routes.draw do
           resources :groups, except: [:show]
           resources :document_series
           resources :corporate_information_pages
+          member do
+            get :documents
+          end
         end
         resources :policy_teams, except: [:show]
         resources :policy_advisory_groups, except: [:show]

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -178,36 +178,49 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_select 'td', text: 'Exempt'
   end
 
-  view_test "showing should allow featured published news articles to be unfeatured" do
+  view_test "documents should allow featured published news articles to be unfeatured" do
     published_news_article = create(:published_news_article)
     organisation = create(:organisation)
     edition_organisation = create(:featured_edition_organisation, organisation: organisation, edition: published_news_article)
 
-    get :show, id: organisation
+    get :documents, id: organisation
 
     assert_select "form[action=#{admin_edition_organisation_path(edition_organisation)}]" do
       assert_select "input[name='edition_organisation[featured]'][value='false']"
     end
   end
 
-  test "showing should display all editions most recently published first" do
+  test "documents should display all editions most recently published first" do
     earlier_news_article = create(:published_news_article, first_published_at: 2.days.ago)
     later_policy = create(:published_policy, first_published_at: 1.days.ago)
     organisation = create(:organisation, editions: [earlier_news_article, later_policy])
 
-    get :show, id: organisation
+    get :documents, id: organisation
 
     assert_equal [later_policy, earlier_news_article], assigns(:editions)
   end
 
-  view_test "showing should display published editions related to the organisation" do
+  test "documents should exclude featured things from editions list" do
+    featured_news_article = create(:published_news_article)
+    published_news_article = create(:published_news_article)
+    organisation = create(:organisation)
+    featured_edition_organisation = create(:featured_edition_organisation, organisation: organisation, edition: featured_news_article)
+    edition_organisation = create(:edition_organisation, organisation: organisation, edition: published_news_article)
+
+    get :documents, id: organisation
+
+    assert_equal [published_news_article], assigns(:editions)
+    assert_equal [featured_news_article], assigns(:featured_editions)
+  end
+
+  view_test "documents should display published editions related to the organisation" do
     published_news_article = create(:published_news_article)
     published_policy = create(:published_policy)
     draft_news_article = create(:draft_news_article)
     another_policy = create(:published_policy)
     organisation = create(:organisation, editions: [published_news_article, published_policy, draft_news_article])
 
-    get :show, id: organisation
+    get :documents, id: organisation
 
     assert_select_object(published_news_article)
     assert_select_object(published_policy)
@@ -215,12 +228,12 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     refute_select_object(another_policy)
   end
 
-  view_test "editing should allow non-featured published news articles to be featured" do
+  view_test "documents should allow non-featured published news articles to be featured" do
     published_news_article = create(:published_news_article)
     organisation = create(:organisation)
     edition_organisation = create(:edition_organisation, organisation: organisation, edition: published_news_article)
 
-    get :show, id: organisation
+    get :documents, id: organisation
 
     assert_select "a[href=?]", edit_admin_edition_organisation_path(edition_organisation), text: "Feature"
   end


### PR DESCRIPTION
This should speed up the organisation pages dramatically, as they no longer load documents on #show.

Additionally we're now paginating the list of organisation editions, to make the featuring experience faster. I've kept the currently featured items at the top of each page to allow for easy unfeaturing, but they're excluded from the "all editions" list to prevent duplicates.

The navigation between tabs should remain the same, as I've co-opted the tab interface to provide a proper URL instead of a fragment identifier.

https://www.pivotaltracker.com/story/show/44486835
