### PR TITLE
Revert removal of title, summary and body from edition

### DIFF
--- a/db/migrate/20130218162129_remove_title_and_summary_and_body_from_editions.rb
+++ b/db/migrate/20130218162129_remove_title_and_summary_and_body_from_editions.rb
@@ -1,13 +1,12 @@
 class RemoveTitleAndSummaryAndBodyFromEditions < ActiveRecord::Migration
   def up
-    remove_column :editions, :title
-    remove_column :editions, :summary
-    remove_column :editions, :body
+    # No-op.
+    # This migration previously removed the title, summary and body fields from the editions table
+    # but that caused us problems with stale Rails processes expecting the fields to exist after
+    # deployment.
   end
 
   def self.down
-    add_column :editions, :body, :text, limit: 16.megabytes - 1
-    add_column :editions, :summary, :text
-    add_column :editions, :title, :string
+    # No-op. See the comment above.
   end
 end

--- a/db/migrate/20130219135606_conditionally_add_title_and_summary_and_body_fields_to_editions.rb
+++ b/db/migrate/20130219135606_conditionally_add_title_and_summary_and_body_fields_to_editions.rb
@@ -1,0 +1,37 @@
+class ConditionallyAddTitleAndSummaryAndBodyFieldsToEditions < ActiveRecord::Migration
+  class Edition < ActiveRecord::Base; end
+
+  def up
+    if title_and_summary_and_body_columns_exist_on_editions?
+      puts "*** Title, summary and body columns already exist on editions - skipping migration."
+      return
+    end
+
+    change_table :editions do |t|
+      t.string :title
+      t.text :summary
+      t.text :body, limit: 16.megabytes - 1
+    end
+
+    update %{
+      UPDATE editions, edition_translations
+        SET editions.title = edition_translations.title,
+            editions.summary = edition_translations.summary,
+            editions.body = edition_translations.body,
+            editions.updated_at = GREATEST(editions.updated_at, edition_translations.updated_at)
+        WHERE editions.id = edition_translations.edition_id
+          AND locale = 'en'
+    }
+  end
+
+  def down
+    # Intentionally blank.
+    #
+    # This migration was added to ensure that our development machines, CI and Preview are kept in sync with Production,
+    # after amending the 20130218162129_remove_title_and_summary_and_body_from_editions.rb migration.
+  end
+
+  def title_and_summary_and_body_columns_exist_on_editions?
+    (%w(title summary body) - Edition.column_names).empty?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130218175954) do
+ActiveRecord::Schema.define(:version => 20130219135606) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -394,9 +394,9 @@ ActiveRecord::Schema.define(:version => 20130218175954) do
   create_table "editions", :force => true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version",                                :default => 0
+    t.integer  "lock_version",                                                    :default => 0
     t.integer  "document_id"
-    t.string   "state",                                       :default => "draft", :null => false
+    t.string   "state",                                                           :default => "draft", :null => false
     t.string   "type"
     t.integer  "role_appointment_id"
     t.string   "location"
@@ -407,29 +407,32 @@ ActiveRecord::Schema.define(:version => 20130218175954) do
     t.datetime "first_published_at"
     t.date     "publication_date"
     t.integer  "speech_type_id"
-    t.boolean  "stub",                                        :default => false
+    t.boolean  "stub",                                                            :default => false
     t.text     "change_note"
     t.boolean  "force_published"
-    t.boolean  "minor_change",                                :default => false
+    t.boolean  "minor_change",                                                    :default => false
     t.integer  "publication_type_id"
     t.string   "related_mainstream_content_url"
     t.string   "related_mainstream_content_title"
     t.string   "additional_related_mainstream_content_url"
     t.string   "additional_related_mainstream_content_title"
     t.integer  "alternative_format_provider_id"
-    t.integer  "published_related_publication_count",         :default => 0,       :null => false
+    t.integer  "published_related_publication_count",                             :default => 0,       :null => false
     t.datetime "public_timestamp"
     t.integer  "primary_mainstream_category_id"
     t.datetime "scheduled_publication"
-    t.boolean  "replaces_businesslink",                       :default => false
-    t.boolean  "access_limited",                                                   :null => false
+    t.boolean  "replaces_businesslink",                                           :default => false
+    t.boolean  "access_limited",                                                                       :null => false
     t.integer  "published_major_version"
     t.integer  "published_minor_version"
     t.integer  "operational_field_id"
     t.text     "roll_call_introduction"
     t.text     "govdelivery_url"
     t.integer  "news_article_type_id"
-    t.boolean  "relevant_to_local_government",                :default => false
+    t.boolean  "relevant_to_local_government",                                    :default => false
+    t.string   "title"
+    t.text     "summary"
+    t.text     "body",                                        :limit => 16777215
   end
 
   add_index "editions", ["alternative_format_provider_id"], :name => "index_editions_on_alternative_format_provider_id"


### PR DESCRIPTION
Even though we don't have any code relying on the these fields being present,
we think that ActiveRecord is automatically including the field names in the
queries it generates. As such, the removal of these fields still causes a
problem with deployment as old processes will expect the fields to exist.

This commit amends the migration[1] so that it'll be a no-op when run on
production (it's already run everywhere else up to and including staging). It
also adds a migration to re-add the title, summary and body fields on all
machines that have already run the original migration. This is almost
identical to the migration we used last time we were in the mess[2].

This was initially triggered by the work on [story 43568447][3]

[1] e01713decd5846580b6220af62a25f2c7ee2083a
[2] 8b26d249637255f71b0f633d2920c5b2273d116c
[3] https://www.pivotaltracker.com/story/show/43568447
