### PR TITLE
Exclude title, summary and body from Edition#columns

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,4 +1,10 @@
 class Edition < ActiveRecord::Base
+  def self.columns
+    # This is here to enable us to gracefully remove the title, summary and body columns
+    # in a future commit, *after* this change has been deployed
+    super.reject { |column| ['title', 'summary', 'body'].include?(column.name) }
+  end
+
   translates :title, :summary, :body
 
   include Edition::Traits

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -3,6 +3,15 @@ require "test_helper"
 class EditionTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
+  ['title', 'summary', 'body'].each do |column_name|
+    # These tests ensure that we're excluding the title, summary and body columns from Edition.columns.
+    # You can safely remove it, and Edition.columns, once it's been deployed and we've subsequently removed
+    # these columns for real.
+    test "#columns excludes #{column_name} so that we can safely it from editions in a future migration" do
+      refute Edition.columns.map(&:name).include?(column_name)
+    end
+  end
+
   test "returns downcased humanized class name as format name" do
     assert_equal 'case study', CaseStudy.format_name
     assert_equal 'publication', Publication.format_name


### PR DESCRIPTION
This is related to a problem we had with deployment, that pull request #243
set out to fix.

Although we're not referencing these columns in our application, ActiveRecord
will automatically include them in certain queries it generates. By overriding
`Edition.columns` in this way, we're essentially telling ActiveRecord to
ignore these unused columns so that we can safely remove them from the
database in a subsequent commit/deploy.

Once deployed to production we should finally be in a position to remove the
title, summary and body fields from the editions table. The additions in this
commit should be removed at that time too.

You can replicate the error we were seeing in staging, on your development
machine, by removing a database column after the application has loaded. You
can do that by following these steps:
1. Import a relatively recent dump of the production data.
2. Start the Rails console
3. Run the following and observe that it doesn't cause any errors. _NOTE_ It
   doesn't matter if you don't get any results.
   
   ```
   o = Organisation.find_by_slug!('attorney-generals-office')
   o.featured_edition_organisations
   ```
4. Leaving the Rails console open, open a mysql session to your development
   database.
5. Drop the title column from the editions table by running:
   
   ```
   alter table editions drop column title;
   ```
6. Back in the Rails console, run the following command and observe that you
   see an error similar to "ActiveRecord::StatementInvalid: Mysql2::Error:
   Unknown column 'editions.title'".
   
   ```
   o = Organisation.find_by_slug!('attorney-generals-office')
   o.featured_edition_organisations
   ```
