### PR TITLE
Send non-images as attachments to force downloads

### DIFF
--- a/app/controllers/uploads_controller_helper.rb
+++ b/app/controllers/uploads_controller_helper.rb
@@ -10,9 +10,9 @@ module UploadsControllerHelper
       end
 
       if mime_type = mime_type_for(path)
-        send_file path, type: mime_type_for(path), disposition: 'inline'
+        send_file path, type: mime_type_for(path), disposition: content_disposition_for(path)
       else
-        send_file path, disposition: 'inline'
+        send_file path, disposition: content_disposition_for(path)
       end
     else
       redirect_to_placeholder(path)
@@ -20,7 +20,7 @@ module UploadsControllerHelper
   end
 
   def redirect_to_placeholder(path)
-    if ['.jpg', '.jpeg', '.png'].include?(File.extname(path))
+    if image? path
       redirect_to view_context.path_to_image('thumbnail-placeholder.png')
     else
       redirect_to placeholder_url
@@ -29,6 +29,18 @@ module UploadsControllerHelper
 
   def mime_type_for(path)
     Mime::Type.lookup_by_extension(File.extname(path).from(1))
+  end
+
+  def content_disposition_for(path)
+    if image?(path)
+      'inline'
+    else
+      'attachment'
+    end
+  end
+
+  def image?(path)
+    ['.jpg', '.jpeg', '.png', '.gif'].include?(File.extname(path))
   end
 
   def upload_exists?(path)


### PR DESCRIPTION
This fixes a bug in IE where it won't download any attachments at all, as we previously sent them all as `inline`.

We may want to fork this behaviour so that only versions of IE get `attachment` - users of sensible browsers may want to display these in their browser as is traditional. Open for discussion.

https://www.pivotaltracker.com/story/show/42949101
