### PR TITLE
Don't send duplicate emails to editors

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -93,7 +93,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   private
 
   def users_to_notify(edition)
-    edition.authors.select(&:has_email?).reject { |a| a == current_user}
+    edition.authors.uniq.select(&:has_email?).reject { |a| a == current_user}
   end
 
   def find_edition


### PR DESCRIPTION
Previously we would send an email to each author of a document. If you
were responsible for many changes this would mean you would be listed as
an author many times. This should restrict it to only send you one
email.

https://www.pivotaltracker.com/story/show/43324411
