### PR TITLE
Sort Whip Organisations

### DIFF
--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -48,6 +48,6 @@ private
           Whitehall::WhipOrganisation.find_by_id(whip_organisation_id),
           role_appointments.sort_by { |ra| ra.role.seniority }
         ]
-    end
+    end.sort_by { |org, whips| org.sort_order }
   end
 end

--- a/lib/whitehall/whip_organisation.rb
+++ b/lib/whitehall/whip_organisation.rb
@@ -2,7 +2,7 @@ module Whitehall
   class WhipOrganisation
     include ActiveRecordLikeInterface
 
-    attr_accessor :id, :label
+    attr_accessor :id, :label, :sort_order
 
     def slug
       label.downcase.gsub(/[^a-z]+/, "-")
@@ -14,10 +14,10 @@ module Whitehall
       all.find { |wo| wo.slug == slug }
     end
 
-    WhipsHouseOfCommons = create(id: 1, label: "House of Commons")
-    WhipsHouseofLords = create(id: 2, label: "House of Lords")
-    JuniorLordsoftheTreasury = create(id: 3, label: "Junior Lords of the Treasury")
-    AssistantWhips = create(id: 4, label: "Assistant Whips")
-    BaronessAndLordsInWaiting = create(id: 5, label: "Baroness and Lords in Waiting")
+    WhipsHouseOfCommons = create(id: 1, label: "House of Commons", sort_order: 1)
+    WhipsHouseofLords = create(id: 2, label: "House of Lords", sort_order: 4 )
+    JuniorLordsoftheTreasury = create(id: 3, label: "Junior Lords of the Treasury", sort_order: 2)
+    AssistantWhips = create(id: 4, label: "Assistant Whips", sort_order: 3)
+    BaronessAndLordsInWaiting = create(id: 5, label: "Baronesses and Lords in Waiting", sort_order: 5)
   end
 end

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -78,6 +78,39 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     assert_equal whips, assigns(:whips_by_organisation).map { |org, role_appointments| [org, role_appointments.map(&:model)] }
   end
 
+  test 'orders whips by organisation sort order' do
+    organisation = create(:ministerial_department)
+
+    person_1 = create(:person)
+    person_2 = create(:person)
+    person_3 = create(:person)
+    person_4 = create(:person)
+    person_5 = create(:person)
+
+    role_1 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 1)
+    role_2 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 2)
+    role_3 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 3)
+    role_4 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 4)
+    role_5 = create(:ministerial_role, organisations: [organisation], whip_organisation_id: 5)
+
+    appointment_1 = create(:ministerial_role_appointment, role: role_1, person: person_1)
+    appointment_2 = create(:ministerial_role_appointment, role: role_2, person: person_2)
+    appointment_3 = create(:ministerial_role_appointment, role: role_3, person: person_3)
+    appointment_4 = create(:ministerial_role_appointment, role: role_4, person: person_4)
+    appointment_5 = create(:ministerial_role_appointment, role: role_5, person: person_5)
+
+    get :index
+
+    whips = [
+      [Whitehall::WhipOrganisation.find_by_id(1), [appointment_1]],
+      [Whitehall::WhipOrganisation.find_by_id(3), [appointment_3]],
+      [Whitehall::WhipOrganisation.find_by_id(4), [appointment_4]],
+      [Whitehall::WhipOrganisation.find_by_id(2), [appointment_2]],
+      [Whitehall::WhipOrganisation.find_by_id(5), [appointment_5]]
+    ]
+    assert_equal whips, assigns(:whips_by_organisation).map { |org, role_appointments| [org, role_appointments.map(&:model)] }
+  end
+
   test "should avoid n+1 queries" do
     MinisterialRole.expects(:includes).with(:current_people).returns([])
     get :index


### PR DESCRIPTION
Whip Organisations need to be displayed in a certain order. This ensures
they are in the order we specify. Also updated the label of the
Baroness and Loards in Waiting to be Baronesses.

https://www.pivotaltracker.com/story/show/44795495
