### PR TITLE
Extract image size checking to an lib class and disable it in tests

### DIFF
--- a/app/models/classification_featuring_image_data.rb
+++ b/app/models/classification_featuring_image_data.rb
@@ -11,9 +11,8 @@ class ClassificationFeaturingImageData < ActiveRecord::Base
   end
 
   def image_must_be_960px_by_640px
-    image = file && file.path && MiniMagick::Image.open(file.path)
-    unless image.nil? || (image[:width] == 960 && image[:height] == 640)
-      errors.add(:image, "must be 960px wide and 640px tall")
+    if file.path
+      errors.add(:file, 'must be 960px wide and 640px tall') unless ImageSizeChecker.new(file.path).size_is?(960, 640)
     end
   end
 end

--- a/app/models/edition_organisation_image_data.rb
+++ b/app/models/edition_organisation_image_data.rb
@@ -11,9 +11,8 @@ class EditionOrganisationImageData < ActiveRecord::Base
   end
 
   def image_must_be_960px_by_640px
-    image = file && file.path && MiniMagick::Image.open(file.path)
-    unless image.nil? || (image[:width] == 960 && image[:height] == 640)
-      errors.add(:image, "must be 960px wide and 640px tall")
+    if file.path
+      errors.add(:file, 'must be 960px wide and 640px tall') unless ImageSizeChecker.new(file.path).size_is?(960, 640)
     end
   end
 end

--- a/app/models/edition_world_location_image_data.rb
+++ b/app/models/edition_world_location_image_data.rb
@@ -11,9 +11,8 @@ class EditionWorldLocationImageData < ActiveRecord::Base
   end
 
   def image_must_be_960px_by_640px
-    image = file && file.path && MiniMagick::Image.open(file.path)
-    unless image.nil? || (image[:width] == 960 && image[:height] == 640)
-      errors.add(:image, "must be 960px wide and 640px tall")
+    if file.path
+      errors.add(:file, 'must be 960px wide and 640px tall') unless ImageSizeChecker.new(file.path).size_is?(960, 640)
     end
   end
 end

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -9,9 +9,8 @@ class ImageData < ActiveRecord::Base
   validate :image_must_be_960px_by_640px
 
   def image_must_be_960px_by_640px
-    image = file.path && MiniMagick::Image.open(file.path)
-    unless image.nil? || (image[:width] == 960 && image[:height] == 640)
-      errors.add(:file, "must be 960px wide and 640px tall")
+    if file.path
+      errors.add(:file, 'must be 960px wide and 640px tall') unless ImageSizeChecker.new(file.path).size_is?(960, 640)
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -82,9 +82,8 @@ class Person < ActiveRecord::Base
   end
 
   def image_must_be_960px_by_640px
-    image_file = image && image.path && MiniMagick::Image.open(image.path)
-    unless image_file.nil? || (image_file[:width] == 960 && image_file[:height] == 640)
-      errors.add(:image, "must be 960px wide and 640px tall")
+    if image.path
+      errors.add(:file, 'must be 960px wide and 640px tall') unless ImageSizeChecker.new(image.path).size_is?(960, 640)
     end
   end
 

--- a/lib/image_size_checker.rb
+++ b/lib/image_size_checker.rb
@@ -1,0 +1,11 @@
+class ImageSizeChecker
+  def initialize(file_path)
+    raise ArgumentError, 'need a file path' unless file_path.present?
+    @file_path = file_path
+  end
+
+  def size_is?(width, height)
+    image = MiniMagick::Image.open(@file_path)
+    (image[:width] == width && image[:height] == height)
+  end
+end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -478,6 +478,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test 'creating an edition with an invalid image should show an error' do
+        ImageSizeChecker.any_instance.stubs(:size_is?).returns false
         attributes = controller_attributes_for(edition_type)
         invalid_image = fixture_file_upload('horrible-image.64x96.jpg')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ class ActiveSupport::TestCase
   setup do
     Timecop.freeze(2011, 11, 11, 11, 11, 11)
     Whitehall.stubs(:search_backend).returns(Whitehall::DocumentFilter::FakeSearch)
+    ImageSizeChecker.any_instance.stubs(:size_is?).returns true
   end
 
   teardown do

--- a/test/unit/edition_organisation_image_data_test.rb
+++ b/test/unit/edition_organisation_image_data_test.rb
@@ -7,11 +7,13 @@ class EditionOrganisationImageDataTest < ActiveSupport::TestCase
   end
 
   test 'should be invalid if image is not 960x640px' do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     image_data = build(:edition_organisation_image_data, file: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     refute image_data.valid?
   end
 
   test 'should be valid if legacy image is not 960x640px' do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     image_data = build(:edition_organisation_image_data, file: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     image_data.save(validate: false)
     assert image_data.reload.valid?

--- a/test/unit/edition_world_location_image_data_test.rb
+++ b/test/unit/edition_world_location_image_data_test.rb
@@ -7,11 +7,13 @@ class EditionWorldLocationImageDataTest < ActiveSupport::TestCase
   end
 
   test 'should be invalid if image is not 960x640px' do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     image_data = build(:edition_world_location_image_data, file: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     refute image_data.valid?
   end
 
   test 'should be valid if legacy image is not 960x640px' do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     image_data = build(:edition_world_location_image_data, file: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     image_data.save(validate: false)
     assert image_data.reload.valid?

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -9,11 +9,13 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test "should be invalid if image isn't 960x640px" do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     person = build(:person, image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     refute person.valid?
   end
 
   test "should be valid if legacy image isn't 960x640px" do
+    ImageSizeChecker.any_instance.unstub(:size_is?)
     person = build(:person, image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     person.save(validate: false)
     assert person.reload.valid?


### PR DESCRIPTION
We noticed that our tests eat a lot of memory, and on a resource constrained VM this can mean we get failures because of running out of memory.  The major cause of the errors in this case seemed to be from the validation on image_data, person, classification_featuring_image_data, edition_organisation_image_data, and edition_world_location_image_data that checks what size the image is.

To try and solve this we extract the bulk of the code from those validations to ImageSizeChecker.new.size_is? in lib, and then use any_instance stubbing to make it always return true.  We unstub this for those few tests that actually want to exercise the method for real.

In unscientific testing on my machine this reduced the unit test duration from 261s to 232s.
