### PR TITLE
Use proper URLs for localised content

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -44,6 +44,6 @@ class DocumentsController < PublicFacingController
   end
 
   def redirect_to_canonical_url
-    redirect_to public_document_path(@document) if params[:locale] && params[:locale] == 'en'
+    redirect_to public_document_path(@document) if request.query_parameters[:locale] == 'en'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Whitehall::Application.routes.draw do
     resources :statistical_data_sets, path: 'statistical-data-sets', only: [:index, :show]
     match "/speeches" => redirect("/announcements")
 
-    resources :worldwide_priorities, path: "priority", only: [:index, :show]
+    resources :worldwide_priorities, path: "priority", only: [:index, :show], localised: true
     resources :consultations, only: [:index, :show] do
       collection do
         get :open
@@ -73,7 +73,7 @@ Whitehall::Application.routes.draw do
 
     resources :ministerial_roles, path: 'ministers', only: [:index, :show]
     resources :people, only: [:index, :show]
-    resources :world_locations, path: 'world', only: [:index, :show]
+    resources :world_locations, path: 'world', only: [:index, :show], localised: true
 
     resources :policy_teams, path: 'policy-teams', only: [:index, :show]
     resources :policy_advisory_groups, path: 'policy-advisory-groups', only: [:index, :show]

--- a/lib/patches/localised_routing.rb
+++ b/lib/patches/localised_routing.rb
@@ -1,0 +1,54 @@
+# This patches rails standard routing to make it easy to generate
+# localised routes.  By adding the localised: true option to a
+# rails route or resource, a :locale will be added before the
+# :format parameter, i.e:
+#
+#     resource :documents, only: [:index], localised: true
+#
+# Will generate a route that matches:
+#
+#     /documents => {locale: 'en'}
+#     /documents.fr => {locale: 'fr'}
+#     /documents.json => {locale: 'en', format: 'json'}
+#     /documents.fr.json => {locale: 'fr', format: 'json'}
+
+class ActionDispatch::Routing::Mapper::Mapping
+  LOCALE_REGEX = Regexp.compile(Locale.non_english.map(&:code).join("|"))
+
+  def localise_routing?
+    @localise_routing ||= @options.delete(:localised)
+  end
+
+  def normalize_path_with_locale(path)
+    if localise_routing?
+      normalize_path_without_locale "#{path}(.:locale)"
+    else
+      normalize_path_without_locale path
+    end
+  end
+
+  def requirements_with_locale
+    @requirements_with_locale ||= requirements_without_locale.tap do |r|
+      if localise_routing?
+        r[:locale] = LOCALE_REGEX
+      end
+    end
+  end
+
+  def defaults_with_locale
+    @defaults_with_locale ||= defaults_without_locale.tap do |d|
+      if localise_routing?
+        d[:locale] = I18n.default_locale.to_s
+      end
+    end
+  end
+
+  alias normalize_path_without_locale normalize_path
+  alias normalize_path normalize_path_with_locale
+
+  alias requirements_without_locale requirements
+  alias requirements requirements_with_locale
+
+  alias defaults_without_locale defaults
+  alias defaults defaults_with_locale
+end

--- a/test/integration/localised_routing_test.rb
+++ b/test/integration/localised_routing_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class RoutingLocaleTest < ActionDispatch::IntegrationTest
+  setup do
+    @show_world_location = {controller: 'world_locations', action: 'show', id: 'spain', locale: 'en'}
+    @show_world_priority = {controller: 'worldwide_priorities', action: 'show', id: 'a-world-priority', locale: 'en'}
+  end
+
+  test 'matches world locations without locale or format' do
+    assert_routing '/government/world/spain', @show_world_location
+  end
+
+  test 'matches world locations with a format' do
+    assert_routing '/government/world/spain.json', @show_world_location.merge(format: 'json')
+  end
+
+  test 'matches world locations with a given locale' do
+    assert_routing '/government/world/spain.es', @show_world_location.merge(locale: 'es')
+  end
+
+  test 'matches world locations with both a locale and format' do
+    assert_routing '/government/world/spain.es.json', @show_world_location.merge(locale: 'es', format: 'json')
+  end
+
+  test 'matches world priorities without locale or format' do
+    assert_routing '/government/priority/a-world-priority', @show_world_priority
+  end
+
+  test 'matches world priorities with a format' do
+    assert_routing '/government/priority/a-world-priority.json', @show_world_priority.merge(format: 'json')
+  end
+
+  test 'matches world priorities with a given locale' do
+    assert_routing '/government/priority/a-world-priority.es', @show_world_priority.merge(locale: 'es')
+  end
+
+  test 'matches world priorities with both a locale and format' do
+    assert_routing '/government/priority/a-world-priority.es.json', @show_world_priority.merge(locale: 'es', format: 'json')
+  end
+end


### PR DESCRIPTION
As requested in https://www.pivotaltracker.com/story/show/44791121

This adds the capability to declare localised routes, and adds them for world locations and worldwide priorities.  See the main commit for more details.
