### PR TITLE
Replace youtube cucumbers with js unit tests

### DIFF
--- a/features/editing-draft-policies.feature
+++ b/features/editing-draft-policies.feature
@@ -34,11 +34,6 @@ Scenario: Creating a new draft policy that applies to multiple nations
   Then I should see in the preview that "Outlaw Moustaches" does not apply to the nations:
     | Scotland | Wales |
 
-@javascript
-Scenario: Creating a new draft policy with a video link
-  When I draft a new policy "Outlaw Moustaches" with a link "http://www.youtube.com/watch?v=OXHPWmnycno" in the body
-  Then I should see in the preview that "Outlaw Moustaches" includes an embedded media player
-
 Scenario: Adding a supporting page to a draft policy
   Given a draft policy "Outlaw Moustaches" exists
   When I add a supporting page "Handlebar Waxing" to the "Outlaw Moustaches" policy

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -348,10 +348,6 @@ When /^I draft a new policy "([^"]*)" with a link "([^"]*)" in the body$/ do |ti
   click_button "Save"
 end
 
-Then /^I should see in the preview that "([^"]*)" includes an embedded media player$/ do |title|
-  assert_video_player_exists
-end
-
 Given /^a published policy "([^"]*)" with a link "([^"]*)" in the body$/ do |title, url|
   body = "A sentence with a [link](#{url}) in the middle."
   create(:published_policy, title: title, body: body)
@@ -366,10 +362,6 @@ Given /^a (.*?) policy "([^"]*)" for the organisations "([^"]*)" and "([^"]*)"$/
   org1 = create(:organisation, name: organisation1)
   org2 = create(:organisation, name: organisation2)
   create("#{state}_policy", title: title, organisations: [org1, org2])
-end
-
-Then /^I should see that the policy "([^"]*)" includes an embedded media player$/ do |arg1|
-  assert_video_player_exists
 end
 
 When /^I visit the list of policies$/ do

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -26,10 +26,6 @@ Given /^a published speech "([^"]*)" with related published policies "([^"]*)" a
   create(:published_speech, title: speech_title, related_policies: [policy_1, policy_2])
 end
 
-Given /^a published video speech "([^"]*)"$/ do |speech_title|
-  create(:published_speech, title: speech_title, body: "[Test video](http://www.youtube.com/watch?v=EwTZ2xpQwpA)")
-end
-
 Given /^a published speech "([^"]*)" for the organisation "([^"]*)"$/ do |title, organisation|
   organisation = create(:organisation, name: organisation)
   create(:published_speech, title: title, organisations: [organisation])
@@ -98,8 +94,4 @@ end
 Then /^I should see the speech was delivered on "([^"]*)" at "([^"]*)"$/ do |delivered_on, location|
   assert page.has_css?('.delivered-on', text: delivered_on)
   assert page.has_css?('.location', text: location)
-end
-
-Then /^I should be able to see a video player$/ do
-  assert page.has_css?('span.player-container .video')
 end

--- a/features/support/media_player.rb
+++ b/features/support/media_player.rb
@@ -1,8 +1,0 @@
-module MediaPlayer
-  def assert_video_player_exists
-    assert page.has_css?(".player-container .video")
-    assert page.has_css?(".player-container .control-bar")
-  end
-end
-
-World(MediaPlayer)

--- a/features/viewing-published-policies.feature
+++ b/features/viewing-published-policies.feature
@@ -26,13 +26,6 @@ Scenario: Viewing a policy that is applicable to certain nations
   Then I should see that the policy only applies to:
     | England | Scotland |
 
-@javascript
-@not-quite-as-fake-search
-Scenario: Viewing a policy with a video link
-  Given a published policy "Policy" with a link "http://www.youtube.com/watch?v=OXHPWmnycno" in the body
-  When I visit the policy "Policy"
-  Then I should see that the policy "Policy" includes an embedded media player
-
 Scenario: Viewing the activity around a policy
   Given a published policy "What Makes A Beard" exists
   And a published publication "Standard Beard Lengths" related to the policy "What Makes A Beard"

--- a/features/viewing-published-speeches.feature
+++ b/features/viewing-published-speeches.feature
@@ -12,10 +12,3 @@ Scenario: Viewing a published speech with related policies
   Given a published speech "Things I Have Thought" with related published policies "Policy 1" and "Policy 2"
   When I visit the speech "Things I Have Thought"
   Then I can see links to the related published policies "Policy 1" and "Policy 2"
-
-@javascript
-@not-quite-as-fake-search
-Scenario: Viewing a published speech shows a video player
-  Given a published video speech "Speech with video"
-  When I visit the speech "Speech with video"
-  Then I should be able to see a video player

--- a/test/javascripts/unit/enhance_youtube_videos_test.js
+++ b/test/javascripts/unit/enhance_youtube_videos_test.js
@@ -1,0 +1,44 @@
+module("Enhance youbute videos test", {
+  setup: function(){
+    this.container = $('<div id="wrap"><p><a></a></p></div>');
+    $('#qunit-fixture').append(this.container);
+  }
+});
+
+test("should replace tiny youtube links", function() {
+  var stub = sinon.stub($.fn, "player");
+  stub.returns(true);
+
+  this.container.find('a').attr('href', 'http://youtu.be/tinyVideo');
+
+  $('#wrap').enhanceYoutubeVideoLinks();
+
+  var playerArgs = stub.getCall(0).args[0];
+  equal('tinyVideo', playerArgs.media);
+  stub.restore();
+});
+
+test("should replace short youtube links", function() {
+  var stub = sinon.stub($.fn, "player");
+  stub.returns(true);
+
+  this.container.find('a').attr('href', 'http://youtube.com/watch?v=shortVideo');
+
+  $('#wrap').enhanceYoutubeVideoLinks();
+
+  var playerArgs = stub.getCall(0).args[0];
+  equal('shortVideo', playerArgs.media);
+  stub.restore();
+});
+test("should replace medium youtube links", function() {
+  var stub = sinon.stub($.fn, "player");
+  stub.returns(true);
+
+  this.container.find('a').attr('href', 'http://youtube.com/watch?v=mediumVideo&source=twitter');
+
+  $('#wrap').enhanceYoutubeVideoLinks();
+
+  var playerArgs = stub.getCall(0).args[0];
+  equal('mediumVideo', playerArgs.media);
+  stub.restore();
+});


### PR DESCRIPTION
The unit tests ensure that the plugin we have calls out to the nomensa
plugin with the correct params. While this would now miss the case that
we change the class round govspeak I feel this is probably ok. In an
ideal world we would be able to mock the nomensa library in cucumber so
we could have such a test, but without that we are then loading youtube
videos into our cucumber tests.
