### PR TITLE
Recognise file type of uploads with upper case file names

### DIFF
--- a/app/controllers/uploads_controller_helper.rb
+++ b/app/controllers/uploads_controller_helper.rb
@@ -28,7 +28,7 @@ module UploadsControllerHelper
   end
 
   def mime_type_for(path)
-    Mime::Type.lookup_by_extension(File.extname(path).from(1))
+    Mime::Type.lookup_by_extension(File.extname(path).from(1).downcase)
   end
 
   def content_disposition_for(path)

--- a/test/integration/upload_access_test.rb
+++ b/test/integration/upload_access_test.rb
@@ -77,6 +77,15 @@ class UploadAccessTest < ActionDispatch::IntegrationTest
     assert_sent_public_upload upload, Mime::JPG
   end
 
+  test 'recognises files with uppercase names (as well as lowercase)' do
+    upload = '/government/uploads/GENERAL-UPLOAD.JPG'
+    create_uploaded_file(path_to_clean_upload(upload))
+
+    get_via_nginx upload
+
+    assert_sent_public_upload upload, Mime::JPG
+  end
+
   test 'redirects requests for unknown uploaded images to the placeholder image' do
     get_via_nginx '/government/uploads/any-missing-image.jpg'
     assert_redirected_to_placeholder_image


### PR DESCRIPTION
The content type used when sending uploads to the user is based on
the file extension.  However, previously it didn't correctly
recognise uppercase file extensions, causing problems like this[1].

[1] https://www.pivotaltracker.com/story/show/44879513
