### PR TITLE
Make documents and imports clean up after themselves.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,7 +31,7 @@ class Document < ActiveRecord::Base
                AND e2.id > editions.id
                AND e2.state <> 'deleted')}
 
-  has_many :document_sources
+  has_many :document_sources, dependent: :destroy
 
   attr_accessor :sluggable_string
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -22,6 +22,8 @@ class Import < ActiveRecord::Base
     fatality_notice: [Whitehall::Uploader::FatalityNoticeRow, FatalityNotice]
   }
 
+  after_destroy :destroy_all_imported_documents
+
   validate :csv_data_supplied
   validates :organisation_id, presence: true
   validate :valid_csv_data_encoding!
@@ -342,4 +344,10 @@ class Import < ActiveRecord::Base
                   end
     end
   end
+
+  private
+  def destroy_all_imported_documents
+    Document.destroy_all(id: self.document_ids)
+  end
+
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -70,6 +70,13 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal nil, EditionRelation.find_by_id(relationship.id)
   end
 
+  test "#destroy also destroys document sources" do
+    document = create(:document)
+    document_source = create(:document_source, document: document)
+    document.destroy
+    assert_equal nil, DocumentSource.find_by_id(document_source.id)
+  end
+
   test "should list change history when only one edition with a minor change exists" do
     edition = create(:published_policy, minor_change: true)
 

--- a/test/unit/import_test.rb
+++ b/test/unit/import_test.rb
@@ -359,6 +359,38 @@ class ImportTest < ActiveSupport::TestCase
     assert_equal attempt3, import.most_recent_force_publication_attempt
   end
 
+  test "#destroy also destroys all imported documents" do
+    import = perform_import
+    documents = import.documents
+    import.destroy
+    documents.each do |imported_doc|
+      assert_equal nil, Document.find_by_id(imported_doc.id)
+    end
+  end
+
+  test "#destroy also destroys the import logs" do
+    import = perform_import
+    logs = import.import_logs
+    import.destroy
+    logs.each do |import_log|
+      assert_equal nil, ImportLog.find_by_id(import_log.id)
+    end
+  end
+
+  test "#destroy also destroys the import errors" do
+    import = perform_import
+    import_error = import.import_errors.create!(row_number: 1, message: 'uh oh')
+    import.destroy
+    assert_equal nil, ImportError.find_by_id(import_error.id)
+  end
+
+  test "#destroy also destroys force publication attempts" do
+    import = perform_import
+    force_attempt = import.force_publication_attempts.create!
+    import.destroy
+    assert_equal nil, ForcePublicationAttempt.find_by_id(force_attempt.id)
+  end
+
   private
   def stub_document_source
     DocumentSource.stubs(:find_by_url).returns(nil)


### PR DESCRIPTION
Documents will remove their document sources
Imports will remove their documents

This is to support https://www.pivotaltracker.com/story/show/44892623 so that we can just Import.destroy(<some id>).

This is a tiny pull request, but I want a sanity check on it first, as it might be dangerous.
