### PR TITLE
Add a healthcheck to show overdue editions

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -4,4 +4,8 @@ class HealthcheckController < ActionController::Base
     Edition.count
     render json: {}
   end
+  def overdue
+    # Check the number of overdue editions
+    render json: { 'overdue' => Edition.due_for_publication.count }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Whitehall::Application.routes.draw do
   end
 
   get 'healthcheck' => 'healthcheck#check'
+  get 'healthcheck/overdue' => 'healthcheck#overdue'
 
   # XXX: we use a blank prefix here because redirect has been
   # overridden further up in the routes


### PR DESCRIPTION
This introduces a route (/healthcheck/overdue) which routes to healthcheck#overdue - which simply renders Edition.due_for_publication.count as json

I've tested it in Dev - when I have no publications at all in my database:

```
[vm:govuk/whitehall]$ curl http://127.0.0.1:3020/healthcheck/overdue
{"overdue":0}
```

When I import from last night's Whitehall dump (there were 4 publications that would have gone out this morning:

```
[vm:govuk/whitehall]$ curl http://127.0.0.1:3020/healthcheck/overdue
{"overdue":4}
```

```
mysql> SELECT id,title,scheduled_publication FROM `editions` WHERE `editions`.`state` = 'scheduled' AND (`editions`.`state` != 'deleted') AND (`editions`.`scheduled_publication` <= '2013-02-25 13:00:01')
    -> ;
+--------+---------------------------------------------------------------+-----------------------+
| id     | title                                                         | scheduled_publication |
+--------+---------------------------------------------------------------+-----------------------+
|  98414 | Coastal projects and investments: Focus on Enforcement review | 2013-02-25 10:00:00   |
| 101985 | Local Infrastructure Fund: prospectus                         | 2013-02-25 09:00:00   |
| 101988 | Increasing the number of available homes                      | 2013-02-25 09:00:00   |
| 102083 | Wokingham                                                     | 2013-02-25 09:00:00   |
+--------+---------------------------------------------------------------+-----------------------+
4 rows in set (0.00 sec)
```

So as far as I can see, I've done this "working" - whether it is correct or not I will leave the assembled masses to comment.
