### PR TITLE
Speed tagging exposes associated document series

### DIFF
--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -25,6 +25,9 @@
     <%= form.label :organisation_ids, 'Organisations:' %>
     <%= form.select :organisation_ids, options_from_collection_for_select(Organisation.all, 'id', 'name', @edition.organisation_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose organisations which produced this document..." } %>
     <%= render partial: 'required_fields_for_imported_editions', locals: { form: form, edition: form.object } %>
+    <% if @edition.can_be_grouped_in_series? %>
+      <%= render partial: 'document_series_fields', locals: { form: form, edition: form.object } %>
+    <% end %>
     <% if @edition.can_be_associated_with_role_appointments? %>
       <div class="row-fluid">
         <h3>Ministers</h3>

--- a/features/speed-tagging-editions.feature
+++ b/features/speed-tagging-editions.feature
@@ -50,3 +50,8 @@ Feature: Speed tagging editions
     When I go to speed tag a newly imported news article "Beards are more costly this year" for "HM Treasury"
     Then I should be able to tag the news article with "Jane Smith"
     And I should not be able to tag the news article with "Joe Bloggs"
+
+  Scenario: Speed tagging shows document series when relevant
+    Given a document series "Beard statistics"
+    When I go to speed tag a newly imported publication "Beard length statistics 2012"
+    Then I should be able to select the document series "Beard statistics"

--- a/features/step_definitions/speed_tagging_steps.rb
+++ b/features/step_definitions/speed_tagging_steps.rb
@@ -37,3 +37,7 @@ end
 When /^I can only tag the (?:publication|news article) with "([^"]*)" once$/ do |label|
   assert page.has_css?("label.checkbox", text: /#{label}/, count: 1)
 end
+
+Then /^I should be able to select the document series "([^"]*)"$/ do |name|
+  select name, from: 'Document series'
+end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/42730705

Exposes document series when speed tagging imported documents.
