### PR TITLE
Remove title, summary and body from editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,10 +1,4 @@
 class Edition < ActiveRecord::Base
-  def self.columns
-    # This is here to enable us to gracefully remove the title, summary and body columns
-    # in a future commit, *after* this change has been deployed
-    super.reject { |column| ['title', 'summary', 'body'].include?(column.name) }
-  end
-
   include Edition::Traits
 
   include Edition::NullImages

--- a/db/migrate/20130226133205_remove_title_and_summary_and_body_from_editions_again.rb
+++ b/db/migrate/20130226133205_remove_title_and_summary_and_body_from_editions_again.rb
@@ -1,0 +1,13 @@
+class RemoveTitleAndSummaryAndBodyFromEditionsAgain < ActiveRecord::Migration
+  def up
+    remove_column :editions, :title
+    remove_column :editions, :summary
+    remove_column :editions, :body
+  end
+
+  def down
+    add_column :editions, :body, :text, limit: 16.megabytes - 1
+    add_column :editions, :summary, :text
+    add_column :editions, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130226132051) do
+ActiveRecord::Schema.define(:version => 20130226133205) do
 
   create_table "attachment_data", :force => true do |t|
     t.string   "carrierwave_file"
@@ -393,13 +393,11 @@ ActiveRecord::Schema.define(:version => 20130226132051) do
   add_index "edition_worldwide_organisations", ["worldwide_organisation_id"], :name => "index_edition_worldwide_orgs_on_worldwide_organisation_id"
 
   create_table "editions", :force => true do |t|
-    t.string   "title"
-    t.text     "body",                                        :limit => 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version",                                                    :default => 0
+    t.integer  "lock_version",                                :default => 0
     t.integer  "document_id"
-    t.string   "state",                                                           :default => "draft", :null => false
+    t.string   "state",                                       :default => "draft", :null => false
     t.string   "type"
     t.integer  "role_appointment_id"
     t.string   "location"
@@ -409,31 +407,30 @@ ActiveRecord::Schema.define(:version => 20130226132051) do
     t.datetime "major_change_published_at"
     t.datetime "first_published_at"
     t.date     "publication_date"
-    t.text     "summary"
     t.integer  "speech_type_id"
-    t.boolean  "stub",                                                            :default => false
+    t.boolean  "stub",                                        :default => false
     t.text     "change_note"
     t.boolean  "force_published"
-    t.boolean  "minor_change",                                                    :default => false
+    t.boolean  "minor_change",                                :default => false
     t.integer  "publication_type_id"
     t.string   "related_mainstream_content_url"
     t.string   "related_mainstream_content_title"
     t.string   "additional_related_mainstream_content_url"
     t.string   "additional_related_mainstream_content_title"
     t.integer  "alternative_format_provider_id"
-    t.integer  "published_related_publication_count",                             :default => 0,       :null => false
+    t.integer  "published_related_publication_count",         :default => 0,       :null => false
     t.datetime "public_timestamp"
     t.integer  "primary_mainstream_category_id"
     t.datetime "scheduled_publication"
-    t.boolean  "replaces_businesslink",                                           :default => false
-    t.boolean  "access_limited",                                                                       :null => false
+    t.boolean  "replaces_businesslink",                       :default => false
+    t.boolean  "access_limited",                                                   :null => false
     t.integer  "published_major_version"
     t.integer  "published_minor_version"
     t.integer  "operational_field_id"
     t.text     "roll_call_introduction"
     t.text     "govdelivery_url"
     t.integer  "news_article_type_id"
-    t.boolean  "relevant_to_local_government",                                    :default => false
+    t.boolean  "relevant_to_local_government",                :default => false
   end
 
   add_index "editions", ["alternative_format_provider_id"], :name => "index_editions_on_alternative_format_provider_id"

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -3,15 +3,6 @@ require "test_helper"
 class EditionTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
-  ['title', 'summary', 'body'].each do |column_name|
-    # These tests ensure that we're excluding the title, summary and body columns from Edition.columns.
-    # You can safely remove it, and Edition.columns, once it's been deployed and we've subsequently removed
-    # these columns for real.
-    test "#columns excludes #{column_name} so that we can safely it from editions in a future migration" do
-      refute Edition.columns.map(&:name).include?(column_name)
-    end
-  end
-
   test "returns downcased humanized class name as format name" do
     assert_equal 'case study', CaseStudy.format_name
     assert_equal 'publication', Publication.format_name


### PR DESCRIPTION
This is the third attempt at removing these columns from the editions table.
They were first removed when we added the edition_translations table[1](77f82bb28a061ce8188245a37c5c515d8798d755) but
that change had to be reverted[2](8b26d249637255f71b0f633d2920c5b2273d116c) when we realised that the removal of the
columns would cause downtime for end users. The second removal attempt[3](ef5f97dd535a1c3af6cd39a49bc227830b6bf17e) came
later but again had to be reverted[4](c967cdd4803096191f7443678e1ae52ef540f0de) when we realised that stale ActiveRecord
processes would still be automagically referring to those columns. We
eventually deployed a fix[5](d1fc876aae4e7a8dbb8ca74e4b80452102e1e4e4) that should mean we can now remove these columns
for good.

This was initially driven by [Story 43568447](https://www.pivotaltracker.com/story/show/43568447).
