### PR TITLE
Make the admin navigation only contain 3 items

### DIFF
--- a/app/assets/stylesheets/admin/layout.scss
+++ b/app/assets/stylesheets/admin/layout.scss
@@ -37,45 +37,15 @@ header {
   overflow: hidden;
 
   .toggler {
-    display: block;
-    cursor: pointer;
-    padding: $gutter-one-third 8px;
-    text-decoration: none;
-    width: 50px;
-
-    @include media(desktop){
-      display: inline-block;
-    }
-
-    &:hover,
-    &:focus {
-      text-decoration: underline;
-      outline: none;
-    }
     &:after {
-      display: inline-block;
-      font-size: 8px;
-      height: 20px;
-      padding-left: 5px;
-      vertical-align: middle;
       content: " \25BC";
     }
   }
-
   &.open {
     .toggler {
       &:after {
         content: " \25B2";
       }
-    }
-  }
-
-  .jump-link {
-    float: right;
-
-    @include media(tablet){
-      position: absolute;
-      left: -99999em;
     }
   }
 
@@ -96,39 +66,16 @@ header {
       @include media(tablet){
         display: inline;
       }
-
-      .subtype {
-        @include media(tablet){
-          width: 14em;
-          text-align: left;
-          background: $inside-gov-secondary;
-          position: absolute;
-          right: 0;
-          z-index: 1;
-          @include box-shadow(0 2px 6px rgba(0, 0, 0, 0.2));
-          @include ie(7){
-            top: 40px;
-          }
-
-          li {
-            width: 100%;
-            display: block;
-            a {
-              display: block;
-            }
-          }
-        }
-      }
       .toggler {
-        position: absolute;
         &:focus {
           text-decoration: none;
+          outline: none;
         }
-
+      }
+      &.user-org {
+        display: none;
         @include media(tablet){
-          position: relative;
-          left: auto;
-          z-index: 10;
+          display: block;
         }
       }
     }
@@ -136,10 +83,8 @@ header {
 }
 
 .navbar .visuallyhidden {
-  display: none;
-  @include media(tablet) {
-    display: block;
-  }
+  position: absolute;
+  left: -9999em;
 }
 
 .navbar-fixed-top,
@@ -252,4 +197,8 @@ header {
       display: block;
     }
   }
+}
+
+.js-enabled .navbar .nav .js-hidden {
+  display: none;
 }

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -1,4 +1,11 @@
 module Admin::UrlHelper
+  def admin_user_organisation_header_link
+    if user_signed_in?
+      organisation = current_user.organisation
+      admin_header_link organisation.name, admin_organisation_path(organisation), nil, class: 'user-org'
+    end
+  end
+
   def admin_topics_header_link
     admin_header_link "Topics", admin_topics_path
   end
@@ -51,10 +58,14 @@ module Admin::UrlHelper
     end
   end
 
-  def admin_header_link(name, path, path_matcher = nil)
+  def admin_header_link(name, path, path_matcher = nil, options = {})
     path_matcher ||= Regexp.new("^#{Regexp.escape(path)}")
     if user_signed_in?
-      content_tag(:li, link_to(name, path), class: active_link_class(path_matcher))
+      li_class = active_link_class(path_matcher)
+      if options[:class]
+        li_class = [li_class, options[:class]].join(' ')
+      end
+      content_tag(:li, link_to(name, path), class: li_class)
     end
   end
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,6 +25,7 @@
   </head>
 
   <body>
+    <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <header class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container-fluid">
@@ -55,13 +56,14 @@
         </div>
 
          <div class="js-toggle-nav" id="global-nav">
-            <div class="inner">
             <nav class="nav-collapse">
               <ul class="nav">
                 <%= admin_documents_header_link %>
-                <%= admin_organisations_header_link %>
-                <li><span class="jump-link"><a href="#navigation" class="toggler">more</a></span></li>
-                <ul class="nav content">
+                <%= admin_document_series_header_link %>
+                <%= admin_user_organisation_header_link %>
+                <li><a href="#navigation" class="toggler">More&hellip;</a></li>
+                <ul class="nav content js-hidden">
+                  <%= admin_organisations_header_link %>
                   <%= admin_policy_teams_header_link %>
                   <%= admin_policy_advisory_groups_header_link %>
                   <%= admin_roles_header_link %>
@@ -71,11 +73,9 @@
                   <%= admin_worldwide_organisations_header_link %>
                   <%= admin_world_locations_header_link %>
                   <%= admin_fields_of_operation_header_link %>
-                  <%= admin_document_series_header_link %>
                 </ul>
               </ul>
             </nav><!--/.nav-collapse -->
-            </div>
           </div>
 
       </div>


### PR DESCRIPTION
The admin nav bar was getting very very long. It was decided that
everything other than "Documents", "Document series" and "[My
department]" should be moved under a sub-nav item.

https://www.pivotaltracker.com/story/show/44907221
https://www.pivotaltracker.com/story/show/45162979
