### PR TITLE
Use tmp folder for temporary test files

### DIFF
--- a/features/support/bulk_upload_zip_file.rb
+++ b/features/support/bulk_upload_zip_file.rb
@@ -1,1 +1,1 @@
-BulkUpload::ZipFile.default_root_directory = Rails.root.join('test-bulk-upload-zip-file-tmp')
+BulkUpload::ZipFile.default_root_directory = Rails.root.join('tmp/test-bulk-upload-zip-file-tmp')

--- a/lib/tasks/test_cleanup.rake
+++ b/lib/tasks/test_cleanup.rake
@@ -4,7 +4,7 @@ namespace :test do
     puts "Removing temporary uploaded files."
     FileUtils.rm_rf Rails.root.join('public/system')
     FileUtils.rm_rf Rails.root.join('public/uploads')
-    FileUtils.rm_rf Rails.root.join('test-bulk-upload-zip-file-tmp')
+    FileUtils.rm_rf Rails.root.join('tmp/test-bulk-upload-zip-file-tmp')
   end
 end
 

--- a/test/support/bulk_upload_zip_file.rb
+++ b/test/support/bulk_upload_zip_file.rb
@@ -1,1 +1,1 @@
-BulkUpload::ZipFile.default_root_directory = Rails.root.join('test-bulk-upload-zip-file-tmp')
+BulkUpload::ZipFile.default_root_directory = Rails.root.join('tmp/test-bulk-upload-zip-file-tmp')


### PR DESCRIPTION
This makes the tests use the tmp folder to put the files for the bulk
upload test into. Previously if the tests didn't finish for what ever
reason it would leave a folder in the root folder. This makes it only
leave that folder in the tmp folder so its not in your way.
