### PR TITLE
Update the styling on worldwide office pages

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -42,11 +42,11 @@
 @import "helpers/_global.scss";
 #whitehall-wrapper {
   @import "helpers/_attachment.scss";
+  @import "helpers/_available-languages.scss";
   @import "helpers/_browse.scss";
   @import "helpers/_change-notes.scss";
   @import "helpers/_collection_list.scss";
   @import "helpers/_contextual-info.scss";
-  @import "helpers/_available-languages.scss";
   @import "helpers/_corporate-information.scss";
   @import "helpers/_document-page-header.scss";
   @import "helpers/_document-series.scss";
@@ -72,6 +72,7 @@
   @import "helpers/_social-media-accounts.scss";
   @import "helpers/_stick_at_top_when_scrolling.scss";
   @import "helpers/_sub-navigation.scss";
+  @import "helpers/_worldwide-organisation-header.scss";
   @import "../vendor/media-player/player-core.scss";
   @import "../vendor/media-player/player-theme.scss";
   @import "../vendor/media-player/player-fix.scss";

--- a/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
+++ b/app/assets/stylesheets/frontend/helpers/_worldwide-organisation-header.scss
@@ -1,0 +1,44 @@
+.worldwide-organisation-header {
+  margin: $gutter-half 0;
+  @include media(tablet){
+    padding-bottom: $gutter;
+  }
+
+  .logo {
+    @include media(tablet){
+      margin-top: $gutter-half;
+      float: left;
+      width: 66.66%;
+    }
+    h1 {
+      margin: 0 $gutter-half;
+    }
+  }
+  .available-languages {
+    ul {
+      margin: 0 $gutter-half;
+    }
+  }
+  .metadata {
+    margin-top: $gutter-one-third;
+
+    @include media(tablet){
+      float: right;
+      width: 33.33%;
+    }
+    dl {
+      @extend %contain-floats;
+      @include core-14;
+      margin: 0 $gutter-half;
+
+      dt {
+        float: left;
+        clear: both;
+        width: 5em;
+      }
+      dd {
+        float: left;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/frontend/views/_worldwide_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_worldwide_organisations.scss
@@ -9,58 +9,41 @@
     margin-bottom: $gutter;
   }
 
-  .organisation-header {
-    margin-bottom: $gutter;
+  .about-block {
+    @extend %contain-floats;
 
-    .available-languages {
-      ul {
-        margin-right: $gutter-half;
-      }
-    }
-
-    .content {
-      padding: 0 $gutter-half;
-    }
-
-    header {
-      display: block;
-
+    .about-us {
       @include media(tablet){
         float: left;
         width: 66.66%;
       }
-
-      .world-location {
-        @include core-19;
-        font-weight: bold;
-        padding: $gutter-half 0 $gutter;
-      }
-      .sponsoring-organisations {
-        @include core-16;
-        color: $secondary-text-colour;
-        padding: $gutter 0 $gutter-half;
-      }
     }
-    aside {
-      display: block;
-
+    .social-media-links {
       @include media(tablet){
         float: left;
         width: 33.33%;
-        margin-top: $gutter;
       }
+
+      h1 {
+        @include copy-19;
+        font-weight: bold;
+      }
+    }
+    .content {
+      margin: 0 $gutter-half;
+    }
+    .summary {
+      @include copy-19;
+      font-weight: bold;
+      margin-bottom: $gutter-half;
     }
   }
 
-  .about-block {
+  .our-services {
     .content {
       @include media(tablet){
-        max-width: 66%;
+        width: 66.66%;
       }
-    }
-    .summary {
-      @include heading-24;
-      margin-bottom: $gutter;
     }
   }
 

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -3,21 +3,27 @@
   link_to_organisation ||= false
   object_for_translation ||= organisation
 %>
-<%= render partial: 'shared/available_languages', locals: {object: object_for_translation } %>
-<header>
-  <div class="content">
-    <% if world_locations.any? %>
-      <h2 class="world-location"><%= world_locations.map {|l| link_to(l.title, l) }.to_sentence %></h2>
-    <% end %>
-    <%= content_tag :h1, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) do %>
-      <% if link_to_organisation %>
-        <% link_to content_tag(:span, format_with_html_line_breaks(h(organisation.logo_formatted_name))), organisation %>
-      <% else %>
-          <%= content_tag :span, format_with_html_line_breaks(h(organisation.logo_formatted_name)) %>
+<header class="block worldwide-organisation-header">
+  <div class="inner-block floated-children">
+    <div class="logo">
+      <%= content_tag :h1, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) do %>
+        <% if link_to_organisation %>
+          <% link_to content_tag(:span, format_with_html_line_breaks(h(organisation.logo_formatted_name))), organisation %>
+        <% else %>
+            <%= content_tag :span, format_with_html_line_breaks(h(organisation.logo_formatted_name)) %>
+        <% end %>
       <% end %>
-    <% end %>
-    <p class="sponsoring-organisations">
-      <%= t('worldwide_organisation.part_of') %> <%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation") }.to_sentence.html_safe %>
-    </p>
+    </div>
+    <%= render partial: 'shared/available_languages', locals: {object: object_for_translation } %>
+    <div class="metadata">
+      <dl>
+        <% if world_locations.any? %>
+          <dt><%= t('worldwide_organisation.location') %>:</dt>
+          <dd><%= world_locations.map {|l| link_to(l.title, l) }.to_sentence %></dd>
+        <% end %>
+        <dt><%= t('worldwide_organisation.part_of') %>:</dt>
+        <dd><%= organisation.sponsoring_organisations.map {|o| link_to(o.name, o, class: "sponsoring-organisation") }.to_sentence.html_safe %></dd>
+      </dl>
+    </div>
   </div>
 </header>

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -1,31 +1,29 @@
 <% page_title @worldwide_organisation.name %>
 <% page_class "worldwide-organisations-show" %>
 
-<div class="block organisation-header">
+<%= render partial: 'header', locals: { organisation: @worldwide_organisation, world_locations: @world_locations } %>
+
+<section class="block about-block" id="about-us">
   <div class="inner-block floated-children">
-    <%= render partial: 'header', locals: { organisation: @worldwide_organisation, world_locations: @world_locations } %>
-    <aside class="organisation-social-media-links">
+    <div class="about-us">
       <div class="content">
+        <p class="summary"><%= @worldwide_organisation.summary %></p>
+        <div class="description">
+          <%= govspeak_to_html @worldwide_organisation.description %>
+        </div>
+      </div>
+    </div>
+    <aside class="social-media-links">
+      <div class="content">
+        <h1><%= t('worldwide_organisation.headings.follow_us') %></h1>
         <%= render 'shared/social_media_accounts', socialable: @worldwide_organisation, followus: true %>
       </div>
     </aside>
   </div>
-</div>
-
-<section class="block about-block" id="about-us">
-  <div class="inner-block">
-    <h1 class="keyline-header"><%= t('worldwide_organisation.headings.about_us' ) %></h1>
-    <div class="content">
-      <p class="summary"><%= @worldwide_organisation.summary %></p>
-      <div class="description">
-        <%= govspeak_to_html @worldwide_organisation.description %>
-      </div>
-    </div>
-  </div>
 </section>
 
 <% if @worldwide_organisation.services.present? %>
-  <section class="block about-block" id="our-services">
+  <section class="block our-services" id="our-services">
     <div class="inner-block">
       <h1 class="keyline-header"><%= t('worldwide_organisation.headings.our_services' ) %></h1>
       <div class="content">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,8 +250,10 @@ en:
   worldwide_organisation:
     find_out_more: See full profile and all contact details
     part_of: Part of
+    location: Location
     headings:
       about_us: About us
+      follow_us: Follow us
       our_services: Our services
       our_people: Our people
       contact_us: Contact us

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -251,9 +251,11 @@ fr:
   worldwide_organisation:
     find_out_more: En savoir plus
     part_of: Une partie de
+    location: Emplacement
     headings:
       about_us: L'ambassade
       contact_us: Contactez-nous
+      follow_us: Suivez-nous
       our_people: Nos responsables
       our_services: Nos services
       corporate_information: Informations sur la société


### PR DESCRIPTION
Moved the styles for the header block into its own helper. This same
style header is used on corporate info pages and this will make styling
them much easier.

https://www.pivotaltracker.com/story/show/45316097
