### PR TITLE
Remove unused tranlsation keys for treaty

### DIFF
--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -72,7 +72,6 @@ class PublicationType
 
   # Less common
   TransparencyData       = create(id: 10, key: "transparency", singular_name: "Transparency data", plural_name: "Transparency data", prevalence: :less_common)
-  Treaty                 = create(id: 11, key: "treaty", singular_name: "Treaty", plural_name: "Treaties", prevalence: :less_common)
   FoiRelease             = create(id: 12, key: "foi_release", singular_name: "FOI release", plural_name: "FOI releases", prevalence: :less_common)
   IndependentReport      = create(id: 14, key: "independent_report", singular_name: "Independent report", plural_name: "Independent reports", prevalence: :less_common)
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -160,12 +160,6 @@ ar:
       transparency:
         one: بيانات تتعلق بالشفافية
         other: بيانات تتعلق بالشفافية
-      treaty:
-        one: اتفاقية
-        other: اتفاقيات
-      worldwide_priority:
-        one: أولوية دولية
-        other: أولويات دولية
       written_statement:
         one: تصريح خطي
         other: تصريحات خطية

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -160,9 +160,6 @@ az:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -160,9 +160,6 @@ be:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -160,9 +160,6 @@ bg:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -160,9 +160,6 @@ bn:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -160,9 +160,6 @@ cs:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -160,9 +160,6 @@ de:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -160,9 +160,6 @@ dr:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -160,9 +160,6 @@ el:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,9 +198,6 @@ en:
       transparency:
         one: Transparency data
         other: Transparency data
-      treaty:
-        one: Treaty
-        other: Treaties
       written_statement:
         one: Written statement to parliament
         other: Written statements to parliament

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -160,9 +160,6 @@ es:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
-      treaty:
-        one: Tratado
-        other: Tratados
       worldwide_priority:
         one: Prioridad en todo el mundo
         other: Prioridades en todo el mundo

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -160,9 +160,6 @@ fa:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -160,9 +160,6 @@ fr:
       transparency:
         one: Données de transparence
         other: Données de transparence
-      treaty:
-        one: Traité
-        other: Traités
       worldwide_priority:
         one: Priorité internationale
         other: Priorités internationales

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -160,9 +160,6 @@ he:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -160,9 +160,6 @@ hi:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -160,9 +160,6 @@ hu:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -160,9 +160,6 @@ hy:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -160,9 +160,6 @@ id:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -160,9 +160,6 @@ it:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -160,9 +160,6 @@ ja:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -160,9 +160,6 @@ ka:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -160,9 +160,6 @@ ko:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -160,9 +160,6 @@ lt:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -160,9 +160,6 @@ lv:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -160,9 +160,6 @@ ms:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -160,9 +160,6 @@ pl:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -160,9 +160,6 @@ ps:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -160,9 +160,6 @@ pt:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -160,9 +160,6 @@ ro:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -160,9 +160,6 @@ ru:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -160,9 +160,6 @@ si:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -160,9 +160,6 @@ sk:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -160,9 +160,6 @@ so:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -160,9 +160,6 @@ sq:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -160,9 +160,6 @@ sr:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -160,9 +160,6 @@ sw:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -160,9 +160,6 @@ ta:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -160,9 +160,6 @@ th:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -160,9 +160,6 @@ tk:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -160,9 +160,6 @@ tr:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -160,9 +160,6 @@ uk:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -160,9 +160,6 @@ ur:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -160,9 +160,6 @@ uz:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -160,9 +160,6 @@ vi:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -160,9 +160,6 @@ zh:
       transparency:
         one:
         other:
-      treaty:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/lib/whitehall/publication_filter_option.rb
+++ b/lib/whitehall/publication_filter_option.rb
@@ -26,7 +26,6 @@ module Whitehall
     ResearchAndAnalysis = create(id: 7, label: "Research and analysis", search_format_types: PublicationType::ResearchAndAnalysis.search_format_types, publication_types: [PublicationType::ResearchAndAnalysis])
     CorporateReport = create(id: 8, label: "Corporate reports", search_format_types: PublicationType::CorporateReport.search_format_types, publication_types: [PublicationType::CorporateReport])
     TransparencyData = create(id: 9, label: "Transparency data", search_format_types: PublicationType::TransparencyData.search_format_types, publication_types: [PublicationType::TransparencyData])
-    Treaty = create(id: 10, label: "Treaties", search_format_types: PublicationType::Treaty.search_format_types, publication_types: [PublicationType::Treaty])
     FoiRelease = create(id: 11, label: "FOI releases", search_format_types: PublicationType::FoiRelease.search_format_types, publication_types: [PublicationType::FoiRelease])
     IndependentReport = create(id: 12, label: "Independent reports", search_format_types: PublicationType::IndependentReport.search_format_types, publication_types: [PublicationType::IndependentReport])
     Correspondence = create(id: 13, label: "Correspondence", search_format_types: PublicationType::Correspondence.search_format_types, publication_types: [PublicationType::Correspondence])


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/43839771

Pretty straight forward - removes the Publication type from admin and from the front-end publication filter selector.

I've also removed the `treaty` key from translations, which we may or may not want to keep for future use.
