### PR TITLE
Use correct supporting page admin url

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -59,7 +59,7 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
       next unless page.edition.present?
       target << row(
         policy_supporting_page_url(page.edition.document, page, host: host_name, protocol: 'https'),
-        admin_edition_supporting_page_url(page, edition_id: page.edition_id, host: admin_host, protocol: 'https')
+        admin_supporting_page_url(page, host: admin_host, protocol: 'https')
       )
     end
 

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -21,6 +21,13 @@ module Whitehall
       assert_equal expected, arrays_to_csv(actual)
     end
 
+    def assert_extraction_contains(expected)
+      actual = []
+      @exporter.export(actual)
+      actual = arrays_to_csv(actual)
+      assert actual.include?(expected.strip), "Expected:\n#{actual} to contain: \n#{expected}"
+    end
+
     test "extract published publication to csv" do
       publication = create(:published_publication)
       organisation = publication.organisations.first
@@ -40,6 +47,15 @@ Old Url,New Url,Status,Slug,Admin Url,State
 "",https://www.preview.alphagov.co.uk/government/organisations/#{organisation.slug},"","",https://whitehall-admin.test.alphagov.co.uk/government/admin/organisations/#{organisation.slug},""
 "",https://www.preview.alphagov.co.uk/government/organisations/#{organisation.slug},"","",https://whitehall-admin.test.alphagov.co.uk/government/admin/organisations/#{organisation.slug}/edit,""
 "",https://www.preview.alphagov.co.uk/government/organisations/#{organisation.slug}/about/publication-scheme,"","",https://whitehall-admin.test.alphagov.co.uk/government/admin/organisations/#{organisation.slug}/corporate_information_pages/publication-scheme/edit,""
+      EOT
+    end
+
+    test "extracts supporting pages to csv" do
+      supporting_page = create(:supporting_page)
+      edition = supporting_page.edition
+      assert_extraction_contains <<-EOT
+"",https://www.preview.alphagov.co.uk/government/policies/#{edition.slug},418,#{edition.slug},https://whitehall-admin.test.alphagov.co.uk/government/admin/policies/#{edition.id},draft
+"",https://www.preview.alphagov.co.uk/government/policies/#{edition.slug}/supporting-pages/#{supporting_page.slug},"","",https://whitehall-admin.test.alphagov.co.uk/government/admin/editions/#{supporting_page.edition_id}/supporting-pages/#{supporting_page.id},""
       EOT
     end
   end


### PR DESCRIPTION
This fixes the supporting page url to use the correct one. This gives us the ability to redirect old urls for supporting pages, when we are supplied with an admin url.

Tracker bug: https://www.pivotaltracker.com/story/show/45070821
