### PR TITLE
Fix first published at label for import documents

### DIFF
--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -1,4 +1,11 @@
+<%
+  if edition.imported?
+    label_text = 'date required'
+  else
+    label_text = 'leave blank to use the publication time of this edition'
+  end
+%>
 <fieldset>
-  <%= form.label :first_published_at, 'First published at (leave blank to use the publication time of this edition)' %>
+  <%= form.label :first_published_at, "First published at (#{label_text})" %>
   <%= form.datetime_select :first_published_at, { include_blank: true }, { class: 'date' } %>
 </fieldset>

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -11,6 +11,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
   should_allow_editing_of :news_article
 
   should_allow_speed_tagging_of :news_article
+  should_allow_setting_first_published_at_during_speed_tagging :news_article
   should_allow_related_policies_for :news_article
   should_allow_organisations_for :news_article
   should_allow_role_appointments_for :news_article

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1092,6 +1092,7 @@ module AdminEditionControllerTestHelpers
 
         admin_editions_path = send("admin_#{edition_type.to_s.tableize}_path")
         assert_select "form#edition_new[action='#{admin_editions_path}']" do
+          assert_select "label[for=edition_first_published_at]", text: "First published at (leave blank to use the publication time of this edition)"
           assert_select "select[name*='edition[first_published_at']", count: 5
         end
       end
@@ -1103,6 +1104,7 @@ module AdminEditionControllerTestHelpers
 
         admin_edition_path = send("admin_#{edition_type}_path", edition)
         assert_select "form#edition_edit[action='#{admin_edition_path}']" do
+          assert_select "label[for=edition_first_published_at]", text: "First published at (leave blank to use the publication time of this edition)"
           assert_select "select[name*='edition[first_published_at']", count: 5
         end
       end
@@ -1125,6 +1127,17 @@ module AdminEditionControllerTestHelpers
 
         edition.reload
         assert_equal first_published_at, edition.first_published_at
+      end
+    end
+
+    def should_allow_setting_first_published_at_during_speed_tagging(edition_type)
+      view_test "show should display first_published_at fields when speed tagging" do
+        edition = create("imported_#{edition_type}")
+
+        get :show, id: edition
+
+        assert_select "label[for=edition_first_published_at]", text: "First published at (date required)"
+        assert_select "select[name*='edition[first_published_at']", count: 5
       end
     end
 


### PR DESCRIPTION
Imported documents need a first published at date to be set. Where as
new or edited documents need exectly the inverse.

https://www.pivotaltracker.com/story/show/45484805
