### PR TITLE
Add xml to the list of allowed uploads types

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -7,7 +7,7 @@ class AttachmentUploader < WhitehallUploader
 
   PDF_CONTENT_TYPE = 'application/pdf'
   FALLBACK_THUMBNAIL_PDF = File.expand_path("../../assets/images/pub-cover.png", __FILE__)
-  EXTENSION_WHITE_LIST = %w(pdf csv rtf png jpg doc docx xls xlsx ppt pptx zip rdf txt kml odt ods)
+  EXTENSION_WHITE_LIST = %w(pdf csv rtf png jpg doc docx xls xlsx ppt pptx zip rdf txt kml odt ods xml)
 
   process :set_content_type
   after :retrieve_from_cache, :set_content_type

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class AttachmentUploaderTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
-  test 'should only allow PDF, CSV, RTF, PNG, JPG, DOC, DOCX, XLS, XLSX, PPT, PPTX, ZIP, RDF, TXT, KML, ODS, ODT attachments' do
+  test 'should only allow PDF, CSV, RTF, PNG, JPG, DOC, DOCX, XLS, XLSX, PPT, PPTX, ZIP, RDF, TXT, KML, ODS, ODT, XML attachments' do
     uploader = AttachmentUploader.new
-    allowed = %w(pdf csv rtf png jpg doc docx xls xlsx ppt pptx zip rdf txt kml odt ods)
+    allowed = %w(pdf csv rtf png jpg doc docx xls xlsx ppt pptx zip rdf txt kml odt ods xml)
     assert_equal allowed.sort, uploader.extension_white_list.sort
   end
 


### PR DESCRIPTION
I can't see any reason we wouldn't allow this. And it was raised in
zendesk ticket that one department really wants to use it.
