### PR TITLE
Govspeak in world org api

### DIFF
--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -53,10 +53,10 @@ class Api::WorldwideOrganisationPresenter < Draper::Base
   end
 
   def offices_as_json
-    {
-      main: office_as_json(model.main_office),
-      other: model.other_offices.map { |office| office_as_json(office) }
-    }
+    offices = {}
+    offices[:main] = office_as_json(model.main_office) if model.main_office
+    offices[:other] = model.other_offices.map { |office| office_as_json(office) }
+    offices
   end
 
   def office_as_json(office_model)

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -116,7 +116,12 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     @office.contact.stubs(:contact_form_url).returns('office-contact-form-url')
     assert_equal 'office-contact-form-url', @presenter.as_json[:offices][:main][:details][:contact_form_url]
   end
-  
+
+  test 'json does not include main key in offices if there is no main office' do
+    @world_org.stubs(:main_office).returns(nil)
+    refute @presenter.as_json[:offices].has_key?(:main)
+  end
+
   test 'json includes main and other offices in offices with separate keys' do
     office1 = stub_record(:worldwide_office, contact: stub_record(:contact, title: 'best-office', contact_numbers: []),
                                              services: [],
@@ -129,7 +134,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     @world_org.stubs(:other_offices).returns([office2])
     main_office_as_json = @presenter.as_json[:offices][:main]
     other_offices_as_json = @presenter.as_json[:offices][:other]
-    
+
     assert_equal 'best-office', main_office_as_json[:title]
     assert_equal 1, other_offices_as_json.size
     assert_equal 'worst-office', other_offices_as_json.first[:title]


### PR DESCRIPTION
Render description and services of a worldwide organisation via govspeak_to_html in the API.  Services can be blank and if so we don't push it through govspeak so you get an empty string (instead of not having the key).

Don't render the main_office at all, and thus don't have an offices[:main] key in the API if the worldwide organisation has no main_office.

I realise now that these two changes take different approaches to missing stuff, should we standardise?  Should this be something that the API docs standardise on?
