### PR TITLE
Stop duplicate validations being created.

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -20,7 +20,15 @@ class CaseStudy < Edition
   end
 
   def apply_any_extra_validations_when_converting_from_imported_to_draft
-    class << self
+    unless singleton_class.ancestors.include?(ImportToDraftValidations)
+      singleton_class.send(:include, ImportToDraftValidations)
+    end
+  end
+
+  module ImportToDraftValidations
+    extend ActiveSupport::Concern
+
+    included do
       validates :first_published_at, presence: true
     end
   end

--- a/app/models/newsesque.rb
+++ b/app/models/newsesque.rb
@@ -7,8 +7,8 @@ class Newsesque < Announcement
   end
 
   def apply_any_extra_validations_when_converting_from_imported_to_draft
-    class << self
-      validates :first_published_at, presence: true
+    unless singleton_class.ancestors.include?(ImportToDraftValidations)
+      singleton_class.send(:include, ImportToDraftValidations)
     end
   end
 
@@ -16,6 +16,13 @@ class Newsesque < Announcement
     true
   end
 
+  module ImportToDraftValidations
+    extend ActiveSupport::Concern
+
+    included do
+      validates :first_published_at, presence: true
+    end
+  end
 end
 
 require_relative 'news_article'

--- a/test/unit/case_study_test.rb
+++ b/test/unit/case_study_test.rb
@@ -30,4 +30,14 @@ class CaseStudyTest < ActiveSupport::TestCase
     refute build(:case_study, state: 'imported', first_published_at: nil).valid_as_draft?
     assert build(:case_study, state: 'draft', first_published_at: nil).valid_as_draft?
   end
+
+  test 'imported case study that are not valid_as_draft? do not create duplicate errors' do
+    case_study = build(:case_study, state: 'imported', first_published_at: nil)
+
+    refute case_study.valid_as_draft?
+    assert_equal ["can't be blank"], case_study.errors[:first_published_at]
+
+    refute case_study.valid_as_draft?
+    assert_equal ["can't be blank"], case_study.errors[:first_published_at]
+  end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -70,6 +70,16 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert build(:news_article, state: 'draft', first_published_at: nil).valid_as_draft?
   end
 
+  test 'imported news article that are not valid_as_draft? do not create duplicate errors' do
+    news_article = build(:news_article, state: 'imported', first_published_at: nil)
+
+    refute news_article.valid_as_draft?
+    assert_equal ["can't be blank"], news_article.errors[:first_published_at]
+
+    refute news_article.valid_as_draft?
+    assert_equal ["can't be blank"], news_article.errors[:first_published_at]
+  end
+
   [:draft, :scheduled, :published, :archived, :submitted, :rejected].each do |state|
     test "#{state} news article is not valid when the news article type is 'imported-awaiting-type'" do
       news_article = build(:news_article, state: state, news_article_type: NewsArticleType.find_by_slug('imported-awaiting-type'))


### PR DESCRIPTION
Tracker https://www.pivotaltracker.com/story/show/45837669

Fixes a bug that was causing duplicate error messages for imported documents with a blank first_published_at.
