### PR TITLE
Add tracking to the number of infinte pages shown

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -14,6 +14,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
   var documentFilter = {
     loading: false,
     $form: null,
+    formType: '',
 
     renderTable: function(data) {
       $('link[rel=next][type=application/json]').remove();
@@ -34,6 +35,8 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         $('link[rel=next][type=application/json]').remove();
         $container.append($results.filter('nav'));
         $('.previous-next-navigation').addClass('infinite');
+
+        window._gaq && _gaq.push(['_trackEvent', 'edd_inside_gov', 'page-'+data.current_page, documentFilter.formType]);
       }
     },
     updateAtomFeed: function(data) {
@@ -337,6 +340,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
           documentFilter.onPopState(event);
         });
         documentFilter.$form = $form;
+        documentFilter.formType = $form.attr('action').split('/').pop();
 
         history.replaceState(documentFilter.currentPageState(), null);
         $form.submit(documentFilter.submitFilters);


### PR DESCRIPTION
To let us know how many people are using the infinite scroll. It should
also let us tune the number of results to return on the first page.

I have put the event namespaced to my name as this was recomended by the
analytics team so they know its mine. I am only planing on running this
for a short period of time (enough to give us a trend) before tracking
something else so I have kept the event name firaly generic.
