### PR TITLE
Unify logo name methods

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
   end
 
   def format_with_html_line_breaks(string)
-    h(string || "").strip.gsub(/(?:\r?\n)/, "<br/>").html_safe
+    ERB::Util.html_escape(string || "").strip.gsub(/(?:\r?\n)/, "<br/>").html_safe
   end
 
   def link_to_attachment(attachment)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -7,6 +7,14 @@ module OrganisationHelper
     end
   end
 
+  def organisation_logo_name(organisation, stacked = true)
+    if stacked
+      format_with_html_line_breaks(ERB::Util.html_escape(organisation.logo_formatted_name))
+    else
+      organisation.name
+    end
+  end
+
   def organisation_type_name(organisation)
     type_name = ActiveSupport::Inflector.singularize(organisation.organisation_type.name.downcase)
   end

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -15,7 +15,7 @@
             <%= content_tag_for(:li, organisation, class: organisation.slug) do %>
               <%= link_to organisation_path(organisation),
                           class: logo_classes(class_name: organisation.organisation_logo_type.class_name, size: 'medium') do %>
-                <span><%= organisation.logo_formatted_name %></span>
+                <span><%= organisation_logo_name(organisation, false) %></span>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -41,7 +41,7 @@
       <%= content_tag_for :section, organisation do %>
         <h3>
           <%= link_to organisation_path(organisation), class: logo_classes(class_name: organisation.organisation_logo_type.class_name,  size: 'medium', stacked: true) do %>
-            <span><%= format_with_html_line_breaks(organisation.logo_formatted_name) %></span>
+            <span><%= organisation_logo_name(organisation) %></span>
           <% end %>
         </h3>
         <ul class="minister-list">

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -18,11 +18,11 @@
   <%= content_tag :h1 do %>
     <% if link_to_organisation %>
       <%= link_to organisation_path(organisation), class: logo_classes(class_name: organisation.organisation_logo_type.class_name, size: logo_size, stacked: true) do %>
-        <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+        <span><%= organisation_logo_name(organisation) %></span>
       <% end %>
     <% else %>
       <span class="<%= logo_classes(class_name: organisation.organisation_logo_type.class_name, size: logo_size, stacked: true) %>">
-        <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+        <span><%= organisation_logo_name(organisation) %></span>
       </span>
     <% end %>
   <% end %>

--- a/app/views/organisations/_organisations_logo_list.html.erb
+++ b/app/views/organisations/_organisations_logo_list.html.erb
@@ -17,7 +17,7 @@
         <%= content_tag_for :li, organisation, class:  organisation.slug do %>
           <%= link_to organisation,
                       class: logo_classes(class_name: organisation.organisation_logo_type.class_name, stacked: !show_hm_government, use_identity: !show_hm_government) do %>
-            <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+            <span><%= organisation_logo_name(organisation, !show_hm_government) %></span>
           <% end %>
         <% end %>
       <% end %>
@@ -42,7 +42,7 @@
       <%= content_tag_for(:div, organisation, class: organisation.slug) do %>
         <%= link_to organisation,
                     class: logo_classes(class_name: organisation.organisation_logo_type.class_name, stacked: true, use_identity: true) do %>
-          <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+          <span><%= organisation_logo_name(organisation) %></span>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -22,7 +22,7 @@
                                     "data-filter-terms" => filter_terms(ministerial_department) do %>
                 <h2 id="<%= ministerial_department.slug %>" class="<%= ministerial_department.slug %>">
                   <%= link_to organisation_path(ministerial_department), class: logo_classes(class_name: ministerial_department.organisation_logo_type.class_name, size: 'medium') do %>
-                    <span><%= ministerial_department.logo_formatted_name %></span>
+                    <span><%= organisation_logo_name(ministerial_department, false) %></span>
                   <% end %>
                 </h2>
                 <%= render partial: 'works_with', locals: { organisation: ministerial_department, link_to_homepage: true } %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -113,9 +113,8 @@
             <% @classification.lead_organisations.each do |organisation| %>
               <%= content_tag_for(:li, organisation, class: organisation.slug) do %>
                 <%= link_to organisation_path(organisation),
-                      title: organisation.logo_formatted_name,
                       class: logo_classes(class_name: organisation.organisation_logo_type.class_name, stacked: true) do %>
-                  <span><%= format_with_html_line_breaks(h(organisation.logo_formatted_name)) %></span>
+                  <span><%= organisation_logo_name(organisation) %></span>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -8,9 +8,9 @@
     <div class="logo">
       <h1>
         <% if link_to_organisation %>
-          <%= link_to content_tag(:span, format_with_html_line_breaks(h(organisation.logo_formatted_name))), organisation, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
+          <%= link_to content_tag(:span, organisation_logo_name(organisation)), organisation, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
         <% else %>
-          <%= content_tag :span, content_tag(:span, format_with_html_line_breaks(h(organisation.logo_formatted_name))), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
+          <%= content_tag :span, content_tag(:span, organisation_logo_name(organisation)), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
         <% end %>
       </h1>
     </div>

--- a/app/views/worldwide_organisations/_logo_list.html.erb
+++ b/app/views/worldwide_organisations/_logo_list.html.erb
@@ -3,7 +3,7 @@
     <% worldwide_organisations.each do |worldwide_organisation| %>
       <%= content_tag_for(:li, worldwide_organisation, class: worldwide_organisation.slug) do %>
         <%= link_to worldwide_organisation, class: 'organisation-logo organisation-logo-stacked-single-identity' do %>
-          <span><%= format_with_html_line_breaks(h(worldwide_organisation.logo_formatted_name)) %></span>
+          <span><%= organisation_logo_name(worldwide_organisation) %></span>
         <% end %>
       <% end %>
     <% end %>

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -17,7 +17,7 @@ class DetailedGuidesControllerTest < ActionController::TestCase
   end
 
   view_test "shows related organisations" do
-    organisation = create(:organisation, logo_formatted_name: 'The Organisation')
+    organisation = create(:organisation, name: 'The Organisation')
     guide = create(:published_detailed_guide, organisations: [organisation])
 
     get :show, id: guide.document

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class OrganisationHelperTest < ActionView::TestCase
+  include ApplicationHelper
   test "returns acroynm in abbr tag if present" do
     organisation = build(:organisation, acronym: "BLAH", name: "Building Law and Hygiene")
     assert_equal %{<abbr title="Building Law and Hygiene">BLAH</abbr>}, organisation_display_name(organisation)
@@ -14,6 +15,12 @@ class OrganisationHelperTest < ActionView::TestCase
   test "returns name when acroynm is empty" do
     organisation = build(:organisation, acronym: "", name: "Building Law and Hygiene")
     assert_equal "Building Law and Hygiene", organisation_display_name(organisation)
+  end
+
+  test "returns name formatted for logos" do
+    organisation = build(:organisation, name: "Building Law and Hygiene", logo_formatted_name: "Building Law\nand Hygiene")
+    assert_equal "Building Law<br/>and Hygiene", organisation_logo_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_logo_name(organisation, false)
   end
 
   test 'organisation header helper should place org specific class onto the div' do


### PR DESCRIPTION
Unified the calls to get a name to put in a logo into a single place.

Switched single line instances of organisations to use name rather than
formatted name.

Removed title from topical event link as the title contained the same as
the link text making it unnecessary.

https://www.pivotaltracker.com/story/show/45936735
