### PR TITLE
Redirect to documents tab when unfeaturing

### DIFF
--- a/app/controllers/admin/edition_organisations_controller.rb
+++ b/app/controllers/admin/edition_organisations_controller.rb
@@ -14,7 +14,7 @@ class Admin::EditionOrganisationsController < Admin::BaseController
       attributes[:alt_text] = nil
     end
     if @edition_organisation.update_attributes(attributes)
-      redirect_to admin_organisation_path(@edition_organisation.organisation, anchor: "documents")
+      redirect_to documents_admin_organisation_path(@edition_organisation.organisation)
     else
       @edition_organisation.build_image unless @edition_organisation.image.present?
       render :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Whitehall::Application.routes.draw do
           resources :contacts
           resources :social_media_accounts
           member do
-            get :documents
+            get :documents, as: 'documents'
             get :document_series
             get :about
             get :people

--- a/test/functional/admin/edition_organisations_controller_test.rb
+++ b/test/functional/admin/edition_organisations_controller_test.rb
@@ -119,11 +119,11 @@ class Admin::EditionOrganisationsControllerTest < ActionController::TestCase
     assert edition_organisation.alt_text.blank?
   end
 
-  test "should redirect back to the documents tab of the organisation's admin page" do
+  test "should redirect back to the documents page of the organisation's admin page" do
     organisation = create(:organisation)
     edition_organisation = create(:edition_organisation, organisation: organisation)
     post :update, id: edition_organisation, edition_organisation: {}
-    assert_redirected_to admin_organisation_path(organisation, anchor: "documents")
+    assert_redirected_to documents_admin_organisation_path(organisation)
   end
 
   test "should prevent access to editon_organisations of inaccessible editions" do


### PR DESCRIPTION
This used to work when there was javascript managing the tabs. This
brings it into line with the new real tab bassed interface.

https://govuk.zendesk.com/tickets/72094
