### PR TITLE
Add pagination to policy activity pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_pagination.scss
+++ b/app/assets/stylesheets/frontend/helpers/_pagination.scss
@@ -1,7 +1,6 @@
 #page .previous-next-navigation {
   position: relative;
   overflow: hidden;
-  background: $detailed-guidance-brand;
   margin-top: $gutter*2;
   width: 100%;
 
@@ -21,7 +20,7 @@
         padding: $gutter-half $gutter-half+30px $gutter-half 0;
       }
       a:before {
-        background: transparent image-url("arrow-sprite.png") no-repeat -102px -11px;
+        background: transparent image-url("arrow-sprite-2B8CC4.png") no-repeat -102px -11px;
         margin: -4px -32px 0 0;
         display: block;
         float: right;
@@ -35,7 +34,7 @@
           padding: $gutter-half 0 $gutter-half $gutter-half+30px;
       }
       a:before {
-        background: transparent image-url("arrow-sprite.png") no-repeat -20px -11px;
+        background: transparent image-url("arrow-sprite-2B8CC4.png") no-repeat -20px -11px;
         margin: -4px 0 0 -32px;
         display: block;
         float: left;
@@ -47,7 +46,6 @@
 
     a {
       display: block;
-      color: $white;
       text-decoration: none;
 
       span {
@@ -58,8 +56,11 @@
       &:hover span {
         text-decoration: underline;
       }
+      &:hover {
+        background: $grey-4;
+      }
       &:active {
-        background: darken($detailed-guidance-brand, 10%);
+        background: $grey-3;
       }
     }
     @media (max-width: 768px) {
@@ -88,7 +89,6 @@
       width: 240px;
       a {
         padding: 15px 0;
-        color: $text-colour;
       }
     }
     &.loading li {

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -39,7 +39,7 @@ class PoliciesController < DocumentsController
 
   def activity
     @policy = @document
-    @recently_changed_documents = Edition.published.related_to(@policy).in_reverse_chronological_order
+    @recently_changed_documents = Edition.published.related_to(@policy).in_reverse_chronological_order.page(params[:page]).per(40)
     expire_on_next_scheduled_publication(Edition.scheduled.related_to(@policy))
 
     if @recently_changed_documents.empty?

--- a/app/views/policies/activity.html.erb
+++ b/app/views/policies/activity.html.erb
@@ -22,6 +22,7 @@
       <%= render partial: "recently_changed_documents",
                 object: @recently_changed_documents,
                 locals: { title: "Latest on this policy" } %>
+      <%= paginate @recently_changed_documents %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I have tried to keep the test for this fairly simple and only assert
that we are exciting the pagination gem we use. There seems little point
to extensivly test the pagination as the we should assume the gem is
tested and works.

Also updated the styling of the pagination slightly to be less
'detailed-guide' as we never use it for detailed guides any more.

https://www.pivotaltracker.com/story/show/45992749
