### PR TITLE
Add & Remove corp info pages from search when their org changes state

### DIFF
--- a/app/models/corporate_information_page_search_index_observer.rb
+++ b/app/models/corporate_information_page_search_index_observer.rb
@@ -1,0 +1,21 @@
+class CorporateInformationPageSearchIndexObserver < ActiveRecord::Observer
+  observe :organisation
+
+  def after_update(org)
+    if going_live_on_govuk?(org)
+      org.corporate_information_pages.each(&:update_in_search_index)
+    elsif leaving_live_on_govuk?(org)
+      org.corporate_information_pages.each(&:remove_from_search_index)
+    end
+  end
+
+  private
+  def going_live_on_govuk?(org)
+    org.govuk_status_changed? && org.govuk_status == 'live'
+  end
+
+  def leaving_live_on_govuk?(org)
+    org.govuk_status_changed? && org.govuk_status_was == 'live'
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,11 @@ module Whitehall
 
     # Activate observers that should always be running.
     unless ENV["SKIP_OBSERVERS_FOR_ASSET_TASKS"].present?
-      config.active_record.observers = :ministerial_role_search_index_observer, :supporting_page_search_index_observer
+      config.active_record.observers = [
+        :ministerial_role_search_index_observer,
+        :supporting_page_search_index_observer,
+        :corporate_information_page_search_index_observer
+      ]
     end
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.

--- a/test/unit/corporate_information_page_search_index_observer_test.rb
+++ b/test/unit/corporate_information_page_search_index_observer_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class CorporateInformationPageSearchIndexObserverTest < ActiveSupport::TestCase
+  test 'should add corp info page to search index when its organisation goes live' do
+    org = create(:organisation, govuk_status: 'joining')
+    corp_page = create(:corporate_information_page, organisation: org)
+
+    Rummageable.stubs(:index).with(anything, Whitehall.government_search_index_path)
+    Rummageable.expects(:index).with(corp_page.search_index, Whitehall.government_search_index_path)
+
+    org.govuk_status = 'live'
+    org.save
+  end
+
+  test 'should remove corp info pages from search index when its organisation becomes no longer live' do
+    org = create(:organisation, govuk_status: 'live')
+    corp_page = create(:corporate_information_page, organisation: org)
+
+    Rummageable.stubs(:delete).with(anything, Whitehall.government_search_index_path)
+    Rummageable.expects(:delete).with(corp_page.search_index['link'], Whitehall.government_search_index_path)
+
+    org.govuk_status = 'joining'
+    org.save
+  end
+
+end


### PR DESCRIPTION
When an org goes from govuk_status `'<whatever>'` to `'live'` we need to add any corp info pages that they have to the search.  We do this with an observer.  It also handles the (admittedly unlikely event of an org going from `'live'` to `'<whatever>'` and removing the pages from the index.

This completes: https://github.com/alphagov/whitehall/pull/337
