### PR TITLE
Remove user 553 and change any refs to 648

### DIFF
--- a/db/data_migration/20130313100034_remove_user_account_553.rb
+++ b/db/data_migration/20130313100034_remove_user_account_553.rb
@@ -1,0 +1,18 @@
+# Replace all mentions of user 553 to user 648. See ticket:
+# https://www.pivotaltracker.com/story/show/46035207
+
+[
+  %w(versions whodunnit),
+  %w(edition_authors user_id),
+  %w(user_world_locations user_id),
+  %w(editorial_remarks author_id),
+  %w(fact_check_requests requestor_id),
+  %w(imports creator_id),
+  %w(recent_edition_openings editor_id)
+].each do |table, column|
+  ActiveRecord::Base.connection.execute %{
+    UPDATE #{table} SET #{column}="648" WHERE #{column}="553";
+  }
+end
+
+ActiveRecord::Base.connection.execute "DELETE FROM users WHERE id=553;"


### PR DESCRIPTION
We first change all references then remove the user record. On a
reasonably recent database dump (two days ago) there were no references
to this user in any of the tables, but left in just in case.

Ran before/after full diffs of the database, and it appears to only
remove the record and bump the migration count.

https://www.pivotaltracker.com/story/show/46035207
