### PR TITLE
Allow images to be referenced from the edition

### DIFF
--- a/app/views/html_versions/show.html.erb
+++ b/app/views/html_versions/show.html.erb
@@ -27,7 +27,7 @@
     <div class="inner-block">
       <article class="document">
         <div class="body govspeak">
-          <%= bare_govspeak_to_html @html_version.body, [] %>
+          <%= bare_govspeak_to_html @html_version.body, @document.images %>
         </div>
       </article>
     </div>

--- a/features/html-versions-of-publications.feature
+++ b/features/html-versions-of-publications.feature
@@ -21,12 +21,18 @@ Feature: HTML version of publication
   html publication and a link back to the publication record page is
   displayed on the html publication.
 
-  Scenario: Adding an HTML version to a publication
+  Background:
     Given I am an editor
-    When I begin drafting a new publication "Beard figures 2013"
-    And I add an HTML version of the publication
+
+  Scenario: Adding an HTML version to a publication
+    When I publish a publication with an HTML version
     Then the HTML version should be visible on the public page
     And citizens should be able to view the HTML version
     And the HTML version should be styled with the organisation logo
     And the HTML version should link back to the publication record page
 
+  Scenario: Adding an image to the HTML version of a publication
+    When I begin drafting a new publication with an HTML version
+    And I select an image for the publication
+    And I reference the image from the HTML version
+    Then the HTML version of the published publication should show the referenced image

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -41,12 +41,6 @@ Given /^I start drafting a new detailed guide$/ do
   begin_drafting_document type: 'detailed_guide', title: "Detailed Guide", primary_mainstream_category: category
 end
 
-When /^I select an image for the detailed guide$/ do
-  within ".images" do
-    attach_file "File", Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")
-  end
-end
-
 When /^I visit the detailed guide "([^"]*)"$/ do |name|
   guide = DetailedGuide.find_by_title!(name)
   visit detailed_guide_path(guide.document)

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -1,0 +1,7 @@
+When /^I select an image for the (?:detailed guide|publication)$/ do
+  within ".images" do
+    attach_file "File", Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")
+    fill_in "Alt text", with: "minister of funk"
+  end
+end
+

--- a/features/step_definitions/publication_html_version_steps.rb
+++ b/features/step_definitions/publication_html_version_steps.rb
@@ -1,8 +1,16 @@
-When /^I add an HTML version of the publication$/ do
+When /^I publish a publication with an HTML version$/ do
+  begin_drafting_publication("Beard figures 2012")
+
   fill_in "HTML version title", with: 'HTML version title'
   fill_in "HTML version text", with: 'HTML version text'
   click_button "Save"
   click_button "Force Publish"
+end
+
+When /^I begin drafting a new publication with an HTML version$/ do
+  begin_drafting_publication("Beard figures 2012")
+  fill_in "HTML version title", with: 'HTML version title'
+  fill_in "HTML version text", with: 'HTML version text'
 end
 
 Then /^the HTML version should be visible on the public page$/ do
@@ -20,4 +28,18 @@ end
 
 Then /^the HTML version should link back to the publication record page$/ do
   assert page.has_css?("a[href*='#{public_document_path(Publication.last)}']")
+end
+
+When /^I reference the image from the HTML version$/ do
+  fill_in "HTML version text", with: "\n\n!!1\n\nRest of publication"
+end
+
+Then /^the HTML version of the published publication should show the referenced image$/ do
+  click_on "Save"
+  click_on "Force Publish"
+
+  visit public_document_path(Publication.last)
+  click_on HtmlVersion.last.title
+
+  assert page.has_css?('img[src*=minister-of-funk]')
 end


### PR DESCRIPTION
This allows writers to attach images to the publication and refer to them in the HTML version using `!!1`.

https://www.pivotaltracker.com/story/show/46067013
