### PR TITLE
Remove corp info translation links for org for now

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -301,6 +301,10 @@ class Organisation < ActiveRecord::Base
     published_publications.where("editions.publication_type_id" => publication_type.id).any?
   end
 
+  def has_corporate_information_page_translations?
+    false
+  end
+
   private
 
   def sub_organisations_must_have_a_parent

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -60,4 +60,8 @@ class WorldwideOrganisation < ActiveRecord::Base
   def unused_corporate_information_page_types
     CorporateInformationPageType.all - corporate_information_pages.map(&:type)
   end
+
+  def has_corporate_information_page_translations?
+    true
+  end
 end

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -24,7 +24,11 @@
           <% @corporate_information_pages.each do |corporate_information_page| %>
             <%= content_tag_for(:tr, corporate_information_page) do %>
               <td><%= link_to corporate_information_page.title, edit_polymorphic_path([:admin, @organisation, corporate_information_page]) %></td>
-              <td><%= link_to "Manage translations", admin_worldwide_organisation_corporate_information_page_translations_path(@organisation, corporate_information_page) %></td>
+              <% if @organisation.has_corporate_information_page_translations? %>
+                <td><%= link_to "Manage translations", admin_worldwide_organisation_corporate_information_page_translations_path(@organisation, corporate_information_page) %></td>
+              <% else %>
+                <td></td>
+              <% end %>
               <td><%= button_to "delete", [:admin, @organisation, corporate_information_page], method: :delete, class: "btn btn-danger", confirm: "Really delete #{corporate_information_page.title} from #{@organisation.name}? This cannot be undone." %></td>
             <% end %>
           <% end %>

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -44,6 +44,13 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     assert_equal [corporate_information_page], assigns(:corporate_information_pages)
   end
 
+  view_test "GET :index should not show manage translations for orgs right now" do
+    corporate_information_page = create(:corporate_information_page, organisation: @organisation)
+    get :index, organisation_id: @organisation
+
+    refute response.body.include?("Manage translations")
+  end
+
   view_test "GET :new should display form" do
     get :new, organisation_id: @organisation
 


### PR DESCRIPTION
Until this story [1] is done, we don't support corporate information
page translations. Remove the link via a switch in the model.

[1] https://www.pivotaltracker.com/story/show/44081009

Ticket for this bug: https://www.pivotaltracker.com/story/show/46145293
