### PR TITLE
Enable Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.9.2
+env:
+  - DB=mysql CUCUMBER_FORMAT=progress GOVUK_APP_DOMAIN=test.gov.uk DISPLAY=:99
+script:
+  - bundle exec rake db:create
+  - bundle exec rake db:schema:load
+  - bundle exec rake
+before_install:
+  - mysql -u root -e "CREATE USER 'whitehall'@'localhost' IDENTIFIED BY 'whitehall'"
+  - mysql -u root -e 'CREATE DATABASE whitehall_test'
+  - mysql -u root -e "GRANT ALL ON whitehall_test.* TO 'whitehall'@'localhost'"
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq xpdf imagemagick
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - cp config/database.travis.yml config/database.yml
+  - mkdir clean-uploads

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,8 @@
+test:
+  adapter: mysql2
+  host: localhost
+  database: whitehall_test
+  username: whitehall
+  password: whitehall
+  encoding: utf8
+  pool: 5


### PR DESCRIPTION
This branch enables support for [Travis CI](https://travis-ci.org), which can comment on our pull requests and branches, and is free for open source projects.
