### PR TITLE
Org editors and writers should be allowed to manage world documents

### DIFF
--- a/lib/whitehall/authority/rules/world_edition_rules.rb
+++ b/lib/whitehall/authority/rules/world_edition_rules.rb
@@ -7,7 +7,10 @@ module Whitehall::Authority::Rules
       elsif actor.world_editor? || actor.world_writer?
         true
       else
-        false
+        # returning true here makes this whole ruleset redundant, but 
+        # it's not clear if this will always be the case once world is
+        # live, so lets leave it for now
+        true
       end
     end
     def can_with_a_class?(action)

--- a/test/unit/whitehall/authority/department_editor_world_location_news_test.rb
+++ b/test/unit/whitehall/authority/department_editor_world_location_news_test.rb
@@ -9,20 +9,20 @@ class DepartmentEditorWorldLocationNewsTest < ActiveSupport::TestCase
 
   include AuthorityTestHelper
 
-  test 'cannot create a new WorldLocationNewsArticle' do
-    refute enforcer_for(department_editor, WorldLocationNewsArticle).can?(:create)
+  test 'can create a new world location news article' do
+    assert enforcer_for(department_editor, WorldLocationNewsArticle).can?(:create)
   end
 
-  test 'cannot see a world location news article that is not access limited' do
-    refute enforcer_for(department_editor, normal_world_location_news_article).can?(:see)
+  test 'can see an world location news article that is not access limited' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:see)
   end
 
-  test 'cannot see an world location news article that is access limited even if it is limited to their organisation' do
+  test 'can see an world location news article that is access limited if it is limited to their organisation' do
     org = 'organisation'
     user = department_editor
     user.stubs(:organisation).returns(org)
     edition = limited_world_location_news_article([org])
-    refute enforcer_for(user, edition).can?(:see)
+    assert enforcer_for(user, edition).can?(:see)
   end
 
   test 'cannot see an world location news article that is access limited if it is limited an organisation they don\'t belong to' do
@@ -35,13 +35,73 @@ class DepartmentEditorWorldLocationNewsTest < ActiveSupport::TestCase
     refute enforcer_for(user, edition).can?(:see)
   end
 
-  test 'cannot do anything to a world location news articles' do
+  test 'cannot do anything to an world location news article they are not allowed to see' do
+    org1 = 'organisation_1'
+    org2 = 'organisation_2'
     user = department_editor
-    edition = normal_world_location_news_article
+    user.stubs(:organisation).returns(org1)
+    edition = limited_world_location_news_article([org2])
     enforcer = enforcer_for(user, edition)
-
-    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+    
+    Whitehall::Authority::Rules::WorldEditionRules.actions.each do |action|
       refute enforcer.can?(action)
     end
+  end
+
+  test 'can create a new world location news article of a document that is not access limited' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:create)
+  end
+
+  test 'can make changes to an world location news article that is not access limited' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:update)
+  end
+
+  test 'can delete an world location news article that is not access limited' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:delete)
+  end
+
+  test 'can make a fact check request for a world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:make_fact_check)
+  end
+
+  test 'can view fact check requests on a world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:review_fact_check)
+  end
+
+  test 'can publish an world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:publish)
+  end
+
+  test 'can reject an world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:reject)
+  end
+
+  test 'can force publish an world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:force_publish)
+  end
+
+  test 'can make editorial remarks' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:make_editorial_remark)
+  end
+
+  test 'can review editorial remarks' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:review_editorial_remark)
+  end
+
+  test 'can clear the "not reviewed" flag on world location news articles they didn\'t force publish' do
+    assert enforcer_for(department_editor(10), force_published_world_location_news_article(department_editor(100))).can?(:approve)
+  end
+
+  test 'cannot clear the "not reviewed" flag on world location news articles they did force publish' do
+    user = department_editor
+    refute enforcer_for(user, force_published_world_location_news_article(user)).can?(:approve)
+  end
+
+  test 'can limit access to an world location news article' do
+    assert enforcer_for(department_editor, normal_world_location_news_article).can?(:limit_access)
+  end
+
+  test 'cannot unpublish an world location news article' do
+    refute enforcer_for(department_editor, normal_world_location_news_article).can?(:unpublish)
   end
 end

--- a/test/unit/whitehall/authority/department_editor_worldwide_priority_test.rb
+++ b/test/unit/whitehall/authority/department_editor_worldwide_priority_test.rb
@@ -9,20 +9,20 @@ class DepartmentEditorWorldwidePriorityTest < ActiveSupport::TestCase
 
   include AuthorityTestHelper
 
-  test 'cannot create a new WorldwidePriority' do
-    refute enforcer_for(department_editor, WorldwidePriority).can?(:create)
+  test 'can create a new worldwide priority' do
+    assert enforcer_for(department_editor, WorldwidePriority).can?(:create)
   end
 
-  test 'cannot see a worldwide priority that is not access limited' do
-    refute enforcer_for(department_editor, normal_worldwide_priority).can?(:see)
+  test 'can see an worldwide priority that is not access limited' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:see)
   end
 
-  test 'cannot see an worldwide priority that is access limited even if it is limited to their organisation' do
+  test 'can see an worldwide priority that is access limited if it is limited to their organisation' do
     org = 'organisation'
     user = department_editor
     user.stubs(:organisation).returns(org)
     edition = limited_worldwide_priority([org])
-    refute enforcer_for(user, edition).can?(:see)
+    assert enforcer_for(user, edition).can?(:see)
   end
 
   test 'cannot see an worldwide priority that is access limited if it is limited an organisation they don\'t belong to' do
@@ -35,13 +35,73 @@ class DepartmentEditorWorldwidePriorityTest < ActiveSupport::TestCase
     refute enforcer_for(user, edition).can?(:see)
   end
 
-  test 'cannot do anything to a worldwide prioritys' do
+  test 'cannot do anything to an worldwide priority they are not allowed to see' do
+    org1 = 'organisation_1'
+    org2 = 'organisation_2'
     user = department_editor
-    edition = normal_worldwide_priority
+    user.stubs(:organisation).returns(org1)
+    edition = limited_worldwide_priority([org2])
     enforcer = enforcer_for(user, edition)
-
-    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+    
+    Whitehall::Authority::Rules::WorldEditionRules.actions.each do |action|
       refute enforcer.can?(action)
     end
+  end
+
+  test 'can create a new worldwide priority of a document that is not access limited' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:create)
+  end
+
+  test 'can make changes to an worldwide priority that is not access limited' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:update)
+  end
+
+  test 'can delete an worldwide priority that is not access limited' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:delete)
+  end
+
+  test 'can make a fact check request for a worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:make_fact_check)
+  end
+
+  test 'can view fact check requests on a worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:review_fact_check)
+  end
+
+  test 'can publish an worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:publish)
+  end
+
+  test 'can reject an worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:reject)
+  end
+
+  test 'can force publish an worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:force_publish)
+  end
+
+  test 'can make editorial remarks' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:make_editorial_remark)
+  end
+
+  test 'can review editorial remarks' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:review_editorial_remark)
+  end
+
+  test 'can clear the "not reviewed" flag on worldwide prioritys they didn\'t force publish' do
+    assert enforcer_for(department_editor(10), force_published_worldwide_priority(department_editor(100))).can?(:approve)
+  end
+
+  test 'cannot clear the "not reviewed" flag on worldwide prioritys they did force publish' do
+    user = department_editor
+    refute enforcer_for(user, force_published_worldwide_priority(user)).can?(:approve)
+  end
+
+  test 'can limit access to an worldwide priority' do
+    assert enforcer_for(department_editor, normal_worldwide_priority).can?(:limit_access)
+  end
+
+  test 'cannot unpublish an worldwide priority' do
+    refute enforcer_for(department_editor, normal_worldwide_priority).can?(:unpublish)
   end
 end

--- a/test/unit/whitehall/authority/department_writer_world_location_news_test.rb
+++ b/test/unit/whitehall/authority/department_writer_world_location_news_test.rb
@@ -9,20 +9,20 @@ class DepartmentWriterWorldLocationNewsTest < ActiveSupport::TestCase
 
   include AuthorityTestHelper
 
-  test 'cannot create a new WorldLocationNewsArticle' do
-    refute enforcer_for(department_writer, WorldLocationNewsArticle).can?(:create)
+  test 'can create a new world location news article' do
+    assert enforcer_for(department_writer, WorldLocationNewsArticle).can?(:create)
   end
 
-  test 'cannot see a world location news article that is not access limited' do
-    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:see)
+  test 'can see an world location news article that is not access limited' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:see)
   end
 
-  test 'cannot see an world location news article that is access limited even if it is limited to their organisation' do
+  test 'can see an world location news article that is access limited if it is limited to their organisation' do
     org = 'organisation'
     user = department_writer
     user.stubs(:organisation).returns(org)
     edition = limited_world_location_news_article([org])
-    refute enforcer_for(user, edition).can?(:see)
+    assert enforcer_for(user, edition).can?(:see)
   end
 
   test 'cannot see an world location news article that is access limited if it is limited an organisation they don\'t belong to' do
@@ -35,13 +35,68 @@ class DepartmentWriterWorldLocationNewsTest < ActiveSupport::TestCase
     refute enforcer_for(user, edition).can?(:see)
   end
 
-  test 'cannot do anything to a world location news articles' do
+  test 'cannot do anything to an world location news article they are not allowed to see' do
+    org1 = 'organisation_1'
+    org2 = 'organisation_2'
     user = department_writer
-    edition = normal_world_location_news_article
+    user.stubs(:organisation).returns(org1)
+    edition = limited_world_location_news_article([org2])
     enforcer = enforcer_for(user, edition)
-
-    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+    
+    Whitehall::Authority::Rules::WorldEditionRules.actions.each do |action|
       refute enforcer.can?(action)
     end
+  end
+
+  test 'can create a new world location news article of a document that is not access limited' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:create)
+  end
+
+  test 'can make changes to an world location news article that is not access limited' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:update)
+  end
+
+  test 'can delete an world location news article that is not access limited' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:delete)
+  end
+
+  test 'can make a fact check request for an world location news article' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:make_fact_check)
+  end
+
+  test 'can view fact check requests on an world location news article' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:review_fact_check)
+  end
+
+  test 'cannot publish an world location news article' do
+    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:publish)
+  end
+
+  test 'cannot reject an world location news article' do
+    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:reject)
+  end
+
+  test 'cannot force publish a world location news article' do
+    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:force_publish)
+  end
+
+  test 'can make editorial remarks' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:make_editorial_remark)
+  end
+
+  test 'can review editorial remarks' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:review_editorial_remark)
+  end
+
+  test 'cannot clear the "not reviewed" flag on world location news article' do
+    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:approve)
+  end
+
+  test 'can limit access to an world location news article' do
+    assert enforcer_for(department_writer, normal_world_location_news_article).can?(:limit_access)
+  end
+
+  test 'cannot unpublish an world location news article' do
+    refute enforcer_for(department_writer, normal_world_location_news_article).can?(:unpublish)
   end
 end

--- a/test/unit/whitehall/authority/department_writer_worldwide_priority_test.rb
+++ b/test/unit/whitehall/authority/department_writer_worldwide_priority_test.rb
@@ -9,20 +9,20 @@ class DepartmentWriterWorldwidePriorityTest < ActiveSupport::TestCase
 
   include AuthorityTestHelper
 
-  test 'cannot create a new WorldwidePriority' do
-    refute enforcer_for(department_writer, WorldwidePriority).can?(:create)
+  test 'can create a new worldwide priority' do
+    assert enforcer_for(department_writer, WorldwidePriority).can?(:create)
   end
 
-  test 'cannot see a worldwide priority that is not access limited' do
-    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:see)
+  test 'can see an worldwide priority that is not access limited' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:see)
   end
 
-  test 'cannot see an worldwide priority that is access limited even if it is limited to their organisation' do
+  test 'can see an worldwide priority that is access limited if it is limited to their organisation' do
     org = 'organisation'
     user = department_writer
     user.stubs(:organisation).returns(org)
     edition = limited_worldwide_priority([org])
-    refute enforcer_for(user, edition).can?(:see)
+    assert enforcer_for(user, edition).can?(:see)
   end
 
   test 'cannot see an worldwide priority that is access limited if it is limited an organisation they don\'t belong to' do
@@ -35,13 +35,68 @@ class DepartmentWriterWorldwidePriorityTest < ActiveSupport::TestCase
     refute enforcer_for(user, edition).can?(:see)
   end
 
-  test 'cannot do anything to a worldwide prioritys' do
+  test 'cannot do anything to an worldwide priority they are not allowed to see' do
+    org1 = 'organisation_1'
+    org2 = 'organisation_2'
     user = department_writer
-    edition = normal_worldwide_priority
+    user.stubs(:organisation).returns(org1)
+    edition = limited_worldwide_priority([org2])
     enforcer = enforcer_for(user, edition)
-
-    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+    
+    Whitehall::Authority::Rules::WorldEditionRules.actions.each do |action|
       refute enforcer.can?(action)
     end
+  end
+
+  test 'can create a new worldwide priority of a document that is not access limited' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:create)
+  end
+
+  test 'can make changes to an worldwide priority that is not access limited' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:update)
+  end
+
+  test 'can delete an worldwide priority that is not access limited' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:delete)
+  end
+
+  test 'can make a fact check request for an worldwide priority' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:make_fact_check)
+  end
+
+  test 'can view fact check requests on an worldwide priority' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:review_fact_check)
+  end
+
+  test 'cannot publish an worldwide priority' do
+    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:publish)
+  end
+
+  test 'cannot reject an worldwide priority' do
+    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:reject)
+  end
+
+  test 'cannot force publish a worldwide priority' do
+    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:force_publish)
+  end
+
+  test 'can make editorial remarks' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:make_editorial_remark)
+  end
+
+  test 'can review editorial remarks' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:review_editorial_remark)
+  end
+
+  test 'cannot clear the "not reviewed" flag on worldwide priority' do
+    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:approve)
+  end
+
+  test 'can limit access to an worldwide priority' do
+    assert enforcer_for(department_writer, normal_worldwide_priority).can?(:limit_access)
+  end
+
+  test 'cannot unpublish an worldwide priority' do
+    refute enforcer_for(department_writer, normal_worldwide_priority).can?(:unpublish)
   end
 end


### PR DESCRIPTION
This _might_ change back again once world is live and we can settle down the permissions properly.  For now, we don't want to disrupt the production of content ahead of the launch so we just allow it.  This does mean that the WorldEditionRules is almost redundant, but that might change.  Of course, if it doesn't then we should remove it and simplify.
