### PR TITLE
Add new corporate info page type for staff updates

### DIFF
--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -68,4 +68,7 @@ class CorporateInformationPageType
   OfficeAccessAndOpeningTimes = create(
     id: 15, title_template: "Office access and opening times", slug: "access-and-opening", menu_heading: :our_information
   )
+  StaffNewsAndInformation = create(
+    id: 16, title_template: "Staff news and information", slug: "staff-update", menu_heading: :other
+  )
 end


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/35260037

This is a new public page that departments can create so that staff have somewhere to check when there is an incident, e.g. www.dft.gov.uk/staff-updates. This doesn't need to be navigatable to, instead, staff will simply know the url of the page to check. There will be  separate story to provide a shorted URL to this page, e.g http://gov.uk/hmrc/staff-update
