### PR TITLE
Merge Country and OverseasTerritory location types

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,7 +5,7 @@ class Contact < ActiveRecord::Base
   has_many :contact_numbers, dependent: :destroy
   belongs_to :country, class_name: "WorldLocation",
     foreign_key: :country_id,
-    conditions: { "world_locations.world_location_type_id" => WorldLocationType::Country.id }
+    conditions: { "world_locations.world_location_type_id" => WorldLocationType::WorldLocation.id }
 
   validates :title, presence: true
   validates :contact_form_url, url: true, allow_blank: true

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -86,7 +86,7 @@ class WorldLocation < ActiveRecord::Base
   end
 
   def self.countries
-    where(world_location_type_id: WorldLocationType::Country.id).ordered_by_name
+    where(world_location_type_id: WorldLocationType::WorldLocation.id).ordered_by_name
   end
 
   def self.geographical

--- a/app/models/world_location_type.rb
+++ b/app/models/world_location_type.rb
@@ -16,10 +16,9 @@ class WorldLocationType
   end
 
   def self.geographic
-    [Country, OverseasTerritory]
+    [WorldLocation]
   end
 
-  Country = create( id: 1, key: "country", name: "Country", sort_order: 0 )
-  OverseasTerritory = create( id: 2, key: "overseas_territory", name: "Overseas territory", sort_order: 1 )
+  WorldLocation = create( id: 1, key: "world_location", name: "World location", sort_order: 0 )
   InternationalDelegation = create( id: 3, key: "international_delegation", name: "International delegation", sort_order: 2 )
 end

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -19,7 +19,7 @@
           <p><span class="js-filter-count"><%= locations.length %></span> <span class="visuallyhidden">locations</span></p>
         </header>
         <div class="content">
-          <% if type === WorldLocationType::Country %>
+          <% if type === WorldLocationType::WorldLocation %>
             <% locations.group_by {|location| location.name.first.upcase }.sort.each do |letter, locations| %>
               <div class="js-filter-block">
                 <h2 class="letter"><%= letter %></h2>
@@ -51,4 +51,3 @@
     </div>
   </div>
 </div>
-

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -454,13 +454,6 @@ ar:
       what_we_do:
   world_location:
     type:
-      country:
-        zero:
-        one: البلد
-        two:
-        few:
-        many:
-        other: البلدان
       international_delegation:
         zero:
         one: وفد دولي
@@ -468,13 +461,13 @@ ar:
         few:
         many:
         other: وفود دولية
-      overseas_territory:
+      world_location:
         zero:
-        one: إقليم في الخارج
+        one:
         two:
         few:
         many:
-        other: أقاليم في الخارج
+        other:
     headings:
       announcements: إعلاناتنا
       country: البلد

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -302,13 +302,10 @@ az:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -338,17 +338,12 @@ be:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        many:
-        other:
       international_delegation:
         one:
         few:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -222,13 +222,10 @@ bg:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -222,13 +222,10 @@ bn:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -280,15 +280,11 @@ cs:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        other:
       international_delegation:
         one:
         few:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         other:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -454,13 +454,6 @@ cy:
       what_we_do:
   world_location:
     type:
-      country:
-        zero:
-        one: Gwlad
-        two:
-        few:
-        many:
-        other: Gwledydd
       international_delegation:
         zero:
         one: Dirprwyaeth ryngwladol
@@ -468,13 +461,13 @@ cy:
         few:
         many:
         other: Dirprwyaethau rhyngwladol
-      overseas_territory:
+      world_location:
         zero:
-        one: Tiriogaeth dramor
+        one:
         two:
         few:
         many:
-        other: Tiriogaethau tramor
+        other:
     headings:
       announcements: Ein cyhoeddiadau
       country: Gwlad

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -222,13 +222,10 @@ de:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -222,13 +222,10 @@ dr:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -222,13 +222,10 @@ el:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,15 +249,12 @@ en:
       statistics: Our statistics
     see_all: See all our %{type}
     type:
-      country:
-        one: Country
-        other: Countries
       international_delegation:
         one: International delegation
         other: International delegations
-      overseas_territory:
-        one: Overseas territory
-        other: Overseas territories
+      world_location:
+        one: World location
+        other: World locations
   worldwide_organisation:
     find_out_more: See full profile and all contact details
     part_of: Part of

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -222,13 +222,10 @@ es-419:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -222,15 +222,12 @@ es:
       what_we_do:
   world_location:
     type:
-      country:
-        one: País
-        other: Países
       international_delegation:
         one: Delegación internacional
         other: Delegaciones internacionales
-      overseas_territory:
-        one: Territorio en el exterior
-        other: Territorios en el exterior
+      world_location:
+        one:
+        other:
     headings:
       announcements: Anuncios
       country: País

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -302,13 +302,10 @@ fa:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -222,15 +222,12 @@ fr:
       what_we_do:
   world_location:
     type:
-      country:
-        one: Pays
-        other: Pays
       international_delegation:
         one: Délégation internationale
         other: Délégations internationales
-      overseas_territory:
-        one: Territoire d'outre-mer
-        other: Territoires d'outre-mer
+      world_location:
+        one: Localisation
+        other: Localisations
     headings:
       announcements: Nos annonces
       country: Pays

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -338,17 +338,12 @@ he:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        two:
-        many:
-        other:
       international_delegation:
         one:
         two:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         two:
         many:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -222,13 +222,10 @@ hi:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -302,13 +302,10 @@ hu:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -222,13 +222,10 @@ hy:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -302,13 +302,10 @@ id:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -222,15 +222,12 @@ it:
       what_we_do:
   world_location:
     type:
-      country:
-        one: Paese
-        other: Paesi
       international_delegation:
         one: Delegazione internazionale
         other: Delegazioni internazionali
-      overseas_territory:
-        one: Territorio d'oltremare
-        other: Territori d'oltremare
+      world_location:
+        one:
+        other:
     headings:
       announcements: I nostri annunci
       country: Paese

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -302,13 +302,10 @@ ja:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -302,13 +302,10 @@ ka:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -302,13 +302,10 @@ ko:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -280,15 +280,11 @@ lt:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        other:
       international_delegation:
         one:
         few:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         other:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -222,13 +222,10 @@ lv:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -302,13 +302,10 @@ ms:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -338,17 +338,12 @@ pl:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        many:
-        other:
       international_delegation:
         one:
         few:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -222,13 +222,10 @@ ps:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -222,13 +222,10 @@ pt:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -280,15 +280,11 @@ ro:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        other:
       international_delegation:
         one:
         few:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         other:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -338,17 +338,12 @@ ru:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        many:
-        other:
       international_delegation:
         one:
         few:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -222,13 +222,10 @@ si:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -280,15 +280,11 @@ sk:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        other:
       international_delegation:
         one:
         few:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -222,13 +222,10 @@ so:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -222,13 +222,10 @@ sq:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -338,17 +338,12 @@ sr:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        many:
-        other:
       international_delegation:
         one:
         few:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         many:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -222,13 +222,10 @@ sw:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -222,13 +222,10 @@ ta:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -302,13 +302,10 @@ th:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -222,13 +222,10 @@ tk:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -302,13 +302,10 @@ tr:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -338,17 +338,12 @@ uk:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        few:
-        many:
-        other:
       international_delegation:
         one:
         few:
         many:
         other:
-      overseas_territory:
+      world_location:
         one:
         few:
         many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -222,13 +222,10 @@ ur:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -222,13 +222,10 @@ uz:
       what_we_do:
   world_location:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
     headings:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -302,13 +302,10 @@ vi:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -302,13 +302,10 @@ zh:
       statistics:
     see_all:
     type:
-      country:
-        one:
-        other:
       international_delegation:
         one:
         other:
-      overseas_territory:
+      world_location:
         one:
         other:
   worldwide_organisation:

--- a/db/data_migration/20130201124727_add_more_countries.rb
+++ b/db/data_migration/20130201124727_add_more_countries.rb
@@ -4,7 +4,7 @@ lines = created = 0
 CSV.read(__FILE__.gsub(/\.rb/, '.csv'), headers: false, encoding: "UTF-8").each do |row|
   unless row[0].blank?
     lines += 1
-    wl = WorldLocation.create(name: row[0], world_location_type: WorldLocationType::Country)
+    wl = WorldLocation.create(name: row[0], world_location_type: WorldLocationType::WorldLocation)
     created += 1 if wl.persisted?
   end
 end

--- a/db/data_migration/20130215150255_add_more_world_locations.rb
+++ b/db/data_migration/20130215150255_add_more_world_locations.rb
@@ -1,11 +1,11 @@
 lines = 0
 created = []
 [
-  ['Bermuda', WorldLocationType::Country, 'bm'],
-  ['Burundi', WorldLocationType::Country, 'bi'],
-  ['El Salvador', WorldLocationType::Country, 'sv'],
-  ['Falkland Islands', WorldLocationType::OverseasTerritory, 'fk'],
-  ['Guinea', WorldLocationType::Country, 'gn'],
+  ['Bermuda', WorldLocationType::WorldLocation, 'bm'],
+  ['Burundi', WorldLocationType::WorldLocation, 'bi'],
+  ['El Salvador', WorldLocationType::WorldLocation, 'sv'],
+  ['Falkland Islands', WorldLocationType::WorldLocation, 'fk'],
+  ['Guinea', WorldLocationType::WorldLocation, 'gn'],
   ['UK Mission to the United Nations, New York', WorldLocationType::InternationalDelegation],
   ['UK Delegation to Council of Europe', WorldLocationType::InternationalDelegation],
   ['The UK Permanent Delegation to the OECD (Organisation for Economic Co-operation and Development)', WorldLocationType::InternationalDelegation],
@@ -18,9 +18,9 @@ created = []
   lines += 1
   name, type, iso2 = *new_world_location
   wl = WorldLocation.new(name: name, world_location_type: type)
-  wl.iso2 = iso2 if [WorldLocationType::Country, WorldLocationType::OverseasTerritory].include? type
+  wl.iso2 = iso2 if [WorldLocationType::WorldLocation].include? type
   wl.title =
-    if [WorldLocationType::Country, WorldLocationType::OverseasTerritory].include? type
+    if [WorldLocationType::WorldLocation].include? type
       'UK in '+name
     else
       name

--- a/db/data_migration/20130225113433_add_even_more_world_locations.rb
+++ b/db/data_migration/20130225113433_add_even_more_world_locations.rb
@@ -1,17 +1,17 @@
 lines = 0
 created = []
 [
-  ['St Helena, Ascension and Tristan da Cunha', WorldLocationType::OverseasTerritory, 'sh'], # territory, ISO: SH, SHN, 654
-  ['St Lucia', WorldLocationType::Country, 'lc'], # country, ISO: LC, LCA, 662
-  ['Kyrgyzstan', WorldLocationType::Country, 'kg'], # Country, ISO: KG, KGZ, 417
-  ['Pitcairn Island', WorldLocationType::OverseasTerritory, 'pn'] # territory, ISO: PN, PCN, 612
+  ['St Helena, Ascension and Tristan da Cunha', WorldLocationType::WorldLocation, 'sh'], # territory, ISO: SH, SHN, 654
+  ['St Lucia', WorldLocationType::WorldLocation, 'lc'], # country, ISO: LC, LCA, 662
+  ['Kyrgyzstan', WorldLocationType::WorldLocation, 'kg'], # Country, ISO: KG, KGZ, 417
+  ['Pitcairn Island', WorldLocationType::WorldLocation, 'pn'] # territory, ISO: PN, PCN, 612
 ].each do |new_world_location|
   lines += 1
   name, type, iso2 = *new_world_location
   wl = WorldLocation.new(name: name, world_location_type: type)
-  wl.iso2 = iso2 if [WorldLocationType::Country, WorldLocationType::OverseasTerritory].include? type
+  wl.iso2 = iso2 if [WorldLocationType::WorldLocation].include? type
   wl.title =
-    if [WorldLocationType::Country, WorldLocationType::OverseasTerritory].include? type
+    if [WorldLocationType::WorldLocation].include? type
       'UK in '+name
     else
       name

--- a/db/data_migration/20130306164001_add_chad_and_mauritania_to_world_locations.rb
+++ b/db/data_migration/20130306164001_add_chad_and_mauritania_to_world_locations.rb
@@ -1,5 +1,5 @@
 puts "Adding Chad and Mauritania to WorldLocations."
-country_type = WorldLocationType::Country
+country_type = WorldLocationType::WorldLocation
 WorldLocation.create(name: 'Chad', title: 'UK in Chad', iso2: 'td', world_location_type: country_type)
 WorldLocation.create(name: 'Mauritania', title: 'UK in Mauritania', iso2: 'mr', world_location_type: country_type)
 

--- a/db/data_migration/20130320114904_add_some_more_countries_again.rb
+++ b/db/data_migration/20130320114904_add_some_more_countries_again.rb
@@ -27,7 +27,7 @@ created = []
 ].each do |country_details|
   lines += 1
   name, slug, iso2 = *country_details
-  country = WorldLocation.new(name: name, iso2: iso2, title: "UK in #{name}", world_location_type: WorldLocationType::Country)
+  country = WorldLocation.new(name: name, iso2: iso2, title: "UK in #{name}", world_location_type: WorldLocationType::WorldLocation)
   country.save
   if country.persisted?
     country.update_column(:slug, slug)

--- a/db/migrate/20130117162735_add_united_kingdom_as_world_location.rb
+++ b/db/migrate/20130117162735_add_united_kingdom_as_world_location.rb
@@ -2,7 +2,7 @@ class AddUnitedKingdomAsWorldLocation < ActiveRecord::Migration
   class WorldLocation < ActiveRecord::Base; end
 
   def up
-    WorldLocation.create!(name: "United Kingdom", iso2: "GB", world_location_type_id: WorldLocationType::Country.id)
+    WorldLocation.create!(name: "United Kingdom", iso2: "GB", world_location_type_id: WorldLocationType::WorldLocation.id)
   end
 
   def down

--- a/db/migrate/20130322201300_merge_country_and_overseas_territory_types.rb
+++ b/db/migrate/20130322201300_merge_country_and_overseas_territory_types.rb
@@ -1,0 +1,14 @@
+class MergeCountryAndOverseasTerritoryTypes < ActiveRecord::Migration
+  class WorldLocation < ActiveRecord::Base; end
+  def up
+    execute %{
+        UPDATE #{WorldLocation.arel_table.name}
+        SET world_location_type_id = 1
+        WHERE world_location_type_id = 2
+    }
+  end
+
+  def down
+    # No down, this is destructive.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130322171426) do
+ActiveRecord::Schema.define(:version => 20130322201300) do
 
   create_table "access_and_opening_times", :force => true do |t|
     t.text     "body"

--- a/features/administering-world-locations.feature
+++ b/features/administering-world-locations.feature
@@ -4,46 +4,46 @@ Feature: Administering world location information
     Given I am an admin
 
   Scenario: Featuring news on an world location page
-    Given an overseas territory "Jamestopia" exists
-    And a published news article "You must buy the X-Factor single, says Queen" exists relating to the overseas territory "Jamestopia" produced 4 days ago
-    When I feature the news article "You must buy the X-Factor single, says Queen" for overseas territory "Jamestopia" with image "minister-of-funk.960x640.jpg"
-    Then I should see the featured items of the overseas territory "Jamestopia" are:
+    Given a world location "Jamestopia" exists
+    And a published news article "You must buy the X-Factor single, says Queen" exists relating to the world location "Jamestopia" produced 4 days ago
+    When I feature the news article "You must buy the X-Factor single, says Queen" for world location "Jamestopia" with image "minister-of-funk.960x640.jpg"
+    Then I should see the featured items of the world location "Jamestopia" are:
       | You must buy the X-Factor single, says Queen | s300_minister-of-funk.960x640.jpg |
 
   Scenario: Defining the order of featured news on an organisation page
-    Given an overseas territory "Jamestopia" exists
-    And a published news article "You must buy the X-Factor single, says Queen" exists relating to the overseas territory "Jamestopia" produced 4 days ago
-    And a published news article "Simon Cowell to receive dubious honour" exists relating to the overseas territory "Jamestopia" produced 2 days ago
-    And a published news article "Bringing back the Charleston" exists relating to the overseas territory "Jamestopia" produced 3 days ago
-    And I feature the news article "Bringing back the Charleston" for overseas territory "Jamestopia"
-    And I feature the news article "You must buy the X-Factor single, says Queen" for overseas territory "Jamestopia"
-    When I order the featured items of the overseas territory "Jamestopia" to:
+    Given a world location "Jamestopia" exists
+    And a published news article "You must buy the X-Factor single, says Queen" exists relating to the world location "Jamestopia" produced 4 days ago
+    And a published news article "Simon Cowell to receive dubious honour" exists relating to the world location "Jamestopia" produced 2 days ago
+    And a published news article "Bringing back the Charleston" exists relating to the world location "Jamestopia" produced 3 days ago
+    And I feature the news article "Bringing back the Charleston" for world location "Jamestopia"
+    And I feature the news article "You must buy the X-Factor single, says Queen" for world location "Jamestopia"
+    When I order the featured items of the world location "Jamestopia" to:
       |Bringing back the Charleston|
       |You must buy the X-Factor single, says Queen|
-    Then I should see the featured items of the overseas territory "Jamestopia" are:
+    Then I should see the featured items of the world location "Jamestopia" are:
       |Bringing back the Charleston|
       |You must buy the X-Factor single, says Queen|
 
   Scenario: Adding a new translation
-    Given a country "Afrolasia" exists with the mission statement "The UK has a long-standing relationship with Afrolasia"
-    When I add a new translation to the country "Afrolasia" with:
+    Given a world location "Afrolasia" exists with the mission statement "The UK has a long-standing relationship with Afrolasia"
+    When I add a new translation to the world location "Afrolasia" with:
       | locale            | Français                                                    |
       | name              | Afrolasie                                                   |
       | title             | UK en Afrolasia                                             |
       | mission_statement | Le Royaume-Uni a une relation de longue date avec Afrolasie |
-    Then when viewing the country "Afrolasia" with the locale "Français" I should see:
+    Then when viewing the world location "Afrolasia" with the locale "Français" I should see:
       | name              | Afrolasie                                                   |
       | title             | UK en Afrolasia                                             |
       | mission_statement | Le Royaume-Uni a une relation de longue date avec Afrolasie |
 
   Scenario: Editing an existing translation
-    Given a country "Afrolasia" exists with a translation for the locale "Français"
+    Given a world location "Afrolasia" exists with a translation for the locale "Français"
     When I edit the "Français" translation for "Afrolasia" setting:
       | locale            | Français                                                    |
       | name              | Afrolandie                                                  |
       | title             | UK en Afrolandie                                            |
       | mission_statement | Enseigner aux gens comment infuser le thé                   |
-    Then when viewing the country "Afrolasia" with the locale "Français" I should see:
+    Then when viewing the world location "Afrolasia" with the locale "Français" I should see:
       | name              | Afrolandie                                                  |
       | title             | UK en Afrolandie                                            |
       | mission_statement | Enseigner aux gens comment infuser le thé                   |

--- a/features/administering-worldwide-organisations.feature
+++ b/features/administering-worldwide-organisations.feature
@@ -82,7 +82,7 @@ Feature: Administering worldwide organisation
     Then I should see the corporate information on the public worldwide organisation page
 
   Scenario: Adding a new translation
-    Given a worldwide organisation "Department of Beards in France" exists for the country "France" with translations into "fr"
+    Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "fr"
     When I add a new translation to the worldwide organisation "Department of Beards in France" with:
       | locale      | Français                                          |
       | name        | Département des barbes en France                  |

--- a/features/speed-tagging-editions.feature
+++ b/features/speed-tagging-editions.feature
@@ -46,7 +46,7 @@ Feature: Speed tagging editions
     And I should be able to set the delivered date of the speech
 
   Scenario: Speed tagging shows world locations when relevant
-    Given a country "Uganda" exists
+    Given a world location "Uganda" exists
     When I go to speed tag a newly imported speech "Speech about Uganda"
     Then I should be able to select the world location "Uganda"
 

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -43,12 +43,13 @@ Given /^a published (publication|policy|news article|consultation) "([^"]*)" was
   create("published_#{document_class(document_type).name.underscore}".to_sym, title: title, organisations: [organisation])
 end
 
-Given /^a published (publication|policy|news article|consultation) "([^"]*)" exists relating to the (?:country|overseas territory|international delegation) "([^"]*)"$/ do |document_type, title, world_location_name|
+Given /^a published (publication|policy|news article|consultation) "([^"]*)" exists relating to the (?:world location|international delegation) "([^"]*)"$/ do |document_type, title, world_location_name|
   world_location = WorldLocation.find_by_name!(world_location_name)
   create("published_#{document_class(document_type).name.underscore}".to_sym, title: title, world_locations: [world_location])
 end
 
-Given /^a published (publication|policy|news article|consultation) "([^"]*)" exists relating to the (?:country|overseas territory|international delegation) "([^"]*)" produced (\d+) days ago$/ do |document_type, title, world_location_name, days_ago|
+Given /^a published (publication|policy|news article|consultation) "([^"]*)" exists relating to the (?:world location|international delegation) "([^"]*)" produced (\d+) days ago$/ do |document_type, title, world_location_name, days_ago|
+
   world_location = WorldLocation.find_by_name!(world_location_name)
   create("published_#{document_class(document_type).name.underscore}".to_sym, title: title, first_published_at: days_ago.to_i.days.ago, world_locations: [world_location])
 end

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -13,30 +13,30 @@ def add_translation_to_world_location(location, translation)
   click_on "Save"
 end
 
-Given /^an? (country|overseas territory|international delegation) "([^"]*)" exists$/ do |world_location_type, name|
+Given /^an? (world location|international delegation) "([^"]*)" exists$/ do |world_location_type, name|
   create(world_location_type.gsub(' ','_').to_sym, name: name)
 end
 
-Given /^an? (country|overseas territory|international delegation) "([^"]*)" exists with the mission statement "([^"]*)"$/ do |world_location_type, name, mission_statement|
+Given /^an? (world location|international delegation) "([^"]*)" exists with the mission statement "([^"]*)"$/ do |world_location_type, name, mission_statement|
   create(world_location_type.gsub(' ','_').to_sym, name: name, mission_statement: mission_statement)
 end
 
-Given /^the (country|overseas territory|international delegation) "([^"]*)" is inactive/ do |world_location_type, name|
+Given /^the (world location|international delegation) "([^"]*)" is inactive/ do |world_location_type, name|
   world_location = WorldLocation.find_by_name(name) || create(world_location_type.gsub(' ','_').to_sym, name: name)
   world_location.update_column(:active, false)
 end
 
-Given /^an? (country|overseas territory|international delegation) "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |world_location_type, name, locale|
+Given /^an? (world location|international delegation) "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |world_location_type, name, locale|
   location = create(world_location_type.gsub(' ','_').to_sym, name: name)
   add_translation_to_world_location(location, locale: locale, name: 'Unimportant', mission_statement: 'Unimportant')
 end
 
-When /^I view the (?:country|overseas territory|international delegation) "([^"]*)"$/ do |name|
+When /^I view the (?:world location|international delegation) "([^"]*)"$/ do |name|
   world_location = WorldLocation.find_by_name!(name)
   visit world_location_path(world_location)
 end
 
-When /^I navigate to the "([^"]*)" (?:country|overseas territory|international delegation)'s (home) page$/ do |world_location_name, page_name|
+When /^I navigate to the "([^"]*)" (?:world location|international delegation)'s (home) page$/ do |world_location_name, page_name|
   within('.world_location nav') do
     click_link \
       case page_name
@@ -49,7 +49,7 @@ When /^I visit the world locations page$/ do
   visit world_locations_path
 end
 
-When /^I feature the news article "([^"]*)" for (?:country|overseas territory|international delegation) "([^"]*)"(?: with image "([^"]*)")?$/ do |news_article_title, organisation_name, image_filename|
+When /^I feature the news article "([^"]*)" for (?:world location|international delegation) "([^"]*)"(?: with image "([^"]*)")?$/ do |news_article_title, organisation_name, image_filename|
   image_filename ||= 'minister-of-funk.960x640.jpg'
   organisation = WorldLocation.find_by_name!(organisation_name)
   visit admin_world_location_featurings_path(organisation)
@@ -62,7 +62,7 @@ When /^I feature the news article "([^"]*)" for (?:country|overseas territory|in
   click_button "Save"
 end
 
-When /^I order the featured items of the (?:country|overseas territory|international delegation) "([^"]*)" to:$/ do |name, table|
+When /^I order the featured items of the (?:world location|international delegation) "([^"]*)" to:$/ do |name, table|
   world_location = WorldLocation.find_by_name!(name)
   visit admin_world_location_featurings_path(world_location)
   table.rows.each_with_index do |(title), index|
@@ -71,7 +71,7 @@ When /^I order the featured items of the (?:country|overseas territory|internati
   click_on "Save"
 end
 
-When /^I add a new translation to the country "([^"]*)" with:$/ do |name, table|
+When /^I add a new translation to the world location "([^"]*)" with:$/ do |name, table|
   world_location = WorldLocation.find_by_name!(name)
   add_translation_to_world_location(world_location, table.rows_hash)
 end
@@ -95,7 +95,7 @@ When /^I visit the worldwide location "([^"]+)"$/ do |name|
   visit world_location_path(world_location)
 end
 
-Then /^I should see the featured items of the (?:country|overseas territory|international delegation) "([^"]*)" are:$/ do |name, expected_table|
+Then /^I should see the featured items of the (?:world location|international delegation) "([^"]*)" are:$/ do |name, expected_table|
   world_location = WorldLocation.find_by_name!(name)
   visit world_location_path(world_location)
   rows = find(featured_documents_selector).all('.news_article')
@@ -109,7 +109,7 @@ Then /^I should see the featured items of the (?:country|overseas territory|inte
   expected_table.diff!(table)
 end
 
-Then /^I should see the "([^"]*)" (?:country|overseas territory|international delegation)'s (home) page$/ do |world_location_name, page_name|
+Then /^I should see the "([^"]*)" (?:world location|international delegation)'s (home) page$/ do |world_location_name, page_name|
   title =
     case page_name
     when 'home'   then world_location_name
@@ -118,19 +118,19 @@ Then /^I should see the "([^"]*)" (?:country|overseas territory|international de
   assert page.has_css?('title', text: title)
 end
 
-Then /^I should see a (?:country|overseas territory|international delegation) called "([^"]*)"$/ do |name|
+Then /^I should see a (?:world location|international delegation) called "([^"]*)"$/ do |name|
   assert page.has_css?(".world_location", text: name)
 end
 
-Then /^I should not see a link to the (?:country|overseas territory|international delegation) called "([^"]*)"$/ do |text|
+Then /^I should not see a link to the (?:world location|international delegation) called "([^"]*)"$/ do |text|
   refute page.has_css?(".world_location a", text: text)
 end
 
-Then /^I should see that it is an? (country|overseas territory|international delegation)$/ do |world_location_type|
+Then /^I should see that it is an? (world location|international delegation)$/ do |world_location_type|
   assert has_css?('.type', text: world_location_type.capitalize)
 end
 
-Then /^when viewing the (?:country|overseas territory|international delegation) "([^"]*)" with the locale "([^"]*)" I should see:$/ do |name, locale, table|
+Then /^when viewing the (?:world location|international delegation) "([^"]*)" with the locale "([^"]*)" I should see:$/ do |name, locale, table|
   world_location = WorldLocation.find_by_name!(name)
   translation = table.rows_hash
   visit world_location_path(world_location)
@@ -139,13 +139,13 @@ Then /^when viewing the (?:country|overseas territory|international delegation) 
   assert page.has_css?('.mission_statement', text: translation["mission_statement"]), "Mission statement wasn't present"
 end
 
-Then /^I should be able to associate "([^"]+)" with the (?:country|overseas territory|international delegation|world location) "([^"]+)"$/ do |title, location|
+Then /^I should be able to associate "([^"]+)" with the (?:world location|international delegation) "([^"]+)"$/ do |title, location|
   begin_editing_document title
   select location, from: "edition_world_location_ids"
   click_on "Save"
 end
 
-When /^I click through to see all the announcements for (?:country|overseas territory|international delegation|world location) "([^"]*)"$/ do |name|
+When /^I click through to see all the announcements for (?:international delegation|world location) "([^"]*)"$/ do |name|
   visit world_location_path(WorldLocation.find_by_name!(name))
   within '#announcements' do
     click_link 'See all'

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -94,8 +94,8 @@ Given /^a worldwide organisation "([^"]*)"$/ do |name|
   create(:worldwide_organisation, name: name)
 end
 
-Given /^a worldwide organisation "([^"]*)" exists for the country "([^"]*)" with translations into "([^"]*)"$/ do |name, country_name, translation|
-  country = create(:country, translated_into: [translation])
+Given /^a worldwide organisation "([^"]*)" exists for the world location "([^"]*)" with translations into "([^"]*)"$/ do |name, country_name, translation|
+  country = create(:world_location, translated_into: [translation])
   create(:worldwide_organisation, name: name, world_locations: [country])
 end
 
@@ -148,7 +148,7 @@ Then /^the "([^"]*)" office details should be shown on the public website$/ do |
 end
 
 Given /^that the world location "([^"]*)" exists$/ do |country_name|
-  create(:country, name: country_name)
+  create(:world_location, name: country_name)
 end
 
 Given /^the worldwide organisation "([^"]*)" exists$/ do |worldwide_organisation_name|
@@ -320,7 +320,7 @@ end
 
 Given /^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |name, native_locale_name|
   locale_code = Locale.find_by_language_name(native_locale_name).code
-  country = create(:world_location, world_location_type: WorldLocationType::Country, translated_into: [locale_code])
+  country = create(:world_location, world_location_type: WorldLocationType::WorldLocation, translated_into: [locale_code])
   create(:worldwide_organisation, name: name, world_locations: [country], translated_into: [locale_code])
 end
 

--- a/features/step_definitions/worldwide_priority_steps.rb
+++ b/features/step_definitions/worldwide_priority_steps.rb
@@ -9,7 +9,7 @@ Given /^a published worldwide priority "([^"]*)" exists$/ do |title|
   create(:published_worldwide_priority, title: title)
 end
 
-Given /^a published worldwide priority "([^"]*)" exists relating to the (?:country|overseas territory|international delegation) "([^"]*)"$/ do |title, world_location_name|
+Given /^a published worldwide priority "([^"]*)" exists relating to the (?:world location|international delegation) "([^"]*)"$/ do |title, world_location_name|
   world_location = WorldLocation.find_by_name!(world_location_name)
   create(:published_worldwide_priority, title: title, world_locations: [world_location])
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,7 +41,7 @@ rescue NameError
 end
 
 Before do
-  create(:country, name: "United Kingdom", iso2: "GB")
+  create(:world_location, name: "United Kingdom", iso2: "GB")
 end
 
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.

--- a/features/viewing-published-publications.feature
+++ b/features/viewing-published-publications.feature
@@ -14,7 +14,7 @@ Scenario: Publishing a publication that has a PDF attachment
   And I should see a thumbnail of the first page of the PDF
 
 Scenario: The publication is about a country
-  Given a country "British Antarctic Territory" exists
+  Given a world location "British Antarctic Territory" exists
   And a published publication "Penguins have rights too" exists that is about "British Antarctic Territory"
   When I visit the publication "Penguins have rights too"
   Then I should see that the publication is about "British Antarctic Territory"

--- a/features/viewing-world-locations.feature
+++ b/features/viewing-world-locations.feature
@@ -1,21 +1,21 @@
 Feature: Viewing world locations
 
-Scenario: View news articles relating to an overseas territory
-  Given an overseas territory "British Antarctic Territory" exists
-  And a published news article "Larsen ice sheet disintegrates" exists relating to the overseas territory "British Antarctic Territory"
-  When I view the overseas territory "British Antarctic Territory"
+Scenario: View news articles relating to an world location
+  Given a world location "British Antarctic Territory" exists
+  And a published news article "Larsen ice sheet disintegrates" exists relating to the world location "British Antarctic Territory"
+  When I view the world location "British Antarctic Territory"
   Then I should see the news article "Larsen ice sheet disintegrates"
 
-Scenario: View policies relating to an overseas territory
-  Given an overseas territory "British Antarctic Territory" exists
-  And a published policy "Icebergs of the World, Unite!" exists relating to the overseas territory "British Antarctic Territory"
-  When I view the overseas territory "British Antarctic Territory"
+Scenario: View policies relating to a world location
+  Given a world location "British Antarctic Territory" exists
+  And a published policy "Icebergs of the World, Unite!" exists relating to the world location "British Antarctic Territory"
+  When I view the world location "British Antarctic Territory"
   Then I should see the policy "Icebergs of the World, Unite!"
 
-Scenario: The publication is about an overseas territory
-  Given an overseas territory "British Antarctic Territory" exists
+Scenario: The publication is about a world location
+  Given a world location "British Antarctic Territory" exists
   And a published publication "Penguins have rights too" exists that is about "British Antarctic Territory"
-  When I view the overseas territory "British Antarctic Territory"
+  When I view the world location "British Antarctic Territory"
   Then I should see the publication "Penguins have rights too"
 
 Scenario: View priorities for an international delegation
@@ -25,21 +25,17 @@ Scenario: View priorities for an international delegation
   Then I should see the worldwide priority "Oil field exploitation"
 
 Scenario: Inactive world locations are listed but not linked
-  Given the country "Democratic People's Republic of South London" is inactive
+  Given the world location "Democratic People's Republic of South London" is inactive
   When I visit the world locations page
-  Then I should see a country called "Democratic People's Republic of South London"
-  But I should not see a link to the country called "Democratic People's Republic of South London"
+  Then I should see a world location called "Democratic People's Republic of South London"
+  But I should not see a link to the world location called "Democratic People's Republic of South London"
 
 Scenario: World locations tell me what type they are
-  Given a country "Spain" exists
-  And an overseas territory "British Antarctic Territory" exists
+  Given a world location "Spain" exists
   And an international delegation "United Nations" exists
 
-  When I view the country "Spain"
-  Then I should see that it is a country
+  When I view the world location "Spain"
+  Then I should see that it is a world location
 
-  When I view the overseas territory "British Antarctic Territory"
-  Then I should see that it is an overseas territory
-
-  When I view the overseas territory "United Nations"
+  When I view the world location "United Nations"
   Then I should see that it is an international delegation

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -51,7 +51,7 @@ Feature: World location news for people local to countries
 
   @not-quite-as-fake-search
   Scenario: Associate a world location news article with a world location
-    Given a country "Indonesia" exists
+    Given a world location "Indonesia" exists
     When I draft a valid world location news article "Indonesian Beer"
     Then I should be able to associate "Indonesian Beer" with the world location "Indonesia"
     When I force publish the world location news article "Indonesian Beer"

--- a/test/factories/contacts.rb
+++ b/test/factories/contacts.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
 
   factory :contact_with_country, parent: :contact do
     street_address '29 Acacier Road'
-    country
+    association :country, factory: :world_location
   end
 end

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -1,15 +1,8 @@
 FactoryGirl.define do
   factory :world_location, traits: [:translated] do
     name 'British Antarctic Territory'
-    world_location_type WorldLocationType::OverseasTerritory
+    world_location_type WorldLocationType::WorldLocation
   end
-
-  factory :country, parent: :world_location do
-    name "France"
-    world_location_type WorldLocationType::Country
-  end
-
-  factory :overseas_territory, parent: :world_location
 
   factory :international_delegation, parent: :world_location do
     name "United Nations"

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCase
   setup do
     login_as :policy_writer
-    @location = create(:country, name: 'Afrolasia', mission_statement: 'Teaching the people how to brew tea')
+    @location = create(:world_location, name: 'Afrolasia', mission_statement: 'Teaching the people how to brew tea')
 
     Locale.stubs(:non_english).returns([
       Locale.new(:fr), Locale.new(:es)

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -528,7 +528,7 @@ class OrganisationsControllerTest < ActionController::TestCase
         { label: "Helpline", number: "02079460000" },
         { label: "Fax", number: "02079460001" }
       ],
-      country: create(:country, iso2: 'GB')
+      country: create(:world_location, iso2: 'GB')
     )
     get :show, id: organisation
 

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -11,8 +11,8 @@ class WorldLocationsControllerTest < ActionController::TestCase
   should_show_published_documents_associated_with :world_location, :worldwide_priorities
 
   view_test "index should display a list of world locations" do
-    bat = create(:overseas_territory, name: "British Antarctic Territory")
-    png = create(:country, name: "Papua New Guinea")
+    bat = create(:world_location, name: "British Antarctic Territory")
+    png = create(:world_location, name: "Papua New Guinea")
 
     get :index
 
@@ -203,7 +203,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   view_test "should display translated page labels when requested in a different locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     create(:published_worldwide_priority, world_locations: [world_location], translated_into: [:fr])
     create(:published_publication, world_locations: [world_location], translated_into: [:fr])
@@ -211,14 +211,14 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     get :show, id: world_location, locale: 'fr'
 
-    assert_select ".type", "Pays"
+    assert_select ".type", "Localisation"
     assert_select "#worldwide-priorities", /Priorités/
     assert_select "#policies .see-all a", /Voir tous nos priorités politiques/
     assert_select "#publications .see-all a", /Voir tous nos publications/
   end
 
   test "should only display translated priorities when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_priority = create(:published_worldwide_priority, world_locations: [world_location], translated_into: [:fr])
     untranslated_priority = create(:published_worldwide_priority, world_locations: [world_location])
@@ -229,7 +229,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated announcements when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_speech = create(:published_speech, world_locations: [world_location], translated_into: [:fr])
     untranslated_speech = create(:published_speech, world_locations: [world_location])
@@ -240,7 +240,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated publications when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_publication = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     untranslated_publication = create(:published_publication, world_locations: [world_location])
@@ -251,7 +251,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated statistics when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_statistics = create(:published_statistics, world_locations: [world_location], translated_into: [:fr])
     untranslated_statistics = create(:published_statistics, world_locations: [world_location])
@@ -262,7 +262,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated policies when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_policy = create(:published_policy, world_locations: [world_location], translated_into: [:fr])
     untranslated_policy = create(:published_policy, world_locations: [world_location])
@@ -273,7 +273,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated featured editions when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_edition = create(:published_news_article, translated_into: [:fr])
     untranslated_edition = create(:published_publication)
@@ -286,7 +286,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   end
 
   test "should only display translated recently updated editions when requested for a locale" do
-    world_location = create(:country, translated_into: [:fr])
+    world_location = create(:world_location, translated_into: [:fr])
 
     translated_publication = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     untranslated_publication = create(:published_publication, world_locations: [world_location])

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -14,29 +14,29 @@ module AdminEditionWorldLocationsBehaviour
       end
 
       test "creating should create a new document with world locations" do
-        country = create(:country)
-        overseas_territory = create(:overseas_territory)
+        world_location = create(:world_location)
+        world_location2 = create(:world_location)
         attributes = controller_attributes_for(document_type)
 
         post :create, edition: attributes.merge(
-          world_location_ids: [country.id, overseas_territory.id]
+          world_location_ids: [world_location.id, world_location2.id]
         )
 
         assert document = edition_class.last
-        assert_equal [country, overseas_territory], document.world_locations
+        assert_equal [world_location, world_location2], document.world_locations
       end
 
       test "updating should save modified document attributes with world locations" do
-        country = create(:country)
-        overseas_territory = create(:overseas_territory)
-        document = create(document_type, world_locations: [overseas_territory])
+        world_location = create(:world_location)
+        world_location2 = create(:world_location)
+        document = create(document_type, world_locations: [world_location2])
 
         put :update, id: document, edition: {
-          world_location_ids: [country.id]
+          world_location_ids: [world_location.id]
         }
 
         document = document.reload
-        assert_equal [country], document.world_locations
+        assert_equal [world_location], document.world_locations
       end
 
       test "updating should remove all world locations if none in params" do
@@ -63,14 +63,14 @@ module AdminEditionWorldLocationsBehaviour
       end
 
       view_test "should display the world locations to which the document relates" do
-        country = create(:country)
-        overseas_territory = create(:overseas_territory)
-        document = create(document_type, world_locations: [overseas_territory, country])
+        country = create(:world_location)
+        world_location = create(:world_location)
+        document = create(document_type, world_locations: [world_location, country])
 
         get :show, id: document
 
         assert_select_object(country)
-        assert_select_object(overseas_territory)
+        assert_select_object(world_location)
       end
 
       view_test "should indicate that the document does not relate to any world location" do

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -145,8 +145,8 @@ module DocumentControllerTestHelpers
 
     def should_show_the_world_locations_associated_with(document_type)
       view_test "should display the world locations associated with this #{document_type}" do
-        first_location = create(:country)
-        second_location = create(:overseas_territory)
+        first_location = create(:world_location)
+        second_location = create(:world_location)
         third_location = create(:international_delegation)
         edition = create("published_#{document_type}", world_locations: [first_location, second_location])
 

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -24,7 +24,7 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "should be invalid with only country but no street address" do
-    country = create(:country)
+    country = create(:world_location)
     contact = build(:contact,
       recipient: "",
       street_address: "",
@@ -49,7 +49,7 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "should be valid with only street address and country" do
-    country = create(:country)
+    country = create(:world_location)
     contact = build(:contact,
       recipient: "",
       street_address: "123 Acacia avenue",
@@ -61,12 +61,12 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "should return a country code" do
-    contact = build(:contact, country: build(:country, iso2: 'GB'))
+    contact = build(:contact, country: build(:world_location, iso2: 'GB'))
     assert_equal 'GB', contact.country_code
   end
 
   test "should return a country name" do
-    contact = build(:contact, country: build(:country, name: 'United Kingdom'))
+    contact = build(:contact, country: build(:world_location, name: 'United Kingdom'))
     assert_equal 'United Kingdom', contact.country_name
   end
 

--- a/test/unit/edition/creating_draft_test.rb
+++ b/test/unit/edition/creating_draft_test.rb
@@ -76,7 +76,7 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
     ministerial_role = create(:ministerial_role)
-    country = create(:country)
+    country = create(:world_location)
 
     published_policy = create(:published_policy, topics: [topic], organisations: [organisation], ministerial_roles: [ministerial_role], world_locations: [country])
 

--- a/test/unit/edition/limited_access_test.rb
+++ b/test/unit/edition/limited_access_test.rb
@@ -79,7 +79,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "if access is not limited, edition is only accessible to a world user if it's about their location, regardless of org" do
-    loc_1, loc_2 = build(:country), build(:country)
+    loc_1, loc_2 = build(:world_location), build(:world_location)
     organisation = build(:organisation)
 
     editor_in_loc_1 = build(:world_editor, world_locations: [loc_1], organisation: organisation)
@@ -97,7 +97,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "if access is limited, edition is only accessible to a world user if it's about their location AND their org" do
-    loc_1, loc_2 = build(:country), build(:country)
+    loc_1, loc_2 = build(:world_location), build(:world_location)
     org_1, org_2 = build(:organisation), build(:organisation)
 
     editor_in_org_1_loc_1 = build(:world_editor, world_locations: [loc_1], organisation: org_1)
@@ -120,7 +120,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
   test "can select all editions accessible to a particular world user, respecting access_limit, org and location" do
     my_organisation, other_organisation = create(:organisation), create(:organisation)
-    my_location, other_location = create(:country), create(:country)
+    my_location, other_location = create(:world_location), create(:world_location)
     user = create(:world_writer, organisation: my_organisation, world_locations: [my_location])
     accessible = [
       create(:draft_publication, access_limited: false, world_locations: [my_location]),

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::WorldLocationPresenterTest < PresenterTestCase
   setup do
-    @location = stub_record(:world_location, world_location_type: WorldLocationType::Country)
+    @location = stub_record(:world_location, world_location_type: WorldLocationType::WorldLocation)
     @presenter = Api::WorldLocationPresenter.decorate(@location)
     stubs_helper_method(:params).returns(format: :json)
   end

--- a/test/unit/uploader/finders/world_locations_finder_test.rb
+++ b/test/unit/uploader/finders/world_locations_finder_test.rb
@@ -13,8 +13,8 @@ class Whitehall::Uploader::Finders::WorldLocationsFinderTest < ActiveSupport::Te
   end
 
   test "returns an array of countries" do
-    world_location_1 = create(:country)
-    world_location_2 = create(:overseas_territory)
+    world_location_1 = create(:world_location)
+    world_location_2 = create(:world_location)
     world_location_3 = create(:international_delegation)
     assert_equal [world_location_1, world_location_2, world_location_3], Whitehall::Uploader::Finders::WorldLocationsFinder.find(world_location_1.slug, world_location_2.slug, world_location_3.slug, @log, @line_number)
   end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -30,7 +30,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "has name of it's world location type as display type" do
-    world_location_type = WorldLocationType::Country
+    world_location_type = WorldLocationType::WorldLocation
     world_location_type.stubs(:name).returns('The Moon')
     world_location = build(:world_location, world_location_type: world_location_type)
     assert_equal "The Moon", world_location.display_type
@@ -80,25 +80,25 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "all_by_type should group world locations by type sorting the types by their sort order" do
-    territory_type = WorldLocationType::OverseasTerritory
-    country_type = WorldLocationType::Country
+    world_location_type = WorldLocationType::WorldLocation
+    delegation_type = WorldLocationType::InternationalDelegation
 
-    location_1 = create(:world_location, world_location_type: territory_type)
-    location_2 = create(:world_location, world_location_type: country_type)
-    location_3 = create(:world_location, world_location_type: country_type)
+    location_1 = create(:world_location, world_location_type: world_location_type)
+    location_2 = create(:world_location, world_location_type: delegation_type)
+    location_3 = create(:world_location, world_location_type: delegation_type)
 
-    assert_equal [ [country_type, [location_2, location_3]] , [territory_type, [location_1]] ], WorldLocation.all_by_type
+    assert_equal [ [world_location_type, [location_1]] , [delegation_type, [location_2, location_3]] ], WorldLocation.all_by_type
   end
 
   test "all_by_type should group world locations by type sorting the locations by their name" do
-    territory_type = WorldLocationType::OverseasTerritory
-    country_type = WorldLocationType::Country
+    world_location_type = WorldLocationType::WorldLocation
+    delegation_type = WorldLocationType::InternationalDelegation
 
-    location_1 = create(:world_location, world_location_type: territory_type, name: 'Neverland')
-    location_2 = create(:world_location, world_location_type: country_type, name: 'Narnia')
-    location_3 = create(:world_location, world_location_type: country_type, name: 'Middle Earth')
+    location_1 = create(:world_location, world_location_type: delegation_type, name: 'Neverland')
+    location_2 = create(:world_location, world_location_type: world_location_type, name: 'Narnia')
+    location_3 = create(:world_location, world_location_type: world_location_type, name: 'Middle Earth')
 
-    assert_equal [ [country_type, [location_3, location_2]] , [territory_type, [location_1]] ], WorldLocation.all_by_type
+    assert_equal [ [world_location_type, [location_3, location_2]] , [delegation_type, [location_1]] ], WorldLocation.all_by_type
   end
 
   test '#featured_edition_world_locations should return editions featured against this world_location' do
@@ -200,24 +200,20 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test 'we can find those that are countries' do
-    country = create(:country)
-    overseas_territory = create(:overseas_territory)
+    country = create(:world_location)
     international_delegation = create(:international_delegation)
 
     countries = WorldLocation.countries
     assert countries.include?(country)
-    refute countries.include?(overseas_territory)
     refute countries.include?(international_delegation)
   end
 
   test 'we can find those that represent something geographic (if not neccessarily a country)' do
-    country = create(:country)
-    overseas_territory = create(:overseas_territory)
+    country = create(:world_location)
     international_delegation = create(:international_delegation)
 
     geographic = WorldLocation.geographical
     assert geographic.include?(country)
-    assert geographic.include?(overseas_territory)
     refute geographic.include?(international_delegation)
   end
 

--- a/test/unit/world_location_type_test.rb
+++ b/test/unit/world_location_type_test.rb
@@ -12,6 +12,6 @@ class WorldLocationTypeTest < ActiveSupport::TestCase
   end
 
   test 'we can find those types that are geographic' do
-    assert_equal [WorldLocationType::Country, WorldLocationType::OverseasTerritory], WorldLocationType.geographic
+    assert_equal [WorldLocationType::WorldLocation], WorldLocationType.geographic
   end
 end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -16,8 +16,8 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   test 'can be associated with multiple world locations' do
     countries = [
-      create(:country, name: 'France'),
-      create(:country, name: 'Spain')
+      create(:world_location, name: 'France'),
+      create(:world_location, name: 'Spain')
     ]
     worldwide_organisation = create(:worldwide_organisation, name: 'Office Name', world_locations: countries)
 


### PR DESCRIPTION
These are now just to be called "World locations".

This is to remove any potential political issues over whether a location is a country or not (the FCO can differ from formal definitions).

This involved considerable noise changing all the factory references to remove calls out to country etc. in order to clean up, but the basic code is simple.

https://www.pivotaltracker.com/story/show/46713179
