### PR TITLE
Correct the parent tags on new mainstream categories

### DIFF
--- a/db/data_migration/20130325114725_correct_mainstream_category_tags.rb
+++ b/db/data_migration/20130325114725_correct_mainstream_category_tags.rb
@@ -1,0 +1,4 @@
+MainstreamCategory.where(parent_tag: 'citizenship/internationial-funding').each do |category|
+  puts "Updating parent tag on category '#{category.title}'"
+  category.update_attributes(parent_tag: 'citizenship/international-development')
+end


### PR DESCRIPTION
The new mainstream categories added for DFID have incorrect parent tags. This corrects them.
