### PR TITLE
Force locale to :en for worldwide root

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -237,7 +237,7 @@ module ApplicationHelper
         organisations_path
       end
     when "world_locations", "worldwide_priorities", "world_location_news_articles", "worldwide_organisations", "worldwide_offices"
-      world_locations_path
+      world_locations_path(locale: :en)
     when "policies", "supporting_pages", "policy_advisory_groups", "policy_teams"
       policies_path
     end

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -8,7 +8,7 @@
           <ul id="navigation">
             <li><%= main_navigation_link_to 'How government works', how_government_works_path %></li>
             <li><%= main_navigation_link_to "Departments", organisations_path %></li>
-            <li><%= main_navigation_link_to "Worldwide", world_locations_path %></li>
+            <li><%= main_navigation_link_to "Worldwide", world_locations_path(locale: :en) %></li>
             <li><%= main_navigation_link_to "Topics", topics_path %></li>
             <li><span class="toggler <%= main_navigation_documents_class %>">Content by type</span>
               <ul class="subtype content js-hidden">

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -165,10 +165,14 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "world-location-related pages should be related to uk and the world main navigation" do
-    assert_equal world_locations_path, current_main_navigation_path(controller: "world_locations", action: "index")
-    assert_equal world_locations_path, current_main_navigation_path(controller: "world_locations", action: "show")
-    assert_equal world_locations_path, current_main_navigation_path(controller: "worldwide_priorities", action: "index")
-    assert_equal world_locations_path, current_main_navigation_path(controller: "worldwide_priorities", action: "show")
+    assert_equal world_locations_path(locale: :en), current_main_navigation_path(controller: "world_locations", action: "index")
+    assert_equal world_locations_path(locale: :en), current_main_navigation_path(controller: "world_locations", action: "show")
+    assert_equal world_locations_path(locale: :en), current_main_navigation_path(controller: "worldwide_priorities", action: "index")
+    assert_equal world_locations_path(locale: :en), current_main_navigation_path(controller: "worldwide_priorities", action: "show")
+  end
+
+  test "world locations index is forced to English locale in main navigation" do
+    assert_equal world_locations_path(locale: :en), current_main_navigation_path(controller: "world_locations", action: "index", locale: :dk)
   end
 
   test "policy pages should be related to policy main navigation" do


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/46807663

Users browsing back to the root of Worldwide via the main navigation should always see it in the English locale. This is primarily to stop the layout being right-to-left when browsing back from a page translated in a right-to-left language.
