### PR TITLE
Remapped edition display_type for feed titles

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -39,8 +39,14 @@ module FeedHelper
     request.host
   end
 
+  def feed_display_type_for(document)
+    return "News story" if (document.is_a?(WorldLocationNewsArticle))
+    return "Priority" if (document.is_a?(WorldwidePriority))
+    document.display_type
+  end
+
   def document_as_feed_entry(document, builder, govdelivery_version = false)
-    builder.title "#{document.display_type}: #{document.title}"
+    builder.title "#{feed_display_type_for(document)}: #{document.title}"
     builder.category label: document.display_type, term: document.display_type
     builder.summary entry_summary(document, govdelivery_version)
     builder.content entry_content(document), type: 'html'

--- a/test/unit/helpers/feed_helper_test.rb
+++ b/test/unit/helpers/feed_helper_test.rb
@@ -114,6 +114,28 @@ class FeedHelperTest < ActionView::TestCase
     document_as_feed_entry(document, builder, false)
   end
 
+  test 'document_as_feed_entry converts world location news article to "News story" in title' do
+    document = WorldLocationNewsArticle.new(title: 'A thing!', summary: 'summary')
+    builder = mock('builder')
+    builder.expects(:title).with "News story: A thing!"
+    builder.stubs(:category)
+    builder.stubs(:summary)
+    builder.stubs(:content)
+    expects(:govspeak_edition_to_html).with(document).returns('govspoken content')
+    document_as_feed_entry(document, builder, false)
+  end
+
+  test 'document_as_feed_entry converts worldwide priority to "Priority" in title' do
+    document = WorldwidePriority.new(title: 'A thing!', summary: 'summary')
+    builder = mock('builder')
+    builder.expects(:title).with "Priority: A thing!"
+    builder.stubs(:category)
+    builder.stubs(:summary)
+    builder.stubs(:content)
+    expects(:govspeak_edition_to_html).with(document).returns('govspoken content')
+    document_as_feed_entry(document, builder, false)
+  end
+
   test 'document_as_feed_entry sets the title, category, summary, and content on the builder prepending the change note to the begining the summary when govdelivery_version is true' do
     document = Edition.new(title: 'A thing!', summary: 'A thing has happened', published_major_version: 2, change_note: 'note')
     builder = mock('builder')


### PR DESCRIPTION
I've gone for a simple solution this time, as it's a localised change
for feeds. We can expand it into something a little more standard and
make it part of the domain as the requirements grow.

https://www.pivotaltracker.com/story/show/46700561
