### PR TITLE
Limit mainstream links for orgs & world locs to 5

### DIFF
--- a/app/models/mainstream_link.rb
+++ b/app/models/mainstream_link.rb
@@ -1,4 +1,14 @@
 class MainstreamLink < ActiveRecord::Base
   validates :url, :title, presence: true
   validates :url, format: URI::regexp(%w(http https))
+
+  DEFAULT_INITIAL_SET_SIZE = 5
+
+  def self.in_creation_order
+    order(:created_at)
+  end
+
+  def self.only_the_initial_set(set_size = MainstreamLink::DEFAULT_INITIAL_SET_SIZE)
+    in_creation_order.limit(set_size)
+  end
 end

--- a/app/views/admin/shared/_mainstream_link_fields.html.erb
+++ b/app/views/admin/shared/_mainstream_link_fields.html.erb
@@ -1,7 +1,12 @@
 <fieldset class="named mainstream-links form-horizontal">
   <legend>Mainstream links</legend>
-  <%= form.fields_for :mainstream_links do |mainstream_link_form| %>
-    <%= mainstream_link_form.text_field :title, horizontal: true %>
-    <%= mainstream_link_form.text_field :url, horizontal: true %>
-  <% end %>
+  <p class="alert alert-info">Only the first <%= MainstreamLink::DEFAULT_INITIAL_SET_SIZE %> mainstream links will be shown on the public site.</p>
+  <ol>
+    <%= form.fields_for(:mainstream_links, form.object.mainstream_links.sort_by { |ml| ml.created_at || Time.current }) do |mainstream_link_form| %>
+      <li>
+        <%= mainstream_link_form.text_field :title, horizontal: true %>
+        <%= mainstream_link_form.text_field :url, horizontal: true %>
+      </li>
+    <% end %>
+  </ol>
 </fieldset>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -41,7 +41,7 @@
     <aside class="organisation-mainstream-links">
       <h4>Quick links</h4>
       <ul>
-        <% organisation.mainstream_links.each do |link| %>
+        <% organisation.mainstream_links.only_the_initial_set.each do |link| %>
           <li><%= link_to link.title, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
         <% end %>
       </ul>

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -15,7 +15,7 @@
       <aside class="mainstream-links">
       <h4><%= t('world_location.headings.quick_links') %></h4>
         <ul>
-          <% @world_location.mainstream_links.each do |link| %>
+          <% @world_location.mainstream_links.only_the_initial_set.each do |link| %>
             <li><%= link_to link.title, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
           <% end %>
         </ul>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -906,6 +906,26 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select ".govdelivery[href='http://my-govdelivery-url.com']"
   end
 
+  view_test 'show lists only the 5 oldest mainstream links' do
+    organisation = create(:organisation)
+    link_1 = create(:mainstream_link, title: '2 days ago', created_at: 2.days.ago)
+    link_2 = create(:mainstream_link, title: '12 days ago', created_at: 12.days.ago)
+    link_3 = create(:mainstream_link, title: '1 hour ago', created_at: 1.hour.ago)
+    link_4 = create(:mainstream_link, title: '2 hours ago', created_at: 2.hours.ago)
+    link_5 = create(:mainstream_link, title: '20 minutes ago', created_at: 20.minutes.ago)
+    link_6 = create(:mainstream_link, title: '2 years ago', created_at: 2.years.ago)
+    organisation.mainstream_links = [link_1, link_2, link_3, link_4, link_5, link_6]
+    organisation.save!
+
+    get :show, id: organisation
+
+    assert_select '.organisation-mainstream-links li', count: 5
+    assert_select '.organisation-mainstream-links li:nth-child(1) a', text: '2 years ago'
+    assert_select '.organisation-mainstream-links li:nth-child(2) a', text: '12 days ago'
+    assert_select '.organisation-mainstream-links li:nth-child(3) a', text: '2 days ago'
+    assert_select '.organisation-mainstream-links li:nth-child(4) a', text: '2 hours ago'
+    assert_select '.organisation-mainstream-links li:nth-child(5) a', text: '1 hour ago'
+  end
 
   private
 

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -347,4 +347,26 @@ class WorldLocationsControllerTest < ActionController::TestCase
       assert_select "a[href='#{link.mainstream_link.url}']", text: link.mainstream_link.title
     end
   end
+
+  view_test 'show lists only the 5 oldest mainstream links' do
+    world_location = create(:world_location)
+    link_1 = create(:mainstream_link, title: '2 days ago', created_at: 2.days.ago)
+    link_2 = create(:mainstream_link, title: '12 days ago', created_at: 12.days.ago)
+    link_3 = create(:mainstream_link, title: '1 hour ago', created_at: 1.hour.ago)
+    link_4 = create(:mainstream_link, title: '2 hours ago', created_at: 2.hours.ago)
+    link_5 = create(:mainstream_link, title: '20 minutes ago', created_at: 20.minutes.ago)
+    link_6 = create(:mainstream_link, title: '2 years ago', created_at: 2.years.ago)
+    world_location.mainstream_links = [link_1, link_2, link_3, link_4, link_5, link_6]
+    world_location.save!
+
+    get :show, id: world_location
+
+    assert_select '.mainstream-links li', count: 5
+    assert_select '.mainstream-links li:nth-child(1) a', text: '2 years ago'
+    assert_select '.mainstream-links li:nth-child(2) a', text: '12 days ago'
+    assert_select '.mainstream-links li:nth-child(3) a', text: '2 days ago'
+    assert_select '.mainstream-links li:nth-child(4) a', text: '2 hours ago'
+    assert_select '.mainstream-links li:nth-child(5) a', text: '1 hour ago'
+  end
+
 end

--- a/test/unit/mainstream_link_test.rb
+++ b/test/unit/mainstream_link_test.rb
@@ -15,4 +15,15 @@ class MainstreamLinkTest < ActiveSupport::TestCase
     link = build(:mainstream_link, url: "not a link")
     refute link.valid?
   end
+
+  test 'only_the_initial_set retreives the first 5 in creation order' do
+    link_1 = create(:mainstream_link, created_at: 2.days.ago)
+    link_2 = create(:mainstream_link, created_at: 12.days.ago)
+    link_3 = create(:mainstream_link, created_at: 1.hour.ago)
+    link_4 = create(:mainstream_link, created_at: 2.hours.ago)
+    link_5 = create(:mainstream_link, created_at: 20.minutes.ago)
+    link_6 = create(:mainstream_link, created_at: 2.years.ago)
+
+    assert_equal [link_6, link_2, link_1, link_4, link_3], MainstreamLink.only_the_initial_set
+  end
 end


### PR DESCRIPTION
Rather than enforcing this in validations, we only show the first 5 (starting with the oldest) on the frontend and show a warning on the admin to let folk know this will happen.  This means we can relax or tighten the rule later without destroying any data.

For: https://www.pivotaltracker.com/story/show/46890187
