### PR TITLE
Iterate over imports 443 and 444 to convert all docs to draft

### DIFF
--- a/db/data_migration/20130326121805_force_to_draft_ho_imports.rb
+++ b/db/data_migration/20130326121805_force_to_draft_ho_imports.rb
@@ -1,0 +1,37 @@
+require 'admin/edition_routes_helper'
+
+module ForceToDraftHOImports
+  ADMIN_HOST = 'whitehall-admin.production.alphagov.co.uk'
+
+  def self.routes_helper
+    @routes_helper ||= Class.new do
+      include Rails.application.routes.url_helpers
+      include PublicDocumentRoutesHelper
+      include Admin::EditionRoutesHelper
+    end.new
+  end
+end
+
+[443, 444].each do |ho_import_id|
+  import = Import.find(ho_import_id)
+  imported_editions = import.imported_editions.where(state: 'imported')
+  puts "Forcing #{imported_editions.count} for Import id: #{ho_import_id} to 'draft'"
+  successes = []
+  failures = []
+  imported_editions.each do |imported_edition|
+    begin
+      if imported_edition.convert_to_draft!
+        successes << imported_edition
+      else
+        failures << imported_edition
+      end
+    rescue ActiveRecord::RecordInvalid, Transitions::InvalidTransition
+      failures << imported_edition
+    end
+  end
+  puts "Result: #{successes.length} successes, #{failures.length} failures"
+  puts "Failures:"
+  failures.each do |failed_import|
+    puts ForceToDraftHOImports.routes_helper.admin_edition_url(failed_import, host: ForceToDraftHOImports::ADMIN_HOST)
+  end
+end


### PR DESCRIPTION
Outputs the urls of any that failed to convert.  When this is run on production please pass the output to @rjc123 so he can check them out before he force publishes.

For: https://www.pivotaltracker.com/story/show/46704197
