### PR TITLE
Ensure that consultation routes are localised

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -25,8 +25,14 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
   end
 
   def edition_values(edition, document, document_source=nil)
+    doc_url_args = { protocol: 'https' }
+    if edition.translatable?
+      locale = document_source.try(:locale)
+      doc_url_args[:locale] = locale unless locale.nil? || Locale.new(locale).english?
+    end
+
     [ (document_source.try(:url) || ''),
-      public_document_url(document.published_edition || document.latest_edition, protocol: 'https', locale: document_source.try(:locale)),
+      public_document_url(document.published_edition || document.latest_edition, doc_url_args),
       http_status(edition),
       document.slug,
       admin_edition_url(edition, host: admin_host, protocol: 'https'),

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -39,6 +39,15 @@ Old Url,New Url,Status,Slug,Admin Url,State
       EOT
     end
 
+    test "extract consultations (with source) to csv" do
+      article = create(:published_consultation)
+      source = create(:document_source, document: article.document)
+
+      assert_extraction_contains <<-EOT
+#{source.url},https://www.preview.alphagov.co.uk/government/consultations/consultation-title,301,consultation-title,https://whitehall-admin.test.alphagov.co.uk/government/admin/consultations/#{article.id},published
+      EOT
+    end
+
     test "extracts corporate information pages to csv" do
       corporate_information_page = create(:corporate_information_page)
       organisation = Organisation.last


### PR DESCRIPTION
This was breaking the document mapper output script when trying to
export consultations with document sources - even when these are only english
sources we still need localised routes to ensure we strip off the
`locale` option.

Thanks @tekin for the sleuthing.

https://www.pivotaltracker.com/story/show/46362409
