### PR TITLE
Additional policies selectable via speed tagging

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,6 +86,16 @@ module ApplicationHelper
     end
   end
 
+  def related_policy_options_excluding(policies)
+    related_policy_options.select do |po|
+      !policies.map(&:id).include?(po.first)
+    end
+  end
+
+  def policies_for_editions_organisations(edition)
+    Policy.in_organisation(edition.organisations).latest_edition.active
+  end
+
   def publication_type_options
     [
       ["", [""]],

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -70,7 +70,7 @@
     <% if @edition.can_be_related_to_policies? %>
       <div class="row-fluid">
         <h3>Related policies</h3>
-        <% Policy.in_organisation(@edition.organisations).latest_edition.active.map do |policy| %>
+        <% policies_for_editions_organisations(@edition).each do |policy| %>
           <label class="checkbox">
             <%= check_box_tag 'edition[related_policy_ids][]', policy.id, @edition.related_policies.include?(policy) %>
             <%= policy.title %><% if policy.topics.any? %>
@@ -78,6 +78,18 @@
             <% end %>
           </label>
         <% end %>
+      </div>
+      <div class="row-fluid">
+        <%= label_tag 'edition[related_policy_ids][]', 'Additional policies' %>
+        <%= select_tag 'edition[related_policy_ids][]',
+          options_from_collection_for_select(
+            related_policy_options_excluding(policies_for_editions_organisations(@edition)),
+            :first, :last, @edition.related_policy_ids),
+          include_blank: true,
+          multiple: true,
+          class: 'chzn-select',
+            data: { placeholder: "Choose from other policies..."}
+        %>
       </div>
     <% end %>
 

--- a/features/speed-tagging-editions.feature
+++ b/features/speed-tagging-editions.feature
@@ -27,7 +27,7 @@ Feature: Speed tagging editions
     And I should be able to tag the publication with "Joe Bloggs"
     And I should not be able to tag the publication with "Jane Smith"
 
-  Scenario: Speed tagging only shows relevant policies
+  Scenario: Speed tagging only shows relevant policies in the checkbox list
     Given a draft policy "Local beards" for the organisation "DCLG"
     And a published policy "Beard taxes" for the organisation "Treasury"
     When I go to speed tag a newly imported publication for "DCLG"
@@ -38,6 +38,13 @@ Feature: Speed tagging editions
     Given a draft policy "Local beards" for the organisations "DCLG" and "Treasury"
     When I go to speed tag a newly imported publication for "DCLG" and "Treasury"
     Then I can only tag the publication with "Local beards" once
+
+  Scenario: Speed taggings shows all the policies as a dropdown at the end of the list
+    Given a published policy "Local beards" for the organisation "DCLG"
+    Given a published policy "Beard taxes" for the organisation "Treasury"
+    When I go to speed tag a newly imported publication for "DCLG"
+    Then I can choose "Beard taxes" from an additional list of policies
+    But I can't select "Local beards" from the additional list
 
   Scenario: Speed tagging shows speech required fields
     When I go to speed tag a newly imported speech "Written statement on Beards"

--- a/features/step_definitions/speed_tagging_steps.rb
+++ b/features/step_definitions/speed_tagging_steps.rb
@@ -66,3 +66,11 @@ Then /^I should be able to set the publication date$/ do
   assert page.has_css?('select[id*=edition_publication_date]')
   select_date "Publication date", with: '02-May-2013'
 end
+
+Then /^I can choose "([^"]*)" from an additional list of policies$/ do |policy_name|
+  select policy_name, from: "Additional policies"
+end
+
+Then /^I can't select "([^"]*)" from the additional list$/ do |policy_name|
+  assert page.has_no_css?('option', text: policy_name)
+end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -213,8 +213,20 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "generates related policy option as title without topics" do
     policy = create(:policy, title: "Policy title", topics: [])
-    options = related_policy_options
     assert_equal [[policy.id, "Policy title"]], related_policy_options
+  end
+
+  test "#related_policy_options_excluding excludes a set of policies" do
+    policy = create(:policy, title: "Policy title", topics: [])
+    excluded = create(:policy, title: "Excluded", topics: [])
+    assert_equal [[policy.id, "Policy title"]], related_policy_options_excluding([excluded])
+  end
+
+  test "#policies_for_editions_organisations returns all active policies that map to an organisation the edition is in" do
+    publication = create(:imported_publication)
+    policy = create(:published_policy, organisations: [publication.organisations.first])
+    another = create(:published_policy)
+    assert_equal [policy], policies_for_editions_organisations(publication)
   end
 
   test "generates related policy option as title with topics" do


### PR DESCRIPTION
We allow other policies to be selected at the bottom of the list. The
select box does not contain policies that are shown in the checkbox
list, but only the additional policies that are selected.

Screenshot: http://cl.ly/image/1s1F352J1M1h

Ticket: https://www.pivotaltracker.com/story/show/46254059
