### PR TITLE
Do not show the people header on ww orgs when there are no people in roles

### DIFF
--- a/app/presenters/role_presenter.rb
+++ b/app/presenters/role_presenter.rb
@@ -9,6 +9,10 @@ class RolePresenter < Draper::Base
     end
   end
 
+  def has_appointment?
+    current_person.present?
+  end
+
   def announcements
     return [] unless ministerial?
     announcements =

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -33,7 +33,7 @@
   </section>
 <% end %>
 
-<% if (@primary_role && @primary_role.current_person.present?) || @other_roles.present? %>
+<% if ([@primary_role]+@other_roles).compact.any?(&:has_appointment?) %>
   <section class="block people" id="people">
     <div class="inner-block floated-children">
       <h1 class="keyline-header"><%= t('worldwide_organisation.headings.our_people' ) %></h1>


### PR DESCRIPTION
Also check for primary_role.current_person in the view as the role is
present but not filled.

https://www.pivotaltracker.com/story/show/45903741
