### PR TITLE
Typography changes to HTML publications

### DIFF
--- a/app/assets/stylesheets/frontend/layouts/html-publication.scss
+++ b/app/assets/stylesheets/frontend/layouts/html-publication.scss
@@ -1,11 +1,8 @@
 .html-publication {
   @include core-19;
   color: #292929;
-/*   color: #0B0C0C; */
   background: #fff image-url('html-publication/texture.png') repeat;
   -webkit-font-smoothing: antialiased;
-  @include media(tablet){
-  }
 }
 
 #whitehall-wrapper {

--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -1,4 +1,3 @@
-
 .html-publications-show {
   @extend %contain-floats;
 
@@ -71,11 +70,9 @@
       }
     }
     .in-page-navigation {
-      line-height: 28/19; 
+      line-height: 28/19;
       margin: 20px 0 14px;
 
-      h2 {
-      }
       ol {
         margin-left: $gutter;
         li {


### PR DESCRIPTION
- uses Transport rather than Helvetica
- uses standard govuk gutters
- uses standard govuk page dimensions
- alignment changes to the header area
- added bold to headers
