### PR TITLE
Track the terms people put in the filter lists

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -35,8 +35,6 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         $('link[rel=next][type=application/json]').remove();
         $container.append($results.filter('nav'));
         $('.previous-next-navigation').addClass('infinite');
-
-        window._gaq && _gaq.push(['_trackEvent', 'edd_inside_gov', 'page-'+data.current_page, documentFilter.formType]);
       }
     },
     updateAtomFeed: function(data) {

--- a/app/assets/javascripts/application/filter-list-items.js
+++ b/app/assets/javascripts/application/filter-list-items.js
@@ -7,6 +7,7 @@
   var filter = {
     _terms: false,
     _regexCache: {},
+    _trackTimeout: false,
 
     init: function(){
       var $filterList = $('.js-filter-list');
@@ -31,6 +32,16 @@
       filter.$filterItems.hide();
       $(itemsToShow).show();
       filter.hideEmptyBlocks(itemsToShow);
+      filter.track(search);
+    },
+    track: function(search){
+      clearTimeout(filter._trackTimeout);
+      filter._trackTimeout = root.setTimeout(function(){
+        var pagePath = window.location.pathname.split('/').pop();
+        if(pagePath){
+          window._gaq && _gaq.push(['_trackEvent', 'edd_inside_gov', search, pagePath]);
+        }
+      }, 250);
     },
     hideEmptyBlocks: function(itemsToShow){
       if(itemsToShow.length === 0){


### PR DESCRIPTION
There are two reasons to want to do this. Firstly is to see if anyone
uses them. The second is to see what people are using them for and what
kinds of things they think they can put in them.

I have put the tracking behind a throttler so we don't track every
keypress but just the word or words when they have finished typing.
