### PR TITLE
Remove world transition bar

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_global-nav.scss
+++ b/app/assets/stylesheets/frontend/helpers/_global-nav.scss
@@ -195,16 +195,4 @@
       left: -9999em;
     }
   }
-
-  &.world-bar {
-    p {
-      background: transparent image-url("information-icon.png") no-repeat 0 0;
-      padding-left: $gutter*1.2;
-
-      a {
-        font-weight: bold;
-      }
-    }
-  }
 }
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -261,10 +261,6 @@ module ApplicationHelper
     end
   end
 
-  def world_page?
-    request.fullpath.match(world_locations_path)
-  end
-
   def linked_author(author)
     if author
       link_to(author.name, admin_author_path(author))

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -25,22 +25,14 @@
     </div>
   </div>
   <div class="whitehall-content">
-    <% if world_page? %>
-      <div class="progress-bar world-bar" id="progress-bar">
-        <p>
-          FCO, DFID and UKTI have moved their overseas websites to GOV.UK. <%= link_to 'Read about the transition', '/government/news/welcome-to-our-new-website-gov-uk' %>
-        </p>
-      </div>
-    <% else %>
-      <div class="progress-bar js-progress-bar js-hidden" id="progress-bar" data-join-count="<%= joined_ministerial_department_count %>">
-        <div class="bar"><div class="joined" style="width: <%= joined_ministerial_department_percent %>"></div></div>
-        <p>
-          <%= joined_ministerial_department_count %> of <%= ministerial_department_count %>
-          ministerial departments have moved their corporate websites to GOV.UK.
-          <%= progress_bar_link %>
-        </p>
-      </div>
-    <% end %>
+    <div class="progress-bar js-progress-bar js-hidden" id="progress-bar" data-join-count="<%= joined_ministerial_department_count %>">
+      <div class="bar"><div class="joined" style="width: <%= joined_ministerial_department_percent %>"></div></div>
+      <p>
+        <%= joined_ministerial_department_count %> of <%= ministerial_department_count %>
+        ministerial departments have moved their corporate websites to GOV.UK.
+        <%= progress_bar_link %>
+      </p>
+    </div>
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>
       <%= render_mustache_templates if Rails.env.development? %>


### PR DESCRIPTION
It is no longer needed. This is bassically a revert of 4e4e1eb.

https://www.pivotaltracker.com/story/show/47295571
