### PR TITLE
Bring breadcrumbs back to detailed guides

### DIFF
--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -25,7 +25,7 @@
     <%= atom_discovery_link_tag %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
-    <% if local_assigns[:remove_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>
+    <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>
     <div id="whitehall-wrapper">
       <%= yield %>
     </div>

--- a/app/views/layouts/detailed-guidance.html.erb
+++ b/app/views/layouts/detailed-guidance.html.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'layouts/frontend_base', locals: {remove_breadcrumbs: true, extra_body_class: 'detailed-guidance'} do %>
+<%= render :layout => 'layouts/frontend_base', locals: {show_breadcrumbs: true, extra_body_class: 'detailed-guidance'} do %>
   <div class="whitehall-content">
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'layouts/frontend_base', locals: {remove_breadcrumbs: true} do %>
+<%= render :layout => 'layouts/frontend_base' do %>
   <nav id="proposition-menu">
     <%= link_to "Inside Government", root_path, id: 'proposition-name' %>
     <ul id="proposition-links">

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'layouts/frontend_base', locals: {remove_breadcrumbs: true, extra_body_class: 'sunset'} do %>
+<%= render :layout => 'layouts/frontend_base', locals: {extra_body_class: 'sunset'} do %>
   <div class="whitehall-content">
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>

--- a/app/views/layouts/html-publication.html.erb
+++ b/app/views/layouts/html-publication.html.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'layouts/frontend_base', locals: {remove_breadcrumbs: true, extra_body_class: 'html-publication', stylesheet: 'html-publication'} do %>
+<%= render :layout => 'layouts/frontend_base', locals: {extra_body_class: 'html-publication', stylesheet: 'html-publication'} do %>
   <div class="whitehall-content">
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >
       <%= yield %>

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -8,6 +8,14 @@ class DetailedGuidesControllerTest < ActionController::TestCase
   should_show_inapplicable_nations :detailed_guide
   should_be_previewable :detailed_guide
 
+  view_test "show doesn't include header-context element which is used for breadcrumbs" do
+    guide = create(:published_detailed_guide)
+
+    get :show, id: guide.document
+
+    refute_select ".header-context"
+  end
+
   view_test "guide <title> contains Detailed guidance" do
     guide = create(:published_detailed_guide)
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -55,6 +55,12 @@ class HomeControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "home includes header-context element to stop breadcrumbs being inserted" do
+    get :home
+
+    assert_select ".header-context"
+  end
+
   view_test "home page doesn't link to itself in the progress bar" do
     get :home
 

--- a/test/functional/mainstream_categories_controller_test.rb
+++ b/test/functional/mainstream_categories_controller_test.rb
@@ -3,6 +3,14 @@ require "test_helper"
 class MainstreamCategoriesControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
+  view_test "show doesn't include header-context element which is used for breadcrumbs" do
+    category = create(:mainstream_category)
+
+    get :show, parent_tag: category.parent_tag, id: category
+
+    refute_select ".header-context"
+  end
+
   test "show orders guides alphabetically by title" do
     category = create(:mainstream_category)
     detailed_guide_a = create(:published_detailed_guide, primary_mainstream_category: category, title: "guide-a")


### PR DESCRIPTION
The breadcrumbs went away when I did some work to reduce copy pasted
layouts. This should bring them back for just the detailed guidance
layout.

Also added test to ensure the appropriate element does and doesn't exist
where it should and shouldn't.

https://www.pivotaltracker.com/story/show/47697951
