### PR TITLE
Include change note in govdelivery email body

### DIFF
--- a/app/models/edition/gov_uk_delivery.rb
+++ b/app/models/edition/gov_uk_delivery.rb
@@ -90,17 +90,21 @@ module Edition::GovUkDelivery
     end
   end
 
-def govuk_delivery_email_body
-  url = document_url(self, host: Whitehall.public_host)
-  ERB.new(%q{
-<div class="rss_item" style="margin-bottom: 2em;">
-  <div class="rss_title" style="font-weight: bold; font-size: 120%; margin: 0 0 0.3em; padding: 0;">
-    <a href="<%= url %>"><%= title %></a>
+  def govuk_delivery_email_body
+    url = document_url(self, host: Whitehall.public_host)
+    change_note = if document.change_history.length > 1
+      document.change_history.first.note
+    end
+    ERB.new(%q{
+  <div class="rss_item" style="margin-bottom: 2em;">
+    <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
+      <% if change_note %>Updated<% end %>
+      <a href="<%= url %>" style="font-weight: bold; "><%= title %></a>
+    </div>
+    <div class="rss_pub_date" style="font-size: 90%; margin: 0 0 0.3em; padding: 0; color: #666666; font-style: italic;"><%= public_timestamp %></div>
+    <br />
+    <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;"><%= change_note || summary %></div>
   </div>
-  <div class="rss_pub_date" style="font-size: 90%; margin: 0 0 0.3em; padding: 0; color: #666666; font-style: italic;"><%= public_timestamp %></div>
-  <br />
-  <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;"><%= summary %></div>
-</div>
 }.encode("UTF-8")).result(binding)
   end
 end


### PR DESCRIPTION
The layout was suggested by @markhurrell 

https://www.pivotaltracker.com/story/show/47628197
