### PR TITLE
World location news articles are news articles

### DIFF
--- a/app/models/world_location_news_article.rb
+++ b/app/models/world_location_news_article.rb
@@ -27,6 +27,6 @@ class WorldLocationNewsArticle < Newsesque
   end
 
   def display_type_key
-    'world_location_news_article'
+    'news_article'
   end
 end

--- a/app/views/world_location_news_articles/show.html.erb
+++ b/app/views/world_location_news_articles/show.html.erb
@@ -1,0 +1,3 @@
+<% page_title @document.title, t_display_type(@document, 10) %>
+<%= render  template: 'documents/show',
+            locals: { header_title: t_display_type(@document) } %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -316,13 +316,6 @@ ar:
         few:
         many:
         other: بيانات تتعلق بالشفافية
-      world_location_news_article:
-        zero:
-        one:
-        two:
-        few:
-        many:
-        other:
       worldwide_priority:
         zero:
         one:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -179,9 +179,6 @@ az:
       transparency:
         one: Şəffaf məlumat
         other: Şəffaf məlumat
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: dünya üzrə prioritet
         other: dünya üzrə prioritetlər

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -228,11 +228,6 @@ be:
         few:
         many:
         other:
-      world_location_news_article:
-        one:
-        few:
-        many:
-        other:
       worldwide_priority:
         one:
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -140,9 +140,6 @@ bg:
       transparency:
         one: Информация за прозрачността
         other: Информация за прозрачността
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Глобален приоритет
         other: Глобални приоритети

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -140,9 +140,6 @@ bn:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -185,10 +185,6 @@ cs:
         one:
         few:
         other:
-      world_location_news_article:
-        one:
-        few:
-        other:
       worldwide_priority:
         one: Světová priorita
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -316,13 +316,6 @@ cy:
         few:
         many:
         other: Data tryloywder
-      world_location_news_article:
-        zero:
-        one: Erthygl newyddion lleoliad byd
-        two:
-        few:
-        many:
-        other: Erthyglau newyddion lleoliad byd
       worldwide_priority:
         zero:
         one: Blaenoriaeth fyd-eang

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -140,9 +140,6 @@ de:
       transparency:
         one: Transparenz-Daten
         other: Transparenz-Daten
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Weltweite Priorität
         other: Weltweite Prioritäten

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -140,9 +140,6 @@ dr:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -140,9 +140,6 @@ el:
       transparency:
         one: Στοιχεία διαφάνειας
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Παγκόσμια προτεραιότητα
         other: Παγκόσμιες προτεραιότητες

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,9 +209,6 @@ en:
       transparency:
         one: Transparency data
         other: Transparency data
-      world_location_news_article:
-        one: World location news article
-        other: World location news articles
       written_statement:
         one: Written statement to Parliament
         other: Written statements to Parliament

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -140,9 +140,6 @@ es-419:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -140,9 +140,6 @@ es:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Prioridad en todo el mundo
         other: Prioridades en todo el mundo

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -179,9 +179,6 @@ fa:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -140,9 +140,6 @@ fr:
       transparency:
         one: Données de transparence
         other: Données de transparence
-      world_location_news_article:
-        one: Actualités du endroits du monde
-        other: Actualités du endroits du monde
       worldwide_priority:
         one: Priorité internationale
         other: Priorités internationales

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -228,11 +228,6 @@ he:
         two:
         many:
         other: שקיפות מידע
-      world_location_news_article:
-        one:
-        two:
-        many:
-        other:
       worldwide_priority:
         one: עדיפות גלובאלית
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -140,9 +140,6 @@ hi:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -179,9 +179,6 @@ hu:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -140,9 +140,6 @@ hy:
       transparency:
         one: Թափանցիկ տվյալ
         other: Թափանցիկ տվյալներ
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Համաշխարհային առաջնայնություն
         other: Համաշխարհային առաջնայնություններ

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -179,9 +179,6 @@ id:
       transparency:
         one: Transparansi data
         other: Transparansi data
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Prioritas di penjuru dunia
         other: Prioritas-prioritas di penjuru dunia

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -140,9 +140,6 @@ it:
       transparency:
         one: Dati sulla trasparenza
         other: Dati sulla trasparenza
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Priorità mondiale
         other: Priorità mondiali

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -179,9 +179,6 @@ ja:
       transparency:
         one: 透明性データ
         other: 透明性データ
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: 優先事項
         other: 優先事項

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -179,9 +179,6 @@ ka:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -179,9 +179,6 @@ ko:
       transparency:
         one: 투명성 데이타
         other: 투명성 데이타
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: 세계 우선과제
         other: 세계 우선과제

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -184,10 +184,6 @@ lt:
         one:
         few:
         other:
-      world_location_news_article:
-        one:
-        few:
-        other:
       worldwide_priority:
         one:
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -140,9 +140,6 @@ lv:
       transparency:
         one: Atklātības dati
         other: Atklātības dati
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Pasaules mēroga prioritāte
         other: Pasaules mēroga prioritātes

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -179,9 +179,6 @@ ms:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -228,11 +228,6 @@ pl:
         few:
         many:
         other:
-      world_location_news_article:
-        one:
-        few:
-        many:
-        other:
       worldwide_priority:
         one:
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -140,9 +140,6 @@ ps:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -140,9 +140,6 @@ pt:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -184,10 +184,6 @@ ro:
         one: Acurateţea datelor
         few:
         other: Acurateţea datelor
-      world_location_news_article:
-        one:
-        few:
-        other:
       worldwide_priority:
         one: Priorități
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -228,11 +228,6 @@ ru:
         few:
         many:
         other: Прозрачность данных
-      world_location_news_article:
-        one:
-        few:
-        many:
-        other:
       worldwide_priority:
         one: Мировой приоритет
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -140,9 +140,6 @@ si:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -184,10 +184,6 @@ sk:
         one:
         few:
         other:
-      world_location_news_article:
-        one:
-        few:
-        other:
       worldwide_priority:
         one:
         few:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -140,9 +140,6 @@ so:
       transparency:
         one: Xog daahfurnaan
         other: Xog daahfurnaan
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Muhiimad caalami ah
         other: Muhiimado caalami ah

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -140,9 +140,6 @@ sq:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -228,11 +228,6 @@ sr:
         few:
         many:
         other:
-      world_location_news_article:
-        one:
-        few:
-        many:
-        other:
       worldwide_priority:
         one:
         few:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -140,9 +140,6 @@ sw:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -140,9 +140,6 @@ ta:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -179,9 +179,6 @@ th:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -140,9 +140,6 @@ tk:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -179,9 +179,6 @@ tr:
       transparency:
         one: ! 'Şeffaflık verileri '
         other: Şeffaflık verileri
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Dünya genelindeki öncelik
         other: Dünya genelindeki öncelikler

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -228,11 +228,6 @@ uk:
         few:
         many:
         other: Прозорість інформації
-      world_location_news_article:
-        one:
-        few:
-        many:
-        other:
       worldwide_priority:
         one: Глобальний пріоритет
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -140,9 +140,6 @@ ur:
       transparency:
         one: ٹرانسپیرنسی ڈیٹا
         other: ٹرانسپیرنسی ڈیٹا
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -140,9 +140,6 @@ uz:
       transparency:
         one:
         other:
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -179,9 +179,6 @@ vi:
       transparency:
         one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: Ưu tiên toàn cầu
         other: Các ưu tiên toàn cầu

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -179,9 +179,6 @@ zh:
       transparency:
         one: 透明化数据
         other: 透明化数据
-      world_location_news_article:
-        one:
-        other:
       worldwide_priority:
         one: 世界范围内的工作重点
         other: 世界范围内的工作重点


### PR DESCRIPTION
For public facing things they should apear as news articles. World
location news is an internal name not for the frontend.

Added a view so that the page can have a page title set and a document
type header apear.

https://www.pivotaltracker.com/story/show/46883653
