### PR TITLE
All prepublished editions have a status of 418

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -43,10 +43,10 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
     case edition.state
     when 'published'
       '301'
-    when 'draft'
-      '418'
+    when 'archived'
+      '301'
     else
-      ''
+      '418'
     end
   end
 

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -80,6 +80,17 @@ Old Url,New Url,Status,Slug,Admin Url,State
       EOF
     end
 
+    test "exports non published editions with 418s" do
+      draft = create(:draft_news_article)
+      submitted = create(:submitted_news_article)
+      archived = create(:archived_news_article)
+      assert_extraction_contains <<-EOF.strip_heredoc
+        "",#{news_article_url(draft)},418,#{draft.slug},#{news_article_admin_url(draft)},#{draft.state}
+        "",#{news_article_url(submitted)},418,#{submitted.slug},#{news_article_admin_url(submitted)},#{submitted.state}
+        "",#{news_article_url(archived)},301,#{archived.slug},#{news_article_admin_url(archived)},#{archived.state}
+      EOF
+    end
+
     test "exports documents with translated sources points to localised version" do
       article = create(:news_article)
       translation_source = create(:document_source, document: article.document, locale: 'es')


### PR DESCRIPTION
This is to ensure that a department that is migrating content has an
appropriate status code for content that isn't yet published.

https://www.pivotaltracker.com/story/show/47873529
