### PR TITLE
Redirect guests to signon

### DIFF
--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -16,4 +16,4 @@ Scenario: Unpublished editions are protected from visitors
   Given a draft publication "Beard Length Review" exists
   And I am a visitor
   When I preview the publication "Beard Length Review"
-  Then I should get a "404" error
+  Then I should get a "302" error

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -246,7 +246,7 @@ module DocumentControllerTestHelpers
                                body: "Draft information")
 
         get :show, id: document.id, preview: draft_edition.id
-        assert_response 404
+        assert_response 302
       end
     end
 


### PR DESCRIPTION
Given I am a guest that is not logged in
When I attempt to preview content
Then I would like to be redirected to the signon page
And I can login
And I will be redirected back to the preview content

Based on a comment discussion with @bradleywright 
https://github.com/alphagov/whitehall/commit/52281e7a0011214319f1e70bb33a24d9b4325da0#commitcomment-3022018

I don't know the application, so I don't know if the change
is valid, but seems to work for me.
