### PR TITLE
Delete a supporting page that has become a policy

### DIFF
--- a/db/data_migration/20130417215755_delete_supporting_page.rb
+++ b/db/data_migration/20130417215755_delete_supporting_page.rb
@@ -1,0 +1,11 @@
+policy = Policy.published_as('providing-versatile-agile-and-battle-winning-armed-forces-and-a-smaller-more-professional-ministry-of-defence')
+
+if policy
+  page = SupportingPage.find_by_slug_and_edition_id('the-armed-forces-covenant', policy)
+  if page
+    page.destroy
+    puts "#{page.title} deleted"
+  else
+    puts "Page doesn't exist"
+  end
+end


### PR DESCRIPTION
This supporting page is now a policy.

https://www.pivotaltracker.com/story/show/48076565
