### PR TITLE
Tweak admin display for authored articles

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -7,6 +7,16 @@ module Admin::EditionsHelper
     end
   end
 
+  def edition_description(edition)
+    if (@edition.is_a?(Speech) && @edition.speech_type.written_article?)
+      type_description = @edition.speech_type.name.titlecase
+    else
+      type_description = @edition.type.underscore.titlecase
+    end
+
+    "#{@edition.state.capitalize} #{type_description}"
+  end
+
   def nested_attribute_destroy_checkbox_options(form, html_args = {})
     checked_value, unchecked_value = '0', '1'
     checked = form.object[:_destroy].present? ? (form.object[:_destroy] == checked_value) : form.object.persisted?

--- a/app/models/speech_type.rb
+++ b/app/models/speech_type.rb
@@ -39,6 +39,10 @@ class SpeechType
     [WrittenStatement, OralStatement]
   end
 
+  def written_article?
+    [AuthoredArticle].include? self
+  end
+
   def search_format_types
     types = ['speech-'+self.name.parameterize]
     types << 'speech-statement-to-parliament' if statement_to_parliament?

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="span6">
-    <h2 class="pull-right"><%= @edition.state.capitalize %> <%= @edition.type.underscore.titlecase %></h2>
+    <h2 class="pull-right"><%= edition_description(@edition) %></h2>
 
     <%= render partial: 'navigation', locals: { edition: @edition } %>
     <%= render partial: "rejected_by", locals: { edition: @edition } %>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="span4">
-    <h2 class="pull-right"><%= @edition.state.capitalize %> <%= @edition.type.underscore.titlecase %></h2>
+    <h2 class="pull-right"><%= edition_description(@edition) %></h2>
 
     <%= render partial: 'navigation', locals: { edition: @edition } %>
     <%= render partial: "rejected_by", locals: { edition: @edition } %>

--- a/app/views/admin/speeches/_speech_details.html.erb
+++ b/app/views/admin/speeches/_speech_details.html.erb
@@ -1,7 +1,11 @@
 <p class="details well">
   <% if @edition.role_appointment %>
     <span class="type"><%= @edition.speech_type.name %></span>
-    for speech delivered by
+    <% if @edition.speech_type.written_article? %>
+      written by
+    <% else %>
+      for speech delivered by
+    <% end %>
     <span class="role_appointment">
       <span class="person"><%= link_to @edition.role_appointment.person.name, @edition.role_appointment.person %></span>
       <span class="role"><%= role_appointment(@edition.role_appointment, true) %></span>
@@ -16,6 +20,8 @@
   <% end %>
   on
   <span class="delivered_on"><%= @edition.delivered_on.to_s(:long_ordinal) %></span>
-  at
-  <span class="location"><%= @edition.location %></span>
+  <% if @edition.speech_type.location_relevant %>
+    at
+    <span class="location"><%= @edition.location %></span>
+  <% end %>
 </p>

--- a/features/editing-draft-speeches.feature
+++ b/features/editing-draft-speeches.feature
@@ -51,5 +51,6 @@ Scenario: Creating authored articles (originally published externally)
 Scenario: Viewing authored articles (originally published externally)
   Given I am an editor
   When I draft a new authored article "Colonel Mustard talks about beards to The Times"
-  And I preview the authored article
+  Then it should be shown as an authored article in the admin screen
+  When I preview the authored article
   Then I should see who wrote it clearly labelled in the metadata

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -122,8 +122,12 @@ Then /^I cannot choose a location for the article$/ do
 end
 
 When /^I preview the authored article$/ do
-  click_button "Save"
   click_link "Preview"
+end
+
+Then /^it should be shown as an authored article in the admin screen$/ do
+  click_button "Save"
+  assert page.has_content?("Draft Authored Article")
 end
 
 Then /^I should see who wrote it clearly labelled in the metadata$/ do


### PR DESCRIPTION
Addresses the changes asked for in this ticket: http://www.pivotaltracker.com/story/show/46394133

This fills the admin screens with (yet more) conditionals - the authored 
article really should be its own edition type. When we come to improve the
way that the images work for authored articles, splitting it out into its own
edition type could well make sense.

Tested via end-to-end cucumber feature as only significant changes are admin
helper code.
