### PR TITLE
Add about and corporate links to executive orgs

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -792,8 +792,7 @@
       margin: 0 $gutter-half;
     }
 
-    .promo,
-    .promotional_feature {
+    .promo {
       float: left;
       width: 100%;
       margin: $gutter-half 0 $gutter;
@@ -807,7 +806,7 @@
         @include core-19;
       }
 
-      .promotional_feature_item {
+      .feature {
         float: left;
         width: 100%;
         margin-bottom: $gutter;
@@ -883,7 +882,9 @@
         ul {
           margin-top: $gutter-one-third;
         }
-        a { @include external-link-16-bold-no-hover; }
+        a[rel=external] {
+          @include external-link-16-bold-no-hover;
+        }
       }
       .large {
         ul {

--- a/app/presenters/promotional_feature_item_presenter.rb
+++ b/app/presenters/promotional_feature_item_presenter.rb
@@ -2,7 +2,7 @@ class PromotionalFeatureItemPresenter < Draper::Base
   decorates :promotional_feature_item
 
   def css_classes
-    'large' if double_width?
+    ['feature', ('large' if double_width?)].compact.join(' ')
   end
 
   def image_url

--- a/app/presenters/promotional_feature_presenter.rb
+++ b/app/presenters/promotional_feature_presenter.rb
@@ -19,6 +19,6 @@ class PromotionalFeaturePresenter < Draper::Base
   end
 
   def css_classes
-    [width_class, clear_class].compact.join(' ')
+    ['promo', width_class, clear_class].compact.join(' ')
   end
 end

--- a/app/presenters/promotional_features_presenter.rb
+++ b/app/presenters/promotional_features_presenter.rb
@@ -5,7 +5,7 @@ class PromotionalFeaturesPresenter
   delegate *array_methods, to: :decorated_collection
 
   def initialize(source)
-    position = 0
+    position = 1
     @decorated_collection ||= source.collect do |feature|
       presenter = PromotionalFeaturePresenter.new(feature, position: position)
       position += presenter.width

--- a/app/views/organisations/_promotional_feature_item.html.erb
+++ b/app/views/organisations/_promotional_feature_item.html.erb
@@ -4,7 +4,7 @@
     <%= item.title %>
     <%= item.summary %>
 
-    <%=content_tag :ul, class: item.link_list_class do %>
+    <%= content_tag :ul, class: item.link_list_class do %>
       <% item.links.each do |link| %>
         <li><%= link_to link.text, link.url, ({rel: 'external'} if is_external?(link.url)) %></li>
       <% end %>

--- a/app/views/organisations/show-executive-office.html.erb
+++ b/app/views/organisations/show-executive-office.html.erb
@@ -55,7 +55,25 @@
         </div>
       <% end %>
 
+
+
       <section class="features">
+        <div class="features-1 promo clear-promo">
+          <h2>About <%= @organisation.name %></h2>
+          <div class="feature">
+            <div class="content">
+              <p class="description"><%= @organisation.description %></p>
+              <% if @organisation.corporate_information_pages.any? %>
+                <ul class="dash-list">
+                  <% @organisation.corporate_information_pages.each do |page| %>
+                    <li><%= link_to page.title, organisation_corporate_information_page_path(@organisation, page) %></li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
         <% @promotional_features.each do |feature| %>
           <%= content_tag_for(:div, feature, class: feature.css_classes) do %>
             <h2><%= feature.title %></h2>
@@ -76,11 +94,6 @@
           </div>
         </div>
       </section>
-
-      <% if @organisation.corporate_information_pages.any? %>
-        <%= render partial: 'corporate_information',
-                    locals: { organisation: @organisation, show_corporate_reports: true } %>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -81,16 +81,6 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "shows organisation name and description" do
-    organisation = create(:organisation,
-      logo_formatted_name: "unformatted name",
-      description: "organisation-description"
-    )
-    get :show, id: organisation
-    assert_select ".organisation h1", text: "unformatted name"
-    assert_select ".organisation .description", text: "organisation-description"
-  end
-
   view_test "provides ids for links with fragment identifiers to jump to relevent sections" do
     topic = create(:topic, published_edition_count: 1)
     management_role = create(:board_member_role)

--- a/test/support/organisation_controller_test_helpers.rb
+++ b/test/support/organisation_controller_test_helpers.rb
@@ -4,6 +4,16 @@ module OrganisationControllerTestHelpers
   module ClassMethods
     def should_display_organisation_page_elements_for(org_type)
 
+      view_test "#{org_type}:shows organisation name and description" do
+        organisation = create(org_type,
+          logo_formatted_name: "unformatted name",
+          description: "organisation-description"
+        )
+        get :show, id: organisation
+        assert_select ".organisation h1", text: "unformatted name"
+        assert_select ".organisation .description", text: "organisation-description"
+      end
+
       test "#{org_type}:shows primary featured editions in ordering defined by association" do
         organisation = create(org_type)
         news_article = create(:published_news_article)

--- a/test/unit/presenters/promotional_feature_item_presenter_test.rb
+++ b/test/unit/presenters/promotional_feature_item_presenter_test.rb
@@ -6,8 +6,8 @@ class PromotionalFeatureItemPresenterTest < ActionView::TestCase
   end
 
   test '#css_classes returns "large" for double-width items' do
-    assert_nil item_presenter.css_classes
-    assert_equal 'large', item_presenter(double_width: true).css_classes
+    assert_equal 'feature', item_presenter.css_classes
+    assert_equal 'feature large', item_presenter(double_width: true).css_classes
   end
 
   test '#image_url returns 300px width images for single-width items' do


### PR DESCRIPTION
Brought the organisation description back onto the executive office
pages.

Moved the corporate information links up to next to the description.

Added the 'promo' and 'feature' classes back to the promo and features
as we should avoid using underscores in our classes where ever possible.
(Do as the language does).

https://www.pivotaltracker.com/story/show/48123295
