### PR TITLE
Allow linking to pre-filled email signup page

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -39,7 +39,12 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
     },
     updateAtomFeed: function(data) {
       if (data.atom_feed_url) {
-        $(".filter-feed .feed").attr("href", data.atom_feed_url);
+        $(".feeds .feed").attr("href", data.atom_feed_url);
+      }
+    },
+    updateEmailSignup: function(data) {
+      if (data.email_signup_url) {
+        $(".feeds .govdelivery").attr("href", data.email_signup_url);
       }
     },
     submitFilters: function(e){
@@ -63,6 +68,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         },
         success: function(data) {
           documentFilter.updateAtomFeed(data);
+          documentFilter.updateEmailSignup(data);
           if (data.results) {
             documentFilter.renderTable(data);
             documentFilter.liveResultSummary(data);

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -11,6 +11,7 @@
 @import "_conditionals.scss";
 @import "_css3.scss";
 @import "_typography.scss";
+@import "_shims.scss";
 
 @import "styleguide/_dimensions.scss";
 @import "styleguide/_font-stacks.scss";

--- a/app/assets/stylesheets/frontend/helpers/_filter.scss
+++ b/app/assets/stylesheets/frontend/helpers/_filter.scss
@@ -140,16 +140,19 @@
   }
 }
 
-.filter-feed {
-  display: inline;
-  .subscribe {
-    float: right;
+.document-filter-page {
+  .feeds {
+    display: inline;
+    .feed,
+    .govdelivery {
+      @include inline-block;
+    }
   }
 }
 
 .filter-results {
   padding-top: $gutter;
-  
+
   .no-results {
     padding: $gutter 0 $gutter-half;
     border-bottom: 1px solid $border-colour;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,22 @@ module ApplicationHelper
     url_for(params.except(:utf8, :_).merge(format: "json").merge(args))
   end
 
+  def filter_email_signup_url(args={})
+    if params[:departments] && params[:departments].first != 'all'
+      params[:organisation] = params[:departments].first
+    end
+    if params[:topics] && params[:topics].first != 'all'
+      params[:topic] = params[:topics].first
+    end
+    if params.has_key?(:announcement_type_option) and params[:announcement_type_option] != 'all'
+      params[:document_type] = "announcement_type_#{params[:announcement_type_option]}"
+    elsif params.has_key?(:publication_filter_option) and params[:publication_filter_option] != 'all'
+      params[:document_type] = "publication_type_#{params[:publication_filter_option]}"
+    end
+
+    url_for(params.slice(:organisation, :topic, :document_type).merge(controller: :email_signups, action: :show))
+  end
+
   def format_in_paragraphs(string)
     safe_join (string||"").split(/(?:\r?\n){2}/).collect { |paragraph| content_tag(:p, paragraph) }
   end

--- a/app/presenters/announcement_filter_json_presenter.rb
+++ b/app/presenters/announcement_filter_json_presenter.rb
@@ -1,5 +1,5 @@
 class AnnouncementFilterJsonPresenter < DocumentFilterPresenter
   def as_json(options = nil)
-    super.merge atom_feed_url: h.filter_atom_feed_url
+    super.merge atom_feed_url: h.filter_atom_feed_url, email_signup_url: h.filter_email_signup_url
   end
 end

--- a/app/presenters/publication_filter_json_presenter.rb
+++ b/app/presenters/publication_filter_json_presenter.rb
@@ -1,5 +1,5 @@
 class PublicationFilterJsonPresenter < DocumentFilterPresenter
   def as_json(options = nil)
-    super.merge atom_feed_url: h.filter_atom_feed_url
+    super.merge atom_feed_url: h.filter_atom_feed_url, email_signup_url: h.filter_email_signup_url
   end
 end

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -1,5 +1,5 @@
 <% page_title t('announcements.heading') %>
-<% page_class "announcements-index" %>
+<% page_class "announcements-index document-filter-page" %>
 <% atom_discovery_link_tag filter_atom_feed_url, "Recent announcements" %>
 
 <div class="block-1">
@@ -38,11 +38,10 @@
     <% if Locale.current.english? %>
       <%= render partial: "documents/filter_results", locals: { filter: @filter } %>
     <% end %>
-
-    <div class="filter-feed">
-      <%= link_to_feed filter_atom_feed_url %>
-    </div>
-
+    <%= render partial: 'shared/feeds',
+        locals: { atom_url: filter_atom_feed_url,
+                  govdelivery_url: filter_email_signup_url }
+    %>
     <div class="filter-results js-filter-results" id="announcements-container" aria-live="polite">
       <%= render_mustache('documents/filter_table', @filter.as_hash) %>
     </div>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -1,5 +1,5 @@
 <% page_title "Policies" %>
-<% page_class "policies-index" %>
+<% page_class "policies-index document-filter-page" %>
 
 
 <div class="block-1">

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -1,5 +1,5 @@
 <% page_title "Publications" %>
-<% page_class "publications-index" %>
+<% page_class "publications-index document-filter-page" %>
 <% atom_discovery_link_tag filter_atom_feed_url, "Recent publications" %>
 
 <div class="block-1">
@@ -37,10 +37,10 @@
     <% if Locale.current.english? %>
       <%= render partial: "documents/filter_results", locals: { filter: @filter } %>
     <% end %>
-    <div class="filter-feed">
-      <%= link_to_feed filter_atom_feed_url %>
-    </div>
-
+    <%= render partial: 'shared/feeds',
+        locals: { atom_url: filter_atom_feed_url,
+                  govdelivery_url: filter_email_signup_url }
+    %>
     <div class="filter-results js-filter-results" id="publications-container" aria-live="polite">
       <%= render_mustache('documents/filter_table', @filter.as_hash) %>
     </div>

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -376,6 +376,25 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_equal json["atom_feed_url"], publications_url(format: "atom", topics: ["topic-1"])
   end
 
+  view_test "index requested as JSON includes email signup path without date parameters" do
+    get :index, format: :json, date: "2012-01-01", direction: "before"
+
+    json = ActiveSupport::JSON.decode(response.body)
+
+    assert_equal json["email_signup_url"], email_signups_path
+  end
+
+  view_test "index requested as JSON includes email signup path with organisation and topic parameters" do
+    topic = create(:topic)
+    organisation = create(:organisation)
+
+    get :index, format: :json, date: "2012-01-01", direction: "before", topics: [topic], departments: [organisation]
+
+    json = ActiveSupport::JSON.decode(response.body)
+
+    assert_equal json["email_signup_url"], email_signups_path(topic: topic.slug, organisation: organisation.slug)
+  end
+
   view_test 'index has atom feed autodiscovery link' do
     get :index
     assert_select_autodiscovery_link publications_url(format: "atom")

--- a/test/javascripts/unit/document_filter_test.js
+++ b/test/javascripts/unit/document_filter_test.js
@@ -22,8 +22,8 @@ module("Document filter", {
     this.filterResults = $('<div class="js-filter-results" />');
     $('#qunit-fixture').append(this.filterResults);
 
-    this.atomLink = $('<div class="filter-feed"><a class="feed">feed</a></div>');
-    $('#qunit-fixture').append(this.atomLink);
+    this.feedLinks = $('<div class="feeds"><a class="feed">feed</a> <a class="govdelivery">email</a></div>');
+    $('#qunit-fixture').append(this.feedLinks);
 
     this.resultsCount = $('<div class="filter-results-summary"><h3 class="selections"></h3></div>');
     $('#qunit-fixture').append(this.resultsCount);
@@ -44,6 +44,7 @@ module("Document filter", {
       "total_pages": 5,
 
       "atom_feed_url": '/atom-feed',
+      "email_signup_url": '/email-signups',
       "results_any?": true,
       "results": [
         {
@@ -90,11 +91,19 @@ test("should show message when ajax data is empty", function() {
 });
 
 test("should update the atom feed url", function() {
-  equals(this.atomLink.find('a[href="/atom-feed"]').length, 0);
+  equals(this.feedLinks.find('a[href="/atom-feed"]').length, 0);
 
   GOVUK.documentFilter.updateAtomFeed(this.ajaxData);
 
-  equals(this.atomLink.find('a[href="/atom-feed"]').length, 1);
+  equals(this.feedLinks.find('a[href="/atom-feed"]').length, 1);
+});
+
+test("should update the email signup url", function() {
+  equals(this.feedLinks.find('a[href="/email-signups"]').length, 0);
+
+  GOVUK.documentFilter.updateEmailSignup(this.ajaxData);
+
+  equals(this.feedLinks.find('a[href="/email-signups"]').length, 1);
 });
 
 test("should visually hide the footer", function(){

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -298,6 +298,33 @@ class ApplicationHelperTest < ActionView::TestCase
     refute is_external?('http://www.preview.alphagov.co.uk/something'), 'good host with path'
   end
 
+  test "email signup url only accepts certain params" do
+    stubs(:params).returns(action: "index", controller: "publications", ignored: "yes")
+    refute filter_email_signup_url.match %r{ignored=yes}
+  end
+
+  test "email signup url transforms filter params" do
+    stubs(:params).returns(action: "index", controller: "publications", topics: ['topic-1'], departments: ['department-1'])
+    assert filter_email_signup_url.match %r{topic=topic-1}
+    assert filter_email_signup_url.match %r{organisation=department-1}
+  end
+
+  test "email signup url ignores 'all' variants of params" do
+    stubs(:params).returns(action: "index", controller: "publications", topics: ['all'], departments: ['all'])
+    refute filter_email_signup_url.match %r{topic=}
+    refute filter_email_signup_url.match %r{organisation=}
+  end
+
+  test "email signup url prefixes publication types" do
+    stubs(:params).returns(action: "index", controller: "publications", publication_filter_option: "publication-type")
+    assert_match %r{document_type=publication_type_publication-type}, filter_email_signup_url
+  end
+
+  test "email signup url prefixes announcement types" do
+    stubs(:params).returns(action: "index", controller: "announcements", announcement_type_option: "announcement-type")
+    assert_match %r{document_type=announcement_type_announcement-type}, filter_email_signup_url
+  end
+
   private
 
   def appoint_minister(attributes = {})


### PR DESCRIPTION
This has nicer URLs of the form ?organisation (rather than the nested form Rails params), and is now enabled and dynamically updated on announcements and publications filter pages.

https://www.pivotaltracker.com/story/show/48180175
