### PR TITLE
Resizing and fixing images on orgs page for mobile view

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_featured_news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_featured_news.scss
@@ -16,8 +16,8 @@
     .content {
       padding: $gutter-half $gutter-half $gutter-one-third;
 
-      .img-holder {
-        width: 25%;
+      .image-holder {
+        width: 33.33%;
         float: left;
         @include right-to-left {
           float: right;
@@ -29,7 +29,7 @@
 
         .img {
           display: block;
-          padding: $gutter-one-third $gutter-half 0 0;
+          padding: $gutter-one-sixth $gutter-half 0 0;
           @include right-to-left {
             padding: $gutter-one-third 0 0 $gutter-half;
           }
@@ -44,7 +44,7 @@
       }
       .text {
         float: left;
-        width: 75%;
+        width: 66.66%;
         @include right-to-left {
           float: right;
         }

--- a/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
@@ -5,7 +5,8 @@
       .content {
         padding: $gutter-half 0 $gutter-one-third 0;
         @extend %contain-floats;
-        .img-holder {
+        .image-holder {
+          width: 100%;
           @include media(tablet){
             width: 66.66%;
             float: left;
@@ -15,6 +16,7 @@
           }
         }
         .text {
+          width: 100%;
           .meta, h2, .summary {
             padding: 0 $gutter-half;
           }

--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -19,57 +19,67 @@
     @extend %contain-floats;
   }
 
-  .image_holder {
+  .image-holder {
+    width: 33.33%;
     float: left;
-    margin: 0;
-    padding-right: $gutter-one-third;
-    width: 25%;
-    min-width: 7.7rem;
-    min-width: 77px;
-    min-height: 5rem;
-    min-height: 50px;
-
+    @include right-to-left {
+      float: right;
+    }
     @include media(tablet){
-      padding: 0;
+      width: 100%;
+      float: none;
+    }
+
+    .img {
+      display: block;
+      padding: 0 $gutter-half 0 0;
+      @include right-to-left {
+        padding: $gutter-one-third 0 0 $gutter-half;
+      }
+      @include media(tablet){
+        padding: 0;
+      }
+
+      img {
+        width: 100%;
+      }
+    }
+  }
+
+  .text {
+    float: left;
+    width: 66.66%;
+    @include media(tablet){
       float: none;
       width: 100%;
     }
+    .current-appointee {
+      padding-top: 0;
+      a {
+        &:hover,
+        &:focus,
+        &:active {
+          text-decoration: none;
 
-    img {
-      display: block;
-      margin: $gutter-one-sixth 0 $gutter-one-third;
-      width: 100%;
-      height: auto;
-
-      @include media(tablet) {
-        width: 100%;
-        height: auto;
-        margin-left: 0;
-      }
-    }
-  }
-
-  .current-appointee {
-    padding-top: 0;
-    a {
-      &:hover,
-      &:focus,
-      &:active {
-        text-decoration: none;
-
-        strong {
-          text-decoration: underline;
+          strong {
+            text-decoration: underline;
+          }
         }
       }
     }
-  }
 
-  .role a {
-    text-decoration: none;
-    &:hover,
-    &:focus,
-    &:active {
-      text-decoration: underline;
+    .role {
+      @include core-14;
+      padding-top: $gutter-one-sixth;
+
+      a {
+        text-decoration: none;
+        &:hover,
+        &:focus,
+        &:active {
+          text-decoration: underline;
+        }
+      }
     }
   }
 
@@ -87,8 +97,5 @@
     padding-top: 0;
   }
 
-  .role {
-    @include core-14;
-    padding-top: $gutter-one-sixth;
-  }
+
 }

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -19,7 +19,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-wood"><%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax' %></a>
+            <a href="/government/history/past-foreign-secretaries/edward-wood" class="img"><%= image_tag 'history/past-foreign-secretaries/viscount-halifax.jpg', alt: 'Edward Frederick Lindley Wood, Viscount Halifax' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-wood">Edward Frederick Lindley Wood, Viscount&nbsp;Halifax</a></h3>
           <p class="term">1938 &ndash; 1940</p>
@@ -28,7 +28,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/austen-chamberlain"><%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain' %></a>
+            <a href="/government/history/past-foreign-secretaries/austen-chamberlain" class="img"><%= image_tag 'history/past-foreign-secretaries/austen-chamberlain.jpg', alt: 'Sir Austen Chamberlain' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/austen-chamberlain">Sir Austen Chamberlain</a></h3>
           <p class="term">1924 &ndash; 1929</p>
@@ -37,7 +37,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-curzon"><%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-curzon" class="img"><%= image_tag 'history/past-foreign-secretaries/george-nathaniel-curzon.jpg', alt: 'George Nathaniel Curzon, Marquess of Kedleston' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-curzon">George Nathaniel Curzon, Marquess of&nbsp;Kedleston</a></h3>
           <p class="term">1919 &ndash; 1924</p>
@@ -46,7 +46,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/edward-grey"><%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon' %></a>
+            <a href="/government/history/past-foreign-secretaries/edward-grey" class="img"><%= image_tag 'history/past-foreign-secretaries/sir-edward-grey.jpg', alt: 'Sir Edward Grey, Viscount Grey of Fallodon' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/edward-grey">Sir Edward Grey, Viscount Grey of&nbsp;Fallodon</a></h3>
           <p class="term">1905 &ndash; 1916</p>
@@ -55,7 +55,7 @@
       <li class="person person-excerpt clear-person">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice"><%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne' %></a>
+            <a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-landsowne.jpg', alt: 'Henry Petty-Fitzmaurice, Marquess of Lansdowne' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/henry-petty-fitzmaurice">Henry Petty&ndash;Fitzmaurice, Marquess of Lansdowne</a></h3>
           <p class="term">1900 &ndash; 1905</p>
@@ -64,7 +64,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/robert-cecil"><%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury' %></a>
+            <a href="/government/history/past-foreign-secretaries/robert-cecil" class="img"><%= image_tag 'history/past-foreign-secretaries/marquess-of-salisbury.jpg', alt: 'Robert Cecil, Marquess of Salisbury' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/robert-cecil">Robert Cecil, Marquess of Salisbury</a></h3>
           <p class="term">1878 &ndash; 1880 / 1885 &ndash; 1886<br />
@@ -74,7 +74,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gower"><%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-gower" class="img"><%= image_tag 'history/past-foreign-secretaries/earl-granville.jpg', alt: 'George Leveson Gower, Earl Granville' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gower">George Leveson Gower, Earl Granville</a></h3>
           <p class="term">1851 &ndash; 1852 / 1870 &ndash; 1874<br />
@@ -84,7 +84,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/george-gordon"><%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen' %></a>
+            <a href="/government/history/past-foreign-secretaries/george-gordon" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-aberdeen.jpg', alt: 'George Hamilton Gordon, Earl of Aberdeen' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/george-gordon">George Hamilton Gordon, Earl of Aberdeen</a></h3>
           <p class="term">1828 &ndash; 1830 / 1841 &ndash; 1846</p>
@@ -93,7 +93,7 @@
       <li class="person person-excerpt clear-person">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/charles-fox"><%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox' %></a>
+            <a href="/government/history/past-foreign-secretaries/charles-fox" class="img"><%= image_tag 'history/past-foreign-secretaries/charles-james-fox.jpg', alt: 'Charles James Fox' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/charles-fox">Charles James Fox</a></h3>
           <p class="term">1782 / 1783 / 1806</p>
@@ -102,7 +102,7 @@
       <li class="person person-excerpt">
         <div class="inner">
           <div class="image-holder">
-            <a href="/government/history/past-foreign-secretaries/william-grenville"><%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville' %></a>
+            <a href="/government/history/past-foreign-secretaries/william-grenville" class="img"><%= image_tag 'history/past-foreign-secretaries/lord-grenville.jpg', alt: 'William Wyndham Grenville, Lord Grenville' %></a>
           </div>
           <h3 class="name"><a href="/government/history/past-foreign-secretaries/william-grenville">William Wyndham Grenville, Lord&nbsp;Grenville</a></h3>
           <p class="term">1791 &ndash; 1801</p>

--- a/app/views/people/_person.html.erb
+++ b/app/views/people/_person.html.erb
@@ -9,15 +9,17 @@
   <%= content_tag_for(wrapping_element, person, prefix, class: "person-excerpt #{extra_class}") do %>
     <div class="inner">
       <% unless hide_image %>
-        <div class="image_holder">
-          <%= link_to person.image, person %>
+        <div class="image-holder">
+          <%= link_to person.image, person, class: "img" %>
         </div>
       <% end %>
-      <<%= hlevel %> class="current-appointee"><%= person.link %></<%= hlevel %>>
-      <p class="role">
-        <%= roles.map { |role| role.link }.join(", ").html_safe -%>
-        <%= roles_footnotes(roles, display_cabinet_attendance) -%>
-      </p>
+      <div class="text">
+        <<%= hlevel %> class="current-appointee"><%= person.link %></<%= hlevel %>>
+        <p class="role">
+          <%= roles.map { |role| role.link }.join(", ").html_safe %>
+          <%= roles_footnotes(roles, display_cabinet_attendance) -%>
+        </p>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/shared/_featured_news.html.erb
+++ b/app/views/shared/_featured_news.html.erb
@@ -12,7 +12,7 @@
 %>
 <%= content_tag_for(:article, edition, nil, class: extra_classes.strip) do %>
   <div class="content">
-    <span class="img-holder">
+    <span class="image-holder">
       <%= link_to edition.image_tag(image_size), public_document_path(edition), title: t("document.read", title: edition.title), class: 'img'%>
     </span>
     <div class="text">


### PR DESCRIPTION
on orgs page

• First news story image full width
• make news story images match people listing images
• refactored people listings and fix bug where people who have long names and titles, the text flows underneath the images
• updated class name with underscore

https://www.pivotaltracker.com/story/show/46700161
