### PR TITLE
Move corporate info links down the EO pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -964,6 +964,13 @@
     }
   }
 
+  .corporate-information {
+    .dash-list {
+      margin-top: $gutter;
+      padding-top: $gutter;
+      border-top: 1px solid $border-colour;
+    }
+  }
 
 }
 

--- a/app/presenters/promotional_features_presenter.rb
+++ b/app/presenters/promotional_features_presenter.rb
@@ -5,7 +5,7 @@ class PromotionalFeaturesPresenter
   delegate *array_methods, to: :decorated_collection
 
   def initialize(source)
-    position = 1
+    position = 0
     @decorated_collection ||= source.collect do |feature|
       presenter = PromotionalFeaturePresenter.new(feature, position: position)
       position += presenter.width

--- a/app/views/organisations/show-executive-office.html.erb
+++ b/app/views/organisations/show-executive-office.html.erb
@@ -56,25 +56,7 @@
         </div>
       <% end %>
 
-
-
       <section class="features">
-        <div class="features-1 promo clear-promo">
-          <h2>About <%= @organisation.name %></h2>
-          <div class="feature">
-            <div class="content">
-              <p class="description"><%= @organisation.description %></p>
-              <% if @organisation.corporate_information_pages.any? %>
-                <ul class="dash-list">
-                  <% @organisation.corporate_information_pages.each do |page| %>
-                    <li><%= link_to page.title, organisation_corporate_information_page_path(@organisation, page) %></li>
-                  <% end %>
-                </ul>
-              <% end %>
-            </div>
-          </div>
-        </div>
-
         <% @promotional_features.each do |feature| %>
           <%= content_tag_for(:div, feature, class: feature.css_classes) do %>
             <h2><%= feature.title %></h2>
@@ -97,4 +79,17 @@
       </section>
     </div>
   </div>
+
+  <% if @organisation.corporate_information_pages.any? %>
+    <div class="block corporate-information">
+      <div class="inner-block">
+        <ul class="dash-list">
+          <% @organisation.corporate_information_pages.each do |page| %>
+            <li><%= link_to page.title, organisation_corporate_information_page_path(@organisation, page) %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
 <% end %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -81,6 +81,14 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "shows organisation description" do
+    organisation = create(:organisation,
+      description: "organisation-description"
+    )
+    get :show, id: organisation
+    assert_select ".organisation .description", text: "organisation-description"
+  end
+
   view_test "provides ids for links with fragment identifiers to jump to relevent sections" do
     topic = create(:topic, published_edition_count: 1)
     management_role = create(:board_member_role)

--- a/test/support/organisation_controller_test_helpers.rb
+++ b/test/support/organisation_controller_test_helpers.rb
@@ -4,14 +4,12 @@ module OrganisationControllerTestHelpers
   module ClassMethods
     def should_display_organisation_page_elements_for(org_type)
 
-      view_test "#{org_type}:shows organisation name and description" do
+      view_test "#{org_type}:shows organisation name" do
         organisation = create(org_type,
-          logo_formatted_name: "unformatted name",
-          description: "organisation-description"
+          logo_formatted_name: "unformatted name"
         )
         get :show, id: organisation
         assert_select ".organisation h1", text: "unformatted name"
-        assert_select ".organisation .description", text: "organisation-description"
       end
 
       test "#{org_type}:shows primary featured editions in ordering defined by association" do


### PR DESCRIPTION
A description of what an EO organisation is apprently not needed so it
has been removed. They have also requested the corporate infomation is
hidden at the bottom of the page.

https://www.pivotaltracker.com/story/show/48123295
