### PR TITLE
Limit the roles that can have historical accounts

### DIFF
--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -6,6 +6,7 @@ class HistoricalAccount < ActiveRecord::Base
   validates_with SafeHtmlValidator
   validates :person, :roles, :summary, :body, :political_party, presence: true
   validates :born, :died, length: { maximum: 256 }
+  validate :roles_support_historical_accounts
 
   def self.for_role(role)
     includes(:historical_account_roles).where('historical_account_roles.role_id' => role)
@@ -25,5 +26,13 @@ class HistoricalAccount < ActiveRecord::Base
 
   def role
     roles.first
+  end
+
+  private
+
+  def roles_support_historical_accounts
+    unless roles.all? { |role| role.supports_historical_accounts? }
+      errors.add(:base, 'The selected role(s) do not all support historical accounts')
+    end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -97,6 +97,10 @@ class Person < ActiveRecord::Base
     [surname, forename].compact.join(' ').downcase
   end
 
+  def can_have_historical_accounts?
+    roles.any?(&:supports_historical_accounts?)
+  end
+
   private
 
   def name_as_words(*elements)

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -3,7 +3,7 @@
 
   <fieldset>
     <%= form.label :role_ids, 'Role(s)' %>
-    <%= form.select :role_ids, options_from_collection_for_select(person.roles.uniq, :id, :name, historical_account.role_ids),
+    <%= form.select :role_ids, options_from_collection_for_select(person.roles.where(supports_historical_accounts: true).uniq, :id, :name, historical_account.role_ids),
                     { include_blank: true },
                     multiple: true,
                     class: 'chzn-select',

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -28,7 +28,11 @@
         </table>
 
         <nav class="form-actions">
-          <%= link_to 'Add an historical account', new_admin_person_historical_account_path, class: "btn btn-primary"  %>
+          <% if @person.can_have_historical_accounts? %>
+            <%= link_to 'Add an historical account', new_admin_person_historical_account_path, class: "btn btn-primary"  %>
+          <% else %>
+            <em>Note: (This person does not have any role appointments in roles that support historial accounts)</em>
+          <% end %>
         </nav>
       </section>
     </div>

--- a/db/data_migration/20130423142623_add_historical_account_support_to_pm_and_chanchellor_roles.rb
+++ b/db/data_migration/20130423142623_add_historical_account_support_to_pm_and_chanchellor_roles.rb
@@ -1,0 +1,3 @@
+puts "Adding historical account support to the Prime Minister and Chancellor roles"
+Role.find_by_slug('prime-minister').update_attribute(:supports_historical_accounts, true)
+Role.find_by_slug('chancellor-of-the-exchequer').update_attribute(:supports_historical_accounts, true)

--- a/db/migrate/20130423141920_add_supports_historical_accounts_to_roles.rb
+++ b/db/migrate/20130423141920_add_supports_historical_accounts_to_roles.rb
@@ -1,0 +1,6 @@
+class AddSupportsHistoricalAccountsToRoles < ActiveRecord::Migration
+  def change
+    add_column :roles, :supports_historical_accounts, :boolean, default: false, null: false
+    add_index :roles, :supports_historical_accounts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130417115108) do
+ActiveRecord::Schema.define(:version => 20130423141920) do
 
   create_table "access_and_opening_times", :force => true do |t|
     t.text     "body"
@@ -944,19 +944,21 @@ ActiveRecord::Schema.define(:version => 20130417115108) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
-    t.string   "type",                       :default => "MinisterialRole", :null => false
-    t.boolean  "permanent_secretary",        :default => false
-    t.boolean  "cabinet_member",             :default => false,             :null => false
+    t.string   "type",                         :default => "MinisterialRole", :null => false
+    t.boolean  "permanent_secretary",          :default => false
+    t.boolean  "cabinet_member",               :default => false,             :null => false
     t.string   "slug"
     t.text     "responsibilities"
-    t.boolean  "chief_of_the_defence_staff", :default => false,             :null => false
+    t.boolean  "chief_of_the_defence_staff",   :default => false,             :null => false
     t.integer  "whip_organisation_id"
-    t.integer  "seniority",                  :default => 100
+    t.integer  "seniority",                    :default => 100
     t.integer  "attends_cabinet_type_id"
     t.integer  "role_payment_type_id"
+    t.boolean  "supports_historical_accounts", :default => false,             :null => false
   end
 
   add_index "roles", ["slug"], :name => "index_roles_on_slug"
+  add_index "roles", ["supports_historical_accounts"], :name => "index_roles_on_supports_historical_accounts"
 
   create_table "social_media_accounts", :force => true do |t|
     t.integer  "socialable_id"

--- a/features/step_definitions/historic_appointment_steps.rb
+++ b/features/step_definitions/historic_appointment_steps.rb
@@ -1,5 +1,5 @@
 Given /^there are previous prime ministers$/ do
-  pm_role = create(:role, name: 'Prime Minister', slug: 'prime-minister')
+  pm_role = create(:role, name: 'Prime Minister', slug: 'prime-minister', supports_historical_accounts: true)
   previous_pm1  = create(:ministerial_role_appointment, role: pm_role, started_at: 8.years.ago, ended_at: 4.years.ago)
   previous_pm2  = create(:ministerial_role_appointment, role: pm_role, started_at: 4.years.ago, ended_at: 1.day.ago)
   current_pm    = create(:ministerial_role_appointment, role: pm_role, started_at: Time.zone.now)

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -13,7 +13,7 @@ end
 
 Given /^a person called "([^"]*)" exists in the role of "([^"]*)"$/ do |name, role_name|
   @person = create_person(name)
-  @role = create(:ministerial_role, name: role_name)
+  @role = create(:ministerial_role, supports_historical_accounts: true, name: role_name)
   create(:role_appointment, role: @role, person: @person)
 end
 

--- a/test/factories/historical_accounts.rb
+++ b/test/factories/historical_accounts.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
 
     after(:build) do |account|
       unless account.roles.present?
-        account.roles << build(:role_appointment, person: account.person).role
+        account.roles << build(:historic_role_appointment, person: account.person).role
       end
     end
   end

--- a/test/factories/role_appointments.rb
+++ b/test/factories/role_appointments.rb
@@ -28,4 +28,8 @@ FactoryGirl.define do
   factory :deputy_head_of_mission_role_appointment, parent: :role_appointment do
     association :role, factory: :deputy_head_of_mission_role
   end
+
+  factory :historic_role_appointment, parent: :role_appointment do
+    association :role, factory: :historic_role
+  end
 end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -10,4 +10,7 @@ FactoryGirl.define do
     type ""
   end
 
+  factory :historic_role, parent: :role do
+    supports_historical_accounts true
+  end
 end

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -4,7 +4,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   setup do
     login_as :policy_writer
     @person = create(:person)
-    @role = create(:role)
+    @role = create(:historic_role)
     @historical_account = create(:historical_account, person: @person, roles: [@role])
   end
 

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -72,11 +72,11 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   private
 
   def pm_role
-    @pm_role ||= create(:role, name: 'Prime Minister', slug: 'prime-minister')
+    @pm_role ||= create(:historic_role, name: 'Prime Minister', slug: 'prime-minister')
   end
 
   def chancellor_role
-    @chancellor_role ||= create(:role, name: 'Chancellor of the Exchequer', slug: 'chancellor-of-the-exchequer')
+    @chancellor_role ||= create(:historic_role, name: 'Chancellor of the Exchequer', slug: 'chancellor-of-the-exchequer')
   end
 
   def assert_equal_role_presenters(role_appointments, expected)

--- a/test/unit/historical_account_test.rb
+++ b/test/unit/historical_account_test.rb
@@ -12,8 +12,18 @@ class HistoricalAccountTest < ActiveSupport::TestCase
     historical_account = build(:historical_account)
     historical_account.roles = []
     refute historical_account.valid?
-    historical_account.roles << create(:role)
+    historical_account.roles << create(:historic_role)
     assert historical_account.valid?
+  end
+
+  test "is not valid unless its role supports historic accounts" do
+
+    historical_account = build(:historical_account, roles: [create(:historic_role)])
+    assert historical_account.valid?
+
+    historical_account = build(:historical_account, roles: [create(:role)])
+    refute historical_account.valid?
+    assert_equal ['The selected role(s) do not all support historical accounts'], historical_account.errors[:base]
   end
 
   test "has accessor for political party" do
@@ -30,8 +40,8 @@ class HistoricalAccountTest < ActiveSupport::TestCase
   end
 
   test "#role defaults to the first role when there are multiple" do
-    role1 = create(:role)
-    role2 = create(:role)
+    role1 = create(:historic_role)
+    role2 = create(:historic_role)
     historical_account = create(:historical_account, roles: [role1, role2])
 
     assert_equal role1, historical_account.role

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -247,4 +247,15 @@ class PersonTest < ActiveSupport::TestCase
 
     refute_includes Person.without_a_current_ministerial_role, person
   end
+
+  test '#can_have_historical_accounts? returns true when person has roles that support them' do
+    person = create(:person)
+    refute person.can_have_historical_accounts?
+
+    create(:role_appointment, person: person)
+    refute person.reload.can_have_historical_accounts?
+
+    create(:historic_role_appointment, person: person)
+    assert person.reload.can_have_historical_accounts?
+  end
 end

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -408,7 +408,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
   end
 
   test "returns an historical account for the role and appointtee if one exists" do
-    role_appointment = create(:role_appointment)
+    role_appointment = create(:historic_role_appointment)
 
     assert_nil role_appointment.historical_account
 
@@ -417,8 +417,8 @@ class RoleAppointmentTest < ActiveSupport::TestCase
   end
 
   test "does not return an historical account if the appointee has one for another role" do
-    role_appointment   = create(:role_appointment)
-    second_appointment = create(:role_appointment, person: role_appointment.person)
+    role_appointment   = create(:historic_role_appointment)
+    second_appointment = create(:historic_role_appointment, person: role_appointment.person)
     create(:historical_account, roles: [second_appointment.role], person: role_appointment.person)
 
     assert_nil role_appointment.historical_account


### PR DESCRIPTION
Currently, creating an historical account for any role other than PM or Chancellor causes admin/historical_accounts#index to 500. This is because front-end routing is limited to those two roles only. This code adds a flag to the Role model that allows us to specify the roles that can have historical accounts. A data migration enables historical accounts for the two roles.
