### PR TITLE
Upgrade sass to the lastest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'link_header'
 
 group :assets do
   gem 'govuk_frontend_toolkit', '0.18.0'
-  gem 'sass', '3.2.5'
+  gem 'sass', '3.2.8'
   gem 'sass-rails', '3.1.4'
   gem 'uglifier'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
       rest-client
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
-    sass (3.2.5)
+    sass (3.2.8)
     sass-rails (3.1.4)
       actionpack (~> 3.1.0)
       railties (~> 3.1.0)
@@ -434,7 +434,7 @@ DEPENDENCIES
   rake (= 0.9.2)
   router-client (~> 3.0.1)
   rummageable (= 0.6.2)
-  sass (= 3.2.5)
+  sass (= 3.2.8)
   sass-rails (= 3.1.4)
   shared_mustache (~> 0.0.2)
   simplecov


### PR DESCRIPTION
I have run the precompile with the old version and the new version. The
differences in our compressed css are as such:
- Spaces added between font family names
- Colour words converted to hex: 'white' -> '#fff' which is shorter
- Space added before '!important'
