### PR TITLE
Data migration to seed historic pm biographies

### DIFF
--- a/db/data_migration/20130424145331_seed_historic_pm_biographies.rb
+++ b/db/data_migration/20130424145331_seed_historic_pm_biographies.rb
@@ -1,0 +1,19 @@
+
+def historic_biography_for(person, role_appointments)
+  appointment_dates = role_appointments.collect { |a| "#{a.started_at.strftime("%Y")} &ndash; #{a.ended_at.strftime("%Y")}" }.to_sentence
+  "#{person.name} served as Prime Minister between #{appointment_dates}. Read more about the life and achievements of #{person.name} in our [past Prime Ministers](/government/history/past-prime-ministers/#{person.slug}) section."
+end
+
+pm_role = Role.find_by_slug('prime-minister')
+previous_pms = pm_role.previous_appointments.collect(&:person)
+
+puts "Updating blank biographies for #{previous_pms.size} previous Prime Ministers"
+previous_pms.each do |person|
+  if person.biography.blank?
+    puts "Setting default biography for #{person.name}"
+    person.biography = historic_biography_for(person, person.role_appointments.for_role(pm_role))
+    person.save!
+  else
+    puts "Warning: #{person.name} (#{person.id}) already has a biography! Not updating..."
+  end
+end


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/48659887

We are now creating people for past Prime Ministers so that we can
give them historical accounts. These people are being created without
biographies, which isn't ideal, as they show up at /government/people
and are also searchable. This data migration seeds the previous PMs
that do not already have a biography with a default one that mentions
their historic role and links to the page in the history section.

Note: We do not want this run until content have added all the past Pms.
