### PR TITLE
Big org counts

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -1,6 +1,6 @@
 .organisations-index {
 
-  .other-departments h1 {
+  .other-departments .type-heading {
     margin-top: 0;
     width: 25%;
   }
@@ -34,7 +34,7 @@
   .ministerial-departments, .executive-offices {
     margin-bottom: $gutter*2;
 
-    h1 {
+    .type-heading {
       padding-top: 17px;
       padding-top: 1.7rem;
     }
@@ -113,6 +113,32 @@
       list-style: none;
       border-bottom: 1px solid $border-colour;
       @include ig-core-19;
+    }
+  }
+  
+  .type-heading {
+    h1 {
+      width: 100%;
+    }
+    @include media(desktop){
+      width: 33.33%;
+      float: left
+    }
+
+    @include media(tablet){
+      p {
+        clear: both;
+        span.count {
+          @include core-80;
+          display: block;
+          font-weight: bold;
+        }
+        span.on-govuk {
+          @include core-24;
+          display: block;
+          color: $secondary-text-colour;
+        }
+      }
     }
   }
 }

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -155,4 +155,18 @@ module OrganisationHelper
       end
     end.to_sentence.html_safe
   end
+
+  def organisation_count_paragraph(org_array, opts = {})
+    opts = {with_live_on_govuk: true}.merge(opts)
+    contents = content_tag(:span, org_array.length, class: 'count js-filter-count')
+
+    if opts[:with_live_on_govuk]
+      organisations_that_are_live = org_array.select { |org| org.live? }.length
+      organisations_that_are_live = 'All' if organisations_that_are_live >= org_array.length
+
+      contents += content_tag(:span, "#{organisations_that_are_live} live on GOV.UK", class: 'on-govuk')
+    end
+
+    content_tag(:p, contents.html_safe)
+  end
 end

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -33,7 +33,10 @@
       </div>
       <% end %>
       <div class="heading-block ministerial-departments js-hide-department-children js-filter-block">
-        <h1 id="departments">Ministerial departments</h1>
+        <header id="departments" class="type-heading">
+          <h1>Ministerial departments</h1>
+          <%= organisation_count_paragraph(@ministerial_departments) %>
+        </header>
         <div class="content">
           <ol>
             <% @ministerial_departments.each do |ministerial_department| %>
@@ -52,7 +55,10 @@
         </div>
       </div>
       <div class="heading-block other-departments js-filter-block js-hide-department-children">
-        <h1 id="non-ministerial-departments">Non ministerial departments</h1>
+        <header id="non-ministerial-departments" class="type-heading">
+          <h1>Non ministerial departments</h1>
+          <%= organisation_count_paragraph(@non_ministerial_departments) %>
+        </header>
         <div class="content">
           <ol class="index-list">
             <% @non_ministerial_departments.each do |organisation| %>
@@ -67,7 +73,10 @@
       </div>
 
       <div class="heading-block other-departments js-filter-block">
-        <h1 id="agencies-and-public-bodies">Agencies &amp; other public bodies</h1>
+        <header id="agencies-and-public-bodies" class="type-heading">
+          <h1>Agencies &amp; other public bodies</h1>
+          <%= organisation_count_paragraph(@agencies_and_government_bodies) %>
+        </header>
         <div class="content">
           <ol class="index-list">
             <% @agencies_and_government_bodies.each do |organisation| %>
@@ -81,7 +90,10 @@
       </div>
 
       <div class="heading-block other-departments js-filter-block">
-        <h1 id="public-corporations">Public corporations</h1>
+        <header id="public-corporations" class="type-heading">
+          <h1>Public corporations</h1>
+          <%= organisation_count_paragraph(@public_corporations, with_live_on_govuk: false) %>
+        </header>
         <div class="content">
           <ol class="index-list">
             <% @public_corporations.each do |organisation| %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -10,13 +10,18 @@ class OrganisationsControllerTest < ActionController::TestCase
   should_display_organisation_page_elements_for(:organisation)
   should_display_organisation_page_elements_for(:executive_office)
 
-  view_test "should display a list of organisations" do
+  view_test "should display a list of ministerial departments" do
     ministerial_org_type = create(:ministerial_organisation_type)
     organisation_1 = create(:organisation, organisation_type_id: ministerial_org_type.id)
+    organisation_2 = create(:organisation, organisation_type_id: ministerial_org_type.id)
+    organisation_3 = create(:organisation, organisation_type_id: ministerial_org_type.id)
 
     get :index
 
-    assert_select_object(organisation_1)
+    assert_select '.ministerial-departments' do
+      assert_select '.js-filter-count', text: '3'
+      assert_select_object(organisation_1)
+    end
   end
 
   view_test "should display a list of executive offices" do
@@ -33,25 +38,29 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should display a list of non-ministerial departments" do
     non_ministerial_org_type = create(:non_ministerial_organisation_type)
-    organisation = create(:organisation, organisation_type_id: non_ministerial_org_type.id)
+    organisation_1 = create(:organisation, organisation_type_id: non_ministerial_org_type.id)
+    organisation_2 = create(:organisation, organisation_type_id: non_ministerial_org_type.id)
 
     get :index
 
     assert_select '#agencies-and-public-bodies'
     assert_select '.other-departments' do
-      assert_select_object(organisation)
+      assert_select '.js-filter-count', text: '2'
+      assert_select_object(organisation_1)
     end
   end
 
   view_test "should display a list of public corporation organisations" do
     public_corporation_org_type = create(:public_corporation_organisation_type)
-    organisation = create(:organisation, organisation_type_id: public_corporation_org_type.id)
+    organisation_1 = create(:organisation, organisation_type_id: public_corporation_org_type.id)
+    organisation_2 = create(:organisation, organisation_type_id: public_corporation_org_type.id)
 
     get :index
 
     assert_select '#public-corporations'
     assert_select '.other-departments' do
-      assert_select_object(organisation)
+      assert_select '.js-filter-count', text: '2'
+      assert_select_object(organisation_1)
     end
   end
 

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -64,6 +64,31 @@ class OrganisationHelperTest < ActionView::TestCase
     list = build(:featured_topics_and_policies_list, link_to_filtered_policies: true)
     assert_equal link_to('See all our policies', policies_path(departments: [o])), link_to_all_featured_policies(o)
   end
+  
+  test 'organisation_count_paragraph includes the number of orgs in a filterable container' do
+    orgs = [build(:organisation), build(:organisation)]
+    render text: organisation_count_paragraph(orgs)
+    assert_select '.js-filter-count', text: '2'
+  end
+
+  test 'organisation_count_paragraph includes the number of orgs live on govuk in a container' do
+    orgs = [build(:organisation, govuk_status: 'live'), build(:organisation, govuk_status: 'joining')]
+    render text: organisation_count_paragraph(orgs)
+    assert_select '.on-govuk'
+    assert_select '.on-govuk', text: '1 live on GOV.UK'
+  end
+
+  test 'organisation_count_paragraph includes "all" instead of a number, if all supplied orgs are live on govuk in a container' do
+    orgs = [build(:organisation, govuk_status: 'live'), build(:organisation, govuk_status: 'live')]
+    render text: organisation_count_paragraph(orgs)
+    assert_select '.on-govuk', text: 'All live on GOV.UK'
+  end
+
+  test 'organisation_count_paragraph won\'t include the live on govuk container if you ask it not to' do
+    orgs = [build(:organisation, govuk_status: 'live'), build(:organisation, govuk_status: 'live')]
+    render text: organisation_count_paragraph(orgs, with_live_on_govuk: false)
+    assert_select '.on-govuk', count: 0
+  end
 end
 
 class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::TestCase
@@ -154,6 +179,8 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_match parent.name, result
     assert_match parent2.name, result
   end
+  
+  
 end
 
 class OrganisationSiteThumbnailPathTest < ActionView::TestCase


### PR DESCRIPTION
Put a big number under the org type header on /government/organisations - under that put a smaller " _n_ live on GOV.UK " description.  The big number does the magic filter thing, the little number doesn't.

For: https://www.pivotaltracker.com/story/show/48389507
