### PR TITLE
Past Chancellors page corrections

### DIFF
--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -7,7 +7,7 @@
       <h1 class="topics">
         <%= link_to 'History', histories_path %>
       </h1>
-      <h2>Past Chancellors</h2>
+      <h2>Past Chancellors of the Exchequer</h2>
     </header>
   </div>
 </div>
@@ -17,10 +17,6 @@
     <div class="year-block" id="modern-appointments">
       <h2 class="profiles">20th &amp; 21st centuries</h2>
       <ol>
-        <li class="person person-excerpt"><div class="inner">
-          <h3 class="name">George Osborne</h3>
-          <p class="term">2010-present</p>
-        </div></li>
         <li class="person person-excerpt"><div class="inner">
           <h3 class="name">Alistair Darling</h3>
           <p class="term">2007-2010</p>


### PR DESCRIPTION
George Osborne isn't a past chancellor just yet. This also updates the title to use the full role title.
