### PR TITLE
Add back to contents link to html pubs

### DIFF
--- a/app/assets/javascripts/application/back-to-content.js
+++ b/app/assets/javascripts/application/back-to-content.js
@@ -6,7 +6,7 @@
   if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
 
   var backToContent = {
-    _hasScrolled: false,
+    _hasScrolled: true,
     _scrollTimeout: false,
 
     init: function(){
@@ -38,18 +38,23 @@
               start = $el.data('backToContent-start'),
               stop = $el.data('backToContent-stop'),
               offset = $el.data('backToContent-offset'),
-              $nav;
+              windowOffset = $el.data('backToContent-windowOffset'),
+              $nav, top;
 
           if(!start) {
             $nav = $($el.find('a').attr('href'));
             start = $nav.height() + $nav.offset().top + padding;
             $el.data('backToContent-start', start);
 
-            offset = $('#whitehall-wrapper').offset().top - 15; // 15px from the $gutter-half in the css
+            top = $el.css('top') == 'auto';
+
+            offset = $('#page').offset().top - (top ? -15 : 15); // 15px from the $gutter-half in the css
             $el.data('backToContent-offset', offset);
 
-            // yes this is brittle. sorry.
-            stop =  $('.block-4').offset().top - padding;
+            windowOffset = top ? $(window).height() - $el.height() : 0;
+            $el.data('backToContent-windowOffset', windowOffset);
+
+            stop =  $('.js-back-to-content-stop').offset().top - padding - windowOffset + $el.height();
             $el.data('backToContent-stop', stop);
           }
 
@@ -59,7 +64,7 @@
             backToContent.hide($el);
           }
           if(stop < windowVerticalPosition){
-            backToContent.stick($el, stop - offset);
+            backToContent.stick($el, stop - offset + windowOffset);
           } else {
             backToContent.unstick($el);
           }

--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -81,6 +81,9 @@
   }
   
   .publication-content {
+    position: relative;
+    z-index: 2;
+
     .govspeak {
       @include media(tablet){
         width: 75%;
@@ -96,21 +99,25 @@
           margin: $gutter*2 0 $gutter-half;
         }
         .number {
+          background: $white image-url('html-publication/texture.png') repeat;
           padding-right: $gutter-one-third;
           font-weight: bold;
           @include media(tablet){
             @include core-80;
             font-weight: bold;
             position: absolute;
-            margin-top: $gutter-one-sixth;
-            margin-left: -23%;
-            padding-right: 0;
+            margin: (-$gutter) 0 0 (-25%);
+            width: 22%;
+            padding: ($gutter+$gutter-one-sixth) 0 $gutter 3%;
           }
         }
       }
       h3 {
+        z-index: 5;
+        position: relative;
         @include core-27;
         .number {
+          background: $white image-url('html-publication/texture.png') repeat;
           padding-right: $gutter-one-third;
           @include media(tablet){
             padding-right: 0;
@@ -192,5 +199,19 @@
         }
       }
     }
+  }
+  .back-to-content {
+    position: fixed;
+    bottom: $gutter-half;
+    a {
+      display: block;
+
+      &:before {
+        content: "\2191 ";
+      }
+    }
+  }
+  .js-back-to-content-stop {
+    clear: both;
   }
 }

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -64,7 +64,7 @@
       <%= render partial: "document_content" %>
     </div>
   </div>
-  <div class="block-4 block related-links">
+  <div class="block-4 block related-links js-back-to-content-stop">
     <div class="inner-block">
       <div class="js-back-to-content back-to-content visuallyhidden">
         <a href="#page-navigation">Back to contents</a>

--- a/app/views/html_versions/show.html.erb
+++ b/app/views/html_versions/show.html.erb
@@ -18,7 +18,7 @@
     </div>
   </div>
 </div>
-<header class="publication-header">
+<header class="publication-header" id="contents">
   <div class="inner-block floated-children">
     <div class="headings">
       <h1><%= @html_version.title %></h1>
@@ -39,3 +39,7 @@
     <%= govspeak_to_html @html_version.body, @document.images, numbered_heading_level: ['h2','h3'] %>
   </div>
 </div>
+<div class="js-back-to-content back-to-content">
+  <a href="#contents">Contents</a>
+</div>
+<div class="js-back-to-content-stop"></div>


### PR DESCRIPTION
Stuck the link to the bottom of the page as we decided that it was less
visible and less confusing as to what was happening when it disappeared
behind a heading number.

Slightly tweaked the large numbers so that they have background to hide
the jump link as it scrolls past.

Updated the JS to handle sticky things at the bottom of the page as well
as the top.

https://www.pivotaltracker.com/story/show/46442875
