### PR TITLE
Remove the heading supporting documents

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -103,12 +103,6 @@ $thumbnail-width: 99px;
     background: transparent;
   }
   
-  h2.supporting-documents-title {
-    @include ig-core-16;
-    margin-top: $gutter;
-    color: $text-colour;
-  }
-  
   .attachment-without-thumbnail {
     margin-top: $gutter;
   }

--- a/app/views/documents/_attachment_full_width.html.erb
+++ b/app/views/documents/_attachment_full_width.html.erb
@@ -17,7 +17,6 @@
       </div>
       <% if attachments.more_than_one? %>
         <div class="attachment-without-thumbnail">
-          <h2 class="supporting-documents-title"><%= t('document.headings.supporting_documents', count: attachments.remaining.length) %></h2>
           <% attachments.remaining.each do |attachment| %>
             <%= render partial: "documents/attachment",
                        object: attachment,

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -29,13 +29,6 @@ ar:
         few:
         many:
         other: سياسات
-      supporting_documents:
-        zero:
-        one:
-        two:
-        few:
-        many:
-        other:
       topics:
         zero:
         one: موضوع

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -51,9 +51,6 @@ az:
         one: siyasət
         other: siyasəti
       policy_team: siyasət komandası
-      supporting_documents:
-        one:
-        other:
       topics:
         one: mövzu
         other: mövzular

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -21,11 +21,6 @@ be:
         few:
         many:
         other:
-      supporting_documents:
-        one:
-        few:
-        many:
-        other:
       topics:
         one:
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -13,9 +13,6 @@ bg:
       policies:
         one: Политика
         other: Политики
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Тема
         other: Теми

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -13,9 +13,6 @@ bn:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -17,10 +17,6 @@ cs:
         one: Politika
         few:
         other: Politiky
-      supporting_documents:
-        one:
-        few:
-        other:
       topics:
         one: Téma
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -29,13 +29,6 @@ cy:
         few:
         many:
         other: Polisïau
-      supporting_documents:
-        zero:
-        one: Dogfen ategol
-        two:
-        few:
-        many:
-        other: Dogfennau ategol
       topics:
         zero:
         one: Pwnc

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,9 +13,6 @@ de:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Thema
         other: Themen

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -13,9 +13,6 @@ dr:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -13,9 +13,6 @@ el:
       policies:
         one: ! 'Πολιτική '
         other: Πολιτικές
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Θέμα
         other: Θέματα

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,9 +96,6 @@ en:
       attachments:
         one: Document
         other: Documents
-      supporting_documents:
-        one: Supporting document
-        other: Supporting documents
     type:
       announcement:
         one: Announcement

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -13,9 +13,6 @@ es-419:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,9 +13,6 @@ es:
       policies:
         one: Política
         other: Políticas
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Tema
         other: Temas

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -51,9 +51,6 @@ fa:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,9 +13,6 @@ fr:
       policies:
         one: Priorité politique
         other: ! 'Priorités politiques '
-      supporting_documents:
-        one: Document d'appui
-        other: Documents à l'appui
       topics:
         one: Sujet
         other: Sujets

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -21,11 +21,6 @@ he:
         two:
         many:
         other: מדיניות
-      supporting_documents:
-        one:
-        two:
-        many:
-        other:
       topics:
         one: נושא
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -13,9 +13,6 @@ hi:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -51,9 +51,6 @@ hu:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -13,9 +13,6 @@ hy:
       policies:
         one: Քաղաքականություն
         other: Քաղաքականություններ
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Թեմա
         other: Թեմաներ

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -51,9 +51,6 @@ id:
         one: Kebijakan
         other: Kebijakan-kebijakan
       policy_team: Tim kebijakan
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Topik
         other: Topik-topik

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -13,9 +13,6 @@ it:
       policies:
         one: Politica
         other: Politiche
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Argomento
         other: Argomenti

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -51,9 +51,6 @@ ja:
         one: 政策
         other: 政策
       policy_team: 政策チーム
-      supporting_documents:
-        one:
-        other:
       topics:
         one: トピックス
         other: トピックス

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -51,9 +51,6 @@ ka:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -51,9 +51,6 @@ ko:
         one: 정책
         other: 정책
       policy_team: 정책팀
-      supporting_documents:
-        one:
-        other:
       topics:
         one: 토픽
         other: 토픽

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -17,10 +17,6 @@ lt:
         one:
         few:
         other:
-      supporting_documents:
-        one:
-        few:
-        other:
       topics:
         one:
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -13,9 +13,6 @@ lv:
       policies:
         one: Plāns
         other: Politika
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Tēma
         other: Tēmas

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -51,9 +51,6 @@ ms:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -21,11 +21,6 @@ pl:
         few:
         many:
         other:
-      supporting_documents:
-        one:
-        few:
-        many:
-        other:
       topics:
         one:
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -13,9 +13,6 @@ ps:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,9 +13,6 @@ pt:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -17,10 +17,6 @@ ro:
         one: Obiectiv strategic
         few:
         other: Obiective strategic
-      supporting_documents:
-        one:
-        few:
-        other:
       topics:
         one: Temă
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -21,11 +21,6 @@ ru:
         few:
         many:
         other: Стратегии
-      supporting_documents:
-        one:
-        few:
-        many:
-        other:
       topics:
         one: Тема
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -13,9 +13,6 @@ si:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -17,10 +17,6 @@ sk:
         one:
         few:
         other:
-      supporting_documents:
-        one:
-        few:
-        other:
       topics:
         one:
         few:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -13,9 +13,6 @@ so:
       policies:
         one: Siyaasad
         other: Siyaasado
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Mowduuc
         other: Mowduucyo

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -13,9 +13,6 @@ sq:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -21,11 +21,6 @@ sr:
         few:
         many:
         other:
-      supporting_documents:
-        one:
-        few:
-        many:
-        other:
       topics:
         one:
         few:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -13,9 +13,6 @@ sw:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -13,9 +13,6 @@ ta:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -51,9 +51,6 @@ th:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -13,9 +13,6 @@ tk:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -51,9 +51,6 @@ tr:
         one: Politika
         other: ! 'Politikalar '
       policy_team: Politika Ekibi
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Konu
         other: Konular

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -21,11 +21,6 @@ uk:
         few:
         many:
         other: Політика
-      supporting_documents:
-        one:
-        few:
-        many:
-        other:
       topics:
         one: Тема
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -13,9 +13,6 @@ ur:
       policies:
         one: پالیسی
         other: پالیسیاں
-      supporting_documents:
-        one:
-        other:
       topics:
         one: موضوع
         other: موضوعات

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -13,9 +13,6 @@ uz:
       policies:
         one:
         other:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -51,9 +51,6 @@ vi:
         one: Chính sách
         other: Các chính sách
       policy_team: Nhóm chính sách
-      supporting_documents:
-        one:
-        other:
       topics:
         one: Chủ đề
         other: Các chủ đề

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -51,9 +51,6 @@ zh-hk:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -51,9 +51,6 @@ zh-tw:
         one:
         other:
       policy_team:
-      supporting_documents:
-        one:
-        other:
       topics:
         one:
         other:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -51,9 +51,6 @@ zh:
         one: 政策
         other: 政策
       policy_team: 政策团队
-      supporting_documents:
-        one:
-        other:
       topics:
         one: 主题
         other: 主题


### PR DESCRIPTION
The heading is confusing as the following documents aren't always
'supporting'. There is a new publications model in the works that will
let editors better model publications but for now we should remove the
title.

https://www.pivotaltracker.com/story/show/48729367
