### PR TITLE
Remove "More will join soon" to ministerial count in header.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -279,12 +279,6 @@ module ApplicationHelper
     end
   end
 
-  def progress_bar_link
-    unless params[:controller] == "home" && params[:action] == "home"
-      link_to "More will join soon", root_path
-    end
-  end
-
   def linked_author(author)
     if author
       link_to(author.name, admin_author_path(author))

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -21,7 +21,6 @@
       <p>
         <%= joined_ministerial_department_count %> of <%= ministerial_department_count %>
         ministerial departments have moved their corporate websites to GOV.UK.
-        <%= progress_bar_link %>
       </p>
     </div>
     <div id="page" class="<%= content_for?(:page_class) ? yield(:page_class) : '' %>" >


### PR DESCRIPTION
As there aren't any more ministries to join!

Completely untested, so feel free to refuse this if I've missed something, or it's waiting on some replacement copy. I'm being overly pesky.
