### PR TITLE
Allow for a "see all" link on the bottom of recently updated box

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_recently_updated.scss
+++ b/app/assets/stylesheets/frontend/helpers/_recently_updated.scss
@@ -64,5 +64,16 @@
     clear: both;
     @include copy-19;
   }
-  
+  .see-all {
+    @include core-16;
+    margin-top: $gutter-one-sixth;
+    padding-top: $gutter-one-third;
+    border-top: 1px solid $grey-2;
+
+    a {
+      font-weight: bold;
+      margin-right: $gutter-one-third;
+      text-decoration: underline;
+    }
+  }
 }

--- a/app/views/organisations/show-executive-office.html.erb
+++ b/app/views/organisations/show-executive-office.html.erb
@@ -30,7 +30,8 @@
                   locals: { recently_updated: @recently_updated,
                             atom_url: organisation_url(@organisation, format: "atom"),
                             govdelivery_url: filter_email_signup_url(organisation: @organisation.slug),
-                            extra_class: 'panel'} %>
+                            extra_class: 'panel',
+                            all_announcements_link: announcements_filter_path(@organisation) } %>
       </section>
     </div>
   </div>

--- a/app/views/shared/_recently_updated.html.erb
+++ b/app/views/shared/_recently_updated.html.erb
@@ -14,5 +14,10 @@
     <%= render partial: 'shared/feeds',
           locals: { atom_url: atom_url,
                     govdelivery_url: govdelivery_url } %>
+    <% if local_assigns[:all_announcements_link] %>
+      <p class="see-all">
+        <%= link_to "See all our announcements", all_announcements_link %>
+      </p>
+    <% end %>
   </div>
 </section>


### PR DESCRIPTION
If we supply the link as an all_announcements_link: local to the partial, and it gets rendered with the text "See all our announcements" in a styled paragraph.  The text matches the form used elsewhere on the exec office page for see all, but not the form on other org pages (they say "See all of our...") - we'll rationalise that text later.
