### PR TITLE
Worldwide API page and Id URLs should use request hostname

### DIFF
--- a/app/presenters/api/page_presenter.rb
+++ b/app/presenters/api/page_presenter.rb
@@ -43,7 +43,7 @@ class Api::PagePresenter < Draper::Base
 
   def url(override_params)
     h.url_for(h.params.merge(
-      override_params.merge(only_path: false, host: h.public_host)
+      override_params.merge(only_path: false)
     ))
   end
 end

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -8,7 +8,7 @@ class Api::WorldLocationPresenter < Draper::Base
 
   def as_json(options = {})
     {
-      id: h.api_world_location_url(model, host: h.public_host),
+      id: h.api_world_location_url(model),
       title: model.name,
       format: model.display_type,
       updated_at: model.updated_at,
@@ -18,7 +18,7 @@ class Api::WorldLocationPresenter < Draper::Base
         iso2: model.iso2,
       },
       organisations: {
-        id: h.api_world_location_worldwide_organisations_url(model, host: h.public_host),
+        id: h.api_world_location_worldwide_organisations_url(model),
         web_url: h.world_location_url(model, host: h.public_host, anchor: 'organisations'),
       }
     }
@@ -26,7 +26,7 @@ class Api::WorldLocationPresenter < Draper::Base
 
   def links
     [
-      [h.api_world_location_url(model, host: h.public_host), {'rel' => 'self'}]
+      [h.api_world_location_url(model), {'rel' => 'self'}]
     ]
   end
 end

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -8,7 +8,7 @@ class Api::WorldwideOrganisationPresenter < Draper::Base
 
   def as_json(options = {})
     {
-      id: h.api_worldwide_organisation_url(model, host: h.public_host),
+      id: h.api_worldwide_organisation_url(model),
       title: model.name,
       format: 'Worldwide Organisation',
       updated_at: model.updated_at,
@@ -26,7 +26,7 @@ class Api::WorldwideOrganisationPresenter < Draper::Base
 
   def links
     [
-      [h.api_worldwide_organisation_url(model, host: h.public_host), {'rel' => 'self'}]
+      [h.api_worldwide_organisation_url(model), {'rel' => 'self'}]
     ]
   end
 

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -16,17 +16,17 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
     assert_equal Api::WorldLocationPresenter.paginate([@location]), Api::PagePresenter.new(decorated_results)
   end
 
-  test 'links has a self link, pointing to the public api location url' do
+  test 'links has a self link, pointing to the request-relative api location url' do
     Whitehall.stubs(:public_host_for).returns('govuk.example.com')
     self_link = @presenter.links.detect { |(url, attrs)| attrs['rel'] == 'self'}
     assert self_link
     url, attrs = *self_link
-    assert_equal api_world_location_url(@location, host: 'govuk.example.com'), url
+    assert_equal api_world_location_url(@location, host: 'test.host'), url
   end
 
-  test "json includes public api location url as id" do
+  test "json includes request-relative api location url as id" do
     Whitehall.stubs(:public_host_for).returns('govuk.example.com')
-    assert_equal api_world_location_url(@location, host: 'govuk.example.com'), @presenter.as_json[:id]
+    assert_equal api_world_location_url(@location, host: 'test.host'), @presenter.as_json[:id]
   end
 
   test "json includes location name as title" do
@@ -60,9 +60,9 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
     assert_equal world_location_url(@location, host: 'govuk.example.com'), @presenter.as_json[:web_url]
   end
 
-  test "json includes public api organisations url as organisations id" do
+  test "json includes request-relative api organisations url as organisations id" do
     Whitehall.stubs(:public_host_for).returns('govuk.example.com')
-    assert_equal api_world_location_worldwide_organisations_url(@location, host: 'govuk.example.com'), @presenter.as_json[:organisations][:id]
+    assert_equal api_world_location_worldwide_organisations_url(@location, host: 'test.host'), @presenter.as_json[:organisations][:id]
   end
 
   test "json includes public location url (anchored on organisations) organisations web_url" do

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -22,17 +22,17 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal Api::WorldwideOrganisationPresenter.paginate([@office]), Api::PagePresenter.new(decorated_results)
   end
 
-  test 'links has a self link, pointing to the public api worldwide organisations url' do
+  test 'links has a self link, pointing to the request-relative api worldwide organisations url' do
     Whitehall.stubs(:public_host_for).returns('govuk.example.com')
     self_link = @presenter.links.detect { |(url, attrs)| attrs['rel'] == 'self'}
     assert self_link
     url, attrs = *self_link
-    assert_equal api_worldwide_organisation_url(@world_org, host: 'govuk.example.com'), url
+    assert_equal api_worldwide_organisation_url(@world_org, host: 'test.host'), url
   end
 
-  test "json includes api worldwide organisations url as id" do
+  test "json includes request-relative api worldwide organisations url as id" do
     Whitehall.stubs(:public_host_for).returns('govuk.example.com')
-    assert_equal api_worldwide_organisation_url(@world_org, host: 'govuk.example.com'), @presenter.as_json[:id]
+    assert_equal api_worldwide_organisation_url(@world_org, host: 'test.host'), @presenter.as_json[:id]
   end
 
   test "json includes world org name as title" do


### PR DESCRIPTION
This fixes that, so that if you start requesting from e.g. whitehall-admin.preview.alphagov.co.uk, the next_page link is also on whitehall-admin.preview.alphagov.co.uk etc.

See: https://www.pivotaltracker.com/story/show/48396379
