### PR TITLE
Fix start_index in Worlwide API responses.

### DIFF
--- a/app/presenters/api/page_presenter.rb
+++ b/app/presenters/api/page_presenter.rb
@@ -37,7 +37,8 @@ class Api::PagePresenter < Draper::Base
   end
 
   def start_index
-    model.current_page * model.limit_value
+    # current_page and start_index start at 1, not 0
+    (model.current_page - 1) * model.limit_value + 1
   end
   private
 

--- a/test/unit/presenters/api/page_presenter_test.rb
+++ b/test/unit/presenters/api/page_presenter_test.rb
@@ -55,7 +55,7 @@ class Api::PagePresenterTest < PresenterTestCase
   test 'json includes start_index by calculating offset from the collection\'s current_page and limit_value' do
     @page.stubs(:current_page).returns 4
     @page.stubs(:limit_value).returns 7
-    assert_equal 28, @presenter.as_json[:start_index]
+    assert_equal 22, @presenter.as_json[:start_index]
   end
 
   test 'links include a rel=self url pointing to the current page' do


### PR DESCRIPTION
This was returning page_number \* page_size, which is incorrect as
pace_number starts at 1.

See: https://www.pivotaltracker.com/story/show/48397943
