### PR TITLE
Strip whitespace from social media urls

### DIFF
--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -1,6 +1,7 @@
 class Admin::SocialMediaAccountsController < Admin::BaseController
   before_filter :find_socialable
   before_filter :find_social_media_account, only: [:edit, :update, :destroy]
+  before_filter :strip_whitespace_from_url
 
   def index
     @social_media_accounts = @socialable.social_media_accounts
@@ -57,5 +58,11 @@ private
 
   def find_social_media_account
     @social_media_account = @socialable.social_media_accounts.find(params[:id])
+  end
+
+  def strip_whitespace_from_url
+    if params[:social_media_account] && params[:social_media_account][:url]
+      params[:social_media_account][:url].strip!
+    end
   end
 end

--- a/db/data_migration/20130501154940_strip_whitespace_from_social_media_urls.rb
+++ b/db/data_migration/20130501154940_strip_whitespace_from_social_media_urls.rb
@@ -1,0 +1,10 @@
+puts "Updating social media accounts: "
+count = 0
+SocialMediaAccount.find_each do |social_media_account|
+  if (social_media_account.url.strip!)
+    puts "Fixing: #{social_media_account.url}"
+    social_media_account.update_column(:url, social_media_account.url)
+    count += 1
+  end
+end
+puts " #{count} accounts updated."

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -40,6 +40,27 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     assert_equal ["http://bar"], worldwide_organisation.social_media_accounts.map(&:url)
   end
 
+  test ":create and :update strip whitespace from urls" do
+    worldwide_organisation = create(:worldwide_organisation)
+    post :create, worldwide_organisation_id: worldwide_organisation, social_media_account: {
+      social_media_service_id: @social_media_service.id,
+      url: "http://foo "
+    }
+
+    social_media_account = worldwide_organisation.social_media_accounts.first
+    assert_equal "http://foo", social_media_account.url
+
+    post :update, {
+      id: social_media_account,
+      worldwide_organisation_id: worldwide_organisation,
+      social_media_account: {
+        social_media_service_id: @social_media_service.id,
+        url: "http://bar "
+      }
+    }
+    assert_equal "http://bar", social_media_account.reload.url
+  end
+
   test "DELETE on :destroy destroys the social media account" do
     organisation = create(:worldwide_organisation)
     social_media_account = create(:social_media_account, socialable: organisation)


### PR DESCRIPTION
We strip the whitespace in the controller before sending it to the model.

Also includes a data migration to update the existing social media urls that
are broken (27 on this morning's database dump)

https://www.pivotaltracker.com/story/show/49053903
