### PR TITLE
Populate world location with the current users

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -10,6 +10,7 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :build_edition_organisations, only: [:new, :edit]
   before_filter :detect_other_active_editors, only: [:edit]
   before_filter :set_default_world_locations, only: :index
+  before_filter :set_default_edition_locations, only: :new
   before_filter :enforce_permissions!
   before_filter :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :reject, :destroy, :confirm_unpublish]
   before_filter :redirect_to_controller_for_type, only: [:show]
@@ -199,6 +200,12 @@ class Admin::EditionsController < Admin::BaseController
     n = @edition.edition_organisations.reject { |eo| eo.lead? }.count
     (n...6).each do |i|
       @edition.edition_organisations.build(lead: false)
+    end
+  end
+
+  def set_default_edition_locations
+    if current_user.world_locations.any? && !@edition.world_locations.any?
+      @edition.world_locations = current_user.world_locations
     end
   end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1541,6 +1541,22 @@ module AdminEditionControllerTestHelpers
         end
       end
 
+      test "should not populate world locations if user doesn't have any" do
+        world_location = create(:world_location)
+        login_as create(:departmental_editor, world_locations: [])
+        get :new
+
+        assert_equal assigns(:edition).world_locations, []
+      end
+
+      test "should populate world locations with the current users locations" do
+        world_location = create(:world_location)
+        login_as create(:departmental_editor, world_locations: [world_location])
+        get :new
+
+        assert_equal assigns(:edition).world_locations, [world_location]
+      end
+
       test "create should associate worldwide organisations with the edition" do
         first_world_organisation = create(:worldwide_organisation)
         second_world_organisation = create(:worldwide_organisation)


### PR DESCRIPTION
When creating a new edition it should have the current users location
pre-poulated. This will save selecting it every time you create a new
edition.

https://www.pivotaltracker.com/story/show/48759213
