### PR TITLE
Improve Atom feed titles

### DIFF
--- a/app/views/announcements/index.atom.builder
+++ b/app/views/announcements/index.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title 'Inside Government'
-  feed.subtitle 'Recent announcements'
+  feed.title 'Announcements on GOV.UK'
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/classifications/show.atom.builder
+++ b/app/views/classifications/show.atom.builder
@@ -1,5 +1,5 @@
 atom_feed language: 'en-GB', root_url: classification_url(@classification) do |feed|
-  feed.title "Latest activity on \"#{@classification.name}\""
+  feed.title [@classification.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/home/feed.atom.builder
+++ b/app/views/home/feed.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', url: atom_feed_url(format: :atom), root_url: root_url do |feed|
-  feed.title 'Inside government'
-  feed.subtitle 'Recently updated'
+  feed.title 'Inside Government'
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/ministerial_roles/show.atom.builder
+++ b/app/views/ministerial_roles/show.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title ['Inside government', @ministerial_role.name].join(" - ")
-  feed.subtitle 'Latest'
+  feed.title [@ministerial_role.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/organisations/show.atom.builder
+++ b/app/views/organisations/show.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title ['Inside government', @organisation.name].join(" - ")
-  feed.subtitle 'Latest'
+  feed.title [@organisation.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/people/show.atom.builder
+++ b/app/views/people/show.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title ['Inside government', @person.name].join(" - ")
-  feed.subtitle 'Latest'
+  feed.title [@person.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/policies/activity.atom.builder
+++ b/app/views/policies/activity.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: activity_policy_url(@policy.document) do |feed|
-  feed.title "Latest activity on \"#{@policy.title}\""
-  feed.subtitle 'Recently associated'
+  feed.title [@policy.title, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/publications/index.atom.builder
+++ b/app/views/publications/index.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title 'Inside government'
-  feed.subtitle 'Recent publications'
+  feed.title 'Publications on GOV.UK'
   feed.author do |author|
     author.name 'HM Government'
   end

--- a/app/views/world_locations/show.atom.builder
+++ b/app/views/world_locations/show.atom.builder
@@ -1,6 +1,5 @@
 atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title ['Inside government', @world_location.name].join(" - ")
-  feed.subtitle 'Latest'
+  feed.title [@world_location.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end


### PR DESCRIPTION
In many atom feed consumers the title gets trucated. It is important
that the actuall title of contents is first. This moves them first an
also unifies the style of them.

https://www.pivotaltracker.com/story/show/45026361
