### PR TITLE
Move latest news back into featured element

### DIFF
--- a/app/views/organisations/_featured_items.html.erb
+++ b/app/views/organisations/_featured_items.html.erb
@@ -1,14 +1,23 @@
-<section class="organisation-news featured-news items-<%= @feature_list.current_feature_count %>" id="featured-documents">
-  <% if @feature_list.any_current_features? %>
+<%
+  all_announcements_link ||= nil
+%>
+<section class="organisation-news featured-news items-<%= feature_list.current_feature_count %>" id="featured-documents">
+  <% if feature_list.any_current_features? %>
     <%= render partial: 'shared/featured_news',
-              locals: { edition: @feature_list.current_featured_editions.first,
+              locals: { edition: feature_list.current_featured_editions.first,
                         extra_class: 'first',
                         show_meta: true,
                         image_size: :s630 } %>
     <%= render partial: 'shared/featured_news',
-               collection: @feature_list.current_featured_editions.to_a.from(1),
+               collection: feature_list.current_featured_editions.to_a.from(1),
                as: :edition,
                locals: { show_meta: true,
                          extra_class: "secondary" } %>
   <% end %>
+  <%= render partial: 'shared/recently_updated',
+            locals: { recently_updated: recently_updated,
+                      atom_url: organisation_url(organisation, format: "atom"),
+                      govdelivery_url: filter_email_signup_url(organisation: organisation.slug),
+                      extra_class: 'panel',
+                      all_announcements_link: all_announcements_link } %>
 </section>

--- a/app/views/organisations/show-executive-office.html.erb
+++ b/app/views/organisations/show-executive-office.html.erb
@@ -12,12 +12,10 @@
 
   <div class="block">
     <div class="inner-block floated-children">
-      <%= render partial: 'featured_items' %>
-      <%= render partial: 'shared/recently_updated',
-                locals: { recently_updated: @recently_updated,
-                          atom_url: organisation_url(@organisation, format: "atom"),
-                          govdelivery_url: filter_email_signup_url(organisation: @organisation.slug),
-                          extra_class: 'panel',
+      <%= render partial: 'featured_items',
+                locals: { feature_list: @feature_list,
+                          recently_updated: @recently_updated,
+                          organisation: @organisation,
                           all_announcements_link: announcements_filter_path(@organisation) } %>
     </div>
   </div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -13,13 +13,10 @@
 
   <div class="block-2 <%= "has-social" if @organisation.social_media_accounts.any? %>">
     <div class="inner-block">
-      <%= render partial: 'featured_items' %>
-      <%= render partial: 'shared/recently_updated',
-                locals: { recently_updated: @recently_updated,
-                          atom_url: organisation_url(@organisation, format: "atom"),
-                          govdelivery_url: filter_email_signup_url(organisation: @organisation.slug),
-                          extra_class: 'panel'} %>
-
+      <%= render partial: 'featured_items',
+                locals: { feature_list: @feature_list,
+                          recently_updated: @recently_updated,
+                          organisation: @organisation } %>
       <section id="what-we-do" class="what-we-do">
         <div class="content">
           <% if @organisation.organisation_type.sub_organisation? %>


### PR DESCRIPTION
Moving the latest news block back after it was moved out in a2f9af94.
This inadvertently caused display issues when there were only 1 or 4
items were featured.

Also used locals rather than instance variables as otherwise the partial
can't be used more than once and forces naming of instance variables.

https://www.pivotaltracker.com/story/show/49185791
