### PR TITLE
Allow admins to also filter by a slug

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -38,7 +38,9 @@ class Edition < ActiveRecord::Base
 
   scope :with_title_containing, -> *keywords {
     pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
-    in_default_locale.where("edition_translations.title REGEXP :pattern", pattern: pattern)
+    in_default_locale
+    .includes(:document)
+    .where("edition_translations.title REGEXP :pattern OR documents.slug = :slug", pattern: pattern, slug: keywords)
   }
 
   def self.alphabetical(locale = I18n.locale)

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -4,7 +4,7 @@
 <nav class="well" style="padding: 8px 0;">
   <ul class="nav nav-list">
     <% if filter_by.include?(:title) %>
-      <li class="nav-header">Filter by Title</li>
+      <li class="nav-header">Filter by Title or Slug</li>
       <li>
         <%= form_tag("", method: :get, class: "pull-left") do %>
           <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :type, :state, :author, :world_location_ids) %>

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -580,6 +580,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons")
   end
 
+  test "should find editions with slug containing keyword" do
+    edition_with_first_keyword = create(:edition, title: "klingons rule")
+    edition_without_first_keyword = create(:edition, title: "this document is about muppets")
+    assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons-rule")
+  end
+
   test "should find editions with title containing regular expression characters" do
     edition_with_nasty_characters = create(:edition, title: "title with [stuff in brackets]")
     assert_equal [edition_with_nasty_characters], Edition.with_title_containing("[stuff")


### PR DESCRIPTION
It is frustrating to not be able to filter by slug when debugging issues. Will save countless hours for everyone.

https://www.pivotaltracker.com/story/show/49665061
