### PR TITLE
Set first edition org to current users org

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -195,7 +195,11 @@ class Admin::EditionsController < Admin::BaseController
   def build_edition_organisations
     n = @edition.edition_organisations.select { |eo| eo.lead? }.count
     (n...4).each do |i|
-      @edition.edition_organisations.build(lead_ordering: i, lead: true)
+      if i == 0 && current_user.organisation
+        @edition.edition_organisations.build(lead_ordering: i, lead: true, organisation: current_user.organisation)
+      else
+        @edition.edition_organisations.build(lead_ordering: i, lead: true)
+      end
     end
     n = @edition.edition_organisations.reject { |eo| eo.lead? }.count
     (n...6).each do |i|

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -818,6 +818,17 @@ module AdminEditionControllerTestHelpers
         end
       end
 
+      test "new should set first lead organisation to users organisation" do
+        editors_org = create(:organisation)
+        login_as create(:departmental_editor, organisation: editors_org)
+
+        get :new
+
+        assert_equal assigns(:edition).edition_organisations.first.organisation, editors_org
+        assert_equal assigns(:edition).edition_organisations.first.lead, true
+        assert_equal assigns(:edition).edition_organisations.first.lead_ordering, 0
+      end
+
       test "create should associate organisations with edition" do
         first_organisation = create(:organisation)
         second_organisation = create(:organisation)


### PR DESCRIPTION
If there are no lead orgs for an edition add the first lead org as the
current users org. The default case is that users will want to create
content for their own organistion.

https://www.pivotaltracker.com/story/show/48759205
