### PR TITLE
Add a liberal sprinkling of class: "previewable"

### DIFF
--- a/app/views/admin/access_and_opening_times/_form.html.erb
+++ b/app/views/admin/access_and_opening_times/_form.html.erb
@@ -3,6 +3,6 @@
           admin_worldwide_organisation_access_and_opening_time_path(accessible) :
           admin_worldwide_organisation_worldwide_office_access_and_opening_time_path(accessible.worldwide_organisation, accessible) do |form| %>
   <%= form.errors %>
-  <%= form.text_area :body, label_text: "Body", "class" => "previewable" %>
+  <%= form.text_area :body, label_text: "Body", class: "previewable" %>
   <%= form.save_or_cancel cancel: accessible_path(accessible) %>
 <% end %>

--- a/app/views/admin/corporate_information_pages/_form.html.erb
+++ b/app/views/admin/corporate_information_pages/_form.html.erb
@@ -9,7 +9,7 @@
 
   <%= form.text_area :summary, label_text: "Summary", rows: 2, disabled: disabled %>
 
-  <%= form.text_area :body, label_text: "Body", "class" => "previewable", disabled: disabled %>
+  <%= form.text_area :body, label_text: "Body", class: "previewable", disabled: disabled %>
 
   <%= render partial: "admin/editions/attachment_fields", locals: { form: form, edition: corporate_information_page, parent_type: :corporate_information_page, show_inline_attachment_help: true } %>
   

--- a/app/views/admin/document_series/_form.html.erb
+++ b/app/views/admin/document_series/_form.html.erb
@@ -5,7 +5,7 @@
   <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
   <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
   
-  <%= form.text_area :description, "class" => "previewable" %>
+  <%= form.text_area :description, class: "previewable" %>
   
   <p class="warning">Warning: changes to document series appear instantly on the live site.</p>
   <%= form.save_or_cancel cancel: admin_organisation_path(@document_series.organisation) %>

--- a/app/views/admin/editions/_html_version_fields.html.erb
+++ b/app/views/admin/editions/_html_version_fields.html.erb
@@ -6,6 +6,6 @@
   <%= form.fields_for :html_version do |html_version_fields| %>
     <%= html_version_fields.text_field :title, label_text: "HTML version title" %>
 
-    <%= html_version_fields.text_area :body, label_text: "HTML version text" %>
+    <%= html_version_fields.text_area :body, label_text: "HTML version text", class: "previewable" %>
   <% end %>
 </fieldset>

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -29,7 +29,7 @@
     <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
     <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
 
-    <%= form.text_area :body, "class" => "previewable" %>
+    <%= form.text_area :body, class: "previewable" %>
 
     <%= form.label :organisation_ids, 'Organisations:' %>
     <%= form.select :organisation_ids, options_from_collection_for_select(Organisation.all, 'id', 'name', @edition.organisation_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose organisations which produced this document..." } %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -9,7 +9,7 @@
   <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
   <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
 
-  <%= form.text_area :body, "class" => "previewable" %>
+  <%= form.text_area :body, class: "previewable" %>
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 </fieldset>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form.errors %>
 
   <%= form.text_field :name, placeholder: "Name of board, committee, etc. e.g. Defence Council" %>
-  <%= form.text_area :description %>
+  <%= form.text_area :description, class: "previewable" %>
 
   <fieldset>
     <legend>Members</legend>

--- a/app/views/admin/operational_fields/_form.html.erb
+++ b/app/views/admin/operational_fields/_form.html.erb
@@ -3,7 +3,7 @@
 
   <fieldset>
     <%= operational_field_form.text_field :name %>
-    <%= operational_field_form.text_area :description, "class" => "previewable" %>
+    <%= operational_field_form.text_area :description, class: "previewable" %>
   </fieldset>
   <p class="warning">Warning: changes to fields of operation appear instantly on the live site.</p>
   <%= operational_field_form.save_or_cancel cancel: admin_operational_fields_path %>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -14,7 +14,7 @@
     <%= organisation_form.fields_for :default_news_image do |image_fields| %>
       <%= render partial: "admin/shared/default_news_image_fields", locals: {image_fields: image_fields} %>
     <% end %>
-    <%= organisation_form.text_area :description %>
+    <%= organisation_form.text_area :description, class: "previewable" %>
     <%= organisation_form.text_field :url %>
     <%= organisation_form.label :organisation_type_id, "Organisation type" %>
     <%= organisation_form.select :organisation_type_id, options_from_collection_for_select(OrganisationType.in_listing_order, "id", "name", organisation.organisation_type_id), {include_blank: true}, class: 'chzn-select', data: { placeholder: "Choose the organisation type..." } %>

--- a/app/views/admin/policy_advisory_groups/_form.html.erb
+++ b/app/views/admin/policy_advisory_groups/_form.html.erb
@@ -5,7 +5,7 @@
     <%= policy_advisory_group_form.text_field :name %>
     <%= policy_advisory_group_form.text_field :email %>
     <%= policy_advisory_group_form.text_area :summary %>
-    <%= policy_advisory_group_form.text_area :description, "class" => "previewable" %>
+    <%= policy_advisory_group_form.text_area :description, class: "previewable" %>
   </fieldset>
 
   <%= render partial: "admin/editions/attachment_fields", locals: { form: policy_advisory_group_form, edition: policy_advisory_group, parent_type: :policy_group, show_inline_attachment_help: true } %>

--- a/app/views/admin/policy_teams/_form.html.erb
+++ b/app/views/admin/policy_teams/_form.html.erb
@@ -4,7 +4,7 @@
   <fieldset>
     <%= policy_team_form.text_field :name %>
     <%= policy_team_form.text_field :email %>
-    <%= policy_team_form.text_area :description, "class" => "previewable" %>
+    <%= policy_team_form.text_area :description, class: "previewable" %>
   </fieldset>
   <p class="warning">Warning: changes to policy teams appear instantly on the live site.</p>
   <%= policy_team_form.save_or_cancel cancel: admin_policy_teams_path %>

--- a/app/views/admin/supporting_pages/_form.html.erb
+++ b/app/views/admin/supporting_pages/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form.errors %>
   <%= form.hidden_field :lock_version %>
   <%= form.text_field :title, disabled: disabled %>
-  <%= form.text_area :body, disabled: disabled, "class" => disabled ? "" : "previewable" %>
+  <%= form.text_area :body, disabled: disabled, class: disabled ? "" : "previewable" %>
 
   <%= render partial: "admin/editions/attachment_fields", locals: { form: form, edition: supporting_page, parent_type: :supporting_page, show_inline_attachment_help: supporting_page.allows_inline_attachments? } %>
 

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -9,7 +9,7 @@
       <%= form.text_field :title %>
       <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' }%>
       <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
-      <%= form.text_area :body, "class" => "previewable" %>
+      <%= form.text_area :body, class: "previewable" %>
       <%= form.upload :image, horizontal: true %>
       <%= form.text_field :image_alt_text, horizontal: true, label_text: "Image description (alt text)" %>
       <%= form.save_or_cancel cancel: admin_take_part_pages_path %>

--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -10,7 +10,7 @@
 
       <%= form.text_field :title %>
 
-      <%= form.text_area :mission_statement %>
+      <%= form.text_area :mission_statement, class: "previewable" %>
 
       <%= form.check_box :active,
                 label_text: "Active (can visitors click through from the world location list?)" %>

--- a/app/views/admin/worldwide_organisations/_form.html.erb
+++ b/app/views/admin/worldwide_organisations/_form.html.erb
@@ -11,8 +11,8 @@
 
     <%= form.text_area :logo_formatted_name, rows: "4", style: "width: auto" %>
     <%= form.text_area :summary, rows: "4" %>
-    <%= form.text_area :description, "class" => "previewable" %>
-    <%= form.text_area :services, "class" => "previewable" %>
+    <%= form.text_area :description, class: "previewable" %>
+    <%= form.text_area :services, class: "previewable" %>
 
     <%= form.fields_for :default_news_image do |image_fields| %>
       <%= render partial: "admin/shared/default_news_image_fields", locals: {image_fields: image_fields} %>


### PR DESCRIPTION
Grepped for all the things that are govspeak_to_html-ified on the frontend and made sure that their form fields were previewable on the admin, so editors can see how what they are writing will be rendered.

Don't think there's a pivotal for this, it just seemed like a sensible (and simple) thing to do.
