### PR TITLE
Archive published editions for docs with more than 1 published edition

### DIFF
--- a/db/data_migration/20130515163315_archive_extra_published_documents.rb
+++ b/db/data_migration/20130515163315_archive_extra_published_documents.rb
@@ -1,0 +1,3 @@
+
+repairer = DataHygiene::ExtraPublishedEditionsRepairer.new()
+repairer.repair!

--- a/lib/data_hygiene/extra_published_editions_repairer.rb
+++ b/lib/data_hygiene/extra_published_editions_repairer.rb
@@ -1,0 +1,42 @@
+module DataHygiene
+  class ExtraPublishedEditionsRepairer
+    def initialize(logger = nil)
+      @logger = logger || Logger.new($stderr)
+    end
+
+    def documents
+      @documents ||= Document.
+        joins("
+INNER JOIN (
+  #{Edition.
+      unscoped.
+      select('document_id, count(editions.id) as pub_count').
+      published.
+      group('document_id').to_sql
+  }) as pub_count ON pub_count.document_id = documents.id").
+        select('documents.*, pub_count.pub_count').
+        where('pub_count.pub_count > 1')
+    end
+
+    def how_many
+      documents.count
+    end
+
+    def most_recent_published_edition_for_document(document)
+      document.editions.published.order(:id).last
+    end
+
+    def repair!
+      @logger.info "#{how_many} documents with > 1 published edition. ARCHIVING Begins"
+      documents.each.with_index do |document, idx|
+        @logger.info "#{idx +1}. '#{document.slug}' Archiving #{document.editions.published.count - 1} extra published editions"
+        begin
+          most_recent_published_edition_for_document(document).archive_previous_editions
+        rescue => e
+          @logger.error "PROBLEM: #{e.message}"
+        end
+      end
+      @logger.info "ARCHIVING Ends"
+    end
+  end
+end

--- a/test/unit/data_hygiene/extra_published_editions_repairer_test.rb
+++ b/test/unit/data_hygiene/extra_published_editions_repairer_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'data_hygiene/extra_published_editions_repairer'
+
+module Whitehall
+  class ExtraPublishedEditionsRepairerTest < ActiveSupport::TestCase
+    setup do
+      @logger = stub_everything("Logger")
+      @repairer = DataHygiene::ExtraPublishedEditionsRepairer.new(@logger)
+    end
+
+    test 'includes a document if it has more than one published edition' do
+      d1 = create(:published_edition, :with_document).document
+      d2 = create(:published_edition, :with_document).document
+      d3 = create(:published_edition, :with_document).document
+      d4 = create(:published_edition, :with_document).document
+      create(:draft_edition, document: d1).update_column(:state, 'published')
+      create(:draft_edition, document: d3).publish_as(create(:gds_editor))
+      create(:draft_edition, document: d4)
+
+      docs_to_be_repaired = @repairer.documents
+      assert docs_to_be_repaired.include?(d1), "expected doc with > 1 published edition to be present"
+      refute docs_to_be_repaired.include?(d2), "expected doc with just one published edition not to be present"
+      refute docs_to_be_repaired.include?(d3), "expected doc with 1 published edition (and 1 archived edition) not to be present"
+      refute docs_to_be_repaired.include?(d4), "expected doc with 1 published edition (and 1 draft edition) not to be present"
+    end
+
+    test 'fetches the newest (by id) published edition for a given document' do
+      e1 = create(:published_edition, :with_document)
+      d = e1.document
+      e2 = create(:draft_edition, document: d); e2.update_column(:state, 'published')
+      e3 = create(:draft_edition, document: d); e3.update_column(:state, 'published')
+      e4 = create(:draft_edition, document: d)
+
+      assert_equal e3, @repairer.most_recent_published_edition_for_document(d)
+    end
+
+    test 'archives all the other published editions for each document' do
+      e1 = create(:published_edition, :with_document)
+      d1 = e1.document
+      e2 = create(:published_edition, :with_document)
+      d2 = e2.document
+      
+      @repairer.stubs(:documents).returns [d2, d1]
+      @repairer.stubs(:most_recent_published_edition_for_document).with(d1).returns e1
+      @repairer.stubs(:most_recent_published_edition_for_document).with(d2).returns e2
+      
+      e1.expects(:archive_previous_editions)
+      e2.expects(:archive_previous_editions)
+      
+      @repairer.repair!
+    end
+
+    test 'happily continues through the list of documents if archiving explodes for a given document' do
+      e1 = create(:published_edition, :with_document)
+      d1 = e1.document
+      e2 = create(:published_edition, :with_document)
+      d2 = e2.document
+      
+      @repairer.stubs(:documents).returns [d2, d1]
+      @repairer.stubs(:most_recent_published_edition_for_document).with(d1).returns e1
+      @repairer.stubs(:most_recent_published_edition_for_document).with(d2).returns e2
+      
+      e1.expects(:archive_previous_editions)
+      e2.expects(:archive_previous_editions).raises("Problem!")
+
+      assert_nothing_raised do
+        @repairer.repair!
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's a data migration to do it this this, but it uses some new code in data_hygiene/extra_published_editions_repairer so we can run it again later.  Lets face it, we're likely to need to.

For: https://www.pivotaltracker.com/story/show/49876401
