### PR TITLE
Index document series on editions

### DIFF
--- a/app/models/edition/document_series.rb
+++ b/app/models/edition/document_series.rb
@@ -21,4 +21,10 @@ module Edition::DocumentSeries
   def part_of_series?
     document_series.any?
   end
+
+  module InstanceMethods
+    def search_index
+      super.merge("document_series" => document_series.map(&:slug))
+    end
+  end
 end

--- a/test/unit/edition/document_series_test.rb
+++ b/test/unit/edition/document_series_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class Edition::DocumentSeriesTest < ActiveSupport::TestCase
+
+  test "should return search index suitable for Rummageable" do
+    document_series = create(:document_series)
+    edition = create(:published_statistical_data_set, document_series: [document_series])
+
+    assert_equal [document_series.slug], edition.search_index["document_series"]
+  end
+end


### PR DESCRIPTION
We want to display the document series of editions in the search results
index. This will help people to recognise whether a result is relevant
to them.

This is the first step towards being able to do that.

https://www.pivotaltracker.com/story/show/50503119
