### PR TITLE
link_to_translated_object handles decorated objects

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -131,7 +131,9 @@ Details of document required:
   end
 
   def link_to_translated_object(object, locale)
-    path = case object.to_model
+    object = object.is_a?(Array) ? object : object.to_model
+
+    path = case object
     when Edition
       public_document_path(object, locale: locale)
     when CorporateInformationPage

--- a/app/views/shared/_available_languages.html.erb
+++ b/app/views/shared/_available_languages.html.erb
@@ -6,7 +6,7 @@
           <% if locale == I18n.locale %>
             <span><%= native_language_name_for(locale) %></span>
           <% else %>
-            <%= link_to_translated_object(defined?(linkable) ? linkable : object, locale) %>
+            <%= link_to_translated_object((defined?(linkable) ? linkable : object), locale) %>
           <% end %>
         </li>
       <% end %>

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -133,4 +133,11 @@ class DocumentHelperTest < ActionView::TestCase
     assert_dom_equal %Q(<a href="#{public_document_path(edition, locale: :en)}">English</a>),
       link_to_translated_object(decorated_edition, :en)
   end
+
+  test "link_to_translated_object handles linking to resource actions, i.e. organisation about pages" do
+    organisation = create(:organisation)
+
+    assert_dom_equal %Q(<a href="#{polymorphic_path([:about, organisation], locale: :cy)}">Cymraeg</a>),
+      link_to_translated_object([:about, organisation], :cy)
+  end
 end


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/50635087

Our hand-rolled presenter classes do not perform as much magic as
draper did, i.e. the class returned by a presenter is the presenter's
class, not that of the decorated object. Therefor we need to ensure
we are dealing with the object itself when deciding how to build its
translation link.
