### PR TITLE
Fixes for mainstream cats on organisations

### DIFF
--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -38,11 +38,11 @@
       <% end %>
     <% end %>
 
-    <h3>Mainstream Categories</h3>
+    <h3>Detailed guidance categories</h3>
     <% organisation_form.object.organisation_mainstream_categories.each do |omc| %>
       <%= label_tag "organisation_mainstream_categories_ids_#{omc.ordering}" do %>
-        Mainstream category <%= omc.ordering + 1 %>
-        <%= select_tag "organisation[organisation_mainstream_categories_attributes][][mainstream_category_id]", options_from_collection_for_select(MainstreamCategory.all, 'id', 'title', omc.mainstream_category_id), include_blank: true, multiple: false, class: 'chzn-select', data: { placeholder: "Choose mainstream category..."}, id: "organisation_mainstream_category_ids_#{omc.ordering}" %>
+        Detailed guidance category <%= omc.ordering + 1 %>
+        <%= select_tag "organisation[organisation_mainstream_categories_attributes][][mainstream_category_id]", options_from_collection_for_select(MainstreamCategory.all, 'id', 'title', omc.mainstream_category_id), include_blank: true, multiple: false, class: 'chzn-select', data: { placeholder: "Choose detailed guidance category..."}, id: "organisation_mainstream_category_ids_#{omc.ordering}" %>
         <%= hidden_field_tag "organisation[organisation_mainstream_categories_attributes][][ordering]", omc.ordering %>
         <%= hidden_field_tag "organisation[organisation_mainstream_categories_attributes][][id]", omc.id %>
       <% end %>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -32,6 +32,13 @@
               None
             <% end %>
           </td></tr>
+          <tr class="mainstream_categories"><th>Detailed guidance categories</th><td>
+            <% if @organisation.mainstream_categories.any? %>
+              <%= @organisation.mainstream_categories.map { |mc| "#{mc.title} (#{mc.parent_title})" }.to_sentence.html_safe %>
+            <% else %>
+              None
+            <% end %>
+          </td></tr>
           <% @organisation.social_media_accounts.each do |sma| %>
             <tr><th><%= sma.social_media_service.name %></th><td><%= link_to sma.url, sma.url %></td></tr>
           <% end %>

--- a/features/administering-organisations.feature
+++ b/features/administering-organisations.feature
@@ -67,11 +67,13 @@ Scenario: Managing social media links
 
 Scenario: Managing mainstream categories
   Given I am an admin called "Jane"
-  And there is an organisation with no mainstream cateegories defined
-  Then the public website for the organisation says nothing about mainstream categories
+  And there is an organisation with no mainstream categories defined
+  Then the public page for the organisation says nothing about mainstream categories
+  But the admin page for the organisation says it has no mainstream categories
   And there are some mainstream categories
   When I add a few of those mainstream categories in a specific order to the organisation
-  Then only the mainstream categories I chose appear on the public website for the organisation, in my specified order
+  Then only the mainstream categories I chose appear on the public page for the organisation, in my specified order
+  And they also appear on the admin page, in my specified order
 
 Scenario: Adding a new translation
   Given I am an admin called "Jane"

--- a/features/step_definitions/mainstream_categories_on_orgs_steps.rb
+++ b/features/step_definitions/mainstream_categories_on_orgs_steps.rb
@@ -1,11 +1,17 @@
-Given /^there is an organisation with no mainstream cateegories defined$/ do
+Given /^there is an organisation with no mainstream categories defined$/ do
   @the_organisation = create(:ministerial_department)
 end
 
-Then /^the public website for the organisation says nothing about mainstream categories$/ do
+Then /^the public page for the organisation says nothing about mainstream categories$/ do
   visit organisation_path(@the_organisation)
 
   refute page.has_css?('#mainstream_categories')
+end
+
+Then /^the admin page for the organisation says it has no mainstream categories$/ do
+  visit admin_organisation_path(@the_organisation)
+
+  assert page.has_css?('.mainstream_categories td', text: 'None')
 end
 
 Given /^there are some mainstream categories$/ do
@@ -22,12 +28,12 @@ When /^I add a few of those mainstream categories in a specific order to the org
   visit edit_admin_organisation_path(@the_organisation)
   @selected_mainstream_categories = @all_mainstream_categories.shuffle.take(3)
   @selected_mainstream_categories.each.with_index do |mainstream_category, idx|
-    select mainstream_category.title, from: "Mainstream category #{idx+1}"
+    select mainstream_category.title, from: "Detailed guidance category #{idx+1}"
   end
   click_on 'Save'
 end
 
-Then /^only the mainstream categories I chose appear on the public website for the organisation, in my specified order$/ do
+Then /^only the mainstream categories I chose appear on the public page for the organisation, in my specified order$/ do
   visit organisation_path(@the_organisation)
 
   within '#mainstream_categories' do
@@ -38,4 +44,10 @@ Then /^only the mainstream categories I chose appear on the public website for t
       refute page.has_css?("li.mainstream_category h2", text: unselected_mainstream_category.title)
     end
   end
+end
+
+Then /^they also appear on the admin page, in my specified order$/ do
+  visit admin_organisation_path(@the_organisation)
+
+  assert page.has_css?('.mainstream_categories td', text: @selected_mainstream_categories.map {|mc| "#{mc.title} (#{mc.parent_title})" }.to_sentence)
 end


### PR DESCRIPTION
Call them "Detailed guidance categories" in admin, and display them on the admin show page.

As per latest comments on: https://www.pivotaltracker.com/story/show/40064585
