### PR TITLE
Allow mainstream categories to be removed.

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -63,7 +63,7 @@ class Admin::OrganisationsController < Admin::BaseController
   def update
     destroy_blank_mainstream_links
     delete_absent_organisation_classifications
-    delete_absent_organisation_classifications
+    delete_absent_organisation_mainstream_categories
     social.destroy_blank_social_media_accounts(params[:organisation])
     if @organisation.update_attributes(params[:organisation])
       redirect_to admin_organisation_path(@organisation)

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -435,6 +435,21 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_equal [], organisation.mainstream_categories
   end
 
+  test "update removes absent mainstream categories via nested attributes" do
+    category1 = create(:mainstream_category)
+    category2 = create(:mainstream_category)
+    organisation_attributes = {name: "Ministry of Sound"}
+    organisation = create(:organisation, organisation_attributes.merge(mainstream_categories: [category1, category2]))
+    category1_join = organisation.organisation_mainstream_categories.where(mainstream_category_id: category1).first
+    category2_join = organisation.organisation_mainstream_categories.where(mainstream_category_id: category2).first
+
+    put :update, id: organisation,
+                 organisation: organisation_attributes.merge( organisation_mainstream_categories_attributes: [ {mainstream_category_id: category1.id, ordering: "0", id: category1_join.id},
+                                                                                                               {mainstream_category_id: "", ordering: "1", id: category2_join.id} ])
+
+    assert_equal [category1], organisation.reload.mainstream_categories
+  end
+
   test "update should remove all parent organisations if none specified" do
     organisation_attributes = {name: "Ministry of Sound"}
     organisation = create(:organisation,


### PR DESCRIPTION
Fixes bug reported here: https://www.pivotaltracker.com/story/show/40064585

Mainstream categories could not be deleted once set using the admin UI because the necessary params for the nested attributes were not being set by the controller.

This makes me think that both the `"update should remove all related topics if none specified"` and `"update should remove all related mainstream categories if none specified"` tests are giving us false confidence - both of them test that the associations are removed when the ids are posted directly, but the UI uses the nested attributes form, so real requests will not look like this. I'm already looking to overhaul a lot of these tests in another story (https://www.pivotaltracker.com/story/show/48860985), this might be a good opportunity to look at how we can balance our coverage better between our functional tests and our cucumber features.
