### PR TITLE
Fix /specialist-guides/ links in detailed guide body text

### DIFF
--- a/db/data_migration/20130530131759_fix_detailed_guides_that_talk_about_specialist_guides.rb
+++ b/db/data_migration/20130530131759_fix_detailed_guides_that_talk_about_specialist_guides.rb
@@ -1,0 +1,45 @@
+
+def fix_specialist_guides_reference(edition)
+  edition.body = edition.body.gsub(/\/specialist-guides\//, '/detailed-guides/')
+end
+
+all_dgs = DetailedGuide.where(state: ['published', 'draft']).includes(:document).map {|dg| dg.latest_edition }.uniq
+
+puts "Looking at #{all_dgs.count} Detailed Guides"
+
+mentioning_specialist_guides = all_dgs.select { |e| e.body =~ /\/specialist-guides\// }
+
+puts "#{mentioning_specialist_guides.count} have /specialist-guides/ in their body"
+
+by_state = mentioning_specialist_guides.group_by { |e| e.state}
+by_state['draft'] ||= []
+by_state['published'] ||= []
+
+puts "Directly fixing references in #{by_state['draft'].count} drafts"
+by_state['draft'].each do |e|
+  fix_specialist_guides_reference(e)
+  e.save(validate: false)
+end
+
+puts "Re-editioning and fixing references in #{by_state['published'].count} published editions"
+acting_as = User.find_by_name("GDS Inside Government Team")
+by_state['published'].each do |e|
+  new_draft = e.create_draft(acting_as)
+  new_draft.reload
+  fix_specialist_guides_reference(new_draft)
+  new_draft.change_note = 'Fixing references to specialist guides'
+  new_draft.save
+  new_draft.publish_as(acting_as, force: true)
+end
+
+puts "Fixed draft detailed guides:"
+by_state['draft'].each do |e|
+  puts Whitehall.url_maker.admin_detailed_guide_url(e, host: 'whitehall-admin.production.alphagov.co.uk', protocol: 'https')
+end
+
+puts "Fixed and re-published detailed guides:"
+by_state['published'].each do |e|
+  puts Whitehall.url_maker.admin_detailed_guide_url(e.latest_edition, host: 'whitehall-admin.production.alphagov.co.uk', protocol: 'https')
+end
+
+puts "Done!"


### PR DESCRIPTION
Some detailed guides have cross links to the old admin url for detailed guides /admin/specialist-guides/ and so these don't get govspokenified on frontend to refer to the public url for the latest edition of that guide.

To fix we look for all published or draft detailed guides that have /specialist-guides/ urls in their body text.  We then fix them by replacing that string with /detailed-guides/.  For drafts we just save it directly, but for published editions we re-edition and then publish that one.

For: https://www.pivotaltracker.com/story/show/50812941
