### PR TITLE
Preload Whitehall in production

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -4,3 +4,23 @@ end
 load_file_if_exists(self, "/etc/govuk/unicorn.rb")
 working_directory File.dirname(File.dirname(__FILE__))
 worker_processes 4
+
+if env == 'production'
+  # We want to preload the entire app in production mode
+  preload_app true
+
+  before_fork do |server, worker|
+    # the following is highly recomended for Rails + "preload_app true"
+    # as there's no need for the master process to hold a connection
+    if defined?(ActiveRecord::Base)
+      ActiveRecord::Base.connection.disconnect!
+    end
+  end
+
+  after_fork do |server, worker|
+    # the following is *required* for Rails + "preload_app true",
+    if defined?(ActiveRecord::Base)
+      ActiveRecord::Base.establish_connection
+    end
+  end
+end


### PR DESCRIPTION
The time before the app begins serving requests is currently quite large due to the way Rails lazily loads its object graph. During this time it times out frequently while it warms up.

This commit tells Unicorn to preload the entire application, and includes the standard database connection futzing that seems to be common to these solutions.
