### PR TITLE
Restore :attr_reader behaviour in delayed jobs

### DIFF
--- a/lib/whitehall/gov_uk_delivery/gov_uk_delivery_end_point.rb
+++ b/lib/whitehall/gov_uk_delivery/gov_uk_delivery_end_point.rb
@@ -145,6 +145,19 @@ class Whitehall::GovUkDelivery::GovUkDeliveryEndPoint < Whitehall::GovUkDelivery
         </div> )
   end
 
+  def encode_with(coder)
+    super
+    coder['title'] = title
+    coder['summary'] = summary
+  end
+
+  def init_with(coder)
+    super
+    @title = coder['title']
+    @summary = coder['summary']
+    self
+  end
+
   private
 
   def escape(string)


### PR DESCRIPTION
In 1.9.3 the YAML parser has changed to psych, which doesn't persist instance variables across serialisations.

This restores the behaviour by explicitly stashing the instance variables before serialisation takes place.

See https://gist.github.com/jrafanie/3011499 for background.

https://www.pivotaltracker.com/story/show/51051549

I'm not sure how to test this properly - any ideas? Also, are there other delayed jobs that will suffer from this issue? Search indexing?
