### PR TITLE
View diff between current edition and any past edition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'shared_mustache', '~> 0.0.2'
 gem 'rails-i18n'
 gem 'globalize3', git: 'https://github.com/svenfuchs/globalize3.git', ref: 'ab69160ad'
 gem 'link_header'
+gem 'diffy'
 
 group :assets do
   gem 'govuk_frontend_toolkit', '0.19.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       activerecord (>= 2.1.0, < 4)
       delayed_job (~> 3.0)
     diff-lcs (1.1.3)
+    diffy (2.1.4)
     erubis (2.7.0)
     eventmachine (1.0.0)
     exception_notification (3.0.1)
@@ -377,6 +378,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.0.5)
   database_cleaner (~> 0.8.0)
   delayed_job_active_record
+  diffy
   exception_notification
   factory_girl
   faker

--- a/app/assets/stylesheets/admin/audit_trail.scss
+++ b/app/assets/stylesheets/admin/audit_trail.scss
@@ -52,3 +52,16 @@
     background: transparent image-url("loading-2b2c2d.gif") no-repeat 50% 0%;
   }
 }
+
+.diff ul{background:#fff;font-size:13px;list-style:none;margin:0;padding:0;display:table;}
+.diff del, .diff ins{display:block;text-decoration:none;}
+.diff li{padding:0; display:table-row;margin: 0;height:1em;}
+.diff li.ins{background:#dfd; color:#080}
+.diff li.del{background:#fee; color:#b00}
+.diff li:hover{background:#ffc}
+/* try 'whitespace:pre;' if you don't want lines to wrap */
+.diff del, .diff ins, .diff span{white-space:pre-wrap;font-family:courier;}
+.diff del strong{font-weight:normal;background:#fcc;}
+.diff ins strong{font-weight:normal;background:#9f9;}
+.diff li.diff-comment { display: none; }
+.diff li.diff-block-info { background: none repeat scroll 0 0 gray; }

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -2,7 +2,7 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :remove_blank_parameters
   before_filter :clean_edition_parameters, only: [:create, :update]
   before_filter :clear_scheduled_publication_if_not_activated, only: [:create, :update]
-  before_filter :find_edition, only: [:show, :edit, :update, :submit, :revise, :reject, :destroy, :confirm_unpublish]
+  before_filter :find_edition, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy, :confirm_unpublish]
   before_filter :prevent_modification_of_unmodifiable_edition, only: [:edit, :update]
   before_filter :default_arrays_of_ids_to_empty, only: [:update]
   before_filter :delete_absent_edition_organisations, only: [:create, :update]
@@ -12,7 +12,7 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :set_default_world_locations, only: :index
   before_filter :set_default_edition_locations, only: :new
   before_filter :enforce_permissions!
-  before_filter :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :reject, :destroy, :confirm_unpublish]
+  before_filter :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy, :confirm_unpublish]
   before_filter :redirect_to_controller_for_type, only: [:show]
 
   def enforce_permissions!
@@ -25,7 +25,7 @@ class Admin::EditionsController < Admin::BaseController
       enforce_permission!(:create, edition_class || Edition)
     when 'create'
       enforce_permission!(:create, @edition)
-    when 'edit', 'update', 'revise'
+    when 'edit', 'update', 'revise', 'diff'
       enforce_permission!(:update, @edition)
     when 'confirm_unpublish'
       enforce_permission!(:unpublish, @edition)
@@ -109,6 +109,11 @@ class Admin::EditionsController < Admin::BaseController
       redirect_to edit_admin_edition_path(@edition.document.unpublished_edition),
         alert: edition.errors.full_messages.to_sentence
     end
+  end
+
+  def diff
+    audit_trail_entry = edition_class.find(params[:audit_trail_entry_id])
+    @audit_trail_entry = LocalisedModel.new(audit_trail_entry, audit_trail_entry.locale)
   end
 
   def confirm_unpublish

--- a/app/helpers/admin/audit_trail_helper.rb
+++ b/app/helpers/admin/audit_trail_helper.rb
@@ -18,6 +18,20 @@ module Admin::AuditTrailHelper
     html << absolute_time(entry.created_at, class: "created_at")
   end
 
+  def render_edition_diff(edition, audit_entry)
+    title = Diffy::Diff.new(edition.title, audit_entry.title).to_s(:html)
+    summary = Diffy::Diff.new(edition.summary, audit_entry.summary).to_s(:html)
+    body = Diffy::Diff.new(edition.body, audit_entry.body).to_s(:html)
+    out = ""
+    out << content_tag(:h2, 'Title')
+    out << title
+    out << content_tag(:h2, 'Summary')
+    out << summary
+    out << content_tag(:h2, 'Body')
+    out << body
+    out.html_safe
+  end
+
   def paginated_audit_trail_url(page)
     url_for(params.merge(controller: 'admin/edition_audit_trail', action: 'index', page: ((page <= 1) ? nil : page)))
   end

--- a/app/views/admin/editions/_audit_trail_entry.html.erb
+++ b/app/views/admin/editions/_audit_trail_entry.html.erb
@@ -1,4 +1,8 @@
 <%= content_tag_for(:li, audit_trail_entry) do %>
+  <% if audit_trail_entry.is_a?(Edition::AuditTrail::VersionAuditEntry) %>
+    <%= link_to "[diff]", diff_admin_edition_path(@edition, audit_trail_entry_id: audit_trail_entry.version.item_id) %>
+  <% end %>
+
   <div class="image">
     <%= gravatar_image(audit_trail_entry.actor, ssl: request.ssl?) %>
   </div>

--- a/app/views/admin/editions/diff.html.erb
+++ b/app/views/admin/editions/diff.html.erb
@@ -1,0 +1,6 @@
+<% page_title @edition.title, @edition.format_name %>
+<div class="span12">
+  <section>
+    <%= render_edition_diff(@edition, @audit_trail_entry) %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,7 @@ Whitehall::Application.routes.draw do
           member do
             post :submit, to: 'edition_workflow#submit'
             post :revise
+            get  :diff
             post :approve_retrospectively, to: 'edition_workflow#approve_retrospectively'
             post :reject, to: 'edition_workflow#reject'
             post :publish, to: 'edition_workflow#publish'


### PR DESCRIPTION
Provides a link next to versions which show a diff against the current version.

The limitations are it only works for editions on title, summary, body
