### PR TITLE
Fix possible issue with IE where html mime type should be first

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -28,9 +28,6 @@ class OrganisationsController < PublicFacingController
     recently_updated_source = @organisation.published_editions.in_reverse_chronological_order
     expires_in 5.minutes, public: true
     respond_to do |format|
-      format.atom do
-        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
-      end
       format.html do
         @recently_updated = recently_updated_source.limit(3)
         if @organisation.live?
@@ -62,6 +59,9 @@ class OrganisationsController < PublicFacingController
         else
           render action: 'external'
         end
+      end
+      format.atom do
+        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
       end
     end
   end

--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -11,12 +11,6 @@ class WorldLocationsController < PublicFacingController
   def show
     recently_updated_source = @world_location.published_editions.with_translations(I18n.locale).in_reverse_chronological_order
     respond_to do |format|
-      format.json do
-        redirect_to api_world_location_path(@world_location, format: :json)
-      end
-      format.atom do
-        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
-      end
       format.html do
         @recently_updated = recently_updated_source.limit(3)
         @worldwide_priorities = decorate_collection(WorldwidePriority.with_translations(I18n.locale).published.in_world_location(@world_location).in_reverse_chronological_order, WorldwidePriorityPresenter)
@@ -27,6 +21,12 @@ class WorldLocationsController < PublicFacingController
         @announcements = decorate_collection(Announcement.with_translations(I18n.locale).published.in_world_location(@world_location).in_reverse_chronological_order.limit(2), AnnouncementPresenter)
         @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
         @worldwide_organisations = @world_location.worldwide_organisations
+      end
+      format.json do
+        redirect_to api_world_location_path(@world_location, format: :json)
+      end
+      format.atom do
+        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
       end
     end
   end

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -10,7 +10,6 @@ class WorldwideOrganisationsController < PublicFacingController
 
   def show
     respond_to do |format|
-      format.json { redirect_to api_worldwide_organisation_path(@worldwide_organisation, format: :json) }
       format.html do
         expires_in 5.minutes, public: true
         @world_locations = @worldwide_organisation.world_locations
@@ -19,6 +18,7 @@ class WorldwideOrganisationsController < PublicFacingController
         @primary_role = primary_role
         @other_roles = ([secondary_role] + office_roles).compact
       end
+      format.json { redirect_to api_worldwide_organisation_path(@worldwide_organisation, format: :json) }
     end
   end
 


### PR DESCRIPTION
The order you specify the formats matter with older versions of IE as it will just take the first - so html should be first.

http://ianma.wordpress.com/2009/05/06/ruby-on-rails-respond_to-bug-on-ie7/
