### PR TITLE
Align background with other parts of GOV.UK

### DIFF
--- a/app/assets/stylesheets/frontend/styleguide/_colours.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_colours.scss
@@ -5,7 +5,7 @@
 // These are our custom extras
 
 $detailed-guidance-brand: $light-blue;
-$detailed-guidance-background: #fafafa;
+$detailed-guidance-background: #fff;
 
 $inside-gov-brand: #2E3191;
 //$inside-gov-secondary: adjust-hue(lighten($inside-gov-brand, 40%), -25%);


### PR DESCRIPTION
The new styles brought across with https://github.com/alphagov/static/pull/253 made mainstream backgrounds white. 

Detailed guidance is now the only one left with a grey background. This fixes that.
