### PR TITLE
Fix issue with not being able to delete doc series

### DIFF
--- a/app/models/document_series.rb
+++ b/app/models/document_series.rb
@@ -4,15 +4,20 @@ class DocumentSeries < ActiveRecord::Base
 
   belongs_to :organisation
 
-  has_many :editions, through: :edition_document_series, order: 'publication_date desc'
+  has_many :editions, through: :edition_document_series
+
+  has_many :published_editions,
+            through: :edition_document_series,
+            conditions: { state: "published" },
+            order: 'publication_date desc',
+            source: :edition
+
   has_many :edition_document_series
 
   validates_with SafeHtmlValidator
   validates :name, presence: true, length: { maximum: 255 }
   validates :summary, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: (64.kilobytes - 1) }
-
-  before_destroy { |dc| dc.destroyable? }
 
   searchable title: :name,
              link: :search_link,
@@ -24,10 +29,6 @@ class DocumentSeries < ActiveRecord::Base
 
   def search_link
     Whitehall.url_maker.organisation_document_series_path(organisation, slug)
-  end
-
-  def published_editions
-    editions.published
   end
 
   def published_publications
@@ -63,6 +64,6 @@ class DocumentSeries < ActiveRecord::Base
   end
 
   def destroyable?
-    editions.empty?
+    published_editions.empty?
   end
 end

--- a/test/unit/document_series_test.rb
+++ b/test/unit/document_series_test.rb
@@ -77,11 +77,20 @@ class DocumentSeriesTest < ActiveSupport::TestCase
     assert_equal [published_statistical_data_set], series.published_statistical_data_sets
   end
 
-  test 'should not be destroyable if editions are associated' do
+  test 'should not be destroyable if published editions are associated' do
     series = create(:document_series)
-    publication = create(:draft_publication, document_series: [series])
-    series.destroy
+    publication = create(:published_publication, document_series: [series])
+    refute series.destroyable?
+    series.delete!
     assert DocumentSeries.find(series.id)
+  end
+
+  test 'should be destroyable if archived editions are associated' do
+    series = create(:document_series)
+    publication = create(:archived_publication, document_series: [series])
+    assert series.destroyable?
+    series.delete!
+    assert series.deleted?
   end
 
   test "should exclude deleted document_series by default" do
@@ -91,10 +100,10 @@ class DocumentSeriesTest < ActiveSupport::TestCase
   end
 
   test "should be deletable when there are no associated editions" do
-    document_series = create(:document_series)
-    assert document_series.destroyable?
-    document_series.delete!
-    assert document_series.deleted?
+    series = create(:document_series)
+    assert series.destroyable?
+    series.delete!
+    assert series.deleted?
   end
 
   test "should generate a slug based on its name" do


### PR DESCRIPTION
before_destroy does nothing as it's covered by a guard

https://www.pivotaltracker.com/s/projects/367813/stories/48855141
