### PR TITLE
Fix errors being raised by searching when index is out of date

### DIFF
--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -156,7 +156,7 @@ module Whitehall::DocumentFilter
       if @results.empty? || @results['results'].empty?
         @documents ||= Kaminari.paginate_array([]).page(@page).per(@per_page)
       else
-        objects = Edition.with_translations.includes(self.edition_eager_load).find(@results['results'].map{ |h| h["id"] })
+        objects = Edition.with_translations.includes(self.edition_eager_load).where(id: @results['results'].map{ |h| h["id"] })
         sorted = @results['results'].map do |doc|
           objects.detect { |obj| obj.id == doc['id'] }
         end


### PR DESCRIPTION
```
irb(main):003:0> Edition.where(id: [99999])
  Edition Load (0.8ms)  SELECT `editions`.* FROM `editions` WHERE `editions`.`id` IN (99999) AND (`editions`.`state` != 'deleted')
=> []
```

vs

```
irb(main):004:0> Edition.find([99999])
  Edition Load (0.4ms)  SELECT `editions`.* FROM `editions` WHERE `editions`.`id` = 99999 AND (`editions`.`state` != 'deleted') LIMIT 1
ActiveRecord::RecordNotFound: Couldn't find Edition with id=99999 [WHERE (`editions`.`state` != 'deleted')]
  from /var/lib/gems/1.9.1/gems/activerecord-3.1.12/lib/active_record/relation/finder_methods.rb:339:in `find_one'
  from /var/lib/gems/1.9.1/gems/activerecord-3.1.12/lib/active_record/relation/finder_methods.rb:310:in `find_with_ids'
  from /var/lib/gems/1.9.1/gems/activerecord-3.1.12/lib/active_record/relation/finder_methods.rb:107:in `find'
  from /var/lib/gems/1.9.1/gems/activerecord-3.1.12/lib/active_record/base.rb:441:in `find'
  from (irb):4
  from /var/lib/gems/1.9.1/gems/railties-3.1.12/lib/rails/commands/console.rb:45:in `start'
  from /var/lib/gems/1.9.1/gems/railties-3.1.12/lib/rails/commands/console.rb:8:in `start'
  from /var/lib/gems/1.9.1/gems/railties-3.1.12/lib/rails/commands.rb:40:in `<top (required)>'
  from script/rails:6:in `require'
  from script/rails:6:in `<main>'
```
