### PR TITLE
Fix IE 8 textarea scrolling weirdness

### DIFF
--- a/app/assets/javascripts/admin/on_ready.js
+++ b/app/assets/javascripts/admin/on_ready.js
@@ -68,4 +68,10 @@ jQuery(document).ready(function($) {
   }
 
   $("form.js-supports-non-english").setupNonEnglishSupport();
+
+  if(window.ieVersion && ieVersion === 8){
+    $('textarea').each(function(i, el){
+      $(el).css('width', $(el).width());
+    });
+  }
 })

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -9,7 +9,7 @@
   <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
   <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
 
-  <%= form.text_area :body, class: "previewable" %>
+  <%= form.text_area :body, class: "previewable", "cols" => 9000 %>
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 <% end %>


### PR DESCRIPTION
There are two bugs here:
1. Cursor jumping over the place when starting to type.
   This was caused by the width being 100%. In IE8 there is a bug where
   it can't work out where you have clicked if the height is a
   percentage width
2. Scroll moving when typing.
   If the width of the textarea is defined in css to be larger than that
   of the cols attribute on the element then the cursor will sometimes
   scroll to the bottom of the box while you type.

https://www.pivotaltracker.com/story/show/51715201
