### PR TITLE
Add quick links to admin dashboard

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1,5 +1,6 @@
 @import "_conditionals";
 @import "_shims";
+@import "_colours";
 
 @import "alerts.scss";
 @import "change_notes.scss";
@@ -18,4 +19,11 @@
 @import "lists.scss";
 @import "get_involved.scss";
 
+// Helpers
+// Objects that can be used in more than one place throughout the admin
 @import "helpers/_document_list.scss";
+
+// Views
+// Controller specific styles. Usually named after the controller whos views
+// they relate to
+@import "views/_dashboard.scss";

--- a/app/assets/stylesheets/admin/views/_dashboard.scss
+++ b/app/assets/stylesheets/admin/views/_dashboard.scss
@@ -1,0 +1,10 @@
+.dashboard-index {
+  .quick-links {
+    @extend %contain-floats;
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: $border-colour;
+    margin: 15px 0;
+    padding: 15px 0;
+  }
+}

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,8 +1,32 @@
 <% page_title 'Dashboard' %>
+<% page_class 'dashboard-index' %>
 
 <h1>Dashboard</h1>
 
-<div id="role_ordering" class="row-fluid">
+<div class="quick-links">
+  <div class="span4">
+    <h3>Guidance for publishers</h3>
+    <ul>
+      <li><a href="http://alphagov.github.io/inside-government-admin-guide/">IG admin user guide</a></li>
+      <li><a href="https://www.gov.uk/designprinciples/styleguide">Content principles</a></li>
+    </ul>
+  </div>
+  <div class="span4">
+    <h3>Product development</h3>
+    <ul>
+      <li><a href="http://inside-inside-gov.tumblr.com/">Inside Inside Government</a></li>
+      <li><a href="https://www.pivotaltracker.com/s/projects/367813">Development backlog (PivotalTracker)</a></li>
+    </ul>
+  </div>
+  <div class="span4">
+    <h3>Support</h3>
+    <ul>
+      <li><a href="https://gov.uk/support/internal">GDS support form</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="row-fluid">
   <div class="span6 draft-documents">
     <h2>Your draft documents</h2>
     <%= render partial: 'document_table', locals: { documents: @draft_documents, title: 'draft documents' } %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -91,7 +91,7 @@
       </section>
     </header>
 
-    <div class="container-fluid">
+    <div class="container-fluid <%= content_for?(:page_class) ? yield(:page_class) : '' %>">
       <section class="row-fluid">
         <%= yield %>
       </section>


### PR DESCRIPTION
Add some links to take people off to other things from the admin
dashboard.

Also added the ability to do per view styling on the admin the same way
that it is handled on the frontend.

https://www.pivotaltracker.com/story/show/51573869
