### PR TITLE
Style contacts in markdown blocks

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -285,4 +285,36 @@
     border-left: 1px solid $border-colour;
     padding-left: $gutter-half;
   }
+
+  .contact {
+    @extend %contain-floats;
+    background: $panel-colour;
+    margin: $gutter $gutter-half*-1;
+    padding: $gutter-one-third $gutter-half;
+    position: relative;
+
+    h3 {
+      @include core-19;
+      font-weight: bold;
+    }
+    .adr,
+    .email-url-number,
+    .comments {
+      @include media(tablet){
+        width: 50%;
+        float: left;
+      }
+    }
+    .email-url-number {
+      p {
+        margin: 0;
+      }
+      span {
+        display: block;
+      }
+    }
+    .comments {
+      @include core-16;
+    }
+  }
 }

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -91,7 +91,7 @@ module GovspeakHelper
     return govspeak if govspeak.blank?
     govspeak.gsub(GovspeakHelper::EMBEDDED_CONTACT_REGEXP) do
       if contact = Contact.find_by_id($1)
-        render(partial: 'contacts/contact', locals: { contact: contact }, formats: ["html"])
+        render(partial: 'contacts/contact', locals: { contact: contact, heading_tag: 'h3' }, formats: ["html"])
       else
         ''
       end

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -1,4 +1,5 @@
 <%
+  heading_tag ||= 'h2'
   extra_class = []
   if local_assigns.include?(:contact_counter) and contact_counter % 3 == 0
     extra_class << "clear-contact"
@@ -9,7 +10,7 @@
 %>
 <%= content_tag_for(:div, contact, class: extra_class.join(' ')) do %>
   <div class="content">
-    <% unless local_assigns[:hide_title] %><h2><%= contact.title %></h2><% end %>
+    <% unless local_assigns[:hide_title] %><%= content_tag heading_tag, contact.title %><% end %>
 
     <div class="vcard contact-inner">
       <% if contact.has_postal_address? %>

--- a/lib/address_formatter/h_card.rb
+++ b/lib/address_formatter/h_card.rb
@@ -6,7 +6,7 @@ module AddressFormatter
   class HCard < Formatter
 
     def render
-      "<div class=\"adr\">\n#{interpolate_address_template}\n</div>\n".html_safe
+      "<p class=\"adr\">\n#{interpolate_address_template}\n</p>\n".html_safe
     end
 
     def interpolate_address_template

--- a/test/unit/address_formatter/h_card_test.rb
+++ b/test/unit/address_formatter/h_card_test.rb
@@ -117,60 +117,60 @@ class AddressFormatter::HCardTest < ActiveSupport::TestCase
 
   def gb_addr
     <<-EOF.strip_heredoc
-    <div class="adr">
+    <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
     <span class="locality">Locality</span><br />
     <span class="region">Region</span><br />
     <span class="postal-code">Postcode</span><br />
     <span class="country-name">Country</span>
-    </div>
+    </p>
     EOF
   end
 
   def es_addr
     <<-EOF.strip_heredoc
-    <div class="adr">
+    <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
     <span class="postal-code">Postcode</span> <span class="locality">Locality</span> <span class="region">Region</span><br />
     <span class="country-name">Country</span>
-    </div>
+    </p>
     EOF
   end
 
   def jp_addr
     <<-EOF.strip_heredoc
-    <div class="adr">
+    <p class="adr">
     〒<span class="postal-code">Postcode</span><br />
     <span class="region">Region</span><span class="locality">Locality</span><span class="street-address">Street</span><br />
     <span class="fn">Recipient</span><br />
     <span class="country-name">Country</span>
-    </div>
+    </p>
     EOF
   end
 
   def addr_without_region
     <<-EOF.strip_heredoc
-    <div class="adr">
+    <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
     <span class="locality">Locality</span><br />
     <span class="postal-code">Postcode</span><br />
     <span class="country-name">Country</span>
-    </div>
+    </p>
     EOF
   end
 
   def addr_without_country
     <<-EOF.strip_heredoc
-    <div class="adr">
+    <p class="adr">
     <span class="fn">Recipient</span><br />
     <span class="street-address">Street</span><br />
     <span class="locality">Locality</span><br />
     <span class="region">Region</span><br />
     <span class="postal-code">Postcode</span>
-    </div>
+    </p>
     EOF
   end
 

--- a/test/unit/helpers/admin/admin_govspeak_helper_test.rb
+++ b/test/unit/helpers/admin/admin_govspeak_helper_test.rb
@@ -122,7 +122,7 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
     Contact.stubs(:find_by_id).with('1').returns(contact)
     input = '[Contact:1]'
     output = govspeak_to_admin_html(input)
-    contact_html = render('contacts/contact', contact: contact)
+    contact_html = render('contacts/contact', contact: contact, heading_tag: 'h3')
     assert_equal "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
@@ -130,7 +130,7 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
     contact = build(:contact)
     Contact.stubs(:find_by_id).with('1').returns(contact)
     input = '[Contact:1]'
-    contact_html = render('contacts/contact', contact: contact)
+    contact_html = render('contacts/contact', contact: contact, heading_tag: 'h3')
     @controller.lookup_context.formats = ['atom']
     assert_nothing_raised(ActionView::MissingTemplate) do
       assert_equal "<div class=\"govspeak\">#{contact_html}</div>", govspeak_to_admin_html(input)

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -268,7 +268,7 @@ class GovspeakHelperTest < ActionView::TestCase
     Contact.stubs(:find_by_id).with('1').returns(contact)
     input = '[Contact:1]'
     output = govspeak_to_html(input)
-    contact_html = render('contacts/contact', contact: contact)
+    contact_html = render('contacts/contact', contact: contact, heading_tag: 'h3')
     assert_equal "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
@@ -308,7 +308,7 @@ class GovspeakHelperTest < ActionView::TestCase
     contact = build(:contact)
     Contact.stubs(:find_by_id).with('1').returns(contact)
     input = '[Contact:1]'
-    contact_html = render('contacts/contact', contact: contact)
+    contact_html = render('contacts/contact', contact: contact, heading_tag: 'h3')
     @controller.lookup_context.formats = ['atom']
     assert_nothing_raised(ActionView::MissingTemplate) do
       assert_equal "<div class=\"govspeak\">#{contact_html}</div>", govspeak_to_html(input)


### PR DESCRIPTION
- Add some styling
- Let you specify the heading tag for contact blocks
- Use a paragraph for the address as it didn't have a semantic wrapper

https://www.pivotaltracker.com/story/show/48480651
