### PR TITLE
Fix passing nil to the presenters

### DIFF
--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -156,14 +156,17 @@ module Whitehall::DocumentFilter
       if @results.empty? || @results['results'].empty?
         @documents ||= Kaminari.paginate_array([]).page(@page).per(@per_page)
       else
-        objects = Edition.with_translations.includes(self.edition_eager_load).where(id: @results['results'].map{ |h| h["id"] })
+        objects = Edition.published.with_translations.includes(self.edition_eager_load).where(id: @results['results'].map{ |h| h["id"] })
         sorted = @results['results'].map do |doc|
           objects.detect { |obj| obj.id == doc['id'] }
-        end
+        end.compact
 
         @documents ||= Kaminari.paginate_array(sorted, total_count: @results['total']).page(@page).per(@per_page)
       end
     end
 
+    def results
+      @results['results']
+    end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/52050419

The issue is that we have some archived or deleted content in the
rummager index.

Added a published scope onto the Edition query, this will result in nil
being passed into the presenter which crashes the app so we also call
compact to remove nil records. This stops the application from crashing.

The side effect is that the total count will be off - but I feel that
keeping the rummager index more in sync is a higher priority than
futher workarounds. A current tech debt task is to improve the quality
and accuracy of the search index.

Also added a method to expose the results from rummager for future
debugging.
