### PR TITLE
Upgrade minitest to 4.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :test do
   gem 'test_track', github: 'episko/test_track'
   gem 'timecop'
   gem 'webmock', require: false
+  gem 'minitest', '4.3.0'
   gem 'ci_reporter'
   gem 'database_cleaner', '1.0.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
     mime-types (1.23)
     mini_magick (3.6.0)
       subexec (~> 0.2.1)
+    minitest (4.3.0)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.7.7)
@@ -362,6 +363,7 @@ DEPENDENCIES
   link_header
   lograge
   mini_magick
+  minitest (= 4.3.0)
   mocha (= 0.14.0)
   mysql2
   newrelic_rpm


### PR DESCRIPTION
Required by Tconsole, which is a good test runner to use with long
running test suites.
