### PR TITLE
Fix tests affected by database sort order

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -187,7 +187,7 @@ class Edition < ActiveRecord::Base
   end
 
   def self.concrete_descendants
-    descendants.reject { |model| model.descendants.any? }
+    descendants.reject { |model| model.descendants.any? }.sort_by { |model| model.name }
   end
 
   def self.concrete_descendant_search_format_types

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -8,26 +8,17 @@ module Whitehall::DocumentFilter
     end
 
     def announcements_search
-      filter_args =
-        standard_filter_args
-          .merge(filter_by_announcement_type)
-
+      filter_args = standard_filter_args.merge(filter_by_announcement_type)
       @results = Whitehall.government_search_client.advanced_search(filter_args)
     end
 
     def publications_search
-      filter_args =
-        standard_filter_args
-          .merge(filter_by_publication_type)
-
+      filter_args = standard_filter_args.merge(filter_by_publication_type)
       @results = Whitehall.government_search_client.advanced_search(filter_args)
     end
 
     def policies_search
-      filter_args =
-        standard_filter_args
-          .merge(search_format_types: [Policy.search_format_type])
-
+      filter_args = standard_filter_args.merge(search_format_types: [Policy.search_format_type])
       @results = Whitehall.government_search_client.advanced_search(filter_args)
     end
 

--- a/test/unit/whitehall/document_filter/rummager_test.rb
+++ b/test/unit/whitehall/document_filter/rummager_test.rb
@@ -7,64 +7,67 @@ module Whitehall::DocumentFilter
       Whitehall.government_search_client.stubs(:advanced_search).returns []
     end
 
+    def format_types(*classes)
+      classes.map { |cls| cls.search_format_type }
+    end
+
+    def expect_search_by_format_types(format_types)
+      Whitehall.government_search_client.expects(:advanced_search).with(
+          has_entry({ search_format_types: format_types }))
+    end
+
     test 'announcements_search looks for NewsArticles, FatalityNotices and Speeches by default' do
-      r = Rummager.new({})
-      expected_search_formats = [NewsArticle.search_format_type, Speech.search_format_type, FatalityNotice.search_format_type]
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.announcements_search
+      rummager = Rummager.new({})
+      expect_search_by_format_types(format_types(FatalityNotice, NewsArticle, Speech))
+      rummager.announcements_search
     end
 
     test 'announcements_search looks for all Announcements if we need to include world location news' do
-      r = Rummager.new({include_world_location_news: '1'})
-      expected_search_formats = [Announcement.search_format_type]
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.announcements_search
+      rummager = Rummager.new({include_world_location_news: '1'})
+      expect_search_by_format_types(format_types(Announcement))
+      rummager.announcements_search
     end
 
     test 'announcements_search looks for a specific announcement sub type if we use the announcement_type option' do
-      r = Rummager.new({announcement_type: 'government-responses'})
-      expected_search_formats = NewsArticleType::GovernmentResponse.search_format_types
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.announcements_search
+      rummager = Rummager.new({announcement_type: 'government-responses'})
+      expect_search_by_format_types(NewsArticleType::GovernmentResponse.search_format_types)
+      rummager.announcements_search
     end
 
     test 'announcements_search will eager load document and organisations' do
-      r = Rummager.new({})
-      r.announcements_search
-      assert_equal [:document, organisations: :translations], r.edition_eager_load
+      rummager = Rummager.new({})
+      rummager.announcements_search
+      assert_equal [:document, organisations: :translations], rummager.edition_eager_load
     end
 
     test 'publications_search looks for Publications, Consultations, and StatisticalDataSets by default' do
-      r = Rummager.new({})
-      expected_search_formats = [Publication.search_format_type, Consultation.search_format_type, StatisticalDataSet.search_format_type]
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.publications_search
+      rummager = Rummager.new({})
+      expect_search_by_format_types(format_types(Consultation, Publication, StatisticalDataSet))
+      rummager.publications_search
     end
 
-    test 'publications_search looks for a specific announcement sub type if we use the announcement_type option' do
-      r = Rummager.new({publication_type: 'policy-papers'})
-      expected_search_formats = PublicationType::PolicyPaper.search_format_types
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.publications_search
+    test 'publications_search looks for a specific announcement sub type if we use the publication_type option' do
+      rummager = Rummager.new({publication_type: 'policy-papers'})
+      expect_search_by_format_types(PublicationType::PolicyPaper.search_format_types)
+      rummager.publications_search
     end
 
     test 'publications_search will eager load document and organisations' do
-      r = Rummager.new({})
-      r.publications_search
-      assert_equal [:document, organisations: :translations], r.edition_eager_load
+      rummager = Rummager.new({})
+      rummager.publications_search
+      assert_equal [:document, organisations: :translations], rummager.edition_eager_load
     end
 
     test 'policies_search looks for Policy documents' do
-      r = Rummager.new({})
-      expected_search_formats = [Policy.search_format_type]
-      Whitehall.government_search_client.expects(:advanced_search).with(has_entry(search_format_types: expected_search_formats))
-      r.policies_search
+      rummager = Rummager.new({})
+      expect_search_by_format_types(format_types(Policy))
+      rummager.policies_search
     end
 
     test 'policies_search will eager load document and organisations' do
-      r = Rummager.new({})
-      r.policies_search
-      assert_equal [:document, organisations: :translations], r.edition_eager_load
+      rummager = Rummager.new({})
+      rummager.policies_search
+      assert_equal [:document, organisations: :translations], rummager.edition_eager_load
     end
 
   end


### PR DESCRIPTION
When running these tests on my VM one of them failed repeatedly, returning the format types in a different order.
