### PR TITLE
Remove 'the' from worldwide corporate info pages listings

### DIFF
--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -12,7 +12,7 @@ class CorporateInformationPageType
   end
 
   def title(organisation)
-    title_template % (organisation.respond_to?(:acronym) && organisation.acronym || "the #{organisation.name}")
+    title_template % (organisation.respond_to?(:acronym) && organisation.acronym || "#{organisation.name}")
   end
 
   def self.by_menu_heading(menu_heading)

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -58,7 +58,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
   test "should derive title from type and interpolate orgnisation name if no acronym" do
     organisation = build(:organisation, acronym: nil, name: "Department for Communities and Local Government")
     corporate_information_page = build(:corporate_information_page, organisation: organisation, type: CorporateInformationPageType::Recruitment)
-    assert_equal "Working for the Department for Communities and Local Government", corporate_information_page.title
+    assert_equal "Working for Department for Communities and Local Government", corporate_information_page.title
   end
 
   test "should derive slug from type" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/46199919
