### PR TITLE
Style HTML attachment contacts

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -107,7 +107,7 @@
           margin: $gutter*2 0 $gutter-half;
         }
         .number {
-          background: $white image-url('html-publication/texture.png') repeat;
+          background: $white;
           padding-right: $gutter-one-third;
           font-weight: bold;
           @include media(tablet){
@@ -125,7 +125,7 @@
         position: relative;
         @include core-27;
         .number {
-          background: $white image-url('html-publication/texture.png') repeat;
+          background: $white;
           color: $secondary-text-colour;
           padding-right: $gutter-one-third;
           @include media(tablet){
@@ -208,6 +208,42 @@
           ol+p {
             margin-top: $gutter-one-third;
           }
+        }
+      }
+      .contact {
+        @extend %contain-floats;
+        background: $panel-colour;
+        margin: $gutter $gutter-half*-1;
+        padding: $gutter-one-third $gutter-half;
+        position: relative;
+
+        h4 {
+          @include core-19;
+          font-weight: bold;
+          margin: $gutter-one-third 0 0;
+        }
+        p {
+          @include copy-19;
+          margin: 0;
+        }
+        .adr,
+        .email-url-number,
+        .comments {
+          @include media(tablet){
+            width: 50%;
+            float: left;
+          }
+        }
+        .email-url-number {
+          p {
+            margin: 0;
+          }
+          span {
+            display: block;
+          }
+        }
+        .comments {
+          @include core-16;
         }
       }
     }

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -77,7 +77,7 @@ module GovspeakHelper
   def bare_govspeak_to_html(govspeak, images = [], options = {}, &block)
     # pre-processors
     govspeak = remove_extra_quotes_from_blockquotes(govspeak)
-    govspeak = render_embedded_contacts(govspeak)
+    govspeak = render_embedded_contacts(govspeak, options[:contact_heading_tag])
 
     markup_to_nokogiri_doc(govspeak, images).tap do |nokogiri_doc|
       # post-processors
@@ -87,11 +87,12 @@ module GovspeakHelper
     end.to_html.html_safe
   end
 
-  def render_embedded_contacts(govspeak)
+  def render_embedded_contacts(govspeak, heading_tag)
     return govspeak if govspeak.blank?
+    heading_tag ||= 'h3'
     govspeak.gsub(GovspeakHelper::EMBEDDED_CONTACT_REGEXP) do
       if contact = Contact.find_by_id($1)
-        render(partial: 'contacts/contact', locals: { contact: contact, heading_tag: 'h3' }, formats: ["html"])
+        render(partial: 'contacts/contact', locals: { contact: contact, heading_tag: heading_tag }, formats: ["html"])
       else
         ''
       end

--- a/app/views/html_versions/show.html.erb
+++ b/app/views/html_versions/show.html.erb
@@ -37,7 +37,7 @@
 </header>
 <div class="block publication-content">
   <div class="inner-block floated-children">
-    <%= govspeak_to_html @html_version.body, @document.images, numbered_heading_level: ['h2','h3'] %>
+    <%= govspeak_to_html @html_version.body, @document.images, numbered_heading_level: ['h2','h3'], contact_heading_tag: 'h4' %>
   </div>
 </div>
 <div class="js-back-to-content back-to-content">

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -272,6 +272,15 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_equal "<div class=\"govspeak\">#{contact_html}</div>", output
   end
 
+  test 'converts [Contact:<id>] into a rendering of contacts/_contact for the Contact with id = <id> with defined header level' do
+    contact = build(:contact)
+    Contact.stubs(:find_by_id).with('1').returns(contact)
+    input = '[Contact:1]'
+    output = govspeak_to_html(input, [], contact_heading_tag: 'h4')
+    contact_html = render('contacts/contact', contact: contact, heading_tag: 'h4')
+    assert_equal "<div class=\"govspeak\">#{contact_html}</div>", output
+  end
+
   test 'silently converts [Contact:<id>] into nothing if there is no Contact with id = <id>' do
     Contact.stubs(:find_by_id).with('1').returns(nil)
     input = '[Contact:1]'


### PR DESCRIPTION
- Add some styling to html publication contacts.
- Let the govspeak helper methods accept a heading level for the
  contacts. This was needed due to the auto number level inserter
- Remove texture from heading number backgrounds as it isn't used on the
  main page anymore.

https://www.pivotaltracker.com/story/show/52444523
