### PR TITLE
Bugfix: don't crash when redrafting policy

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -35,10 +35,6 @@ class Policy < Edition
   end
 
   class Trait < Edition::Traits::Trait
-    def process_associations_after_save(edition)
-      edition.related_editions = @edition.related_editions
-    end
-
     def process_associations_before_save(edition)
       @edition.edition_policy_groups.each do |association|
         edition.edition_policy_groups.build(association.attributes.except(["id", "edition_id"]))

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -38,6 +38,27 @@ class PolicyTest < ActiveSupport::TestCase
     assert draft_policy.related_editions.include?(publication)
   end
 
+  test "should build a draft copy with references to related editions which have multiple drafts" do
+    editor = create(:departmental_editor)
+
+    published_policy = create(:published_policy)
+    first_draft = create(:draft_publication, related_editions: [published_policy])
+    assert first_draft.publish_as(editor, force: true)
+    first_draft.reload
+    second_draft = first_draft.create_draft(editor)
+    second_draft.change_note = 'change-note'
+    assert second_draft.valid?
+
+    draft_policy = published_policy.create_draft(editor)
+    draft_policy.change_note = 'change-note'
+    assert draft_policy.valid?
+
+    draft_policy.reload
+
+    assert draft_policy.related_editions.include?(first_draft)
+    assert draft_policy.related_editions.include?(second_draft)
+  end
+
   test "should build a draft copy with policy groups" do
     published_policy = create(:published_policy)
     policy_team = create(:policy_team, policies: [published_policy])


### PR DESCRIPTION
It's common for a policy to reference multiple editions of the same
document. For example, consider a news article N which references a
policy P. There would be an EditionRelation (N, P).

When that news article is re-drafted, a new EditionRelation is created
with (N', P).

Now suppose that we create a new policy P'. The policy trait (deleted by
this commit) would attempt to duplicate both (N, P) and (N', P). It does
this by assigning P'.related_editions = [N, N'].

In fact this is not necessary because the actual join is via the
document_id of P, which is unchanged for P'. In other words, as far as I
can tell, this trait has always been redundant, but for some reason has
not been causing any harm until now.

Something must have changed in the Rails 3.2 upgrade which has affected
the behaviour of the assignment or the validation check. I haven't been
able to pinpoint exactly what.

I added a failing test case to catch the existing failure mode. Removing
this trait allows that to pass.

https://www.pivotaltracker.com/story/show/52374563
