### PR TITLE
Add screenshot helper for cucumber @javascript scenarios

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -2,3 +2,11 @@
 # We think this may be due to timeouts (the default is 2 secs),
 # so we've increased the default timeout.
 Capybara.default_wait_time = 5
+
+module ScreenshotHelper
+  def screenshot(name = 'capybara')
+    page.driver.render(File.join(Rails.root, 'tmp', "#{name}.png"), full: true)
+  end
+end
+
+World(ScreenshotHelper)


### PR DESCRIPTION
Call `screenshot` within a Cucumber step and Poltergeist (the capybara
driver) will create a tmp/capybara.png file containing a screenshot of
the current page. Pass an argument to give the screenshot a different
name.

Useful when debugging failing steps.
