### PR TITLE
Fix access limited being switched on for policy papers

### DIFF
--- a/app/assets/javascripts/admin/edition_publishing.js
+++ b/app/assets/javascripts/admin/edition_publishing.js
@@ -99,7 +99,7 @@ jQuery(function($) {
     var accessLimitedByDefaultIds = publicationTypeChooser.data('access-limited-by-default-type-ids');
     var accessLimitedByDefault = function() {
       var chosenId = parseInt(publicationTypeChooser.val(), 10);
-      if ((""+accessLimitedByDefaultIds).indexOf(chosenId) >= 0) {
+      if (accessLimitedByDefaultIds.indexOf(chosenId) >= 0) {
         $("input[name$='[access_limited]'][type=checkbox]").attr('checked', 'checked');
       }
     }


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/50349095

Caused by what appears to be a typo that was casting the array to a string.
