### PR TITLE
Remove tokenizer used when validating long strings

### DIFF
--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -2,10 +2,7 @@ class TakePartPage < ActiveRecord::Base
 
   validates_with SafeHtmlValidator
   validates :title, :summary, presence: true, length: { maximum: 255 }
-  # default tokenizer does value.split(//) which takes forever on large strings
-  # and serves no purpose whatsoever on ruby > 1.9 - rails 3.2+ don't
-  # tokenize strings by default so it's safe to remove
-  validates :body, presence: true, length: { maximum: (16.megabytes - 1), tokenizer: ->(value) {value} }
+  validates :body, presence: true, length: { maximum: (16.megabytes - 1) }
 
   before_save :ensure_ordering!
   scope :in_order, -> { order(:ordering) }


### PR DESCRIPTION
See Murray's initial commit message (2b4b7343) for context (2b4b).

Rails 3.2 no longer has performance problems when validating the length
of a very long string.

See https://github.com/rails/rails/commit/5ff71ac9f844f2c8bcde8cdd5de767c9bdd4cc9e#activemodel/lib/active_model/validations/length.rb
