### PR TITLE
Organisation index is not localised

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,8 @@ Whitehall::Application.routes.draw do
     resources :topics, path: "topics", only: [:index, :show]
     resources :topical_events, path: "topical-events", only: [:index, :show]
 
-    resources :organisations, only: [:index, :show], localised: true do
+    resources :organisations, only: [:index], localised: false
+    resources :organisations, only: [:show], localised: true do
       resources :document_series, only: [:index, :show], path: 'series'
       member do
         get :about, localised: true


### PR DESCRIPTION
avoid localisation of the organisation index. 

This prevents the default link helper from passing on the locale argument when linking to the
organisation index.

For example when linking from the Welsh language
version of the Wales Office page to the organisation index, we were
previously preserving the .cy locale parameter and therefore getting a
version of the organisation index page containing only welsh language
organisations.

https://www.pivotaltracker.com/story/show/52318885
