### PR TITLE
Updating closing consultations on get involved page

### DIFF
--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -39,14 +39,15 @@
       </div>
       <div class="consultation-lists">
         <div class="consultation-closing-soon">
-          <h3>Closing soon</h3>
+          <% @next_closing_consultations.each do |consultation| %>
+            <h3><%= consultation.time_until_closure %></h3>
+          <% end %>
           <ol class="document-list">
             <% @next_closing_consultations.each do |consultation| %>
               <%= content_tag_for(:li, consultation, class: 'document-row') do %>
-                <h3><%= link_to consultation.title, public_document_path(consultation) %></h3>
+                <h3><%= consultation.title %></h3>
                 <ul class="attributes">
-                  <li class="publication-date"><%= consultation.time_until_closure %></li>
-                  <li><%= link_to "Respond now", public_document_path(consultation) %></li>
+                  <li><%= link_to "Read and respond", public_document_path(consultation) %></li>
                 </ul>
               <% end %>
             <% end %>


### PR DESCRIPTION
1) It would be great if the box title could be dynamic - moving from 'Closing in X days' to 'Closing today' (so no need for the repeat).
2) 'Respond now' on its own suggests that you might be linking straight to a response form. Possible alternative wording: 'Read and respond'.
3) Drop the link on the consultation title.

https://www.pivotaltracker.com/story/show/48988875
