### PR TITLE
Remove infinte scroll

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -17,25 +17,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
     formType: '',
 
     renderTable: function(data) {
-      $('link[rel=next][type=application/json]').remove();
       $('.js-filter-results').mustache('documents-_filter_table', data);
-      $('.previous-next-navigation').addClass('infinite');
-    },
-    extendTable: function(data){
-      var $container = $('.js-filter-results'),
-          $results;
-
-      if (data.results.length > 0) {
-        // we don't want a previous page link
-        data['prev_page?'] = false;
-        $results = $($.mustache('documents-_filter_table', data));
-        $('.js-document-list').append($results.filter('.js-document-list').children());
-
-        $container.find('nav').remove();
-        $('link[rel=next][type=application/json]').remove();
-        $container.append($results.filter('nav'));
-        $('.previous-next-navigation').addClass('infinite');
-      }
     },
     updateAtomFeed: function(data) {
       if (data.atom_feed_url) {
@@ -278,66 +260,6 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
           $("#" + checked.id).attr('checked', true);
         });
       }
-    },
-    loadMoreInline: function(){
-      var url = $('link[rel=next][type=application/json]').attr('href')
-
-      if(!documentFilter.loading && url){
-        documentFilter.loading = true;
-        $.ajax(url, {
-          cache: false,
-          dataType:'json',
-          complete: function(){
-            documentFilter.loading = false;
-            $('.infinite.loading').removeClass('loading');
-          },
-          success: function(data) {
-            if (data.results) {
-              documentFilter.extendTable(data)
-            }
-          }
-        });
-      }
-    },
-    initScroll: function(){
-      documentFilter.scrolled = false;
-      $('#show-more-documents .previous-next-navigation').addClass('infinite');
-
-      $(window).scroll(function(){
-        documentFilter.scrolled = true;
-      });
-
-      var scrollInterval = window.setInterval(documentFilter.onScroll, 250);
-    },
-    onScroll: function(){
-      if(documentFilter.scrolled){
-        documentFilter.scrolled = false;
-        var $window = $(window),
-            $nav = $('.previous-next-navigation'),
-            bottomOfWindow = $window.scrollTop() + $window.height(),
-            navOffset = $nav.offset();
-
-        documentFilter.hideFooter();
-        $nav.addClass('loading').find('.next a').text('Loading more...');
-        if(navOffset && (bottomOfWindow + 100 > navOffset.top)){
-          documentFilter.loadMoreInline();
-        } else {
-          documentFilter.showFooter();
-        }
-      }
-    },
-    hideFooter: function(){
-      if(documentFilter.footerHidden !== true){
-        $('#footer').addClass('visuallyhidden');
-        documentFilter.footerHidden = false;
-      }
-    },
-    showFooter: function(){
-      var $next = $('#show-more-documents .next a');
-
-      if($next.length === 0){
-        $('#footer').removeClass('visuallyhidden');
-      }
     }
   };
   window.GOVUK.documentFilter = documentFilter;
@@ -382,9 +304,6 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
 
         $(".submit").addClass("js-hidden");
 
-      }
-      if($('#show-more-documents .previous').length === 0){
-        documentFilter.initScroll();
       }
     });
     return this;

--- a/app/presenters/document_filter_presenter.rb
+++ b/app/presenters/document_filter_presenter.rb
@@ -26,7 +26,6 @@ class DocumentFilterPresenter < Struct.new(:filter, :context)
       data[:next_page?] = true
       data[:next_page] = filter.documents.current_page + 1
       data[:next_page_url] = url(page: filter.documents.current_page + 1)
-      data[:next_page_json] = context.filter_json_url(page: filter.documents.current_page + 1)
     end
     unless filter.documents.first_page?
       data[:prev_page?] = true

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -32,7 +32,6 @@
           <li class="next">
             <a href="{{next_page_url}}">Next page <span>{{next_page}} of {{total_pages}}</span></a>
           </li>
-          <link rel="next" type="application/json" href="{{next_page_json}}">
         {{/next_page?}}
       </ul>
     </nav>

--- a/test/javascripts/unit/document_filter_test.js
+++ b/test/javascripts/unit/document_filter_test.js
@@ -30,14 +30,10 @@ module("Document filter", {
 
     this.selections = this.resultsCount.find('.selections');
 
-    this.jsonNextPageLink = $('<link rel="next" type="application/json" />');
-    $('#qunit-fixture').append(this.jsonNextPageLink);
-
     this.ajaxData = {
       "next_page?": true,
       "next_page": 2,
       "next_page_url": '/next-page-url',
-      "next_page_json": '/next-page-url.json',
 
       "prev_page_url": '/prev-page-url',
       "more_pages?": true,
@@ -106,28 +102,6 @@ test("should update the email signup url", function() {
   equals(this.feedLinks.find('a[href="/email-signups"]').length, 1);
 });
 
-test("should visually hide the footer", function(){
-  $('#qunit-fixture').append('<div id="footer"></div>');
-
-  equals($('#footer.visuallyhidden').length, 0);
-  GOVUK.documentFilter.hideFooter();
-  equals($('#footer.visuallyhidden').length, 1);
-});
-
-test("should visually show the footer", function(){
-  $('#qunit-fixture').append('<div id="footer"></div><div id="show-more-documents"><i class="next"><a>next</a></i></div>');
-
-  GOVUK.documentFilter.hideFooter();
-  equals($('#footer.visuallyhidden').length, 1);
-
-  GOVUK.documentFilter.showFooter();
-  equals($('#footer.visuallyhidden').length, 1);
-
-  $('#show-more-documents').remove();
-  GOVUK.documentFilter.showFooter();
-  equals($('#footer.visuallyhidden').length, 0);
-});
-
 test("should make an ajax request on form submission to obtain filtered results", function() {
   this.filterForm.enableDocumentFilter();
 
@@ -135,19 +109,6 @@ test("should make an ajax request on form submission to obtain filtered results"
   var server = this.sandbox.useFakeServer();
 
   this.filterForm.submit();
-  server.respond();
-
-  sinon.assert.calledOnce(ajax);
-});
-
-test("should make an ajax request to load more results inline", function() {
-  this.filterForm.enableDocumentFilter();
-  GOVUK.documentFilter.renderTable(this.ajaxData);
-
-  var ajax = this.spy(jQuery, "ajax");
-  var server = this.sandbox.useFakeServer();
-
-  GOVUK.documentFilter.loadMoreInline();
   server.respond();
 
   sinon.assert.calledOnce(ajax);
@@ -193,31 +154,10 @@ test("should render results based on successful ajax response", function() {
   this.filterForm.submit();
   server.respond();
 
-  equals($('link[rel=next][type=application/json]').length, 1);
-  equals($('link[rel=next][type=application/json]').attr('href'), this.ajaxData.next_page_json);
   equals(this.filterResults.find(".document-row").length, 2);
   equals(this.filterResults.find(".document-row .document-series").text(), 'series-1');
   equals(this.filterResults.find(".document-row .topics").text(), 'topic-name-1, topic-name-2');
   equals(this.filterResults.find(".document-row .field-of-operation").text(), 'place-of-war');
-});
-
-test("should add extra results to table results", function() {
-  this.filterForm.enableDocumentFilter();
-
-  var server = this.sandbox.useFakeServer();
-  server.respondWith(JSON.stringify(this.ajaxData));
-
-  this.filterForm.submit();
-  server.respond();
-
-  equals(this.filterResults.find(".document-row").length, 2);
-
-  GOVUK.documentFilter.loadMoreInline();
-  server.respond();
-
-  equals($('link[rel=next][type=application/json]').length, 1);
-  equals($('link[rel=next][type=application/json]').attr('href'), this.ajaxData.next_page_json);
-  equals(this.filterResults.find(".document-row").length, 4);
 });
 
 test("should fire analytics on successful ajax response", function() {

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -325,18 +325,6 @@ module DocumentControllerTestHelpers
         end
       end
 
-      view_test "infinite pagination link should appear when there are more records for #{edition_type}" do
-        without_delay! do
-          documents = (1..4).to_a.map { |i| create("published_#{edition_type}", title: "keyword-#{i}") }
-
-          with_number_of_documents_per_page(3) do
-            get :index
-          end
-
-          assert_select "link[rel='next'][type='application/json']"
-        end
-      end
-
       view_test "should show previous page link when not on the first page for #{edition_type}" do
         without_delay! do
           documents = (1..4).to_a.map { |i| create("published_#{edition_type}", title: "keyword-#{i}") }
@@ -364,18 +352,6 @@ module DocumentControllerTestHelpers
             assert_select ".previous span", text: "1 of 3"
             assert_select ".next span", text: "3 of 3"
           end
-        end
-      end
-
-      view_test "should preserve query params in next pagination link for #{edition_type}" do
-        without_delay! do
-          documents = (1..4).to_a.map { |i| create("published_#{edition_type}", title: "keyword-#{i}") }
-
-          with_number_of_documents_per_page(3) do
-            get :index, keywords: 'keyword'
-          end
-
-          assert_select "link[rel=next][type='application/json'][href*='keywords=keyword']"
         end
       end
     end


### PR DESCRIPTION
Analytics was saying that not many people ever got to the second page of
results with infinite scroll enabled. We were also reciving feedback
that people found it hard work not being able to use the back button
after scrolling down many pages of results.

This should remove infinite scroll but leave in the ability to ajax in
new pages of results.
