### PR TITLE
Only init the back to content after images load

### DIFF
--- a/app/assets/javascripts/application/on_ready.js
+++ b/app/assets/javascripts/application/on_ready.js
@@ -1,3 +1,4 @@
+// Happen as soon as the DOM is loaded and before assets are downloaded
 jQuery(function($) {
   $('.js-hide-other-links').hideOtherLinks();
   $('.js-hide-other-departments').hideOtherLinks({ linkElement: 'span', alwaysVisibleClass: '.lead' });
@@ -7,7 +8,6 @@ jQuery(function($) {
   $('.detailed-guides-show').trackExternalLinks();
 
   GOVUK.stickAtTopWhenScrolling.init();
-  GOVUK.backToContent.init();
 
   $('.js-toggle-change-notes').toggler({actLikeLightbox: true});
   $('.js-toggle-change-notes').click(function(){
@@ -34,4 +34,8 @@ jQuery(function($) {
   GOVUK.showHide.init();
   GOVUK.emailSignup.init();
   GOVUK.virtualTour.init();
+});
+// These want images to be loaded before they run so the page height doesn't change.
+jQuery(window).load(function(){
+  GOVUK.backToContent.init();
 });


### PR DESCRIPTION
The back to contents link needs to know the height of the page before it
runs. Images loading can cause problems as they change the height of the
page. This moves the init from on ready when the dom has finished
loading to on load when all the assets are loaded in.

https://www.pivotaltracker.com/story/show/53139373
