### PR TITLE
Use the actual current database configuration

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -310,9 +310,9 @@ class Import < ActiveRecord::Base
     # This is so we can log information as we process
     # files without worrying about transactional
     # rollbacks for the actual import process.
-    Import.establish_connection Rails.configuration.database_configuration[Rails.env]
-    ImportError.establish_connection Rails.configuration.database_configuration[Rails.env]
-    ImportLog.establish_connection Rails.configuration.database_configuration[Rails.env]
+    Import.establish_connection ActiveRecord::Base.configurations[Rails.env]
+    ImportError.establish_connection ActiveRecord::Base.configurations[Rails.env]
+    ImportLog.establish_connection ActiveRecord::Base.configurations[Rails.env]
   end
 
   class ProgressLogger

--- a/test/support/consultation_csv_sample_helpers.rb
+++ b/test/support/consultation_csv_sample_helpers.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module ConsultationCsvSampleHelpers
   def consultation_csv_sample(additional_fields = {}, extra_rows = [])
     data = minimally_valid_consultation_row.merge(additional_fields)


### PR DESCRIPTION
`Rails.configuration.database_configuration` returns config found in the database_configuration file, rather than the currently set config. This causes sporadic issues during parallel test runs because our `ParallelTestRunner` customises the config per-fork. Instead of loading the config from the YAML file, we grab the config that is  currently
set one on `ActiveRecord::Base`.
