### PR TITLE
Order the attachment extensions whitelist

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -7,7 +7,7 @@ class AttachmentUploader < WhitehallUploader
 
   PDF_CONTENT_TYPE = 'application/pdf'
   FALLBACK_THUMBNAIL_PDF = File.expand_path("../../assets/images/pub-cover.png", __FILE__)
-  EXTENSION_WHITE_LIST = %w(pdf csv rtf png jpg doc docx xls xlsx ppt pptx zip rdf txt kml odt ods xml)
+  EXTENSION_WHITE_LIST = %w(csv doc docx jpg kml ods odt pdf png ppt pptx rdf rtf txt xls xlsx xml zip)
 
   process :set_content_type
   after :retrieve_from_cache, :set_content_type


### PR DESCRIPTION
In a blog post [0], Neil Williams suggested that people read the code
to find out the canonical list of attachment types that can be
uploaded.

It is difficult to scan the list quickly, because it is not ordered
alphabetically. This commit orders the whitelist.

[0] http://bit.ly/18b3ZgH
