### PR TITLE
World location news doesn't have organisations

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -6,6 +6,8 @@ module LeadImagePresenterHelper
       lead_organisations.first.default_news_image.file.url(:s300)
     elsif organisations.any? && organisations.first.default_news_image
       organisations.first.default_news_image.file.url(:s300)
+    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
+      worldwide_organisations.first.default_news_image.file.url(:s300)
     elsif organisations.any? && placeholder_image_exisits?
       "organisation_default_news/s300_#{organisations.first.slug}.jpg"
     else

--- a/app/presenters/world_location_news_article_presenter.rb
+++ b/app/presenters/world_location_news_article_presenter.rb
@@ -4,18 +4,6 @@ class WorldLocationNewsArticlePresenter < Whitehall::Decorators::Decorator
 
   delegate_instance_methods_of WorldLocationNewsArticle
 
-  def organisations
-    @orgs ||= model.worldwide_organisations.map { |wo| WorldwideOrganisationPresenter.new(wo, context) }
-  end
-
-  def sorted_organisations
-    organisations.sort_by {|wo| wo.name }
-  end
-
-  def lead_organisations
-    []
-  end
-
   private
 
   def find_asset(asset)

--- a/app/views/documents/_metadata.html.erb
+++ b/app/views/documents/_metadata.html.erb
@@ -1,12 +1,14 @@
 <aside class="meta">
   <div class="inner-heading">
     <dl>
-      <dt><%= t('document.headings.organisations', count: document.organisations.length) %>:</dt>
-      <dd>
-        <%= render  partial: 'organisations/organisations_name_list',
-                    locals: { organisations: document.sorted_organisations,
-                              lead_organisations: document.lead_organisations } %>
-      </dd>
+      <% if document.organisations.any?  %>
+        <dt><%= t('document.headings.organisations', count: document.organisations.length) %>:</dt>
+        <dd>
+          <%= render  partial: 'organisations/organisations_name_list',
+                      locals: { organisations: document.sorted_organisations,
+                                lead_organisations: document.lead_organisations } %>
+        </dd>
+      <% end %>
       <%= render  partial: 'document_extra_metadata',
                   locals: { document: document } %>
       <%= render  partial: 'documents/change_notes',

--- a/test/unit/presenters/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/world_location_news_article_presenter_test.rb
@@ -13,15 +13,4 @@ class WorldLocationNewsArticlePresenterTest < ActionView::TestCase
     presenter = WorldLocationNewsArticlePresenter.new(world_location_news_article, @view_context)
     assert_match worldwide_organisation.default_news_image.file.url(:s300), presenter.lead_image_path
   end
-
-  test '#sorted_organisations returns decorted worldwide organisations in alphabetical order' do
-    world_org1 = create(:worldwide_organisation, name: 'Ministry of Jazz')
-    world_org2 = create(:worldwide_organisation, name: 'Free Jazz Foundation')
-    world_org3 = create(:worldwide_organisation, name: 'Jazz Bizniz')
-    edition = create(:world_location_news_article, worldwide_organisations: [world_org3, world_org1, world_org2])
-
-    sorted_decorated_orgs = [world_org2, world_org3, world_org1].collect {|wo| WorldwideOrganisationPresenter.new(wo) }
-
-    assert_equal sorted_decorated_orgs, WorldLocationNewsArticlePresenter.new(edition, 'context stub').sorted_organisations
-  end
 end


### PR DESCRIPTION
World location news has world organisations not organisations. They are
displayed differently on the frontend.

We do still however want the right default news image for the first
world organisation.

https://www.pivotaltracker.com/story/show/53086407
