### PR TITLE
Move change notes toggle to its own link

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_change-notes.scss
+++ b/app/assets/stylesheets/frontend/helpers/_change-notes.scss
@@ -9,6 +9,7 @@
     display: inline-block;
     color: $link-colour;
     white-space: nowrap;
+    cursor: pointer;
 
     &:focus,
     &:hover {
@@ -39,7 +40,7 @@
     height: 0;
     position: absolute;
     top: -4px;
-    left: 20%;
+    left: 75%;
     margin-left: -2px;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;

--- a/app/views/document_series/show.html.erb
+++ b/app/views/document_series/show.html.erb
@@ -16,9 +16,9 @@
           </dd>
           <% unless @document_series.published_editions.empty? %>
             <% most_recent_change = @document_series.published_editions.first.public_timestamp %>
-            <dt class="change-notes-title"><%= t('change_notes.updated') %>:</dt>
+            <dt class="change-notes-title"><%= t('change_notes.page_history') %>:</dt>
             <dd class="change-notes">
-              <%= absolute_date(most_recent_change, class: 'published-at') %>
+              <%= t('change_notes.published_at', date: absolute_date(most_recent_change, class: 'published-at')).html_safe %>
             </dd>
           <% end %>
         </dl>

--- a/app/views/documents/_change_notes.html.erb
+++ b/app/views/documents/_change_notes.html.erb
@@ -1,5 +1,5 @@
+<dt class="change-notes-title"><%= t('change_notes.page_history') %>:</dt>
 <% if document.state != 'published' %>
-  <dt class="change-notes-title"><%= t('change_notes.published') %>:</dt>
   <dd>Preview</dd>
 <% else %>
   <%-
@@ -7,12 +7,10 @@
     most_recent_change = history.first.public_timestamp
   -%>
   <% if history.length == 1 %>
-    <dt class="change-notes-title"><%= t('change_notes.published') %>:</dt>
-    <dd class="change-notes"><%= absolute_date(most_recent_change, class: 'published-at') %></dd>
+    <dd class="change-notes"><%= t('change_notes.published_at', date: absolute_date(most_recent_change, class: 'published-at')).html_safe %></dd>
   <% else %>
-    <dt class="change-notes-title"><%= t('change_notes.updated') %>:</dt>
     <dd class="js-toggle-change-notes change-notes">
-      <%= absolute_date(most_recent_change, class: 'published-at toggle') %>
+      <%= t('change_notes.updated_at', date: absolute_date(most_recent_change, class: 'published-at')).html_safe %>
       <div class="overlay js-hidden" id="change-notes">
         <dl>
           <% history.each do |change| %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -517,8 +517,9 @@ ar:
       published: تاريخ النشر
       reference: إشارة
   change_notes:
-    published: تاريخ النشر
-    updated: تحديث
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: نموذج اتصال
     email: بريد إلكتروني

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -16,8 +16,9 @@ az:
       published:
       reference:
   change_notes:
-    published: çap edilib
-    updated: Yenilənmiş
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Əlaqə vasitəsi
     email: elektron poçt

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -395,8 +395,9 @@ be:
       published: Апублікаваны
       reference: Спасылка
   change_notes:
-    published: Апублікаваны
-    updated: Адноўлены
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Кантактная форма
     email: Электронная пошта

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -284,8 +284,9 @@ bg:
       published: Публикувано
       reference: Справка
   change_notes:
-    published: Публикувано
-    updated: Обновено
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Контактна форма
     email: И-мейл

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -271,8 +271,9 @@ bn:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -336,8 +336,9 @@ cs:
       published: Uveřejněno
       reference: Reference
   change_notes:
-    published: Uveřejněno
-    updated: Aktualizováno
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Kontaktní formulář
     email: Email

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -518,8 +518,9 @@ cy:
       published: Cyhoeddwyd
       reference: Cyf
   change_notes:
-    published: Cyhoeddwyd
-    updated: Diweddarwyd
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Ffurflen cysylltu
     email: E-bost

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -274,8 +274,9 @@ de:
       published: Veröffentlicht
       reference: Aktenzeichen
   change_notes:
-    published: veröffentlicht
-    updated: aktualisiert
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Kontaktformular
     email: E-Mail

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -273,8 +273,9 @@ dr:
       published: نشر شده
       reference: ماخذ
   change_notes:
-    published: نشر شده
-    updated: به روز شده
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: فارم تماس
     email: ایمیل

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -276,8 +276,9 @@ el:
       published: Δημοσιεύτηκε
       reference: Σχετικά
   change_notes:
-    published: Δημοσιευμένο
-    updated: Ανανεωμενη έκδοση
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Φόρμα επικοινωνίας
     email: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,8 +288,9 @@ en:
     contact_form: Contact form
   read_more: Read more
   change_notes:
-    published: Published
-    updated: Updated
+    page_history: Page history
+    published_at: Published %{date}
+    updated_at: Updated %{date}, <span class="toggle">see change history</span>
   organisation:
     type:
       Ministerial department:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -274,8 +274,9 @@ es-419:
       published: Publicado
       reference: Ref
   change_notes:
-    published: Publicado
-    updated: Actualizado
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formulario de contacto
     email: Correo electrónico

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -274,8 +274,9 @@ es:
       published: Publicado
       reference: Referencia
   change_notes:
-    published: Publicado
-    updated: Actualizado
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formulario de contacto
     email: Email

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -18,8 +18,9 @@ fa:
       published: منتشر شده
       reference: مرجع
   change_notes:
-    published: منتشر شده
-    updated: به روز شده
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: فرم ارتباط
     email: ایمیل

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -278,8 +278,9 @@ fr:
       published: Publié
       reference: Réf
   change_notes:
-    published: Publié
-    updated: Mise à jour
+    page_history: Historique de page
+    published_at:
+    updated_at:
   contact:
     contact_form: Formulaire de contact
     email: Email

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -399,8 +399,9 @@ he:
       published: פורסם
       reference: הפניה
   change_notes:
-    published: פורסם
-    updated: עודכן
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: טופס יצירת קשר
     email: דואר אלקטרוני

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -275,8 +275,9 @@ hi:
       published: प्रकाशित
       reference: संदर्भ
   change_notes:
-    published: प्रकाशित
-    updated: अद्यतन
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: संपर्क प्रपत्र
     email: ईमेल

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -19,8 +19,9 @@ hu:
       published: Közzététel időpontja
       reference: Ref
   change_notes:
-    published: Közzététel időpontja
-    updated: Frissítve
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Kapcsolati űrlap
     email: E-mail

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -274,8 +274,9 @@ hy:
       published: Հրապարակված
       reference: Հղում
   change_notes:
-    published: Հրապարակված
-    updated: Թարմացված
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Կապի միջոց
     email: Էլելտրոնային հասցե

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -18,8 +18,9 @@ id:
       published: Diterbitkan
       reference: Ref
   change_notes:
-    published: Diterbitkan
-    updated: Diperbaharui
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formulir kontak
     email: Email

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -274,8 +274,9 @@ it:
       published: Pubblicato
       reference: Rif
   change_notes:
-    published: Pubblicato
-    updated: Aggiornato
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Contattaci
     email: Email

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,8 +17,9 @@ ja:
       published: 掲載日
       reference: Ref
   change_notes:
-    published: 掲載日
-    updated: 更新日
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: 連絡フォーム
     email: Email

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -16,8 +16,9 @@ ka:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -17,8 +17,9 @@ ko:
       published: 퍼블리시
       reference: 레퍼런스
   change_notes:
-    published: 퍼블리시
-    updated: 업데이트
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: 콘택트 폼
     email: 이메일

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -334,8 +334,9 @@ lt:
       published: Publikuota
       reference: Nuorodos
   change_notes:
-    published: Publikuota
-    updated: Atnaujinta
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Parašykite mums
     email: El.paštas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -273,8 +273,9 @@ lv:
       published: Publicēts
       reference: Ref.
   change_notes:
-    published: Publicēts
-    updated: Atjaunināts
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Saziņas forma
     email: E-pasts

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -16,8 +16,9 @@ ms:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -397,8 +397,9 @@ pl:
       published: Opublikowano
       reference: Odsyłacz
   change_notes:
-    published: Opublikowano
-    updated: Zaktualizowano
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formularz kontaktowy
     email: Email

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -275,8 +275,9 @@ ps:
       published: خپور شوی
       reference: مواخذ
   change_notes:
-    published: خپور شوی
-    updated: تازه شوی
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: د اړیکوپاڼه
     email: برښنالیک

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -273,8 +273,9 @@ pt:
       published: Publicado
       reference: Ref
   change_notes:
-    published: Publicado
-    updated: Atualizado
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formulário de contato
     email: E-mail

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -339,8 +339,9 @@ ro:
       published: ! 'Data publicării '
       reference: ! 'Referință '
   change_notes:
-    published: Publicat
-    updated: Actualizat
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Formular de contact
     email: Email

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -394,8 +394,9 @@ ru:
       published: Опубликовано
       reference: Ссылка
   change_notes:
-    published: Опубликовано
-    updated: Обновлено
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Контактная форма
     email: Электронный адрес

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -275,8 +275,9 @@ si:
       published: පල කරනලද
       reference: අංකය
   change_notes:
-    published: පල කරනලද
-    updated: යාවත්කාලීන කල
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: තොරතුරු පෝරමය
     email: විද්‍යුත් තැපැල්

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -332,8 +332,9 @@ sk:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -275,8 +275,9 @@ so:
       published: La-daabacay
       reference: Xigasho
   change_notes:
-    published: La-daabacay/nashriyey
-    updated: Wax lagu kordhiyey
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Foom cinwaan
     email: E-mail

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -274,8 +274,9 @@ sq:
       published: Publikuar
       reference: Ref
   change_notes:
-    published: Publikuar
-    updated: Rifreskuar
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Forme kontakti
     email: Email

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -400,8 +400,9 @@ sr:
       published: Objavljeno
       reference: Ref
   change_notes:
-    published: Obavljeno
-    updated: Ažurirano
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: formular za kontakt
     email: e-mail

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -271,8 +271,9 @@ sw:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -275,8 +275,9 @@ ta:
       published: பிரசுரிக்கப்பட்டது
       reference: குறிப்புரை
   change_notes:
-    published: பிரசுரிக்கப்பட்டது
-    updated: இற்றைப்படுத்தப்பட்டது
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: தொடர்புகொள்ளல் படிவம்
     email: மின்னஞ்சல்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -17,8 +17,9 @@ th:
       published: ตีพิมพ์
       reference: อ้างอิง
   change_notes:
-    published: ติพิมพ์
-    updated: ปรับปรุง
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: แบบฟอร์มการติดต่อ
     email: อีเมล์

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -271,8 +271,9 @@ tk:
       published:
       reference:
   change_notes:
-    published:
-    updated:
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form:
     email:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -19,8 +19,9 @@ tr:
       published: Yayında
       reference: Ref
   change_notes:
-    published: Yayında
-    updated: Güncellendi
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: İletişim Formu
     email: E-posta

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -395,8 +395,9 @@ uk:
       published: Опубліковано
       reference: Ref
   change_notes:
-    published: Опубліковано
-    updated: Оновлено
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Форма зворотнього зв'язку
     email: Електронна пошта

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -274,8 +274,9 @@ ur:
       published: شائع شدہ
       reference: حوالہ
   change_notes:
-    published: شائع شدہ
-    updated: تجدیدشدہ
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: کانٹیکٹ فارم
     email: ای میل

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -273,8 +273,9 @@ uz:
       published: Nashr qilindi
       reference: Ishora
   change_notes:
-    published: Nashr qilindi
-    updated: Yangilandi
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Aloqa uchun
     email: Elektron manzil

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -19,8 +19,9 @@ vi:
       published: Đã đăng
       reference: đối với
   change_notes:
-    published: Xuất bản
-    updated: Cập nhật
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: Mẫu liên hệ
     email: Email

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -16,8 +16,9 @@ zh-hk:
       published: 已發布
       reference: 參考
   change_notes:
-    published: 已發布
-    updated: 已更新
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: 聯絡資料表
     email: 電子郵件

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -16,8 +16,9 @@ zh-tw:
       published: 發行
       reference: 參考
   change_notes:
-    published: 發行
-    updated: 更新
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: 聯絡資料表
     email: 電子郵件

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -16,8 +16,9 @@ zh:
       published: 已发布
       reference: Ref
   change_notes:
-    published: 已发布
-    updated: 已更新
+    page_history:
+    published_at:
+    updated_at:
   contact:
     contact_form: 联系表格
     email: 邮件

--- a/test/functional/worldwide_priorities_controller_test.rb
+++ b/test/functional/worldwide_priorities_controller_test.rb
@@ -60,7 +60,7 @@ class WorldwidePrioritiesControllerTest < ActionController::TestCase
     get :show, id: priority.document, locale: 'fr'
 
     assert_select ".type", /Priorité internationale/
-    assert_select ".change-notes-title", /Publié/
+    assert_select ".change-notes-title", /Historique de page/
   end
 
   test '#activity loads the recently changed documents related to the priority' do


### PR DESCRIPTION
People didn't realise that you could click the date to see the document
history. This makes it very clear when there is a history that you can
click the toggle to see it.

https://www.pivotaltracker.com/story/show/49294633
