### PR TITLE
Response published date set in the DB

### DIFF
--- a/app/helpers/consultations_helper.rb
+++ b/app/helpers/consultations_helper.rb
@@ -13,8 +13,8 @@ module ConsultationsHelper
 
   def consultation_response_published_phrase(response)
     return "Not yet published" unless response.published?
-    date = render_datetime_microformat(response, :published_on_or_default) { response.published_on_or_default.to_s(:long_ordinal) }
-    (((response.published_on_or_default < Date.today) ? "Published response on " : "Publishing response on ") + date).html_safe
+    date = render_datetime_microformat(response, :published_on) { response.published_on.to_s(:long_ordinal) }
+    (((response.published_on < Date.today) ? "Published response on " : "Publishing response on ") + date).html_safe
   end
 
   def consultation_css_class(consultation)

--- a/db/data_migration/20130717110612_set_response_published_at.rb
+++ b/db/data_migration/20130717110612_set_response_published_at.rb
@@ -1,0 +1,9 @@
+responses = Response.where("published_on IS NULL AND summary <> ''").each do |response|
+  response.update_column(:published_on, response.updated_at)
+end
+puts "#{responses.count} Responses updated with a summary and no published date"
+
+responses = Response.joins(:attachments).where("published_on IS NULL").uniq.each do |response|
+	response.update_column(:published_on, response.consultation_response_attachments.order("created_at ASC").first.created_at)
+end
+puts "#{responses.count} Responses updated with a attachment and no published date"

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -48,7 +48,7 @@ Then /^the published date should be visible on save$/ do
   date = 1.day.ago.strftime("%Y-%m-%d")
   click_button "Save"
 
-  assert_equal date, find("abbr.published_on_or_default")[:title]
+  assert_equal date, find("abbr.published_on")[:title]
   publish force: true
 
   select_most_recent_consultation_from_list

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -98,10 +98,11 @@ class ConsultationTest < ActiveSupport::TestCase
   end
 
   test "published_consultation_response returns the response when just a summary is present" do
-    consultation = create(:published_consultation)
+    consultation = create(:closed_consultation)
     published_response = consultation.create_response!
-    published_response.stubs(:summary).returns("The summary")
-    assert_equal published_response, consultation.published_consultation_response
+    published_response.summary = "This is the summary"
+    published_response.save
+    assert_equal published_response, consultation.reload.published_consultation_response
   end
 
   test ".closed includes consultations closing in the past" do
@@ -283,7 +284,7 @@ class ConsultationTest < ActiveSupport::TestCase
     today = Date.today
     consultation = create(:consultation)
     response = consultation.create_response!
-    response.stubs(:published_on_or_default).returns(today)
+    response.stubs(:published_on).returns(today)
 
     assert_equal today, consultation.response_published_on
   end

--- a/test/unit/helpers/consultations_helper_test.rb
+++ b/test/unit/helpers/consultations_helper_test.rb
@@ -34,22 +34,22 @@ class ConsultationsHelperTest < ActionView::TestCase
   end
 
   test "#consultation_response_published_phrase uses future tense if publish date is in future" do
-    response = stub('Response', published_on_or_default: 2.days.from_now, published?: true)
+    response = stub('Response', published_on: 2.days.from_now, published?: true)
     assert consultation_response_published_phrase(response).starts_with?("Publishing response on")
   end
 
   test "#consultation_response_published_phrase uses past tense if publish date is in past" do
-    response = stub('Response', published_on_or_default: 2.days.ago, published?: true)
+    response = stub('Response', published_on: 2.days.ago, published?: true)
     assert consultation_response_published_phrase(response).starts_with?("Published response on")
   end
 
   test "#consultation_response_published_phrase includes long form date" do
-    response = stub('Response', published_on_or_default: Date.new(2012, 12, 12), published?: true)
+    response = stub('Response', published_on: Date.new(2012, 12, 12), published?: true)
     assert_match Regexp.new(Regexp.escape("12 December 2012")), consultation_response_published_phrase(response)
   end
 
   test "#consultation_response_published_phrase shows not yet published if not published yet" do
-    response = stub('Response', published_on_or_default: nil, published?: false)
+    response = stub('Response', published_on: nil, published?: false)
     assert_equal "Not yet published", consultation_response_published_phrase(response)
   end
 

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -79,7 +79,8 @@ class ResponseTest < ActiveSupport::TestCase
     response = create(:response)
     response.attachments.create! title: 'attachment-title', attachment_data: create(:attachment_data, file: fixture_file_upload('greenpaper.pdf'))
 
-    assert response.published?
+    response.save
+    assert response.reload.published?
   end
 
   test "should use the date that the earliest response attachment was created as the date the response was published" do
@@ -88,21 +89,22 @@ class ResponseTest < ActiveSupport::TestCase
     latest_response_attachment = response.consultation_response_attachments.create!(attachment: attachment, created_at: 1.day.ago)
     earliest_response_attachment = response.consultation_response_attachments.create!(attachment: attachment, created_at: 1.month.ago)
 
-    assert_equal earliest_response_attachment.created_at, response.published_on_or_default
+    response.save
+    assert_equal earliest_response_attachment.created_at.to_date, response.reload.published_on
   end
 
   test "should return nil if the response isn't published" do
     response = create(:response)
     response.stubs(:published?).returns(false)
 
-    assert_equal nil, response.published_on_or_default
+    assert_equal nil, response.published_on
   end
 
   test "should return the published_on date if set and the response is published" do
     published_date = Date.parse('2012-03-03')
     response = create(:response, published_on: published_date)
     response.stubs(:published?).returns(true)
-    assert_equal published_date, response.published_on_or_default
+    assert_equal published_date, response.published_on
   end
 
   test "should return the alternative_format_contact_email of the consultation" do


### PR DESCRIPTION
This allows us to ensure the date is set in the DB which can then be used to check the presence of a published consultation response, by using the published_on date.

Also add a data migration to set the published_on date on responses with summaries and no published_on date, or attachments and no published_on date. This is because we are currently treating the response as 'outcome' if it has an attachment or a summary but not setting the published_on date, and there is old data that needs cleaning up.

Also move class methods into scopes.

This work was part of fixing this bug duplication of consultations in the get invloved page: https://www.pivotaltracker.com/story/show/53350895
