### PR TITLE
Fix error messages on nested attachment validation failures

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -500,8 +500,57 @@ ar:
     see_all: اطلع على كافة %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: فئة توجيهات مفصلة أساسية
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: إعلانات
   attachment:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,8 +1,57 @@
 az:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Ilkin qaydalar kateqoriyasi
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Elanlar
   attachment:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -378,8 +378,57 @@ be:
     see_all: Паглядзець усе %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: ! 'Першасная катэгорыя падрабязнага кіраўніцтва '
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Аб'явы
   attachment:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -258,8 +258,57 @@ bg:
     see_all: Вижте всички наши %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Първоначална  категория с подробни указания
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Съобщения
   attachment:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -256,8 +256,57 @@ bn:
     see_all:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -317,8 +317,57 @@ cs:
     see_all: Podívejte se na
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Návod
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Oznámení
   attachment:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -500,8 +500,57 @@ cy:
     see_all: Gweld ein holl %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Prif gategori cyfarwyddyd manwl
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Cyhoeddiadau
   attachment:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -256,8 +256,57 @@ de:
     see_all: Alle unsere %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Kategorie detaillierte Hinweise
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Meldungen
   attachment:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -256,8 +256,57 @@ dr:
     see_all: همه را ببینید %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: کتگوری رهنمود مفصل ابتدائی
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: اعلانات
   attachment:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -257,8 +257,57 @@ el:
     see_all: Δείτε τα %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Βασική κατηγορία οδηγιών
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Ανακοινώσεις
   attachment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,36 @@ en:
     uz: Uzbeki
     id: Indonesian
   activerecord:
+    nested_attachment_field_names: &nested_attachment_field_names
+      command_paper_number: Attachment command paper number
+      isbn: Attachment ISBN
+      order_url: Attachment order url
+      price: Attachment price
+      title: Attachment title
+      unique_reference: Attachment unique reference
+    nested_attachment_data_field_names: &nested_attachment_data_field_names
+      file: The attached file
     attributes:
+      attachment:
+        isbn: ISBN
+      attachment_data:
+        file: File
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        <<: *nested_attachment_field_names
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        <<: *nested_attachment_data_field_names
+      policy_advisory_group/policy_group_attachments/attachment:
+        <<: *nested_attachment_field_names
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        <<: *nested_attachment_data_field_names
+      response/consultation_response_attachments/attachment:
+        <<: *nested_attachment_field_names
+      response/consultation_response_attachments/attachment/attachment_data:
+        <<: *nested_attachment_data_field_names
+      supporting_page/supporting_page_attachments/attachment:
+        <<: *nested_attachment_field_names
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        <<: *nested_attachment_data_field_names
       detailed_guide:
         primary_mainstream_category: Primary detailed guidance category
   date:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -256,8 +256,57 @@ es-419:
     see_all: Vea todos nuestros %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Categoría de orientación principal en detalle
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Novedades
   attachment:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -256,8 +256,57 @@ es:
     see_all: Ver toda nuestra %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Categoría principal guía en detalle
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Anuncios
   attachment:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,8 +1,57 @@
 fa:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: دسته بندی راهنمایی های اولیه
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: اطلاعیه ها
   attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -256,8 +256,57 @@ fr:
     see_all: Voir tous nos %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Catégorie d'instructions détaillées
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Nos actualités
   attachment:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -378,8 +378,57 @@ he:
     see_all: ראה כל %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: קטגוריית פרטים ראשית
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: הודעות
   attachment:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -256,8 +256,57 @@ hi:
     see_all: देखें हमारे सभी %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: प्राथमिक विस्तृत मार्गदर्शन श्रेणी
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: घोषणाएं
   attachment:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,8 +1,57 @@
 hu:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Részletes utasításkategóriák
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Közlemények
   attachment:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -256,8 +256,57 @@ hy:
     see_all: Տես՝ մեր բոլոր %{type} -ը
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Ուղեցույցի առաջնային մանրամասն կատեգորիա
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Հայտարարություններ
   attachment:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,8 +1,57 @@
 id:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Kategori rincian panduan utama
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Pengumuman
   attachment:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -256,8 +256,57 @@ it:
     see_all: Vedi tutte le nostre %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Categoria principale indicazioni dettagliate
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Annunci
   attachment:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,8 +1,57 @@
 ja:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: 主要説明カテゴリー
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: ニュース
   attachment:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,8 +1,57 @@
 ka:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,8 +1,57 @@
 ko:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: 상세 안내 카테고리
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: 공지사항
   attachment:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -317,8 +317,57 @@ lt:
     see_all: Pažiūrėkite  mūsų %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Pagrindinės kategorijos
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Skelbimai
   attachment:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -256,8 +256,57 @@ lv:
     see_all: Skatīt visas %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Izvērstā pamatojuma pamata kategorija
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Paziņojumi
   attachment:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,8 +1,57 @@
 ms:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -378,8 +378,57 @@ pl:
     see_all: Zobacz wszystkie nasze %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Podstawowa kategoria szczegółowych wytycznych
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Ogłoszenia
   attachment:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -258,8 +258,57 @@ ps:
     see_all: ټول وګوری %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: د مفصل لومړني لارښونې کتګوري
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: اعلانونه
   attachment:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -256,8 +256,57 @@ pt:
     see_all: Veja todos os nossos %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: ! 'Categoria principal do guia detalhado '
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Anúncios
   attachment:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -318,8 +318,57 @@ ro:
     see_all: Toate %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: ! 'Ghid detaliat '
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Știri
   attachment:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -378,8 +378,57 @@ ru:
     see_all: Посмотреть все наши %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Основная категория подробной инструкции
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Объявления
   attachment:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -258,8 +258,57 @@ si:
     see_all: අපගේ සියලු %{type} බලන්න
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: ප්‍රාථමික විස්තරාත්මක උපදෙස් වර්ගීකරණය
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: නිවේදන
   attachment:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -317,8 +317,57 @@ sk:
     see_all:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -256,8 +256,57 @@ so:
     see_all: Fiiri dhammaan %{type} yadeenna
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Qayb tilmaan faahfaahsan oo aasaasi ah
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Ogeysiisyo
   attachment:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -256,8 +256,57 @@ sq:
     see_all: Shiko te gjitha %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: kategori primare udhezimesh te detajuara
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Njoftime shtypi
   attachment:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -382,8 +382,57 @@ sr:
     see_all: Pogledajte sve naše %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Najave
   attachment:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -256,8 +256,57 @@ sw:
     see_all:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -256,8 +256,57 @@ ta:
     see_all: எங்களது அனைத்து %{type} பார்க்கவும்
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: முதனிலை விளக்க வழிகாட்டல் வகை
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: அறிவிப்பு
   attachment:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,8 +1,57 @@
 th:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: หมวดคู่มือเบื้องต้นอย่างละเอียด
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: ข่าวสาร
   attachment:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -256,8 +256,57 @@ tk:
     see_all:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category:
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading:
   attachment:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,8 +1,57 @@
 tr:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Ayrıntılı Temel Kılavuz Kategorisi
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Duyurular
   attachment:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -378,8 +378,57 @@ uk:
     see_all: Дивіться всі наші %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Первинна деталізована категорія
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Оголошення
   attachment:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -256,8 +256,57 @@ ur:
     see_all: تما م دیکھئیے %{type}
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: ابتدائی مفصل رہنمائی کیٹیگری
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: اعلانات
   attachment:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -256,8 +256,57 @@ uz:
     see_all: Bizning butun %{type} ko'ring
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Asosiy batafsil ko'mak toifasi
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: E'lonlar
   attachment:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,8 +1,57 @@
 vi:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: Hạng mục hướng dẫn chi tiết sơ cấp
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: Thông báo
   attachment:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,8 +1,57 @@
 zh-hk:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: 主要細節指引類
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: 公告
   attachment:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,8 +1,57 @@
 zh-tw:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: 主要細節指引類
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: 公告
   attachment:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,8 +1,57 @@
 zh:
   activerecord:
     attributes:
+      attachment:
+        isbn:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
       detailed_guide:
         primary_mainstream_category: 首要详细指导类别
+      policy_advisory_group/policy_group_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      policy_advisory_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+      supporting_page/supporting_page_attachments/attachment:
+        command_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+      supporting_page/supporting_page_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
   announcements:
     heading: 公告
   attachment:


### PR DESCRIPTION
We used to report things like this:

> Supporting page attachments attachment attachment data file can't be blank

Now we say:

> The attached file can't be blank

The need for some (but not all) of this YAML will go away once we drop all these non-polymorphic relationships between documents of different types, and Attachment.
