### PR TITLE
Create stick at top when scrolling shim with minimum height

### DIFF
--- a/app/assets/javascripts/application/stick_at_top_when_scrolling.js
+++ b/app/assets/javascripts/application/stick_at_top_when_scrolling.js
@@ -58,7 +58,8 @@
     stick: function($el){
       if (!$el.hasClass('content-fixed')) {
         $el.data('scrolled-from', $el.offset().top);
-        $el.before('<div class="shim" style="width: '+ $el.width() + 'px; height: ' + $el.height() + 'px">&nbsp;</div>');
+        var height = Math.max($el.height(), 1);
+        $el.before('<div class="shim" style="width: '+ $el.width() + 'px; height: ' + height + 'px">&nbsp;</div>');
         $el.css('width', $el.width() + "px").addClass('content-fixed');
       }
     },

--- a/test/javascripts/unit/stick_at_top_when_scrolling_test.js
+++ b/test/javascripts/unit/stick_at_top_when_scrolling_test.js
@@ -24,3 +24,8 @@ test('should insert shim when sticking content', function(){
   equal($('.shim').length, 1);
 });
 
+test('should insert shim with minimum height', function(){
+  GOVUK.stickAtTopWhenScrolling.stick(this.$nav);
+  equal($('.shim').height(), 1);
+});
+


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/53617185

Series pages have a bit of content that is set to stick to the top when the page scrolled down. Though in the series linked to in the pivotal story, the piece of content was blank. The JavaScript to stick things to the top of the page creates a shim element that is the same size as the content to keep other elements on the page in the correct place, but in this case created it of zero height, causing other content to collapse on top of it.
