### PR TITLE
Add unique index to financial_reports

### DIFF
--- a/db/migrate/20130730095758_add_index_to_financial_reports.rb
+++ b/db/migrate/20130730095758_add_index_to_financial_reports.rb
@@ -1,0 +1,5 @@
+class AddIndexToFinancialReports < ActiveRecord::Migration
+  def change
+    add_index :financial_reports, ["organisation_id", "year"], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130729124957) do
+ActiveRecord::Schema.define(:version => 20130730095758) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -594,6 +594,7 @@ ActiveRecord::Schema.define(:version => 20130729124957) do
     t.integer "year"
   end
 
+  add_index "financial_reports", ["organisation_id", "year"], :name => "index_financial_reports_on_organisation_id_and_year", :unique => true
   add_index "financial_reports", ["organisation_id"], :name => "index_financial_reports_on_organisation_id"
   add_index "financial_reports", ["year"], :name => "index_financial_reports_on_year"
 

--- a/lib/tasks/load_public_bodies_report_csv.rake
+++ b/lib/tasks/load_public_bodies_report_csv.rake
@@ -27,9 +27,7 @@ namespace :public_bodies do
         funding = clean_money(raw_funding)
 
         unless spending.nil? && funding.nil?
-          financial_report = FinancialReport.new
-          financial_report.year = args[:year].to_i
-          financial_report.organisation_id = organisation.id
+          financial_report = FinancialReport.where(organisation_id: organisation, year: args[:year].to_i).first_or_initialize
           financial_report.spending = spending
           financial_report.funding = funding
           financial_report.save


### PR DESCRIPTION
Updated migration to add uniqueness constraint
Updated rake task to remove any duplication

This is the rake task can be run idempotently and when names are corrected on GOV.UK the script can be rerun, adding new records that it finds.
