### PR TITLE
Redirect attachments on unpublished editions

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,9 +1,12 @@
 class AttachmentsController < ApplicationController
   include UploadsControllerHelper
+  include PublicDocumentRoutesHelper
 
   def show
-    if attachment_visible?
+    if attachment_visibility.visible?
       send_upload file_path, public: current_user.nil?
+    elsif edition = attachment_visibility.unpublished_edition
+      redirect_to public_document_path(edition, id: edition.unpublishing.slug)
     else
       replacement = attachment_data.replaced_by
       if replacement
@@ -32,7 +35,7 @@ class AttachmentsController < ApplicationController
     attachment_data.file.store_path(file_with_extensions)
   end
 
-  def attachment_visible?
-    AttachmentVisibility.new(attachment_data, current_user).visible?
+  def attachment_visibility
+    @attachment_visibility ||= AttachmentVisibility.new(attachment_data, current_user)
   end
 end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -28,7 +28,7 @@ class AttachmentsControllerTest < ActionController::TestCase
   end
 
   test 'document attachments that are visible are sent to the browser inline' do
-    visible_edition = create( :published_publication, :with_attachment)
+    visible_edition = create(:published_publication, :with_attachment)
     attachment_data = visible_edition.attachments.first.attachment_data
 
     simulate_virus_scan(attachment_data.file)
@@ -52,7 +52,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
   test 'attachments that are images are sent inline' do
     attachment_data = create(:image_attachment_data)
-    visible_edition = create( :published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
+    visible_edition = create(:published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
 
     simulate_virus_scan(attachment_data.file)
     get_show attachment_data
@@ -64,7 +64,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
   test "requesting an attachment's thumbnail returns the thumbnail inline" do
     attachment_data = create(:attachment_data)
-    visible_edition = create( :published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
+    visible_edition = create(:published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
     simulate_virus_scan(attachment_data.file)
     create_thumbnail_for_upload(attachment_data.file)
     get :show, id: attachment_data.to_param, file: attachment_data.filename, extension: 'png'
@@ -76,11 +76,20 @@ class AttachmentsControllerTest < ActionController::TestCase
 
   test 'requesting an attachment that has not been virus checked redirects to the placeholder page' do
     attachment_data = create(:attachment_data)
-    visible_edition = create( :published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
+    visible_edition = create(:published_publication, :with_attachment, attachments: [create(:attachment, attachment_data: attachment_data)])
 
     get_show attachment_data
 
     assert_redirected_to placeholder_url
+  end
+
+  test "requesting an attachment on an unpublished edition redirects to the edition's unpublishing page" do
+    unpublished_edition = create(:draft_publication, :unpublished, :with_attachment)
+    attachment_data = unpublished_edition.attachments.first.attachment_data
+
+    get_show attachment_data
+
+    assert_redirected_to publication_url(unpublished_edition.unpublishing.slug)
   end
 
   private

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class AttachmentVisibilityTest < ActiveSupport::TestCase
+
+  test '#visible? returns true when attachment data is associated with a published edition' do
+    edition = create(:published_publication, :with_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    assert attachment_visibility.visible?
+    assert_nil attachment_visibility.unpublished_edition
+  end
+
+  test '#visible? returns false when edition is unpublished' do
+    edition = create(:draft_publication, :with_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    refute attachment_visibility.visible?
+  end
+
+  test '#visible? returns true when attachment is associated with a corporate info page' do
+    info_page = create(:corporate_information_page, :with_alternative_format_provider)
+    info_page.attachments << create(:attachment)
+    attachment_data = info_page.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    assert attachment_visibility.visible?
+  end
+
+  test '#visible? returns true when attachment is associated with a response on a published consultation' do
+    response = create(:consultation_with_outcome).outcome
+    response.attachments << create(:attachment)
+    attachment_data = response.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    assert attachment_visibility.visible?
+  end
+
+  test '#unpublished_edition returns the edition for an attachment associated with an unpublished edition' do
+    unpublished_edition = create(:draft_publication, :unpublished, :with_attachment)
+    attachment_data = unpublished_edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    refute attachment_visibility.visible?
+    assert_equal unpublished_edition, attachment_visibility.unpublished_edition
+  end
+
+  test '#unpublished_edition returns the edition, even if it is deleted' do
+    unpublished_edition = create(:deleted_publication, :unpublished, :with_attachment)
+    attachment_data = unpublished_edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data,nil)
+
+    refute attachment_visibility.visible?
+    assert_equal unpublished_edition, attachment_visibility.unpublished_edition
+  end
+end


### PR DESCRIPTION
Instead of showing the placeholder page for attachments on unpublished editions, we redirect to the unpublished edition's old slug, which will render the unpublishing information to the user.

https://www.pivotaltracker.com/story/show/52377493
