### PR TITLE
Clarify label of alternative format email address input field

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -89,7 +89,7 @@ module Admin::EditionsHelper
           selected: object.alternative_format_provider_id,
           disabled: organisations_for_edition_organisations_fields.reject { |o| o.alternative_format_contact_email.present? }.map(&:id))
         @template.content_tag(:div, class: 'control-group') do
-          label(:alternative_format_provider_id, "Email address for ordering this #{object.format_name} in an alternative format", required: alternative_format_required) +
+          label(:alternative_format_provider_id, "Email address for ordering attached files in an alternative format", required: alternative_format_required) +
             @template.content_tag(:div, class: 'controls') do
               select(
                 :alternative_format_provider_id,

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -18,7 +18,7 @@
     <%= organisation_form.text_field :url %>
     <%= organisation_form.label :organisation_type_id, "Organisation type" %>
     <%= organisation_form.select :organisation_type_id, options_from_collection_for_select(OrganisationType.in_listing_order, "id", "name", organisation.organisation_type_id), {include_blank: true}, class: 'chzn-select', data: { placeholder: "Choose the organisation type..." } %>
-    <%= organisation_form.text_field :alternative_format_contact_email, label_text: "Email address for ordering publications or consultations in alternative formats" %>
+    <%= organisation_form.text_field :alternative_format_contact_email, label_text: "Email address for ordering attached files in an alternative format" %>
     <%= organisation_form.label :govuk_status, "Status on gov.uk" %>
     <%= organisation_form.select :govuk_status, [["Currently live", "live"], ["Coming soon", "joining"], ["Exempt from joining", "exempt"], ["Currently transitioning", "transitioning"]], {}, class: 'chzn-select' %>
   </fieldset>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -17,7 +17,7 @@
           <tr><th>URL</th><td><%= link_to @organisation.url, @organisation.url %></td></tr>
           <tr><th>gov.uk status</th><td><%= @organisation.govuk_status.titleize %></td></tr>
           <tr><th>Description</th><td><%= govspeak_to_html @organisation.description %></td></tr>
-          <tr><th>Email address for ordering publications or consultations in alternative formats</th><td><%= @organisation.alternative_format_contact_email %></td></tr>
+          <tr><th>Email address for ordering attached files in an alternative format</th><td><%= @organisation.alternative_format_contact_email %></td></tr>
           <tr><th>Sponsoring organisations</th><td>
             <% if @organisation.parent_organisations.any? %>
               <%= @organisation.parent_organisations.map {|o| link_to(o.name, [:admin, o]) }.to_sentence.html_safe %>


### PR DESCRIPTION
- Changed for edition editing - applied to all editions and not just
  "news" and "detailed guide" that are mentioned in the story.
- Changed for organisation show & form in admin

https://www.pivotaltracker.com/story/show/45974277
