### PR TITLE
Fix report a problem margin on mobile

### DIFF
--- a/app/assets/stylesheets/frontend/views/_layouts.scss
+++ b/app/assets/stylesheets/frontend/views/_layouts.scss
@@ -21,8 +21,11 @@
 
 p.report-a-problem-toggle {
   clear: both;
-  margin: $gutter;
+  margin: $gutter-half;
   direction: ltr;
+  @include media(tablet){
+    margin: $gutter;
+  }
 
   a {
     color: $secondary-text-colour;


### PR DESCRIPTION
This isn't intentional, right? The report a problem link sits in the middle of the page on two lines on mobile.
