### PR TITLE
Losen validation of house of commons number

### DIFF
--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -61,7 +61,7 @@ class AttachmentValidator < ActiveModel::Validator
 
   def check_format_of_hoc_paper_number(attachment)
     number = attachment.hoc_paper_number
-    if number.present? && (number !~ /^\d{4}/)
+    if number.present? && (number !~ /^\d/)
       attachment.errors[:hoc_paper_number] << 'must start with a number'
     end
   end

--- a/test/unit/attachment_validator_test.rb
+++ b/test/unit/attachment_validator_test.rb
@@ -35,9 +35,11 @@ class AttachmentValidatorTest < ActiveSupport::TestCase
   end
 
   test 'house of commons paper numbers starting with an integer are valid' do
-    attachment = build(:attachment, hoc_paper_number: '1234-i')
-    @validator.validate(attachment)
-    assert attachment.errors[:hoc_paper_number].empty?, 'expected no error'
+    %w(1 12 1234-i).each do |valid_hoc_number|
+      attachment = build(:attachment, hoc_paper_number: valid_hoc_number)
+      @validator.validate(attachment)
+      assert attachment.errors[:hoc_paper_number].empty?, "Expected no error with house of commons number: '#{valid_hoc_number}'"
+    end
   end
 
   test 'house of commons papers cannot have a number while unnumbered' do


### PR DESCRIPTION
As long as they start with a digit, they should be valid.

https://www.pivotaltracker.com/story/show/49849655
