### PR TITLE
Only cache edition show page 404s for 5 minutes

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -33,6 +33,7 @@ class DocumentsController < PublicFacingController
           render :unpublished
         end
       else
+        expires_in 5.minutes, public: true
         render text: "Not found", status: :not_found
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/46200225

Rationale: 404s are cheap to serve, there are low number of 404s (only 10k/day) and this will increase misses by only 22%. 

Analysis of effect of changing cache times:

https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1EDfC55ytBF7SdNgTDXoENTKBFFrgTCLTRsV8KcWcgIE/edit#heading=h.fvr0n4f7domo
