### PR TITLE
Fix 'Save & Convert to Draft & Next' button

### DIFF
--- a/app/assets/javascripts/admin/speed_tagging.js
+++ b/app/assets/javascripts/admin/speed_tagging.js
@@ -1,7 +1,0 @@
-(function($) {
-  $(function() {
-    $("input#js-speed-convert").on("click", function(){
-      $('#speed_save_convert')[0].value=1;
-    });
-  })
-})(jQuery);

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -102,7 +102,6 @@
     <% end %>
 
     <%= submit_tag "Save", class: 'btn btn-primary' %>
-    <%= hidden_field_tag 'speed_save_convert', '' %>
-    <%= submit_tag "Save & Convert to Draft & Next", class: 'btn btn-success', id: "js-speed-convert" %>
+    <%= submit_tag "Save & Convert to Draft & Next", class: 'btn btn-success', id: "js-speed-convert", name: "speed_save_convert" %>
   <% end %>
 </div>


### PR DESCRIPTION
The javascript was not working as it was clobbered by the
double_click_protection.js. However it's not needed, we just need to set
the button name.

https://www.pivotaltracker.com/story/show/54183504
