### PR TITLE
Display publication summary across top of page

### DIFF
--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -129,13 +129,13 @@ nav.consultations_scope {
       }
     }
 
-    .summary {
+    .consultation-summary {
       @include media(tablet) {
         float: left;
         margin-top: 0;
         width: 66.66%;
       }
-      .summary-inner {
+      .consultation-summary-inner {
         border-top: 1px solid $white;
         padding-top: $gutter-half;
         margin-top: -$gutter-half + 1px;

--- a/app/assets/stylesheets/frontend/views/_new-document-page.scss
+++ b/app/assets/stylesheets/frontend/views/_new-document-page.scss
@@ -21,7 +21,7 @@
   }
 
   .summary {
-    margin-top: $gutter;
+    padding-bottom: $gutter + $gutter-half;
 
     p {
       @include ig-core-24;
@@ -29,7 +29,7 @@
   }
 
   .sidebar {
-    padding-top: $gutter+$gutter-one-third;
+    padding-top: $gutter-one-third;
 
     p {
       @include ig-core-16;
@@ -37,7 +37,7 @@
   }
 
   .document {
-    padding: $gutter 0;
+    padding-bottom: $gutter;
   }
 
   .meta {

--- a/app/assets/stylesheets/frontend/views/_statistical-data-sets.scss
+++ b/app/assets/stylesheets/frontend/views/_statistical-data-sets.scss
@@ -24,9 +24,4 @@
       }
     }
   }
-
-  .summary {
-    margin-bottom: $gutter;
-  }
-
 }

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -31,8 +31,8 @@
           <div class="consultation-dates">
             <p>This consultation closes on <span><%= absolute_date(@document.closing_on, class: 'closing-on') %></span></p>
           </div>
-          <div class="summary">
-            <div class="summary-inner">
+          <div class="consultation-summary">
+            <div class="consultation-summary-inner">
               <h2>Summary</h2>
               <p><%= @document.summary %></p>
               <% if @document.external? %>

--- a/app/views/documents/_attachment_full_width.html.erb
+++ b/app/views/documents/_attachment_full_width.html.erb
@@ -1,7 +1,6 @@
 <%
   attachments = AttachmentsPresenter.new(document)
   title = t('document.headings.attachments', count: attachments.length) unless local_assigns.include?(:title)
-  summary = document.summary unless local_assigns.include?(:summary)
   published_on = '' unless local_assigns.include?(:published_on)
 %>
 <section class="heading-block attachment-full-width">
@@ -10,27 +9,16 @@
     <div class="content">
       <article>
         <div class="govspeak">
-          <div class="first-attachment">
+          <% attachments.attachments.each do |attachment| %>
             <%= render partial: "documents/attachment",
-                      object: attachments.first,
-                      locals: { alternative_format_contact_email: document.alternative_format_contact_email,
-                        extra_description: summary,
+                      object: attachment,
+                      locals: {
+                        hide_thumbnail: false,
+                        alternative_format_contact_email: document.alternative_format_contact_email,
                         published_on: published_on } %>
-          </div>
-          <% if attachments.more_than_one? %>
-            <div class="attachment-without-thumbnail">
-              <% attachments.remaining.each do |attachment| %>
-                <%= render partial: "documents/attachment",
-                            object: attachment,
-                            locals: { hide_thumbnail: false,
-                                      alternative_format_contact_email: document.alternative_format_contact_email } %>
-              <% end %>
-            </div>
           <% end %>
         </div>
       </article>
     </div>
-  <% else %>
-    <p class="extra-description summary"><%= summary %></p>
   <% end %>
 </section>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -12,6 +12,12 @@
     </div>
   </header>
 
+  <div class="block-2 ">
+    <div class="inner-block">
+      <%= render partial: "document_summary", locals: { document: @document } %>
+    </div>
+  </div>
+
   <div class="block-2">
     <div class="inner-block">
       <%= render partial: "documents/attachment_full_width",

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -39,7 +39,7 @@ class PublicationsControllerTest < ActionController::TestCase
     publication = create(:published_publication, summary: 'plain text & so on')
     get :show, id: publication.document
 
-    assert_select ".extra-description", text: "plain text &amp; so on"
+    assert_select ".document-page .summary", text: "plain text &amp; so on"
   end
 
   view_test "show renders the publication body using govspeak" do


### PR DESCRIPTION
Previously this was included in the first attachment for historial
reasons when there was only a single attachment.

https://www.pivotaltracker.com/story/show/54496974
