### PR TITLE
Stop organisations in meta footer clashing IDs

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -137,7 +137,7 @@ module OrganisationHelper
     link_to 'See all our policies', url
   end
 
-  def organisations_link_array(lead_organisations, organisations)
+  def organisations_link_array(lead_organisations, organisations, prefix = nil)
     all_organisations = []
     lead_organisations.map do |o|
       all_organisations << { organisation: o, lead: true }
@@ -147,7 +147,7 @@ module OrganisationHelper
     end
 
     all_organisations.map do |o|
-      content_tag_for :span, o[:organisation], ({class: "lead"} if o[:lead]) do
+      content_tag_for :span, o[:organisation], prefix, ({class: "lead"} if o[:lead]) do
         link_to o[:organisation].name, o[:organisation]
       end
     end

--- a/app/views/documents/_document_footer_meta.html.erb
+++ b/app/views/documents/_document_footer_meta.html.erb
@@ -36,7 +36,7 @@
     <dl class="primary-metadata">
       <% if document.organisations.any?  %>
         <dt><%= t('document.headings.organisations', count: document.organisations.length) %>:</dt>
-        <% organisations_link_array(document.lead_organisations, document.sorted_organisations).each do |item| %>
+        <% organisations_link_array(document.lead_organisations, document.sorted_organisations, :footer).each do |item| %>
           <dd><%= item.html_safe %></dd>
         <% end %>
       <% end %>
@@ -51,4 +51,3 @@
     </dl>
   </div>
 </div>
-


### PR DESCRIPTION
Because we use `content_tag_for`, the IDs are automatically generated. We can work around this using the [prefix argument](http://api.rubyonrails.org/classes/ActionView/Helpers/RecordTagHelper.html#method-i-content_tag_for), but that should only be overridden in the template, since the helpers won't know how to do this correctly.

The problem this causes is that there are two things with IDs of `organisation_1234` on the publications page, as the organisation is shown more than once.
