### PR TITLE
Close unclosed div tag in Policy view

### DIFF
--- a/app/views/policies/show.html.erb
+++ b/app/views/policies/show.html.erb
@@ -38,4 +38,5 @@
     <div class="inner-block">
       <%= render partial: 'documents/document_footer_meta', locals: { document: @document, policies: @related_policies } %>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
This is purely to remove the warnings that were generated. The small tab spacing made the missing close div essentially invisible.
