### PR TITLE
Remove pry from development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ group :development, :test do
   gem 'parallel_tests'
   gem 'bullet'
   gem 'test-queue'
-  gem 'pry-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
     chronic (0.6.7)
     ci_reporter (1.8.4)
       builder (>= 2.1.2)
-    coderay (1.0.9)
     crack (0.4.0)
       safe_yaml (~> 0.9.0)
     cucumber (1.3.2)
@@ -173,7 +172,6 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.1)
-    method_source (0.8.1)
     mime-types (1.23)
     mini_magick (3.6.0)
       subexec (~> 0.2.1)
@@ -214,12 +212,6 @@ GEM
       faye-websocket (>= 0.4.4, < 0.5.0)
       http_parser.rb (~> 0.5.3)
     polyglot (0.3.3)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-    pry-rails (0.3.1)
-      pry (>= 0.9.10)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
     rabl (0.8.5)
@@ -373,7 +365,6 @@ DEPENDENCIES
   parallel_tests
   plek (= 1.1.0)
   poltergeist (~> 1.3.0)
-  pry-rails
   quiet_assets
   rabl
   rack-test!


### PR DESCRIPTION
allow people to use their prefered debugger
