### PR TITLE
speed up spot checking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'link_header'
 gem 'diffy'
 gem 'logstasher', '0.2.5'
 gem 'slop', '3.4.5'
+gem 'chronic'
 
 group :assets do
   gem 'govuk_frontend_toolkit', '0.34.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ DEPENDENCIES
   bullet
   capybara (~> 2.1.0)
   carrierwave (= 0.8.0)
+  chronic
   ci_reporter
   cucumber (~> 1.3.2)
   cucumber-rails (~> 1.3.1)

--- a/app/assets/javascripts/admin/date_filters.js
+++ b/app/assets/javascripts/admin/date_filters.js
@@ -1,0 +1,10 @@
+(function($) {
+  $(function() {
+    $(".date-filter input[type=submit]").hide();
+    $(".date-filter .date").keypress(function(e) {
+      if(e.which == 13) {
+        $(".date-filter form").submit();
+      };
+    })
+  })
+})(jQuery);

--- a/app/assets/javascripts/admin/edition_kind_filter.js
+++ b/app/assets/javascripts/admin/edition_kind_filter.js
@@ -1,0 +1,8 @@
+(function($) {
+  $(function() {
+    $(".edition-kind-filter input[type=submit]").hide();
+    $(".edition-kind-filter select").change(function() {
+      $(".edition-kind-filter form").submit();
+    })
+  })
+})(jQuery);

--- a/app/assets/stylesheets/admin/document_index.scss
+++ b/app/assets/stylesheets/admin/document_index.scss
@@ -4,6 +4,11 @@
     margin-top: 1em;
   }
 
+  .publishing-stats {
+    margin: 18px 0;
+    text-align: right;
+  }
+
   .author-filter, .organisation-filter, .world-location-filter {
     form {
       margin: 0 -15px;

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,7 +3,7 @@ class Admin::DashboardController < Admin::BaseController
   def index
     if current_user.organisation
       @draft_documents = Edition.authored_by(current_user).where(state: 'draft').includes(:translations, :versions).in_reverse_chronological_order
-      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(20)
+      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5)
     end
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -273,7 +273,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def params_filters
-    sanitized_filters(params.slice(:type, :state, :organisation, :author, :page, :title, :world_location_ids))
+    sanitized_filters(params.slice(:type, :state, :organisation, :author, :page, :title, :world_location_ids, :from_date, :to_date))
   end
 
   def params_filters_with_default_state
@@ -287,7 +287,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def filter
-    @filter ||= params_filters.any? && Admin::EditionFilter.new(edition_class, current_user, params_filters_with_default_state)
+    @filter ||= Admin::EditionFilter.new(edition_class, current_user, params_filters_with_default_state) if params_filters.any?
   end
 
   def detect_other_active_editors

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -81,6 +81,7 @@ module Admin::EditionActionsHelper
     button_to 'Unpublish', confirm_unpublish_admin_edition_path(edition), title: "Unpublish", class: "btn btn-danger", method: :get
   end
 
+  # If adding new models also update filter_options_for_edition
   def document_creation_dropdown
     content_tag(:ul, class: "more-nav left") do
       [Policy, Publication, NewsArticle, FatalityNotice,
@@ -91,6 +92,32 @@ module Admin::EditionActionsHelper
         end if can?(:create, edition_type)
       end.compact.join.html_safe
     end
+  end
+
+  def filter_options_for_edition(user)
+    options = []
+    [
+      Policy,
+      Publication,
+      NewsArticle,
+      Consultation,
+      Speech,
+      DetailedGuide,
+      WorldwidePriority,
+      WorldLocationNewsArticle,
+      CaseStudy,
+      StatisticalDataSet,
+      FatalityNotice
+    ].map do |e|
+      next if e == FatalityNotice && !user.can_handle_fatalities?
+      options << [e.model_name.human, e.model_name.underscore]
+      if e.respond_to?(:subtypes)
+        e.subtypes.map do |subtype|
+          options << ["&nbsp;&nbsp;#{subtype.plural_name}".html_safe, "#{e.model_name.underscore}_subtype_#{subtype.plural_name}"]
+        end
+      end
+    end
+    options
   end
 
   private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -464,12 +464,27 @@ class Edition < ActiveRecord::Base
       end
     end
 
+    # used by Admin::EditionFilter
     def by_type(type)
       where(type: type)
     end
 
+    # used by Admin::EditionFilter
+    def by_subtype(type, plural_name)
+      type.constantize.by_subtype_plural_name(plural_name)
+    end
+
+    # used by Admin::EditionFilter
     def in_world_location(world_location)
       joins(:world_locations).where('world_locations.id' => world_location)
+    end
+
+    def from_date(date)
+      where("editions.updated_at >= ?", date)
+    end
+
+    def to_date(date)
+      where("editions.updated_at <= ?", date)
     end
 
     def related_to(edition)

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -10,6 +10,15 @@ class NewsArticle < Newsesque
   validates :news_article_type_id, presence: true
   validate :only_news_article_allowed_invalid_data_can_be_awaiting_type
 
+  def self.subtypes
+    NewsArticleType.all
+  end
+
+  def self.by_subtype_plural_name(plural_name)
+    subtype = NewsArticleType.find_by_plural_name(plural_name)
+    where(news_article_type_id: subtype.id) if subtype
+  end
+
   def news_article_type
     NewsArticleType.find_by_id(news_article_type_id)
   end

--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -12,7 +12,11 @@ class NewsArticleType
   end
 
   def self.find_by_slug(slug)
-    all.detect { |pt| pt.slug == slug }
+    all.detect { |type| type.slug == slug }
+  end
+
+  def self.find_by_plural_name(plural_name)
+    all.detect { |type| type.plural_name == plural_name }
   end
 
   def self.all_slugs
@@ -20,7 +24,7 @@ class NewsArticleType
   end
 
   def self.by_prevalence
-    all.group_by { |pt| pt.prevalence }
+    all.group_by { |type| type.prevalence }
   end
 
   def self.ordered_by_prevalence

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -17,6 +17,15 @@ class Publication < Publicationesque
 
   after_update { |p| p.published_related_policies.each(&:update_published_related_publication_count) }
 
+  def self.subtypes
+    PublicationType.all
+  end
+
+  def self.by_subtype_plural_name(plural_name)
+    subtype = PublicationType.find_by_plural_name(plural_name)
+    where(publication_type_id: subtype.id) if subtype
+  end
+
   def self.not_statistics
     where("publication_type_id NOT IN (?)", PublicationType.statistical.map(&:id))
   end

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -7,20 +7,12 @@ class PublicationType
 
   attr_accessor :id, :singular_name, :plural_name, :prevalence, :access_limited_by_default, :key
 
-  def slug
-    plural_name.downcase.gsub(/[^a-z]+/, "-")
-  end
-
-  def access_limited_by_default?
-    !! self.access_limited_by_default
-  end
-
   def self.access_limitable
     all.select(&:access_limited_by_default?)
   end
 
   def self.by_prevalence
-    all.group_by { |pt| pt.prevalence }
+    all.group_by { |type| type.prevalence }
   end
 
   def self.ordered_by_prevalence
@@ -28,7 +20,11 @@ class PublicationType
   end
 
   def self.find_by_slug(slug)
-    all.detect { |pt| pt.slug == slug }
+    all.detect { |type| type.slug == slug }
+  end
+
+  def self.find_by_plural_name(plural_name)
+    all.detect { |type| type.plural_name == plural_name }
   end
 
   def self.primary
@@ -49,6 +45,14 @@ class PublicationType
 
   def self.statistical
     [Statistics, NationalStatistics]
+  end
+
+  def slug
+    plural_name.downcase.gsub(/[^a-z]+/, "-")
+  end
+
+  def access_limited_by_default?
+    !! self.access_limited_by_default
   end
 
   def search_format_types

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -13,6 +13,15 @@ class Speech < Announcement
   delegate :display_type_key, :explanation, to: :speech_type
   validate :only_speeches_allowed_invalid_data_can_be_awaiting_type
 
+  def self.subtypes
+    SpeechType.all
+  end
+
+  def self.by_subtype_plural_name(plural_name)
+    subtype = SpeechType.find_by_plural_name(plural_name)
+    where(speech_type_id: subtype.id) if subtype
+  end
+
   def search_format_types
     super + [Speech.search_format_type] + speech_type.search_format_types
   end
@@ -22,7 +31,7 @@ class Speech < Announcement
   end
 
   def speech_type=(speech_type)
-    self.speech_type_id = speech_type && speech_type.id
+    self.speech_type_id = speech_type.id if speech_type
   end
 
   def display_type

--- a/app/models/speech_type.rb
+++ b/app/models/speech_type.rb
@@ -1,7 +1,7 @@
 class SpeechType
   include ActiveRecordLikeInterface
 
-  attr_accessor :id, :name, :genus_key, :explanation, :key, :owner_key_group, :published_externally_key, :location_relevant
+  attr_accessor :id, :name, :plural_name, :genus_key, :explanation, :key, :owner_key_group, :published_externally_key, :location_relevant
 
   def self.create(attributes)
     super({
@@ -20,7 +20,11 @@ class SpeechType
   end
 
   def self.find_by_name(name)
-    all.detect { |pt| pt.name == name }
+    all.detect { |type| type.name == name }
+  end
+
+  def self.find_by_plural_name(plural_name)
+    all.detect { |type| type.plural_name == plural_name }
   end
 
   def self.find_by_slug(slug)
@@ -51,33 +55,39 @@ class SpeechType
 
   Transcript = create(
     id: 1, name: "Transcript", genus_key: "speech", key: "transcript",
-    explanation: "This is a transcript of the speech, exactly as it was delivered."
+    explanation: "This is a transcript of the speech, exactly as it was delivered.",
+    plural_name: "Transcripts"
   )
 
   DraftText = create(
     id: 2, name: "Draft text", genus_key: "speech", key: "draft_text",
-    explanation: "This is the text of the speech as drafted, which may differ slightly from the delivered version."
+    explanation: "This is the text of the speech as drafted, which may differ slightly from the delivered version.",
+    plural_name: "Draft texts"
   )
 
   SpeakingNotes = create(
     id: 3, name: "Speaking notes", genus_key: "speech", key: "speaking_notes",
-    explanation: "These are the speaker's notes, not a transcript of the speech as it was delivered."
+    explanation: "These are the speaker's notes, not a transcript of the speech as it was delivered.",
+    plural_name: "Speaking notes"
   )
 
   WrittenStatement = create(
-    id: 4, key: "written_statement", name: "Written statement to Parliament"
+    id: 4, key: "written_statement", name: "Written statement to Parliament",
+    plural_name: "Written statements to Parliament"
   )
 
   OralStatement = create(
-    id: 5, key: "oral_statement", name: "Oral statement to Parliament"
+    id: 5, key: "oral_statement", name: "Oral statement to Parliament",
+    plural_name: "Oral statements to Parliament"
   )
 
   AuthoredArticle = create(
     id: 6, key: "authored_article", name: "Authored article",
-    owner_key_group: "author_title", published_externally_key: "written_on", location_relevant: false
+    owner_key_group: "author_title", published_externally_key: "written_on", location_relevant: false,
+    plural_name: "Authored article"
   )
 
   ImportedAwaitingType = create(
-    id: 1000, key: "imported", name: "Imported - Awaiting Type"
+    id: 1000, key: "imported", name: "Imported - Awaiting Type", plural_name: "Imported"
   )
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -35,6 +35,7 @@
     <div class="span6 force-published-documents">
       <h2><%= current_user.organisation.acronym %>'s force-published documents</h2>
       <%= render partial: 'document_table', locals: { documents: @force_published_documents, title: 'force published documents' } %>
+      <p><%= link_to "See all", admin_editions_path(state: :force_published, organisation: current_user.organisation) %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <%
-  filter_by ||= [:title, :author, :world_location, :type, :state]
+  filter_by ||= [:title, :author, :world_location, :type, :state, :date]
 %>
 <nav class="well" style="padding: 8px 0;">
   <ul class="nav nav-list">
@@ -7,7 +7,7 @@
       <li class="nav-header">Filter by Title or Slug</li>
       <li>
         <%= form_tag("", method: :get, class: "pull-left") do %>
-          <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :type, :state, :author, :world_location_ids) %>
+          <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :type, :state, :author, :world_location_ids, :from_date, :to_date) %>
           <input type="search" id="search_title" name="title" value="<%= @filter.options[:title] %>" placeholder="Search title">
         <% end %>
       </li>
@@ -21,7 +21,7 @@
       <li class="organisation-filter <%= active_filter_unless_values_match_class(@filter, :organisation, current_user.organisation_id) %>">
         <%= form_tag("", method: :get) do %>
           <%= select_tag :organisation, options_from_collection_for_select(Organisation.with_translations(:en).all - [current_user.organisation], 'id', 'select_name', @filter.options[:organisation]), class: 'chzn-select', include_blank: true, data: { placeholder: "Other organisations..." } %>
-          <%= pass_through_filter_options_as_hidden_fields(@filter, :type, :state, :world_location_ids) %>
+          <%= pass_through_filter_options_as_hidden_fields(@filter, :type, :state, :world_location_ids, :from_date, :to_date) %>
           <%= submit_tag "Go", class: "btn" %>
         <% end %>
       </li>
@@ -29,7 +29,7 @@
       <li class="author-filter <%= active_filter_unless_values_match_class(@filter, :author, current_user.id.to_s) %>">
         <%= form_tag("", method: :get) do %>
           <%= select_tag :author, options_from_collection_for_select(User.all - [current_user], 'id', 'name', @filter.options[:author]), class: 'chzn-select', include_blank: true, data: { placeholder: "Other authors..." } %>
-          <%= pass_through_filter_options_as_hidden_fields(@filter, :type, :state, :world_location_ids) %>
+          <%= pass_through_filter_options_as_hidden_fields(@filter, :type, :state, :world_location_ids, :from_date, :to_date) %>
           <%= submit_tag "Go", class: "btn" %>
         <% end %>
       </li>
@@ -48,7 +48,7 @@
                          multiple: true,
                          class: 'chzn-select',
                          data: { placeholder: "World locations..."} %>
-          <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :type, :state, :author) %>
+          <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :type, :state, :author, :from_date, :to_date) %>
           <%= submit_tag "Go", class: "btn" %>
         <% end %>
       </li>
@@ -57,19 +57,17 @@
     <% if filter_by.include?(:type) %>
       <li class="nav-header">Filter by Kind</li>
       <%= link_to_filter 'All', {locale: params[:locale], type: nil}, @filter, title: "Show all kinds of document" %>
-      <%= link_to_filter 'Policies', {locale: params[:locale], type: 'policy'}, @filter, title: "Show only policies" %>
-      <%= link_to_filter 'Publications', {locale: params[:locale], type: 'publication'}, @filter, title: "Show only publications" %>
-      <%= link_to_filter 'News articles', {locale: params[:locale], type: 'news_article'}, @filter, title: "Show only news articles" %>
-      <%= link_to_filter 'Consultations', {locale: params[:locale], type: 'consultation'}, @filter, title: "Show only consultations" %>
-      <%= link_to_filter 'Speeches', {locale: params[:locale], type: 'speech'}, @filter, title: "Show only speeches" %>
-      <%= link_to_filter 'Detailed guide', {locale: params[:locale], type: 'detailed_guide'}, @filter, title: "Show only detailed guides" %>
-      <%= link_to_filter 'Worldwide priorities', {locale: params[:locale], type: 'worldwide_priorities'}, @filter, title: "Show only worldwide priorities" %>
-      <%= link_to_filter 'World location news article', {locale: params[:locale], type: 'world_location_news_article'}, @filter, title: "Show only worldwide priorities" %>
-      <%= link_to_filter 'Case studies', {locale: params[:locale], type: 'case_studies'}, @filter, title: "Show only case studies" %>
-      <%= link_to_filter 'Statistical data sets', {locale: params[:locale], type: 'statistical_data_sets'}, @filter, title: "Show only statistical data sets" %>
-      <% if current_user.can_handle_fatalities? %>
-        <%= link_to_filter 'Fatality notices', {locale: params[:locale], type: 'fatality_notices'}, @filter, title: "Show only fatality notices" %>
-      <% end %>
+      <li class="edition-kind-filter">
+        <%= form_tag("", method: :get) do  %>
+          <%= select_tag :type,
+                          options_for_select(filter_options_for_edition(current_user), @filter.options[:type]),
+                          class: 'chzn-select',
+                          include_blank: true,
+                          data: { placeholder: "Kind..."} %>
+            <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :world_location_ids, :state, :author, :from_date, :to_date) %>
+            <%= submit_tag "Go", class: "btn" %>
+          <% end %>
+      </li>
     <% end %>
 
     <% if filter_by.include?(:state) %>
@@ -83,6 +81,20 @@
       <%= link_to_filter 'Scheduled', {locale: params[:locale], state: :scheduled}, @filter, title: "Show only scheduled #{document_type}" %>
       <%= link_to_filter 'Published', {locale: params[:locale], state: :published}, @filter, title: "Show only published #{document_type}" %>
       <%= link_to_filter 'Force Published <br/>(not reviewed)'.html_safe, {locale: params[:locale], state: :force_published}, @filter, title: "Show only force published #{document_type}" %>
+    <% end %>
+
+    <% if filter_by.include?(:date) %>
+      <li class="nav-header">Filter by date (last updated)</li>
+      <li class="date-filter">
+        <%= form_tag("", method: :get) do  %>
+          <%= label_tag :from_date, "From" %>
+          <%= text_field_tag :from_date, @filter.options[:from_date], class: 'date' %>
+          <%= label_tag :to_date, "To" %>
+          <%= text_field_tag :to_date, @filter.options[:to_date], class: 'date' %>
+          <%= pass_through_filter_options_as_hidden_fields(@filter, :organisation, :world_location_ids, :state, :author, :type) %>
+          <%= submit_tag "Go", class: "btn" %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </nav>

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -9,20 +9,23 @@
       <h1>
         <%= "#{@filter.page_title}" %>
       </h1>
-      <table class="table">
-        <tbody>
-          <tr>
-            <td>Documents</td>
-            <td><%= @filter.editions.total_count %></td>
-            <td>Published</td>
-            <td><%= @filter.published_count %></td>
-            <td>Force Published</td>
-            <td><%= @filter.force_published_count %></td>
-            <td><%= @filter.force_published_percentage %></td>
-          </tr>
-        </tbody>
-      </table>
-      <%= paginate @filter.editions, theme: 'twitter-bootstrap' %>
+      <div class="span7">
+        <%= paginate @filter.editions, theme: 'twitter-bootstrap' %>
+      </div>
+      <div class="span4">
+        <p class="publishing-stats">
+          <% if @filter.show_stats %>
+            Published
+            <span class="badge"><%= @filter.published_count %></span>
+            Force Published
+            <span class="badge badge-important"><%= @filter.force_published_count %></span>
+            <span class="badge badge-important"><%= @filter.force_published_percentage %>%</span>
+          <% else %>
+            Documents
+            <span class="badge"><%= @filter.editions.total_count %></span>
+          <% end %>
+        </p>
+      </div>
       <table class="table table-striped">
         <thead>
           <tr>
@@ -43,7 +46,7 @@
           <% end %>
           <% @filter.editions.each do |edition| %>
             <%= content_tag_for(:tr, edition, class: ('force_published' if edition.force_published?)) do %>
-              <td class="type"><%= edition.type.underscore.humanize %></td>
+              <td class="type"><%= edition.display_type %></td>
               <td class="title">
                 <span class="title"><%= link_to edition.title, admin_edition_path(edition), title: "View document #{edition.title}" %></span>
                 <% if edition.non_english_edition? %>

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -18,7 +18,7 @@ Scenario: Viewing only publications written by me
   And I visit the list of draft documents
 
   When I filter by author "Janice"
-  And I select the "publications" filter
+  And I select the "Publication" edition filter
   Then I should see the publication "Janice's Publication"
   And I should not see the policy "My Policy"
 

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -100,6 +100,13 @@ When /^I select the "([^"]*)" filter$/ do |filter|
   click_link filter
 end
 
+When /^I select the "([^"]*)" edition filter$/ do |filter|
+  within ".edition-kind-filter" do
+    select filter
+    click_button "Go"
+  end
+end
+
 When /^I filter by author "([^"]*)"$/ do |author_filter|
   within ".author-filter" do
     select author_filter

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -46,12 +46,13 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     policy = create(:draft_policy)
     publication = create(:draft_publication)
     stub_filter = stub_edition_filter(editions: [policy, publication])
+    stub_filter.stubs(:show_stats)
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
     get :index, state: :draft
 
     assert_select_object(policy) { assert_select ".type", text: "Policy" }
-    assert_select_object(publication) { assert_select ".type", text: "Publication" }
+    assert_select_object(publication) { assert_select ".type", text: "Policy paper" }
   end
 
   test "diffing against a previous version" do

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -73,11 +73,23 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [world_location_news_article], Admin::EditionFilter.new(Edition, @current_user, type: 'world_location_news_article').editions
   end
 
+  test "should filter by subtype of press releases" do
+    press_release = create(:news_article, news_article_type: NewsArticleType::PressRelease)
+    assert_equal [press_release], Admin::EditionFilter.new(Edition, @current_user, type: 'news_article_subtype_Press releases').editions
+  end
+
   test "should filter by title" do
     detailed = create(:policy, title: "Test mcTest")
     policy = create(:policy, title: "A policy")
 
     assert_equal [detailed], Admin::EditionFilter.new(Edition, @current_user, title: "test").editions
+  end
+
+  test "should filter by date" do
+    older_policy = create(:draft_policy, updated_at: 3.days.ago)
+    newer_policy = create(:draft_policy, updated_at: 1.minute.ago)
+
+    assert_equal [newer_policy], Admin::EditionFilter.new(Edition, @current_user, from_date: 2.days.ago.to_date.to_s(:short)).editions
   end
 
   test "should return the editions ordered by most recent first" do


### PR DESCRIPTION
Adds filtering by publication sub types and dates. We also display force publishing stats to aid spot checking.

Not too keen about passing the subtype filter option as string e.g. Press releases, instead of it's ID, but to change this would require refactoring more of the admin filter, as the name is also used for display purposes, and could slow it down doing more lookups.

https://www.pivotaltracker.com/story/show/53339299

Also contains fixes for https://www.pivotaltracker.com/story/show/51968687
