### PR TITLE
Use public_timestamp for consultation email notifications

### DIFF
--- a/lib/whitehall/gov_uk_delivery/notifier.rb
+++ b/lib/whitehall/gov_uk_delivery/notifier.rb
@@ -32,7 +32,7 @@ class Whitehall::GovUkDelivery::Notifier
 
   def notification_date
     case edition
-    when Speech, Consultation
+    when Speech
       edition.major_change_published_at
     else
       edition.public_timestamp

--- a/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
@@ -68,13 +68,6 @@ class Whitehall::GovUkDelivery::NotifierTest < ActiveSupport::TestCase
     assert_equal notification_date_for(speech), Time.zone.parse('2011-01-01 12:13:14')
   end
 
-  test "#notification_date uses the major_change_published_at for the notification_date of consultations" do
-    consultation = create(:consultation)
-    consultation.major_change_published_at = Time.zone.parse('2011-01-01 12:13:14')
-    consultation.public_timestamp = Time.zone.parse('2010-12-31 12:13:14')
-    assert_equal notification_date_for(consultation), Time.zone.parse('2011-01-01 12:13:14')
-  end
-
   test "#notification_date uses the public_timestamp for the notification_date of other editions" do
     policy = create(:policy)
     policy.major_change_published_at = Time.zone.parse('2011-01-01 12:13:14')


### PR DESCRIPTION
For a new consultation the public_timestamp will be set to the
opening_on date of the consultation. I think that when this notifier
code was written, that was not the case, which is why there was a special
exception for consultations in the code. However, it's not needed any
more.

This means that when adding a consultation to gov.uk, if the opening_on
date is in the past then no notification will go out.

For a major change to a consultation, the public_timestamp will be set
to the major change date, and so all major changes will cause an email
notification and cause the document to appear at the top of
chronological lists. This is the desired behaviour.

https://www.pivotaltracker.com/story/show/55288280
- [x] Waiting for travis to run tests
