### PR TITLE
All-document-mappings file now excludes non-valid "open" attachments

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -101,7 +101,9 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
       attachment_url = attachment_source.attachment ? host_name + attachment_source.attachment.url : ""
       status = (attachment_url.blank? ? '' : '301')
       state = (attachment_url.blank? ? 'Open' : 'Closed')
-      target << [attachment_source.url, attachment_url, status, '', '', '', state]
+      if state == 'Closed' 
+        target << [attachment_source.url, attachment_url, status, '', '', '', state]
+      end
     end
 
     SupportingPage.find_each do |page|


### PR DESCRIPTION
A change to the redirector-generation script to remove the enforced precedence of 301 over 410 exposed the inclusion of now-invalid, but previously imported attachments in the all document mappings file.    https://www.pivotaltracker.com/story/show/55377246
