### PR TITLE
49121005 - make publications with no attachment invalid

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -14,6 +14,7 @@ class Publication < Publicationesque
   validates :publication_date, recent_date: true, unless: ->(edition) { edition.can_have_some_invalid_data? }
   validates :publication_type_id, presence: true
   validate :only_publications_allowed_invalid_data_can_be_awaiting_type
+  validate :must_have_attachment, if: :published?
 
   after_update { |p| p.published_related_policies.each(&:update_published_related_publication_count) }
 
@@ -100,6 +101,14 @@ class Publication < Publicationesque
 
   def translatable?
     !non_english_edition?
+  end
+
+  def must_have_attachment
+    errors.add(:base, "Must have an attachment") unless attachment_present?
+  end
+
+  def attachment_present?
+    !attachments.empty? || html_version.present?
   end
 
   private

--- a/features/step_definitions/force_publishing_imports_steps.rb
+++ b/features/step_definitions/force_publishing_imports_steps.rb
@@ -10,9 +10,9 @@ end
 Given /^I have imported a file that succeeded$/ do
   organisation = create(:organisation)
   data = %Q{
-old_url,title,summary,body,organisation,policy_1,publication_type,document_series_1,publication_date,order_url,price,isbn,urn,command_paper_number,ignore_1,attachment_1_url,attachment_1_title,country_1
-http://example.com/1,title-1,a-summary,a-body,,,,,14-Dec-2011,,,,,,,,,
-http://example.com/2,title-2,a-summary,a-body,,,,,14-Dec-2011,,,,,,,,,
+old_url,title,summary,body,organisation,policy_1,publication_type,document_series_1,publication_date,order_url,price,isbn,urn,command_paper_number,ignore_1,html_title,html_body,attachment_1_url,attachment_1_title,country_1
+http://example.com/1,title-1,a-summary,a-body,,,,,14-Dec-2011,,,,,,,html-title-A,html-body-A,,,
+http://example.com/2,title-2,a-summary,a-body,,,,,14-Dec-2011,,,,,,,html-title-B,html-body-B,,,
     }.strip
   @force_publish_import = import_data_as_document_type_for_organisation(data, 'Publication', organisation)
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -114,6 +114,8 @@ module DocumentHelper
   def fill_in_publication_fields
     select_date "2010-01-01", from: "Publication date"
     select "Research and analysis", from: "edition_publication_type_id"
+    fill_in "HTML version title", with: "HTML version title"
+    fill_in "HTML version text", with: "HTML version text"
   end
 
   def visit_edition_admin(title, scope = :scoped)

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     summary "publication-summary"
     publication_date { 10.days.ago.to_date }
     publication_type_id { PublicationType::PolicyPaper.id }
+    association :html_version, strategy: :build
 
     trait(:corporate) do
       publication_type_id { PublicationType::CorporateReport.id }
@@ -30,13 +31,8 @@ FactoryGirl.define do
       publication_type_id { PublicationType::PolicyPaper.id }
     end
 
-    trait(:with_html_version) do
-      html_version_attributes do
-        {
-          title: "title",
-          body: "body"
-        }
-      end
+    trait(:without_html_version) do
+      html_version nil
     end
 
     ignore do

--- a/test/functional/html_versions_controller_test.rb
+++ b/test/functional/html_versions_controller_test.rb
@@ -4,7 +4,7 @@ class HtmlVersionsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
   test "#show displays the HTML version of the publication" do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
 
     get :show, publication_id: publication.document, id: publication.html_version.slug
 
@@ -14,7 +14,7 @@ class HtmlVersionsControllerTest < ActionController::TestCase
   end
 
   test "#show displays the published edition of the version" do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
     draft = publication.create_draft(create(:user))
 
     get :show, publication_id: publication.document, id: publication.html_version.slug
@@ -23,7 +23,7 @@ class HtmlVersionsControllerTest < ActionController::TestCase
   end
 
   test "#show 404s if the slug is wrong" do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
     get :show, publication_id: publication.document, id: 'not-the-real-slug'
     assert_response :not_found
   end
@@ -35,7 +35,7 @@ class HtmlVersionsControllerTest < ActionController::TestCase
   end
 
   test "#show 404s if the publication hasn't been published yet" do
-    publication = create(:draft_publication, :with_html_version)
+    publication = create(:draft_publication)
     get :show, publication_id: publication.document, id: 'slug'
     assert_response :not_found
   end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -225,7 +225,8 @@ module AdminEditionControllerTestHelpers
       end
 
       test "should destroy html version when all fields are blank" do
-        edition = create("draft_#{edition_type}", :with_html_version)
+        edition = create("draft_#{edition_type}")
+        edition.html_version = build(:html_version)
         put :update, id: edition, edition: controller_attributes_for_instance(edition,
           html_version_attributes: {
             title: "", body: "", id: edition.html_version.id

--- a/test/unit/edition/html_version_test.rb
+++ b/test/unit/edition/html_version_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Edition::HtmlVersionTest < ActiveSupport::TestCase
   test 'has optional html version' do
-    publication = build(:publication)
+    publication = build(:publication, :without_html_version)
     refute publication.html_version.present?
 
     publication.html_version_attributes = {
@@ -15,14 +15,14 @@ class Edition::HtmlVersionTest < ActiveSupport::TestCase
   end
 
   test 'html version is destroyed if the publication is destroyed' do
-    publication = create(:publication, :with_html_version)
+    publication = create(:publication)
     html_version = publication.html_version
     publication.destroy
     refute HtmlVersion.find_by_id(html_version.id)
   end
 
   test 'html version is not saved if all blank' do
-    publication = build(:publication)
+    publication = build(:publication, :without_html_version)
     publication.html_version_attributes = {
       title: "",
       body: ""
@@ -42,7 +42,7 @@ class Edition::HtmlVersionTest < ActiveSupport::TestCase
   end
 
   test 'html version is copied over on republish' do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
     new_draft = publication.create_draft(create(:author))
 
     assert_equal publication.html_version.title, new_draft.html_version.title
@@ -53,9 +53,9 @@ class Edition::HtmlVersionTest < ActiveSupport::TestCase
     refute_equal 'new title', publication.reload.html_version.title
   end
 
-  test 'slugs are saved on new html versions for editions that previously didn\'t have one' do
+  test "slugs are saved on new html versions for editions that previously didn't have one" do
     editor = create(:gds_editor)
-    pub = create(:draft_publication, html_version: nil)
+    pub = create(:draft_publication, :without_html_version, :with_attachment)
     pub.publish_as(editor, force: true)
     draft = pub.create_draft(editor)
     draft.change_note = 'Added html version'

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -72,7 +72,7 @@ class DocumentHelperTest < ActionView::TestCase
   end
 
   test "should return HTML specific thumbnail for HTML attachments" do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
     attachments = AttachmentsPresenter.new(publication)
     assert_match /pub-cover-html\.png/, attachment_thumbnail(attachments.first)
   end

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -17,7 +17,7 @@ class PublicationTest < ActiveSupport::TestCase
   end
 
   test 'slug of html version does not change when we republish several times' do
-    publication = create(:published_publication, :with_html_version)
+    publication = create(:published_publication)
     initial_slug = publication.html_version.slug
 
     new_draft = draft_with_new_title(publication, 'Title changed once')
@@ -28,7 +28,9 @@ class PublicationTest < ActiveSupport::TestCase
   end
 
   test 'slug of html version changes whilst in draft' do
-    publication = create(:draft_publication, :with_html_version)
+    publication = build(:draft_publication)
+    publication.html_version.title = "title"
+    publication.save!
     assert_equal 'title', publication.html_version.slug
 
     publication.html_version.title = 'new title'
@@ -66,6 +68,12 @@ class PublicationTest < ActiveSupport::TestCase
       edition = build(:publication, state: state, publication_date: nil)
       refute edition.valid?
     end
+  end
+
+  test "shouldn't be able to publish a publication without any attachments" do
+    published_publication = create(:published_publication)
+    published_publication.html_version = nil
+    refute published_publication.valid?
   end
 
   test "should build a draft copy of the existing publication" do


### PR DESCRIPTION
Prevent publishing of publications without attachments
Allows either HTML or normal attachments.
- Adds a test to check the new behaviour.
- Fixes all the tests broken by the change to the publication factory (please check carefully).
- Removes the with_html_version trait from the publication factory as the factory now always adds an html version; I have done this cleanup to avoid confusion over a trait that has no obvious effect and to keep the codebase clean, I would appreciate validation that this is the correct thing to do.

https://www.pivotaltracker.com/story/show/49121005
