### PR TITLE
Align keys to the top of magna-charta barcharts.

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -130,7 +130,6 @@ module GovspeakHelper
        stacked,
        compact,
        negative,
-       '.left-key', 
        '.mc-auto-outdent',
        '}'
       ].join(' ')


### PR DESCRIPTION
Where keys are long the chart is covered by the key (this is a bug in
magna-charta when pages are narrow, but this is an easy fix for now).
