### PR TITLE
Cache associated objects used in filter result pages

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,9 @@ Whitehall::Application.configure do
 
   config.slimmer.asset_host = ENV['GOVUK_ASSET_ROOT'] || "https://static.preview.alphagov.co.uk"
 
+  # Disable cache in development
+  config.cache_store = :null_store
+
   config.after_initialize do
     Bullet.enable = true
     # Bullet.alert = true
@@ -40,7 +43,6 @@ Whitehall::Application.configure do
     Bullet.rails_logger = true
     # Bullet.airbrake = true
   end
-
 
   if ENV['SHOW_PRODUCTION_IMAGES']
     orig_host = config.asset_host

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,8 +44,8 @@ Whitehall::Application.configure do
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
 
-  # Use a different cache store in production
-  # config.cache_store = :mem_cache_store
+  # Use per-process in memory store in production
+  config.cache_store = :memory_cache, size: 32.megabytes
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   config.action_controller.asset_host = Whitehall.asset_host

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,9 @@ Whitehall::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
+  # Disable cache in test
+  config.cache_store = :null_store
+
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"

--- a/lib/whitehall/document_filter/result_set.rb
+++ b/lib/whitehall/document_filter/result_set.rb
@@ -3,25 +3,13 @@ module Whitehall::DocumentFilter
     def initialize(results, page, per_page)
       @results = results
       @docs = results.is_a?(Hash) ? results['results'] : []
-      @organisations = prefetch("organisations", Organisation.includes(:translations))
-      @topics = prefetch("topics", Classification.scoped)
-      @document_series = prefetch("document_series", DocumentSeries.scoped)
-      @operational_fields = prefetch("operational_field", OperationalField.scoped)
       @page = page
       @per_page = per_page
     end
 
-    def prefetch(field_name, association)
-      return [] if @docs.empty?
-      slugs = @docs.map { |doc| doc[field_name] }.flatten.uniq
-      association.where(slug: slugs).each_with_object({}) do |item, memo|
-        memo[item.slug] = item
-      end
-    end
-
     def merged_results
       @docs.map do |doc|
-        Result.new(doc, @organisations, @topics, @document_series, @operational_fields)
+        Result.new(doc)
       end
     end
 


### PR DESCRIPTION
We cache on a per-item basis for 30 minutes. The total space used is of
the order of 500-1000KB.

I've configured the in-memory cache for production which is a
per-process cache store.
