### PR TITLE
Fix schema.rb to reflect schema in production

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,9 +63,9 @@ ActiveRecord::Schema.define(:version => 20130823095707) do
     t.string   "order_url"
     t.integer  "price_in_pence"
     t.integer  "attachment_data_id"
+    t.integer  "ordering"
     t.string   "hoc_paper_number"
     t.string   "parliamentary_session"
-    t.integer  "ordering"
     t.boolean  "unnumbered_command_paper"
     t.boolean  "unnumbered_hoc_paper"
   end


### PR DESCRIPTION
Because code is merged and deployed out of sequence, migrations may get run out of order on preview/production. If a developer then runs migrations locally in order, we end up with a discrepancy between the local schema.rb and our production schema. This commit puts schema.rb back to the same state as our production database. If you're local database keeps moving this column in schema.rb, then the remedy is to pull down the latest dump from preview and not to commit this change. Your local database will then be in sync with production and schema.rb.
