### PR TITLE
Fix the spacing in the global header on devices

### DIFF
--- a/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
+++ b/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
@@ -16,8 +16,10 @@ body.js-enabled {
       color: $inside-gov-secondary;
     }
     #proposition-menu {
-      margin-top: $gutter+$gutter-one-sixth+2px;
-      // 37px is the amount of margin required to line up the nav list with the top of the search box after removing Inside Gov heading
+      @include media(desktop){
+        margin-top: $gutter+$gutter-one-sixth+2px;
+        // 37px is the amount of margin required to line up the nav list with the top of the search box after removing Inside Gov heading
+      }
     }
   }
   form#search input.submit {


### PR DESCRIPTION
Due to the way the extra spacing is added where the text used to be on
mobile it pushes the menu down to far. This removes that space.

![Header before and after](http://f.cl.ly/items/0r1X1P2p3s0Q1h2V2v15/Screen%20Shot%202013-08-29%20at%2015.03.01.png)
