### PR TITLE
Include rack-mini-profiler in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 
 group :development do
   gem 'newrelic_rpm'
+  gem 'rack-mini-profiler'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
       rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-mini-profiler (0.1.29)
+      rack (>= 1.1.3)
     rack-ssl (1.3.3)
       rack
     rails (3.2.14)
@@ -369,6 +371,7 @@ DEPENDENCIES
   plek (= 1.1.0)
   poltergeist (~> 1.3.0)
   quiet_assets
+  rack-mini-profiler
   rack-test!
   rails (= 3.2.14)
   rails-dev-boost


### PR DESCRIPTION
I find rack-mini-profiler has a far bigger impact on the performance of what I do than newrelic does. The RailsCast covers its features nicely, though I don't tend to bother with anything beyond inspecting the queries that ActiveRecord has been generating.

http://railscasts.com/episodes/368-miniprofiler?view=asciicast
