### PR TITLE
Add middleware to strip Client-IP headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'logstasher', '0.2.5'
 gem 'slop', '3.4.5'
 gem 'chronic'
 gem 'jbuilder'
+gem 'rack_strip_client_ip', '0.0.1'
 
 group :assets do
   gem 'govuk_frontend_toolkit', '0.34.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,7 @@ GEM
       rack (>= 1.1.3)
     rack-ssl (1.3.3)
       rack
+    rack_strip_client_ip (0.0.1)
     rails (3.2.14)
       actionmailer (= 3.2.14)
       actionpack (= 3.2.14)
@@ -373,6 +374,7 @@ DEPENDENCIES
   quiet_assets
   rack-mini-profiler
   rack-test!
+  rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.14)
   rails-dev-boost
   rails-i18n


### PR DESCRIPTION
`Client-IP` isn't required by our downstream servers as our web server layer is already setting `X-Forwarded-For` from the incoming TCP/IP connection. We get the client IP from this header.

However, some misconfigured routers (or indeed malicious users) will set `Client-IP` to an erroneous value, which causes Rails to blow up because of `ActionDispatch::RemoteIp::IpSpoofAttackError`.

This uses [alext/rack_strip_client_ip](https://github.com/alext/rack_strip_client_ip) by @alext to just remove the entire problematic header completely. This is best done within the Rails app itself as we're always fronted by a web-server layer in production, but only Rails suffers from this issue.
