### PR TITLE
Add web_url to worldwide org offices in API.

### DIFF
--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -57,6 +57,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       title: office_worldwide_organisation.contact.title,
       format: 'World Office',
       updated_at: office_worldwide_organisation.updated_at,
+      web_url: context.worldwide_organisation_worldwide_office_url(model, office_worldwide_organisation, host: context.public_host),
       details: {
         email: office_worldwide_organisation.contact.email || '',
         description: office_worldwide_organisation.contact.comments || '',

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -109,6 +109,11 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal 'office-title', @presenter.as_json[:offices][:main][:title]
   end
 
+  test 'json includes public office url in offices as web_url' do
+    Whitehall.stubs(:public_host_for).returns('govuk.example.com')
+    assert_equal worldwide_organisation_worldwide_office_url(@world_org, @office, host: 'govuk.example.com'), @presenter.as_json[:offices][:main][:web_url]
+  end
+
   test 'json includes office contact comments in offices as decscription' do
     @office.contact.stubs(:comments).returns('office-comments')
     assert_equal 'office-comments', @presenter.as_json[:offices][:main][:details][:description]


### PR DESCRIPTION
So that mainstream tools can link to the pages instead of having to include reams of access/opening hours information etc.
