### PR TITLE
Fixes issue with display of html versions with manual numbering where numbers not appearing at start of heading text were being extracted.

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -202,7 +202,7 @@ module GovspeakHelper
   end
 
   def extract_number_from_heading(nokogiri_el)
-    nokogiri_el.inner_text[/\d+.?\d*/]
+    nokogiri_el.inner_text[/^\d+.?\d*/]
   end
 
   def markup_to_nokogiri_doc(govspeak, images = [])

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -262,6 +262,12 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_equal expected_output, govspeak_to_html(input, [], heading_numbering: :manual).gsub(/\s+/, ' ')
   end
 
+  test "leaves heading numbers not occuring at the start of the heading text alone when using manual heading numbering" do
+    input = "## Number 8"
+    result =  Nokogiri::HTML::DocumentFragment.parse(govspeak_to_html(input, [], heading_numbering: :manual))
+    assert_equal "Number 8", result.css('h2').first.text
+  end
+
   test "should not corrupt character encoding of numbered headings" do
     input = '# café'
     actual_output = govspeak_to_html(input, [], heading_numbering: :auto)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/56344590
