### PR TITLE
Correct meta data url for worldwide priorities

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -291,7 +291,7 @@ Details of document required:
     if document.respond_to?(:worldwide_priorities) && document.worldwide_priorities.any?
       metadata << {
         title: t('document.type.worldwide_priority', count: 2), # always want the plural form for consistency
-        data: document.worldwide_priorities.map {|priority| link_to(priority.title, priority) },
+        data: document.worldwide_priorities.map {|priority| link_to(priority.title, public_document_path(priority)) },
         classes: ['document-worldwide-priorities']
       }
     end

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -325,7 +325,7 @@ class DocumentHelperTest < ActionView::TestCase
     assert_equal 'Worldwide priorities', metadata[:title]
     assert_select_within_html metadata[:data][0],
                               "a[href=?]",
-                              worldwide_priority_path(priority),
+                              public_document_path(priority),
                               text: priority.title
   end
 end


### PR DESCRIPTION
Our custom routing helper for linking to editions was not being used.

Tracker https://www.pivotaltracker.com/story/show/56368396
