### PR TITLE
Drop redundant publication_date from editions

### DIFF
--- a/db/migrate/20130906093144_drop_publication_date_from_editions.rb
+++ b/db/migrate/20130906093144_drop_publication_date_from_editions.rb
@@ -1,0 +1,5 @@
+class DropPublicationDateFromEditions < ActiveRecord::Migration
+  def change
+    remove_column :editions, :publication_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130823095707) do
+ActiveRecord::Schema.define(:version => 20130906093144) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -487,7 +487,6 @@ ActiveRecord::Schema.define(:version => 20130823095707) do
     t.date     "closing_on"
     t.datetime "major_change_published_at"
     t.datetime "first_published_at"
-    t.datetime "publication_date"
     t.integer  "speech_type_id"
     t.boolean  "stub",                                        :default => false
     t.text     "change_note"
@@ -525,7 +524,6 @@ ActiveRecord::Schema.define(:version => 20130823095707) do
   add_index "editions", ["primary_mainstream_category_id"], :name => "index_editions_on_primary_mainstream_category_id"
   add_index "editions", ["public_timestamp", "document_id"], :name => "index_editions_on_public_timestamp_and_document_id"
   add_index "editions", ["public_timestamp"], :name => "index_editions_on_public_timestamp"
-  add_index "editions", ["publication_date"], :name => "index_editions_on_publication_date"
   add_index "editions", ["publication_type_id"], :name => "index_editions_on_publication_type_id"
   add_index "editions", ["role_appointment_id"], :name => "index_editions_on_role_appointment_id"
   add_index "editions", ["speech_type_id"], :name => "index_editions_on_speech_type_id"

--- a/test/unit/document_series_group_test.rb
+++ b/test/unit/document_series_group_test.rb
@@ -16,12 +16,12 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal [published], group.published_editions
   end
 
-  test 'should list latest editions in reverse chronological order' do
+  test 'should list latest editions in reverse chronological order, with drafts at the end' do
     group = create(:document_series_group)
-    oldest = create(:draft_publication)
-    old = create(:published_publication, publication_date: 2.days.ago)
-    new = create(:published_publication, publication_date: 1.day.ago)
-    group.documents = [oldest.document, old.document, new.document]
-    assert_equal [new, old, oldest], group.latest_editions
+    draft = create(:draft_publication)
+    new = create(:published_publication, first_published_at: 1.day.ago)
+    old = create(:published_publication, first_published_at: 2.days.ago)
+    group.documents = [draft.document, new.document, old.document]
+    assert_equal [new, old, draft], group.latest_editions
   end
 end


### PR DESCRIPTION
This cleans up after some work that brought publications more in line with the way other edition types work.

https://www.pivotaltracker.com/story/show/56118648
