### PR TITLE
Don't include open consultations in outcomes list

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,7 +21,7 @@ class HomeController < PublicFacingController
     @closed_consultation_count = Consultation.published.closed_since(1.year.ago).count
     @next_closing_consultations = decorate_collection(Consultation.published.open.order("closing_on asc").limit(1), PublicationesquePresenter)
     @recently_opened_consultations = decorate_collection(Consultation.published.open.order("opening_on desc").limit(3), PublicationesquePresenter)
-    @recent_consultation_outcomes = decorate_collection(Consultation.published.responded.order("closing_on desc").limit(3), PublicationesquePresenter)
+    @recent_consultation_outcomes = decorate_collection(Consultation.published.closed.responded.order("closing_on desc").limit(3), PublicationesquePresenter)
     @take_part_pages = TakePartPage.in_order
   end
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -119,6 +119,9 @@ class HomeControllerTest < ActionController::TestCase
       create(:consultation_with_outcome, opening_on: 2.years.ago, closing_on: 1.year.ago - 5.day),
     ]
 
+    # Add a response ahead of the closing date
+    create(:consultation_outcome, consultation: next_closing)
+
     get :get_involved
 
     assert_equal recently_opened_consultations.size, assigns[:open_consultation_count]


### PR DESCRIPTION
Still-open consultations that already have a response (not sure why they would already have a response before closing, but there you go...) were incorrectly being listed in the "Recent outcomes" section of the get involved page. This prevents that from happening.

https://www.pivotaltracker.com/story/show/56503166
