### PR TITLE
World location smart ordering

### DIFF
--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -1,0 +1,7 @@
+module WorldLocationHelper
+
+  def group_and_sort(locations)
+    locations.sort_by(&:name_without_prefix).group_by {|location| location.name_without_prefix.first.upcase }.sort
+  end
+
+end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -83,6 +83,10 @@ class WorldLocation < ActiveRecord::Base
     world_location_type.key
   end
 
+  def name_without_prefix
+    name.gsub(/^The/, "").strip
+  end
+
   def self.all_by_type
     ordered_by_name.group_by(&:world_location_type).sort_by { |type, location| type.sort_order }
   end

--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -20,7 +20,7 @@
         </header>
         <div class="content">
           <% if type === WorldLocationType::WorldLocation %>
-            <% locations.group_by {|location| location.name.first.upcase }.sort.each do |letter, locations| %>
+            <% group_and_sort(locations).each do |letter, locations| %>
               <div class="js-filter-block">
                 <h2 class="letter"><%= letter %></h2>
                 <ol class="location-list">


### PR DESCRIPTION
World locations starting "The.." should be sorted as though they didn't.

Note: as with organisations this will only work in English due to a hardcoded prefix.
