### PR TITLE
Corporate info pages fix and additition

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -1271,44 +1271,45 @@
       @include bold;
     }
   }
-  .wales-office {
-    .homepage-link {
-      @include media(desktop) {
-        float: left;
-        width: 50%;
-      }
+}
+
+.wales-office {
+  .homepage-link {
+    @include media(desktop) {
+      float: left;
+      width: 50%;
     }
-    .organisation-mainstream-links {
-      @include media(tablet){
-        float: left;
-        width: 50%;
-        padding-top: 0;
-        margin-top: ($gutter-one-third * -1);
-      }
-      .available-languages {
-        margin: $gutter-one-third 0 0 0;
-        ul {
-          @extend %contain-floats;
-          list-style: none;
-          padding: $gutter 0 $gutter-one-sixth;
-          border-bottom: 1px solid $border-colour;
+  }
+  .organisation-mainstream-links {
+    @include media(tablet){
+      float: right;
+      width: 50%;
+      padding-top: 0;
+      margin-top: ($gutter-one-third * -1);
+    }
+    .available-languages {
+      margin: $gutter-one-third 0 0 0;
+      ul {
+        @extend %contain-floats;
+        list-style: none;
+        padding: $gutter 0 $gutter-one-sixth;
+        border-bottom: 1px solid $border-colour;
 
-          li {
-            float: left;
+        li {
+          float: left;
+          display: block;
+          border-right: 1px solid $border-colour;
+          padding: 0 $gutter-one-third 0 0;
+          height: 16px;
+          margin: 3px $gutter-one-third 2px 0;
+          &.last {
+            border-right: 0;
+          }
+
+          a, span {
             display: block;
-            border-right: 1px solid $border-colour;
-            padding: 0 $gutter-one-third 0 0;
-            height: 16px;
-            margin: 3px $gutter-one-third 2px 0;
-            &.last {
-              border-right: 0;
-            }
-
-            a, span {
-              display: block;
-              margin-top: -1px;
-              @include core-16;
-            }
+            margin-top: -1px;
+            @include core-16;
           }
         }
       }

--- a/app/views/corporate_information_pages/show.html.erb
+++ b/app/views/corporate_information_pages/show.html.erb
@@ -10,8 +10,13 @@
       </div>
     </div>
     <div class="block-2">
-      <%= render partial: 'shared/available_languages', locals: {object: @corporate_information_page } %>
       <div class="inner-block">
+        <%= content_tag :p, class: 'homepage-link' do %>
+          <%= link_to "#{@organisation.name} homepage", organisation_path(@organisation) %>
+        <% end %>
+        <aside class="organisation-mainstream-links">
+          <%= render partial: 'shared/available_languages', locals: {object: @corporate_information_page } %>
+        </aside>
         <h1 class="main"><%= @corporate_information_page.title %></h1>
         <p class="description">
           <%= @corporate_information_page.summary %>


### PR DESCRIPTION
While pairing with Graham on a story regarding custom logos for orgs
I noticed that the wales office translations werer broken on corporate info pages.
Also, I added a back to homepage 'Org name homepage' link to corporate info pages to reflect the changes made on the about page.

No story created for this.
