### PR TITLE
Use db:schema:load on jenkins

### DIFF
--- a/jenkins-parallel.sh
+++ b/jenkins-parallel.sh
@@ -12,7 +12,8 @@ mkdir -p ./attachment-cache
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
-time bundle exec rake db:create db:migrate db:test:prepare --trace
+time bundle exec rake db:drop db:create db:schema:load --trace
+time bundle exec rake db:test:prepare --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:clean --trace
 RAILS_ENV=test CUCUMBER_FORMAT=progress time bundle exec rake ci:setup:minitest parallel:create parallel:prepare test_queue shared_mustache:compile parallel:features test:javascript test:cleanup --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:precompile --trace

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -12,7 +12,8 @@ mkdir -p ./attachment-cache
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
-time bundle exec rake db:create db:schema:load db:test:prepare --trace
+time bundle exec rake db:drop db:create db:schema:load --trace
+time bundle exec rake db:test:prepare --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:clean --trace
 RAILS_ENV=test CUCUMBER_FORMAT=progress time bundle exec rake ci:setup:minitest default test:cleanup --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:precompile --trace


### PR DESCRIPTION
Rather than running migrations we should load the schema. It avoids the
need to keep all of the historical migrations (in a runnable condition).

Also need to do db:test:prepare in a separate rake process. For some
reason it didn't work properly when done in the same command.
