### PR TITLE
Don't use `class << self` to define class methods

### DIFF
--- a/app/models/classification_membership.rb
+++ b/app/models/classification_membership.rb
@@ -17,14 +17,12 @@ class ClassificationMembership < ActiveRecord::Base
   after_create :update_classification_counts
   after_destroy :update_classification_counts
 
-  class << self
-    def published
-      joins(:edition).where("editions.state" => "published")
-    end
+  def self.published
+    joins(:edition).where("editions.state" => "published")
+  end
 
-    def for_type(type)
-      joins(:edition).where("editions.type" => type)
-    end
+  def self.for_type(type)
+    joins(:edition).where("editions.type" => type)
   end
 
   private

--- a/app/models/classification_relation.rb
+++ b/app/models/classification_relation.rb
@@ -21,10 +21,8 @@ class ClassificationRelation < ActiveRecord::Base
   after_create :create_inverse_relation
   after_destroy :destroy_inverse_relation
 
-  class << self
-    def relation_for(classification_id, related_classification_id)
-      where(classification_id: classification_id, related_classification_id: related_classification_id).first
-    end
+  def self.relation_for(classification_id, related_classification_id)
+    where(classification_id: classification_id, related_classification_id: related_classification_id).first
   end
 
   def inverse_relation

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -94,9 +94,7 @@ class DetailedGuide < Edition
     end
   end
 
-  class << self
-    def format_name
-      'detailed guidance'
-    end
+  def self.format_name
+    'detailed guidance'
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -65,6 +65,14 @@ class Document < ActiveRecord::Base
     end
   end
 
+  def self.published
+    joins(:published_edition)
+  end
+
+  def self.at_slug(document_types, slug)
+    where(document_type: document_types, slug: slug).first
+  end
+
   def published?
     published_edition(true).present?
   end
@@ -83,16 +91,6 @@ class Document < ActiveRecord::Base
     editions.map { |e|
       Change.new(e.public_timestamp, e.change_note)
     }.push(oldest_change)
-  end
-
-  class << self
-    def published
-      joins(:published_edition)
-    end
-
-    def at_slug(document_types, slug)
-      where(document_type: document_types, slug: slug).first
-    end
   end
 
   private

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -3,13 +3,13 @@ module Edition::AuditTrail
 
   class << self
     attr_accessor :whodunnit
+  end
 
-    def acting_as(actor)
-      original_actor, Edition::AuditTrail.whodunnit = Edition::AuditTrail.whodunnit, actor
-      yield
-    ensure
-      Edition::AuditTrail.whodunnit = original_actor
-    end
+  def self.acting_as(actor)
+    original_actor, Edition::AuditTrail.whodunnit = Edition::AuditTrail.whodunnit, actor
+    yield
+  ensure
+    Edition::AuditTrail.whodunnit = original_actor
   end
 
   included do
@@ -117,10 +117,8 @@ module Edition::AuditTrail
   end
 
   class VersionAuditEntry < AuditEntry
-    class << self
-      def model_name
-        ActiveModel::Name.new(Version, nil)
-      end
+    def self.model_name
+      ActiveModel::Name.new(Version, nil)
     end
 
     alias_method :version, :object
@@ -143,10 +141,8 @@ module Edition::AuditTrail
   end
 
   class EditorialRemarkAuditEntry < AuditEntry
-    class << self
-      def model_name
-        ActiveModel::Name.new(EditorialRemark, nil)
-      end
+    def self.model_name
+      ActiveModel::Name.new(EditorialRemark, nil)
     end
 
     alias_method :editorial_remark, :object

--- a/app/models/ministerial_role_search_index_observer.rb
+++ b/app/models/ministerial_role_search_index_observer.rb
@@ -3,15 +3,15 @@ class MinisterialRoleSearchIndexObserver < ActiveRecord::Observer
 
   class << self
     attr_accessor :disabled
+  end
 
-    def while_disabled
-      original_disabled = disabled
-      begin
-        self.disabled = true
-        yield
-      ensure
-        self.disabled = original_disabled
-      end
+  def self.while_disabled
+    original_disabled = disabled
+    begin
+      self.disabled = true
+      yield
+    ensure
+      self.disabled = original_disabled
     end
   end
 

--- a/app/models/nation.rb
+++ b/app/models/nation.rb
@@ -8,19 +8,17 @@ class Nation
   Wales = create(id: 3, name: "Wales")
   NorthernIreland = create(id: 4, name: "Northern Ireland")
 
-  class << self
-    def england; England; end
-    def scotland; Scotland; end
-    def wales; Wales; end
-    def northern_ireland; NorthernIreland; end
+  def self.england; England; end
+  def self.scotland; Scotland; end
+  def self.wales; Wales; end
+  def self.northern_ireland; NorthernIreland; end
 
-    def potentially_inapplicable
-      [Scotland, Wales, NorthernIreland]
-    end
+  def self.potentially_inapplicable
+    [Scotland, Wales, NorthernIreland]
+  end
 
-    def find_by_name!(name)
-      nation = all.detect { |n| n.name == name }
-      nation || raise("Couldn't find Nation with name = #{name}")
-    end
+  def self.find_by_name!(name)
+    nation = all.detect { |n| n.name == name }
+    nation || raise("Couldn't find Nation with name = #{name}")
   end
 end

--- a/app/presenters/api/base_presenter.rb
+++ b/app/presenters/api/base_presenter.rb
@@ -1,9 +1,7 @@
 class Api::BasePresenter < Struct.new(:model, :context)
-  class << self
-    def paginate(collection, view_context)
-      page = Api::Paginator.paginate(collection, view_context.params)
-      collection = Whitehall::Decorators::CollectionDecorator.new(page, self, view_context)
-      Api::PagePresenter.new(collection, view_context)
-    end
+  def self.paginate(collection, view_context)
+    page = Api::Paginator.paginate(collection, view_context.params)
+    collection = Whitehall::Decorators::CollectionDecorator.new(page, self, view_context)
+    Api::PagePresenter.new(collection, view_context)
   end
 end

--- a/app/presenters/api/paginator.rb
+++ b/app/presenters/api/paginator.rb
@@ -1,8 +1,6 @@
 class Api::Paginator < Struct.new(:collection, :params)
-  class << self
-    def paginate(collection, params)
-      new(collection, params).page
-    end
+  def self.paginate(collection, params)
+    new(collection, params).page
   end
 
   def current_page

--- a/app/presenters/role_type_presenter.rb
+++ b/app/presenters/role_type_presenter.rb
@@ -45,21 +45,19 @@ class RoleTypePresenter
 
   DEFAULT_NAME, DEFAULT_TYPE = NAMES_VS_TYPES.first
 
-  class << self
-    def options
-      GROUPS_VS_NAMES_VS_TYPES.map do |group, names_vs_types|
-        [group, names_vs_types.map { |name, type| [name.humanize, name] }]
-      end
+  def self.options
+    GROUPS_VS_NAMES_VS_TYPES.map do |group, names_vs_types|
+      [group, names_vs_types.map { |name, type| [name.humanize, name] }]
     end
+  end
 
-    def option_value_for(role, role_type)
-      role_type = RoleType.new(role_type, role.cabinet_member?, role.permanent_secretary?, role.chief_of_the_defence_staff?)
-      NAMES_VS_TYPES.invert[role_type] || DEFAULT_NAME
-    end
+  def self.option_value_for(role, role_type)
+    role_type = RoleType.new(role_type, role.cabinet_member?, role.permanent_secretary?, role.chief_of_the_defence_staff?)
+    NAMES_VS_TYPES.invert[role_type] || DEFAULT_NAME
+  end
 
-    def role_attributes_from(params)
-      role_type = NAMES_VS_TYPES[params[:type]] || DEFAULT_TYPE
-      params.merge(role_type.attributes)
-    end
+  def self.role_attributes_from(params)
+    role_type = NAMES_VS_TYPES[params[:type]] || DEFAULT_TYPE
+    params.merge(role_type.attributes)
   end
 end

--- a/lib/locale.rb
+++ b/lib/locale.rb
@@ -4,36 +4,34 @@ class Locale < Struct.new(:code)
 
   extend ActiveModel::Naming
 
-  class << self
-    def model_name
-      ActiveModel::Name.new(Translations)
-    end
+  def self.model_name
+    ActiveModel::Name.new(Translations)
+  end
 
-    def current
-      new(I18n.locale)
-    end
+  def self.current
+    new(I18n.locale)
+  end
 
-    def all
-      I18n.available_locales.map do |l|
-        new(l)
-      end
+  def self.all
+    I18n.available_locales.map do |l|
+      new(l)
     end
+  end
 
-    def non_english
-      all.reject(&:english?)
-    end
+  def self.non_english
+    all.reject(&:english?)
+  end
 
-    def right_to_left
-      all.select(&:rtl?)
-    end
+  def self.right_to_left
+    all.select(&:rtl?)
+  end
 
-    def find_by_language_name(native_language_name)
-      all.detect { |l| l.native_language_name == native_language_name }
-    end
+  def self.find_by_language_name(native_language_name)
+    all.detect { |l| l.native_language_name == native_language_name }
+  end
 
-    def find_by_code(code)
-      all.detect { |l| l.code == code.to_sym }
-    end
+  def self.find_by_code(code)
+    all.detect { |l| l.code == code.to_sym }
   end
 
   def english?

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -49,161 +49,161 @@ module Whitehall
       news: "news",
       detailed_guidance: "detailed_guidance"
     }
+  end
 
-    def available_locales
-      [
-        :en, :ar, :az, :be, :bg, :bn, :cs, :cy, :de, :dr, :el,
-        :es, 'es-419', :fa, :fr, :he, :hi, :hu, :hy, :id, :it,
-        :ja, :ka, :ko, :lt, :lv, :ms, :pl, :ps, :pt, :ro, :ru,
-        :si, :sk, :so, :sq, :sr, :sw, :ta, :th, :tk, :tr, :uk,
-        :ur, :uz, :vi, :zh, 'zh-hk', 'zh-tw'
-      ]
-    end
+  def self.available_locales
+    [
+      :en, :ar, :az, :be, :bg, :bn, :cs, :cy, :de, :dr, :el,
+      :es, 'es-419', :fa, :fr, :he, :hi, :hu, :hy, :id, :it,
+      :ja, :ka, :ko, :lt, :lv, :ms, :pl, :ps, :pt, :ro, :ru,
+      :si, :sk, :so, :sq, :sr, :sw, :ta, :th, :tk, :tr, :uk,
+      :ur, :uz, :vi, :zh, 'zh-hk', 'zh-tw'
+    ]
+  end
 
-    def system_binaries
-      {
-        zipinfo: "/usr/bin/zipinfo",
-        unzip: "/usr/bin/unzip"
-      }
-    end
+  def self.system_binaries
+    {
+      zipinfo: "/usr/bin/zipinfo",
+      unzip: "/usr/bin/unzip"
+    }
+  end
 
-    def asset_host
-      ENV['GOVUK_ASSET_ROOT'] || raise(NoConfigurationError, 'Expected GOVUK_ASSET_ROOT to be set. Perhaps you should run your task through govuk_setenv <appname>?')
-    end
+  def self.asset_host
+    ENV['GOVUK_ASSET_ROOT'] || raise(NoConfigurationError, 'Expected GOVUK_ASSET_ROOT to be set. Perhaps you should run your task through govuk_setenv <appname>?')
+  end
 
-    def router_prefix
-      "/government"
-    end
+  def self.router_prefix
+    "/government"
+  end
 
-    def admin_hosts
-      ADMIN_HOSTS
-    end
+  def self.admin_hosts
+    ADMIN_HOSTS
+  end
 
-    def public_hosts
-      PUBLIC_HOSTS.values.uniq
-    end
+  def self.public_hosts
+    PUBLIC_HOSTS.values.uniq
+  end
 
-    def government_single_domain?(request)
-      PUBLIC_HOSTS.values.include?(request.host) || request.headers["HTTP_X_GOVUK_ROUTER_REQUEST"].present?
-    end
+  def self.government_single_domain?(request)
+    PUBLIC_HOSTS.values.include?(request.host) || request.headers["HTTP_X_GOVUK_ROUTER_REQUEST"].present?
+  end
 
-    def admin_whitelist?(request)
-      !Rails.env.production? || ADMIN_HOSTS.include?(request.host)
-    end
+  def self.admin_whitelist?(request)
+    !Rails.env.production? || ADMIN_HOSTS.include?(request.host)
+  end
 
-    def platform
-      ENV["FACTER_govuk_platform"] || Rails.env
-    end
+  def self.platform
+    ENV["FACTER_govuk_platform"] || Rails.env
+  end
 
-    def public_host_for(request_host)
-      PUBLIC_HOSTS[request_host] || request_host
-    end
+  def self.public_host_for(request_host)
+    PUBLIC_HOSTS[request_host] || request_host
+  end
 
-    def public_protocol
-      ENV['FACTER_govuk_platform'] == 'development' ? 'http': 'https'
-    end
+  def self.public_protocol
+    ENV['FACTER_govuk_platform'] == 'development' ? 'http': 'https'
+  end
 
-    def secrets
-      @secrets ||= load_secrets
-    end
+  def self.secrets
+    @secrets ||= load_secrets
+  end
 
-    def aws_access_key_id
-      secrets["aws_access_key_id"]
-    end
+  def self.aws_access_key_id
+    secrets["aws_access_key_id"]
+  end
 
-    def aws_secret_access_key
-      secrets["aws_secret_access_key"]
-    end
+  def self.aws_secret_access_key
+    secrets["aws_secret_access_key"]
+  end
 
-    # The base folder where incoming-uploads and clean-uploads live.
-    def uploads_root
-      (Rails.env.test? ? uploads_root_for_test_env : Rails.root).to_s
-    end
+  # The base folder where incoming-uploads and clean-uploads live.
+  def self.uploads_root
+    (Rails.env.test? ? uploads_root_for_test_env : Rails.root).to_s
+  end
 
-    def uploads_root_for_test_env
-      env_number = ENV['TEST_ENV_NUMBER'].blank? ? '1' : ENV['TEST_ENV_NUMBER']
-      Rails.root.join("tmp/test/env_#{env_number}")
-    end
+  def self.uploads_root_for_test_env
+    env_number = ENV['TEST_ENV_NUMBER'].blank? ? '1' : ENV['TEST_ENV_NUMBER']
+    Rails.root.join("tmp/test/env_#{env_number}")
+  end
 
-    def incoming_uploads_root
-      File.join(uploads_root, 'incoming-uploads')
-    end
+  def self.incoming_uploads_root
+    File.join(uploads_root, 'incoming-uploads')
+  end
 
-    def clean_uploads_root
-      File.join(uploads_root, 'clean-uploads')
-    end
+  def self.clean_uploads_root
+    File.join(uploads_root, 'clean-uploads')
+  end
 
-    def infected_uploads_root
-      File.join(uploads_root, 'infected-uploads')
-    end
+  def self.infected_uploads_root
+    File.join(uploads_root, 'infected-uploads')
+  end
 
-    def government_search_index_path
-      '/government'
-    end
+  def self.government_search_index_path
+    '/government'
+  end
 
-    def detailed_guidance_search_index_path
-      '/detailed'
-    end
+  def self.detailed_guidance_search_index_path
+    '/detailed'
+  end
 
-    def government_search_index
-      Enumerator.new do |y|
-        government_edition_classes.each do |klass|
-          klass.search_index.each do |search_index_entry|
-            y << search_index_entry
-          end
+  def self.government_search_index
+    Enumerator.new do |y|
+      government_edition_classes.each do |klass|
+        klass.search_index.each do |search_index_entry|
+          y << search_index_entry
         end
       end
     end
+  end
 
-    def detailed_guidance_search_index
-      DetailedGuide.search_index
-    end
+  def self.detailed_guidance_search_index
+    DetailedGuide.search_index
+  end
 
-    def edition_classes
-      [
-        CaseStudy,
-        FatalityNotice,
-        WorldwidePriority,
-        StatisticalDataSet,
-        Policy,
-        Consultation,
+  def self.edition_classes
+    [
+      CaseStudy,
+      FatalityNotice,
+      WorldwidePriority,
+      StatisticalDataSet,
+      Policy,
+      Consultation,
+      WorldLocationNewsArticle,
+      Speech,
+      DetailedGuide,
+      NewsArticle,
+      Publication
+    ]
+  end
+
+  def self.searchable_classes
+    additional_classes = [
+      Organisation,
+      MinisterialRole,
+      Person,
+      Topic,
+      TopicalEvent,
+      DocumentSeries,
+      CorporateInformationPage,
+      OperationalField,
+      PolicyAdvisoryGroup,
+      PolicyTeam,
+      SupportingPage,
+      TakePartPage
+    ]
+    not_yet_searchable_classes = []
+    if world_feature?
+      additional_classes += [
+        WorldLocation,
+        WorldwideOrganisation
+      ]
+    else
+      not_yet_searchable_classes += [
         WorldLocationNewsArticle,
-        Speech,
-        DetailedGuide,
-        NewsArticle,
-        Publication
+        WorldwidePriority
       ]
     end
-
-    def searchable_classes
-      additional_classes = [
-        Organisation,
-        MinisterialRole,
-        Person,
-        Topic,
-        TopicalEvent,
-        DocumentSeries,
-        CorporateInformationPage,
-        OperationalField,
-        PolicyAdvisoryGroup,
-        PolicyTeam,
-        SupportingPage,
-        TakePartPage
-      ]
-      not_yet_searchable_classes = []
-      if world_feature?
-        additional_classes += [
-          WorldLocation,
-          WorldwideOrganisation
-        ]
-      else
-        not_yet_searchable_classes += [
-          WorldLocationNewsArticle,
-          WorldwidePriority
-        ]
-      end
-      additional_classes + edition_classes - not_yet_searchable_classes
-    end
+    additional_classes + edition_classes - not_yet_searchable_classes
 
     def edition_route_path_segments
       %w(news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities world-location-news)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,34 +74,32 @@ class ActiveSupport::TestCase
     @routes_helper ||= Whitehall::UrlMaker.new
   end
 
-  class << self
-    def disable_database_queries
-      self.use_transactional_fixtures = false
-      setup do
-        ActiveRecord::Base.connection.expects(:select).never
-      end
+  def self.disable_database_queries
+    self.use_transactional_fixtures = false
+    setup do
+      ActiveRecord::Base.connection.expects(:select).never
+    end
+  end
+
+  def self.class_for(document_type)
+    document_type.to_s.classify.constantize
+  end
+
+  def self.class_from_test_name
+    name.sub(/Test$/, '').constantize
+  end
+
+  def self.factory_name_from_test
+    name.sub(/Test$/, '').underscore.to_sym
+  end
+
+  def self.with_not_quite_as_fake_search
+    setup do
+      Whitehall::NotQuiteAsFakeSearch.stop_faking_it_quite_so_much!
     end
 
-    def class_for(document_type)
-      document_type.to_s.classify.constantize
-    end
-
-    def class_from_test_name
-      name.sub(/Test$/, '').constantize
-    end
-
-    def factory_name_from_test
-      name.sub(/Test$/, '').underscore.to_sym
-    end
-
-    def with_not_quite_as_fake_search
-      setup do
-        Whitehall::NotQuiteAsFakeSearch.stop_faking_it_quite_so_much!
-      end
-
-      teardown do
-        Whitehall::NotQuiteAsFakeSearch.start_faking_it_again!
-      end
+    teardown do
+      Whitehall::NotQuiteAsFakeSearch.start_faking_it_again!
     end
   end
 


### PR DESCRIPTION
Many people define their class methods by opening up the current class's meta class, changing the value of self within the block to be the meta class, and then defining instance methods on the meta class.

If you don't follow that description, you'll recognise the syntax:

```
class << self
  def foo
    'oh god!'
  end
end
```

There are two problems with this:
1. You can't grep for class methods (e.g. for /def self.thing/).
2. You can't tell whether a method is a class method when you're reading the code, unless you're fortunate enough for both a) `class << self` to be visible in your editor window, and b) to have actually noticed it (it could be some distance away).

In other words, it's obfuscation.

I propose we stop doing this, and always say `def self.foo` instead.

Dave Thomas agrees, and says "I think it's a really bad habit to fall into ... my strong recommendation is that you don't use `class << self` if all you're doing is defining class methods." That quote is from episode 2 of [The Ruby Object Model and Metaprogramming](http://pragprog.com/screencasts/v-dtrubyom/the-ruby-object-model-and-metaprogramming); start watching from 17m 10s in.

There are a few occassions that `class << self` is useful, and Dave shows you some examples in the video.
