### PR TITLE
Sort document series group editions

### DIFF
--- a/app/models/document_series_group.rb
+++ b/app/models/document_series_group.rb
@@ -26,7 +26,7 @@ class DocumentSeriesGroup < ActiveRecord::Base
   end
 
   def published_editions
-    editions.published
+    editions.published.in_reverse_chronological_order
   end
 
   def latest_editions

--- a/test/unit/document_series_group_test.rb
+++ b/test/unit/document_series_group_test.rb
@@ -8,12 +8,13 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal [1, 2], series.groups.reload.map(&:ordering)
   end
 
-  test 'should list published editions' do
+  test 'should list published editions in reverse chronological order' do
     group = create(:document_series_group)
-    published = create(:published_publication)
+    published_1 = create(:published_publication, first_published_at: 2.days.ago)
+    published_2 = create(:published_publication, first_published_at: 1.day.ago)
     draft = create(:draft_publication)
-    group.documents << [published.document, draft.document]
-    assert_equal [published], group.published_editions
+    group.documents << [published_1.document, published_2.document, draft.document]
+    assert_equal [published_2, published_1], group.published_editions
   end
 
   test 'should list latest editions in reverse chronological order, with drafts at the end' do


### PR DESCRIPTION
This matches DocumentSeries#published_editions and causes the order to be set correctly.

There's a separate `order` column for DocumentSeriesGroup items, but it's simpler and fulfils the ticket to just use `public_timestamp`.

https://www.pivotaltracker.com/story/show/56704236
