### PR TITLE
Fix duplication in historic appointment routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,10 +46,11 @@ Whitehall::Application.routes.draw do
     get "history/past-chancellors" => 'historic_appointments#past_chancellors'
     get "/history/:role" => "historic_appointments#index", constraints: { role: /(past-prime-ministers)|(past-chancellors)/ }, as: 'historic_appointments'
     get "/history/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)/ }, as: 'historic_appointment'
+
+    # Past foreign secretaries are currently hard-coded, so this
+    # resource falls straight through to views.
     resources :past_foreign_secretaries, path: "/history/past-foreign-secretaries", only: [:index, :show]
-    get "history/past-chancellors" => 'historic_appointments#past_chancellors'
-    get "/history/:role" => "historic_appointments#index", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: 'historic_appointments'
-    get "/history/:role/:person_id" => "historic_appointments#show", constraints: { role: /(past-prime-ministers)|(past-chancellors)|(past-foreign-secretaries)/ }, as: 'historic_appointment'
+
     resources :histories, path: "history", only: [:index, :show]
 
     resource :email_signups, path: 'email-signup', only: [:show, :create]


### PR DESCRIPTION
This route duplication is confusing and unnecessary.

Past foreign secretaries doesn't need to have a constraint in the regular historic_appointments controller, as it's served entirely as hard-coded views.

This was originally erroneously duplicated in 23636d839e6439114213cba0e446ac551eccc84a.
