### PR TITLE
Prevent unpublished docs redirecting to themselves

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -83,9 +83,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
   end
 
   def unpublish
-    if @edition.unpublish_as(current_user)
-      @edition.create_unpublishing!(params[:unpublishing])
-      redirect_options = {notice: "This document has been unpublished and will no longer appear on the public website"}
+    if @edition.unpublish_as(current_user, params[:unpublishing])
+        redirect_options = {notice: "This document has been unpublished and will no longer appear on the public website"}
     else
       redirect_options = {alert: @edition.errors.full_messages.to_sentence}
     end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,4 +1,6 @@
 class Admin::EditionsController < Admin::BaseController
+  include PublicDocumentRoutesHelper
+
   before_filter :remove_blank_parameters
   before_filter :clean_edition_parameters, only: [:create, :update]
   before_filter :clear_scheduled_publication_if_not_activated, only: [:create, :update]
@@ -115,7 +117,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def confirm_unpublish
-    @unpublishing = Unpublishing.new(document_type: @edition.type, slug: @edition.slug)
+    @unpublishing = Unpublishing.new(document_type: @edition.type, slug: @edition.slug, edition_url: public_document_url(@edition))
   end
 
   def destroy

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -6,6 +6,8 @@ class Unpublishing < ActiveRecord::Base
     message: "must be entered if you want to redirect to it",
     if: -> unpublishing { unpublishing.redirect? }
   }
+  validates :alternative_url, uri: true, if: -> unpublishing { unpublishing.redirect? }
+  validate :redirect_not_circular
 
   def self.from_slug(slug, type)
     where(slug: slug, document_type: type.to_s).first
@@ -17,5 +19,13 @@ class Unpublishing < ActiveRecord::Base
 
   def reason_as_sentence
     unpublishing_reason.as_sentence
+  end
+
+  def redirect_not_circular
+    if alternative_url.present?
+      if edition_url == alternative_url
+        errors.add(:alternative_url, "cannot redirect to itself")
+      end
+    end
   end
 end

--- a/app/views/admin/editions/confirm_unpublish.html.erb
+++ b/app/views/admin/editions/confirm_unpublish.html.erb
@@ -8,6 +8,7 @@
         <%= fields_for :unpublishing do |unpublish| %>
           <%= unpublish.hidden_field :document_type %>
           <%= unpublish.hidden_field :slug %>
+          <%= unpublish.hidden_field :edition_url %>
           <%= unpublish.label :unpublishing_reason_id, "Reason for unpublishing" %>
           <%= unpublish.select :unpublishing_reason_id, options_from_collection_for_select(UnpublishingReason.all, :id, :name) %>
           <%= unpublish.text_area :explanation, label_text: 'Further explanation', rows: 5, class: "previewable"  %>

--- a/db/migrate/20130912114453_add_edtion_url_to_unpublishing.rb
+++ b/db/migrate/20130912114453_add_edtion_url_to_unpublishing.rb
@@ -1,0 +1,5 @@
+class AddEdtionUrlToUnpublishing < ActiveRecord::Migration
+  def change
+    add_column :unpublishings, :edition_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130911140104) do
+ActiveRecord::Schema.define(:version => 20130912114453) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -865,6 +865,15 @@ ActiveRecord::Schema.define(:version => 20130911140104) do
   add_index "organisation_translations", ["name"], :name => "index_organisation_translations_on_name"
   add_index "organisation_translations", ["organisation_id"], :name => "index_organisation_translations_on_organisation_id"
 
+  create_table "organisation_types", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "analytics_prefix"
+  end
+
+  add_index "organisation_types", ["name"], :name => "index_organisation_types_on_name"
+
   create_table "organisational_relationships", :force => true do |t|
     t.integer  "parent_organisation_id"
     t.integer  "child_organisation_id"
@@ -879,6 +888,7 @@ ActiveRecord::Schema.define(:version => 20130911140104) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug"
+    t.integer  "organisation_type_id"
     t.string   "url"
     t.string   "alternative_format_contact_email"
     t.string   "govuk_status",                            :default => "live", :null => false
@@ -899,7 +909,9 @@ ActiveRecord::Schema.define(:version => 20130911140104) do
   end
 
   add_index "organisations", ["default_news_organisation_image_data_id"], :name => "index_organisations_on_default_news_organisation_image_data_id"
+  add_index "organisations", ["id", "organisation_type_id"], :name => "index_organisations_on_id_and_organisation_type_id"
   add_index "organisations", ["organisation_logo_type_id"], :name => "index_organisations_on_organisation_logo_type_id"
+  add_index "organisations", ["organisation_type_id"], :name => "index_organisations_on_organisation_type_id"
   add_index "organisations", ["organisation_type_key"], :name => "index_organisations_on_organisation_type_key"
   add_index "organisations", ["slug"], :name => "index_organisations_on_slug"
 
@@ -1124,6 +1136,7 @@ ActiveRecord::Schema.define(:version => 20130911140104) do
     t.string   "document_type"
     t.string   "slug"
     t.boolean  "redirect",               :default => false
+    t.string   "edition_url"
   end
 
   add_index "unpublishings", ["edition_id"], :name => "index_unpublishings_on_edition_id"

--- a/test/unit/edition/searchable_test.rb
+++ b/test/unit/edition/searchable_test.rb
@@ -84,7 +84,15 @@ class Edition::SearchableTest < ActiveSupport::TestCase
 
     Searchable::Delete.expects(:later).with(edition)
 
-    edition.unpublish_as(create(:gds_editor))
+    unpublish_params = {
+      'unpublishing_reason_id' => '1',
+      'explanation' => 'Was classified',
+      'alternative_url' => 'http://website.com/alt',
+      'document_type' => 'Policy',
+      'slug' => 'some-slug'
+    }
+
+    edition.unpublish_as(create(:gds_editor), unpublish_params)
   end
 
   test "should remove published edition from search index when it's archived" do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -495,7 +495,7 @@ class EditionTest < ActiveSupport::TestCase
 
     Searchable::Delete.expects(:later).with(policy)
 
-    policy.unpublish_as(create(:gds_editor))
+    policy.unpublish_as(create(:gds_editor), unpublish_params)
   end
 
   test "swallows errors from search index when it's unpublished" do
@@ -503,7 +503,7 @@ class EditionTest < ActiveSupport::TestCase
 
     Searchable::Delete.expects(:later).raises(RuntimeError, 'Problem?')
 
-    assert_nothing_raised { policy.unpublish_as(create(:gds_editor)) }
+    assert_nothing_raised { policy.unpublish_as(create(:gds_editor), unpublish_params) }
   end
 
   test "should remove published edition from search index when it's archived" do
@@ -789,5 +789,15 @@ class EditionTest < ActiveSupport::TestCase
 
     refute non_local_gov_editions.include? local_gov_policy
     refute non_local_gov_editions.include? local_gov_publication
+  end
+
+  def unpublish_params
+    {
+      'unpublishing_reason_id' => '1',
+      'explanation' => 'Was classified',
+      'alternative_url' => 'http://website.com/alt',
+      'document_type' => 'Policy',
+      'slug' => 'some-slug'
+    }
   end
 end

--- a/test/unit/policy_search_index_observer_test.rb
+++ b/test/unit/policy_search_index_observer_test.rb
@@ -14,7 +14,15 @@ class PolicySearchIndexObserverTest < ActiveSupport::TestCase
 
     PolicySearchIndexObserver::ReindexRelatedEditions.expects(:later).with(policy)
 
-    policy.unpublish_as(create(:gds_editor))
+    unpublish_params = {
+      'unpublishing_reason_id' => '1',
+      'explanation' => 'Was classified',
+      'alternative_url' => 'http://website.com/alt',
+      'document_type' => 'Policy',
+      'slug' => 'some-slug'
+    }
+
+    policy.unpublish_as(create(:gds_editor), unpublish_params)
   end
 
   test 'ReindexRelatedEditions.later enqueues a job for the supplied policy onto the rummager work queue' do

--- a/test/unit/supporting_page_search_index_observer_test.rb
+++ b/test/unit/supporting_page_search_index_observer_test.rb
@@ -20,7 +20,15 @@ class SupportingPageSearchIndexObserverTest < ActiveSupport::TestCase
 
     Searchable::Delete.expects(:later).with(supporting_page)
 
-    policy.unpublish_as(create(:gds_editor))
+    unpublish_params = {
+      'unpublishing_reason_id' => '1',
+      'explanation' => 'Was classified',
+      'alternative_url' => 'http://website.com/alt',
+      'document_type' => 'Policy',
+      'slug' => 'some-slug'
+    }
+
+    policy.unpublish_as(create(:gds_editor), unpublish_params)
   end
 
   test 'should remove supporting page from search index when its edition is archived' do

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -23,13 +23,23 @@ class UnpublishingTest < ActiveSupport::TestCase
 
   test 'is not valid without a url if redirect is chosen' do
     unpublishing = build(:unpublishing, redirect: true)
+    unpublishing.stubs(edition_url: "http://example.com/new")
     refute unpublishing.valid?
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "http://example.com")
+    unpublishing.stubs(edition_url: "http://example.com/new")
     assert unpublishing.valid?
 
     unpublishing = build(:unpublishing, redirect: false, alternative_url: "http://example.com")
+    unpublishing.stubs(edition_url: "http://example.com/new")
     assert unpublishing.valid?
+  end
+
+  test 'cannot redirect to itself' do
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "http://example.com")
+    unpublishing.stubs(edition_url: "http://example.com")
+    refute unpublishing.valid?
+    assert_equal ["cannot redirect to itself"], unpublishing.errors[:alternative_url]
   end
 
   test 'returns an unpublishing reason' do
@@ -42,7 +52,7 @@ class UnpublishingTest < ActiveSupport::TestCase
   end
 
   test 'can be retrieved by slug and document type' do
-    unpublishing = create(:unpublishing, document_type: 'CaseStudy', slug: 'some-slug')
+    unpublishing = create(:unpublishing, document_type: 'CaseStudy', slug: 'some-slug', alternative_url: "http://example.com")
 
     refute Unpublishing.from_slug('not-a-match','CaseStudy')
     refute Unpublishing.from_slug('some-slug','OtherDocumentType')

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -105,7 +105,16 @@ Old Url,New Url,Status,Slug,Admin Url,State
       user = create(:gds_editor)
       publication = create(:published_publication)
       old_slug = publication.document.slug
-      publication.unpublish_as(user)
+
+      unpublish_params = {
+        'unpublishing_reason_id' => '1',
+        'explanation' => 'Was classified',
+        'alternative_url' => 'http://website.com/alt',
+        'document_type' => 'Policy',
+        'slug' => 'some-slug'
+      }
+
+      publication.unpublish_as(user, unpublish_params)
       unpublishing = publication.create_unpublishing!(attributes_for(:unpublishing))
       publication.title = "This is a new title"
       publication.save!


### PR DESCRIPTION
Discovered validation errors in unpublish did not prevent an edition from being unpublished.

Added validations to prevent circular references, also adds the URI validator.

https://www.pivotaltracker.com/story/show/52623681
