### PR TITLE
Make default admin filter scoped to org only

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -251,11 +251,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def default_filters
-    if current_user.departmental_editor?
-      {organisation: current_user.organisation.try(:id), state: :submitted}
-    else
-      {state: :draft, author: current_user}
-    end
+    {organisation: current_user.organisation.try(:id)}
   end
 
   def session_filters

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -154,17 +154,11 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_redirected_to admin_editions_path(state: :submitted, author: current_user, organisation: organisation)
   end
 
-  test "index should redirect to submitted in my department if logged an editor has no remembered filters" do
+  test "index should redirect to department if logged in with no remembered filters" do
     organisation = create(:organisation)
     editor = login_as create(:departmental_editor, organisation: organisation)
     get :index
-    assert_redirected_to admin_editions_path(state: :submitted, organisation: organisation.id)
-  end
-
-  test "index should render a list of drafts I have written if a writer has no remembered filters" do
-    writer = login_as create(:policy_writer)
-    get :index
-    assert_redirected_to admin_editions_path(state: :draft, author: writer)
+    assert_redirected_to admin_editions_path(organisation: organisation.id)
   end
 
   view_test "should not show published editions as force published" do


### PR DESCRIPTION
This removes the previous role-specific functionality and replaces it with a single piece of logic that defaults to all active documents in the user's organisation.

https://www.pivotaltracker.com/story/show/56207006
