### PR TITLE
Pin rack-test to the actual upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,7 @@ group :development do
 end
 
 group :test do
-  # NOTE: keep until https://github.com/brynary/rack-test/pull/69 is merged
-  gem 'rack-test', github: 'alphagov/rack-test'
+  gem 'rack-test', github: 'brynary/rack-test'
   gem 'factory_girl'
   gem 'hash_syntax'
   gem 'mocha', '0.14.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/alphagov/rack-test.git
-  revision: c98433f5f6a45842520913c31968cde5cd782d55
+  remote: git://github.com/brynary/rack-test.git
+  revision: 8cdb86e1d710194ce45f439915707db7fb2b27e5
   specs:
     rack-test (0.6.2)
       rack (>= 1.0)


### PR DESCRIPTION
They've [merged our changes in upstream](https://github.com/brynary/rack-test/pull/69) so we can drop our fork.
