### PR TITLE
Don't modify the translation store

### DIFF
--- a/test/unit/helpers/translation_helper_test.rb
+++ b/test/unit/helpers/translation_helper_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test_helper'
 
 class TranslationHelperTest < ActionView::TestCase
@@ -22,25 +23,28 @@ class TranslationHelperTest < ActionView::TestCase
     assert_equal [:de, :es, :fr], sorted_locales([:fr, :de, :es])
   end
 
-  test "t_delivery_title returns minister value if document was delivered by minister" do
-    I18n.backend.store_translations :en, {document: {speech: {delivery_title: {minister: 'minister-value'}}}}
-    assert_equal "minister-value", t_delivery_title(stub('document', speech_type: stub('type', owner_key_group: 'delivery_title'), delivered_by_minister?: true))
+  test "t_delivery_title returns translation of 'Minister' if document was delivered by minister" do
+    I18n.with_locale(:fr) do
+      assert_equal "Ministre", t_delivery_title(stub('document', speech_type: stub('type', owner_key_group: 'delivery_title'), delivered_by_minister?: true))
+    end
   end
 
-  test "t_delivery_title returns speaker value if document was not delivered by minister" do
-    I18n.backend.store_translations :en, {document: {speech: {delivery_title: {speaker: 'speaker-value'}}}}
-    assert_equal "speaker-value", t_delivery_title(stub('document', speech_type: stub('type', owner_key_group: 'delivery_title'), delivered_by_minister?: false))
+  test "t_delivery_title returns translation of 'Speaker' if document was not delivered by minister" do
+    I18n.with_locale(:fr) do
+      assert_equal "Orateur", t_delivery_title(stub('document', speech_type: stub('type', owner_key_group: 'delivery_title'), delivered_by_minister?: false))
+    end
   end
 
-  test "t_corporate_information_page_type uses display_type_key from the page" do
-    I18n.backend.store_translations :en, {corporate_information_page: {type: {page_type: "the-page-type"}}}
-    assert_equal "the-page-type", t_corporate_information_page_type(stub('corp info page', display_type_key: "page_type"))
+  test "t_corporate_information_page_type tranlsates the type of corporate informaton page" do
+    I18n.with_locale(:fr) do
+      assert_equal "Charte de données personnelles", t_corporate_information_page_type(stub('corp info page', display_type_key: "personal_information_charter"))
+    end
   end
 
-  test "t_delivered_on returns written value if document is a written speech" do
-    I18n.backend.store_translations :en, {document: {speech: {delivered_on: 'delivered-on-value'}}}
-    I18n.backend.store_translations :en, {document: {speech: {written_on: 'written-on-value'}}}
-    assert_equal "delivered-on-value", t_delivered_on(stub('speech_type', published_externally_key: 'delivered_on'))
-    assert_equal "written-on-value", t_delivered_on(stub('speech_type', published_externally_key: 'written_on'))
+  test "t_delivered_on returns appropriate translation depending on whether speech was written or delivered" do
+    I18n.with_locale(:fr) do
+      assert_match /Prononcé le/, t_delivered_on(stub('speech_type', published_externally_key: 'delivered_on'))
+      assert_match /Ecrit le/, t_delivered_on(stub('speech_type', published_externally_key: 'written_on'))
+    end
   end
 end


### PR DESCRIPTION
Working towards fixing https://www.pivotaltracker.com/story/show/56873538

Modifying the translation store during tests was causing [this test](https://github.com/alphagov/whitehall/blob/e93bca0eb16b2a1c38309033d62bb0408c345680/test/unit/helpers/document_helper_test.rb#L198) to sporadically fail because the translation for "Minister" was being overwritten in the translation store and so it was being translated as 'minister-value'.  I did look into adding a teardown that reset the
translation store, but this is very slow (blowing away and reloading all translations).

Although there is now the risk that these tests will break if the French translations for these words should ever
change, I think this is better than stubbing the translation helper, which feels way too much like testing implementation.
