### PR TITLE
Destroy dependent edition curation queue items

### DIFF
--- a/app/models/email_curation_queue_item.rb
+++ b/app/models/email_curation_queue_item.rb
@@ -1,5 +1,5 @@
 class EmailCurationQueueItem < ActiveRecord::Base
-  belongs_to :edition
+  belongs_to :edition, inverse_of: :email_curation_queue_items
 
   validates :edition, :title, :summary, :notification_date, presence: true
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -790,4 +790,12 @@ class EditionTest < ActiveSupport::TestCase
     refute non_local_gov_editions.include? local_gov_policy
     refute non_local_gov_editions.include? local_gov_publication
   end
+
+  test 'deleting an edition also deletes any associated email curation queue items' do
+    edition =  create(:edition)
+    queue_item = EmailCurationQueueItem.create_from_edition(edition, Date.today)
+
+    edition.delete!
+    refute EmailCurationQueueItem.exists?(queue_item)
+  end
 end


### PR DESCRIPTION
If an edition is deleted, we also want to destroy any related curation queue items, otherwise the curation queue admin interface blows up.

Tracker: https://www.pivotaltracker.com/story/show/54276024
