### PR TITLE
Prevent test interference due to stale uploaded files

### DIFF
--- a/features/support/uploads.rb
+++ b/features/support/uploads.rb
@@ -1,4 +1,3 @@
 # Blow away the incoming/clean test uploads for this env to avoid clashes during test run
-  [(Whitehall.incoming_uploads_root + '/system'), (Whitehall.clean_uploads_root + '/system'), (Whitehall.infected_uploads_root + '/system')].each do |folder|
-    FileUtils.rm_rf(folder) if Dir.exists?(folder)
-  end
+require File.dirname(__FILE__) + "/../../test/support/virus_scan_helpers"
+VirusScanHelpers.erase_test_files

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -1,5 +1,3 @@
-require 'whitehall/virus_scan_helpers'
-
 class GenericEdition < Edition
   class << self
     attr_accessor :translatable

--- a/test/support/virus_scan_helpers.rb
+++ b/test/support/virus_scan_helpers.rb
@@ -26,4 +26,20 @@ module VirusScanHelpers
       end
     end
   end
+
+  def self.erase_test_files
+    raise "Only use VirusScanHelpers.erase_test_files in test mode" unless Rails.env.test?
+    folders = [
+      Whitehall.incoming_uploads_root,
+      Whitehall.clean_uploads_root,
+      Whitehall.infected_uploads_root
+    ]
+
+    folders.each do |folder|
+      next unless Dir.exists?(folder)
+      Dir.glob("#{folder}/*").each do |path|
+        FileUtils.rm_rf(path)
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,6 @@ require 'slimmer/test'
 require 'factories'
 require 'webmock/test_unit'
 require 'whitehall/not_quite_as_fake_search'
-require 'whitehall/virus_scan_helpers'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
@@ -33,6 +32,7 @@ class ActiveSupport::TestCase
     Timecop.freeze(2011, 11, 11, 11, 11, 11)
     Whitehall.search_backend = Whitehall::DocumentFilter::FakeSearch
     ImageSizeChecker.any_instance.stubs(:size_is?).returns true
+    VirusScanHelpers.erase_test_files
   end
 
   teardown do


### PR DESCRIPTION
This is a bit of a brute force approach but will ensure that no stale
test files are lying around.

Also moved the virus_scan_helpers to test/support (where they belong).
