### PR TITLE
Clean up carrierwave temporary directory

### DIFF
--- a/jenkins-new.sh
+++ b/jenkins-new.sh
@@ -30,6 +30,9 @@ function error_handler {
 trap "error_handler ${LINENO}" ERR
 github_status pending "is running on Jenkins"
 
+# Empty and recreate carrierwave directory
+rm -rf ./carrierwave-tmp && mkdir -p ./carrierwave-tmp
+
 # Generate directories for upload tests
 mkdir -p ./incoming-uploads
 mkdir -p ./clean-uploads

--- a/jenkins-parallel.sh
+++ b/jenkins-parallel.sh
@@ -4,6 +4,9 @@ export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env
 
+# Empty and recreate carrierwave directory
+rm -rf ./carrierwave-tmp && mkdir -p ./carrierwave-tmp
+
 # Generate directories for upload tests
 mkdir -p ./incoming-uploads
 mkdir -p ./clean-uploads


### PR DESCRIPTION
This was previously never being cleaned up, which means we could run into directory size issues. We now clean it before running our tests.
