### PR TITLE
Use transactional fixtures even when db queries disabled

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,7 +75,6 @@ class ActiveSupport::TestCase
   end
 
   def self.disable_database_queries
-    self.use_transactional_fixtures = false
     setup do
       ActiveRecord::Base.connection.expects(:select).never
     end


### PR DESCRIPTION
The disable_database_queries method should prevent db operations.
However it does not block INSERT queries, so data can be inadvertently
changed by associations on FactoryGirl factories.

This was causing test interference and intermittent failures because
User objects were getting created in some tests and persisting across
test runs.

I've logged a tech-debt story[1] to review the use of
disable_database_queries and possibly remove it as I think that the cost
of the added complication in tests is excessive compared to the
benefits of any test speedup.

[1] https://www.pivotaltracker.com/story/show/57500426
