### PR TITLE
Make the search toggle match the search input

### DIFF
--- a/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
+++ b/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
@@ -22,7 +22,8 @@ body.js-enabled {
       }
     }
   }
-  form#search input.submit {
+  form#search input.submit,
+  .search-toggle {
     background-color: $inside-gov-secondary;
     &:hover {
       background-color: lighten($inside-gov-secondary, 5%);


### PR DESCRIPTION
The search toggle (that appears in mobile-view to show/hide the search box) is getting the static colour. This makes it match the whitehall green.
