### PR TITLE
Optimise organisations#index page

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -21,7 +21,7 @@ module Organisation::OrganisationTypeConcern
     }
 
     scope :listable, lambda {
-      excluding_govuk_status_closed.where("organisation_type_key != 'sub_organisation'")
+      excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'")
     }
   end
 
@@ -41,7 +41,7 @@ module Organisation::OrganisationTypeConcern
 
   def active_child_organisations_excluding_sub_organisations
     @active_child_organisations_excluding_sub_organisations ||=
-      child_organisations.excluding_govuk_status_closed.where("organisation_type_key != 'sub_organisation'")
+      child_organisations.excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'")
   end
 
   def active_child_organisations_excluding_sub_organisations_grouped_by_type

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -28,7 +28,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       assert_select_object(organisation)
     end
   end
-  
+
   view_test "should display a list of ministerial departments" do
     organisation_1 = create(:organisation, organisation_type: OrganisationType.ministerial_department)
     organisation_2 = create(:organisation, organisation_type: OrganisationType.ministerial_department)
@@ -76,7 +76,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       assert_select '.js-filter-count', text: '2'
       assert_select_object(organisation_1)
     end
-  end  
+  end
 
   view_test "index shouldn't include sub-organisations" do
     sub_organisation = create(:sub_organisation)
@@ -104,7 +104,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
 
 
-  ### Describing :show ###  
+  ### Describing :show ###
 
   view_test "shows organisation description" do
     organisation = create(:organisation,
@@ -739,7 +739,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
 
 
-  ### Describing :about ###  
+  ### Describing :about ###
 
   view_test "should show description on organisation about subpage" do
     organisation = create(:organisation, description: "organisation-description")


### PR DESCRIPTION
Reduces the number of queries from just under 500 to 80. Page load time halved from 7 seconds to 3.5.
