### PR TITLE
Remove dodgy rescue_from

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -12,12 +12,6 @@ class Admin::EditionWorkflowController < Admin::BaseController
     redirect_to admin_edition_path(@edition), alert: "This document has been edited since you viewed it; you are now viewing the latest version"
   end
 
-  rescue_from ActiveRecord::RecordInvalid do
-    redirect_to admin_edition_path(@edition),
-      alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is invalid (#{@edition.errors.full_messages.to_sentence}). " +
-             "Please edit it and try again."
-  end
-
   rescue_from Transitions::InvalidTransition do
     redirect_to admin_edition_path(@edition),
       alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is not ready yet. Please try again."

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -230,14 +230,6 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal 'This document has been edited since you viewed it; you are now viewing the latest version', flash[:alert]
   end
 
-  test 'submit redirects back to the edition with an error message on validation error' do
-    @edition.errors.add(:change_note, "can't be blank")
-    @edition.stubs(:submit!).raises(ActiveRecord::RecordInvalid, @edition)
-    post :submit, id: @edition, lock_version: 1
-    assert_redirected_to admin_policy_path(@edition)
-    assert_equal "Unable to submit this edition because it is invalid (Change note can't be blank). Please edit it and try again.", flash[:alert]
-  end
-
   test 'submit responds with 422 if missing a lock version' do
     post :submit, id: @edition
     assert_equal 422, response.status
@@ -303,14 +295,6 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     post :reject, id: @edition, lock_version: 1
     assert_redirected_to admin_policy_path(@edition)
     assert_equal 'This document has been edited since you viewed it; you are now viewing the latest version', flash[:alert]
-  end
-
-  test 'reject redirects back to the edition with an error message on validation error' do
-    @edition.errors.add(:change_note, "can't be blank")
-    @edition.stubs(:reject!).raises(ActiveRecord::RecordInvalid, @edition)
-    post :reject, id: @edition, lock_version: 1
-    assert_redirected_to admin_policy_path(@edition)
-    assert_equal "Unable to reject this edition because it is invalid (Change note can't be blank). Please edit it and try again.", flash[:alert]
   end
 
   test 'reject responds with 422 if missing a lock version' do


### PR DESCRIPTION
This caught me recently when publishing an edition that had invalid previous editions. The error gets swallowed and a cryptic error message is shown to the user:

`Unable to publish this edition because it is invalid (). Please edit it and try again`

This is despite the fact that the edition has actually been published just fine; it's just the previous editions that have not been transitioned to archived.

I think this will be causing all sorts of insidious problems within the app and we should remove it asap, even if it is likely to increases the chances of users seeing 500 errors when they perform workflow actions on editions. Our approach should be to aggressively fix any issues that are causing the app to attempt invalid transitions, rather than to catch exceptions and brush things under the carpet.
