### PR TITLE
Fix supporting page attachments handling on draft

### DIFF
--- a/app/models/edition/supporting_pages.rb
+++ b/app/models/edition/supporting_pages.rb
@@ -6,8 +6,8 @@ module Edition::SupportingPages
       @edition.supporting_pages.each do |sd|
         new_supporting_page = edition.supporting_pages.create(sd.attributes.except("id", "edition_id"))
         new_supporting_page.update_column(:slug, sd.slug)
-        sd.attachments.each do |a|
-          new_supporting_page.supporting_page_attachments.create(attachment_id: a.id)
+        sd.attachments.each do |attachment|
+          new_supporting_page.attachments << attachment.class.new(attachment.attributes)
         end
       end
     end

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -100,7 +100,7 @@ class AttachableTest < ActiveSupport::TestCase
     edition
   end
 
-  test 'should say a edition has a thumbnail when it has a thumbnailable attachment' do
+  test 'should say an edition has a thumbnail when it has a thumbnailable attachment' do
     edition = build_edition_with_three_attachments
 
     assert edition.has_thumbnail?

--- a/test/unit/edition/supporting_pages_test.rb
+++ b/test/unit/edition/supporting_pages_test.rb
@@ -14,4 +14,22 @@ class Edition::SupportingPagesTest < ActiveSupport::TestCase
     edition.destroy
     refute SupportingPage.find_by_id(supporting_page.id)
   end
+
+  test "supporting pages and their attachments are versioned when a new draft is created" do
+    policy = create(:published_policy)
+    attachment = create(:attachment)
+    supporting_page = create(:supporting_page, edition: policy, attachments: [attachment])
+
+    new_draft = policy.create_draft(create(:policy_writer))
+
+    assert new_supporting_page = new_draft.supporting_pages.first
+    assert_not_equal supporting_page, new_supporting_page
+    assert_equal supporting_page.title, new_supporting_page.title
+    assert_equal supporting_page.body, new_supporting_page.body
+
+    assert new_attachment = new_supporting_page.attachments.first
+    assert_not_equal attachment, new_attachment
+    assert_equal attachment.title, new_attachment.title
+    assert_equal attachment.attachment_data_id, new_attachment.attachment_data_id
+  end
 end


### PR DESCRIPTION
This trait was broken during the recent attachments refactoring and slipped through the net. The behaviour was also incorrect in that attachments on supporting pages were not being correctly versioned.
