### PR TITLE
Fix editions with broken first_published_at

### DIFF
--- a/db/data_migration/20130926091146_fix_broken_first_published_at_timestamps.rb
+++ b/db/data_migration/20130926091146_fix_broken_first_published_at_timestamps.rb
@@ -1,0 +1,19 @@
+nineteen_hundreds = Date.new(1900)
+
+documents = Edition.where('first_published_at < ? and state != ?', nineteen_hundreds, 'imported').collect(&:document).uniq
+documents.each do |document|
+  fallback_timestamp = document.latest_edition.first_published_at
+
+  document.editions.where('first_published_at < ?', nineteen_hundreds).each do |edition|
+    if edition.first_published_at < nineteen_hundreds
+      if edition.public_timestamp < nineteen_hundreds
+        fix = fallback_timestamp
+      else
+        fix = edition.public_timestamp
+      end
+
+      puts "Fixing timestamp on #{edition.id}|#{edition.title} - setting it to #{fix}"
+      edition.update_attribute(:first_published_at, fix)
+    end
+  end
+end


### PR DESCRIPTION
There are a dozen or so editions with a `first_published_at` timestamp that is broken (e.g. 0001-01-01). This fixes them, using the edition's `public_timestamp` if that is a sensible value, otherwise falling back to the latest edition's `first_published_at`

Tracker: https://www.pivotaltracker.com/story/show/56769702
