### PR TITLE
Fix inconsistent govspeak contacts

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -292,11 +292,6 @@
     }
   }
 
-  .address {
-    border-left: 1px solid $border-colour;
-    padding-left: $gutter-half;
-  }
-
   .fraction {
     sup,
     sub {
@@ -309,11 +304,15 @@
     }
   }
 
+  .address,
+  .contact {
+    border-left: 1px solid $border-colour;
+    padding-left: $gutter-half;
+  }
+
   .contact {
     @extend %contain-floats;
-    background: $panel-colour;
-    margin: $gutter $gutter-half*-1;
-    padding: $gutter-one-third $gutter-half;
+    margin-bottom: $gutter;
     position: relative;
     .content {
       float: none;
@@ -321,6 +320,7 @@
       h3 {
         @include core-19;
         font-weight: bold;
+        margin-bottom: 5px;
       }
       .adr,
       .email-url-number,


### PR DESCRIPTION
Both addresses and contacts now have a line to the left instead
of being a grey box.

https://www.pivotaltracker.com/story/show/52705481
