### PR TITLE
Set expiry on TopicsController#Show to be 5 mins

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,8 +1,6 @@
 class TopicsController < ClassificationsController
   include CacheControlHelper
 
-  skip_before_filter :set_cache_control_headers, only: [:show], if: :is_html?
-
   def show
     @classification = Topic.find(params[:id])
 
@@ -35,9 +33,5 @@ class TopicsController < ClassificationsController
   def set_cache_max_age
     @cache_max_age = 5.minutes
     set_expiry @cache_max_age
-  end
-
-  def is_html?
-    request.format.html?
   end
 end

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -150,4 +150,13 @@ class TopicsControllerTest < ActionController::TestCase
 
     assert_cache_control("max-age=#{5.minutes}")
   end
+
+  test 'GET :show caps max expiry to 5 minute when there are future scheduled editions' do
+    topic = create(:topic)
+    create(:scheduled_publication, scheduled_publication: 1.day.from_now, topics: [topic])
+
+    get :show, id: topic
+
+    assert_cache_control("max-age=#{5.minutes}")
+  end
 end


### PR DESCRIPTION
We need this to be 5 minutes so changes to the featured set will show up reasonably quickly.

As part of this I've refactored the controller a bit to hide most of the logic which only applies to HTML formats inside a conditional.

cc @tekin 

https://www.pivotaltracker.com/story/show/53342563
