### PR TITLE
Remove unnecessary setting of empty arrays

### DIFF
--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -1,7 +1,6 @@
 class Admin::ClassificationsController < Admin::BaseController
   helper_method :model_class, :model_name, :human_friendly_model_name
 
-  before_filter :default_arrays_of_ids_to_empty, only: [:update]
   before_filter :build_object, only: [:new]
   before_filter :load_object, only: [:show, :edit]
 
@@ -63,9 +62,5 @@ class Admin::ClassificationsController < Admin::BaseController
 
   def object_params
     params[model_name]
-  end
-
-  def default_arrays_of_ids_to_empty
-    object_params[:related_classification_ids] ||= []
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -169,36 +169,6 @@ class Admin::EditionsController < Admin::BaseController
       params[:edition][:lead_organisation_ids] ||= []
       params[:edition][:supporting_organisation_ids] ||= []
     end
-    if @edition.can_be_associated_with_topics?
-      params[:edition][:topic_ids] ||= []
-    end
-    if @edition.can_be_associated_with_ministers?
-      params[:edition][:ministerial_role_ids] ||= []
-    end
-    if @edition.can_be_associated_with_role_appointments?
-      params[:edition][:role_appointment_ids] ||= []
-    end
-    if @edition.can_be_associated_with_statistical_data_sets?
-      params[:edition][:statistical_data_set_document_ids] ||= []
-    end
-    if @edition.can_be_related_to_policies?
-      params[:edition][:related_policy_ids] ||= []
-    end
-    if @edition.can_be_associated_with_world_locations?
-      params[:edition][:world_location_ids] ||= []
-    end
-    if @edition.can_be_associated_with_mainstream_categories?
-      params[:edition][:other_mainstream_category_ids] ||= []
-    end
-    if @edition.can_be_associated_with_topical_events?
-      params[:edition][:topical_event_ids] ||= []
-    end
-    if @edition.can_be_associated_with_worldwide_organisations?
-      params[:edition][:worldwide_organisation_ids] ||= []
-    end
-    if @edition.can_be_associated_with_worldwide_priorities?
-      params[:edition][:worldwide_priority_ids] ||= []
-    end
   end
 
   def build_edition_dependencies

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -26,8 +26,6 @@ class Admin::RolesController < Admin::BaseController
   end
 
   def update
-    params[:role][:organisation_ids] ||= []
-    params[:role][:worldwide_organisation_ids] ||= []
     attributes = RoleTypePresenter.role_attributes_from(params[:role])
     if new_type = attributes.delete(:type)
       @role.type = new_type

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -69,21 +69,6 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
     assert_equal [soul], DetailedGuide.first.other_mainstream_categories
   end
 
-  test "update allows removal of other mainstream categories" do
-    funk = create(:mainstream_category, title: "Funk")
-    soul = create(:mainstream_category, title: "Soul")
-    existing_edition = create(:detailed_guide, primary_mainstream_category: funk, other_mainstream_categories: [soul])
-
-    attributes = controller_attributes_for_instance(existing_edition)
-    attributes.delete(:other_mainstream_category_ids)
-
-    put :update,
-      id: existing_edition,
-      edition: attributes
-
-    assert_equal [], existing_edition.reload.other_mainstream_categories
-  end
-
   private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -321,33 +321,6 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_equal [], organisation.topics
   end
 
-  test "PUT on :update should remove all related mainstream categories if none specified" do
-    organisation_attributes = {name: "Ministry of Sound"}
-    organisation = create(:organisation,
-      organisation_attributes.merge(mainstream_categories: [create(:mainstream_category)])
-    )
-
-    put :update, id: organisation, organisation: organisation_attributes.merge(mainstream_category_ids: [""])
-
-    organisation.reload
-    assert_equal [], organisation.mainstream_categories
-  end
-
-  test "PUT on :update removes absent mainstream categories via nested attributes" do
-    category1 = create(:mainstream_category)
-    category2 = create(:mainstream_category)
-    organisation_attributes = {name: "Ministry of Sound"}
-    organisation = create(:organisation, organisation_attributes.merge(mainstream_categories: [category1, category2]))
-    category1_join = organisation.organisation_mainstream_categories.where(mainstream_category_id: category1).first
-    category2_join = organisation.organisation_mainstream_categories.where(mainstream_category_id: category2).first
-
-    put :update, id: organisation,
-                 organisation: organisation_attributes.merge( organisation_mainstream_categories_attributes: [ {mainstream_category_id: category1.id, ordering: "0", id: category1_join.id},
-                                                                                                               {mainstream_category_id: "", ordering: "1", id: category2_join.id} ])
-
-    assert_equal [category1], organisation.reload.mainstream_categories
-  end
-
   test "PUT on :update ordering featured editions should not lose topics or parent organisations" do
     topic = create(:topic)
     parent_organisation = create(:organisation)

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -275,26 +275,6 @@ class Admin::RolesControllerTest < ActionController::TestCase
     assert_equal [org_two], role.organisations
   end
 
-  test "update should allow removal of all organisations" do
-    org = create(:organisation)
-    role = create(:role, organisations: [org])
-
-    put :update, id: role, role: attributes_for(:role).except(:organisation_ids)
-
-    role = Role.find(role.id)
-    assert_equal [], role.organisations
-  end
-
-  test "update should allow removal of all world organisations" do
-    worg = create(:worldwide_organisation)
-    role = create(:role, worldwide_organisations: [worg])
-
-    put :update, id: role, role: attributes_for(:role).except(:worldwide_organisation_ids)
-
-    role = Role.find(role.id)
-    assert_equal [], role.worldwide_organisations
-  end
-
   test "update redirects to the index on success" do
     role = create(:role)
 

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -76,17 +76,6 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     assert_equal "new-description", topic.description
   end
 
-  test "PUT :update removes all related topics if none specified" do
-    first_topic = create(:topic)
-    second_topic = create(:topic)
-    topic = create(:topic, related_classification_ids: [first_topic.id, second_topic.id])
-
-    put :update, id: topic, topic: {}
-
-    assert_response :redirect
-    assert_equal [], topic.reload.related_classifications
-  end
-
   view_test "PUT :update with bad data renders errors" do
     topic = create(:topic, name: 'topic')
     put :update, id: topic.id, topic: {name: "Blah", description: ""}

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -614,16 +614,6 @@ module AdminEditionControllerTestHelpers
         assert_equal [second_policy], document.related_policies
       end
 
-      test "updating should remove all related policies if none in params" do
-        policy = create(:policy)
-        document = create(document_type, related_editions: [policy])
-
-        put :update, id: document, edition: controller_attributes_for_instance(document, related_policy_ids: [])
-
-        document.reload
-        assert_equal [], document.related_policies
-      end
-
       view_test "updating a stale document should render edit page with conflicting document and its related policies" do
         policy = create(:policy)
         document = create(document_type, related_editions: [policy])
@@ -686,16 +676,6 @@ module AdminEditionControllerTestHelpers
 
         edition.reload
         assert_equal [second_data_set], edition.statistical_data_sets
-      end
-
-      test "update should remove all statistical data sets if none specified" do
-        data_set = create(:statistical_data_set, document: create(:document))
-        edition = create(edition_type, statistical_data_sets: [data_set])
-
-        put :update, id: edition, edition: {}
-
-        edition.reload
-        assert_equal [], edition.statistical_data_sets
       end
     end
 
@@ -841,19 +821,6 @@ module AdminEditionControllerTestHelpers
         assert_equal [second_topic], edition.topics
       end
 
-      test "update should remove all topics if none specified" do
-        topic = create(:topic)
-
-        edition = create("draft_#{edition_type}", topics: [topic])
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition,
-          topic_ids: []
-        )
-
-        edition.reload
-        assert_equal [], edition.topics
-      end
-
       view_test "updating a stale document should render edit page with conflicting document and its related topics" do
         topic = create(:topic)
         edition = create(edition_type, topics: [topic])
@@ -918,19 +885,6 @@ module AdminEditionControllerTestHelpers
         edition.reload
         assert_equal [second_appointment], edition.role_appointments
       end
-
-      test "update should remove all role appointments if none specified" do
-        appointment = create(:role_appointment)
-
-        edition = create(edition_type, role_appointments: [appointment])
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition,
-          role_appointment_ids: []
-        )
-
-        edition.reload
-        assert_equal [], edition.role_appointments
-      end
     end
 
 
@@ -980,19 +934,6 @@ module AdminEditionControllerTestHelpers
 
         edition.reload
         assert_equal [second_minister], edition.ministerial_roles
-      end
-
-      test "update should remove all ministerial roles if none specified" do
-        minister = create(:ministerial_role)
-
-        edition = create(edition_type, ministerial_roles: [minister])
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition,
-          ministerial_role_ids: []
-        )
-
-        edition.reload
-        assert_equal [], edition.ministerial_roles
       end
     end
 
@@ -1332,30 +1273,6 @@ module AdminEditionControllerTestHelpers
         edition.reload
         assert_equal [second_topical_event], edition.topical_events
       end
-
-      test "update should remove all topical_events if empty param specified" do
-        topical_event = create(:topical_event)
-
-        edition = create("draft_#{edition_type}", topical_events: [topical_event])
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition,
-          topical_event_ids: []
-        )
-
-        edition.reload
-        assert_equal [], edition.topical_events
-      end
-
-      test "update should remove all topical_events if none specified at all" do
-        topical_event = create(:topical_event)
-
-        edition = create("draft_#{edition_type}", topical_events: [topical_event])
-
-        put :update, id: edition, edition: controller_attributes_for_instance(edition).except(:topical_event_ids)
-
-        edition.reload
-        assert_equal [], edition.topical_events
-      end
     end
 
     def should_allow_association_with_worldwide_organisations(edition_type)
@@ -1397,14 +1314,6 @@ module AdminEditionControllerTestHelpers
         assert edition = edition_class.last
         assert_equal [first_world_organisation, second_world_organisation], edition.worldwide_organisations
       end
-
-      test "update should remove all worldwide organisations if none specified at all" do
-        world_organisation = create(:worldwide_organisation)
-        edition = create("draft_#{edition_type}", worldwide_organisations: [world_organisation])
-        put :update, id: edition, edition: controller_attributes_for_instance(edition).except(:worldwide_organisation_ids)
-
-        assert_equal [], edition.reload.worldwide_organisations
-      end
     end
 
     def should_allow_association_with_worldwide_priorities(edition_type)
@@ -1429,14 +1338,6 @@ module AdminEditionControllerTestHelpers
 
         assert edition = edition_class.last
         assert_equal [first_worldwide_priority, second_worldwide_priority], edition.worldwide_priorities
-      end
-
-      test "update should remove all worldwide priorities if none specified at all" do
-        worldwide_priority = create(:worldwide_priority)
-        edition = create("draft_#{edition_type}", worldwide_priority_ids: [worldwide_priority.id])
-        put :update, id: edition, edition: controller_attributes_for_instance(edition).except(:worldwide_priority_ids)
-
-        assert_equal [], edition.reload.worldwide_priorities
       end
     end
 

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -39,17 +39,6 @@ module AdminEditionWorldLocationsBehaviour
         assert_equal [world_location], document.world_locations
       end
 
-      test "updating should remove all world locations if none in params" do
-        world_location = create(:world_location)
-
-        document = create(document_type, world_locations: [world_location])
-
-        put :update, id: document, edition: {}
-
-        document.reload
-        assert_equal [], document.world_locations
-      end
-
       view_test "updating a stale document should render edit page with conflicting document and its world locations" do
         document = create(document_type)
         lock_version = document.lock_version
@@ -61,7 +50,6 @@ module AdminEditionWorldLocationsBehaviour
           assert_select "h1", "World locations"
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
We don't actually need to massage the params in this way anymore because Rails 3.2 does some magic for us: it inserts a hidden input for multi-selects, which will always get submitted, meaning we get an empty array when all the options are deselected. See https://github.com/rails/rails/commit/faba406fa15251cdc9588364d23c687a14ed6885
