### PR TITLE
Fix topics#show and other refactorings.

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -9,7 +9,7 @@ class TopicalEventsController < ClassificationsController
     @publications = fetch_associated(:published_publications, PublicationesquePresenter)
     @consultations = fetch_associated(:published_consultations, PublicationesquePresenter)
     @announcements = fetch_associated(:published_announcements, AnnouncementPresenter)
-    @detailed_guides = @classification.detailed_guides.published.includes(:translations, :document).limit(5)
+    @detailed_guides = @classification.published_detailed_guides.includes(:translations, :document).limit(5)
     @related_classifications = @classification.related_classifications
     @featured_editions = decorate_collection(@classification.classification_featurings.includes(:image, edition: :document).limit(5), FeaturedEditionPresenter)
     set_slimmer_organisations_header(@classification.organisations)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,11 +7,11 @@ class TopicsController < ClassificationsController
     respond_to do |format|
       format.html do
         @policies = @classification.published_policies.includes(:translations, :document)
-        @consultations = latest_presenters(Consultation.published_in_topic(@classification))
-        @publications = latest_presenters(Publication.published_in_topic(@classification))
-        @statistical_data_sets = latest_presenters(StatisticalDataSet.published_in_topic(@classification))
-        @announcements = latest_presenters(Announcement.published_in_topic(@classification))
-        @detailed_guides = @classification.detailed_guides.published.includes(:translations, :document).limit(5)
+        @consultations = latest_presenters(@classification.published_consultations)
+        @publications = latest_presenters(@classification.published_non_statistics_publications)
+        @statistics = latest_presenters(@classification.published_statistics_publications)
+        @announcements = latest_presenters(@classification.published_announcements)
+        @detailed_guides = @classification.published_detailed_guides.includes(:translations, :document).limit(5)
         @related_classifications = @classification.related_classifications
         @featured_editions = decorate_collection(@classification.classification_featurings.includes(:image, edition: [:document, :translations]).limit(5), FeaturedEditionPresenter)
 

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -13,8 +13,8 @@ module TopicsHelper
 
   def classification_contents_breakdown(classification)
     capture do
-      concat content_tag(:span, pluralize(classification.policies.published.count, "published policy"))
-      concat content_tag(:span, pluralize(classification.detailed_guides.published.count, "published detailed guide"))
+      concat content_tag(:span, pluralize(classification.published_policies.count, "published policy"))
+      concat content_tag(:span, pluralize(classification.published_detailed_guides.count, "published detailed guide"))
     end
   end
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -12,38 +12,9 @@ class Classification < ActiveRecord::Base
 
   has_many :classification_memberships
   has_many :editions, through: :classification_memberships
-  has_many :policies, through: :classification_memberships, order: 'classification_memberships.ordering ASC'
-  has_many :detailed_guides, through: :classification_memberships
-  has_many :published_detailed_guides,
-            through: :classification_memberships,
-            class_name: "DetailedGuide",
-            conditions: { "editions.state" => "published" },
-            source: :detailed_guide
 
   has_many :organisation_classifications
   has_many :organisations, through: :organisation_classifications
-
-  has_many :published_policies,
-            through: :classification_memberships,
-            class_name: "Policy",
-            conditions: { "editions.state" => "published" },
-            source: :policy,
-            order: 'classification_memberships.ordering ASC'
-  has_many :archived_policies,
-            through: :classification_memberships,
-            class_name: "Policy",
-            conditions: { state: "archived" },
-            source: :policy
-
-  has_many :published_editions,
-            through: :classification_memberships,
-            conditions: { "editions.state" => "published" },
-            source: :edition
-  has_many :scheduled_editions,
-            through: :classification_memberships,
-            conditions: { "editions.state" => "scheduled" },
-            source: :edition
-
   has_many :classification_relations
   has_many :related_classifications,
             through: :classification_relations,
@@ -74,41 +45,49 @@ class Classification < ActiveRecord::Base
 
   scope :with_content, where("published_edition_count <> 0")
   scope :with_policies, where("published_policies_count <> 0")
+  scope :alphabetical, order("name ASC")
+  scope :randomized, order('RAND()')
 
   mount_uploader :logo, ImageUploader, mount_on: :carrierwave_image
 
-  def self.with_related_detailed_guides
-    joins(:published_detailed_guides).group(arel_table[:id])
-  end
-
-  def self.with_related_announcements
-    joins(:published_policies).
-      group(arel_table[:id]).
-      where("EXISTS (
-        SELECT * FROM edition_relations er_check
-        JOIN editions announcement_check
-          ON announcement_check.id=er_check.edition_id
-            AND announcement_check.state='published'
-        WHERE
-          er_check.document_id=editions.document_id AND
-          announcement_check.type in (?)
-          )", Announcement.sti_names)
-  end
-
-  def self.with_related_publications
-    includes(:published_policies).select { |t| t.published_policies.map(&:published_related_publication_count).sum > 0 }
-  end
-
-  def self.with_related_policies
-    joins(:published_policies).group(arel_table[:id])
-  end
-
-  scope :alphabetical, order("name ASC")
-
-  scope :randomized, order('RAND()')
-
   extend FriendlyId
   friendly_id
+
+  def policies
+    editions.policies.order('classification_memberships.ordering ASC')
+  end
+
+  def published_editions
+    editions.published
+  end
+
+  def scheduled_editions
+    editions.scheduled.order('scheduled_publication ASC')
+  end
+
+  def published_announcements
+    published_editions.announcements
+  end
+
+  def published_consultations
+    published_editions.consultations
+  end
+
+  def published_detailed_guides
+    published_editions.detailed_guides
+  end
+
+  def published_policies
+    policies.published
+  end
+
+  def published_non_statistics_publications
+    published_editions.non_statistical_publications
+  end
+
+  def published_statistics_publications
+    published_editions.statistical_publications
+  end
 
   def lead_organisations
     organisations.where(organisation_classifications: {lead: true}).reorder("organisation_classifications.lead_ordering")
@@ -124,8 +103,7 @@ class Classification < ActiveRecord::Base
   end
 
   def destroyable?
-    non_archived_policies = policies - archived_policies
-    non_archived_policies.blank?
+    (policies - policies.archived).empty?
   end
 
   def search_link
@@ -133,7 +111,7 @@ class Classification < ActiveRecord::Base
   end
 
   def latest(limit = 3)
-    editions.published.without_editions_of_type(WorldLocationNewsArticle).in_reverse_chronological_order.includes(:translations).limit(limit)
+    published_editions.without_editions_of_type(WorldLocationNewsArticle).in_reverse_chronological_order.includes(:translations).limit(limit)
   end
 
   def description_without_markup

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -50,7 +50,15 @@ class Edition < ActiveRecord::Base
     .where("edition_translations.title REGEXP :pattern OR documents.slug = :slug", pattern: pattern, slug: keywords)
   }
 
-  scope :force_published, -> { where(state: "published", force_published: true) }
+  scope :force_published, where(state: "published", force_published: true)
+
+  scope :announcements,            -> { where(type: Announcement.concrete_descendants.collect(&:name)) }
+  scope :consultations,                 where(type: "Consultation")
+  scope :detailed_guides,               where(type: "DetailedGuide")
+  scope :policies,                      where(type: "Policy")
+  scope :statistical_publications,      where("publication_type_id IN (?)", PublicationType.statistical.map(&:id))
+  scope :non_statistical_publications,  where("publication_type_id NOT IN (?)", PublicationType.statistical.map(&:id))
+  scope :corporate_publications,        where(publication_type_id: PublicationType::CorporateReport.id)
 
   # @!group Callbacks
   before_save :set_public_timestamp

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -26,71 +26,10 @@ class Organisation < ActiveRecord::Base
             order: "edition_organisations.ordering ASC"
   has_many :editions,
             through: :edition_organisations
-  has_many :published_editions,
-            through: :edition_organisations,
-            class_name: "Edition",
-            conditions: { state: "published" },
-            source: :edition
-  has_many :corporate_publications,
-            through: :edition_organisations,
-            class_name: "Publication",
-            conditions: { "editions.publication_type_id" => PublicationType::CorporateReport.id },
-            source: :edition
   has_many :featured_editions,
             through: :featured_edition_organisations,
             source: :edition,
             order: "edition_organisations.ordering ASC"
-  has_many :detailed_guides,
-            through: :edition_organisations,
-            class_name: "DetailedGuide",
-            source: :edition
-  has_many :published_detailed_guides,
-            through: :edition_organisations,
-            class_name: "DetailedGuide",
-            conditions: { "editions.state" => "published" },
-            source: :edition
-  has_many :published_publications,
-            through: :edition_organisations,
-            class_name: "Publicationesque",
-            conditions: { "editions.state" => "published" },
-            source: :edition
-  has_many :published_consultations,
-            through: :edition_organisations,
-            class_name: "Consultation",
-            conditions: { "editions.state" => "published" },
-            source: :edition
-  has_many :published_non_statistics_publications,
-            through: :edition_organisations,
-            class_name: "Publication",
-            conditions: [ "editions.state='published' AND editions.publication_type_id NOT IN (?)",
-              PublicationType.statistical.map(&:id) ],
-            source: :edition
-  has_many :published_statistics_publications,
-            through: :edition_organisations,
-            class_name: "Publication",
-            conditions: [ "editions.state='published' AND editions.publication_type_id IN (?)",
-              PublicationType.statistical.map(&:id) ],
-            source: :edition
-  has_many :published_announcements,
-            through: :edition_organisations,
-            class_name: "Announcement",
-            conditions: { "editions.state" => "published"},
-            source: :edition
-  has_many :policies,
-            through: :edition_organisations,
-            class_name: "Policy",
-            source: :edition
-  has_many :published_policies,
-            through: :edition_organisations,
-            class_name: "Policy",
-            conditions: { "editions.state" => "published"},
-            source: :edition
-  has_many :scheduled_editions,
-            through: :edition_organisations,
-            class_name: "Edition",
-            conditions: { state: "scheduled" },
-            order: "scheduled_publication ASC",
-            source: :edition
 
   has_many :document_series
 
@@ -276,6 +215,12 @@ class Organisation < ActiveRecord::Base
     where("exists (#{published_editions_conditions})")
   end
 
+  def self.parent_organisations
+    where("not exists (" +
+      "select * from organisational_relationships " +
+      "where organisational_relationships.child_organisation_id=organisations.id)")
+  end
+
   def sub_organisations
     child_organisations.where(organisation_type_key: :sub_organisation)
   end
@@ -331,10 +276,40 @@ class Organisation < ActiveRecord::Base
     ministerial_roles.map { |mr| mr.speeches.published }.flatten.uniq
   end
 
-  def self.parent_organisations
-    where("not exists (" +
-      "select * from organisational_relationships " +
-      "where organisational_relationships.child_organisation_id=organisations.id)")
+  def published_editions
+    editions.published
+  end
+
+  def scheduled_editions
+    editions.scheduled.order('scheduled_publication ASC')
+  end
+
+  def published_announcements
+    published_editions.announcements
+  end
+
+  def published_consultations
+    published_editions.consultations
+  end
+
+  def published_detailed_guides
+    published_editions.detailed_guides
+  end
+
+  def published_policies
+    published_editions.policies
+  end
+
+  def published_non_statistics_publications
+    published_editions.non_statistical_publications
+  end
+
+  def published_statistics_publications
+    published_editions.statistical_publications
+  end
+
+  def corporate_publications
+    editions.corporate_publications
   end
 
   def destroyable?
@@ -354,7 +329,7 @@ class Organisation < ActiveRecord::Base
   end
 
   def has_published_publications_of_type?(publication_type)
-    published_publications.where("editions.publication_type_id" => publication_type.id).any?
+    published_editions.where(publication_type_id: publication_type.id).any?
   end
 
   private

--- a/app/views/classifications/_document_list.html.erb
+++ b/app/views/classifications/_document_list.html.erb
@@ -1,9 +1,10 @@
-<section id="<%= type %>" class="document-block documents-<%= document_block_counter %>">
-  <h1 class="label"><%= type.to_s.humanize %></h1>
+<% heading ||= type.to_s.humanize %>
+<section id="<%= heading.downcase %>" class="document-block documents-<%= document_block_counter %>">
+  <h1 class="label"><%= heading %></h1>
   <div class="content">
     <%= render partial: "shared/list_description", locals: { editions: documents } %>
     <p class="see-all">
-      <%= link_to "See all #{type.to_s.humanize.downcase}", public_send("#{type}_filter_path", @classification) %>
+      <%= link_to "See all #{heading.downcase}", public_send("#{type}_filter_path", @classification, publication_filter_option: heading.downcase) %>
     </p>
   </div>
 </section>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -79,12 +79,12 @@
     </div>
   </div>
 
-  <div class="documents-grid <%= topic_grid_size_class(@announcements, @consultations, @publications, @statistical_data_sets) %>">
+  <div class="documents-grid <%= topic_grid_size_class(@announcements, @consultations, @publications, @statistics) %>">
     <div class="inner-block">
       <%= render(partial: 'document_list', locals: { documents: @announcements, type: :announcements }) if @announcements.any? %>
       <%= render(partial: 'document_list', locals: { documents: @consultations, type: :consultations }) if @consultations.any? %>
       <%= render(partial: 'document_list', locals: { documents: @publications, type: :publications }) if @publications.any? %>
-      <%= render(partial: 'document_list', locals: { documents: @statistical_data_sets, type: :statistical_data_sets }) if @statistical_data_sets.any? %>
+      <%= render(partial: 'document_list', locals: { documents: @statistics, type: :publications, heading: 'Statistics' }) if @statistics.any? %>
     </div>
   </div>
 

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -13,8 +13,8 @@ end
 
 Given /^a published policy "([^"]*)" that appears in the "([^"]*)" and "([^"]*)" topics$/ do |policy_title, topic_1, topic_2|
   policy = create(:published_policy, title: policy_title)
-  create(:topic, name: topic_1, policies: [policy])
-  create(:topic, name: topic_2, policies: [policy])
+  create(:topic, name: topic_1, editions: [policy])
+  create(:topic, name: topic_2, editions: [policy])
 end
 
 Given /^a published policy "([^"]*)" that does not apply to the nations:$/ do |policy_title, nation_names|

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -140,14 +140,14 @@ end
 Then /^I should see published policies belonging to the "([^"]*)" topic$/ do |name|
   topic = Topic.find_by_name!(name)
   actual_editions = records_from_elements(Edition, page.all(".policy")).sort_by(&:id)
-  expected_editions = topic.policies.published.all.sort_by(&:id)
+  expected_editions = topic.published_policies.sort_by(&:id)
   assert_equal expected_editions, actual_editions
 end
 
 Then /^I should only see published detailed guides belonging to the "([^"]*)" topic$/ do |name|
   topic = Topic.find_by_name!(name)
   actual_editions = records_from_elements(Edition, page.all(".detailed_guide")).sort_by(&:id)
-  expected_editions = topic.detailed_guides.published.all.sort_by(&:id)
+  expected_editions = topic.published_detailed_guides.all.sort_by(&:id)
   assert_equal expected_editions, actual_editions
 end
 
@@ -171,7 +171,7 @@ Then /^I should see a link to the related topic "([^"]*)"$/ do |related_name|
 end
 
 When(/^I feature one of the policies on the topic$/) do
-  @policy = @topic.policies.published.last
+  @policy = @topic.published_policies.last
   visit admin_topic_path(@topic)
   click_on 'Featured documents'
 

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -118,7 +118,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   end
 
   test "DELETE :destroy does not delete topics with associated content" do
-    topic = create(:topic, policies: [build(:published_policy)])
+    topic = create(:topic, editions: [build(:published_policy)])
 
     delete :destroy, id: topic
     assert_equal "Cannot destroy Topic with associated content", flash[:alert]

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -31,7 +31,7 @@ class TopicsControllerTest < ActionController::TestCase
 
   view_test "GET :show lists the published policies and their summaries" do
     published_policy = create(:published_policy, title: "policy-title", summary: "policy-summary")
-    topic = create(:topic, policies: [published_policy])
+    topic = create(:topic, editions: [published_policy])
 
     get :show, id: topic
 
@@ -83,18 +83,18 @@ class TopicsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "GET :show lists published statistic data sets and links to more" do
+  view_test "GET :show lists published statistical publications and links to more" do
     topic = create(:topic)
     published = []
     4.times do |i|
-      published << create(:published_statistical_data_set, {
+      published << create(:published_statistics, {
         title: "title-#{i}", topics: [topic], first_published_at: i.days.ago
       })
     end
 
     get :show, id: topic
 
-    assert_select "#statistical_data_sets" do
+    assert_select "#statistics" do
       published.take(3).each do |edition|
         assert_select "a", text: edition.title, href: public_document_path(edition)
       end
@@ -128,7 +128,7 @@ class TopicsControllerTest < ActionController::TestCase
     6.times do |i|
       published_detailed_guides << create(:published_detailed_guide, title: "detailed-guide-title-#{i}")
     end
-    topic = create(:topic, detailed_guides: published_detailed_guides)
+    topic = create(:topic, editions: published_detailed_guides)
 
     get :show, id: topic
 

--- a/test/unit/email_signup_test.rb
+++ b/test/unit/email_signup_test.rb
@@ -9,7 +9,7 @@ class EmailSignupTest < ActiveSupport::TestCase
     topic_1 = create(:topic)
     topic_2 = create(:topic)
     policy  = create(:published_policy)
-    topic_1.published_policies << policy
+    topic_1.editions << policy
 
     topics_by_type = EmailSignup.valid_topics_by_type
     assert topics_by_type[:topic].include?(topic_1)
@@ -22,7 +22,7 @@ class EmailSignupTest < ActiveSupport::TestCase
     topical_event_1 = create(:topical_event, :active)
     topical_event_2 = create(:topical_event, :active)
     policy  = create(:published_policy)
-    topical_event_1.published_policies << policy
+    topical_event_1.editions << policy
 
     topics_by_type = EmailSignup.valid_topics_by_type
     assert topics_by_type[:topical_event].include?(topical_event_1)

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -344,16 +344,6 @@ class OrganisationTest < ActiveSupport::TestCase
     assert organisation.featured_editions.include?(new_version)
   end
 
-  test '#published_detailed_guides returns published detailed guides' do
-    organisation = create(:organisation)
-    alpha = create(:draft_detailed_guide, organisations: [organisation], title: "Alpha")
-    beta = create(:published_detailed_guide, organisations: [organisation], title: "Beta")
-    gamma = create(:published_detailed_guide, organisations: [organisation], title: "Gamma")
-    delta = create(:published_detailed_guide, organisations: [organisation], title: "Delta")
-
-    assert_same_elements [gamma, beta, delta], organisation.published_detailed_guides
-  end
-
   test '#published_announcements returns published news or speeches' do
     organisation = create(:organisation)
     role = create(:ministerial_role, organisations: [organisation])


### PR DESCRIPTION
The main thrust of this commit is to fix the topics#show page so that it correctly lists statistical publications as apposed to statistical data sets, mirroring organisations#show. As part of the work, I thought I'd tidy up some stuff that's been bothering me for a while. In particular, the use of associations in place of scopes.

Associations are being used in a few places where scopes are more appropriate. They are both simpler and more re-usable - by adding scopes to the Edition model, they can be used by anything that has an :editions association. This reduces the duplication between models.

Also, the state machine gives us scopes for edition states for free, so we don't need to define associations for stuff like published_polices. Associations should only ever be used if you intend to manipulate the association by adding/removing from it.

I've also killed off some unused class methods on Classification.

Note that the ordering by classification_memberships.ordering on the policies association was a red herring - this column is not being used and editions that are associated with topics are generally ordered explicitly using the in_reverse_chronological_order scope. The column should probably be dropped.
