### PR TITLE
Add main edition type to admin edition list

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -1,10 +1,15 @@
 module Admin::EditionsHelper
 
   def edition_type(edition)
-    if (@edition.is_a?(Speech) && @edition.speech_type.written_article?)
-      @edition.speech_type.name
+    if (edition.is_a?(Speech) && edition.speech_type.written_article?)
+      type = edition.speech_type.name
     else
-      @edition.type.underscore.humanize
+      type = edition.type.underscore.humanize
+    end
+    if type == edition.display_type
+      type
+    else
+      "#{type}: #{edition.display_type}"
     end
   end
 

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -57,7 +57,7 @@
           <% end %>
           <% @filter.editions.each do |edition| %>
             <%= content_tag_for(:tr, edition, class: ('force_published' if edition.force_published?)) do %>
-              <td class="type"><%= edition.display_type %></td>
+              <td class="type"><%= edition_type(edition) %></td>
               <td class="title">
                 <span class="title"><%= link_to edition.title, admin_edition_path(edition), title: "View document #{edition.title}" %></span>
                 <% if edition.non_english_edition? %>

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -45,7 +45,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, state: :draft
 
     assert_select_object(policy) { assert_select ".type", text: "Policy" }
-    assert_select_object(publication) { assert_select ".type", text: "Policy paper" }
+    assert_select_object(publication) { assert_select ".type", text: "Publication: Policy paper" }
   end
 
   test "diffing against a previous version" do


### PR DESCRIPTION
Also added subtype to edition show pages because it
uses the edition_type helper.

https://www.pivotaltracker.com/story/show/57977482
