### PR TITLE
Tidy virus scanning column in admin

### DIFF
--- a/app/assets/stylesheets/admin/document.scss
+++ b/app/assets/stylesheets/admin/document.scss
@@ -172,3 +172,7 @@ ol.existing-attachments {
 input[name="save_and_continue"] {
   margin-left: 0.4em;
 }
+
+.virus-status {
+  width: 15%;
+}

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -281,9 +281,9 @@ module Admin::EditionsHelper
     when :clean
       nil
     when :pending
-      content_tag(:p, "Scanning For Viruses", class: "virus-scanning")
+      content_tag(:p, "Virus scanning", class: "virus-scanning")
     else
-      content_tag(:p, "Virus Found", class: "virus")
+      content_tag(:p, "Virus found", class: "virus")
     end
   end
 


### PR DESCRIPTION
• update virus scanning text and remove camel case
• add width to column so it's more likely to sit on 1 line
