### PR TITLE
Fixes regression bug with document filter.

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -274,7 +274,6 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
         history.replaceState(documentFilter.currentPageState(), null);
 
         $form.submit(documentFilter.submitFilters);
-        $form.find('select, input[type=checkbox]').change(documentFilter.submitFilters);
 
         var delay = (function(){
           var timer = 0;
@@ -283,6 +282,10 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
             timer = setTimeout(callback, ms);
           }
         })();
+
+        $form.find('select, input[type=checkbox]').change(function() {
+          $form.submit();
+        });
 
         $('#keyword-filter').add('#date-range-filter').find('input[type=text]').keyup(function () {
           delay(function () {


### PR DESCRIPTION
Document filter selects and checkboxes didn't do anything, now they do.

Regression introduced by https://www.pivotaltracker.com/story/show/52381589

I wasn't able to determine how it used to work before the bug was introduced.  The events weren't being bound anywhere and the script hadn't been changed for a while.  I can only guess that something else was causing changes in selects to submit the parent form.
