### PR TITLE
Add SupportingPage attachment fixer

### DIFF
--- a/lib/cleanups/supporting_page_attachment_fixer.rb
+++ b/lib/cleanups/supporting_page_attachment_fixer.rb
@@ -1,0 +1,70 @@
+# Legacy supporting page attachment association
+# We need to use this to reconstruct the missing attachment records
+class SupportingPageAttachment < ActiveRecord::Base
+  belongs_to :attachment
+  belongs_to :supporting_page
+end
+
+# Load the original model and add legacy associations
+require 'supporting_page'
+class SupportingPage < ActiveRecord::Base
+  has_many :supporting_page_attachments
+  has_many :legacy_attachments, source: :attachment, through: :supporting_page_attachments, class_name: "Attachment"
+end
+
+module Cleanups
+  class SupportingPageAttachmentFixer
+    def initialize(logger = nil)
+      @logger = logger || Logger.new($stdout)
+    end
+
+    def run!
+      legacy_attachment_joins = SupportingPageAttachment.includes(supporting_page: :attachments).order("attachments.created_at asc")
+
+      legacy_attachment_joins.group_by { |la| la.supporting_page }.each do |supporting_page, legacy_attachment_joins|
+        next if supporting_page.nil?
+
+        legacy_attachment_joins.each.with_index do |spa, i|
+          attachment = spa.attachment
+          next if attachment.nil?
+
+          if has_attachment(supporting_page.attachments, attachment)
+            @logger.info "Found:    #{supporting_page.slug} - #{attachment.id} '#{attachment.title}', changing order from #{attachment.ordering} to #{i}, created_at = #{attachment.created_at}"
+            attachment.update_column(:ordering, i)
+          else
+            @logger.info "Creating: #{supporting_page.slug} - #{attachment.id} '#{attachment.title}', seting order to #{i}, created_at = #{attachment.created_at}"
+            new_attachment_attributes = attachment.attributes.except(*ignored_attributes)
+            new_attachment_attributes["ordering"] = i
+            supporting_page.attachments.create!(new_attachment_attributes)
+          end
+        end
+      end
+    end
+
+    def show_problems
+      errors = []
+      existing = Attachment.where(attachable_type: "SupportingPage").includes(:attachable).group_by do |a|
+        a.attachable
+      end
+      SupportingPageAttachment.includes(supporting_page: :attachments).find_each do |spa|
+        existing_attachments = existing.fetch(spa.supporting_page, [])
+        next if spa.attachment.nil?
+
+        if ! has_attachment(existing_attachments, spa.attachment)
+          errors << "#{spa.supporting_page.edition_id}: #{spa.attachment.id}"
+        end
+      end
+      errors
+    end
+
+    def ignored_attributes
+      %w{id attachable_id attachable_type updated_at ordering}
+    end
+
+    def has_attachment(actual_attachments, expected_attachment)
+      actual_attachments.any? do |actual|
+        actual.attributes.except(*ignored_attributes) == expected_attachment.attributes.except(*ignored_attributes)
+      end
+    end
+  end
+end

--- a/test/unit/cleanups/supporting_page_attachment_fixer_test.rb
+++ b/test/unit/cleanups/supporting_page_attachment_fixer_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+require 'cleanups/supporting_page_attachment_fixer'
+
+class SupportingPageAttachmentFixerTest < ActiveSupport::TestCase
+  setup do
+    @editor = create(:gds_editor)
+    @null_logger = Logger.new(nil)
+  end
+
+  def excluded_attributes
+    Cleanups::SupportingPageAttachmentFixer.new.ignored_attributes
+  end
+
+  def create_document_with_one_edition_missing_an_attachment!
+    Timecop.freeze 2.weeks.ago do
+      @first_edition = create(:published_policy)
+      @supporting_page = create(:supporting_page, attachments: [], edition: @first_edition)
+    end
+
+    Timecop.freeze 1.week.ago do
+      @second_edition = @first_edition.create_draft(@editor)
+      @attachment = create(:attachment)
+      @second_edition.supporting_pages.first.attachments = [@attachment]
+      @second_edition.reload
+      @second_edition.minor_change = true
+    end
+
+    Timecop.freeze 1.day.ago do
+      @second_edition.publish_as(@editor, force: true)
+    end
+
+    # Create legacy associations
+    SupportingPageAttachment.create!(attachment: @attachment, supporting_page: @first_edition.supporting_pages.first)
+    SupportingPageAttachment.create!(attachment: @attachment, supporting_page: @second_edition.supporting_pages.first)
+
+    @first_edition.reload
+  end
+
+  def create_document_with_no_missing_attachments!
+    @first_edition = create(:published_policy)
+    @attachment = create(:attachment)
+    @supporting_page = create(:supporting_page, attachments: [@attachment], edition: @first_edition)
+
+    # Create legacy associations
+    SupportingPageAttachment.create!(attachment: @attachment, supporting_page: @first_edition.supporting_pages.first)
+
+    @first_edition.reload
+  end
+
+  test "fix creates a duplicate attachment object for each missing legacy supporting page attachment" do
+    create_document_with_one_edition_missing_an_attachment!
+
+    Cleanups::SupportingPageAttachmentFixer.new(@null_logger).run!
+
+    @first_edition.reload
+
+    supporting_page = @first_edition.supporting_pages.first
+    assert_equal 1, supporting_page.attachments.count
+    assert_equal @attachment.attributes.except(*excluded_attributes), supporting_page.attachments.first.attributes.except(*excluded_attributes)
+    refute_equal @attachment.id, supporting_page.attachments.first.id
+
+    second_supporting_page = @second_edition.supporting_pages.first
+    assert_equal [@attachment], second_supporting_page.attachments
+  end
+
+  test "show_problems displays a list of supporting pages with missing attachments" do
+    create_document_with_one_edition_missing_an_attachment!
+
+    problems = Cleanups::SupportingPageAttachmentFixer.new(@null_logger).show_problems
+
+    assert_equal 1, problems.count
+    assert_equal "#{@first_edition.id}: #{@attachment.id}", problems.first
+  end
+
+  test "show_problems does not report problems where no attachments are missing" do
+    create_document_with_no_missing_attachments!
+
+    problems = Cleanups::SupportingPageAttachmentFixer.new(@null_logger).show_problems
+
+    assert_equal 0, problems.count
+  end
+
+end


### PR DESCRIPTION
commit 0e0bfbf9 included a database migration which moved Attachments to
have polymorphic associations to the thing they are attached to, rather
than relying on join tables.

Unfortunately this cleanup didn't properly migrate supporting page
attachments because the supporting page attachments had historically
worked incorrectly. The historical behaviour was that when a policy was
redrafted, rather than cloning the actual Attachment objects on the
supporting page, only the association (SupportingPageAttachment) was
cloned, referencing the original Attachment.

Fortunately, we're able to restore the original data from the
SupportingPageAttachment table.

This fixer class adds a copy of the Attachment record for each missing
Attachment.
