### PR TITLE
Fix unexpected attachment reordering

### DIFF
--- a/db/data_migration/20131011095042_fix_unexpected_attachment_reordering.rb
+++ b/db/data_migration/20131011095042_fix_unexpected_attachment_reordering.rb
@@ -47,7 +47,7 @@ attachable_ids_by_type.each do |attachable_type, attachable_ids|
       STDOUT.flush
 
       attachable.attachments.sort_by(&:created_at).each_with_index do |attachment, index|
-        attachment.update_attribute(:ordering, index)
+        attachment.update_column(:ordering, index)
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/58633492

Please carefully check this PR and give me a shout if you want a walk through of what I think it's doing.

The intention here is to overwrite all ordering on any attachable using the attachment created_at dates (which are carried over during editioning).

Ordering should be rewritten in the following circumstances:
1. Any attachments have null ordering because:
  a) a complete set of null orders means a non-broken attachable that we need to prevent from breaking in the future.
  b) a partial set of null orders means a non-broken attachable which will break on the next edition (or has already been editioned and broken).
2. Any duplicate orderings, because this indicates a broken attachable.

This should be followed up by a schema change and validation to force presence and uniqueness of `ordering` on `Attachment`.
