### PR TITLE
Fix the hosts for organisations' web_urls in API

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -28,7 +28,7 @@ private
     model.parent_organisations.map do |parent|
       {
         id: context.api_organisation_url(parent),
-        web_url: context.organisation_url(parent)
+        web_url: context.organisation_url(parent, host: context.public_host)
       }
     end
   end
@@ -37,7 +37,7 @@ private
     model.child_organisations.map do |child|
       {
         id: context.api_organisation_url(child),
-        web_url: context.organisation_url(child)
+        web_url: context.organisation_url(child, host: context.public_host)
       }
     end
   end

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -80,7 +80,7 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     parent = stub_record(:organisation)
     @organisation.stubs(:parent_organisations).returns([parent])
     assert_equal api_organisation_url(parent, host: 'test.host'), @presenter.as_json[:parent_organisations].first[:id]
-    assert_equal organisation_url(parent, host: 'test.host'), @presenter.as_json[:parent_organisations].first[:web_url]
+    assert_equal organisation_url(parent, host: 'govuk.example.com'), @presenter.as_json[:parent_organisations].first[:web_url]
   end
 
   test "json includes request-relative api child organisations" do
@@ -88,6 +88,6 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     child = stub_record(:organisation)
     @organisation.stubs(:child_organisations).returns([child])
     assert_equal api_organisation_url(child, host: 'test.host'), @presenter.as_json[:child_organisations].first[:id]
-    assert_equal organisation_url(child, host: 'test.host'), @presenter.as_json[:child_organisations].first[:web_url]
+    assert_equal organisation_url(child, host: 'govuk.example.com'), @presenter.as_json[:child_organisations].first[:web_url]
   end
 end


### PR DESCRIPTION
The organisations API correctly returned the web_url for an
organisation using the public host, but those for child and
parent organisations were incorrectly using the API host. This
commit makes all web_urls returned by the organisations API use
the public host.
