### PR TITLE
Support attachments on world location news

### DIFF
--- a/app/models/world_location_news_article.rb
+++ b/app/models/world_location_news_article.rb
@@ -1,6 +1,7 @@
 class WorldLocationNewsArticle < Newsesque
   include Edition::WorldLocations
   include Edition::WorldwideOrganisations
+  include ::Attachable
 
   def can_be_related_to_policies?
     false

--- a/app/views/admin/world_location_news_articles/_form.html.erb
+++ b/app/views/admin/world_location_news_articles/_form.html.erb
@@ -1,6 +1,8 @@
 <%= edition_editing_tabs(edition) do %>
   <%= standard_edition_form(edition) do |form| %>
 
+    <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>
+
     <fieldset>
       <legend>Associations</legend>
       <%= render partial: 'topic_fields', locals: { form: form, edition: edition } %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -31,7 +31,7 @@
   <div class="block-4">
     <div class="inner-block">
       <div class="document body">
-        <%= govspeak_to_html @document.body, @document.images %>
+        <%= govspeak_edition_to_html @document %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Also changed the default way of rendering govspeak to use
govspeak_edition_to_html. This does the same thing as
govspeak_to_html, but parses attachment tags if the document
supports it.

https://www.pivotaltracker.com/story/show/58083090
