### PR TITLE
Change 'acronym' to 'abbreviation' in organisations API

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -8,7 +8,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
       web_url: context.organisation_url(model, host: context.public_host),
       details: {
         slug: model.slug,
-        acronym: model.acronym,
+        abbreviation: model.acronym,
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
       },

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -46,9 +46,9 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     assert_equal now, @presenter.as_json[:updated_at]
   end
 
-  test "json includes acronym in details hash" do
+  test "json includes acronym in details hash as abbreviation" do
     @organisation.stubs(:acronym).returns('decc')
-    assert_equal 'decc', @presenter.as_json[:details][:acronym]
+    assert_equal 'decc', @presenter.as_json[:details][:abbreviation]
   end
 
   test "json includes slug in details hash" do


### PR DESCRIPTION
Although the column here is called 'acronym', its values are more varied
than that suggests. Some organisations have acronyms which are identical
to their names, and some acronyms are shorter forms of the name (putting
to one side pedantry over acronyms versus initialisms...) e.g.:

```
  name                                           acronym
Home Office                                    Home Office
Forestry Commission                            Forestry
Interception of Communications Commissioner    Interception Commissioner
```

Using the more general term 'abbreviation' for these short forms in the
organisations API makes it clearer what kind of data to expect here.
