### PR TITLE
Allow multiple translation modals per page

### DIFF
--- a/app/views/admin/contacts/_contact.html.erb
+++ b/app/views/admin/contacts/_contact.html.erb
@@ -36,8 +36,8 @@
     <% end %>
   <% end %>
   <% if contact.missing_translations.any? %>
-    <a href="#add-translation-modal" id="open-add-translation-modal" class="btn btn-small" data-toggle="modal"><i class="icon-plus-sign"></i> Add translation</a>
-    <%= render partial: 'admin/shared/translation_modal', locals: { form_path: [:admin, contactable, contact, :translations], locales: contact.missing_translations } %>
+    <a href="#add-translation-modal-<%= contact.id %>" class="btn btn-small" data-toggle="modal"><i class="icon-plus-sign"></i> Add translation</a>
+    <%= render partial: 'admin/shared/translation_modal', locals: { id: "add-translation-modal-#{contact.id}", form_path: [:admin, contactable, contact, :translations], locales: contact.missing_translations } %>
   <% end %>
 
   <% contact.non_english_localised_models([:contact_numbers]).each do |translated_contact| %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -86,7 +86,7 @@
       <% end %>
     </h2>
     <% if @edition.editable? and @edition.missing_translations.any? %>
-      <%= render partial: 'admin/shared/translation_modal', locals: { form_path: admin_edition_translations_path(@edition), locales: @edition.missing_translations } %>
+      <%= render partial: 'admin/shared/translation_modal', locals: { id: "add-translation-modal", form_path: admin_edition_translations_path(@edition), locales: @edition.missing_translations } %>
     <% end %>
     <% if @edition.non_english_translations.any? %>
       <table class="table">

--- a/app/views/admin/shared/_translation_modal.html.erb
+++ b/app/views/admin/shared/_translation_modal.html.erb
@@ -1,4 +1,4 @@
-<div id="add-translation-modal" class="modal hide">
+<div id="<%= id %>" class="modal hide">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
     <h3>Add translation</h3>

--- a/app/views/admin/worldwide_offices/_worldwide_office.html.erb
+++ b/app/views/admin/worldwide_offices/_worldwide_office.html.erb
@@ -48,8 +48,8 @@
     <% end %>
   <% end %>
   <% if worldwide_office.contact.missing_translations.any? %>
-    <a href="#add-translation-modal" id="open-add-translation-modal" class="btn btn-small" data-toggle="modal"><i class="icon-plus-sign"></i> Add translation</a>
-    <%= render partial: 'admin/shared/translation_modal', locals: { form_path: [:admin, worldwide_organisation, worldwide_office, :translations], locales: worldwide_office.contact.missing_translations } %>
+    <a href="#add-translation-modal-<%= worldwide_office.contact.id %>" class="btn btn-small" data-toggle="modal"><i class="icon-plus-sign"></i> Add translation</a>
+    <%= render partial: 'admin/shared/translation_modal', locals: { id: "add-translation-modal-#{worldwide_office.contact.id}", form_path: [:admin, worldwide_organisation, worldwide_office, :translations], locales: worldwide_office.contact.missing_translations } %>
   <% end %>
 
   <% worldwide_office.contact.non_english_localised_models([:contact_numbers]).each do |translated_contact| %>


### PR DESCRIPTION
The fixed ID meant that when multiple modals were included on a page
only the first modal would ever be accessed. This addresses the issue
by forcing the ID of the modal to be passed into the partial.

https://www.pivotaltracker.com/story/show/53558977
