### PR TITLE
Fix 3 'acroynm' typos in test descriptions

### DIFF
--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -243,8 +243,8 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_match parent.name, result
     assert_match parent2.name, result
   end
-  
-  
+
+
 end
 
 class OrganisationSiteThumbnailPathTest < ActionView::TestCase


### PR DESCRIPTION
Also remove trailing whitespace from 2 lines in the same file.
