### PR TITLE
Add rel="alternate" API links from organisations

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,5 +1,6 @@
 <% page_title "Departments, agencies & public bodies" %>
 <% page_class "index-list-page" %>
+<%= api_link_tag api_organisations_url %>
 
 <div class="organisations-index">
   <div class="block-1">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,6 +1,7 @@
 <% page_title @organisation.name %>
 <% page_class "organisations-show" %>
 <% atom_discovery_link_tag organisation_url(@organisation, format: :atom), "Latest activity" %>
+<%= api_link_tag api_organisation_url(@organisation) %>
 
 <%= organisation_wrapper(@organisation) do %>
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -100,6 +100,11 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "should include a rel='alternate' link to JSON representation of organisations" do
+    get :index
+
+    assert_select "link[rel=alternate][type=application/json][href=#{api_organisations_url}]"
+  end
 
 
   ### Describing :show ###
@@ -537,6 +542,14 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select_atom_feed do
       assert_select_atom_entries([pol, pub])
     end
+  end
+
+  view_test "show should include a rel='alternate' link to the organisation's JSON representation" do
+    organisation = create(:organisation, name: "org-name")
+
+    get :show, id: organisation
+
+    assert_select "link[rel=alternate][type=application/json][href=#{api_organisation_url(organisation)}]"
   end
 
   test "shows ministerial roles in the specified order" do


### PR DESCRIPTION
(Requested by @jystewart)

I don't entirely understand why these links appear in the `<head>` when the frontend base layout only yields in the `<body>` - I think it's Slimmer doing magic with [TagMover](https://github.com/alphagov/slimmer/blob/master/lib/slimmer/processors/tag_mover.rb), but if anyone can explain a bit more, I'd be grateful.
