### PR TITLE
Fix AnnouncementPresenter#publication_collection

### DIFF
--- a/app/presenters/announcement_presenter.rb
+++ b/app/presenters/announcement_presenter.rb
@@ -6,7 +6,7 @@ class AnnouncementPresenter < Whitehall::Decorators::Decorator
   def as_hash
     super.merge({
       field_of_operation: field_of_operation,
-      publication_collection: publication_collection
+      publication_collections: publication_collections
     })
   end
 
@@ -16,10 +16,10 @@ class AnnouncementPresenter < Whitehall::Decorators::Decorator
     end
   end
 
-  def publication_collection
+  def publication_collections
     if model.respond_to?(:part_of_published_collection?) && model.part_of_published_collection?
       links = model.published_document_collections.map do |dc|
-        context.link_to(dc.name, context.public_document_path(dc))
+        context.link_to(dc.title, context.public_document_path(dc))
       end
       "Part of a collection: #{links.to_sentence}"
     end

--- a/test/unit/presenters/announcement_presenter_test.rb
+++ b/test/unit/presenters/announcement_presenter_test.rb
@@ -45,4 +45,16 @@ class AnnouncementPresenterTest < PresenterTestCase
     hash = AnnouncementPresenter.new(fatality_notice, @view_context).as_hash
     assert hash[:field_of_operation]
   end
+
+  test "shows the collection the announcement belongs to" do
+    document = stub_record(:document)
+    article = stub_record(:news_article, document: document)
+    collection = stub_record(:document_collection, title: "CollectionTitle", document: stub_record(:document))
+
+    article.stubs(:part_of_published_collection?).returns(true)
+    article.stubs(:published_document_collections).returns([collection])
+
+    presenter = AnnouncementPresenter.new(article, @view_context)
+    assert presenter.publication_collections =~ /CollectionTitle/
+  end
 end


### PR DESCRIPTION
- Call `DocumentCollection#title` instead of `#name`.
- Rename to `publication_collections` to match other presenters.

https://www.pivotaltracker.com/story/show/59039040
