### PR TITLE
Fix and refactor column alignment for heading-block

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_heading-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_heading-block.scss
@@ -1,21 +1,37 @@
 
 .heading-block {
-  margin-bottom: $gutter;
   @extend %contain-floats;
+  clear: both;
+  margin-bottom: $gutter;
 
   h1 {
     @include ig-core-27;
     font-weight: bold;
+  }
 
+  .inner-block {
+    padding: 0 $gutter-half;
+  }
+
+  section {
+    @extend %contain-floats;
+    margin-bottom: $gutter;
+  }
+
+  .head-section { 
     @include media(tablet){
+      h1 {
+        padding: 0 $gutter-half;        
+      }
       float: left;
       clear: both;
       width: 33.3%;
       @include right-to-left {
         float: right;
       }
-    }
+    }     
   }
+
   .content {
     @include media(tablet){
       float: right;
@@ -38,7 +54,7 @@
 
     .document-list {
       @include media(tablet){
-        padding-left: $gutter-half;
+        padding: 0 $gutter-half;
         margin-top: -$gutter-one-third;
       }
     }

--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -101,6 +101,7 @@ nav.consultations_scope {
     margin-bottom: $gutter * 1.5;
     @include media(tablet) {
       padding: $gutter;
+      margin: 0 $gutter-half $gutter*1.5;
     }
 
     a {

--- a/app/views/classifications/index.html.erb
+++ b/app/views/classifications/index.html.erb
@@ -24,10 +24,12 @@
     <% end %>
     <% if @topical_events.any? %>
       <div class="heading-block js-filter-block">
+        <div class="head-section">
           <h1 class="label">Topical events</h1>
-          <div class="content">
-            <%= render partial: "list", locals: { topics: @topical_events } %>
-          </div>
+        </div>
+        <div class="content">
+          <%= render partial: "list", locals: { topics: @topical_events } %>
+        </div>
       </div>
     <% end %>
     <div class="js-filter-no-results">

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -24,7 +24,7 @@
 
   </header>
 
-  <div class="block-2">
+  <div class="block-2 heading-block">
     <div class="inner-block">
       <% if @document.open? %>
         <div class="consultation-block <%= consultation_css_class(@document) %>">
@@ -46,8 +46,10 @@
                           summary: nil } %>
             <% end %>
             <% if @document.outcome.summary.present? %>
-              <section class="heading-block consultation-response-summary">
-                <h1>Detail of outcome</h1>
+              <section class="consultation-response-summary">
+                <div class="head-section">
+                  <h1>Detail of outcome</h1>
+                </div>
                 <div class="content">
                   <article>
                     <%= govspeak_to_html @document.outcome.summary %>
@@ -68,8 +70,10 @@
                           summary: nil } %>
             <% end %>
 
-            <section class="heading-block consultation-response-summary">
-              <h1>Detail of feedback received</h1>
+            <section class="consultation-response-summary">
+              <div class="head-section">
+                <h1>Detail of feedback received</h1>
+              </div>
               <div class="content">
                 <article>
                   <%= govspeak_to_html @document.public_feedback.summary %>
@@ -92,8 +96,10 @@
       <%= render partial: "documents/attachment_full_width",
                  locals: { document: @document, title: 'Documents' } %>
 
-      <section class="heading-block">
-        <h1>Consultation description</h1>
+      <section>
+        <div class="head-section">
+          <h1>Consultation description</h1>
+        </div>
         <div class="content">
           <article>
             <%= govspeak_edition_to_html @document %>
@@ -103,8 +109,10 @@
 
       <% unless @document.external? %>
         <% if @document.open? && @document.has_consultation_participation? %>
-          <section id="response-formats" class="heading-block participation">
-            <h1>Ways to respond</h1>
+          <section id="response-formats" class="participation">
+            <div class="head-section">
+              <h1>Ways to respond</h1>
+            </div>
             <div class="content">
               <article>
                 <% if @document.consultation_participation.has_link? %>

--- a/app/views/documents/_attachment_full_width.html.erb
+++ b/app/views/documents/_attachment_full_width.html.erb
@@ -4,8 +4,10 @@
   published_on = '' unless local_assigns.include?(:published_on)
   external = false unless defined?(:external)
 %>
-<section class="heading-block attachment-full-width">
-  <h1><%= title %></h1>
+<section class="attachment-full-width">
+  <div class="head-section">
+    <h1><%= title %></h1>
+  </div>
   <div class="content">
     <article>
       <div class="govspeak">

--- a/app/views/organisations/not_live.html.erb
+++ b/app/views/organisations/not_live.html.erb
@@ -43,11 +43,12 @@
 
 
   <% if @recently_updated.present? %>
-    <div class="block-5">
+    <div class="block-5 heading-block">
       <div class="inner-block">
-        <section id="recently-updated" class="heading-block latest-documents">
-          <h1>Mentions on GOV.UK</h1>
-
+        <section id="recently-updated" class="latest-documents">
+          <div class="head-section">
+            <h1>Mentions on GOV.UK</h1>
+          </div>
           <div class="content">
             <%= render partial: "shared/recently_updated_documents", locals: {recently_updated: @recently_updated} %>
           </div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -88,19 +88,19 @@
   <% end %>
 
   <% if @policies.any? %>
-    <div class="block-7">
+    <div class="block-7 heading-block">
       <div class="inner-block">
-        <% if @policies.any? %>
-          <section id="policies" class="heading-block">
+        <section id="policies">
+          <div class="head-section">
             <h1 class="label"><%= link_to t('organisation.headings.our_policies'), policies_filter_path(@organisation) %></h1>
-            <div class="content">
-              <%= render partial: "policies/list_description", locals: {policies: @policies} %>
-              <p class="see-all">
-                <%= link_to t_see_all_our(:policy), policies_filter_path(@organisation) %>
-              </p>
-            </div>
-          </section>
-        <% end %>
+          </div>
+          <div class="content">
+            <%= render partial: "policies/list_description", locals: {policies: @policies} %>
+            <p class="see-all">
+              <%= link_to t_see_all_our(:policy), policies_filter_path(@organisation) %>
+            </p>
+          </div>
+        </section>
       </div>
     </div>
   <% end %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -18,17 +18,19 @@
     </div>
   </div>
 
-  <div class="block-2">
+  <div class="block-2 heading-block">
     <div class="inner-block">
       <%= render partial: "documents/attachment_full_width",
                  locals: { document: @document, external: @document.external? } %>
     </div>
   </div>
 
-  <div class="block-3">
+  <div class="block-3 heading-block">
     <div class="inner-block">
-      <section id="details" class="heading-block">
-        <h1><%= t('publications.headings.detail') %></h1>
+      <section id="details">
+        <div class="head-section">
+          <h1><%= t('publications.headings.detail') %></h1>
+        </div>
         <div class="content">
           <article>
             <div class="body">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -118,11 +118,13 @@
   </div>
 
 
-  <div class="block">
+  <div class="block heading-block">
     <div class="inner-block">
       <% if @classification.lead_organisations.any? %>
-        <section id="organisations" class="heading-block organisations">
-          <h1 class="label">Who&rsquo;s involved</h1>
+        <section id="organisations" class="organisations">
+          <div class="head-section">
+            <h1 class="label">Who&rsquo;s involved</h1>
+          </div>
           <div class="content">
             <ul>
               <% @classification.lead_organisations.each do |organisation| %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -62,14 +62,15 @@
     </div>
   <% end %>
 
-  <div class="block block-4">
+  <div class="block block-4 heading-block">
     <div class="inner-block">
       <% if @policies.any? %>
-        <section id="policies" class="policies heading-block">
-          <h1 class="label">Policies
-            <span class="count"><%= @policies.count %></span>
-          </h1>
-
+        <section id="policies" class="policies">
+          <div class="head-section">
+            <h1 class="label">Policies
+              <span class="count"><%= @policies.count %></span>
+            </h1>
+          </div>
           <div class="content">
             <%= render partial: "policies/list_description", locals: { policies: @policies.limit(5) } %>
             <% if @policies.count > 5 %>

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -69,10 +69,12 @@
   <% end %>
 
   <% if @policies.any? %>
-    <div class="block-5">
+    <div class="block-5 heading-block">
       <div class="inner-block">
-        <section id="policies" class="heading-block">
-          <h1 class="label"><%= link_to t('world_location.headings.related_policies'), policies_filter_path(@world_location) %></h1>
+        <section id="policies">
+          <div class="head-section">
+            <h1 class="label"><%= link_to t('world_location.headings.related_policies'), policies_filter_path(@world_location) %></h1>
+          </div>
           <div class="content">
             <%= render partial: "policies/list_description", locals: {policies: @policies} %>
             <p class="see-all">


### PR DESCRIPTION
Because this is shared across many templates, to fix properly,
I've had to refactor heading-block. Which fixes this issue across all templates.
Topics index/show, topical events, orgs page/index/external,
publications show, consultations show,
attachment full width and world locations.

https://www.pivotaltracker.com/story/show/59109348
