### PR TITLE
Add Raindrops to Rack configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'chronic'
 gem 'jbuilder'
 gem 'rack_strip_client_ip', '0.0.1'
 gem 'sidekiq', '2.14.1'
+gem 'raindrops', '0.11.0'
 
 group :assets do
   gem 'govuk_frontend_toolkit', '0.34.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,6 +397,7 @@ DEPENDENCIES
   rails (= 3.2.14)
   rails-dev-boost
   rails-i18n
+  raindrops (= 0.11.0)
   rake (= 0.9.2)
   router-client (~> 3.0.1)
   rummageable (= 1.0.0)

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
+use Raindrops::Middleware
 run Whitehall::Application


### PR DESCRIPTION
Add Raindrops to Rack configuration so we can monitor idle/used workers using Nagios.

https://www.pivotaltracker.com/story/show/58976338
