### PR TITLE
Removed duplicate searchable in DocumentCollection

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -20,12 +20,6 @@ class DocumentCollection < Edition
 
   add_trait ClonesGroupsTrait
 
-  searchable title:       :title,
-             slug:        :slug,
-             link:        :search_link,
-             content:     :indexable_content,
-             description: :summary
-
   def search_link
     Whitehall.url_maker.public_document_path(self)
   end

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -79,14 +79,14 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal original.groups.map(&:documents), draft.groups.map(&:documents)
   end
 
+  test "only indexes published collections" do
+    refute create(:unpublished_document_collection).can_index_in_search?
+    assert create(:published_document_collection).can_index_in_search?
+  end
+
   test 'indexes the title as title' do
     collection = create(:document_collection, title: 'a title')
     assert_equal 'a title', collection.search_index['title']
-  end
-
-  test "includes slug in search index data" do
-    collection = create(:document_collection, title: "Coffee for the win")
-    assert_equal 'coffee-for-the-win', collection.search_index['slug']
   end
 
   test 'indexes the full URL to the collection show page as link' do


### PR DESCRIPTION
Addresses bug: https://www.pivotaltracker.com/story/show/59311828

DocumentCollection had a searchable declaration, duplicating
one inherited from edition anyway. The second version didn't
restrict to only published collections.

As a by-product of the fix, slug has been removed from the index.
