### PR TITLE
DocumentCollection indexes slug.

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -20,6 +20,10 @@ class DocumentCollection < Edition
 
   add_trait ClonesGroupsTrait
 
+  def search_index
+    super.merge("slug" => slug)
+  end
+
   def search_link
     Whitehall.url_maker.public_document_path(self)
   end

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -94,6 +94,11 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal "/government/collections/#{collection.slug}", collection.search_index['link']
   end
 
+  test 'indexes the slug' do
+    collection = create(:published_document_collection)
+    assert_equal collection.slug, collection.search_index['slug']
+  end
+
   test "indexes the body without markup as indexable_content" do
     collection = create(:document_collection,
                     title: "A doc collection", body: "This is a *body*")


### PR DESCRIPTION
Seems like slug was required on DocumentCollection after all.  Restoring it.

post-merge fix for story https://www.pivotaltracker.com/story/show/59311828
