### PR TITLE
Replace refute + positive capabara matcher in cucumber steps

### DIFF
--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -20,13 +20,13 @@ Then /^I can traverse the audit trail with newer and older navigation$/ do
   click_on 'History'
   within '#history' do
     assert page.has_css?('.version', count: 30)
-    refute page.has_link? '<< Newer'
+    assert page.has_no_link? '<< Newer'
     find('.audit-trail-nav', match: :first).click_link('Older >>')
   end
   within '#history' do
     # there are 51 versions (1 real via create 50 fake from step above)
     assert page.has_css?('.version', count: 21)
-    refute page.has_link? 'Older >>'
+    assert page.has_no_link? 'Older >>'
     find('.audit-trail-nav', match: :first).click_link('<< Newer')
   end
   within '#history' do

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -74,7 +74,7 @@ Then /^that contact is no longer visible on the home page of the organisation$/ 
   visit organisation_path(@the_organisation)
 
   within '.addresses' do
-    refute page.has_css?("div.contact h2", text: @the_removed_contact.title)
+    assert page.has_no_css?("div.contact h2", text: @the_removed_contact.title)
   end
 end
 
@@ -135,7 +135,7 @@ Then /^that office is no longer visible on the home page of the worldwide organi
   visit worldwide_organisation_path(@the_organisation)
 
   within '.contact-us' do
-    refute page.has_css?("div.contact h2", text: @the_removed_office.title)
+    assert page.has_no_css?("div.contact h2", text: @the_removed_office.title)
   end
 end
 
@@ -160,20 +160,20 @@ Then /^I cannot add or reorder the new FOI contact in the home page list$/ do
   click_on 'All'
 
   within record_css_selector(@the_new_foi_contact) do
-    refute page.has_button?('Add to home page')
-    refute page.has_button?('Remove from home page')
+    assert page.has_no_button?('Add to home page')
+    assert page.has_no_button?('Remove from home page')
   end
 
   click_on 'Order on home page'
 
-  refute page.has_field?("ordering[#{@the_new_foi_contact.id}]")
+  assert page.has_no_field?("ordering[#{@the_new_foi_contact.id}]")
 end
 
 Then /^I see the new FOI contact listed on the home page(?: only once,)? in the FOI section$/ do
   visit organisation_path(@the_organisation)
 
   within '#org-contacts + .org-contacts' do
-    refute page.has_css?("div.contact h2", text: @the_new_foi_contact.title)
+    assert page.has_no_css?("div.contact h2", text: @the_new_foi_contact.title)
   end
 
   within '#foi-contacts .org-contacts' do

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -185,7 +185,7 @@ Then /^I should see (#{THE_DOCUMENT})$/ do |edition|
 end
 
 Then /^I should not see (#{THE_DOCUMENT})$/ do |edition|
-  refute has_css?(record_css_selector(edition))
+  assert has_no_css?(record_css_selector(edition))
 end
 
 Then /^I should see (#{THE_DOCUMENT}) in the list of draft documents$/ do |edition|

--- a/features/step_definitions/featured_topics_and_policies_steps.rb
+++ b/features/step_definitions/featured_topics_and_policies_steps.rb
@@ -107,7 +107,7 @@ Then /^the removed items are no longer displayed on the executive office page$/ 
       assert page.has_css?("li:nth-child(#{idx + 1})", text: item.respond_to?(:name) ? item.name : item.title)
     end
     @the_removed_featured_items.each do |item|
-      refute page.has_css?("li", text: item.respond_to?(:name) ? item.name : item.title)
+      assert page.has_no_css?("li", text: item.respond_to?(:name) ? item.name : item.title)
     end
   end
 end

--- a/features/step_definitions/mainstream_categories_on_orgs_steps.rb
+++ b/features/step_definitions/mainstream_categories_on_orgs_steps.rb
@@ -5,7 +5,7 @@ end
 Then /^the public page for the organisation says nothing about mainstream categories$/ do
   visit organisation_path(@the_organisation)
 
-  refute page.has_css?('#mainstream_categories')
+  assert page.has_no_css?('#mainstream_categories')
 end
 
 Then /^the admin page for the organisation says it has no mainstream categories$/ do
@@ -41,7 +41,7 @@ Then /^only the mainstream categories I chose appear on the public page for the 
       assert page.has_css?("li.mainstream_category:nth-child(#{idx+1}) h2", text: selected_mainstream_category.title)
     end
     (@all_mainstream_categories - @selected_mainstream_categories).each do |unselected_mainstream_category|
-      refute page.has_css?("li.mainstream_category h2", text: unselected_mainstream_category.title)
+      assert page.has_no_css?("li.mainstream_category h2", text: unselected_mainstream_category.title)
     end
   end
 end

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -221,7 +221,7 @@ end
 
 Then /^I cannot see links to Transparency data on the "([^"]*)" about page$/ do |name|
   visit_organisation_about_page name
-  refute page.has_css?('a', text: 'Transparency data')
+  assert page.has_no_css?('a', text: 'Transparency data')
 end
 
 Then /^I can see a link to "([^"]*)" on the "([^"]*)" about page$/ do |link_text, name|
@@ -384,6 +384,6 @@ Then /^I can not see information about uk aid on the "(.*?)" page$/ do |org_name
   org = Organisation.find_by_name!(org_name)
 
   visit organisation_path(org)
-  refute page.has_css?('.uk-aid')
+  assert page.has_no_css?('.uk-aid')
 end
 

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -341,7 +341,7 @@ end
 
 Then /^I should not see a link to "([^"]*)" in the list of related documents$/ do |title|
   edition = Edition.find_by_title(title)
-  refute page.has_css?("#inbound-links a", text: title), "unexpected link to '#{title}' found"
+  assert page.has_no_css?("#inbound-links a", text: title), "unexpected link to '#{title}' found"
 end
 
 Given /^a (.*?) policy "([^"]*)" for the organisation "([^"]*)"$/ do |state, title, organisation|

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -83,7 +83,7 @@ end
 
 Then /^I should no longer see the promotional feature$/ do
   assert_current_url admin_organisation_promotional_features_url(@executive_office)
-  refute page.has_css?(record_css_selector(@promotional_feature))
+  assert page.has_no_css?(record_css_selector(@promotional_feature))
 end
 
 Then /^I should see the promotional feature item's summary has been updated to "([^"]*)"$/ do |summary_text|
@@ -101,7 +101,7 @@ Then /^I should no longer see the promotional item$/ do
 end
 
 Then /^I should not be able to add any further feature items$/ do
-  refute page.has_link?("Add feature item")
+  assert page.has_no_link?("Add feature item")
 end
 
 Then /^I should see the promotional feature on the executive office page$/ do

--- a/features/step_definitions/speed_tagging_steps.rb
+++ b/features/step_definitions/speed_tagging_steps.rb
@@ -32,7 +32,7 @@ When /^I should be able to tag the (?:publication|news article) with "([^"]*)"$/
 end
 
 When /^I should not be able to tag the (?:publication|news article) with "([^"]*)"$/ do |label|
-  refute page.has_css?("label.checkbox", text: /#{label}/)
+  assert page.has_no_css?("label.checkbox", text: /#{label}/)
 end
 
 Then /^I should be able to select the world location "([^"]*)"$/ do |name|

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -72,7 +72,7 @@ Then /^the removed take part page is no longer displayed on the frontend get inv
 
   within '.take-part-pages' do
     @the_removed_pages.each do |removed_page|
-      refute page.has_css?('article h3', text: removed_page.title)
+      assert page.has_no_css?('article h3', text: removed_page.title)
     end
   end
 

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -13,7 +13,7 @@ end
 Then /^I should not see the topical event "([^"]*)" on the topics listing$/ do |topical_event_name|
   topical_event = TopicalEvent.find_by_name!(topical_event_name)
   visit topics_path
-  refute page.has_css?(record_css_selector(topical_event))
+  assert page.has_no_css?(record_css_selector(topical_event))
 end
 
 Then /^I should see the topical event "([^"]*)" on the frontend is archived$/ do |topical_event_name|

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -21,7 +21,7 @@ end
 Then /^I should see that the document was published in error on the public site$/ do
   edition = Edition.last
   visit public_document_path(edition)
-  refute page.has_content?(edition.title)
+  assert page.has_no_content?(edition.title)
   assert page.has_content?('The information on this page has been removed because it was published in error')
   assert page.has_content?('This page should never have existed')
   assert page.has_css?('a[href="https://www.gov.uk/government/how-government-works"]')
@@ -29,7 +29,7 @@ end
 
 Then /^I should see that the document was published in error at the original url$/ do
   visit policy_path(@original_slug)
-  refute page.has_content?(@document.title)
+  assert page.has_no_content?(@document.title)
   assert page.has_content?('The information on this page has been removed because it was published in error')
   assert page.has_content?('This page should never have existed')
   assert page.has_css?('a[href="https://www.gov.uk/government/how-government-works"]')

--- a/features/step_definitions/world_location_news_article_steps.rb
+++ b/features/step_definitions/world_location_news_article_steps.rb
@@ -30,7 +30,7 @@ Then /^I should only see the world location news article on the French version o
   end
 
   visit world_location_path(world_location)
-  refute page.has_css?(record_css_selector(@world_location_news_article))
+  assert page.has_no_css?(record_css_selector(@world_location_news_article))
 end
 
 Then /^I should only be able to view the world location news article article in French$/ do
@@ -79,7 +79,7 @@ Given /^there is a world location news article$/ do
 end
 
 Then /^I should not be able to see the world location news article$/ do
-  refute page.has_css?(record_css_selector(@world_location_news))
+  assert page.has_no_css?(record_css_selector(@world_location_news))
 end
 
 When /^I explicitly ask for world location news to be included$/ do

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -107,7 +107,7 @@ Then /^I should see a (?:world location|international delegation) called "([^"]*
 end
 
 Then /^I should not see a link to the (?:world location|international delegation) called "([^"]*)"$/ do |text|
-  refute page.has_css?(".world_location a", text: text)
+  assert page.has_no_css?(".world_location a", text: text)
 end
 
 Then /^I should see that it is an? (world location|international delegation)$/ do |world_location_type|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -175,7 +175,7 @@ Then /^I should not see his picture on the worldwide organisation page$/ do
   person = Person.last
 
   within record_css_selector(person) do
-    refute page.has_css?('img')
+    assert page.has_no_css?('img')
   end
 end
 

--- a/features/support/document_collection_helper.rb
+++ b/features/support/document_collection_helper.rb
@@ -7,7 +7,7 @@ module DocumentCollectionStepHelpers
 
   def refute_document_is_part_of_document_collection(document_title)
     within '#document_collection' do
-      refute page.has_content? document_title
+      assert page.has_no_content? document_title
     end
   end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -131,7 +131,7 @@ module DocumentHelper
   end
 
   def refute_flash_alerts_exist
-    refute has_css?(".flash.alert")
+    assert has_no_css?(".flash.alert")
   end
 
   def publish(options = {})


### PR DESCRIPTION
In general it's a bad idea to use patterns like the following with Capybara:

```
refute page.has_content? "something"
```

With most of Capybara's matchers, it'll wait around a bit and try
again if the matcher returns false. Capybara does this to support
Javascripty / AJAXy stuff, but it can cause unnecessary delays (regardless of
driver).

Capybara provides negative versions of all it's matchers, so something like this 
is the way to go:

```
assert page.has_no_content? "something"' 
```

This commit changes 27 instances of the negative pattern in cucumber steps,
and that small change shaves nearly 15 secs off the test run. 
"Every little helps".
Dominic Baggott (C. Oct. 2013)
