### PR TITLE
Data migration to fix failed archivings

### DIFF
--- a/db/data_migration/20131024093412_fix_documents_with_multiple_published_editions.rb
+++ b/db/data_migration/20131024093412_fix_documents_with_multiple_published_editions.rb
@@ -1,0 +1,18 @@
+puts "Re-archiving previous editions on documents with more than one published edition"
+
+dodgy_documents = Edition.published.group(:document_id).having("count(*)>1").collect(&:document).uniq
+puts "#{dodgy_documents.count} document(s) found with multiple published editions:"
+puts '----------------------'
+dodgy_documents.each do |document|
+  latest_published_edition = document.editions.published.order(:public_timestamp).last
+  puts "#{latest_published_edition.id} #{latest_published_edition.title} (#{latest_published_edition.created_at})"
+  puts "\t#{document.editions.published.count} published editions - archiving outdated ones."
+  latest_published_edition.archive_previous_editions
+end
+
+dodgy_docs_count_after = Edition.published.group(:document_id).having("count(*)>1").collect(&:document).uniq.count
+if dodgy_docs_count_after == 0
+  puts "Script completed successfully. 0 documents found with multiple publised editions"
+else
+  puts "Error: #{dodgy_docs_count_after} documents found with multiple published editions"
+end


### PR DESCRIPTION
There are a small handful of documents that have multiple "published" editions. This data migration repairs things, archiving all but the most recently published edition.

For a period, we had validations that meant archived editions were not passing validation. This should have meant that a publishing attempt would fail because the archiving of previous editions would blow up, but because `EditionWorkflowController` rescues `ActiveRecord::RecordInvalid`, we were publishing the new edition and
carrying on, despite the exception thrown during the archive attempt. The validations have been corrected now, so we shouldn't see this anymore, but we should still remove the `rescue_from` from the controller once we have reliable service objects for all workflow actions.

(Part of https://www.pivotaltracker.com/story/show/57899408)
