### PR TITLE
Hide documents heading for consultations without attachments

### DIFF
--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -93,8 +93,10 @@
         </div>
       <% end %>
 
-      <%= render partial: "documents/attachment_full_width",
-                 locals: { document: @document, title: 'Documents' } %>
+      <% if @document.attachments.any? || @document.html_version.present? %>
+        <%= render partial: "documents/attachment_full_width",
+                   locals: { document: @document, title: 'Documents' } %>
+      <% end %>
 
       <section>
         <div class="head-section">


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/59399084
