### PR TITLE
Add superseded state ahead of data migration

### DIFF
--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -36,6 +36,7 @@ module Edition::Workflow
       state :scheduled
       state :published
       state :archived
+      state :superseded
       state :deleted
 
       event :try_draft do

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -63,6 +63,9 @@ FactoryGirl.define do
         edition.refresh_index_if_required
       end
     }
+    trait(:superseded) {
+      state "superseded"
+    }
     trait(:featured) { featured true }
     trait(:scheduled) {
       state "scheduled"

--- a/test/unit/edition/workflow_test.rb
+++ b/test/unit/edition/workflow_test.rb
@@ -70,7 +70,7 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     end
 
     assert_equal [:imported, :draft, :submitted, :rejected, :scheduled], pre
-    assert_equal [:published, :archived, :deleted], post
+    assert_equal [:published, :archived, :superseded, :deleted], post
   end
 
   test "rejecting a submitted edition transitions it into the rejected state" do


### PR DESCRIPTION
To make deploying the renaming of the "archived" state to "superseded" smoother, we need the state to be defined on the model. This is to stop the transitions library from blowing up when the data is migrated but the code has not
been reloaded.

Part of https://www.pivotaltracker.com/story/show/57899408
