### PR TITLE
Fixes 500 error on document collection editorial remarks form.

### DIFF
--- a/app/views/admin/editorial_remarks/new.html.erb
+++ b/app/views/admin/editorial_remarks/new.html.erb
@@ -11,7 +11,7 @@
     back to <%= link_to 'document', admin_edition_path(@edition) %>
   </span>
 
-  <%= form_for [:admin, @edition, @editorial_remark] do |feedback_form| %>
+  <%= form_for [:admin, @edition, @editorial_remark], url: admin_edition_editorial_remarks_path(@edition) do |feedback_form| %>
     <%= feedback_form.errors %>
     <%= feedback_form.text_area :body, label_text: "Remark" %>
     <%= feedback_form.submit "Submit remark", class: "btn" %>

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -22,6 +22,12 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
     assert_select "form#new_editorial_remark"
   end
 
+  view_test "should render the editorial remark form for a document collection" do
+    edition = create(:draft_document_collection, title: "collection-title", body: "collection-body")
+    get :new, edition_id: edition
+    assert_select "form#new_editorial_remark"
+  end
+
   test "should redirect to the edition" do
     edition = create(:submitted_speech)
     post :create, edition_id: edition, editorial_remark: { body: "editorial-remark-body" }


### PR DESCRIPTION
Form url in editorial_remarks/new is now explicit

Because of <%= rails_black_magic %> the form_for helper in 
admin/editorial_remarks/new.html.erb was trying to use a route
name which didn't exist when used in the context of a document
collection.

Fixes: https://www.pivotaltracker.com/story/show/59399628
