### PR TITLE
Pending migration to remove unused contact columns

### DIFF
--- a/db/pending_migration_cleanups/20131106094930_remove_translated_contact_columns.rb
+++ b/db/pending_migration_cleanups/20131106094930_remove_translated_contact_columns.rb
@@ -1,0 +1,12 @@
+class RemoveTranslatedContactColumns < ActiveRecord::Migration
+  def up
+    remove_column :contacts, :title
+    remove_column :contacts, :comments
+    remove_column :contacts, :recipient
+    remove_column :contacts, :street_address
+    remove_column :contacts, :locality
+    remove_column :contacts, :region
+    remove_column :contacts, :email
+    remove_column :contacts, :contact_form_url
+  end
+end


### PR DESCRIPTION
Contact details are now translatable, so all data (even for the English
locale) are kept in a separate table.

Clean up from https://www.pivotaltracker.com/story/show/53558977
