### PR TITLE
Migration to remove unused contact columns

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -36,8 +36,9 @@ class Admin::ContactsController < Admin::BaseController
   end
 
   def destroy
+    title = @contact.title
     if @contact.destroy
-      redirect_to [:admin, @contact.contactable, Contact], notice: %{"#{@contact.title}" deleted successfully}
+      redirect_to [:admin, @contact.contactable, Contact], notice: %{"#{title}" deleted successfully}
     else
       render :edit
     end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -16,7 +16,11 @@ class WorldwideOffice < ActiveRecord::Base
   is_stored_on_home_page_lists
 
   # WorldOffice quacks like a Contact
-  contact_methods = Contact.column_names + %w(contact_numbers country country_code country_name has_postal_address?) -  %w(id contactable_id contactable_type)
+  contact_methods = Contact.column_names +
+                    Contact::Translation.column_names +
+                    %w(contact_numbers country country_code country_name has_postal_address?) -
+                    %w(id contactable_id contactable_type contact_id locale created_at updated_at)
+
   delegate *contact_methods, to: :contact, allow_nil: true
 
   delegate :non_english_translated_locales, to: :worldwide_organisation

--- a/db/migrate/20131106094930_remove_translated_contact_columns.rb
+++ b/db/migrate/20131106094930_remove_translated_contact_columns.rb
@@ -1,0 +1,12 @@
+class RemoveTranslatedContactColumns < ActiveRecord::Migration
+  def up
+    remove_column :contacts, :title
+    remove_column :contacts, :comments
+    remove_column :contacts, :recipient
+    remove_column :contacts, :street_address
+    remove_column :contacts, :locality
+    remove_column :contacts, :region
+    remove_column :contacts, :email
+    remove_column :contacts, :contact_form_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131031094414) do
+ActiveRecord::Schema.define(:version => 20131106094930) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -219,16 +219,8 @@ ActiveRecord::Schema.define(:version => 20131031094414) do
   create_table "contacts", :force => true do |t|
     t.decimal "latitude",         :precision => 15, :scale => 10
     t.decimal "longitude",        :precision => 15, :scale => 10
-    t.string  "email"
-    t.string  "contact_form_url"
     t.integer "contactable_id"
     t.string  "contactable_type"
-    t.string  "title"
-    t.text    "comments"
-    t.string  "recipient"
-    t.text    "street_address"
-    t.string  "locality"
-    t.string  "region"
     t.string  "postal_code"
     t.integer "country_id"
     t.integer "contact_type_id",                                  :null => false

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -49,7 +49,7 @@ Given(/^the organisation "(.*?)" is translated into Welsh and has a contact "(.*
 end
 
 When(/^I add a welsh translation "(.*?)" to the "(.*?)" contact$/) do |welsh_title, english_title|
-  contact = Contact.where(title: english_title).first
+  contact = Contact.find_by_title(english_title)
   visit admin_organisation_contacts_path(contact.contactable)
   click_link "Add translation"
   select "Cymraeg", from: "Locale"
@@ -62,7 +62,7 @@ When(/^I add a welsh translation "(.*?)" to the "(.*?)" contact$/) do |welsh_tit
 end
 
 Then(/^I should see on the admin organisation contacts page that "(.*?)" has a welsh translation "(.*?)"$/) do |english_title, welsh_title|
-  contact = Contact.where(title: english_title).first
+  contact = Contact.find_by_title(english_title)
   visit admin_organisation_contacts_path(contact.contactable)
   assert page.has_text?("Cymraeg (Welsh) translation")
   assert page.has_text?(welsh_title)
@@ -78,7 +78,7 @@ Given(/^the world organisation "(.*?)" is translated into French and has an offi
 end
 
 When(/^I add a french translation "(.*?)" to the "(.*?)" office$/) do |french_title, english_title|
-  office = Contact.where(title: english_title).first.contactable
+  office = Contact.find_by_title(english_title).contactable
   visit admin_worldwide_organisation_worldwide_offices_path(office.worldwide_organisation)
   click_link "Add translation"
   select "Français", from: "Locale"
@@ -91,7 +91,7 @@ When(/^I add a french translation "(.*?)" to the "(.*?)" office$/) do |french_ti
 end
 
 Then(/^I should see on the admin world organisation offices page that "(.*?)" has a french translation "(.*?)"$/) do |english_title, french_title|
-  office = Contact.where(title: english_title).first.contactable
+  office = Contact.find_by_title(english_title).contactable
   visit admin_worldwide_organisation_worldwide_offices_path(office.worldwide_organisation)
   assert page.has_text?("Français (French) translation")
   assert page.has_text?(french_title)

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -118,7 +118,7 @@ end
 Then /^the "([^"]*)" office details should be shown on the public website$/ do |description|
   worldwide_org = WorldwideOrganisation.last
   visit worldwide_organisation_path(worldwide_org)
-  worldwide_office = worldwide_org.offices.includes(:contact).where(contacts: {title: description}).first
+  worldwide_office = worldwide_org.offices.joins(contact: :translations).where(contact_translations: {title: description}).first
 
   within "#{record_css_selector(worldwide_office)}.contact" do
     assert page.has_css?("h2", text: worldwide_office.contact.title)
@@ -144,7 +144,7 @@ Given /^a worldwide organisation "([^"]*)" with offices "([^"]*)" and "([^"]*)"$
 end
 
 When /^I choose "([^"]*)" to be the main office$/ do |contact_title|
-  worldwide_office = WorldwideOffice.includes(:contact).where(contacts: {title: contact_title}).first
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: {title: contact_title}).first
   visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
   click_link "Offices"
   within record_css_selector(worldwide_office) do
@@ -154,7 +154,7 @@ end
 
 Then /^the "([^"]*)" should be shown as the main office on the public website$/ do |contact_title|
   worldwide_organisation = WorldwideOrganisation.last
-  worldwide_office = WorldwideOffice.includes(:contact).where(contacts: {title: contact_title}).first
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: {title: contact_title}).first
   visit worldwide_organisation_path(worldwide_organisation)
   within "#{record_css_selector(worldwide_office)}.main" do
     assert page.has_content?(contact_title)
@@ -189,7 +189,7 @@ end
 
 Then /^I should see the default access information on the public "([^"]*)" office page$/ do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
-  worldwide_office = Contact.where(title: office_name).first.contactable
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: {title: office_name}).first
   visit worldwide_organisation_path(worldwide_organisation)
   within record_css_selector(worldwide_office) do
     click_link 'Access and opening times'
@@ -222,7 +222,7 @@ end
 
 When /^I give "([^"]*)" custom access information$/ do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
-  worldwide_office = Contact.where(title: office_name).first.contactable
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: {title: office_name}).first
   visit admin_worldwide_organisation_path(worldwide_organisation)
   click_link 'Offices'
   within record_css_selector(worldwide_office) do
@@ -235,7 +235,7 @@ end
 
 Then /^I should see the custom access information on the public "([^"]*)" office page$/ do |office_name|
   worldwide_organisation = WorldwideOrganisation.last
-  worldwide_office = Contact.where(title: office_name).first.contactable
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: {title: office_name}).first
   visit worldwide_organisation_path(worldwide_organisation)
   within record_css_selector(worldwide_office) do
     click_link 'Access and opening times'


### PR DESCRIPTION
Contact details are now translatable, so all data (even for the English
locale) are kept in a separate table.

Clean up from https://www.pivotaltracker.com/story/show/53558977
