### PR TITLE
Fix broken search results after GDS API Adapters change

### DIFF
--- a/lib/whitehall/document_filter/result_set.rb
+++ b/lib/whitehall/document_filter/result_set.rb
@@ -2,7 +2,7 @@ module Whitehall::DocumentFilter
   class ResultSet
     def initialize(results, page, per_page)
       @results = results
-      @docs = results.is_a?(Hash) ? results['results'] : []
+      @docs = results.respond_to?(:[]) ? results['results'] : []
       @page = page
       @per_page = per_page
     end


### PR DESCRIPTION
The new version of GDS API Adapters changes the type of return values
from API calls. It now returns a GdsApi::Response instead of native
types like Array or Hash. GdsApi::Response quacks like a Hash but it
isn't one.

This switch on the concrete class is a code smell, and changing to
switch on respond_to? is not much of an improvement. I think that this
switch may no longer be needed as we'll always get a hash back, but need
to investigate.

I've added a tech debt story to improve the rummager integration
tests:

https://www.pivotaltracker.com/story/show/60324804
