### PR TITLE
Ensure managing editors can always unpublish

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -36,6 +36,8 @@ module Whitehall::Authority::Rules
         return true
       elsif !can_see?
         return false
+      elsif action == :unpublish && actor.managing_editor?
+        return true
       else
         if actor.gds_editor?
           gds_editor_can?(action)
@@ -135,12 +137,7 @@ module Whitehall::Authority::Rules
     end
 
     def managing_editor_can?(action)
-      case action
-      when :unpublish
-        true
-      else
-        departmental_editor_can?(action)
-      end
+      departmental_editor_can?(action)
     end
 
     def world_editor_can?(action)

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -137,6 +137,13 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(managing_editor, normal_edition).can?(:unpublish)
   end
 
+  test 'can unpublish an edition with multiple roles' do
+    editor = managing_editor
+    editor.send("departmental_editor?=", true)
+    editor.send("gds_editor?=", true)
+    assert enforcer_for(editor, normal_edition).can?(:unpublish)
+  end
+
   test 'cannot reorder cabinet ministers' do
     refute enforcer_for(managing_editor, MinisterialRole).can?(:reorder_cabinet_ministers)
   end


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/58707108

The authority rules are not currently set up to deal with resolving
permissions when a user has multiple roles. Up to now, we have got
away with this because roles have privileges base on a linear
hierarchy, with GDS editors at the top and world writers at the
bottom. This has allowed us to check the user's access level by
checking which role they have, starting at the top of the hierarchy
and working down, granting them access once a matching role is found.
However, the new "Managing Editor" role breaks this hierarchy as,
although it is a less priviledged role than GDS Editor, managing
editors can unpublish editions whereas GDS Editors cannot. This means
that a linear check would prevent a user that has both the GDS Editor
and Managing Editor roles from unpublishing editions.

In lieu of rewriting the enforcer rules to check against multiple
roles, this commit ensures that a user with the "Managing Editor" role
will always be able to unpublish editions they have access to.
