### PR TITLE
Unpublishing detailed guides

### DIFF
--- a/app/services/edition_unpublisher.rb
+++ b/app/services/edition_unpublisher.rb
@@ -1,8 +1,6 @@
 class EditionUnpublisher < EditionService
   def failure_reason
-    @failure_reason ||= if !edition.valid?
-      "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
-    elsif !can_transition?
+    @failure_reason ||= if !can_transition?
       "An edition that is #{edition.current_state} cannot be #{past_participle}"
     elsif edition.other_draft_editions.any?
       "There is already a draft edition of this document. You must discard it before you can #{verb} this edition."
@@ -18,6 +16,11 @@ class EditionUnpublisher < EditionService
   end
 
 private
+
+  def fire_transition!
+    edition.public_send("#{verb}")
+    edition.save(validate: false)
+  end
 
   def prepare_edition
     edition.force_published = false

--- a/test/unit/services/edition_archiver_test.rb
+++ b/test/unit/services/edition_archiver_test.rb
@@ -26,12 +26,15 @@ class EditionArchiverTest < ActiveSupport::TestCase
     end
   end
 
-  test 'cannot archive an invalid edition' do
-    edition = build(:published_edition, title: nil)
+  test 'even invalid editions can be archived' do
+    edition = create(:published_edition)
+    edition.build_unpublishing(unpublishing_params)
+    edition.summary = nil
     unpublisher = EditionArchiver.new(edition)
 
-    refute unpublisher.can_perform?
-    assert_equal "This edition is invalid: Title can't be blank", unpublisher.failure_reason
+    assert unpublisher.can_perform?
+    assert unpublisher.perform!
+    assert edition.reload.archived?
   end
 
   test 'cannot archive a published editions if a newer draft exists' do

--- a/test/unit/services/edition_unpublisher_test.rb
+++ b/test/unit/services/edition_unpublisher_test.rb
@@ -36,12 +36,15 @@ class EditionUnpublisherTest < ActiveSupport::TestCase
     end
   end
 
-  test 'cannot unpublish an invalid edition' do
-    edition = build(:published_edition, title: nil)
+  test 'even invalid editions can be unpublished' do
+    edition = create(:published_edition)
+    edition.build_unpublishing(unpublishing_params)
+    edition.summary = nil
     unpublisher = EditionUnpublisher.new(edition)
 
-    refute unpublisher.can_perform?
-    assert_equal "This edition is invalid: Title can't be blank", unpublisher.failure_reason
+    assert unpublisher.can_perform?
+    assert unpublisher.perform!
+    assert edition.reload.draft?
   end
 
   test 'cannot unpublish a published editions if a newer draft exists' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/59226824

Unpublishing is now possible, even on invalid editions. This allows older detailed guides to be unpublished without having to add a user need to them. Given that we only ever unpublish published editions, and unpublished editions are no longer visible on frontend, this should be safe.
