### PR TITLE
Arrayify some input to DocumentFilter::Filterer

### DIFF
--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -18,10 +18,10 @@ module Whitehall::DocumentFilter
       @relevant_to_local_government = params[:relevant_to_local_government]
       @include_world_location_news  = params[:include_world_location_news]
 
-      @topics          = @params[:topics]
-      @departments     = @params[:departments]
-      @people_ids      = @params[:people_id]
-      @world_locations = @params[:world_locations]
+      @topics          = Array(@params[:topics])
+      @departments     = Array(@params[:departments])
+      @people_ids      = Array(@params[:people_id])
+      @world_locations = Array(@params[:world_locations])
     end
 
     def announcements_search
@@ -59,21 +59,13 @@ module Whitehall::DocumentFilter
     end
 
     def selected_people_option
-      if @people_ids.try(:any?) && @people_ids != ["all"]
-        @people_ids.reject! {|l| l == "all"}
-        People.where(id: @people_ids)
-      else
-        []
-      end
+      @people_ids.reject! { |l| l == "all" }
+      People.where(id: @people_ids)
     end
 
     def selected_locations
-      if @world_locations.try(:any?) && @world_locations != ["all"]
-        @world_locations.reject! {|l| l == "all"}
-        WorldLocation.find_all_by_slug(@world_locations)
-      else
-        []
-      end
+      @world_locations.reject! { |l| l == "all" }
+      WorldLocation.find_all_by_slug(@world_locations)
     end
 
     def keywords

--- a/test/unit/whitehall/document_filter/mysql_test.rb
+++ b/test/unit/whitehall/document_filter/mysql_test.rb
@@ -195,6 +195,10 @@ module Whitehall::DocumentFilter
       filter = Whitehall::DocumentFilter::Mysql.new(world_locations: [])
       filter.publications_search
       assert_same_elements [item_1, item_2, item_3, item_4], filter.documents
+
+      filter = Whitehall::DocumentFilter::Mysql.new(world_locations: "all")
+      filter.publications_search
+      assert_same_elements [item_1, item_2, item_3, item_4], filter.documents
     end
 
     test "can filter consultations" do


### PR DESCRIPTION
Strings get passed through to the document filter from query parameters
like "world_locations=all". Arrayifying means we can be sure we're
dealing with an array and call #any? on it.

Fixes https://www.pivotaltracker.com/story/show/59416132
