### PR TITLE
Fix some migration issues on markdown links.

### DIFF
--- a/db/data_migration/20131106163843_clean_up_bad_markdown_links.rb
+++ b/db/data_migration/20131106163843_clean_up_bad_markdown_links.rb
@@ -59,7 +59,7 @@ where("editions.state NOT IN ('deleted', 'superseded', 'archived')
   body = et.body
   new_body = nil
 
-  et.body.scan(/(\[(.*?)\]\((\S*?)(:?\s+"[^"]+")?\))/) do |capture_groups|
+  et.body.scan(/(\[(.*?)\]\((\S*?)(\s+"[^"]+")?\))/) do |capture_groups|
     original_markdown, original_text, original_link, original_title = capture_groups
     body = new_body || body
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/60397412
- Add editorial remarks
- Replace whole markdown to prevent overeager
  replacements (e.g. replacing email addresses
  with mailto links in link text)
