### PR TITLE
Fix document collection membership in speed tagger

### DIFF
--- a/app/helpers/admin/document_collection_helper.rb
+++ b/app/helpers/admin/document_collection_helper.rb
@@ -1,7 +1,7 @@
 module Admin::DocumentCollectionHelper
   def document_collection_select_options(edition, user, selected_ids)
     options = Rails.cache.fetch("document_collection_select_options", expires_in: 30.minutes) do
-      DocumentCollection.alphabetical.map  do |collection|
+      DocumentCollection.alphabetical.includes(:groups).flat_map  do |collection|
         collection.groups.map do |group|
           ["#{collection.title} (#{group.heading})", group.id]
         end


### PR DESCRIPTION
Also eager load document collection groups to avoid an N+1 query

Fixes https://www.pivotaltracker.com/story/show/59242784
