### PR TITLE
Show transition progress for non ministerial orgs

### DIFF
--- a/app/views/organisations/_transition_state_visualisation.html.erb
+++ b/app/views/organisations/_transition_state_visualisation.html.erb
@@ -1,5 +1,5 @@
 <div class="transition-state-visualisation">
   <%= horizontal_percent_bar(organisations.live_count.to_f / organisations.potentially_live_count) %>
-  <p class="num-agencies-live"><span class="count"><strong><%= organisations.live_count %></strong>/<strong><%= organisations.potentially_live_count %></strong></span> agencies on GOV.UK</p>
+  <p class="num-agencies-live"><span class="count"><strong><%= organisations.live_count %></strong>/<strong><%= organisations.potentially_live_count %></strong></span> on GOV.UK</p>
   <p class="num-agencies-exempt"><span class="count">+<strong><%= organisations.exempt_count %></strong></span> not moving to GOV.UK</p>
 </div>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -34,7 +34,8 @@
                                   block_id:           'non-ministerial-departments',
                                   include_works_with: true,
                                   list_item_partial:  'index_item_plain',
-                                  show_govuk_status:  true %>
+                                  show_govuk_status:  !Whitehall::organisations_transition_visualisation_feature_enabled,
+                                  show_transition_state: Whitehall::organisations_transition_visualisation_feature_enabled %>
 
       <%= render 'index_section', organisations:      @organisations.agencies_and_government_bodies,
                                   header_text:        'Agencies &amp; other public bodies',

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -119,7 +119,7 @@ Scenario: Viewing the organisations index and seeing organisations grouped into 
   When I visit the organisations page
   Then I should see the executive offices listed
   And I should see the ministerial departments including their sub-organisations listed with count and number live
-  And I should see the non ministerial departments including their sub-organisations listed with count and number live
+  And I should see the non ministerial departments including their sub-organisations listed with count
   And I should see the agencies and government bodies listed with count
   And I should see the public corporations listed with count
   And I should see the devolved administrations listed with count
@@ -128,7 +128,13 @@ Scenario: Viewing the organisations index and seeing a visualisation of the numb
   Given 1 live, 1 transitioning and 1 exempt executive agencies
   When I visit the organisations page
   Then I should see a transition visualisation showing 1 out of 2 agencies moved plus 1 agency
-  And I should see metadata in the organisation list indicating the status of each organisation which is not live
+  And I should see metadata in the agency list indicating the status of each organisation which is not live
+
+Scenario: Viewing the organisations index and seeing a visualisation of the number of non ministerial departments
+  Given 1 live, 1 transitioning and 1 exempt non ministerial departments
+  When I visit the organisations page
+  Then I should see a transition visualisation showing 1 out of 2 non ministerial departments moved plus 1 not moving
+  And I should see metadata in the non ministerial department list indicating the status of each organisation which is not live
 
 Scenario: Organisation page should show policies
   Given the organisation "Attorney General's Office" contains some policies

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -105,6 +105,12 @@ Given(/^1 live, 1 transitioning and 1 exempt executive agencies$/) do
   @exempt_agency =        create :organisation, organisation_type_key: :executive_agency, govuk_status: 'exempt'
 end
 
+Given(/^1 live, 1 transitioning and 1 exempt non ministerial departments$/) do
+  @live_agency =          create :organisation, organisation_type_key: :non_ministerial_department, govuk_status: 'live'
+  @transitioning_agency = create :organisation, organisation_type_key: :non_ministerial_department, govuk_status: 'transitioning'
+  @exempt_agency =        create :organisation, organisation_type_key: :non_ministerial_department, govuk_status: 'exempt'
+end
+
 When /^I add a new organisation called "([^"]*)"$/ do |organisation_name|
   create(:topic, name: 'Jazz Bizniz')
   create(:mainstream_category, title: 'Jazzy Bizzle')
@@ -201,7 +207,7 @@ Then(/^I should see the ministerial departments including their sub\-organisatio
   end
 end
 
-Then(/^I should see the non ministerial departments including their sub\-organisations listed with count and number live$/) do
+Then(/^I should see the non ministerial departments including their sub\-organisations listed with count$/) do
   within "#non-ministerial-departments" do
     assert page.has_link?(@non_ministerial_department_1.name, href: organisation_path(@non_ministerial_department_1))
     assert page.has_link?(@non_ministerial_department_2.name, href: organisation_path(@non_ministerial_department_2))
@@ -210,7 +216,6 @@ Then(/^I should see the non ministerial departments including their sub\-organis
     end
     within "header" do
       assert page.has_content? "2"
-      assert page.has_content? "1 live on GOV.UK"
     end
   end
 end
@@ -253,13 +258,28 @@ end
 Then(/^I should see a transition visualisation showing 1 out of 2 agencies moved plus 1 agency$/) do
   within "#agencies-and-government-bodies .transition-state-visualisation" do
     assert page.find('.horizontal-percent-bar .bar-inner')['style'].include?("width: 50%")
-    assert page.has_content? "1/2 agencies on GOV.UK"
+    assert page.has_content? "1/2 on GOV.UK"
     assert page.has_content? "+1 not moving to GOV.UK"
   end
 end
 
-Then(/^I should see metadata in the organisation list indicating the status of each organisation which is not live$/) do
+Then(/^I should see a transition visualisation showing 1 out of 2 non ministerial departments moved plus 1 not moving$/) do
+  within "#non-ministerial-departments .transition-state-visualisation" do
+    assert page.find('.horizontal-percent-bar .bar-inner')['style'].include?("width: 50%")
+    assert page.has_content? "1/2 on GOV.UK"
+    assert page.has_content? "+1 not moving to GOV.UK"
+  end
+end
+
+Then(/^I should see metadata in the agency list indicating the status of each organisation which is not live$/) do
   within('#agencies-and-government-bodies') do
+    assert page.has_content? "#{@transitioning_agency.name} moving to GOV.UK"
+    assert page.has_content? "#{@exempt_agency.name} separate website"
+  end
+end
+
+Then(/^I should see metadata in the non ministerial department list indicating the status of each organisation which is not live$/) do
+  within('#non-ministerial-departments') do
     assert page.has_content? "#{@transitioning_agency.name} moving to GOV.UK"
     assert page.has_content? "#{@exempt_agency.name} separate website"
   end


### PR DESCRIPTION
- Remove show_govuk_status from non-ministerial orgs when
  progress bar is shown.
- Change text from "n agencies on GOV.UK" to "n on GOV.UK"

https://www.pivotaltracker.com/s/projects/367813/stories/60673236
