### PR TITLE
Fix bug with published related policies.

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -5,10 +5,7 @@ module Edition::RelatedPolicies
 
   included do
     has_many :related_policies, through: :related_documents, source: :latest_edition, class_name: 'Policy'
-  end
-
-  def published_related_policies
-    related_policies.published
+    has_many :published_related_policies, through: :related_documents, source: :published_edition, class_name: 'Policy'
   end
 
   # Ensure that when we set policy ids we don't remove other types of edition from the array


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/60688864

Mapping to #latest_edition then filtering by published will get you false negatives if the policy has a newer unpublished edition.

This is exacerbated by the unnatural conversion to editions when really the editions are linked to documents.  See the tech debt around the edition/document conflux.
