### PR TITLE
Consultation#process_associations_after_save doesn't break when outcome ...

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -35,17 +35,19 @@ class Consultation < Publicationesque
       end
 
       if @edition.outcome.present?
-        new_outcome = edition.create_outcome(@edition.outcome.attributes.except('edition_id'))
+        new_outcome = edition.build_outcome(@edition.outcome.attributes.except('edition_id'))
         @edition.outcome.attachments.each do |attachment|
-          new_outcome.attachments.create(attachment.attributes)
+          new_outcome.attachments.build(attachment.attributes)
         end
+        new_outcome.save!
       end
 
       if @edition.public_feedback.present?
-        new_feedback = edition.create_public_feedback(@edition.public_feedback.attributes.except('edition_id'))
+        new_feedback = edition.build_public_feedback(@edition.public_feedback.attributes.except('edition_id'))
         @edition.public_feedback.attachments.each do |attachment|
-          new_feedback.attachments.create(attachment.attributes)
+          new_feedback.attachments.build(attachment.attributes)
         end
+        new_feedback.save!
       end
     end
   end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -170,6 +170,18 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal attachment.attachment_data, new_draft.outcome.attachments.first.attachment_data
   end
 
+  test "should copy the outcome without falling over if the outcome has attachments but no summary" do
+    consultation = create(:published_consultation)
+    outcome = create(:consultation_outcome, consultation: consultation, summary: '', attachments: [
+      create(:attachment, title: 'attachment-title', attachment_data_attributes: { file: fixture_file_upload('greenpaper.pdf') })
+    ])
+
+    assert_nothing_raised {
+      new_draft = consultation.create_draft(build(:user))
+      assert_equal 1, new_draft.outcome.attachments.length
+    }
+  end
+
   test "copies public feedback and its attachments when creating a new draft" do
     consultation = create(:published_consultation)
     feedback = create(:consultation_public_feedback, consultation: consultation)
@@ -186,6 +198,18 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal 'attachment-title', new_feedback.attachments.first.title
     assert_not_equal attachment, new_feedback.attachments.first
     assert_equal attachment.attachment_data, new_feedback.attachments.first.attachment_data
+  end
+
+  test "should copy public feedback without falling over if the feedback has attachments but no summary" do
+    consultation = create(:published_consultation)
+    public_feedback = create(:consultation_public_feedback, consultation: consultation, summary: '', attachments: [
+      create(:attachment, title: 'attachment-title', attachment_data_attributes: { file: fixture_file_upload('greenpaper.pdf') })
+    ])
+
+    assert_nothing_raised {
+      new_draft = consultation.create_draft(build(:user))
+      assert_equal 1, new_draft.public_feedback.attachments.length
+    }
   end
 
   test "should report that the outcome has not been published if the consultation is still open" do


### PR DESCRIPTION
...has no summary

also affects public_feedback

Fixes: https://www.pivotaltracker.com/story/show/60689516
