### PR TITLE
Only show latest doc collections in speed tagger

### DIFF
--- a/app/helpers/admin/document_collection_helper.rb
+++ b/app/helpers/admin/document_collection_helper.rb
@@ -1,7 +1,7 @@
 module Admin::DocumentCollectionHelper
   def document_collection_select_options(edition, user, selected_ids)
     options = Rails.cache.fetch("document_collection_select_options", expires_in: 30.minutes) do
-      DocumentCollection.alphabetical.includes(:groups).flat_map  do |collection|
+      DocumentCollection.latest_edition.alphabetical.includes(:groups).flat_map  do |collection|
         collection.groups.map do |group|
           ["#{collection.title} (#{group.heading})", group.id]
         end


### PR DESCRIPTION
Previously all editions of every document collection were being shown
which meant the same document collection would show multiple times with
no indication which should be chosen. This change makes only the latest
edition for each document collection display.

Further fix for https://www.pivotaltracker.com/story/show/59242784
