### PR TITLE
Fix document list feed panel not updating

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -22,6 +22,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
     updateAtomFeed: function(data) {
       if (data.atom_feed_url) {
         $(".feeds .feed").attr("href", data.atom_feed_url);
+        $(".feed-panel input").val(data.atom_feed_url);
       }
     },
     updateEmailSignup: function(data) {


### PR DESCRIPTION
When changing the filters, it updated the link but not the
copy & paste box.
