### PR TITLE
Add slugs for document collection groups

### DIFF
--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -48,6 +48,10 @@ class DocumentCollectionGroup < ActiveRecord::Base
     new_group
   end
 
+  def slug
+    heading.parameterize
+  end
+
   private
 
   def assign_ordering

--- a/app/views/document_collections/show.html.erb
+++ b/app/views/document_collections/show.html.erb
@@ -25,7 +25,7 @@
       <h1>Contents</h1>
       <ol class="dash-list">
         <% @document_collection.groups.each do |group| %>
-          <li><%= link_to group.heading, "#group_#{group.id}" %></li>
+          <li><%= link_to group.heading, "##{group.slug}" %></li>
         <% end %>
       </ol>
     </div>
@@ -44,7 +44,7 @@
 
       <% @groups.each do |group, editions| %>
         <div class="editions">
-          <%= content_tag :h2, group.heading, id: "group_#{group.id}" %>
+          <%= content_tag :h2, group.heading, id: group.slug %>
           <% unless group.body.blank? %>
             <div class="group-body">
               <%= govspeak_to_html group.body %>

--- a/test/functional/document_collections_controller_test.rb
+++ b/test/functional/document_collections_controller_test.rb
@@ -47,8 +47,8 @@ class DocumentCollectionsControllerTest < ActionController::TestCase
     group_2 = create_group_from_editions(collection, 'Group 2', create(:published_publication))
     get :show, id: collection.slug
 
-    assert_select "ol li a[href=#group_#{group_1.id}]", text: 'Group 1'
-    assert_select "ol li a[href=#group_#{group_2.id}]", text: 'Group 2'
+    assert_select "ol li a[href=##{group_1.slug}]", text: 'Group 1'
+    assert_select "ol li a[href=##{group_2.slug}]", text: 'Group 2'
   end
 
   test "GET #show sets Cache-Control: max-age to the time of the next scheduled publication in the collection" do

--- a/test/unit/models/document_collection_group_test.rb
+++ b/test/unit/models/document_collection_group_test.rb
@@ -67,4 +67,9 @@ class DocumentSeriesGroupTest < ActiveSupport::TestCase
     assert_equal     1,                             new_group.memberships[1].ordering
     assert_equal     3,                             new_group.memberships[2].ordering
   end
+
+  test '#slug generates slugs of the heading' do
+    group = create(:document_collection_group, heading: 'Foo bar')
+    assert_equal group.slug, 'foo-bar'
+  end
 end


### PR DESCRIPTION
We opted against a database field, because if the group is
renamed, the page will still load fine.

https://www.pivotaltracker.com/s/projects/367813/stories/56955348
