### PR TITLE
Prevent scheduling of editions with bad links.

### DIFF
--- a/app/models/edition/scheduled_publishing.rb
+++ b/app/models/edition/scheduled_publishing.rb
@@ -26,6 +26,8 @@ module Edition::ScheduledPublishing
       "This edition has been #{current_state}"
     elsif scheduled_publication.blank?
       "This edition does not have a scheduled publication date set"
+    elsif DataHygiene::GovspeakLinkValidator.new(body).errors.any?
+      "This edition contains bad links"
     end
   end
 
@@ -38,6 +40,8 @@ module Edition::ScheduledPublishing
       "This edition has been #{current_state}"
     elsif scheduled_publication.blank?
       "This edition does not have a scheduled publication date set"
+    elsif DataHygiene::GovspeakLinkValidator.new(body).errors.any?
+      "This edition contains bad links"
     end
   end
 

--- a/test/unit/edition/scheduled_publishing_test.rb
+++ b/test/unit/edition/scheduled_publishing_test.rb
@@ -68,6 +68,16 @@ class Edition::ScheduledPublishingTest < ActiveSupport::TestCase
     assert_nil edition.reason_to_prevent_scheduling
   end
 
+  test "#reason_to_prevent_scheduling reports bad links in the edition" do
+    edition = build(:edition, :submitted, scheduled_publication: 1.day.from_now, body: "[Example](government/admin/editions/12324)")
+    assert_equal "This edition contains bad links", edition.reason_to_prevent_scheduling
+  end
+
+  test "#reason_to_prevent_force_scheduling reports bad links in the edition" do
+    edition = build(:edition, scheduled_publication: 1.day.from_now, body: "[Example](government/admin/editions/12324)")
+    assert_equal "This edition contains bad links", edition.reason_to_prevent_force_scheduling
+  end
+
   test "scheduling returns true and marks edition as scheduled" do
     edition = create(:submitted_edition, scheduled_publication: 1.day.from_now)
     assert edition.perform_schedule


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/61197910

After deploy, this ticket requires us to review all scheduled documents to make sure they won't fail link validation when being published.

There's also more work to be done at some point in terms of splitting away the concept of "can be published" from the concept of "should be published" and the wording that comes along with that in the interface.
