### PR TITLE
Only show visible groups in doc collection contents

### DIFF
--- a/app/views/document_collections/show.html.erb
+++ b/app/views/document_collections/show.html.erb
@@ -24,7 +24,7 @@
     <div class="contextual-info js-stick-at-top-when-scrolling">
       <h1>Contents</h1>
       <ol class="dash-list">
-        <% @document_collection.groups.each do |group| %>
+        <% @groups.each do |group, _| %>
           <li><%= link_to group.heading, "##{group.slug}" %></li>
         <% end %>
       </ol>


### PR DESCRIPTION
Groups containing no documents or no published documents would be
displayed in the contents list but not in the main content.

Follow up for https://www.pivotaltracker.com/story/show/61211960
