### PR TITLE
Submitted supporting pages are active as well

### DIFF
--- a/app/models/edition/supporting_pages.rb
+++ b/app/models/edition/supporting_pages.rb
@@ -13,7 +13,7 @@ module Edition::SupportingPages
     # Approach: Join editions to itself where the document IDs match
     # and the edition ID is smaller than another edition ID. The row
     # which has a null later edition is the most recent.
-    supporting_pages.where(state: [:published, :draft]).joins(%(
+    supporting_pages.where(state: %w(draft submitted published)).joins(%(
       LEFT OUTER JOIN editions AS later_editions
       ON editions.document_id = later_editions.document_id
       AND editions.id < later_editions.id

--- a/test/factories/supporting_pages.rb
+++ b/test/factories/supporting_pages.rb
@@ -18,4 +18,5 @@ FactoryGirl.define do
 
   factory :draft_supporting_page, parent: :supporting_page
   factory :published_supporting_page, parent: :supporting_page, traits: [:published]
+  factory :submitted_supporting_page, parent: :supporting_page, traits: [:submitted]
 end

--- a/test/unit/edition/supporting_pages_test.rb
+++ b/test/unit/edition/supporting_pages_test.rb
@@ -17,12 +17,13 @@ class Edition::SupportingPagesTest < ActiveSupport::TestCase
     assert_equal [supporting_page], policy.published_supporting_pages
   end
 
-  test "#active_supporting_pages should return the latest draft or published editions" do
+  test "#active_supporting_pages should return the latest draft, submitted or published editions" do
     policy = create(:policy)
-    supporting_page = create(:published_supporting_page, related_policies: [policy])
+    published_page = create(:published_supporting_page, related_policies: [policy])
     other_page = create(:published_supporting_page, related_policies: [policy])
-    draft = other_page.create_draft(create(:policy_writer))
+    draft_page = other_page.create_draft(create(:policy_writer))
+    submitted_page = create(:submitted_supporting_page, related_policies: [policy])
 
-    assert_equal [supporting_page, draft], policy.active_supporting_pages
+    assert_equal [published_page, draft_page, submitted_page], policy.active_supporting_pages
   end
 end


### PR DESCRIPTION
This fixes a bug where submitted editions were being excluded from the list of active supporting pages listed in the admin interface.

https://www.pivotaltracker.com/story/show/61301412
