### PR TITLE
Speculative fix for intermittently failing feature

### DIFF
--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -60,6 +60,8 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
       GOVUK.instances.DocumentGroupOrdering[0].onDrop({}, {item: doc_1_li});
     })(jQuery);
   }
+  # Wait for post to complete
+  assert page.has_no_css?(".loading-spinner")
 end
 
 Then(/^I (?:can )?preview the document collection$/) do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/61376422

Scenario in question is features/document-collections.feature:33

This scenario often fails on the step:
"And I see that "Feeding Wombats" is before "Wombats of Wimbledon" in the document collection"

I'm thinking that this might be because the post made in
"And I move "Feeding Wombats" before "Wombats of Wimbledon" in the document collection"
was aborted before completing by navigating straight to the preview page. If I'm right,
putting in this sleep statement should fix it.
- [x] Confirm fix works.
