### PR TITLE
Fix comparison of AuditEntry objects

### DIFF
--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -89,15 +89,7 @@ module Edition::AuditTrail
     end
 
     def <=>(other)
-      if created_at == other.created_at
-        if sort_priority = other.sort_priority
-          object <=> other.object
-        else
-          sort_priority <=> other.sort_priority
-        end
-      else
-        created_at <=> other.created_at
-      end
+      [created_at, sort_priority] <=> [other.created_at, other.sort_priority]
     end
 
     def ==(other)


### PR DESCRIPTION
The <=> method incorrectly used assignment when trying to check if the
sort_priority of the two objects was equal.

I've updated it to use a simpler approach for multi-field sorting by
putting the comparison fields into arrays and comparing those. I've also
removed the object comparison as the <=> method inherited from
ActiveRecord::Base returns nil if the records aren't the same class
breaking the sort.
