### PR TITLE
Handle unrecognised request formats

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -45,13 +45,13 @@ class PublicFacingController < ApplicationController
 
   def restrict_request_formats
     unless can_handle_format?(request.format)
-      render status: :not_found, text: "Request format #{request.format} not handled."
+      render status: :not_acceptable, text: "Request format #{request.format} not handled."
     end
   end
 
   def can_handle_format?(format)
     return true if format == Mime::HTML
-    self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
+    format && self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
   end
 
   def set_expiry(duration = 30.minutes)

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -78,7 +78,7 @@ class PublicFacingControllerTest < ActionController::TestCase
     [:json, :xml, :atom].each do |format|
       get :test, format: format
 
-      assert_response :not_found
+      assert_response :not_acceptable
     end
   end
 
@@ -94,7 +94,7 @@ class PublicFacingControllerTest < ActionController::TestCase
     assert_equal '{}', response.body
 
     get :json, format: :atom
-    assert_response :not_found
+    assert_response :not_acceptable
   end
 
   test "multiple formats can be enabled" do
@@ -114,7 +114,12 @@ class PublicFacingControllerTest < ActionController::TestCase
     assert_equal 'atom', response.body
 
     get :js_or_atom, format: :json
-    assert_response :not_found
+    assert_response :not_acceptable
+  end
+
+  test "returns an appropriate response for unrecognised/invalid request formats" do
+    get :test, format: 'atom\\'
+    assert_response :not_acceptable
   end
 
   test "all public facing requests without a locale should use the default locale" do


### PR DESCRIPTION
This also changes the response status code to the more appropriate 406
