### PR TITLE
Include supporting pages in admin when filtering by org

### DIFF
--- a/app/models/edition/findable_by_organisation.rb
+++ b/app/models/edition/findable_by_organisation.rb
@@ -3,9 +3,17 @@ module Edition::FindableByOrganisation
   def in_organisation(organisation)
     organisation_ids = Array(organisation).map(&:id)
 
-    where('exists (SELECT * FROM edition_organisations eo_orgcheck
-                   WHERE eo_orgcheck.edition_id = editions.id
-                   AND eo_orgcheck.organisation_id IN (:ids))',
+    where('(editions.type <> "SupportingPage"
+            AND exists (SELECT * FROM edition_organisations eo_orgcheck
+                        WHERE eo_orgcheck.edition_id = editions.id
+                        AND eo_orgcheck.organisation_id IN (:ids)))
+           OR
+           (editions.type = "SupportingPage"
+            AND exists (SELECT * FROM edition_organisations eo_orgcheck
+                        JOIN editions policies_orgcheck ON eo_orgcheck.edition_id = policies_orgcheck.id
+                        JOIN edition_relations er_orgcheck ON policies_orgcheck.document_id = er_orgcheck.document_id
+                        WHERE er_orgcheck.edition_id = editions.id
+                        AND eo_orgcheck.organisation_id IN (:ids)))',
           ids: organisation_ids)
   end
 end

--- a/test/unit/supporting_page_test.rb
+++ b/test/unit/supporting_page_test.rb
@@ -31,4 +31,12 @@ class SupportingPageTest < ActiveSupport::TestCase
 
     assert_equal [org1, org2, org3], supporting_page.organisations
   end
+
+  test "should be findable via #in_organisation" do
+    org = create(:organisation)
+    policy = create(:policy, organisations: [org])
+    page = create(:supporting_page, related_policies: [policy])
+
+    assert_equal [page], SupportingPage.in_organisation(org).to_a
+  end
 end


### PR DESCRIPTION
In my local environment this change seems to add about 0.5s to the load time for the admin editions index.

This change will not be required once we move to an elastic search index for the admin system.

Fixes https://www.pivotaltracker.com/story/show/61539712
