### PR TITLE
Send exceptions generated when publishing scheduled editions to ExceptionNotifier

### DIFF
--- a/lib/scheduled_editions_publisher.rb
+++ b/lib/scheduled_editions_publisher.rb
@@ -42,6 +42,7 @@ class ScheduledEditionsPublisher
     end
   rescue Exception => exception
     log_unsuccessful_publication(edition, exception.message)
+    ExceptionNotifier::Notifier.background_exception_notification(exception)
   end
 
   def publishing_robot


### PR DESCRIPTION
ScheduledEditionPublisher caught any exceptions raised by
trying to publish a scheduled edition. This PR sends
raised exceptions to ExceptionNotifier.

Fixes: https://www.pivotaltracker.com/story/show/61606938
