### PR TITLE
Remove unneeded code from statistical data set row

### DIFF
--- a/lib/whitehall/uploader/statistical_data_set_row.rb
+++ b/lib/whitehall/uploader/statistical_data_set_row.rb
@@ -1,15 +1,6 @@
 module Whitehall::Uploader
   class StatisticalDataSetRow < Row
     DEFAULT_CHANGE_NOTE = 'Data set updated.'
-    attr_reader :row
-
-    def initialize(row, line_number, attachment_cache, default_organisation, logger = Logger.new($stdout))
-      @row = row
-      @line_number = line_number
-      @logger = logger
-      @attachment_cache = attachment_cache
-      @default_organisation = default_organisation
-    end
 
     def self.validator
       HeadingValidator.new
@@ -19,10 +10,6 @@ module Whitehall::Uploader
         .multiple(%w{attachment_#_url attachment_#_title attachment_#_URN attachment_#_published_date}, 0..100)
         .ignored("ignore_*")
         .multiple("topic_#", 0..4)
-    end
-
-    def title
-      row['title']
     end
 
     def summary
@@ -35,20 +22,7 @@ module Whitehall::Uploader
     end
 
     def body
-      body = row['body']
-      body.blank? ? generated_attachment_body : body
-    end
-
-    def legacy_urls
-      [row["old_url"]]
-    end
-
-    def organisations
-      Finders::OrganisationFinder.find(row['organisation'], @logger, @line_number, @default_organisation)
-    end
-
-    def lead_organisations
-      organisations
+      super.presence || generated_attachment_body
     end
 
     def document_collections

--- a/test/unit/uploader/statistical_data_set_row_test.rb
+++ b/test/unit/uploader/statistical_data_set_row_test.rb
@@ -5,7 +5,7 @@ module Whitehall::Uploader
   class StatisticalDataSetRowTest < ActiveSupport::TestCase
     setup do
       @attachment_cache = stub('attachment cache')
-      @default_organisation = stub('Organisation')
+      @default_organisation = stubbed_organisation
     end
 
     def statistical_data_set_row(data)
@@ -113,21 +113,21 @@ module Whitehall::Uploader
     end
 
     test "finds organisation by slug in org column" do
-      organisation = stub("organisation")
+      organisation = stubbed_organisation
       Finders::OrganisationFinder.stubs(:find).with("name or slug", anything, anything, @default_organisation).returns([organisation])
       row = statistical_data_set_row("organisation" => "name or slug")
       assert_equal [organisation], row.organisations
     end
 
     test "takes lead_organisations from the found organisations" do
-      o = stub(:organisation)
+      o = stubbed_organisation
       row = statistical_data_set_row({})
       row.stubs(:organisations).returns([o])
       assert_equal [o], row.lead_organisations
     end
 
     test "uses the organisation as the alternative format provider" do
-      organisation = stub("organisation")
+      organisation = stubbed_organisation
       Finders::OrganisationFinder.stubs(:find).with("name or slug", anything, anything, @default_organisation).returns([organisation])
       row = statistical_data_set_row("organisation" => "name or slug")
       assert_equal organisation, row.alternative_format_provider
@@ -160,6 +160,10 @@ module Whitehall::Uploader
       end
 
       [attachments, attributes]
+    end
+
+    def stubbed_organisation
+      stub("organisation", url: "url")
     end
   end
 end


### PR DESCRIPTION
It was overriding a lot of methods defined in its parent class without
actually changing the behaviour.
