### PR TITLE
Use integers (not strings) to sort attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -8,7 +8,7 @@ class Admin::AttachmentsController < Admin::BaseController
   def index; end
 
   def order
-    attachment_ids = params[:ordering].sort_by { |_, ordering| ordering }.map { |id, _| id }
+    attachment_ids = params[:ordering].sort_by { |_, ordering| ordering.to_i }.map { |id, _| id }
     @attachable.reorder_attachments(attachment_ids)
 
     redirect_to attachable_attachments_path(@attachable), notice: 'Attachments re-ordered'

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -55,6 +55,18 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  test "PUT :order sorts attachment orderings as numbers" do
+    a, b, c = 3.times.map { |n| create(:file_attachment, attachable: @edition, ordering: n) }
+
+    Consultation.any_instance.expects(:reorder_attachments).with([a.id.to_s, b.id.to_s, c.id.to_s]).once
+
+    put :order, edition_id: @edition, ordering: { a.id.to_s => '9',
+                                                  b.id.to_s => '10',
+                                                  c.id.to_s => '11' }
+
+    assert_response :redirect
+  end
+
   view_test "GET :new renders the attachment form" do
     get :new, edition_id: @edition
 


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/61889412
