### PR TITLE
Handle nil strings when checking govspeak links.

### DIFF
--- a/lib/data_hygiene/govspeak_link_validator.rb
+++ b/lib/data_hygiene/govspeak_link_validator.rb
@@ -46,6 +46,8 @@ module DataHygiene
       start_at = 0
       matches = []
 
+      return matches if @string.nil?
+
       while (match = @string.match(regex, start_at))
         error = yield(match)
         matches << error if error

--- a/test/unit/data_hygiene/govspeak_link_validator_test.rb
+++ b/test/unit/data_hygiene/govspeak_link_validator_test.rb
@@ -2,6 +2,11 @@ require "fast_test_helper"
 
 class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
 
+  test "should be valid if the input is nil" do
+    validator = DataHygiene::GovspeakLinkValidator.new(nil)
+    assert_equal [], validator.errors
+  end
+
   test "should be valid if it contains a correct absolute URL" do
     validator = DataHygiene::GovspeakLinkValidator.new("
       [example text](http://www.example.com/example)


### PR DESCRIPTION
In the rare (but extant) case where the body of an edition is nil, the govspeak link checker should not explode.
