### PR TITLE
Add survey bar to 3 world location pages

### DIFF
--- a/app/assets/javascripts/application/custom-user-satisfaction-survey.js
+++ b/app/assets/javascripts/application/custom-user-satisfaction-survey.js
@@ -1,0 +1,24 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  /*
+   * Show a custom user satisfaction survey with a custom URL.
+   *
+   * This is a separate module because the survey is in static as a singleton,
+   * so whitehall has no control over its initialisation.
+   */
+  function CustomUserSatisfactionSurvey(options) {
+    // Loading GOVUK.userSatisfaction is deferred
+    $(function() {
+      if (!GOVUK.userSatisfaction) {
+        return;
+      }
+
+      GOVUK.userSatisfaction.setSurveyUrl(options.surveyUrl);
+      GOVUK.userSatisfaction.showSurveyBar();
+    });
+  }
+
+  GOVUK.CustomUserSatisfactionSurvey = CustomUserSatisfactionSurvey;
+})();

--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -4,4 +4,25 @@ module WorldLocationHelper
     locations.sort_by(&:name_without_prefix).group_by {|location| location.name_without_prefix.first.upcase }.sort
   end
 
+  def world_location_survey_url(location)
+    case location.slug
+    when "usa"
+      "https://www.surveymonkey.com/s/873FC35"
+    when "pakistan"
+      case Locale.current.code
+      when :en
+        "https://www.surveymonkey.com/s/8VZC9G5"
+      when :ur
+        "https://www.surveymonkey.com/s/MVS53GS"
+      end
+    when "spain"
+      case Locale.current.code
+      when :en
+        "https://www.surveymonkey.com/s/ML7GNTZ"
+      when :es
+        "https://www.surveymonkey.com/s/87WF3CC"
+      end
+    end
+  end
+
 end

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -2,6 +2,10 @@
 <% page_class "world-locations-show" %>
 <% atom_discovery_link_tag world_location_url(@world_location, format: :atom), t("feeds.latest_activity") %>
 
+<% if world_location_survey_url(@world_location) %>
+  <% initialise_script('GOVUK.CustomUserSatisfactionSurvey', surveyUrl: world_location_survey_url(@world_location)) %>
+<% end %>
+
 <%= content_tag_for(:article, @world_location) do %>
   <header class="block headings-block">
     <div class="inner-block floated-children">

--- a/test/unit/helpers/world_location_helper_test.rb
+++ b/test/unit/helpers/world_location_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class WorldLocationHelperTest < ActionView::TestCase
+  test 'world_location_survey_url returns a URL for spain' do
+    location = build(:world_location, slug: 'spain')
+    assert world_location_survey_url(location).include? "surveymonkey.com"
+  end
+
+  test 'world_location_survey_url returns a URL for spain in spanish' do
+    with_locale :es do
+      location = build(:world_location, slug: 'spain')
+      assert world_location_survey_url(location).include? "surveymonkey.com"
+    end
+  end
+end


### PR DESCRIPTION
Survey bar will only display if no survey bar on the site has been
clicked, in line with the behaviour of other survey bars on gov.uk.

Requires alphagov/static@1db9617f6c3 to be deployed to production.

https://www.pivotaltracker.com/s/projects/367813/stories/60399770
