### PR TITLE
Use correct class for chosen in admin CSS

### DIFF
--- a/app/assets/stylesheets/admin/forms.scss
+++ b/app/assets/stylesheets/admin/forms.scss
@@ -1,4 +1,4 @@
-.chzn-container {
+.chosen-container {
   margin-bottom: 9px;
 }
 
@@ -49,7 +49,7 @@ form {
     input, textarea {
       direction: rtl;
     }
-    .chzn-container-multi input {
+    .chosen-container-multi input {
       direction: ltr;
     }
   }


### PR DESCRIPTION
The dropdowns all use .chosen-container but our CSS was still using .chzn-container from a previous version. Here's what it looks like before and after:

![chzn-margins](https://f.cloud.github.com/assets/74812/1674408/e389c236-5cf8-11e3-87e8-1f8072d26252.png)
