### PR TITLE
Improve govspeak link help.

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -39,8 +39,13 @@ Don't use a single # - this is H1 and is for the title only</pre>
 
 <h3><a data-toggle="collapse" data-target="#govspeak-links">Links</a></h3>
 <div class="collapse" id="govspeak-links">
-  <p>All documents created in the publisher - policies, publications, news, speeches, detailed guides etc - should be linked to using absolute paths from within the publisher:</p>
-  <pre>[link text](/government/admin/policies/3373)</pre>
+  <p>
+    All documents created in the publisher - policies, publications, news, speeches, detailed guides etc -
+    should be linked to using absolute admin paths or full public URLs:
+  </p>
+  <pre>
+[an admin path](/government/admin/policies/12345)
+[a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
 
   <p>All content created under an organisation tab - collection pages, topics, organisations, people, roles etc - should be linked to using the full, public URLs:</p>
   <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/61296902

Full public URLs should be permitted for linking to published documents.
