### PR TITLE
Fix closed consultation reindex rake task

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -22,7 +22,7 @@ class Consultation < Publicationesque
   accepts_nested_attributes_for :consultation_participation, reject_if: :all_blank_or_empty_hashes
 
   scope :closed, -> { where("closing_at < ?",  Time.zone.now) }
-  scope :closed_since, ->(earliest_closing_date) { closed.where('closing_at >= ?', earliest_closing_date.to_date) }
+  scope :closed_since, ->(time) { closed.where('closing_at >= ?', time) }
   scope :open, -> { where('closing_at >= ? AND opening_at <= ?', Time.zone.now, Time.zone.now) }
   scope :upcoming, -> { where('opening_at > ?', Time.zone.now) }
   scope :responded, -> { joins(:outcome) }

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -23,10 +23,10 @@ namespace :rummager do
       index.commit
     end
 
-    desc "reindex consultations which close today"
+    desc "reindex consultations which closed in the past day"
     task :closed_consultations => [:environment, :warn_about_no_op] do
       index = Whitehall::SearchIndex.for(:government)
-      index.add_batch(Consultation.published.closed_since(Date.today).map(&:search_index))
+      index.add_batch(Consultation.published.closed_since(25.hours.ago).map(&:search_index))
       index.commit
     end
   end


### PR DESCRIPTION
Stop forcing the argument to a date in the closed_since scope and make
the rake task ask for all consultations which closed in the past 25
hours -- one hour longer than a day to allow for timing issues.

When closing_on was converted to a datetime and renamed to closing_at
the closed_since scope started behaving with a subtle difference.
When you give MySQL a date to use in a query against a datetime it
treats the date as being at 00:00:00. If you compare using
`closing_at >= '2013-12-06'` then if closing_at is a datetime on that
day it will not be matched, but if closing_at is a date of that day then
it will match.

Fixes https://www.pivotaltracker.com/story/show/61978984
