### PR TITLE
Make sub organisations output in alphabetical order

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -41,7 +41,7 @@ module Organisation::OrganisationTypeConcern
 
   def active_child_organisations_excluding_sub_organisations
     @active_child_organisations_excluding_sub_organisations ||=
-      child_organisations.excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'")
+      child_organisations.excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'").ordered_by_name_ignoring_prefix
   end
 
   def active_child_organisations_excluding_sub_organisations_grouped_by_type

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -75,15 +75,15 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     refute Organisation.listable.include?(closed_org)
   end
 
-  test "active_child_organisations_excluding_sub_organisations should live up to it's name" do
+  test "active_child_organisations_excluding_sub_organisations should live up to it's name and in alphabetical order" do
     parent_org_1 = create(:organisation)
     parent_org_2 = create(:organisation)
-    child_org_1 = create(:organisation, parent_organisations: [parent_org_1])
+    child_org_1 = create(:organisation, parent_organisations: [parent_org_1], name: "b second")
     child_org_2 = create(:sub_organisation, parent_organisations: [parent_org_1])
-    child_org_3 = create(:organisation, parent_organisations: [parent_org_1])
+    child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
     child_org_4 = create(:organisation, parent_organisations: [parent_org_1], govuk_status: 'closed')
 
-    assert_equal [child_org_1, child_org_3], parent_org_1.active_child_organisations_excluding_sub_organisations
+    assert_equal [child_org_3, child_org_1], parent_org_1.active_child_organisations_excluding_sub_organisations
   end
 
   test "active_child_organisations_excluding_sub_organisations_grouped_by_type should return a 2D array with each 1st level member being a OrganisationType and a collection of organisations" do


### PR DESCRIPTION
Sub organisations on organisations index were not alphabetically sorted, which was confusing.

https://www.pivotaltracker.com/story/show/60418666
