### PR TITLE
Written articles should state their key as header

### DIFF
--- a/app/models/speech_type.rb
+++ b/app/models/speech_type.rb
@@ -1,7 +1,7 @@
 class SpeechType
   include ActiveRecordLikeInterface
 
-  attr_accessor :id, :singular_name, :plural_name, :explanation, :key, :owner_key_group, :published_externally_key, :location_relevant, :prevalence
+  attr_accessor :id, :singular_name, :plural_name, :explanation, :key, :owner_key_group, :published_externally_key, :location_relevant, :prevalence, :use_key_as_display_key
 
   def self.create(attributes)
     super({
@@ -58,7 +58,7 @@ class SpeechType
   end
 
   def display_type_key
-    statement_to_parliament? ? key : genus_key
+    use_key_as_display_key ? key : genus_key
   end
 
   Transcript = create(
@@ -81,18 +81,18 @@ class SpeechType
 
   WrittenStatement = create(
     id: 4, key: "written_statement", singular_name: "Written statement to Parliament",
-    plural_name: "Written statements to Parliament"
+    plural_name: "Written statements to Parliament", use_key_as_display_key: true
   )
 
   OralStatement = create(
     id: 5, key: "oral_statement", singular_name: "Oral statement to Parliament",
-    plural_name: "Oral statements to Parliament"
+    plural_name: "Oral statements to Parliament", use_key_as_display_key: true
   )
 
   AuthoredArticle = create(
     id: 6, key: "authored_article", singular_name: "Authored article",
     owner_key_group: "author_title", published_externally_key: "written_on", location_relevant: false,
-    plural_name: "Authored article"
+    plural_name: "Authored article", use_key_as_display_key: true
   )
 
   ImportedAwaitingType = create(

--- a/test/functional/speeches_controller_test.rb
+++ b/test/functional/speeches_controller_test.rb
@@ -92,6 +92,15 @@ class SpeechesControllerTest < ActionController::TestCase
     assert_select ".type", "Oral statement to Parliament"
   end
 
+  view_test "should display details about a written article" do
+    speech_type = SpeechType::AuthoredArticle
+    published_speech = create(:published_speech, speech_type: speech_type)
+
+    get :show, id: published_speech.document
+    refute_select ".explanation"
+    assert_select ".type", "Authored article"
+  end
+
   view_test "should omit location if not given" do
     published_speech = create(:published_speech, location: '')
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/61380028
