### PR TITLE
Fix New URLs for attachments in Mappings CSV

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -98,7 +98,7 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
     ###### ATTACHMENT SOURCES
 
     AttachmentSource.all.each do |attachment_source|
-      attachment_url = attachment_source.attachment ? host_name + attachment_source.attachment.url : ""
+      attachment_url = attachment_source.attachment ? 'https://' + host_name + attachment_source.attachment.url : ""
       status = (attachment_url.blank? ? '' : '301')
       target << [attachment_source.url, attachment_url, status, '', '', '', 'Closed'] if attachment_url.present?
     end

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -131,7 +131,7 @@ Old Url,New Url,Status,Slug,Admin Url,State
       attachment_source = create(:attachment_source)
       assert_extraction <<-EOT
 Old Url,New Url,Status,Slug,Admin Url,State
-#{attachment_source.url},www.preview.alphagov.co.uk#{attachment_source.attachment.url},301,"","","",Closed
+#{attachment_source.url},https://www.preview.alphagov.co.uk#{attachment_source.attachment.url},301,"","","",Closed
       EOT
     end
 


### PR DESCRIPTION
Without a protocol it isn't a URL (at least not one that URI.parse can understand).
