### PR TITLE
Make attachment mappings consistent with others

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -100,7 +100,7 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
     AttachmentSource.all.each do |attachment_source|
       attachment_url = attachment_source.attachment ? 'https://' + host_name + attachment_source.attachment.url : ""
       status = (attachment_url.blank? ? '' : '301')
-      target << [attachment_source.url, attachment_url, status, '', '', '', 'Closed'] if attachment_url.present?
+      target << [attachment_source.url, attachment_url, status, '', '', 'published'] if attachment_url.present?
     end
 
     Person.find_each do |person|

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -131,7 +131,7 @@ Old Url,New Url,Status,Slug,Admin Url,State
       attachment_source = create(:attachment_source)
       assert_extraction <<-EOT
 Old Url,New Url,Status,Slug,Admin Url,State
-#{attachment_source.url},https://www.preview.alphagov.co.uk#{attachment_source.attachment.url},301,"","","",Closed
+#{attachment_source.url},https://www.preview.alphagov.co.uk#{attachment_source.attachment.url},301,"","",published
       EOT
     end
 


### PR DESCRIPTION
This assumes that all attachments are published; I can't see any workflow or state associated with them.

Until now, the "Closed" value has been an extra column without a header. Looking at the history, it comes from when the mappings were "Closed" or "Open".
