### PR TITLE
An attachment's state depends on its visibility

### DIFF
--- a/lib/whitehall/exporters/document_mappings.rb
+++ b/lib/whitehall/exporters/document_mappings.rb
@@ -100,7 +100,11 @@ class Whitehall::Exporters::DocumentMappings < Struct.new(:platform)
     AttachmentSource.all.each do |attachment_source|
       attachment_url = attachment_source.attachment ? 'https://' + host_name + attachment_source.attachment.url : ""
       status = (attachment_url.blank? ? '' : '301')
-      target << [attachment_source.url, attachment_url, status, '', '', 'published'] if attachment_url.present?
+      if attachment_url.present?
+        visibility = AttachmentVisibility.new(attachment_source.attachment.attachment_data, nil)
+        state = visibility.visible? ? 'published' : 'draft'
+        target << [attachment_source.url, attachment_url, status, '', '', state]
+      end
     end
 
     Person.find_each do |person|

--- a/test/unit/whitehall/exporters/document_mappings_test.rb
+++ b/test/unit/whitehall/exporters/document_mappings_test.rb
@@ -142,6 +142,15 @@ Old Url,New Url,Status,Slug,Admin Url,State
       EOT
     end
 
+    test "attachment sources use their visibility to populate 'State'" do
+      edition = create(:publication, :draft)
+      attachment = create(:csv_attachment, attachable: edition)
+      attachment_source = create(:attachment_source, attachment: attachment)
+      assert_extraction_contains <<-EOT
+#{attachment_source.url},https://www.preview.alphagov.co.uk#{attachment.url},301,"","",draft
+      EOT
+    end
+
     private
 
     def news_article_url(article)


### PR DESCRIPTION
There was an invalid assumption that all attachments could be considered
'published', whereas they are only accessible if the thing to which they are
attached is accessible.
