### PR TITLE
Don't remove detailed guides from the router

### DIFF
--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -5,4 +5,3 @@ Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |event, edit
 Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |event, edition, options| Whitehall::GovUkDelivery::Notifier.new(edition).edition_published! }
 Whitehall.edition_services.subscribe("unpublish") { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |_, edition, _| ServiceListeners::RouterRegistrar.new(edition).register! }
-Whitehall.edition_services.subscribe("unpublish") { |_, edition, _| ServiceListeners::RouterRegistrar.new(edition).unregister! }


### PR DESCRIPTION
Detailed guides may have special redirection or other behaviour when unpublishing which means that they should continue to be served from Whitehall rather than being marked as deleted in the router.

This is the quick fix to further and deeper redirect/router integration.
