### PR TITLE
Remove Edition.in_ministerial_roles scope

### DIFF
--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -16,7 +16,7 @@ class MinisterialRolesController < PublicFacingController
 
   def show
     @ministerial_role = RolePresenter.new(MinisterialRole.find(params[:id]), view_context)
-    @policies = decorate_collection(Policy.published.in_reverse_chronological_order.in_ministerial_role(@ministerial_role), PolicyPresenter)
+    @policies = decorate_collection(@ministerial_role.policies.published.in_reverse_chronological_order, PolicyPresenter)
     set_slimmer_organisations_header(@ministerial_role.organisations)
     set_slimmer_page_owner_header(@ministerial_role.organisations.first)
   end

--- a/app/models/edition/ministers.rb
+++ b/app/models/edition/ministers.rb
@@ -17,10 +17,4 @@ module Edition::Ministers
   def can_be_associated_with_ministers?
     true
   end
-
-  module ClassMethods
-    def in_ministerial_role(role)
-      joins(:ministerial_roles).where('roles.id' => role.to_model)
-    end
-  end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -128,19 +128,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [published_in_second_organisation], Publication.in_organisation(organisation_2)
   end
 
-  test "should return a list of editions in a ministerial role" do
-    ministerial_role_1 = create(:ministerial_role)
-    ministerial_role_2 = create(:ministerial_role)
-    draft_policy = create(:draft_policy, ministerial_roles: [ministerial_role_1])
-    published_policy = create(:published_policy, ministerial_roles: [ministerial_role_1])
-    published_publication = create(:published_publication, ministerial_roles: [ministerial_role_1])
-    published_in_second_ministerial_role = create(:published_policy, ministerial_roles: [ministerial_role_2])
-
-    assert_equal [draft_policy, published_policy], Policy.in_ministerial_role(ministerial_role_1)
-    assert_equal [published_policy], Policy.published.in_ministerial_role(ministerial_role_1)
-    assert_equal [published_in_second_ministerial_role], Policy.in_ministerial_role(ministerial_role_2)
-  end
-
   test "return editions bi-directionally related to specific edition" do
     policy = create(:policy)
     publication_1 = create(:publication, related_editions: [policy])


### PR DESCRIPTION
The scope was only used in the ministerial roles controller where we
already had a MinisterialRole object which has an association for
policies.
