### PR TITLE
Clean up Role#current_person_name

### DIFF
--- a/app/helpers/ministerial_roles_helper.rb
+++ b/app/helpers/ministerial_roles_helper.rb
@@ -9,7 +9,7 @@ module MinisterialRolesHelper
 
   def array_of_links_to_ministers(ministers)
     ministers.map do |minister|
-      link_to minister.current_person_name(minister.name), minister
+      link_to minister.current_person_name, minister
     end
   end
 

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -55,4 +55,9 @@ class MinisterialRole < Role
     # is still marked as dirty during after_save callbacks.
     Whitehall.url_maker.ministerial_role_path(slug)
   end
+
+private
+  def default_person_name
+    name
+  end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -89,8 +89,8 @@ class Role < ActiveRecord::Base
     role_appointments.where(["ended_at is not null AND ended_at < ?", Time.zone.now])
   end
 
-  def current_person_name(default = "No one is assigned to this role")
-    current_person ? current_person.name : default
+  def current_person_name
+    current_person.try(:name) || default_person_name
   end
 
   delegate :surname, to: :current_person, prefix: true, allow_nil: true
@@ -143,5 +143,9 @@ class Role < ActiveRecord::Base
 
   def prevent_destruction_unless_destroyable
     return false unless destroyable?
+  end
+
+  def default_person_name
+    "No one is assigned to this role"
   end
 end

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -202,7 +202,7 @@ class DocumentHelperTest < ActionView::TestCase
     assert_select_within_html metadata[:data][0],
                               "a[href=?]",
                               ministerial_role_path(role),
-                              text: role.current_person_name(role.name)
+                              text: role.name
   end
 
   test "document_metadata generates speech delivery metadata" do

--- a/test/unit/ministerial_role_test.rb
+++ b/test/unit/ministerial_role_test.rb
@@ -162,4 +162,9 @@ class MinisterialRoleTest < ActiveSupport::TestCase
                   'format' => 'minister',
                   'description' => ''}, results[3])
   end
+
+  test "#current_person_name should return the role name when vacant" do
+    role = create(:ministerial_role, name: "Minister of Importance", people: [])
+    assert_equal "Minister of Importance", role.current_person_name
+  end
 end


### PR DESCRIPTION
Rather than allowing a default value to be passed in, define a default
as a method and override it in MinisterialRole.
