### PR TITLE
Add panopticon task group

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -1,0 +1,38 @@
+require 'ostruct'
+
+namespace :panopticon do
+  require 'gds_api/panopticon'
+
+  desc "Register application metadata with Panopticon"
+  task :register do
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend')
+    logger.info "Registering application with Panopticon..."
+
+    record = OpenStruct.new(
+      slug: 'government',
+      title: "Departments and Policy",
+      description: "All government department and organisation corporate publishing",
+      prefixes: ['/government'],
+      state: 'live',
+      indexable_content: "Departments and Policy")
+    registerer.register(record)
+  end
+
+  desc "Register detailed guides with Panopticon"
+  task :register_guidance => :environment do
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+    logger.info "Registering detailed guides with Panopticon..."
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: 'detailed_guide')
+    DetailedGuide.published.includes(:document).each do |guide|
+      record = OpenStruct.new(
+        slug: guide.slug,
+        title: guide.title,
+        description: guide.summary,
+        state: 'live')
+      logger.info "Registering /#{guide.slug} with Panopticon..."
+      registerer.register(record)
+    end
+  end
+end


### PR DESCRIPTION
Allow registration of the whitehall-frontend application and the detailed guides therein in Panopticon via a manual Rake task.

This is the first pull request of several to integrate detailed guides properly into Panopticon, and is the minimum integration to help get the new specialist navigation work up and running.
