### PR TITLE
Sub org layout fixes

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -257,7 +257,7 @@
     h1 {
       padding: 0;
 
-      @include media(tablet){
+      @include media(tablet) {
         float: left;
         width: 66.66%;
       }
@@ -277,7 +277,10 @@
             clear: both;
             font-weight: bold;
             margin-top: $gutter-half;
-            width: auto;
+            @include media(tablet) {
+              float: left;
+              width: $two-thirds;
+            }
           }
 
           ul {
@@ -290,9 +293,20 @@
           .organisations-icon-list {
             margin-top: 0;
           }
+          @include media(tablet) {
+            float: left;
+            width: $two-thirds;            
+          }
         }
       }
     }
+
+    .govspeak {
+      @include media(tablet) {
+        width: $two-thirds;
+      }
+    }
+
     .organisation-news {
       @extend %contain-floats;
       article {


### PR DESCRIPTION
• limit govspeak to two thirds width - better line length
• fix header layout

https://www.pivotaltracker.com/story/show/62833060
