### PR TITLE
Fix rake task name to reindex closed consultations

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,5 +22,5 @@ every :day, at: ['3am', '12:45pm'], roles: [:admin] do
 end
 
 every :day, at: ['1:30am'], roles: [:backend] do
-  rake "rummager:index:closed_consultation"
+  rake "rummager:index:closed_consultations"
 end


### PR DESCRIPTION
There was a typo in the name of the rake task being run to reindex closed consultations. This corrects it.

Fixes https://www.pivotaltracker.com/story/show/63460432
