### PR TITLE
Fix headers skipping from h1 -> h3 in latest sections on pages

### DIFF
--- a/app/views/shared/_recently_updated_documents.html.erb
+++ b/app/views/shared/_recently_updated_documents.html.erb
@@ -1,7 +1,7 @@
 <ol class="document-list">
   <% recently_updated.each do |document| %>
     <%= content_tag_for :li, document, :recent, class: 'document-row' do %>
-      <h3><%= link_to document.title, public_document_path(document) %></h3>
+      <h2><%= link_to document.title, public_document_path(document) %></h2>
       <ul class="attributes">
         <li class="published-date">
           <%= published_or_updated(document) %>


### PR DESCRIPTION
• update h3's to h2's so they follow h1's correctly

https://www.pivotaltracker.com/story/show/63447620
