### PR TITLE
Upgrade delayed_job gem to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rake', '10.1.0'
 gem 'rails', '3.2.16'
 gem 'statsd-ruby', '~> 1.2.1', require: 'statsd'
 gem 'mysql2'
+gem 'delayed_job', '~> 4.0.0'
 gem 'delayed_job_active_record'
 gem 'jquery-rails', '1.0.19'
 gem 'transitions', require: ['transitions', 'active_record/transitions']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,11 +112,11 @@ GEM
       debugger-ruby_core_source (~> 1.2.3)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.2.4)
-    delayed_job (3.0.5)
-      activesupport (~> 3.0)
-    delayed_job_active_record (0.4.4)
-      activerecord (>= 2.1.0, < 4)
-      delayed_job (~> 3.0)
+    delayed_job (4.0.0)
+      activesupport (>= 3.0, < 4.1)
+    delayed_job_active_record (4.0.0)
+      activerecord (>= 3.0, < 4.1)
+      delayed_job (>= 3.0, < 4.1)
     diff-lcs (1.2.4)
     equivalent-xml (0.3.0)
       nokogiri (>= 1.4.3)
@@ -369,6 +369,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.3.1)
   database_cleaner (= 1.0.1)
   debugger
+  delayed_job (~> 4.0.0)
   delayed_job_active_record
   equivalent-xml (= 0.3.0)
   exception_notification


### PR DESCRIPTION
Required for Rails 4 compatibility
