### PR TITLE
Update test_track to rails 4 compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,12 +82,12 @@ group :test do
   gem 'factory_girl'
   gem 'hash_syntax'
   gem 'mocha', '0.14.0', require: false
-  gem 'test_track', github: 'episko/test_track'
   gem 'timecop'
   gem 'webmock', require: false
   gem 'ci_reporter'
   gem 'database_cleaner', '1.0.1'
   gem 'equivalent-xml', '0.3.0', require: false
+  gem 'test_track', '~> 0.1.0', github: 'alphagov/test_track'
 end
 
 group :test_coverage do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,18 +7,18 @@ GIT
       nokogiri (>= 1.4.4)
 
 GIT
+  remote: git://github.com/alphagov/test_track.git
+  revision: 1f997082e2f1be94274d294c2f8d34ab0b21bb7f
+  specs:
+    test_track (0.1.0)
+      rails (>= 3.1.0)
+
+GIT
   remote: git://github.com/brynary/rack-test.git
   revision: 8cdb86e1d710194ce45f439915707db7fb2b27e5
   specs:
     rack-test (0.6.2)
       rack (>= 1.0)
-
-GIT
-  remote: git://github.com/episko/test_track.git
-  revision: d223c352851e54c9bb6b6dc80a6961945606b4cd
-  specs:
-    test_track (0.0.4)
-      rails (>= 3.1.0)
 
 GIT
   remote: git://github.com/globalize/globalize.git
@@ -420,7 +420,7 @@ DEPENDENCIES
   slop (= 3.4.5)
   statsd-ruby (~> 1.2.1)
   test-queue
-  test_track!
+  test_track (~> 0.1.0)!
   thin (= 1.5.1)
   timecop
   transitions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -367,10 +367,10 @@ Whitehall::Application.routes.draw do
   # Detailed guidance lives at the root
   get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide'
 
-  mount TestTrack::Engine => "test" if Rails.env.test?
-
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "attachments#preview", as: :preview_attachment
   get '/government/uploads/*path.:extension' => "public_uploads#show"
+
+  mount TestTrack::Engine => "test" if Rails.env.test?
 end

--- a/lib/tasks/test_javascript.rake
+++ b/lib/tasks/test_javascript.rake
@@ -26,7 +26,7 @@ namespace :test do
     Rake::Task["shared_mustache:compile"].invoke
 
     puts "Starting the test server on port #{test_port}"
-    `cd #{Rails.root} && script/rails server -p #{test_port} --daemon --environment=test --pid=#{pid_file}`
+    `cd #{Rails.root} && rails server -p #{test_port} --daemon --environment=test --pid=#{pid_file}`
 
     puts "Waiting for the server to come up"
     not_connected = true

--- a/script/javascript-test-server
+++ b/script/javascript-test-server
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 echo "Starting test server on http://localhost:3100/test/qunit"
-script/rails server -p 3100 --environment=test --pid=tmp/pids/javascript_tests.pid
+rails server -p 3100 --environment=test --pid=tmp/pids/javascript_tests.pid
 


### PR DESCRIPTION
Uses alphagov version.  I'll submit a PR back to quickleft's version once I've seen it happily working in Rails 4.
