### PR TITLE
Add user org name to admin dashboard when org acronym not present

### DIFF
--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -1,0 +1,6 @@
+module Admin::DashboardHelper
+
+  def organisation_acronym_or_name(organisation)
+    organisation.acronym.presence || organisation.name
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -35,12 +35,9 @@
   <% if current_user.organisation %>
     <div class="span6 force-published-documents">
       <h2>
-        <% if current_user.organisation.acronym.present? %>
-          <%= current_user.organisation.acronym %>'s
-        <% else %>
-          <%= current_user.organisation.name %>'s
-        <% end %>
-        force-published documents</h2>
+        <%= organisation_acronym_or_name(current_user.organisation) %>'s
+        force-published documents
+      </h2>
       <%= render partial: 'document_table', locals: { documents: @force_published_documents, title: 'force published documents' } %>
       <p><%= link_to "See all", admin_editions_path(state: :force_published, organisation: current_user.organisation) %></p>
     </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/63455432
