### PR TITLE
Create new detailed guide categories for oil & gas

### DIFF
--- a/db/data_migration/20140110142811_add_oil_and_gas_detailed_guide_categories.rb
+++ b/db/data_migration/20140110142811_add_oil_and_gas_detailed_guide_categories.rb
@@ -1,0 +1,25 @@
+def oil_and_gas_topics
+  [
+    { slug: "carbon-capture-and-storage", title: "Carbon capture and storage" },
+    { slug: "environment-reporting-and-regulation", title: "Environment reporting and regulation" },
+    { slug: "exploration-and-development", title: "Exploration and development" },
+    { slug: "fields-and-wells", title: "Fields and wells" },
+    { slug: "finance-and-taxation", title: "Finance and taxation" },
+    { slug: "infrastructure-and-decommissioning", title: "Infrastructure and decommissioning" },
+    { slug: "licensing", title: "Licensing" },
+    { slug: "onshore-oil-and-gas", title: "Onshore oil and gas" }
+  ]
+end
+
+def slug_for_topic(topic)
+  "industry-sector-oil-and-gas-#{topic[:slug]}"
+end
+
+oil_and_gas_topics.each do |topic|
+  MainstreamCategory.create!(
+    slug: slug_for_topic(topic),
+    title: "Oil and gas: #{topic[:title]}",
+    parent_title: "Industry sector: Oil and gas",
+    parent_tag: "oil-and-gas"
+  )
+end


### PR DESCRIPTION
This migration creates eight new detailed guide categories for the Oil and Gas sector. A future change will use these categories to push the correct `industry_sector` tags into Panopticon for each detailed guide.

I've chosen to prefix each topic with quite a long slug for two reasons: to make it clear that these are different to regular topics; and, to avoid conflicts with the existing "Oil and gas licensing" category with the slug "oil-and-gas-licensing". 
