### PR TITLE
Exclude sectors from detailed guide category lists

### DIFF
--- a/app/controllers/detailed_guides_controller.rb
+++ b/app/controllers/detailed_guides_controller.rb
@@ -7,7 +7,7 @@ class DetailedGuidesController < DocumentsController
   before_filter :set_analytics_format, only: [:show]
 
   def show
-    @categories = @document.mainstream_categories
+    @categories = non_sector_mainstream_categories
     @topics = @document.topics
   end
 
@@ -37,5 +37,11 @@ private
     # There's no index for detailed guides, so we don't need to worry
     # about this complaing about a lack of id
     detailed_guide_url(redir_params.except(:controller, :action))
+  end
+
+  def non_sector_mainstream_categories
+    @document.mainstream_categories.reject {|category|
+      category.slug =~ /\Aindustry-sector/
+    }
   end
 end

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -122,6 +122,20 @@ That's all
     assert_equal "detailed_guidance", response.headers["X-Slimmer-Format"]
   end
 
+  test "industry sector categories are not included in category list" do
+    sector_category = create(:mainstream_category, slug: "industry-sector-education-teaching")
+    other_category = create(:mainstream_category)
+
+    guide = create(:published_detailed_guide, primary_mainstream_category: sector_category)
+    guide.other_mainstream_categories << other_category
+    guide.save!
+
+    get :show, id: guide.document
+
+    assert_equal 1, assigns(:categories).size
+    assert_equal other_category.slug, assigns(:categories).first.slug
+  end
+
   view_test "guides have their mainstream categories added as classes" do
     category = create(:mainstream_category)
     guide = create(:published_detailed_guide, primary_mainstream_category: category)


### PR DESCRIPTION
Right now, we don't want to link directly to the sector pages from a detailed guide.

This change filters any categories with a slug starting with 'industry-sector' from being displayed in the category list.
