### PR TITLE
Set cache-control private for previews

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -48,7 +48,10 @@ class DocumentsController < PublicFacingController
   def find_document_or_edition_for_preview
     return unless current_user_can_preview?
     document = document_class.with_translations(I18n.locale).find(params[:preview])
-    document if can_preview?(document)
+    if can_preview?(document)
+      response.headers['Cache-Control'] = 'no-cache, max-age=0, private'
+      document
+    end
   end
 
   def find_document_or_edition_for_public

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -289,6 +289,7 @@ module DocumentControllerTestHelpers
         login_as create(:departmental_editor)
         get :show, id: document.id, preview: draft_edition.id
         assert_response 200
+        assert_equal 'no-cache, max-age=0, private', response.headers['Cache-Control']
       end
 
       test "#{document_type} preview should be hidden from public" do
@@ -310,6 +311,7 @@ module DocumentControllerTestHelpers
         get :show, id: draft.document.id, preview: draft.id
 
         assert_response 200
+        assert_equal 'no-cache, max-age=0, private', response.headers['Cache-Control']
       end
 
       test "access limited #{document_type} preview should be hidden for unauthorised users" do


### PR DESCRIPTION
We already set appropriate cache-control headers for [attachments](https://github.com/alphagov/whitehall/blob/master/app/controllers/attachments_controller.rb#L53) and [HTML attachments](https://github.com/alphagov/whitehall/blob/master/app/controllers/html_attachments_controller.rb#L15).

Fixes https://www.pivotaltracker.com/story/show/63957740
