### PR TITLE
Catch errors raised by edition service observers

### DIFF
--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -41,6 +41,8 @@ private
 
   def notify!
     notifier && notifier.publish(verb, edition, options)
+  rescue
+    # Do nothing
   end
 
   def prepare_edition

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -107,6 +107,17 @@ class EditionPublisherTest < ActiveSupport::TestCase
     refute publisher.perform!
   end
 
+  test '#perform! rescues errors from notified observers' do
+    edition = create(:submitted_edition)
+    notifier = mock
+    notifier.expects(:publish).raises('Error')
+    publisher = EditionPublisher.new(edition, {notifier: notifier})
+
+    assert_nothing_raised do
+      publisher.perform!
+    end
+  end
+
   test 'a submitted edition with a scheduled publication time cannot be published' do
     edition = build(:submitted_edition, scheduled_publication: 1.day.from_now)
     publisher = EditionPublisher.new(edition)


### PR DESCRIPTION
This is a quick fix to address in particular the issue that scheduled
publishing could fail if any of the observers fail. We had an problem
where the email service failed and the AuthorNotifier failed, causing
scheduled publishing to fail.

This needs to be revisited to provide a proper fix, in particular:
- the main service object should run in a transaction
- the failure of one observer should not prevent other observers from
  firing

See https://www.pivotaltracker.com/story/show/64036694
