### PR TITLE
Exclude fake source URLs from mappings CSV

### DIFF
--- a/lib/whitehall/exporters/mappings.rb
+++ b/lib/whitehall/exporters/mappings.rb
@@ -8,6 +8,7 @@ class Whitehall::Exporters::Mappings < Struct.new(:platform)
       if edition && STATES_TO_INCLUDE.include?(edition.state)
         document.document_sources.each do |document_source|
           begin
+            next if fake_source_url?(document_source)
             target << document_row(edition, document, document_source)
           rescue StandardError => e
             Rails.logger.error("#{self.class.name}: when exporting #{edition} - #{e} - #{e.backtrace.join("\n")}")
@@ -18,6 +19,7 @@ class Whitehall::Exporters::Mappings < Struct.new(:platform)
 
     AttachmentSource.find_each do |attachment_source|
       begin
+        next if fake_source_url?(attachment_source)
         if attachment_source.attachment
           path = attachment_source.attachment.url
           attachment_url = 'https://' + public_host + path
@@ -49,6 +51,10 @@ private
     end
     edition_type_for_route = edition.class.name.underscore
     url_maker.polymorphic_url(edition_type_for_route, doc_url_args)
+  end
+
+  def fake_source_url?(source)
+    source.url =~ /(fabricatedurl|placeholderunique)/
   end
 
   def url_maker

--- a/test/unit/whitehall/exporters/mappings_test.rb
+++ b/test/unit/whitehall/exporters/mappings_test.rb
@@ -131,11 +131,37 @@ module Whitehall
       EOT
     end
 
+    test "excludes document sources with fabricated or placeholder URLs" do
+      publication = create(:published_publication)
+      create(:document_source, document: publication.document, url: 'http://oldurl1/fabricatedurl/foo')
+      create(:document_source, document: publication.document, url: 'http://oldurl2/placeholderunique/1')
+      create(:document_source, document: publication.document, url: 'http://oldurl3')
+
+      assert_csv_does_not_contain 'oldurl1'
+      assert_csv_does_not_contain 'oldurl2'
+      assert_csv_contains <<-EOT.strip_heredoc
+        http://oldurl3,https://www.preview.alphagov.co.uk/government/publications/#{publication.slug},https://whitehall-admin.test.alphagov.co.uk/government/admin/publications/#{publication.id},published
+      EOT
+    end
+
     test "attachment sources are included, without an admin URL" do
       attachment = create(:csv_attachment)
       attachment_source = create(:attachment_source, url: 'http://oldurl', attachment: attachment)
       assert_csv_contains <<-EOT.strip_heredoc
         http://oldurl,https://www.preview.alphagov.co.uk#{attachment.url},"",published
+      EOT
+    end
+
+    test "excludes attachment sources with fabricated or placeholder URLs" do
+      attachment = create(:csv_attachment)
+      create(:attachment_source, url: 'http://oldurl1/fabricatedurl/foo', attachment: attachment)
+      create(:attachment_source, url: 'http://oldurl2/placeholderunique/1', attachment: attachment)
+      create(:attachment_source, url: 'http://oldurl3', attachment: attachment)
+
+      assert_csv_does_not_contain 'oldurl1'
+      assert_csv_does_not_contain 'oldurl2'
+      assert_csv_contains <<-EOT.strip_heredoc
+        http://oldurl3,https://www.preview.alphagov.co.uk#{attachment.url},"",published
       EOT
     end
 


### PR DESCRIPTION
Some document sources have fake old URLs which were added on import.
These URLs have paths containing 'fabricatedurl' or 'placeholderunique'.
Because these URLs never existed, they should not be included as old URLs
in the mappings CSV consumed by Transition.

It looks as though the existing URLs of this type are on document
sources, but check attachment source URLs as well for safety.
