### PR TITLE
Fix consultation published dates

### DIFF
--- a/app/models/document_history.rb
+++ b/app/models/document_history.rb
@@ -56,7 +56,7 @@ class DocumentHistory
   end
 
   def first_published_at
-    first_public_edition.first_published_at
+    first_public_edition.first_public_at
   end
 
   def first_public_edition_note

--- a/test/unit/document_history_test.rb
+++ b/test/unit/document_history_test.rb
@@ -22,6 +22,16 @@ class DocumentHistoryTest < ActiveSupport::TestCase
     assert_history_equal [[4.days.ago, edition.change_note]], history
   end
 
+  test "#changes on a consultation derives the timestamp from the consultation opening time" do
+    opening_at = 1.day.from_now
+    edition  = create(:draft_consultation, opening_at: opening_at, closing_at: 2.days.from_now)
+    EditionForcePublisher.new(edition).perform!
+    edition.reload
+    history  = DocumentHistory.new(edition.document)
+
+    assert_equal opening_at, history.first.public_timestamp
+  end
+
   test "#changes returns change history for all historic editions, excluding those with minor changes" do
     original_edition = create(:superseded_edition, first_published_at: 3.days.ago, change_note: nil)
     document         = original_edition.document


### PR DESCRIPTION
A previous refactoring[1] mistakenly broke the behaviour of the document
history for consultations.

Consultations display the opening_at date rather than their first
publication date. To do this they rely on the Edition#first_public_at
method to provide an alternative behviour. Unfortunately the refactoring
broke this behaviour.

Added a unit test and fixed the behaviour.

[1]
https://github.com/alphagov/whitehall/commit/4981e263ac05b22af5efa9eb9eaf1ad5fa46346e
