### PR TITLE
Fix corporate information page links on executive offices

### DIFF
--- a/app/views/organisations/show-executive-office.html.erb
+++ b/app/views/organisations/show-executive-office.html.erb
@@ -66,7 +66,7 @@
         <section class="corporate-information">
           <ul class="dash-list">
             <% @organisation.corporate_information_pages.each do |page| %>
-              <li><%= link_to page.title, organisation_corporate_information_page_path(@organisation, page) %></li>
+              <li><%= link_to page.title, organisation_corporate_information_page_path(@organisation, page.slug) %></li>
             <% end %>
           </ul>
         </section>

--- a/test/support/organisation_controller_test_helpers.rb
+++ b/test/support/organisation_controller_test_helpers.rb
@@ -159,6 +159,15 @@ module OrganisationControllerTestHelpers
 
         assert_select ".govdelivery[href='#{email_signups_path(organisation: organisation.slug)}']"
       end
+
+      view_test "#{org_type}:show has link to corporate information pages" do
+        organisation = create(org_type)
+        corporate_information_page = create(:corporate_information_page, organisation: organisation)
+
+        get :show, id: organisation
+
+        assert_select ".corporate-information a[href='#{organisation_corporate_information_page_path(organisation, corporate_information_page.slug)}']"
+      end
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/63976448
