### PR TITLE
Permit id in top tasks attributes for orgs

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -97,7 +97,7 @@ class Admin::OrganisationsController < Admin::BaseController
       organisation_mainstream_categories_attributes: [
         :mainstream_category_id, :ordering, :id, :_destroy
       ],
-      top_tasks_attributes: [:title, :url, :_destroy]
+      top_tasks_attributes: [:title, :url, :_destroy, :id]
     )
   end
 

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -337,4 +337,19 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert organisation.public_minutes?
     refute organisation.regulatory_function?
   end
+
+  test 'PUT on :update handles existing top task attributes' do
+    organisation = create(:organisation)
+    top_task = create(:top_task, linkable: organisation)
+
+    put :update, id: organisation, organisation: { top_tasks_attributes: { '0' => {
+      id: top_task.id,
+      title: 'New title',
+      url: top_task.url,
+      _destroy: 'false'
+    } } }
+
+    assert_response :redirect
+    assert_equal 'New title', top_task.reload.title
+  end
 end


### PR DESCRIPTION
Follow up fix for strong parameters work.
