### PR TITLE
Make Mappings export (more) atomic

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,4 +1,5 @@
 require "csv"
+require "fileutils"
 
 namespace :export do
 
@@ -22,9 +23,13 @@ namespace :export do
 
     exporter = Whitehall::Exporters::Mappings.new(ENV['FACTER_govuk_platform'])
 
-    CSV.open(Rails.root.join('public/government/mappings.csv'), 'wb') do |csv_out|
+    filename = 'public/government/mappings.csv'
+    temporary_filename = filename + '.new'
+    CSV.open(Rails.root.join(temporary_filename), 'wb') do |csv_out|
       exporter.export(csv_out)
     end
+
+    FileUtils.mv(temporary_filename, filename)
   end
 
   desc "Export Redirector compatible document mappings"


### PR DESCRIPTION
At the moment, if you happen to download the file during the 42 minute window in which it is being generated, you will get a partial file.

With this change, whilst the same user might get an older file (~12 hours), they will at least get a complete one.
