### PR TITLE
Allow archived attachments to be viewed

### DIFF
--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -100,7 +100,7 @@ class AttachmentVisibility
     if user
       Edition.accessible_to(user).where(id: edition_ids)
     else
-      Edition.published.where(id: edition_ids)
+      Edition.publicly_visible.where(id: edition_ids)
     end
   end
 
@@ -108,7 +108,7 @@ class AttachmentVisibility
     if user
       Edition.accessible_to(user).where(id: consultation_ids)
     else
-      Edition.published.where(id: consultation_ids)
+      Edition.publicly_visible.where(id: consultation_ids)
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -62,6 +62,7 @@ class Edition < ActiveRecord::Base
   scope :non_statistical_publications,  -> { where("publication_type_id NOT IN (?)", PublicationType.statistical.map(&:id)) }
   scope :corporate_publications,        -> { where(publication_type_id: PublicationType::CorporateReport.id) }
   scope :worldwide_priorities,          -> { where(type: "WorldwidePriority") }
+  scope :publicly_visible,              -> { where(state: ['published', 'archived']) }
 
   # @!group Callbacks
   before_save :set_public_timestamp

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -46,6 +46,14 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     assert_equal edition, attachment_visibility.visible_edition
   end
 
+  test '#visible_edition returns an archived edition that the attachment is assigned to' do
+    edition = create(:publication, :archived, :with_file_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+
+    assert_equal edition, attachment_visibility.visible_edition
+  end
+
   test '#visible_consultation_response a published response that the attachment is associated with' do
     response   = create(:consultation_with_outcome).outcome
     response.attachments << attachment = build(:file_attachment)


### PR DESCRIPTION
AttachmentVisibility was only allowing attachments for published
editions to be accessed for non-logged in users.

This commit adds a publicly_visible Edition scope which includes both
published and archived editions.

Fixes https://www.pivotaltracker.com/story/show/64750912
