### PR TITLE
Publish editions in a transaction

### DIFF
--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -10,8 +10,10 @@ class EditionService
 
   def perform!
     if can_perform?
-      prepare_edition
-      fire_transition!
+      ActiveRecord::Base.transaction do
+        prepare_edition
+        fire_transition!
+      end
       notify!
       true
     end


### PR DESCRIPTION
we want changes to the edition to be atomic. The changes which occur in
observers are not core to the atomic operation of publishing an edition.

Furthermore, failure of an observer should not cause failure of the
publishing operation (see f67c5bdce83a), and therfore should not be part
of the transaction.
