### PR TITLE
Permit logo file param on topical events.

### DIFF
--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -62,7 +62,7 @@ class Admin::ClassificationsController < Admin::BaseController
 
   def object_params
     params.require(model_name).permit(
-      :name, :description, :logo_alt_text, :logo_cache, :remove_logo,
+      :name, :description, :logo, :logo_alt_text, :logo_cache, :remove_logo,
       :start_date, :end_date,
       related_classification_ids: [],
       classification_memberships_attributes: [:id, :ordering],


### PR DESCRIPTION
Exceptions received this morning due to logo param not being permitted on topical events.
