### PR TITLE
Ensure all attachment records have a type set

### DIFF
--- a/db/data_migration/20140203155427_fix_attachment_type_data.rb
+++ b/db/data_migration/20140203155427_fix_attachment_type_data.rb
@@ -1,0 +1,2 @@
+
+Attachment.where(type: nil).update_all(type: 'FileAttachment')


### PR DESCRIPTION
Currently a number of attachments in the database have a blank STI "type" attribute. This is because we were previously creating attachments using a nested attributes-based UI, which doesn't allow
the type to be set. We no longer use nested attributes for managing attachments so we are free to fix this data now.

Once the data is fixed, we can update the `Attachment` and `FileAttachment` classes such that file-related code lives in `FileAttachment` and not in the base class.
