### PR TITLE
Heading wider for off-site organisations.

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -827,7 +827,7 @@
       @include media(desktop) {
         float: left;
         padding-top: 0;
-        width: $one-third;
+        width: $two-thirds;
       }
     }
 


### PR DESCRIPTION
Line breaks for organisation names can be set in the admin suite anyway.

https://www.pivotaltracker.com/story/show/64609692
