### PR TITLE
Handle HTTP errors when registering with Panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -32,7 +32,7 @@ namespace :panopticon do
       begin
         registerer.register(artefact)
       rescue GdsApi::HTTPErrorResponse => e
-        logger.warn "Failed to register /#{guide.slug} with #{e.code}: #{e.error_details}"
+        logger.error "Failed to register /#{guide.slug} with #{e.code}: #{e.error_details}"
       end
     end
   end


### PR DESCRIPTION
Because detailed guides live at `/`, we occasionally get slug clashes when registering with Panopticon. Prior to this change the script would just die, now we print a warning and full error and continue.

CC @JordanHatch @mattbostock 
