### PR TITLE
Rescue from Chronic parse failures

### DIFF
--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -105,6 +105,9 @@ module Whitehall::DocumentFilter
     def parse_date(date)
       date = Chronic.parse(date, endian_precedence: :little)
       date.to_date if date
+    rescue NoMethodError
+      #Rescue from a bug in Chronic which throws exceptions with certain specifc date strings (eg. 't')
+      nil
     end
   end
 end


### PR DESCRIPTION
Chronic.parse is supposed to return a date or nil.  With some date strings,
(eg. a single 't') it throws an exception instead which would be
better to catch.

Fixes: https://www.pivotaltracker.com/story/show/64168430
