### PR TITLE
Fix slug change data migrations

### DIFF
--- a/db/data_migration/20140205133122_rename_cesg_device_guidance_slug.rb
+++ b/db/data_migration/20140205133122_rename_cesg_device_guidance_slug.rb
@@ -1,3 +1,5 @@
+require 'gds_api/router'
+
 OLD_SLUG = 'end-user-devices-security-guidance--2'
 NEW_SLUG = 'end-user-devices-security-guidance'
 

--- a/db/data_migration/20140205134702_rename_world_org_slugs.rb
+++ b/db/data_migration/20140205134702_rename_world_org_slugs.rb
@@ -1,3 +1,5 @@
+require 'gds_api/router'
+
 router = GdsApi::Router.new(Plek.current.find('router-api'))
 
 # hanover -> hamburg


### PR DESCRIPTION
They need to explicitly include gds_api/router before they can make use of it.

The migrations won't have run successfully on either preview or production yet because of this, and will have rolled back cleanly and not been recorded as run. Because of this modifying the migration and running it again should be safe.
