### PR TITLE
Use correct specialist sector tag type

### DIFF
--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -20,7 +20,7 @@ private
   end
 
   def self.fetch_sectors
-    Whitehall.content_api.tags('specialist_sectors')
+    Whitehall.content_api.tags('specialist_sector')
   rescue
     raise DataUnavailable.new
   end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -12,7 +12,7 @@ module SpecialistSectorHelper
       { slug: 'oil-and-gas/offshore', title: 'Offshore', parent: parent_tag }
     ]
 
-    content_api_has_tags('specialist_sectors', sector_tags)
+    content_api_has_tags('specialist_sector', sector_tags)
   end
 
   def select_specialist_sectors_in_form

--- a/test/unit/specialist_sector_test.rb
+++ b/test/unit/specialist_sector_test.rb
@@ -25,7 +25,7 @@ class SpecialistSectorTest < ActiveSupport::TestCase
       { slug: 'tax/capital-gains-tax', title: 'Capital Gains Tax', parent: tax }
     ]
 
-    content_api_has_tags('specialist_sectors', sector_tags)
+    content_api_has_tags('specialist_sector', sector_tags)
 
     oil_and_gas = OpenStruct.new(
       slug: 'oil-and-gas',


### PR DESCRIPTION
The tag type for the content API tags call is `specialist_sector` not `specialist_sectors`.
