### PR TITLE
Remove unused accessors from search results

### DIFF
--- a/lib/whitehall/document_filter/result.rb
+++ b/lib/whitehall/document_filter/result.rb
@@ -2,8 +2,7 @@ module Whitehall::DocumentFilter
   class Result
     ACCESSORS = %w{title description indexable_content attachments
       format display_type link id search_format_types
-      relevant_to_local_government presentation_format
-      humanized_format}
+      relevant_to_local_government}
     ACCESSORS.each do |attribute_name|
       define_method attribute_name.to_sym do
         @doc[attribute_name.to_s]


### PR DESCRIPTION
The `presentation_format` and `humanized_format` fields aren't used in this app; as far as I'm aware, these were only ever used in the search code from the [frontend](https://github.com/alphagov/frontend) app (and formerly the [rummager](https://github.com/alphagov/rummager) app itself).
