### PR TITLE
Remove unnecessary cleverness from Speech model

### DIFF
--- a/features/importing-new-editions.feature
+++ b/features/importing-new-editions.feature
@@ -205,7 +205,6 @@ Feature: Importing new editions
     Then I can't make the imported speech into a draft edition yet
     When I set the deliverer of the speech to "Joe Bloggs" from the "Foreign Commonwealth Office"
     Then I can make the imported speech into a draft edition
-    And the speech's organisation is set to "Foreign Commonwealth Office"
 
   Scenario: Importing speeches with blank delivered on means it must be filled in later, along with the deliverer
     Given a person called "Joe Bloggs"

--- a/lib/whitehall/uploader/speech_row.rb
+++ b/lib/whitehall/uploader/speech_row.rb
@@ -52,7 +52,7 @@ module Whitehall::Uploader
         :location,
         :role_appointment,
         :speech_type,
-        :organisations,
+        :lead_organisations,
         :related_editions,
         :topics,
         :world_locations

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -89,9 +89,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
       first_org = create(:organisation, name: 'first-org', acronym: "FO")
       second_org = create(:organisation, name: 'second-org', acronym: "SO")
       news_article = create(:published_news_article, first_published_at: 4.days.ago, organisations: [first_org, second_org])
-      role = create(:ministerial_role, organisations: [second_org])
-      role_appointment = create(:ministerial_role_appointment, role: role)
-      speech = create(:published_speech, delivered_on: 5.days.ago, role_appointment: role_appointment)
+      speech = create(:published_speech, delivered_on: 5.days.ago, organisations: [second_org])
 
       get :index
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -317,10 +317,8 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should display 2 announcements with details and a link to announcements filter if there are many announcements" do
     organisation = create(:organisation)
-    role = create(:ministerial_role, organisations: [organisation])
-    role_appointment = create(:ministerial_role_appointment, role: role)
     announcement_1 = create(:published_news_article, organisations: [organisation], first_published_at: 1.days.ago)
-    announcement_2 = create(:published_speech, role_appointment: role_appointment, first_published_at: 2.days.ago.to_date, speech_type: SpeechType::WrittenStatement)
+    announcement_2 = create(:published_speech, organisations: [organisation], first_published_at: 2.days.ago.to_date, speech_type: SpeechType::WrittenStatement)
     announcement_3 = create(:published_news_article, organisations: [organisation], first_published_at: 3.days.ago)
 
     get :show, id: organisation

--- a/test/functional/speeches_controller_test.rb
+++ b/test/functional/speeches_controller_test.rb
@@ -110,9 +110,7 @@ class SpeechesControllerTest < ActionController::TestCase
 
   view_test "shoud set Google Analytics headers based on the organisation of the person who delivered the speech" do
     organisation = create(:organisation, acronym: "ABC")
-    ministerial_role = create(:ministerial_role, organisations: [organisation])
-    role_appointment = create(:role_appointment, role: ministerial_role)
-    speech = create(:published_speech, role_appointment: role_appointment)
+    speech = create(:published_speech, organisations: [organisation])
 
     get :show, id: speech.document
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -324,13 +324,11 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test '#published_announcements returns published news or speeches' do
     organisation = create(:organisation)
-    role = create(:ministerial_role, organisations: [organisation])
-    role_appointment = create(:ministerial_role_appointment, role: role)
-    create(:draft_speech, role_appointment: role_appointment, title: "One")
+    create(:draft_speech, organisations: [organisation], title: "One")
     create(:draft_news_article, organisations: [organisation], title: "Two")
     create(:published_consultation, organisations: [organisation], title: "Three")
     expected_documents = [
-      create(:published_speech, role_appointment: role_appointment, title: "Alpha"),
+      create(:published_speech, organisations: [organisation], title: "Alpha"),
       create(:published_news_article, organisations: [organisation], title: "Beta")
     ]
 


### PR DESCRIPTION
It is not currently possible to set a second organisation on a speech because of some cleverness in the model that automatically overrides organisations to that of the person who delivered the speech. This is
unnecessary cleverness - we should allow editors to set the organisation(s) explicitly as with all other editions.

This required a small change to the behaviour of the speech importer to set the lead organisation based on the import row (previously it was relying on the lead organisation being inferred from the role appointment set during speed tagging)

Verified with Neil Williams and Robin Carswell.

Tracker: https://www.pivotaltracker.com/story/show/66132548
