### PR TITLE
Use new slave DB config for export.rake

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -17,7 +17,7 @@ namespace :export do
     # Read off the MySQL slave - we want performance here and
     # non-contention as this job runs for up to 45 minutes.
     if ENV['FACTER_govuk_platform'] == 'production'
-      mysql_slave_config = ActiveRecord::Base.configurations['production'].merge('host' => 'slave.mysql')
+      mysql_slave_config = ActiveRecord::Base.configurations['production_slave']
       ActiveRecord::Base.establish_connection(mysql_slave_config)
     end
 
@@ -45,7 +45,7 @@ namespace :export do
     # Read off the MySQL slave - we want performance here and
     # non-contention as this job runs for up to 45 minutes.
     if ENV['FACTER_govuk_platform'] == 'production'
-      mysql_slave_config = ActiveRecord::Base.configurations['production'].merge('host' => 'slave.mysql')
+      mysql_slave_config = ActiveRecord::Base.configurations['production_slave']
       ActiveRecord::Base.establish_connection(mysql_slave_config)
     end
 


### PR DESCRIPTION
Use a new section in the database config to select the hostname of the MySQL
slave when running `export:*` rake tasks. This allows the hostname to be
controlled by alphagov-deployment and set differently on Platform1, where
Whitehall has it's own MySQL master/slave.

PRs gds/alphagov-deployment#471 and gds/alphagov-deployment#472 must be
merged and promoted to `release` first.

Story in Infra's Pivotal has more information:
https://www.pivotaltracker.com/story/show/66419616
