### PR TITLE
Prevents time-outs if too many published documents

### DIFF
--- a/app/controllers/admin/classification_featurings_controller.rb
+++ b/app/controllers/admin/classification_featurings_controller.rb
@@ -3,7 +3,10 @@ class Admin::ClassificationFeaturingsController < Admin::BaseController
   before_filter :load_featuring, only: [:edit, :destroy]
 
   def index
-    @tagged_editions = @classification.editions.published.with_translations
+    @tagged_editions = @classification.editions.published
+                                      .with_translations
+                                      .order('editions.created_at DESC')
+                                      .page(params[:page])
     @classification_featurings = @classification.classification_featurings
   end
 

--- a/app/views/admin/classification_featurings/index.html.erb
+++ b/app/views/admin/classification_featurings/index.html.erb
@@ -68,6 +68,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @tagged_editions, theme: 'twitter-bootstrap' %>
 <% end %>
 
 <%= render partial: "admin/classifications/tab_wrapper", locals: { model: @classification } %>

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -8,6 +8,23 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     login_as :policy_writer
   end
 
+  test "GET :index assigns tagged_editions with a paginated collection of published editions related to the topic ordered by most recently created editions first" do
+    @news_article_foo = create(:published_news_article, :with_topics, topics: [@topic])
+    Timecop.travel(10.minutes) do
+      @news_article_bar = create(:published_news_article, :with_topics, topics: [@topic])
+    end
+    draft_article = create(:news_article, :with_topics, topics: [@topic])
+    unrelated_article = create(:news_article, :with_topics)
+
+    get :index, topic_id: @topic, page: 1
+
+    tagged_editions = assigns(:tagged_editions)
+    assert_equal [@news_article_bar, @news_article_foo], tagged_editions
+    assert_equal 1, tagged_editions.current_page
+    assert_equal 1, tagged_editions.num_pages
+    assert_equal 25, tagged_editions.limit_value
+  end
+
   test "PUT :order saves the new order of featurings" do
     feature1 = create(:classification_featuring, classification: @topic)
     feature2 = create(:classification_featuring, classification: @topic)


### PR DESCRIPTION
Added pagination as required to fix:
https://www.pivotaltracker.com/story/show/66349416
and a few more tests to cover the controller index.
