### PR TITLE
Handle changes to first_published_at in history

### DIFF
--- a/app/models/document_history.rb
+++ b/app/models/document_history.rb
@@ -48,15 +48,15 @@ class DocumentHistory
   end
 
   def first_public_edition
-    all_published_editions.last
+    all_published_editions_in_creation_order.first
   end
 
   def latest_public_edition
-    all_published_editions.first
+    all_published_editions_in_creation_order.last
   end
 
   def first_published_at
-    first_public_edition.first_public_at
+    all_published_editions_in_creation_order.last.first_public_at
   end
 
   def first_public_edition_note
@@ -64,11 +64,11 @@ class DocumentHistory
   end
 
   def subsequent_major_editions
-    (all_published_editions - [first_public_edition]).reject(&:minor_change?)
+    (all_published_editions_in_creation_order.reverse - [first_public_edition]).reject(&:minor_change?)
   end
 
-  def all_published_editions
-    document.ever_published_editions.in_reverse_chronological_order
+  def all_published_editions_in_creation_order
+    document.ever_published_editions.order('created_at')
   end
 
   def supporting_pages

--- a/test/unit/document_history_test.rb
+++ b/test/unit/document_history_test.rb
@@ -50,6 +50,18 @@ class DocumentHistoryTest < ActiveSupport::TestCase
     assert_history_equal expected, history
   end
 
+  test '#changes handles the fact that first_published_at might be changed in later editions' do
+    original_edition = create(:superseded_edition, first_published_at: 3.days.ago, change_note: nil)
+    document         = original_edition.document
+    updated_published_time = 6.days.ago
+    Timecop.travel(1.day) do
+      new_edition_1    = create(:superseded_edition, document: document, first_published_at: updated_published_time, published_major_version: 1, published_minor_version: 1, minor_change: true)
+    end
+    history          = DocumentHistory.new(document)
+
+    assert_history_equal [[updated_published_time, 'First published.']], history
+  end
+
   test "#changes includes changes for any supporting pages" do
     policy            = create(:policy, :superseded, first_published_at: 5.days.ago, change_note: nil)
     support_page_1    = create(:supporting_page, :superseded, first_published_at: 4.days.ago, change_note: nil, related_policies: [policy])


### PR DESCRIPTION
Editors have the ability to change the first_published_at timestamp in subsequent editions. This means we cannot base the displayed time on the value in the first edition. Instead we use the value in the
most recently pubished edition as the source of truth. 

This also changes the query used to get all published editions as we cannot rely on the in_reverse_chronological_order scope as that returns editions based on the public timestamps. Document history is concerned with the order editions were created in and not the public timestamps, which can change based on changes to first_published_at.

Fixes https://www.pivotaltracker.com/story/show/66133570
