### PR TITLE
Add task to register sector content with Panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -36,4 +36,32 @@ namespace :panopticon do
       end
     end
   end
+
+  desc "Register all content for a specialist sector with Panopticon"
+  task :register_specialist_sector_content => :environment do
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+
+    unless ENV["TAG"].present?
+      logger.error "Please provide a value for TAG in the environment."
+    end
+    tag_id_fragment = ENV["TAG"]
+
+    # use a fuzzy match so that "oil-and-gas" will also include child tags like "oil-and-gas/fields-and-wells"
+    edition_ids = SpecialistSector.where("tag LIKE ?", "#{tag_id_fragment}%").map(&:edition_id)
+
+    published_editions = Edition.published.where(id: edition_ids)
+    logger.info "Found #{published_editions.count} published editions with tag #{tag_id_fragment}"
+
+    published_editions.each do |edition|
+      artefact = RegisterableEdition.new(edition)
+      registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+      logger.info "Registering /#{artefact.slug} with Panopticon..."
+
+      begin
+        registerer.register(artefact)
+      rescue GdsApi::HTTPErrorResponse => e
+        logger.error "Failed to register /#{edition.slug} with #{e.code}: #{e.error_details}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds a new Rake task to register all published editions tagged with a given specialist sector tag with Panopticon. 
