### PR TITLE
Bad link report tweaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'invalid_utf8_rejector', '~> 0.0.1'
 gem 'sidekiq', '2.14.1'
 gem 'raindrops', '0.11.0'
 gem 'airbrake', '3.1.15'
-gem 'bad_link_finder', '~> 0.3.0'
+gem 'bad_link_finder', '~> 0.3.1'
 
 # This sanitize fork branch fizes an issue with sanitize seeing colons in ids (when used as anchor tag references in an href)
 # as links with protocols. This has been fixed and merged in rgrove's Sanitize, but will only be released with version 2.1.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       multi_json
     arel (3.0.3)
     babosa (0.3.11)
-    bad_link_finder (0.3.0)
+    bad_link_finder (0.3.1)
       mechanize (~> 2.7)
       nokogiri (~> 1.5)
     bootstrap-kaminari-views (0.0.2)
@@ -382,7 +382,7 @@ DEPENDENCIES
   addressable
   airbrake (= 3.1.15)
   babosa
-  bad_link_finder (~> 0.3.0)
+  bad_link_finder (~> 0.3.1)
   bootstrap-kaminari-views
   bullet
   capybara (~> 2.1.0)

--- a/lib/whitehall/bad_link_finder.rb
+++ b/lib/whitehall/bad_link_finder.rb
@@ -8,7 +8,7 @@ module Whitehall
 
     def generate_report(report_path)
       csv = CSV.open(report_path, 'w', encoding: 'UTF-8')
-      csv << ["page", "admin link", "department", "bad link count", "bad links"]
+      csv << ["page", "admin link", "department", "format", "bad link count", "bad links"]
 
       ::BadLinkFinder::Site.new(@mirror_directory, nil).each do |page|
         page_checker = ::BadLinkFinder::PageChecker.new(public_host, page, result_cache)
@@ -26,9 +26,10 @@ module Whitehall
             data = {
               public_url:     page_checker.page_url,
               admin_url:      Whitehall.url_maker.admin_edition_url(edition, host: 'whitehall-admin.production.alphagov.co.uk'),
-              organisation:   edition.lead_organisations.first.name,
+              organisation:   (edition.lead_organisations || edition.worldwide_organisations).first.name,
+              content_type:   edition.type,
               bad_link_count: bad_links.size,
-              bad_links:      bad_links.join(' ')
+              bad_links:      bad_links.join("\n")
             }
 
             csv << data.values


### PR DESCRIPTION
1. Include format type in the report
2. Handle worldwide content better
3. Nicer formatting of bad links (new lines to make them more readable)
4. Bump bad_link_finder (fewer false positives)
