### PR TITLE
Drop user_need tables, remove temporary admin fix.

### DIFF
--- a/app/controllers/admin/detailed_guides_controller.rb
+++ b/app/controllers/admin/detailed_guides_controller.rb
@@ -8,9 +8,4 @@ class Admin::DetailedGuidesController < Admin::EditionsController
   def edition_class
     DetailedGuide
   end
-
-  def clean_edition_parameters
-    super
-    params[:edition].delete_if { |k, v| ["user_need_ids", "user_needs_attributes"].include?(k.to_s) }
-  end
 end

--- a/db/migrate/20140307095755_drop_user_needs.rb
+++ b/db/migrate/20140307095755_drop_user_needs.rb
@@ -1,0 +1,6 @@
+class DropUserNeeds < ActiveRecord::Migration
+  def up
+    drop_table :edition_user_needs
+    drop_table :user_needs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140306105311) do
+ActiveRecord::Schema.define(:version => 20140307095755) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -396,15 +396,6 @@ ActiveRecord::Schema.define(:version => 20140306105311) do
 
   add_index "edition_translations", ["edition_id"], :name => "index_edition_translations_on_edition_id"
   add_index "edition_translations", ["locale"], :name => "index_edition_translations_on_locale"
-
-  create_table "edition_user_needs", :force => true do |t|
-    t.integer  "edition_id"
-    t.integer  "user_need_id"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
-  end
-
-  add_index "edition_user_needs", ["edition_id"], :name => "index_edition_user_needs_on_edition_id"
 
   create_table "edition_world_locations", :force => true do |t|
     t.integer  "edition_id"
@@ -1032,8 +1023,8 @@ ActiveRecord::Schema.define(:version => 20140306105311) do
   create_table "specialist_sectors", :force => true do |t|
     t.integer  "edition_id"
     t.string   "tag"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
     t.boolean  "primary",    :default => false
   end
 
@@ -1109,17 +1100,6 @@ ActiveRecord::Schema.define(:version => 20140306105311) do
 
   add_index "unpublishings", ["edition_id"], :name => "index_unpublishings_on_edition_id"
   add_index "unpublishings", ["unpublishing_reason_id"], :name => "index_unpublishings_on_unpublishing_reason_id"
-
-  create_table "user_needs", :force => true do |t|
-    t.string   "user"
-    t.string   "need"
-    t.string   "goal"
-    t.integer  "organisation_id"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
-  end
-
-  add_index "user_needs", ["organisation_id"], :name => "index_user_needs_on_organisation_id"
 
   create_table "user_world_locations", :force => true do |t|
     t.integer "user_id"

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -68,17 +68,6 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
     assert_equal [soul], DetailedGuide.first.other_mainstream_categories
   end
 
-  test "providing user_needs parameters doesn't cause error" do
-    funk = create(:mainstream_category)
-
-    attributes = controller_attributes_for(:detailed_guide, primary_mainstream_category_id: funk.id)
-    attributes[:user_needs_attributes] = { user: "test user", need: "this to work", goal: "pass my tests" }
-    attributes[:user_need_ids] = [1, 2, 3]
-
-    post :create, edition: attributes
-    assert_response 302
-  end
- 
   private
 
   def controller_attributes_for(edition_type, attributes = {})


### PR DESCRIPTION
Second part of https://www.pivotaltracker.com/story/show/66600214.

Should not be deployed until d87dc27b0ee7cf5306f70e2f524866df9e29897f has been deployed and the existing data exported.
