### PR TITLE
Removing 'parent' department from NMD description

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -65,25 +65,22 @@ module OrganisationHelper
     type_name = organisation_type_name(organisation)
     relationship = ERB::Util.h(add_indefinite_article(type_name))
     parents = organisation.parent_organisations.map { |parent| organisation_relationship_html(parent) }
-    if parents.any?
-      if type_name == 'other'
-        "%s works with %s." % [name, parents.to_sentence]
-      elsif type_name == 'non-ministerial department'
-        if organisation.active_child_organisations_excluding_sub_organisations.any?
-          "%s is %s" % [name, relationship]
-        else
-          "%s is %s." % [name, relationship]
-        end
+
+    description = if parents.any?
+      case type_name
+      when 'other'
+        "#{name} works with #{parents.to_sentence}."
+      when 'non-ministerial department'
+        "#{name} is #{relationship}."
       else
-        "%s is %s of %s." % ([name, relationship, parents.to_sentence])
+        "#{name} is #{relationship} of #{parents.to_sentence}."
       end
     else
-      if organisation.active_child_organisations_excluding_sub_organisations.any?
-        "%s is %s" % [name, relationship]
-      else
-        "%s is %s." % [name, relationship]
-      end
-    end.html_safe
+      "#{name} is #{relationship}."
+    end
+
+    description.chomp!('.') if organisation.active_child_organisations_excluding_sub_organisations.any?
+    description.html_safe
   end
 
   def organisation_relationship_html(organisation)

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -196,9 +196,8 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
 
   def assert_relationship_type_is_described_as(type_key, expected_description)
     parent = create(:organisation)
-    child = create(:organisation, parent_organisations: [parent],
-      organisation_type: OrganisationType.get(type_key))
-    expected_text = %Q{#{child.name} #{expected_description} the #{parent.name}.}
+    child = create(:organisation, parent_organisations: [parent], organisation_type: OrganisationType.get(type_key))
+    expected_text = expected_description.sub('{this_org_name}', child.name).sub('{parent_org_name}', parent.name)
     actual_html = organisation_display_name_and_parental_relationship(child)
     assert_equal expected_text, strip_html_tags(actual_html)
   end
@@ -247,14 +246,24 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test 'relationship types are described correctly' do
-    assert_relationship_type_is_described_as(:ministerial_department, 'is a ministerial department of')
-    assert_relationship_type_is_described_as(:executive_agency, 'is an executive agency of')
-    assert_relationship_type_is_described_as(:executive_ndpb, 'is an executive non-departmental public body of')
-    assert_relationship_type_is_described_as(:advisory_ndpb, 'is an advisory non-departmental public body of')
-    assert_relationship_type_is_described_as(:tribunal_ndpb, 'is a tribunal non-departmental public body of')
-    assert_relationship_type_is_described_as(:public_corporation, 'is a public corporation of')
-    assert_relationship_type_is_described_as(:independent_monitoring_body, 'is an independent monitoring body of')
-    assert_relationship_type_is_described_as(:other, 'works with')
+    assert_relationship_type_is_described_as(:ministerial_department, '{this_org_name} is a ministerial department of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:non_ministerial_department, '{this_org_name} is a non-ministerial department.')
+    assert_relationship_type_is_described_as(:executive_agency, '{this_org_name} is an executive agency of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:executive_ndpb, '{this_org_name} is an executive non-departmental public body of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:advisory_ndpb, '{this_org_name} is an advisory non-departmental public body of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:tribunal_ndpb, '{this_org_name} is a tribunal non-departmental public body of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:public_corporation, '{this_org_name} is a public corporation of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:independent_monitoring_body, '{this_org_name} is an independent monitoring body of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:other, '{this_org_name} works with the {parent_org_name}.')
+  end
+
+  test 'organisations with active_child_organisations_excluding_sub_organisations are described without a full stop' do
+    org = create(:ministerial_department, acronym: "DBR", name: "Department of Building Regulation")
+    org.stubs(:active_child_organisations_excluding_sub_organisations).returns([:an_active_child])
+    refute organisation_display_name_and_parental_relationship(org).include? '.'
+
+    org.stubs(:active_child_organisations_excluding_sub_organisations).returns([])
+    assert organisation_display_name_and_parental_relationship(org).include? '.'
   end
 
   test 'definite article skipped for certain parent organisations' do


### PR DESCRIPTION
Non-ministerial departments are currently described as being "of" their parent department. This isn't the case as they report independently to ministers. This removes the implied parent/child relationship.

Delivers https://www.pivotaltracker.com/s/projects/1008986/stories/66542606
