### PR TITLE
Allow setting of primary specialist sector.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -13,6 +13,7 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :enforce_permissions!
   before_filter :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
   before_filter :redirect_to_controller_for_type, only: [:show]
+  before_filter :deduplicate_specialist_sectors, only: [:create, :update]
 
   def enforce_permissions!
     case action_name
@@ -148,6 +149,8 @@ class Admin::EditionsController < Admin::BaseController
       :related_mainstream_content_title,
       :additional_related_mainstream_content_url,
       :additional_related_mainstream_content_title,
+      :primary_specialist_sector_tag,
+      secondary_specialist_sector_tags: [],
       ministerial_role_ids: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],
@@ -165,7 +168,6 @@ class Admin::EditionsController < Admin::BaseController
       policy_team_ids: [],
       policy_advisory_group_ids: [],
       document_collection_group_ids: [],
-      specialist_sector_tags: [],
       topic_suggestion_attributes: [:name, :id],
       images_attributes: [
         :id, :alt_text, :caption, :_destroy,
@@ -335,4 +337,10 @@ class Admin::EditionsController < Admin::BaseController
     @force_publisher ||= Whitehall.edition_services.force_publisher(@edition)
   end
   helper_method :force_publisher
+
+  def deduplicate_specialist_sectors
+    if params[:edition] && params[:edition][:secondary_specialist_sectors] && params[:edition][:primary_specialist_sector]
+      params[:edition][:secondary_specialist_sectors].delete(params[:edition][:primary_specialist_sector])
+    end
+  end
 end

--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -3,23 +3,47 @@ module Edition::SpecialistSectors
 
   included do
     has_many :specialist_sectors, foreign_key: :edition_id, dependent: :destroy
+    has_many :primary_specialist_sectors, conditions: {primary: true}, class_name: 'SpecialistSector', foreign_key: :edition_id, dependent: :destroy
+    has_many :secondary_specialist_sectors, conditions: {primary: false}, class_name: 'SpecialistSector', foreign_key: :edition_id, dependent: :destroy
 
     add_trait do
       def process_associations_before_save(edition)
-        edition.specialist_sector_tags = @edition.specialist_sector_tags
+        edition.specialist_sectors = @edition.specialist_sectors
       end
     end
   end
 
-  def specialist_sector_tags
-    specialist_sectors.map(&:tag)
+  def primary_specialist_sector_tag
+    primary_specialist_sectors.first.try(:tag)
   end
 
-  def specialist_sector_tags=(sector_tags)
-    self.specialist_sectors = Array(sector_tags).reject(&:blank?).map do |tag|
-      self.specialist_sectors.where(tag: tag).first_or_initialize.tap do |sector|
+  def primary_specialist_sector_tag=(sector_tag)
+    set_specialist_sectors([sector_tag], primary: true)
+  end
+
+  def secondary_specialist_sector_tags
+    secondary_specialist_sectors.map(&:tag)
+  end
+
+  def secondary_specialist_sector_tags=(sector_tags)
+    set_specialist_sectors(sector_tags, primary: false)
+  end
+
+private
+
+  def set_specialist_sectors(tags, primary: false)
+    relation = if primary
+      'primary_specialist_sectors'
+    else
+      'secondary_specialist_sectors'
+    end
+
+    sectors = tags.reject(&:blank?).map do |tag|
+      self.public_send(relation).where(tag: tag).first_or_initialize.tap do |sector|
         sector.edition = self
       end
     end
+
+    self.public_send("#{relation}=", sectors)
   end
 end

--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -27,6 +27,6 @@ class RegisterableEdition
   end
 
   def specialist_sectors
-    @edition.specialist_sector_tags
+    [@edition.primary_specialist_sector_tag].compact + @edition.secondary_specialist_sector_tags
   end
 end

--- a/app/views/admin/editions/_specialist_sector_fields.html.erb
+++ b/app/views/admin/editions/_specialist_sector_fields.html.erb
@@ -1,10 +1,18 @@
 <%= specialist_sector_fields do |sectors| %>
   <fieldset class="edition-specialist-sector-fields">
-    <%= form.label :specialist_sector_tags do %>
-      <strong>ALPHA:</strong> Specialist sectors (this is an evolving feature, 
+    <legend>
+      <strong>ALPHA:</strong> Specialist sectors (this is an evolving feature,
       <a href="https://insidegovuk.blog.gov.uk/2014/02/20/new-specialist-sector-option-in-publisher/">read more in our blog post</a>)
-    <% end %>
-    <%= form.select :specialist_sector_tags,
+    </legend>
+    <%= form.label :primary_specialist_sector_tag %>
+    <%= form.select :primary_specialist_sector_tag,
+                    specialist_sector_options_for_select(sectors),
+                    {},
+                    { class: 'chzn-select',
+                      data: { placeholder: 'Choose specialist sectors…' } } %>
+
+    <%= form.label :secondary_specialist_sector_tags, 'Additional specialist sectors' %>
+    <%= form.select :secondary_specialist_sector_tags,
                     specialist_sector_options_for_select(sectors),
                     {},
                     { multiple: true,

--- a/db/migrate/20140306105311_add_primary_to_specialist_sector.rb
+++ b/db/migrate/20140306105311_add_primary_to_specialist_sector.rb
@@ -1,0 +1,13 @@
+class AddPrimaryToSpecialistSector < ActiveRecord::Migration
+  def up
+    add_column :specialist_sectors, :primary, :boolean, default: false
+
+    SpecialistSector.all.group_by(&:edition).each do |edition, sectors|
+      sectors.first.update_attribute(:primary, true) unless edition.nil?
+    end
+  end
+
+  def down
+    remove_column :specialist_sectors, :primary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140227121604) do
+ActiveRecord::Schema.define(:version => 20140306105311) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -1034,6 +1034,7 @@ ActiveRecord::Schema.define(:version => 20140227121604) do
     t.string   "tag"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.boolean  "primary",    :default => false
   end
 
   add_index "specialist_sectors", ["edition_id", "tag"], :name => "index_specialist_sectors_on_edition_id_and_tag", :unique => true

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -16,15 +16,16 @@ module SpecialistSectorHelper
   end
 
   def select_specialist_sectors_in_form
-    select 'Oil and Gas: Wells', from: 'Specialist sectors'
-    select 'Oil and Gas: Offshore', from: 'Specialist sectors'
+    select 'Oil and Gas: Wells', from: 'Primary specialist sector'
+    select 'Oil and Gas: Offshore', from: 'Additional specialist sectors'
+    select 'Oil and Gas: Fields', from: 'Additional specialist sectors'
   end
 
   def assert_specialist_sectors_were_saved
     assert has_css?('.flash.notice')
     click_on 'Edit draft'
-    assert_equal ['oil-and-gas/wells', 'oil-and-gas/offshore'],
-                 find_field('Specialist sectors').value
+    assert_equal 'oil-and-gas/wells', find_field('Primary specialist sector').value
+    assert_equal ['oil-and-gas/offshore', 'oil-and-gas/fields'].to_set, find_field('Additional specialist sectors').value.to_set
   end
 
   def save_document

--- a/test/unit/edition/specialist_sectors_test.rb
+++ b/test/unit/edition/specialist_sectors_test.rb
@@ -2,11 +2,13 @@ require 'test_helper'
 
 class Edition::SpecialistSectorsTest < ActiveSupport::TestCase
   test '#create_draft should copy specialist sectors' do
-    expected_tags = ['oil-and-gas/taxation', 'tax/corporation-tax']
-    edition = create(:published_policy, specialist_sector_tags: expected_tags)
+    expected_primary_tag = 'tax/vat'
+    expected_secondary_tags = ['oil-and-gas/taxation', 'tax/corporation-tax']
+    edition = create(:published_policy, primary_specialist_sector_tag: expected_primary_tag, secondary_specialist_sector_tags: expected_secondary_tags)
 
     draft = edition.create_draft(create(:policy_writer))
 
-    assert_equal expected_tags, draft.specialist_sector_tags
+    assert_equal expected_primary_tag, draft.primary_specialist_sector_tag
+    assert_equal expected_secondary_tags, draft.secondary_specialist_sector_tags
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -37,14 +37,16 @@ class RegisterableEditionTest < ActiveSupport::TestCase
   end
 
   test "attaches specialist sector tags based on specialist sectors" do
-    expected_tags = ["oil-and-gas/licensing", "oil-and-gas/fields-and-wells"]
+    expected_primary_tag = "oil-and-gas/taxation"
+    expected_secondary_tags = ["oil-and-gas/licensing", "oil-and-gas/fields-and-wells"]
 
     detailed_guide = create(:published_detailed_guide,
-                            specialist_sector_tags: expected_tags)
+                            primary_specialist_sector_tag: expected_primary_tag,
+                            secondary_specialist_sector_tags: expected_secondary_tags)
 
     registerable_edition = RegisterableEdition.new(detailed_guide)
 
-    assert_equal expected_tags, registerable_edition.specialist_sectors
+    assert_equal [expected_primary_tag] + expected_secondary_tags, registerable_edition.specialist_sectors
   end
 
   test "sets the kind for a generic type" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/66934064

After much faffing and discussion there is no GUI or model restriction preventing editors from setting the same sector in both primary and secondary, this is handled in the controller.
