### PR TITLE
Save and next button on speed tagging interface

### DIFF
--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -109,6 +109,7 @@
     <% end %>
 
     <%= submit_tag "Save", class: 'btn btn-primary' %>
-    <%= submit_tag "Save & Convert to Draft & Next", class: 'btn btn-success', id: "js-speed-convert", name: "speed_save_convert" %>
+    <%= submit_tag "Save & Show Next", class: 'btn btn-primary', name: "speed_save_next" %>
+    <%= submit_tag "Save, Convert to Draft & Show Next", class: 'btn btn-success', name: "speed_save_convert" %>
   <% end %>
 </div>

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Admin::EditionsControllerTest < ActionController::TestCase
+  include Admin::EditionRoutesHelper
+
   setup do
     login_as :policy_writer
   end
@@ -276,6 +278,19 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
     delete :destroy, id: inaccessible
     assert_response :forbidden
+  end
+
+  test "should redirect to the next edition after update without changing state if Save and Next was clicked" do
+    edition_foo, edition_bar = *create_list(:imported_publication, 2)
+
+    put :update, id: edition_foo, speed_save_next: 1, edition: {
+      title: "new-title",
+      body: "new-body"
+    }
+
+    edition_foo.reload
+    assert_equal "imported", edition_foo.state
+    assert_redirected_to admin_edition_path(edition_bar)
   end
 
   def stub_edition_filter(attributes = {})


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67119790

"Save and show next" button on speed tagging interface, to do what it says.
