### PR TITLE
Relax validation primary_mainstream_category

### DIFF
--- a/app/models/edition/has_mainstream_categories.rb
+++ b/app/models/edition/has_mainstream_categories.rb
@@ -20,7 +20,7 @@ module Edition::HasMainstreamCategories
     add_trait Trait
 
     validate :avoid_duplication_between_primary_and_other_mainstream_categories
-    validates :primary_mainstream_category, presence: true, unless: ->(edition) { edition.can_have_some_invalid_data? }
+    validates :primary_mainstream_category, presence: true, if: ->(edition) { edition.other_mainstream_categories.any? }
   end
 
   def mainstream_categories

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -6,16 +6,6 @@ class DetailedGuideTest < ActiveSupport::TestCase
   should_allow_inline_attachments
   should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
-  test 'imported detailed guides are valid when the primary_mainstream_category is blank' do
-    detailed_guide = build(:detailed_guide, state: 'imported', primary_mainstream_category: nil)
-    assert detailed_guide.valid?
-  end
-
-  test 'imported detailed guides are not valid_as_draft? when the primary_mainstream_category is blank' do
-    detailed_guide = build(:detailed_guide, state: 'imported', primary_mainstream_category: nil)
-    refute detailed_guide.valid_as_draft?
-  end
-
   test "should be able to relate to topics" do
     article = build(:detailed_guide)
     assert article.can_be_associated_with_topics?
@@ -106,12 +96,6 @@ class DetailedGuideTest < ActiveSupport::TestCase
     detailed_guide = build(:detailed_guide, body: body)
     refute detailed_guide.valid?
     assert_equal ["must have a level-2 heading (h2 - ##) before level-3 heading (h3 - ###): 'Orphan'"], detailed_guide.errors[:body]
-  end
-
-  test "should be invalid without a primary mainstream category" do
-    detailed_guide = build(:detailed_guide, primary_mainstream_category: nil)
-    refute detailed_guide.valid?
-    assert detailed_guide.errors.full_messages.include?("Primary detailed guidance category can't be blank")
   end
 
   test "should include breadcrumb metadata in search index" do

--- a/test/unit/edition/has_mainstream_categories_test.rb
+++ b/test/unit/edition/has_mainstream_categories_test.rb
@@ -21,6 +21,14 @@ class Edition::HasMainstreamCategoriesTest < ActiveSupport::TestCase
     assert edition.errors[:other_mainstream_categories].include?("should not contain the primary mainstream category")
   end
 
+  test "edition should be invalid with other categories and no primary category" do
+    category = create(:mainstream_category)
+    edition = build(:draft_detailed_guide, primary_mainstream_category: nil,
+                                           other_mainstream_categories: [category])
+
+    refute edition.valid?
+  end
+
   test "#destroy should also remove the relationship" do
     mainstream_category = create(:mainstream_category)
     edition = create(:draft_detailed_guide, other_mainstream_categories: [mainstream_category])


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67200884

It should only be required if one or more other_mainstream_categories
have been selected. This allows detailed guides to be added to
specialist sectors without having a mainstream category.

Mainstream categories will eventually be phased out in favour of
specialist sectors, at which point this whole thing will disappear.

(This is a new copy of #1311 due to Github weirdness)
