### PR TITLE
Update locale label on attachment edit form

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -1,5 +1,6 @@
 <% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
-  <%= form.label :locale, 'This attachment displays in' %>
+  <%= form.label :locale, 'Display language' %>
+  <p class="help-block">This determines the translations of the publication that the attachment will appear in.</p>
   <%= form.select :locale, options_for_locales(attachable.translated_locales), include_blank: 'All languages' %>
 <% end %>
 <%= form.text_field :isbn, label_text: 'ISBN' %>


### PR DESCRIPTION
To clarify the purpose of the language field.
