### PR TITLE
Consistently label GOV.UK status field

### DIFF
--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -39,7 +39,7 @@
       <%= organisation_form.text_field :alternative_format_contact_email, label_text: "Email address for ordering attached files in an alternative format" %>
     </p>
     <p>
-      <%= organisation_form.label :govuk_status, "Status on gov.uk" %>
+      <%= organisation_form.label :govuk_status, "Status on GOV.UK" %>
       <%= organisation_form.select :govuk_status, [["Currently live", "live"], ["Coming soon", "joining"], ["Exempt from joining", "exempt"], ["Currently transitioning", "transitioning"], ["Closed", "closed"]], {}, class: 'chzn-select' %>
     </p>
     <p class="js-closed-organisation-field">

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -15,7 +15,7 @@
           <tr><th>Type</th><td><%= @organisation.organisation_type.name %></td></tr>
           <tr><th>Acronym</th><td><%= @organisation.acronym %></td></tr>
           <tr><th>URL</th><td><%= link_to @organisation.url %></td></tr>
-          <tr><th>gov.uk status</th><td><%= @organisation.govuk_status.titleize %></td></tr>
+          <tr><th>Status on GOV.UK</th><td><%= @organisation.govuk_status.titleize %></td></tr>
           <% if @organisation.closed? %>
             <% if @organisation.closed_at.present? %>
               <tr><th>Organisation closed on</th><td><%= absolute_date(@organisation.closed_at) %></td></tr>

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -578,7 +578,7 @@ end
 When(/^I close the organisation "(.*?)", superseding it with the organisation "(.*?)"$/) do |org_name, superseding_org_name|
   organisation = Organisation.find_by_name!(org_name)
   visit edit_admin_organisation_path(organisation.slug)
-  select "Closed", from: "Status on gov.uk"
+  select "Closed", from: "Status on GOV.UK"
   select superseding_org_name, from: "Superseded by"
   click_on "Save"
 end


### PR DESCRIPTION
Cap it up too, because apparently [we mean business](https://gds.blog.gov.uk/2012/02/07/writing-simply/).
