### PR TITLE
Get rid of noisy gems and profit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,7 @@ end
 
 group :development do
   gem 'thin', '1.5.1'
-  gem 'bullet'
   gem 'newrelic_rpm'
-  gem 'rack-mini-profiler'
-  gem 'rails-dev-boost'
   gem 'quiet_assets'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,6 @@ GEM
       kaminari (>= 0.13)
       rails (>= 3.1)
     builder (3.0.4)
-    bullet (4.6.0)
-      uniform_notifier
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -258,8 +256,6 @@ GEM
       rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-mini-profiler (0.1.29)
-      rack (>= 1.1.3)
     rack-ssl (1.3.3)
       rack
     rack_strip_client_ip (0.0.1)
@@ -271,8 +267,6 @@ GEM
       activesupport (= 3.2.17)
       bundler (~> 1.0)
       railties (= 3.2.17)
-    rails-dev-boost (0.2.1)
-      rails (>= 3.0)
     rails-i18n (0.7.3)
       i18n (~> 0.5)
     railties (3.2.17)
@@ -361,7 +355,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    uniform_notifier (1.2.0)
     validates_email_format_of (1.5.3)
     warden (1.2.3)
       rack (>= 1.0)
@@ -384,7 +377,6 @@ DEPENDENCIES
   babosa
   bad_link_finder (~> 0.3.1)
   bootstrap-kaminari-views
-  bullet
   capybara (~> 2.1.0)
   carrierwave (= 0.9.0)
   chronic
@@ -422,11 +414,9 @@ DEPENDENCIES
   plek (= 1.5.0)
   poltergeist (~> 1.3.0)
   quiet_assets
-  rack-mini-profiler
   rack-test!
   rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.17)
-  rails-dev-boost
   rails-i18n
   raindrops (= 0.11.0)
   rake (= 10.1.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,18 +36,6 @@ Whitehall::Application.configure do
   # Disable cache in development
   config.cache_store = :null_store
 
-  config.after_initialize do
-    Bullet.enable = true
-    # Bullet.alert = true
-    Bullet.bullet_logger = true
-    Bullet.console = true
-    Bullet.rails_logger = true
-    # Bullet.airbrake = true
-
-    Rack::MiniProfiler.config.position = 'right'
-    Rack::MiniProfiler.config.start_hidden = ENV['HIDE_RACK_MINI_PROFILER'].present? # Use Alt-P shortcut to show
-  end
-
   if ENV['SHOW_PRODUCTION_IMAGES']
     orig_host = config.asset_host
     config.asset_host = Proc.new do |source|


### PR DESCRIPTION
- Bullet fills the logs with noise regarding potential n+1 queries but is often wrong and basically ignored
- rack-mini-profile is very obstructive (blocks the "import" link), slows page loading down considerably and is basically ignored
- rails-dev-boost no longer provides much of a boost as rails optimises code reloading pretty well itself.
