### PR TITLE
Clear HtmlAttachment slug when changing to non-english

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -2,6 +2,8 @@ class HtmlAttachment < Attachment
   extend FriendlyId
   friendly_id :sluggable_string
 
+  before_validation :clear_slug_if_non_english_locale
+
   validates :body, presence: true
   validates_with SafeHtmlValidator
 
@@ -58,5 +60,11 @@ class HtmlAttachment < Attachment
 
   def sluggable_string
     sluggable_locale? ? title : nil
+  end
+
+  def clear_slug_if_non_english_locale
+    if locale_changed? and ! sluggable_locale?
+      self.slug = nil
+    end
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -61,4 +61,11 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected_slug, attachment.slug
     assert_equal expected_slug, attachment.to_param
   end
+
+  test "slug is cleared when changing from english to non-english" do
+    attachment = create(:html_attachment, locale: "en")
+
+    attachment.update_attributes!(locale: "fr")
+    assert_blank attachment.slug
+  end
 end


### PR DESCRIPTION
This is to cover the case where the locale is not changed from the
default (English) when first saving a new attachment, but is then
subsequently changed.
