### PR TITLE
Don't raise on unpermitted params

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,10 +8,6 @@ Whitehall::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
-  # Log unpermitted parameters. This can be removed once we're confident the
-  # strong parameters change is complete
-  config.action_controller.action_on_unpermitted_parameters = :raise
-
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_assets = true
 


### PR DESCRIPTION
We're confident that we have permitted all parameters currently in use so this is no longer serving any purpose.

Additionally, it's causing issues during deployments where form fields are removed or renamed as an exception is raised instead of the parameter being silently dropped.

Note: This will stop editors losing changes where we've changed fields they don't care about, but could still result in some data being lost, eg when renaming the `specialist_sectors` field to `secondary_specialist_sectors`.
