### PR TITLE
Re-render speed tagging interface on update errors

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -79,10 +79,14 @@ class Admin::EditionsController < Admin::BaseController
       redirect_to after_update_path, saved_confirmation_notice
     else
       flash.now[:alert] = "There are some problems with the document"
-      extract_edition_information_from_errors
-      build_edition_dependencies
-      fetch_version_and_remark_trails
-      render action: "edit"
+      if speed_tagging?
+        render :show
+      else
+        extract_edition_information_from_errors
+        build_edition_dependencies
+        fetch_version_and_remark_trails
+        render :edit
+      end
     end
   rescue ActiveRecord::StaleObjectError
     flash.now[:alert] = "This document has been saved since you opened it"
@@ -117,6 +121,10 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   private
+
+  def speed_tagging?
+    params[:speed_save_convert] || params[:speed_save_next] || params[:speed_save]
+  end
 
   def after_update_path
     # infer the next action the user wants to take

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -108,7 +108,7 @@
       </div>
     <% end %>
 
-    <%= submit_tag "Save", class: 'btn btn-primary' %>
+    <%= submit_tag "Save", class: 'btn btn-primary', name: "speed_save" %>
     <%= submit_tag "Save & show next", class: 'btn btn-primary', name: "speed_save_next" %>
     <%= submit_tag "Save, convert to draft & show next", class: 'btn btn-success', name: "speed_save_convert" %>
   <% end %>

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -295,6 +295,15 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_redirected_to admin_edition_path(second_document.latest_edition)
   end
 
+  test "re-renders the show page when there are errors during speed tagging update" do
+    imported_news_article = create(:imported_news_article, title: 'News article')
+    put :update, id: imported_news_article, speed_save: 'Save', edition: { title: '' }
+
+    assert_response :success
+    assert_template :show
+    assert_equal 'News article', imported_news_article.reload.title
+  end
+
   def stub_edition_filter(attributes = {})
     default_attributes = {
       editions: Kaminari.paginate_array(attributes[:editions] || []).page(1),


### PR DESCRIPTION
This changes the behaviour so that instead of rendering the "edit" form when a user submits changes with validation errors from the speed-tagging interface, they are shown the speed-tagging interface again.

Pivotal: https://www.pivotaltracker.com/story/show/67236308
