### PR TITLE
Handle badly formatted feed urls better

### DIFF
--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -10,7 +10,7 @@ module Whitehall
       def initialize(feed_url)
         @feed_url = feed_url
         @filter_options_describer = DocumentFilter::Options.new
-        parse_feed_url if recognised_url?
+        parse_feed_url if uri && recognised_url?
       end
 
       def description
@@ -20,7 +20,7 @@ module Whitehall
       end
 
       def valid?
-        recognised_url? && resource_exists? && filter_parameters_are_valid?
+        uri && recognised_url? && resource_exists? && filter_parameters_are_valid?
       end
 
       def feed_params
@@ -72,7 +72,11 @@ module Whitehall
       end
 
       def uri
-        @uri ||= URI.parse(feed_url)
+        @uri ||= begin
+          URI.parse(feed_url)
+        rescue URI::InvalidURIError
+          nil
+        end
       end
 
       def parse_feed_url

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
   include Whitehall::GovUkDelivery
 
+  test 'handles badly formatted feed urls' do
+    refute FeedUrlValidator.new('https://www.glue=latvia').valid?
+    refute FeedUrlValidator.new('https://www.gov.uk/government]').valid?
+  end
+
   test 'validates and describes a base publication filter feed url' do
     feed_url  = feed_url_for(document_type: "publications")
     validator = FeedUrlValidator.new(feed_url)


### PR DESCRIPTION
The site shouldn't blow up when validating badly formatted feed urls because: exception notification noise.

Tracker: https://www.pivotaltracker.com/story/show/67463168
