### PR TITLE
Drop parallel test databases before running create

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -39,11 +39,8 @@ mkdir -p ./infected-uploads
 mkdir -p ./attachment-cache
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-
-time bundle exec rake db:drop db:create db:schema:load --trace
-time bundle exec rake db:test:prepare --trace
+time bundle exec rake ci:setup:minitest test:in_parallel --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:clean --trace
-RAILS_ENV=test CUCUMBER_FORMAT=progress time bundle exec rake ci:setup:minitest parallel:create parallel:prepare test_queue shared_mustache:compile parallel:features test:javascript test:cleanup --trace
 RAILS_ENV=production SKIP_OBSERVERS_FOR_ASSET_TASKS=true time bundle exec rake assets:precompile --trace
 
 EXIT_STATUS=$?

--- a/lib/tasks/test_parallel.rake
+++ b/lib/tasks/test_parallel.rake
@@ -7,9 +7,17 @@ namespace :test do
   task :in_parallel => :environment do
     ENV['CUCUMBER_FORMAT'] = 'progress'
     ENV['RAILS_ENV'] = 'test'
-    ['parallel:create', 'parallel:prepare', 'test_queue', 'shared_mustache:compile', 'parallel:features', 'test:javascript', 'test:cleanup'].each do |task|
-      Rake::Task[task].invoke
-    end
+
+    setup_tasks = ['parallel:drop', 'parallel:create', 'parallel:load_schema']
+    test_tasks = ['test_queue', 'shared_mustache:compile', 'parallel:features', 'test:javascript']
+    cleanup_tasks = ['test:cleanup']
+
+    setup_tasks.each { |task| Rake::Task[task].invoke }
+    ParallelTests::Tasks.check_for_pending_migrations
+
+    test_tasks.each { |task| Rake::Task[task].invoke }
+
+    cleanup_tasks.each { |task| Rake::Task[task].invoke }
   end
 end
 


### PR DESCRIPTION
If the database isn't dropped in full then tables dropped in a migration will still exist in the parallel databases.

Because the primary database was being dropped before creation this lead to intermittent false positives where a test would fail if run against the primary but would pass if run against one of the parallels where the table still exists.

This cleans up the `test:in_parallel` rake task and uses that for the Jenkins script.
