### PR TITLE
Add specialist sector info to document headers.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '8.4.1'
+gem 'gds-api-adapters', '10.2.0'
 gem 'whenever', '0.9.0', require: false
 gem 'mini_magick'
 gem 'shared_mustache', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     friendly_id (4.0.9)
-    gds-api-adapters (8.4.1)
+    gds-api-adapters (10.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -384,7 +384,7 @@ DEPENDENCIES
   equivalent-xml (= 0.3.0)
   factory_girl
   friendly_id (= 4.0.9)
-  gds-api-adapters (= 8.4.1)
+  gds-api-adapters (= 10.2.0)
   gds-sso (= 9.2.0)
   globalize3!
   govspeak (~> 1.2.4)

--- a/app/assets/stylesheets/frontend/helpers/_headings.scss
+++ b/app/assets/stylesheets/frontend/helpers/_headings.scss
@@ -17,7 +17,8 @@
       @include core-36;
       font-weight: bold;
     }
-    .type {
+    .type,
+    .type a {
       @include core-27;
       color: $secondary-text-colour;
       margin-bottom: $gutter-one-sixth;

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -188,7 +188,7 @@ Details of document required:
     link_to native_language_name_for(locale), locale: locale
   end
 
-  def document_metadata(document, policies = [], topics = [], links_only = false)
+  def document_metadata(document, policies = [], topics = [], sectors = [], links_only = false)
     metadata = []
     if policies.any?
       metadata << {
@@ -209,6 +209,13 @@ Details of document required:
         title: t('document.headings.topical_events', count: document.topical_events.length),
         data: array_of_links_to_topical_events(document.topical_events),
         classes: ['document-topical-events']
+      }
+    end
+    if sectors.any?
+      metadata << {
+        title: t('document.headings.sectors', count: sectors.length),
+        data: array_of_links_to_sectors(sectors),
+        classes: ['document-sectors']
       }
     end
     if !(document.respond_to?(:statistics?) && document.statistics?)

--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -1,0 +1,44 @@
+module SpecialistSectorHelper
+
+  def add_sector_name(title)
+    if primary_subsector_tag && sector_tag = primary_subsector_tag.parent
+      "#{link_to(sector_tag.title, sector_tag.web_url)} - #{title.downcase}".html_safe
+    else
+      title
+    end
+  end
+
+  def add_subsector_name(title)
+    if primary_subsector_tag
+      "#{primary_subsector_tag.title} - #{title}"
+    else
+      title
+    end
+  end
+
+  def array_of_links_to_sectors(subsectors)
+    sectors_and_subsectors = specialist_sector_tags.map { |s| [s, s.parent] }
+
+    sectors_and_subsectors.flatten.compact.uniq.map { |sector|
+      link_to sector.title, sector.web_url
+    }
+  end
+
+private
+
+  def artefact
+    @artefact ||= Whitehall.content_api.artefact(RegisterableEdition.new(@document).slug)
+  end
+
+  def specialist_sector_tags
+    return [] if artefact.nil?
+    @specialist_sector_tags ||= artefact.tags.select {|t| t.details['type'] == 'specialist_sector' }
+  end
+
+  def primary_subsector_tag
+    @primary_subsector_tag ||= if primary_tag_slug = @document.primary_specialist_sector_tag
+      specialist_sector_tags.find {|t| t.slug == primary_tag_slug }
+    end
+  end
+
+end

--- a/app/views/documents/_document_footer_meta.html.erb
+++ b/app/views/documents/_document_footer_meta.html.erb
@@ -40,7 +40,7 @@
           <dd><%= item.html_safe %></dd>
         <% end %>
       <% end %>
-      <% document_metadata(document, policies, topics, links_only = true).each do |metadata| %>
+      <% document_metadata(document, policies, topics, [], links_only = true).each do |metadata| %>
         <dt><%= metadata[:title] %>:</dt>
         <% metadata[:data].each do |item| %>
           <dd class="<%= metadata.fetch(:classes, []).join(' ') %>">

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -4,8 +4,8 @@
   topics ||= []
 %>
 <%= render partial: 'shared/heading',
-          locals: { type: header_title,
-                    heading: document.title,
+          locals: { type: add_sector_name(header_title),
+                    heading: add_subsector_name(document.title),
                     extra: true } %>
 
 <%= render('documents/archive_notice', document: document, type: document.format_name) if document.archived? %>
@@ -16,4 +16,4 @@
     <%= national_statistics_logo(document) %>
   </div>
 </div>
-<%= render partial: 'documents/metadata', locals: { document: document, policies: policies, topics: topics } %>
+<%= render partial: 'documents/metadata', locals: { document: document, policies: policies, topics: topics, sectors: specialist_sector_tags } %>

--- a/app/views/documents/_metadata.html.erb
+++ b/app/views/documents/_metadata.html.erb
@@ -18,7 +18,7 @@
       <%= render  partial: 'documents/change_notes',
                   locals: { document: document } %>
 
-      <% document_metadata(document, policies, topics).each do |metadata| %>
+      <% document_metadata(document, policies, topics, sectors).each do |metadata| %>
         <dt><%= metadata[:title] %>:</dt>
         <dd class="js-hide-other-links <%= metadata.fetch(:classes, []).join(' ') %>">
           <%= metadata[:data].to_sentence.html_safe %>

--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -8,6 +8,10 @@ class GdsApi::ContentApi::Fake
   def tags(tag_type)
     []
   end
+
+  def artefact(*args)
+    nil
+  end
 end
 
 if endpoint_url = ENV["CONTENT_API_ENDPOINT_URL"]

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -9,3 +9,9 @@ Feature: Tagging content with specialist sectors
       And there are some specialist sectors
     When I start editing a draft document
     Then I can tag it to some specialist sectors
+
+  @real_content_api
+  Scenario: sectors are shown on tagged content
+    Given there is a document tagged to specialist sectors
+    When I view the document
+    Then I should see the specialist sub-sector and its parent sector

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -11,3 +11,18 @@ Then /^I can tag it to some specialist sectors$/ do
   save_document
   assert_specialist_sectors_were_saved
 end
+
+Given(/^there is a document tagged to specialist sectors$/) do
+  @document = create_document_tagged_to_a_specialist_sector
+  stub_content_api_tags(@document)
+end
+
+When(/^I view the document$/) do
+  visit public_document_path(@document)
+end
+
+Then(/^I should see the specialist sub\-sector and its parent sector$/) do
+  check_for_primary_sector_in_heading
+  check_for_primary_subsector_in_title(@document.title)
+  check_for_all_sectors_in_metadata
+end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -15,6 +15,15 @@ module SpecialistSectorHelper
     content_api_has_tags('specialist_sector', sector_tags)
   end
 
+  def stub_content_api_tags(document)
+    artefact_slug = RegisterableEdition.new(document).slug
+    tag_slugs = document.specialist_sectors.map(&:tag)
+
+    # These methods are located in gds_api_adapters
+    stubbed_artefact = artefact_for_slug_with_a_child_tags('specialist_sector', artefact_slug, tag_slugs)
+    content_api_has_an_artefact(artefact_slug, stubbed_artefact)
+  end
+
   def select_specialist_sectors_in_form
     select 'Oil and Gas: Wells', from: 'Primary specialist sector'
     select 'Oil and Gas: Offshore', from: 'Additional specialist sectors'
@@ -30,6 +39,27 @@ module SpecialistSectorHelper
 
   def save_document
     click_button 'Save'
+  end
+
+  def create_document_tagged_to_a_specialist_sector
+    create(:published_publication, :guidance,
+            primary_specialist_sector_tag: 'oil-and-gas/wells',
+            secondary_specialist_sector_tags: ['oil-and-gas/offshore', 'oil-and-gas/fields']
+    )
+  end
+
+  def check_for_primary_sector_in_heading
+    assert has_content?("Oil and gas - guidance")
+  end
+
+  def check_for_primary_subsector_in_title(document_title)
+    assert has_content?("Wells - #{document_title}")
+  end
+
+  def check_for_all_sectors_in_metadata
+    ['Oil and gas', 'Wells', 'Offshore', 'Fields'].each do |sector_name|
+      assert has_css?('.document-sectors', text: sector_name)
+    end
   end
 end
 

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -30,6 +30,10 @@ FactoryGirl.define do
       publication_type_id { PublicationType::PolicyPaper.id }
     end
 
+    trait(:guidance) do
+      publication_type_id { PublicationType::Guidance.id }
+    end
+
     trait(:with_command_paper) do
       attachments { [build(:file_attachment, unnumbered_command_paper: true)] }
       alternative_format_provider { build(:organisation, :with_alternative_format_contact_email) }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/66346196

Includes:
- Primary sector in document type header
- Primary subsector in document title header
- All (sub)sectors in metadata

**Edit**: The branch name for this is misleading because I am bad at git.  It should read something like `add-specialist-sectors-to-document-headers`.
