### PR TITLE
Ensure document filtering is always be paginated

### DIFF
--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -9,7 +9,7 @@ module Whitehall::DocumentFilter
     def initialize(params = {})
       @params          = params
       @per_page        = params[:per_page] || Whitehall::DocumentFilter::Filterer.number_of_documents_per_page
-      @page            = params[:page]
+      @page            = params[:page] || 1
       @from_date       = parse_date(params[:from_date])
       @to_date         = parse_date(params[:to_date])
       @keywords        = params[:keywords]

--- a/lib/whitehall/document_filter/mysql.rb
+++ b/lib/whitehall/document_filter/mysql.rb
@@ -123,9 +123,7 @@ INNER JOIN `world_locations` ON `world_locations`.`id` = `edition_world_location
     end
 
     def paginate!
-      if page.present?
-        @documents = @documents.page(page).per(per_page)
-      end
+      @documents = @documents.page(page).per(per_page)
     end
 
     def apply_sort_direction!

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -256,6 +256,14 @@ class AnnouncementsControllerTest < ActionController::TestCase
     refute_select_object english_article
   end
 
+  view_test 'index for non-english locale copes when a nil page is specified' do
+    english_article = create(:published_news_article)
+    spanish_article = create(:published_news_article, translated_into: [:fr])
+    get :index, locale: 'fr', page: nil
+
+    assert_response :success
+  end
+
   view_test 'index for non-english locales only allows filtering by world location' do
     get :index, locale: 'fr'
 

--- a/test/unit/whitehall/document_filter/mysql_test.rb
+++ b/test/unit/whitehall/document_filter/mysql_test.rb
@@ -113,6 +113,12 @@ module Whitehall::DocumentFilter
       create_filter(document_scope, {})
     end
 
+    test "defaults pagination to the first page if a page is not specified" do
+      filtered_scope = stub_document_scope('filtered scope')
+      document_scope.expects(:page).with(1).returns(filtered_scope)
+      filter = create_filter(document_scope, page: nil)
+    end
+
     test "strips leading and trailing spaces from keywords" do
       filtered_scope = stub_document_scope('filtered scope')
       document_scope.expects(:with_title_or_summary_containing).with("alpha", "beta").returns(filtered_scope)


### PR DESCRIPTION
`DocumentFilter::Mysql` should always paginate results just the same as `DocumentFilter::Rummager` does.

This was causing exceptions when a filter page request was made with the `:page` param as `nil`.

Tracker: https://www.pivotaltracker.com/story/show/67544590
