### PR TITLE
make contacts on org homepage sit side by side if they <= 2

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -645,6 +645,33 @@
       margin-left: 0;
     }
 
+    &.two-people-or-fewer {
+      margin: 0 (-$gutter-half);
+
+      #ministers,
+      #management {
+        float: left;
+        clear: none;
+        margin: 0;
+        padding: 0;
+        width: $half;
+
+        h1 {
+          margin: 0 $gutter-half $gutter-two-thirds;
+        }
+
+        ul {
+          margin: 0;
+          width: $full-width;
+          .person-excerpt {
+            float: left;
+            clear: none;
+            padding: 0;
+            width: $half;
+          }
+        }
+      }
+    }
   } // end #who
 
   .contact-wrapper, .corporate-information {

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -226,4 +226,14 @@ module OrganisationHelper
 
     content_tag(:p, contents.html_safe)
   end
+
+  def two_people_or_fewer
+    [
+      @ministers,
+      @important_board_members + @board_members,
+      @traffic_commissioners,
+      @special_representatives,
+      @chief_professional_officers
+    ].any? {|group| group.count <= 2}
+  end
 end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -111,7 +111,7 @@
   <% if people_to_show? %>
     <div class="block-9">
       <div class="inner-block" id="people">
-        <section id="who">
+        <section id="who" <% if two_people_or_fewer? %>class="two-people-or-fewer"<% end %>>
           <% if @ministers.any? %>
             <section id="ministers">
               <h1 class="label"><%= t('organisation.headings.our_ministers') %></h1>


### PR DESCRIPTION
DO NOT MERGE.

for an example of what this is fixing see -
https://www.gov.uk/government/organisations/uk-visas-and-immigration

Assigning to @evilstreak as have been discussing this with him
