### PR TITLE
Organisation API: Add logo formatted name and brand color class

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -9,6 +9,8 @@ class Api::OrganisationPresenter < Api::BasePresenter
       details: {
         slug: model.slug,
         abbreviation: model.acronym,
+        logo_formatted_name: model.logo_formatted_name,
+        organisation_brand_colour_class_name: model.organisation_brand_colour.try(:class_name),
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
       },


### PR DESCRIPTION
If another application wants to display the logo we need to have both the class and the logo formatted name.
