### PR TITLE
Include document_collections in the main nav so publications is active

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -232,7 +232,7 @@ module ApplicationHelper
       announcements_path
     when "topics", "classifications", "topical_events", "about_pages"
       topics_path
-    when "publications", "statistical_data_sets"
+    when "publications", "statistical_data_sets", "document_collections"
       if parameters[:publication_filter_option] == 'consultations'
         publications_path(publication_filter_option: 'consultations')
       elsif parameters[:publication_filter_option] == 'statistics' || parameters[:controller] == 'statistical_data_sets'


### PR DESCRIPTION
At the moment nothing in the nav is in the active state when viewing a document collection.

A collection can contain many document types, so perhaps this is the expected behaviour but it looks odd. I have defaulted to use the publications type to be active as most collections contain publications.
## Before

![screen shot 2014-03-17 at 17 19 27](https://f.cloud.github.com/assets/215/2438977/5a1aaf00-adf8-11e3-9085-03ff2d1c5005.png)
## After

![screen shot 2014-03-17 at 17 19 31](https://f.cloud.github.com/assets/215/2438978/5f40855e-adf8-11e3-9df5-bd03ae57d7c5.png)
