### PR TITLE
Fix nav to make statistics highlight the correct nav item

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -235,7 +235,9 @@ module ApplicationHelper
     when "publications", "statistical_data_sets"
       if parameters[:publication_filter_option] == 'consultations'
         publications_path(publication_filter_option: 'consultations')
-      elsif parameters[:publication_filter_option] == 'statistics' || parameters[:controller] == 'statistical_data_sets'
+      elsif parameters[:publication_filter_option] == 'statistics' || 
+            parameters[:controller] == 'statistical_data_sets' ||
+            @document && @document.try(:statistics?)
         publications_path(publication_filter_option: 'statistics')
       else
         publications_path


### PR DESCRIPTION
Some statistics are actually publications so we have to extend the check to include documents of statistic sub types which are actually publications.
## Before

![screen shot 2014-03-17 at 17 41 28](https://f.cloud.github.com/assets/215/2439323/78fc3eea-adfb-11e3-9fd1-290d78057435.png)
## After

![screen shot 2014-03-17 at 17 41 49](https://f.cloud.github.com/assets/215/2439329/8079e8ac-adfb-11e3-932c-55d8160588cc.png)
