### PR TITLE
Add additional exclusions to fake_source_url

### DIFF
--- a/lib/whitehall/exporters/mappings.rb
+++ b/lib/whitehall/exporters/mappings.rb
@@ -54,7 +54,7 @@ private
   end
 
   def fake_source_url?(source)
-    source.url =~ /(fabricatedurl|fabricatedURL|placeholderunique|github)/
+    source.url =~ /(fabricatedurl|placeholderunique|github)/i
   end
 
   def url_maker


### PR DESCRIPTION
- fabricatedURL was used in alternate to fabricatedurl when importing GO-Science's content
- github was used as a temporary host for some scraped PDFs
