### PR TITLE
Show document summaries on detailed-guides

### DIFF
--- a/app/assets/stylesheets/frontend/views/_detailed_guides.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides.scss
@@ -72,6 +72,18 @@
     }
   }
 
+  .summary {
+    padding-bottom: $gutter-half;
+
+    @include media(tablet){
+      padding-top: $gutter-half;
+      padding-bottom: $gutter*1.5;
+    }
+    p {
+      @include core-24;
+    }
+  }
+
   .contextual-info {
     padding-top: $gutter-one-sixth;
 

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -30,6 +30,12 @@
 
   <%= render('documents/archive_notice', document: @document, type: 'guidance') if @document.archived? %>
 
+  <div class="summary-block">
+    <div class="inner-block">
+      <%= render partial: "document_summary", locals: { document: @document } %>
+    </div>
+  </div>
+
   <div class="block-2">
     <div class="inner-block">
       <%= render partial: "document_contextual", locals: {edition: @document} %>


### PR DESCRIPTION
This was accidentally removed in https://github.com/alphagov/whitehall/pull/1343
