### PR TITLE
Organisation API: Include the logo type class in the response

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -11,6 +11,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
         abbreviation: model.acronym,
         logo_formatted_name: model.logo_formatted_name,
         organisation_brand_colour_class_name: model.organisation_brand_colour.try(:class_name),
+        organisation_logo_type_class_name: model.organisation_logo_type.try(:class_name),
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
       },


### PR DESCRIPTION
So we can tell if the logo should use the single identity crest or not
