### PR TITLE
Move edition state filtering out of controller and into the filter

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -287,21 +287,15 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def session_filters
-    sanitized_filters(session[:document_filters] || {})
+    session[:document_filters] || {}
   end
 
   def params_filters
-    sanitized_filters(params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date))
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date)
   end
 
   def params_filters_with_default_state
     params_filters.reverse_merge(state: 'active')
-  end
-
-  def sanitized_filters(filters)
-    valid_states = %w(active imported draft submitted rejected published scheduled force_published archived)
-    filters.delete(:state) unless filters[:state].nil? || valid_states.include?(filters[:state].to_s)
-    filters
   end
 
   def filter

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -88,6 +88,10 @@ module Admin
       end
     end
 
+    def valid_scopes
+      %w(active imported draft submitted rejected published scheduled force_published archived)
+    end
+
     private
 
     def unpaginated_editions
@@ -96,7 +100,7 @@ module Admin
       editions = @source
       editions = editions.by_type(type) if type
       editions = editions.by_subtype(type, subtype) if subtype
-      editions = editions.send(state) if state
+      editions = editions.public_send(state) if state
       editions = editions.authored_by(author) if author
       editions = editions.in_organisation(organisation) if organisation
       editions = editions.with_title_containing(title) if title
@@ -108,7 +112,7 @@ module Admin
     end
 
     def state
-      options[:state].presence
+      options[:state] if valid_scopes.include?(options[:state])
     end
 
     def title

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -23,13 +23,6 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, state: :draft, author: ""
   end
 
-  test 'should strip out any invalid states passed as parameters and replace them with "active"' do
-    stub_filter = stub_edition_filter
-    Admin::EditionFilter.expects(:new).with(anything, anything, has_entry("state" => "active")).returns(stub_filter)
-
-    get :index, state: :haxxor_method, type: :policy
-  end
-
   test 'should add state param set to "active" if none is supplied' do
     stub_filter = stub_edition_filter
     Admin::EditionFilter.expects(:new).with(anything, anything, has_entry("state" => "active")).returns(stub_filter)

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -5,6 +5,18 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     @current_user = build(:gds_editor)
   end
 
+  test "knows which states/scopes are valid for filtering" do
+    expected_scopes = %w(imported draft submitted rejected scheduled published archived active force_published)
+    assert_same_elements expected_scopes, Admin::EditionFilter.new(Edition, @current_user).valid_scopes
+  end
+
+  test "ignores invalid state scopes" do
+    policy = create(:draft_policy)
+
+    assert_equal [policy], Admin::EditionFilter.new(Edition, @current_user, state: 'delete_all').editions
+    assert_equal [policy], Edition.all
+  end
+
   test "should filter by edition type" do
     policy = create(:policy)
     another_edition = create(:publication)


### PR DESCRIPTION
This is a better place for it as it slims down the controller and also means the sanitisation is performed wherever `Admin::EditionFilter` is used rather than just in `Admin::EditionsController`.
