### PR TITLE
Remove validation of User email format.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,6 @@ class User < ActiveRecord::Base
   serialize :permissions, Array
 
   validates :name, presence: true
-  validates :email, email_format: { allow_blank: true }
 
   module Permissions
     SIGNIN = 'signin'

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -6,16 +6,6 @@ class UserTest < ActiveSupport::TestCase
     refute user.valid?
   end
 
-  test 'should be invalid with an invalid email address' do
-    user = build(:user, email: "invalid-email-address")
-    refute user.valid?
-  end
-
-  test 'should be valid without an email address' do
-    user = build(:user, email: nil)
-    assert user.valid?
-  end
-
   test 'should be a departmental editor if has whitehall Editor role' do
     user = build(:user, permissions: [User::Permissions::DEPARTMENTAL_EDITOR])
     assert user.departmental_editor?


### PR DESCRIPTION
These come from signon which has its own email validation.  This is only
going to cause issues when the validation regexes don't match.
