### PR TITLE
Add task to export Organisation analytics codes

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -140,4 +140,29 @@ namespace :export do
     end
   end
 
+  desc "Exports mappings between organisations and analytics keys"
+  task :organisation_analytics => :environment do
+    puts 'Mappings orgs to analytics keys...'
+    path = 'tmp/organisation-analytics.csv'
+    puts "Generating CSV in #{path}"
+
+    CSV.open(path, 'w') do |csv|
+      csv << [
+        'Name',
+        'Acronym',
+        'Slug',
+        'Analytics key'
+      ]
+
+      Organisation.all.each do |org|
+        csv << [
+          org.name,
+          org.acronym,
+          org.slug,
+          org.analytics_identifier
+        ]
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Performance Platform have asked for a way to map analytics data with specific organisations. This Rake task provides a CSV file with organisation to analytics code mappings that they can use.
