### PR TITLE
Hard coded links in header for UKVI

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -334,6 +334,66 @@ class Organisation < ActiveRecord::Base
     name
   end
 
+  def alternate_style_top_tasks
+    case slug
+    when 'driver-and-vehicle-licensing-agency'
+      {
+        services_in: {
+          link: 'https://www.gov.uk/browse/driving',
+          text: 'Driving and transport',
+        },
+        prominent: [
+          {
+            link: 'https://www.gov.uk/tax-disc',
+            text: 'Get a tax disc for your vehicle',
+            description: 'You will need your numberplate, a credit/debit card and either your tax disc renewal reminder or your vehicle logbook.'
+          },
+          {
+            link: 'https://www.gov.uk/vehicle-registration-certificate-v5c-log-book',
+            text: 'Get a V5C (logbook)',
+            description: 'Apply by phone or post to get a replacement V5C vehicle registration certificate (log book). There is a £25 fee.'
+          }
+        ],
+        top_tasks: [
+          {
+            link: 'https://www.gov.uk/register-sorn-statutory-off-road-notification',
+            text: 'Make a SORN'
+          },
+          {
+            link: 'https://www.gov.uk/change-address-driving-licence',
+            text: 'Change the address on your driving licence'
+          },
+          {
+            link: 'https://www.gov.uk/get-vehicle-information-from-dvla',
+            text: 'Get vehicle information from DVLA'
+          }
+        ]
+      }
+    when 'uk-visas-and-immigration'
+      {
+        prominent: [
+          {
+            link: 'https://www.gov.uk/visas-immigration',
+            text: 'Visas, settlement and asylum',
+            description: 'Information on different UK visas, how to settle in the UK and claiming asylum.'
+          },
+          {
+            link: 'https://www.gov.uk/browse/visas-immigration/eu-eea-commonwealth',
+            text: 'European nationals',
+            description: 'Living and working in the UK for EU and EEA nationals, their partners and family.'
+          },
+          {
+            link: 'https://www.gov.uk/becoming-a-british-citizen',
+            text: 'British citizenship ',
+            description: 'How to become a British citizen and types of UK nationality.'
+          }
+        ]
+      }
+    else
+      {}  
+    end
+  end
+
   private
 
   def sub_organisations_must_have_a_parent

--- a/app/views/organisations/_alternate_style_top_tasks.html.erb
+++ b/app/views/organisations/_alternate_style_top_tasks.html.erb
@@ -1,30 +1,41 @@
-<aside class="heading-extra">
-  <p class="all-services">View all services in:</p>
-  <ul class="top-tasks">
-    <li><a href="https://www.gov.uk/browse/driving">Driving and transport</a></li>
-  </ul>
-</aside>
+<% links = organisation.alternate_style_top_tasks %>
 
-<section class="prominent-top-tasks">
-  <article>
-    <div class="content">
-      <h2><a href="https://www.gov.uk/tax-disc">Get a tax disc for your vehicle</a></h2>
-      <p>You will need your numberplate, a credit/debit card and either your tax disc renewal reminder or your vehicle logbook.</p>
-    </div>
-  </article>
-  <article>
-    <div class="content">
-      <h2><a href="https://www.gov.uk/vehicle-registration-certificate-v5c-log-book">Get a V5C (logbook)</a></h2>
-      <p>Apply by phone or post to get a replacement V5C vehicle registration certificate (log book). There is a &pound;25 fee.</p>
-    </div>
-  </article>
-  <article>
-    <div class="content">
-      <ul class="top-tasks">
-        <li><a href="https://www.gov.uk/register-sorn-statutory-off-road-notification">Make a SORN </a></li>
-        <li><a href="https://www.gov.uk/change-address-driving-licence">Change the address on your driving licence </a></li>
-        <li><a href="https://www.gov.uk/get-vehicle-information-from-dvla">Get vehicle information from DVLA </a></li>
-      </ul>
-    </div>
-  </article>
-</section>
+<% if links[:services_in] %>
+  <aside class="heading-extra">
+    <p class="all-services">View all services in:</p>
+    <ul class="top-tasks">
+      <li>
+        <%= link_to links[:services_in][:text], links[:services_in][:link] %>
+      </li>
+    </ul>
+  </aside>
+<% end -%>
+
+<% if links[:prominent] || links[:top_tasks] %>
+  <section class="prominent-top-tasks">
+    <% links[:prominent].each do |prominent_link| %>
+      <article>
+        <div class="content">
+          <h2>
+            <%= link_to prominent_link[:text], prominent_link[:link] %>
+          </h2>
+          <p><%= prominent_link[:description] %></p>
+        </div>
+      </article>
+    <% end -%>
+
+    <% if links[:top_tasks] %> 
+      <article>
+        <div class="content">
+          <ul class="top-tasks">
+            <% links[:top_tasks].each do |top_task| %>
+              <li>
+                <%= link_to top_task[:text], top_task[:link] %> 
+              </li>
+            <% end -%>
+          </ul>
+        </div>
+      </article>
+    <% end -%>
+  </section>
+<% end -%>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -5,7 +5,6 @@
   sub_organisation = organisation.organisation_type.sub_organisation?
   logo_size = 'medium' if sub_organisation
   languages_available ||= false
-  alternate_style_top_tasks ||= false
 %>
 
 <header class="page-header">
@@ -27,8 +26,8 @@
     <h1><%= organisation_logo(organisation, linked: link_to_organisation, size: logo_size) %></h1>
   <% end %>
 
-  <% if alternate_style_top_tasks %>
-    <%= render 'alternate_style_top_tasks' %>
+  <% if organisation.alternate_style_top_tasks != {} %>
+    <%= render partial: 'alternate_style_top_tasks', locals: {organisation: organisation} %>
   <% else %>
     <%= content_tag_if_not_empty :aside, class: "heading-extra" do %>
       <% if languages_available %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -7,8 +7,7 @@
 
   <div class="block-1 headings-block">
     <div class="inner-block">
-      <%= render 'header', organisation: @organisation, show_top_tasks: true, languages_available: true,
-                           alternate_style_top_tasks: (@organisation.slug == 'driver-and-vehicle-licensing-agency') %>
+      <%= render 'header', organisation: @organisation, show_top_tasks: true, languages_available: true %>
     </div>
   </div>
 


### PR DESCRIPTION
Relates to https://www.pivotaltracker.com/story/show/67911210. This is a temporary solution and should be refactored if more orgs request this feature. Ideally we should move it out to an actual attr instead of having a big messy hash in the org model. Currently a WIP as my VM is broken and this needs double checked that the UKVI page works before merging.
