### PR TITLE
add hide transition visualisation and hide department live

### DIFF
--- a/app/assets/javascripts/application/filter-list-items.js
+++ b/app/assets/javascripts/application/filter-list-items.js
@@ -31,6 +31,7 @@
       $(document).trigger('govuk.hideDepartmentChildren.hideAll');
       filter.$filterItems.hide();
       $(itemsToShow).show();
+      filter.hideTransitionStateVisualisations(search);
       filter.hideEmptyBlocks(itemsToShow);
       filter.track(search);
     },
@@ -94,6 +95,15 @@
       }
 
       return filter._terms
+    },
+    hideTransitionStateVisualisations: function(search){
+      if(search === ""){
+        // show visualisations
+        $(".transition-state-visualisation").show();
+      } else {
+        // hide visualisations
+        $(".transition-state-visualisation").hide();
+      }
     }
   };
 

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -27,7 +27,7 @@
                                   header_text:        'Ministerial departments',
                                   include_works_with: true,
                                   list_item_partial:  'index_item_with_branding',
-                                  show_govuk_status:  true  %>
+                                  show_govuk_status:  false  %>
 
       <%= render 'index_section', organisations:      @organisations.non_ministerial_departments,
                                   header_text:        'Non ministerial departments',


### PR DESCRIPTION
removed progress bar for departments when a user searches 
removed department status as all departments are live
part of https://www.pivotaltracker.com/story/show/67464500 story
