### PR TITLE
Only manage Lead Organisations in speed tagging

### DIFF
--- a/app/models/edition/organisations.rb
+++ b/app/models/edition/organisations.rb
@@ -34,6 +34,10 @@ module Edition::Organisations
     organisations.where(edition_organisations: { lead: true }).reorder('edition_organisations.lead_ordering')
   end
 
+  def lead_organisation_ids
+    lead_organisations.pluck(:id)
+  end
+
   def sorted_organisations
     organisations.alphabetical
   end

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -31,8 +31,8 @@
 
     <%= form.text_area :body, class: "previewable" %>
 
-    <%= form.label :organisation_ids, 'Organisations:' %>
-    <%= form.select :organisation_ids, options_from_collection_for_select(Organisation.scoped.includes(:translations), 'id', 'name', @edition.organisation_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose organisations which produced this document..." } %>
+    <%= form.label :lead_organisation_ids, 'Lead Organisations:' %>
+    <%= form.select :lead_organisation_ids, options_from_collection_for_select(Organisation.scoped.includes(:translations), 'id', 'name', @edition.lead_organisation_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose organisations which produced this document..." } %>
 
     <%= render partial: 'required_fields_for_imported_editions', locals: { form: form, edition: form.object } %>
 


### PR DESCRIPTION
there was an issue with saving organisations from the
speed tagging interface. modifying that field was giving
an error - "Lead organisations at least one required".

this was caused because the assignment was not setting
the `lead` attribute on edition_assignments to true. later
we decided to only allow modification of lead orgs from
speed tagging interface, so here it is. 
