### PR TITLE
Removing status and url for closed organisations

### DIFF
--- a/app/views/organisations/not_live.html.erb
+++ b/app/views/organisations/not_live.html.erb
@@ -23,9 +23,10 @@
     <div class="inner-block">
       <div class="description">
         <%= govspeak_to_html @organisation.description %>
+        <% unless @organisation.closed? %>
         <p class="parent_organisations"><%= organisation_display_name_and_parental_relationship(@organisation) %></p>
-
         <p><%= link_to @organisation.url, @organisation.url, class: 'url-link' %></p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -223,6 +223,17 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_template 'not_live'
   end
 
+  view_test "showing a closed organisation does not render the parent_organisations or the url" do
+    organisation = create(:organisation, govuk_status: 'closed')
+
+    get :show, id: organisation
+
+    assert_template 'not_live'
+    refute_select ".parent_organisations"
+    refute_select ".url_link"
+  end
+
+
   view_test "doesn't show a thumbnail if the organisation has no url" do
     organisation = create(:organisation, govuk_status: 'exempt', url: '')
 


### PR DESCRIPTION
Closed organisations display a status and url which are of no value.

![closed_org_screenshot_250314](https://f.cloud.github.com/assets/1897393/2509534/fa2f9742-b3f4-11e3-8295-16e579a0d265.jpg)
