### PR TITLE
GovDelivery handles speeches with person override

### DIFF
--- a/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
+++ b/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
@@ -148,7 +148,7 @@ module Whitehall
           appointments += edition.role_appointments
         end
 
-        if edition.respond_to?(:role_appointment)
+        if edition.respond_to?(:role_appointment) && edition.role_appointment.present?
           appointments << edition.role_appointment
         end
 

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -327,6 +327,12 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     )
   end
 
+  test '#subscription_urls handles speeches that have a person override instead of a role appointment' do
+    @edition = create(:speech, role_appointment: nil, person_override: 'The Queen')
+
+    assert_subscription_urls_for_edition_include('announcements.atom')
+  end
+
   test '#subscription_urls includes relevant_to_local_government variations' do
     role_appointment = create(:ministerial_role_appointment)
     role = role_appointment.role


### PR DESCRIPTION
Prevents SubscriptionUrlGenerator blowing up when handed a speech that does not have a role appointment - a current source of exception notifications.

Tracker: https://www.pivotaltracker.com/story/show/68177008
