### PR TITLE
Use the updated URL for the style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Frontend code should follow the [css](https://github.com/alphagov/whitehall/tree
 
 - Titles and navigation links should only capitalise first letter, not every word.
 - URLs should use hyphens, not underscores.
-- Follow the [style guide](https://www.gov.uk/designprinciples/styleguide).
+- Follow the [style guide](https://www.gov.uk/design-principles/style-guide).
 
 ## Code ##
 

--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -7,7 +7,7 @@ module Admin::SidebarHelper
         tab_content << render("admin/editions/words_to_avoid_guidance")
         tab_content << content_tag(:h3, 'Style', class: 'style-title')
         tab_content << content_tag(:p) do
-          raw %Q<For style, see the #{link_to("style guide", "https://www.gov.uk/designprinciples/styleguide")}>
+          raw %Q<For style, see the #{link_to("style guide", "https://www.gov.uk/design-principles/style-guide")}>
         end
         raw tab_content.join("\n")
       end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,7 +7,7 @@
   <div class="span4">
     <h3>Writing and publishing</h3>
     <ul>
-      <li><a href="https://www.gov.uk/designprinciples/styleguide">GOV.UK style guide</a></li>
+      <li><a href="https://www.gov.uk/design-principles/style-guide">GOV.UK style guide</a></li>
       <li><a href="http://alphagov.github.io/inside-government-admin-guide/">How to publish content on GOV.UK</a></li>
     </ul>
   </div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -38,7 +38,7 @@
                                     govspeak_link_errors: force_publisher.govspeak_link_errors %>
         <%= render "words_to_avoid_guidance" %>
         <h3 class="style-title">Style</h3>
-        <p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a></p>
+        <p>For style, see the <a href="https://www.gov.uk/design-principles/style-guide">style guide</a></p>
       <% end %>
 
       <%= tabs.pane class: "audit-trail", id: "notes" do %>


### PR DESCRIPTION
We have redirects in place so haven't broken the web, but we can link to the
canonical URL.
