### PR TITLE
Keep non-latin characters out of slugs

### DIFF
--- a/app/models/slugging.rb
+++ b/app/models/slugging.rb
@@ -4,6 +4,6 @@ module Slugging
   end
 
   def normalize_friendly_id(input)
-    input.to_s.to_slug.truncate(150).normalize.to_s
+    super input.to_s.to_slug.truncate(150).normalize.to_s
   end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -362,6 +362,11 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 'bobs-bike', edition.document.slug
   end
 
+  test "should not include ellipsis in the slug" do
+    edition = create(:edition, title: "Something… going on")
+    assert_equal 'something-going-on', edition.document.slug
+  end
+
   test "is filterable by edition type" do
     policy = create(:policy)
     publication = create(:publication)


### PR DESCRIPTION
The babosa gem has a slightly different idea of what a normalised slug can and cannot contain and lets ellipsis through. Calling super allows friendly_id to do it's thing and ensures the slug only has valid latin
characters in it.

Tracker: https://www.pivotaltracker.com/story/show/68181832
