### PR TITLE
Show alert only if there are words to avoid

### DIFF
--- a/app/assets/javascripts/admin/modules/words_to_avoid_highlighter.js
+++ b/app/assets/javascripts/admin/modules/words_to_avoid_highlighter.js
@@ -90,7 +90,7 @@
         $(textarea).highlightTextarea('highlight');
       });
       $($textareaHighlightSelector).show();
-      $wordsToAvoidAlert.show();
+      updateHighlightedWordsCount();
     }
     $(document).bind("govuk.wordsToAvoidHighlighter.enable", enable);
   }


### PR DESCRIPTION
we showed words to avoid alert on initial page load or when switching back from markdown preview even when there were 0 words to avoid. fixed that.
