### PR TITLE
Ensure edition is also in published state before notifying

### DIFF
--- a/lib/whitehall/gov_uk_delivery/notifier.rb
+++ b/lib/whitehall/gov_uk_delivery/notifier.rb
@@ -28,7 +28,11 @@ module Whitehall
     protected
 
       def should_notify_govuk_delivery?
-        edition_type_is_deliverable? && major_change? && published_today? && available_in_english?
+        edition.published? &&
+        edition_type_is_deliverable? &&
+        major_change? &&
+        published_today? &&
+        available_in_english?
       end
 
       def edition_type_is_deliverable?

--- a/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
@@ -124,4 +124,14 @@ class Whitehall::GovUkDelivery::NotifierTest < ActiveSupport::TestCase
     Whitehall::GovUkDelivery::Worker.expects(:notify!).with(policy, Time.zone.parse('2010-12-31 12:13:14')).once
     notifier_for(policy).notify_govuk_delivery
   end
+
+  test "#edition_published! does nothing if the edition is not published" do
+    policy = create(:draft_policy, first_published_at: 1.hour.ago)
+    notifier = notifier_for(policy)
+
+    notifier.expects(:notify_email_curation_queue).never
+    notifier.expects(:notify_govuk_delivery).never
+
+    notifier.edition_published!
+  end
 end


### PR DESCRIPTION
GovDelivery notifications blow up with documents that have been unpublished.

https://www.pivotaltracker.com/story/show/67543526
