### PR TITLE
Add missing valid parameter key

### DIFF
--- a/lib/whitehall/document_filter/cleaned_params.rb
+++ b/lib/whitehall/document_filter/cleaned_params.rb
@@ -15,7 +15,8 @@ module Whitehall::DocumentFilter
                                          publication_type
                                          announcement_type
                                          publication_filter_option
-                                         announcement_filter_option)
+                                         announcement_filter_option
+                                         announcement_type_option)
 
 
     def initialize(unclean_params)

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -222,6 +222,19 @@ class AnnouncementsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "index generates an atom feed with the legacy announcement_type_option param set" do
+    without_delay! do
+      news = create(:published_news_story, first_published_at: 1.week.ago)
+      speech = create(:published_speech, delivered_on: 3.days.ago)
+
+      get :index, format: :atom, announcement_type_option: 'news-stories'
+
+      assert_select_atom_feed do
+        assert_select_atom_entries([news])
+      end
+    end
+  end
+
   view_test 'index atom feed should return a valid feed if there are no matching documents' do
     get :index, format: :atom
 


### PR DESCRIPTION
`Whitehall::DocumentFilter::Filterer` handles the legacy parameter `announcement_type_option` so `CleanedParams` should not scrub it.

Background: there are still legacy feeds that use this parameter.
