### PR TITLE
Turn off notification on unpermitted params

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,6 @@ class DocumentsController < PublicFacingController
   before_filter :redirect_to_canonical_url
   before_filter :find_document, only: [:show]
   before_filter :set_slimmer_headers_for_document, only: [:show]
-  before_filter :notify_if_unpermitted_filter_params, only: :index
 
 private
 
@@ -16,13 +15,6 @@ private
 
   def cleaned_document_filter_params
     Whitehall::DocumentFilter::CleanedParams.new(params.except(:format, :commit, :_))
-  end
-
-  def notify_if_unpermitted_filter_params
-    if cleaned_document_filter_params.unpermitted_keys.any?
-      ex = ActionController::UnpermittedParameters.new(cleaned_document_filter_params.unpermitted_keys)
-      notify_airbrake(ex)
-    end
   end
 
   def preview?

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -686,24 +686,6 @@ class PublicationsControllerTest < ActionController::TestCase
     refute_select ".translations"
   end
 
-  test "#index notifies airbrake when unpermitted filter parameters are received" do
-    begin
-      @old_config_value = ActionController::Parameters.action_on_unpermitted_parameters
-      ActionController::Parameters.action_on_unpermitted_parameters = false
-
-      @controller.expects(:notify_airbrake).with do |ex|
-        ex.is_a?(ActionController::UnpermittedParameters) && ex.params == ['hax']
-      end
-
-      get :index, keywords: 'statistics', hax: 'boo'
-
-      assert_response :success
-      assert_template :index
-    ensure
-      ActionController::Parameters.action_on_unpermitted_parameters = @old_config_value
-    end
-  end
-
   private
 
   def publication_with_attachment(params = {})


### PR DESCRIPTION
We've had a flood of notifications, mainly for bots sending strange requests. [This commit](https://github.com/alphagov/whitehall/commit/e352de7bbcea1febf66c7b6eb492680e13aed333) adds back the legacy announcement type param so it's probably safe to turn this off now.
