### PR TITLE
Disable words to avoid highlighting in IE <= 8

### DIFF
--- a/app/views/admin/editions/_words_to_avoid_guidance.html.erb
+++ b/app/views/admin/editions/_words_to_avoid_guidance.html.erb
@@ -54,9 +54,9 @@
   </ul>
 </div>
 
-<% if ENABLE_WORDS_TO_AVOID_HIGHLIGHTING %>
+<!--[if gte IE 9]>
   <% initialise_script "GOVUK.WordsToAvoidHighlighter",
       el: "form textarea",
       wordsToAvoidAlert: "#js-words-to-avoid-alert",
       wordsToAvoidCounter: "#js-words-to-avoid-count" %>
-<% end %>
+<![endif]-->

--- a/config/initializers/enable_words_to_avoid_highlighting.rb
+++ b/config/initializers/enable_words_to_avoid_highlighting.rb
@@ -1,2 +1,0 @@
-# this feature flag gets overridden on deploy
-ENABLE_WORDS_TO_AVOID_HIGHLIGHTING = ! Rails.env.production?


### PR DESCRIPTION
words to avoid highlighting works perfectly in IE9+
and all other modern browsers. also getting rid of
feature flag.

also merge this related PR for cleaning up the
feature flag from deployment - https://github.gds/gds/alphagov-deployment/pull/521
