### PR TITLE
Bump to latest gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '10.2.0'
+gem 'gds-api-adapters', '10.3.0'
 gem 'whenever', '0.9.0', require: false
 gem 'mini_magick'
 gem 'shared_mustache', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     friendly_id (4.0.9)
-    gds-api-adapters (10.2.0)
+    gds-api-adapters (10.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -393,7 +393,7 @@ DEPENDENCIES
   equivalent-xml (= 0.3.0)
   factory_girl
   friendly_id (= 4.0.9)
-  gds-api-adapters (= 10.2.0)
+  gds-api-adapters (= 10.3.0)
   gds-sso (= 9.2.0)
   globalize3!
   govspeak (~> 1.2.4)


### PR DESCRIPTION
The latest version handles "Gone" responses, which will resolve these
exceptions: https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/533302940da115938403ecec
