### PR TITLE
Don't show sector metadata if there is none

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -211,11 +211,10 @@ Details of document required:
         classes: ['document-topical-events']
       }
     end
-    if sector_tag_finder
-      sectors_and_subsectors = sector_tag_finder.sectors_and_subsectors
+    if sector_tag_finder && (all_sectors = sector_tag_finder.sectors_and_subsectors).any?
       metadata << {
-        title: t('document.headings.sectors', count: sectors_and_subsectors.length),
-        data: array_of_links_to_sectors(sectors_and_subsectors),
+        title: t('document.headings.sectors', count: all_sectors.length),
+        data: array_of_links_to_sectors(all_sectors),
         classes: ['document-sectors']
       }
     end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -68,6 +68,18 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_select ".change-notes .published-at", text: "31 May 1916"
   end
 
+  view_test "#show should not render empty sector metadata" do
+    publication = create(:published_publication,
+      first_published_at: Date.parse("1916-05-31"),
+      publication_type_id: PublicationType::Form.id
+    )
+
+    get :show, id: publication.document
+
+    refute_select ".document-sectors"
+  end
+
+
   def assert_featured(doc)
     assert_select "#{record_css_selector(doc)}.featured"
   end


### PR DESCRIPTION
The `sector_tag_finder` always returns true because it is an object that
exists. We need to also test that there are sectors which want
displaying before adding the data to the metadata block.

https://www.pivotaltracker.com/story/show/68445322
