### PR TITLE
/consultations retains query params when redirecting

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -1,6 +1,7 @@
 class ConsultationsController < DocumentsController
   def index
-    redirect_to publications_path(publication_filter_option: 'consultations')
+    filter_params = params.except(:controller, :action, :format, :_)
+    redirect_to publications_path(filter_params.merge(publication_filter_option: 'consultations'))
   end
 
   def show

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -11,9 +11,9 @@ class ConsultationsControllerTest < ActionController::TestCase
   should_set_the_article_id_for_the_edition_for :consultation
   should_show_share_links_for :consultation
 
-  test 'index redirects to the publications index filtering consultations' do
-    get :index
-    assert_redirected_to publications_path(publication_filter_option: Whitehall::PublicationFilterOption::Consultation.slug)
+  test 'index redirects to the publications index filtering consultations, retaining any other filter params' do
+    get :index, topics: ["a-topic-slug"], departments: ['an-org-slug']
+    assert_redirected_to publications_path(publication_filter_option: Whitehall::PublicationFilterOption::Consultation.slug, topics: ["a-topic-slug"], departments: ['an-org-slug'])
   end
 
   test 'show displays published consultations' do


### PR DESCRIPTION
Zendesk: https://govuk.zendesk.com/agent/#/tickets/612037

The consultations controller index action redirects onto the publications controller setting publication_filter_option=consultations.  There are links which use the consultations_path helper adding  in pre-set filter values.  These were getting dropped by the redirect.

For an example, see the "See all consultations" link on a topic page (https://www.gov.uk/government/topics/public-health).  The link takes the user to the publications index showing all consultations instead of only consultations related to that topic.
