### PR TITLE
Add missing opt_value to ga event tracking

### DIFF
--- a/app/assets/javascripts/application/filter-list-items.js
+++ b/app/assets/javascripts/application/filter-list-items.js
@@ -40,7 +40,7 @@
       filter._trackTimeout = root.setTimeout(function(){
         var pagePath = window.location.pathname.split('/').pop();
         if(pagePath){
-          window._gaq && _gaq.push(['_trackEvent', 'edd_inside_gov', search, pagePath, true]);
+          window._gaq && _gaq.push(['_trackEvent', 'edd_inside_gov', search, pagePath, 0, true]);
         }
       }, 1000);
     },


### PR DESCRIPTION
The 4th attribute in track event is opt_value which has to be
numeric, the 5th is the opt_noninteraction. When adding the
opt_noninteraction the opt_value was skipped so the wrong variable type
was being sent. ga ignores incorrect calls so the tracking in its
current state doesn't do anything.
