### PR TITLE
Don't use rails autoload

### DIFF
--- a/lib/address_formatter.rb
+++ b/lib/address_formatter.rb
@@ -1,5 +1,3 @@
-module AddressFormatter
-  autoload :Text, 'address_formatter/text'
-  autoload :HCard, 'address_formatter/h_card'
-  autoload :Json, 'address_formatter/json'
-end
+require 'address_formatter/text'
+require 'address_formatter/h_card'
+require 'address_formatter/json'


### PR DESCRIPTION
Using rails autoload meant that the address format configuration was being lost in development mode
because the class is reloaded on each request but the initialiser that sets the address formats is not.
