### PR TITLE
Fix reordering of empty document groups.

### DIFF
--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -45,7 +45,7 @@
         </hgroup>
         <div class="js-group-body">
           <% if group.latest_editions.empty? %>
-            <p class="alert alert-info">
+            <p class="alert alert-info js-document-group" data-group-id="<%= group.id %>">
               This group doesn't have any documents in it yet &ndash; add some
               by searching for documents (above), or moving them here from another group.
             </p>


### PR DESCRIPTION
Ensure empty groups display with the class and ID used by the JS to create the params for Ajax reordering.

https://www.pivotaltracker.com/story/show/68815430
