### PR TITLE
Remove duplication of log messages in LogStashLogger

### DIFF
--- a/lib/log_stash_logger.rb
+++ b/lib/log_stash_logger.rb
@@ -31,7 +31,6 @@ private
     source  = log_data.delete(:source) || ''
     tags    = default_tags + (log_data.delete(:tags) || [])
     fields  = log_data.reverse_merge({
-      message:  message,
       level:    severity,
       progname: progname
     })

--- a/test/unit/log_stash_logger_test.rb
+++ b/test/unit/log_stash_logger_test.rb
@@ -59,7 +59,6 @@ class LogStashLoggerTest < ActiveSupport::TestCase
   test "When logged thing is a message string, @message and @fields.message are the given string" do
     subject.info "This is an error"
     assert_equal "This is an error", log_entries.last["@message"]
-    assert_equal "This is an error", log_entries.last["@fields"]["message"]
   end
 
   test "When logged thing is a message string, @tags are the default tags for that logger instance" do
@@ -73,7 +72,6 @@ class LogStashLoggerTest < ActiveSupport::TestCase
     subject.error(message: "This is a message")
 
     assert_equal "This is a message", log_entries.last["@message"]
-    assert_equal "This is a message", log_entries.last["@fields"]["message"]
   end
 
   test "When logged thing is a hash, given tags are merged with default tags and logged" do


### PR DESCRIPTION
We were inserting the message twice, once at the top level, and once in
the fileds hash.
