### PR TITLE
Add moar logging to scheduled publisher.

### DIFF
--- a/lib/scheduled_editions_publisher.rb
+++ b/lib/scheduled_editions_publisher.rb
@@ -37,7 +37,9 @@ class ScheduledEditionsPublisher
   end
 
   def publish_edition!(edition)
+    log "Waiting to publish Edition (#{edition.id}) until #{edition.scheduled_publication.iso8601}"
     Whitehall::Wait.until edition.scheduled_publication do
+      log "About to publish Edition (#{edition.id}) at #{Time.zone.now.iso8601}"
       EditionPublishingWorker.new.perform(edition.id, publishing_robot.id)
       log_successful_publication(edition)
     end

--- a/test/unit/scheduled_editions_publisher_test.rb
+++ b/test/unit/scheduled_editions_publisher_test.rb
@@ -26,6 +26,7 @@ class ScheduledEditionsPublisherTest < ActiveSupport::TestCase
   test '#publish_edition! publishes the edition using the publishing robot and logs the result' do
     EditionPublishingWorker.any_instance.expects(:perform).with(stubbed_edition.id, publishing_robot.id)
     publisher = ScheduledEditionsPublisher.new(stubbed_scope)
+    publisher.stubs(:log) # Allow other log calls
     publisher.expects(:log).with("Edition (#{stubbed_edition.id}) successfully published at #{Time.zone.now}")
     stats_collector = stub_everything("stats_collector")
     stats_collector.expects(:increment).with('scheduled_publishing.published').once
@@ -37,6 +38,7 @@ class ScheduledEditionsPublisherTest < ActiveSupport::TestCase
 
   test '#publish_edition! recovers from exceptions and logs the failure' do
     publisher = ScheduledEditionsPublisher.new(stubbed_scope)
+    publisher.stubs(:log) # Allow other log calls
     EditionPublishingWorker.any_instance.expects(:perform).raises(EditionPublishingWorker::ScheduledPublishingFailure, 'Some failure message')
     publisher.expects(:log).with("Edition (#{stubbed_edition.id}) failed to publish: Some failure message", :warn)
     publisher.publish_edition!(stubbed_edition)


### PR DESCRIPTION
We've had an incident where this seems to have waited longer than
specified, resulting in things being published a little late.

Adding some more logging here so that we can debug further in future.
