### PR TITLE
Remove duplicate resource in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,8 +141,6 @@ Whitehall::Application.routes.draw do
     get 'world/organisations/:organisation_id/office' =>redirect('/world/organisations/%{organisation_id}')
     get 'world/organisations/:organisation_id/about' => redirect('/world/organisations/%{organisation_id}')
 
-    resources :statistics_announcements
-
     constraints(AdminRequest) do
       namespace :admin do
         root to: 'dashboard#index', via: :get


### PR DESCRIPTION
The resourceful routing for stats announcements is specified twice in the routes file, once with an alternative :path set and once here without. The version with the :path is what we want.
