### PR TITLE
Stats announcements - Fix behaviour of popstate in remote_search_filter.js

### DIFF
--- a/app/assets/javascripts/application/modules/remote_search_filter.js
+++ b/app/assets/javascripts/application/modules/remote_search_filter.js
@@ -29,12 +29,11 @@
 
   RemoteSearchFilter.prototype.updateResults = function updateResults() {
     this.pushToHistory();
-    var params = this.getFilterParams();
-    params.push({name: 'xhr', value: 'true'});
-    this.getResultsFromRemote(params);
+    this.getResultsFromRemote(this.getFilterParams());
   };
 
   RemoteSearchFilter.prototype.getResultsFromRemote = function getResultsFromRemote(params) {
+    params.push({name: 'xhr', value: 'true'});
     this.renderLoadingMessage();
     $.get(this.searchUrl, params, this.handleResponse);
   };
@@ -83,8 +82,11 @@
 
   RemoteSearchFilter.prototype.onHistoryPopState = function onHistoryPopState(event) {
     var filterParams = event.state || event.originalEvent.state;
-    this.setFieldValues(filterParams);
-    this.getResultsFromRemote(filterParams);
+
+    if ( filterParams != null ) {
+      this.setFieldValues(filterParams);
+      this.getResultsFromRemote(filterParams);
+    }
   };
 
   RemoteSearchFilter.prototype.setFieldValues = function setFieldValues(filterParams) {


### PR DESCRIPTION
This fixes a couple of issues in the Statistics announcement filter script, one of which was causing a cache confusion between xhr and non-xhr versions of the page :-(

• Popstate was firing on page load in Chrome.  The popstate event handler now does nothing if called with no state.
• Popstate wasn't appending the xhr=true param.  Move this 'appendage' into getResultsFromRemote.
