### PR TITLE
Destroy the offending policy document

### DIFF
--- a/db/data_migration/20140408_set_policy_state_to_deleted.rb
+++ b/db/data_migration/20140408_set_policy_state_to_deleted.rb
@@ -1,0 +1,1 @@
+Edition.find(309962).update_attribute(:state, 'deleted')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/68735100

The policy with id 309962 has an incorrect state and stops policy id 309961 from being tagged in other items.

Destroying 309962 fixes the problem.
