### PR TITLE
Rename meta css helper to metadata-list

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -75,7 +75,7 @@
   @import "helpers/_index-list.scss";
   @import "helpers/_js-list-items.scss";
   @import "helpers/_lead-image.scss";
-  @import "helpers/_meta.scss";
+  @import "helpers/_metadata-list.scss";
   @import "helpers/_organisations.scss";
   @import "helpers/_organisation-news.scss";
   @import "helpers/_page-header.scss";

--- a/app/assets/stylesheets/frontend/helpers/_metadata-list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_metadata-list.scss
@@ -1,4 +1,4 @@
-.meta {
+.metadata-list {
   @extend %contain-floats;
   display: block;
   margin-bottom: $gutter;

--- a/app/views/documents/_metadata.html.erb
+++ b/app/views/documents/_metadata.html.erb
@@ -3,7 +3,7 @@
   topics ||= []
   primary_mainstream_category ||= nil
 %>
-<aside class="meta">
+<aside class="meta metadata-list">
   <div class="inner-heading">
     <dl>
       <% if document.organisations.any?  %>

--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -15,7 +15,7 @@
         </div>
       </div>
 
-      <aside class="meta">
+      <aside class="meta metadata-list">
         <div class="inner-heading">
           <dl>
             <dt><%= t('document.headings.organisations', count: @ministerial_role.organisations.count) %>:</dt>

--- a/app/views/statistics_announcements/show.html.erb
+++ b/app/views/statistics_announcements/show.html.erb
@@ -14,7 +14,7 @@
                            extra: true } %>
 
 
-      <aside class="meta">
+      <aside class="meta metadata-list">
         <div class="inner-heading">
           <dl>
             <dt>Release date:</dt>
@@ -47,7 +47,7 @@
       <% if @announcement.release_date_change_note.present? %>
         <div class="release-date-change-information">
           <h3>The release date has been changed</h3>
-          <aside class="meta">
+          <aside class="meta metadata-list">
             <div class="inner-heading">
               <dl>
                 <dt>Previous date:</dt>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -18,7 +18,7 @@
         </div>
       <% end %>
       <% if @classification.organisations.any? %>
-        <aside class="meta">
+        <aside class="meta metadata-list">
           <div class="inner-heading">
             <dl>
               <dt><%= t('document.headings.organisations', count: @classification.organisations.length) %>:</dt>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,7 +15,7 @@
         <%= render 'shared/top_tasks', top_tasks: @classification.top_tasks.only_the_initial_set %>
       </aside>
 
-      <aside class="meta">
+      <aside class="meta metadata-list">
         <div class="inner-heading">
           <dl>
             <dt><%= t('document.headings.organisations', count: @classification.organisations.length) %>:</dt>


### PR DESCRIPTION
The 'meta' class was too generic and was causing conflicts. I've left
the meta class in as well as it seems semantically useful and some tests
rely on it.
