### PR TITLE
Send organisation slugs to Panopticon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '10.3.0'
+gem 'gds-api-adapters', '10.7.0'
 gem 'whenever', '0.9.0', require: false
 gem 'mini_magick'
 gem 'shared_mustache', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     friendly_id (4.0.9)
-    gds-api-adapters (10.3.0)
+    gds-api-adapters (10.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -386,7 +386,7 @@ DEPENDENCIES
   equivalent-xml (= 0.3.0)
   factory_girl
   friendly_id (= 4.0.9)
-  gds-api-adapters (= 10.3.0)
+  gds-api-adapters (= 10.7.0)
   gds-sso (= 9.2.0)
   globalize3!
   govspeak (~> 1.2.4)

--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -47,4 +47,10 @@ class RegisterableEdition
   def specialist_sectors
     [edition.primary_specialist_sector_tag].compact + edition.secondary_specialist_sector_tags
   end
+
+  def organisation_ids
+    return [] unless edition.respond_to?(:organisations)
+
+    edition.organisations.pluck(:slug)
+  end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -103,4 +103,21 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     assert_equal "statistical_data_set", registerable_edition.kind
   end
+
+  test "attaches tagged organisations' slugs as `organisation_ids`" do
+    primary_org = create(:organisation)
+    secondary_org = create(:organisation)
+
+    edition = create(:publication, lead_organisations: [primary_org], supporting_organisations: [secondary_org])
+    registerable_edition = RegisterableEdition.new(edition)
+
+    assert_same_elements [primary_org, secondary_org].map(&:slug), registerable_edition.organisation_ids
+  end
+
+  class EditionWithoutOrgs < Edition; end
+  test "deals with editions which don't do organisation tagging" do
+    registerable_edition = RegisterableEdition.new(EditionWithoutOrgs.new)
+
+    assert_same_elements [], registerable_edition.organisation_ids
+  end
 end


### PR DESCRIPTION
Sent when registering editions.
- [x] Waiting on bump to GDS API adapters https://github.com/alphagov/gds-api-adapters/pull/144

https://trello.com/c/OXVAxGZm
