### PR TITLE
Don't generate empty Google analytics tags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,11 +41,15 @@ class ApplicationController < ActionController::Base
   end
 
   def set_slimmer_organisations_header(organisations)
-    set_slimmer_headers(organisations: "<#{organisations.map(&:analytics_identifier).join('><')}>")
+    if organisations.any?
+      set_slimmer_headers(organisations: "<#{organisations.map(&:analytics_identifier).join('><')}>")
+    end
   end
 
   def set_slimmer_world_locations_header(locations)
-    set_slimmer_headers(world_locations: "<#{locations.map(&:analytics_identifier).join('><')}>")
+    if locations.any?
+      set_slimmer_headers(world_locations: "<#{locations.map(&:analytics_identifier).join('><')}>")
+    end
   end
 
   def set_slimmer_page_owner_header(organisation)

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -68,6 +68,20 @@ class PeopleControllerTest < ActionController::TestCase
     assert_select_autodiscovery_link atom_feed_url_for(@person)
   end
 
+  test "GET :show sets the slimmer header for the person's organisation" do
+    role_appointment = create(:role_appointment, person: @person)
+    organisation = role_appointment.organisations.first
+    get :show, id: @person
+
+    assert_equal "<#{organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
+  end
+
+  test 'GET :show does not set the organisations slimmer header if the person is not associated with one' do
+    get :show, id: @person
+
+    assert_nil response.headers["X-Slimmer-Organisations"]
+  end
+
   view_test "#show generates an atom feed of news and speeches associated with the person" do
     person = create(:person)
     role_appointment = create(:role_appointment, person: person)

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -165,6 +165,13 @@ class WorldLocationsControllerTest < ActionController::TestCase
     assert_equal "<#{related_organisations.map(&:analytics_identifier).join('><')}>", response.headers["X-Slimmer-Organisations"]
   end
 
+  test "GET :show does not set empty slimmer header for locations without an org" do
+    world_location = create(:world_location)
+    get :show, id: world_location.id
+
+    assert_nil response.headers["X-Slimmer-Organisations"]
+  end
+
   test "should display world_location's latest two announcements in reverse chronological order" do
     world_location = create(:world_location)
     announcement_2 = create(:published_news_article, world_locations: [world_location], first_published_at: 2.days.ago)

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -19,21 +19,21 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "should populate slimmer organisations header with worldwide organisation and its sponsored organisations" do
     organisation = create(:worldwide_organisation, :translated, :with_sponsorships)
-    sponsoring_organisations = organisation.sponsoring_organisations
+    sponsoring_organisation = organisation.sponsoring_organisations.first
 
     get :show, id: organisation.id
 
-    expected_header_value = "<#{([organisation] + sponsoring_organisations).map(&:analytics_identifier).join('><')}>"
+    expected_header_value = "<#{organisation.analytics_identifier}><#{sponsoring_organisation.analytics_identifier}>"
     assert_equal expected_header_value, response.headers["X-Slimmer-Organisations"]
   end
 
   test "should set slimmer worldwide locations header" do
-    organisation = create(:worldwide_organisation, :translated)
+    world_location = create(:world_location)
+    organisation = create(:worldwide_organisation, world_locations: [world_location])
 
     get :show, id: organisation.id
 
-    expected_header_value = "<#{organisation.world_locations.map(&:analytics_identifier).join('><')}>"
-    assert_equal expected_header_value, response.headers["X-Slimmer-World-Locations"]
+    assert_equal "<#{world_location.analytics_identifier}>", response.headers["X-Slimmer-World-Locations"]
   end
 
   view_test "shows links to associated world locations" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67097606

We were setting empty Google analytics tags because we weren't checking that any orgs were present before setting the slimmer headers.
