### PR TITLE
[DISCUSS] Don't fail silently when creating a new draft

### DIFF
--- a/app/models/edition/images.rb
+++ b/app/models/edition/images.rb
@@ -4,7 +4,7 @@ module Edition::Images
   class Trait < Edition::Traits::Trait
     def process_associations_after_save(edition)
       @edition.images.each do |a|
-        edition.images.create(a.attributes.except('id'))
+        edition.images.create!(a.attributes.except('id'))
       end
     end
   end


### PR DESCRIPTION
don't merge this PR yet. i'm opening this PR as a
way to get inputs from everyone about this proposed
change.

when creating a new draft from a published edition
if images have validation errors, we should raise an
exception to highlight that. otherwise, the newly
created edition is not the same as the published
one.

if this goes unnoticed, it can lead to loss of data
between editions.

this PR is part of [a bug fix](https://www.pivotaltracker.com/story/show/69553374) where we've seen this
happening, and editors having lost data.
