### PR TITLE
Skip image errors on create from published edition

### DIFF
--- a/app/models/edition/images.rb
+++ b/app/models/edition/images.rb
@@ -4,7 +4,11 @@ module Edition::Images
   class Trait < Edition::Traits::Trait
     def process_associations_after_save(edition)
       @edition.images.each do |a|
-        edition.images.create(a.attributes.except('id'))
+        image = edition.images.build(a.attributes.except('id'))
+        if image.invalid?
+          Rails.logger.warn "Ignoring errors on saving image for edition with id #{edition.id}: #{image.errors.full_messages.join(', ')}"
+        end
+        image.save(validate: false)
       end
     end
   end


### PR DESCRIPTION
fixes: https://www.pivotaltracker.com/story/show/69553374

content that was imported had smaller inline
images than the ones we allow - 960x640. for
now, we are allowing such images to be carried
over to new drafts created from such published
editions. there will be more work done on this
as part of:

https://www.pivotaltracker.com/story/show/69931140
