### PR TITLE
Prevent double-width feature 500ing with no image.

### DIFF
--- a/app/presenters/promotional_feature_item_presenter.rb
+++ b/app/presenters/promotional_feature_item_presenter.rb
@@ -11,6 +11,8 @@ class PromotionalFeatureItemPresenter < Whitehall::Decorators::Decorator
   end
 
   def display_image
+    return '' if image_tag.blank?
+
     if model.title_url.blank?
       image_tag
     else
@@ -19,6 +21,8 @@ class PromotionalFeatureItemPresenter < Whitehall::Decorators::Decorator
   end
 
   def image_tag
+    return '' if image_url.blank?
+
     context.image_tag(image_url, alt: image_alt_text)
   end
 

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -1,5 +1,8 @@
 <%= content_tag_for(:section, promotional_feature_item, class: 'well') do %>
-  <%= image_tag  promotional_feature_item.image.s300.url, alt: promotional_feature_item.image_alt_text %>
+  <% unless promotional_feature_item.image.s300.url.blank? %>
+    <%= image_tag promotional_feature_item.image.s300.url, alt: promotional_feature_item.image_alt_text %>
+  <% end %>
+
   <% if promotional_feature_item.title.present? %>
     <p><%= link_to_unless promotional_feature_item.title_url.blank?, promotional_feature_item.title, promotional_feature_item.title_url %></p>
   <% end %>

--- a/test/unit/presenters/promotional_feature_item_presenter_test.rb
+++ b/test/unit/presenters/promotional_feature_item_presenter_test.rb
@@ -37,6 +37,12 @@ class PromotionalFeatureItemPresenterTest < ActionView::TestCase
     assert_dom_equal %(<a href="http://external.com"><img alt="#{item.image_alt_text}" src="#{item.image_url}" /></a>), item.display_image
   end
 
+  test '#display_image returns nil if there is no image' do
+    item = item_presenter
+    item.stubs(image_url: '')
+    assert_equal '', item.display_image
+  end
+
   test '#link_list_class returns "dash-list" for single-width items' do
     assert_equal "dash-list", item_presenter.link_list_class
     assert_nil item_presenter(double_width: true).link_list_class


### PR DESCRIPTION
We recently allowed featured items to have no images, which is now causing problems.

https://trello.com/c/GUgCfHG7
