### PR TITLE
Add tracking to metadata links

### DIFF
--- a/app/assets/javascripts/application/track-metadata-links.js
+++ b/app/assets/javascripts/application/track-metadata-links.js
@@ -1,0 +1,26 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  /*
+   * Track metadata links
+   */
+  GOVUK.trackMetadataLinks = function (options) {
+    $(function() {
+      $('.js-track-metadata-links').on('click', 'a', function(e){
+        var $link = $(e.target),
+            gaParams = ['_setCustomVar', 14, 'metadata_click_track', '', 3],
+            $metadataBlock = $link.closest('.js-track-metadata-links'),
+            type = $link.closest('dd').data('tracktype'),
+            linkPosition = $metadataBlock.find('.'+ type + ' a').index($link) + 1, // zero offset so +1
+            position = $metadataBlock.data('trackposition');
+
+        gaParams[3] = [ type, position, linkPosition ].join('|');
+
+        if($link.attr('class') !== 'show-other-content'){
+          GOVUK.cookie('ga_nextpage_params', gaParams.join(','));
+        }
+      });
+    });
+  };
+})();

--- a/app/views/documents/_document_footer_meta.html.erb
+++ b/app/views/documents/_document_footer_meta.html.erb
@@ -33,17 +33,17 @@
     <% end %>
   </div>
   <div class="links">
-    <dl class="primary-metadata">
+    <dl class="primary-metadata js-track-metadata-links" data-trackposition="bottom">
       <% if document.organisations.any?  %>
         <dt><%= t('document.headings.organisations', count: document.organisations.length) %>:</dt>
         <% organisations_link_array(document.lead_organisations, document.sorted_organisations, :footer).each do |item| %>
-          <dd><%= item.html_safe %></dd>
+          <dd class="organisations" data-tracktype="organisations"><%= item.html_safe %></dd>
         <% end %>
       <% end %>
       <% document_metadata(document, policies, topics, nil, links_only = true).each do |metadata| %>
         <dt><%= metadata[:title] %>:</dt>
         <% metadata[:data].each do |item| %>
-          <dd class="<%= metadata.fetch(:classes, []).join(' ') %>">
+          <dd class="<%= metadata.fetch(:classes, []).join(' ') %>" data-tracktype="<%= metadata.fetch(:classes, []).join(' ') %>">
             <%= item.html_safe %>
           </dd>
         <% end %>

--- a/app/views/documents/_metadata.html.erb
+++ b/app/views/documents/_metadata.html.erb
@@ -5,10 +5,10 @@
 %>
 <aside class="meta metadata-list">
   <div class="inner-heading">
-    <dl>
+    <dl class="js-track-metadata-links" data-trackposition="top">
       <% if document.organisations.any?  %>
         <dt><%= t('document.headings.organisations', count: document.organisations.length) %>:</dt>
-        <dd>
+        <dd data-tracktype="organisations">
           <%= render  partial: 'organisations/organisations_name_list',
                       locals: { organisations: document.sorted_organisations,
                                 lead_organisations: document.lead_organisations } %>
@@ -21,14 +21,14 @@
 
       <% document_metadata(document, policies, topics, specialist_tag_finder).each do |metadata| %>
         <dt><%= metadata[:title] %>:</dt>
-        <dd class="js-hide-other-links <%= metadata.fetch(:classes, []).join(' ') %>">
+        <dd class="js-hide-other-links <%= metadata.fetch(:classes, []).join(' ') %>" data-tracktype="<%= metadata.fetch(:classes, []).join(' ') %>">
           <%= metadata[:data].to_sentence.html_safe %>
         </dd>
       <% end %>
 
       <% if primary_mainstream_category.present? %>
         <dt>Primary category:</dt>
-        <dd>
+        <dd data-tracktype="primary-category">
           <%= link_to primary_mainstream_category.title,
                       mainstream_category_path(primary_mainstream_category)%>
         </dd>
@@ -36,7 +36,7 @@
 
       <% if document.location && document.location.present? %>
         <dt><%= t('document.headings.location') %>:</dt>
-        <dd class="location"><%= document.location %></dd>
+        <dd class="location" data-tracktype="location"><%= document.location %></dd>
       <% end %>
 
     </dl>

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -29,6 +29,7 @@
       <%= yield %>
     </div>
     <%= javascript_include_tag "application" %>
+    <% initialise_script "GOVUK.trackMetadataLinks" %>
     <%= javascript_tag(yield :javascript_initialisers) %>
   </body>
 </html>


### PR DESCRIPTION
So that we can make smarter decisions about how to change the metadata
patterns some data on usage of metadata links is needed. This adds click
tracking to the metadata links.

https://www.pivotaltracker.com/story/show/70350492
