### PR TITLE
Don't overwrite file attachments with html ones

### DIFF
--- a/app/workers/import_row_worker.rb
+++ b/app/workers/import_row_worker.rb
@@ -28,7 +28,7 @@ protected
 
       model = import.model_class.new(attributes)
       attachment = HtmlAttachment.new(html_attachment_attributes.merge(attachable: model))
-      model.attachments = [attachment] if attachment.valid?
+      model.attachments << attachment if attachment.valid?
 
       if model.save
         save_translation!(model, row) if row.translation_present?

--- a/test/support/csv_sample_helpers.rb
+++ b/test/support/csv_sample_helpers.rb
@@ -54,7 +54,7 @@ module CsvSampleHelpers
   end
 
   def sample_organisation
-    @sample_organisation ||= (Organisation.first || create(:organisation))
+    @sample_organisation ||= (Organisation.first || create(:organisation, :with_alternative_format_contact_email))
   end
 
   def sample_topic


### PR DESCRIPTION
Currently, if you upload an import file that has publications containing both file attachments and HTML attachments, only the HTML attachments are imported. This fixes that.

Tracker: https://www.pivotaltracker.com/story/show/70293180
