### PR TITLE
Fix "See all publications" link filtering

### DIFF
--- a/app/views/classifications/_document_list.html.erb
+++ b/app/views/classifications/_document_list.html.erb
@@ -1,10 +1,13 @@
-<% heading ||= type.to_s.humanize %>
+<%
+   heading ||= type.to_s.humanize
+   filter_option = (heading == "Publications") ? "all" : heading.downcase
+%>
 <section id="<%= heading.downcase %>" class="document-block documents-<%= document_block_counter %>">
   <h1 class="label"><%= heading %></h1>
   <div class="content">
     <%= render partial: "shared/list_description", locals: { editions: documents } %>
     <p class="see-all">
-      <%= link_to "See all #{heading.downcase}", public_send("#{type}_filter_path", @classification, publication_filter_option: heading.downcase) %>
+      <%= link_to "See all #{heading.downcase}", public_send("#{type}_filter_path", @classification, publication_filter_option: filter_option) %>
     </p>
   </div>
 </section>


### PR DESCRIPTION
To fix: 
https://govuk.zendesk.com/agent/#/tickets/612032

This bug affects all pages with a "See all publications" link. 
Current work-around is to select another option in the publications dropdown, then reset to "all publications". 
