### PR TITLE
Stop listing archived status of detailed guide twice

### DIFF
--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -28,8 +28,6 @@
     </div>
   </header>
 
-  <%= render('documents/archive_notice', document: @document, type: 'guidance') if @document.archived? %>
-
   <div class="summary-block">
     <div class="inner-block">
       <%= render partial: "document_summary", locals: { document: @document } %>


### PR DESCRIPTION
Used to be in the document header as well as detailed guide "show" view
Now only in header
Fix to the bug: https://govuk.zendesk.com/agent/#/tickets/624347
