### PR TITLE
Don't include info pages in orgs latest filter

### DIFF
--- a/app/models/latest_documents_filter.rb
+++ b/app/models/latest_documents_filter.rb
@@ -39,6 +39,7 @@ private
     def documents_source
       subject.published_editions
              .in_reverse_chronological_order
+             .without_editions_of_type(CorporateInformationPage)
              .with_translations(I18n.locale)
     end
   end

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -74,6 +74,13 @@ class OrganisationFilterTest < ActiveSupport::TestCase
     assert_equal expected, filter.documents
   end
 
+  test '#documents does not include corporate information pages' do
+    create(:corporate_information_page, :published, organisation: organisation)
+    filter = LatestDocumentsFilter::OrganisationFilter.new(organisation)
+
+    assert_equal [], filter.documents
+  end
+
 private
   def organisation
     @organisation ||= create(:organisation)


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/70841898

We don't want these included in the public-facing latest pages.
