### PR TITLE
Make sure edition id is used, not document id

### DIFF
--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -19,7 +19,7 @@
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
 
       <%= form.label :related_detailed_guide_ids, 'Related guides' %>
-      <%= form.select :related_detailed_guide_ids, options_from_collection_for_select(DetailedGuide.alphabetical.latest_edition.active, :document_id, :title, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose related detailed guides..."} %>
+      <%= form.select :related_detailed_guide_ids, options_from_collection_for_select(DetailedGuide.alphabetical.latest_edition.active, :id, :title, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose related detailed guides..."} %>
     </fieldset>
 
     <%= render partial: 'inline_attachments_info', locals: { form: form, edition: edition } %>


### PR DESCRIPTION
A previous commit (https://github.com/alphagov/whitehall/commit/50851298a3df6fecd9b639680643602e7f07584c)
changed the name of this form field, but forgot to change the fact that we now want the edition's ID, not its document ID. This corrects that.
