### PR TITLE
Circle styling — minister and policy counts.

### DIFF
--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -309,12 +309,18 @@
       padding:0;
       margin-bottom: $gutter-half;
       vertical-align: middle;
+
+      &:hover {
+        background-color: darken($inside-gov-secondary,10%);
+        border-color: darken($inside-gov-secondary,10%);
+      }
+
       a {
         text-decoration: none;
         color: $black;
         &:hover,
         &:focus {
-          text-decoration: underline;
+          text-decoration: none;
         }
       }
 


### PR DESCRIPTION
This update affects the minister and policy counts in the circles visible here — https://www.gov.uk/government/how-government-works.

There's now a background colour on hover.
This is also an attempt to better centre the count text in the circles.

(may be of interest to @stephenjoe1 :)
