### PR TITLE
Fix RegisterableEdition.organisation_ids for CIPs.

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -55,6 +55,6 @@ class RegisterableEdition
   def organisation_ids
     return [] unless edition.respond_to?(:organisations)
 
-    edition.organisations.pluck(:slug)
+    edition.organisations.map(&:slug)
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -114,6 +114,14 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_same_elements [primary_org, secondary_org].map(&:slug), registerable_edition.organisation_ids
   end
 
+  test "organisation_ids works with class whose organisation method is not a scope" do
+    primary_org = create(:organisation)
+
+    edition = create(:corporate_information_page, organisation: primary_org)
+    registerable_edition = RegisterableEdition.new(edition)
+    assert_same_elements [primary_org.slug], registerable_edition.organisation_ids
+  end
+
   class EditionWithoutOrgs < Edition; end
   test "deals with editions which don't do organisation tagging" do
     registerable_edition = RegisterableEdition.new(EditionWithoutOrgs.new)


### PR DESCRIPTION
Method was relying on calling `pluck` on edition.organisations, which requires
an ActiveRecord scope, but CIP.organisations returns an array. Switched to `map`
instead.

https://www.pivotaltracker.com/story/show/71122120
