### PR TITLE
Revert "Handle legacy params temporarily"

### DIFF
--- a/app/controllers/admin/detailed_guides_controller.rb
+++ b/app/controllers/admin/detailed_guides_controller.rb
@@ -1,19 +1,10 @@
 class Admin::DetailedGuidesController < Admin::EditionsController
   include Admin::EditionsController::NationalApplicability
 
-  prepend_before_filter :massage_legacy_related_detailed_guide_ids, only: [:create, :update]
   before_filter :build_image, only: [:new, :edit]
 
 private
   def edition_class
     DetailedGuide
-  end
-
-  # TODO: This can be removed once the code has been successfully deployed
-  def massage_legacy_related_detailed_guide_ids
-    if params.fetch(:edition, {})[:outbound_related_detailed_guide_ids]
-      detailed_guides = Document.find(params[:edition].delete(:outbound_related_detailed_guide_ids)).map(&:latest_edition)
-      params[:edition][:related_detailed_guide_ids] = detailed_guides.map(&:id)
-    end
   end
 end

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -126,16 +126,6 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
     assert_same_elements [policy.document, related_guide.document], new_guide.related_documents
   end
 
-  test "#create handles legacy related detailed guides param" do
-    related_guide = create(:published_detailed_guide)
-    attributes = controller_attributes_for(:detailed_guide, outbound_related_detailed_guide_ids: [related_guide.document_id])
-    post :create, edition: attributes
-
-    assert new_guide = DetailedGuide.last
-
-    assert_equal [related_guide.document], new_guide.related_documents
-  end
-
   private
 
   def controller_attributes_for(edition_type, attributes = {})


### PR DESCRIPTION
Now that https://github.com/alphagov/whitehall/pull/1451 has been deployed, this code is no longer required.
