### PR TITLE
Fix spacing for translations on whitehall people pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_people.scss
+++ b/app/assets/stylesheets/frontend/views/_people.scss
@@ -2,4 +2,12 @@
   .inner-block {
     @extend %contain-floats;
   }
+
+  .headings-block {
+    .heading-extra {
+      @include media(tablet) {
+        margin: $gutter+$gutter-half 0 $gutter 0
+      }
+    }
+  }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/71230496
