### PR TITLE
WorldwideOrganisation quacks more like Organisation

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -68,6 +68,10 @@ class WorldwideOrganisation < ActiveRecord::Base
     self.name
   end
 
+  def acronym
+    nil
+  end
+
   def main_office
     original_main_office || offices.first
   end

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -18,6 +18,11 @@ class OrganisationHelperTest < ActionView::TestCase
     assert_equal "Building Law and Hygiene", organisation_display_name(organisation)
   end
 
+  test "returns the name of a worldwide organisation" do
+    organisation = build(:worldwide_organisation, name: "British Embassy, Atlantis")
+    assert_equal "British Embassy, Atlantis", organisation_display_name(organisation)
+  end
+
   test "returns name formatted for logos" do
     organisation = build(:organisation, name: "Building Law and Hygiene", logo_formatted_name: "Building Law\nand Hygiene")
     assert_equal "Building Law<br/>and Hygiene", organisation_logo_name(organisation)


### PR DESCRIPTION
The fact that WorldwideOrganisation didn't respond to #acronym was
causing the organisation_display_name helper to blow up (see https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/537227110da115fb25001627)
