### PR TITLE
Hide the global header bar

### DIFF
--- a/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
+++ b/app/assets/stylesheets/frontend/reset/_govuk-overrides.scss
@@ -30,3 +30,6 @@ body.js-enabled {
     }
   }
 }
+#global-header-bar {
+  display: none;
+}


### PR DESCRIPTION
Hide this element that is being introduced in static. Once static has
been deployed this can be removed and the custom header bar in this
project can be removed.

Hiding the new element means that deploys don't need to be synchronised
and the new colour bar can be adopted when this repo is ready.
