### PR TITLE
Remove subsector name from title

### DIFF
--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -8,14 +8,6 @@ module SpecialistSectorHelper
     end
   end
 
-  def add_subsector_name(title, subsector_tag)
-    if subsector_tag
-      "#{subsector_tag.title} - #{title}"
-    else
-      title
-    end
-  end
-
   def array_of_links_to_sectors(sectors_and_subsectors)
     sectors_and_subsectors.map { |sector|
       link_to sector.title, sector.web_url

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -7,7 +7,7 @@
 %>
 <%= render partial: 'shared/heading',
           locals: { type: add_sector_name(header_title, specialist_tag_finder.primary_sector_tag),
-                    heading: add_subsector_name(document.title, specialist_tag_finder.primary_subsector_tag),
+                    heading: document.title,
                     extra: true } %>
 
 <%= render('documents/archive_notice', document: document, type: document.format_name) if document.archived? %>

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -19,6 +19,5 @@ end
 
 Then(/^I should see the specialist sub\-sector and its parent sector$/) do
   check_for_primary_sector_in_heading
-  check_for_primary_subsector_in_title(@document.title)
   check_for_sectors_and_subsectors_in_metadata
 end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -52,10 +52,6 @@ module SpecialistSectorHelper
     assert has_content?("Oil and gas - guidance")
   end
 
-  def check_for_primary_subsector_in_title(document_title)
-    assert has_content?("Wells - #{document_title}")
-  end
-
   def check_for_sectors_and_subsectors_in_metadata
     ['Oil and gas', 'Wells', 'Offshore', 'Fields'].each do |sector_name|
       assert has_css?('.document-sectors', text: sector_name)


### PR DESCRIPTION
It causes confusion because things can be repeated in the title and the
subsector name. Remove it from the title. It will still be in the
metadata so it isn't gone completely.

https://www.pivotaltracker.com/story/show/71389554
