### PR TITLE
Redirect to untranslated edition when requested translation not available

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -31,7 +31,10 @@ private
         expire_on_next_scheduled_publication([scheduled_document])
       end
     else
-      if @document = document_class.scheduled_for_publication_as(params[:id])
+      if I18n.locale != I18n.default_locale && untranslated_edition = I18n.with_locale(I18n.default_locale) { find_document_or_edition }
+        # Redirect to untranslated version if translation isn't available
+        redirect_to document_path(untranslated_edition, locale: I18n.default_locale)
+      elsif @document = document_class.scheduled_for_publication_as(params[:id])
         expire_on_next_scheduled_publication([@document])
         render :coming_soon
       elsif @unpublishing = Unpublishing.from_slug(params[:id], document_class)

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -105,12 +105,13 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "requests for documents in a locale it is not translated into should respond with a not_found" do
-    edition = create(:draft_publication)
-    force_publish(edition)
+  test "show redirects to english version if requested translation does not exist" do
+    login_as(:departmental_editor)
+    edition = create(:published_publication)
 
-    get :show, id: edition.document, locale: 'fr'
+    get :show, id: edition.document.slug, locale: 'fr'
 
-    assert_response :not_found
+    assert_response :redirect
+    assert_redirected_to document_path(edition, locale: I18n.default_locale)
   end
 end


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/71661194

Previously, if a translation for a document is requested which doesn't exist, a 404 is thrown. This PR changes this to instead redirect to the english language version if one exists.
