### PR TITLE
Consistent feature new item form

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -6,7 +6,7 @@ class Feature < ActiveRecord::Base
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image
   validates :document, presence: true, unless: -> feature { feature.topical_event_id.present? }
   validates :started_at, presence: true
-  validates :image, presence: true, on: :create
+  validates :image, :alt_text, presence: true, on: :create
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 
   before_validation :set_started_at!, on: :create

--- a/app/views/admin/classification_featurings/new.html.erb
+++ b/app/views/admin/classification_featurings/new.html.erb
@@ -9,7 +9,7 @@
       <%= form.hidden_field :edition_id %>
 
       <%= form.fields_for :image do |image_fields| %>
-        <%= image_fields.upload :file, horizontal: true, label_text: 'Select an image to be shown when featuring' %>
+        <%= image_fields.upload :file, horizontal: true, label_text: 'Select a 960px wide and 640px tall image to be shown when featuring' %>
       <% end %>
       <%= form.text_field :alt_text, horizontal: true, label_text: "Image description (alt text)" %>
       <%= form.save_or_cancel cancel: polymorphic_path([:admin, @classification, :classification_featurings]) %>

--- a/app/views/admin/edition_organisations/edit.html.erb
+++ b/app/views/admin/edition_organisations/edit.html.erb
@@ -8,7 +8,7 @@
       <%= form.errors %>
       <%= form.hidden_field :featured %>
       <%= form.fields_for :image do |image_fields| %>
-        <%= image_fields.upload :file, horizontal: true, label_text: 'Select an image to be shown when featuring' %>
+        <%= image_fields.upload :file, horizontal: true, label_text: 'Select a 960px wide and 640px tall image to be shown when featuring' %>
       <% end %>
       <%= form.text_field :alt_text, horizontal: true, label_text: "Image description (alt text)" %>
       <%= form.save_or_cancel cancel: admin_organisation_path(@edition_organisation.organisation) %>

--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -8,7 +8,7 @@
       <%= form.errors %>
       <%= form.hidden_field :document_id %>
       <%= form.hidden_field :topical_event_id %>
-      <%= form.upload :image, horizontal: true, label_text: 'Select an image to be shown when featuring' %>
+      <%= form.upload :image, horizontal: true, label_text: 'Select a 960px wide and 640px tall image to be shown when featuring' %>
       <%= form.text_field :alt_text, horizontal: true, label_text: "Image description (alt text)" %>
       <%= form.save_or_cancel cancel: admin_feature_list_path(@feature_list) %>
     <% end %>

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -165,7 +165,7 @@ When /^I feature the news article "([^"]*)" for "([^"]*)" with image "([^"]*)"$/
   within record_css_selector(news_article) do
     click_link "Feature"
   end
-  attach_file "Select an image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
+  attach_file "Select a 960px wide and 640px tall image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
   fill_in :feature_alt_text, with: "An accessible description of the image"
   click_button "Save"
 end
@@ -487,7 +487,7 @@ When /^I feature the topical event "([^"]*)" for "([^"]*)" with image "([^"]*)"$
   within record_css_selector(topical_event) do
     click_link "Feature"
   end
-  attach_file "Select an image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
+  attach_file "Select a 960px wide and 640px tall image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
   fill_in :feature_alt_text, with: "An accessible description of the image"
   click_button "Save"
 end

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -181,7 +181,7 @@ When(/^I feature one of the policies on the topic$/) do
   within record_css_selector(@policy) do
     click_link "Feature"
   end
-  attach_file "Select an image to be shown when featuring", jpg_image
+  attach_file "Select a 960px wide and 640px tall image to be shown when featuring", jpg_image
   fill_in :classification_featuring_alt_text, with: "An accessible description of the image"
   click_button "Save"
 end

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -85,7 +85,7 @@ When /^I feature the document "([^"]*)" for topical event "([^"]*)" with image "
   within record_css_selector(edition) do
     click_link "Feature"
   end
-  attach_file "Select an image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
+  attach_file "Select a 960px wide and 640px tall image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
   fill_in :classification_featuring_alt_text, with: "An accessible description of the image"
   click_button "Save"
 end

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -59,7 +59,7 @@ def feature_news_article_in_world_location(news_article_title, world_location_na
   within record_css_selector(news_article) do
     click_link "Feature"
   end
-  attach_file "Select an image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
+  attach_file "Select a 960px wide and 640px tall image to be shown when featuring", Rails.root.join("test/fixtures/#{image_filename}")
   fill_in :feature_alt_text, with: "An accessible description of the image"
   click_button "Save"
 end


### PR DESCRIPTION
Validate that featured items have an alt_text for their image.
Modify the text on the featuring form to specify the size required for the image. 
