### PR TITLE
Exclude CIPs from Latest box on Organisation page.

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -13,7 +13,7 @@ class OrganisationsController < PublicFacingController
   end
 
   def show
-    recently_updated_source = @organisation.published_editions.in_reverse_chronological_order
+    recently_updated_source = @organisation.published_non_corporate_information_pages.in_reverse_chronological_order
     set_expiry 5.minutes
     respond_to do |format|
       format.html do

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -336,6 +336,10 @@ class Organisation < ActiveRecord::Base
     editions.scheduled.order('scheduled_publication ASC')
   end
 
+  def published_non_corporate_information_pages
+    published_editions.without_editions_of_type(CorporateInformationPage)
+  end
+
   def published_announcements
     published_editions.announcements
   end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -449,6 +449,16 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "should exclude corporate information pages from Latest block" do
+    organisation = create(:organisation)
+    cip = create(:published_corporate_information_page, organisation: organisation, first_published_at: 1.day.ago.to_date)
+    publication_1 = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
+    publication_2 = create(:published_publication, organisations: [organisation], first_published_at: 2.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
+    publication_3 = create(:published_publication, organisations: [organisation], first_published_at: 3.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
+    get :show, id: organisation
+    assert_equal [publication_1, publication_2, publication_3], assigns[:recently_updated].take(3)
+  end
+
   view_test "should display sub-organisations" do
     organisation = create(:organisation)
     sub_organisation = create(:sub_organisation, parent_organisations: [organisation])


### PR DESCRIPTION
Pulled this out to a separate pull request whilst the issues around CIP about pages not having a body is resolved.

Tracker: https://www.pivotaltracker.com/story/show/71763204
