### PR TITLE
Use polymorphic URL for classification delete link.

### DIFF
--- a/app/views/admin/classifications/edit.html.erb
+++ b/app/views/admin/classifications/edit.html.erb
@@ -12,7 +12,7 @@
   <section class="display_heading">
     <h1>Delete <%= human_friendly_model_name.downcase %></h1>
     <% if @classification.destroyable? %>
-      <%= button_to 'Delete', admin_topic_path(@classification), method: :delete, confirm: "Are you sure you want to delete: #{@classification} ?", class: 'btn btn-danger' %>
+      <%= button_to 'Delete', [:admin, @classification], method: :delete, confirm: "Are you sure you want to delete: #{@classification} ?", class: 'btn btn-danger' %>
     <% else %>
       <div class="policies_preventing_destruction">
         <p>This topic can't be deleted as it has associated policies:</p>

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -139,3 +139,11 @@ end
 When /^I view that topical event page$/ do
   visit topical_event_path(@topical_event)
 end
+
+Then /^I should be able to delete the topical event "([^"]*)"$/ do |name|
+  topical_event = TopicalEvent.find_by_name!(name)
+  visit admin_topical_event_path(topical_event)
+  click_on 'Edit'
+  click_button 'Delete'
+end
+

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -66,3 +66,8 @@ Scenario: Adding more information about the event
   And I add a page of information about the event
   Then I should be able to edit the event's about page
   And the information about the event should be visible on its public page
+
+Scenario: Deleting a topical event
+  Given a topical event called "An event" with description "A topical event"
+  Then I should be able to delete the topical event "An event"
+


### PR DESCRIPTION
Fix bug with deleting topical events: both Topic and TopicalEvent subclass Classification, but delete button was linking specifically to admin_topic_path helper.
https://www.agileplannerapp.com/boards/173808/cards/3352
