### PR TITLE
Use pdf-reader gem to count pdf pages.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'sidekiq', '2.17.7'
 gem 'raindrops', '0.11.0'
 gem 'airbrake', '3.1.15'
 gem 'bad_link_finder', '0.3.3'
+gem 'pdf-reader', '1.3.3'
 
 # This sanitize fork branch fizes an issue with sanitize seeing colons in ids (when used as anchor tag references in an href)
 # as links with protocols. This has been fixed and merged in rgrove's Sanitize, but will only be released with version 2.1.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.0.2)
     PriorityQueue (0.1.2)
     actionmailer (3.2.18)
       actionpack (= 3.2.18)
@@ -63,6 +64,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.4)
+    afm (0.2.0)
     airbrake (3.1.15)
       builder
       multi_json
@@ -156,6 +158,7 @@ GEM
     govuk_frontend_toolkit (0.47.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    hashery (2.1.1)
     hashie (2.1.1)
     hike (1.2.3)
     htmlentities (4.3.1)
@@ -243,6 +246,12 @@ GEM
     parallel (0.7.0)
     parallel_tests (0.13.3)
       parallel
+    pdf-reader (1.3.3)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.0)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     plek (1.5.0)
     poltergeist (1.3.0)
       capybara (~> 2.1.0)
@@ -285,6 +294,7 @@ GEM
       redis (~> 3.0.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    ruby-rc4 (0.1.5)
     rummageable (1.0.0)
       multi_json
       null_logger
@@ -343,6 +353,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
+    ttfunk (1.1.1)
     tzinfo (0.3.39)
     uglifier (2.1.1)
       execjs (>= 0.3.0)
@@ -409,6 +420,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri
   parallel_tests
+  pdf-reader (= 1.3.3)
   plek (= 1.5.0)
   poltergeist (~> 1.3.0)
   quiet_assets

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require 'pdf-reader'
 
 class AttachmentData < ActiveRecord::Base
   mount_uploader :file, AttachmentUploader, mount_on: :carrierwave_file
@@ -123,7 +123,7 @@ class AttachmentData < ActiveRecord::Base
   end
 
   def calculate_number_of_pages
-    `identify -format %n #{Shellwords.shellescape(path)}`.strip.to_i
+    PDF::Reader.new(path).page_count
   rescue Exception => e
     if Rails.env.production?
       Airbrake.notify_or_ignore(e,


### PR DESCRIPTION
Further to https://github.com/alphagov/whitehall/pull/1458

Although pdfinfo is slower than imagemagic in some cases, imagemagic is
significantly slower for pdfs with a large number of pages:

```
$ time pdfinfo test.pdf
Title:          Salisbury Plain army basing programme OEA
Keywords:
CreationDate:   Tue May 20 12:46:01 2014
ModDate:        Tue May 20 12:46:01 2014
Tagged:         yes
Pages:          836
Encrypted:      yes (print:yes copy:yes change:no addNotes:no)
Page size:      595 x 842 pts (A4)
File size:      7161312 bytes
Optimized:      yes
PDF version:    1.6

real  0m0.012s
user  0m0.004s
sys 0m0.007s

$ time identify -format %n test.pdf
836

real  1m23.043s
user  1m21.184s
sys 0m1.810s
```

The pdf-reader gem is near instant for both this example, and the one
used in the previous PR.
