### PR TITLE
Exclude worldwide orgs in org tags for now

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -53,8 +53,14 @@ class RegisterableEdition
   end
 
   def organisation_ids
-    return [] unless edition.respond_to?(:organisations)
+    registered_organisations.map(&:slug)
+  end
 
-    edition.organisations.map(&:slug)
+  def registered_organisations
+    if edition.respond_to?(:organisations)
+      edition.organisations.reject {|organisation| organisation.is_a?(WorldwideOrganisation) }
+    else
+      []
+    end
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -122,6 +122,14 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_same_elements [primary_org.slug], registerable_edition.organisation_ids
   end
 
+  test "does not tag worldwide organisations yet as they are not registered in Panopticon" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    edition = create(:corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation)
+    registerable_edition = RegisterableEdition.new(edition)
+    assert_equal [], registerable_edition.organisation_ids
+  end
+
   class EditionWithoutOrgs < Edition; end
   test "deals with editions which don't do organisation tagging" do
     registerable_edition = RegisterableEdition.new(EditionWithoutOrgs.new)


### PR DESCRIPTION
worldwide organisations are not yet registerd with panopticon so we want to exclude them from `organisation_ids`, otherwise registration fails. This has become an issue since we converted `CorporateInformationPages` to an `Edition` type as `CorporateInformationPage#organisations` will return an array containing the owning organisation, which will be either a normal `Organisation` or a `WorldwideOrganisation`.
