### PR TITLE
Changed govspeak URL in document edit interface

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -27,7 +27,7 @@
 <% end %>
 
 <h3>Formatting</h3>
-<p>For details, see <a href="http://alphagov.github.io/inside-government-admin-guide/creating-documents/markdown.html">Using govspeak on GOV.UK</a></p>
+<p>For details, see <a href="https://alphagov.github.io/inside-government-admin-guide/creating-documents/markdown.html">Using govspeak on GOV.UK</a></p>
 <h3><a data-toggle="collapse" data-target="#govspeak-headings">Headings</a></h3>
 <div class="collapse" id="govspeak-headings">
   <pre>## Top level heading - H2


### PR DESCRIPTION
Changed govspeak URL to point to the relevant guide for Whitehall editors. It is currently pointing to the markdown for GDS Content Designers using Publisher.
