### PR TITLE
Handle unhandled feed types

### DIFF
--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -20,7 +20,11 @@ module Whitehall
       end
 
       def valid?
-        uri && recognised_url? && resource_exists? && filter_parameters_are_valid?
+        uri &&
+        recognised_url? &&
+        recognised_feed_type? &&
+        resource_exists? &&
+        filter_parameters_are_valid?
       end
 
       def feed_params
@@ -45,6 +49,10 @@ module Whitehall
         Rails.application.routes.recognize_path(uri.path)
       rescue ActionController::RoutingError
         false
+      end
+
+      def recognised_feed_type?
+        !!feed_type
       end
 
       def valid_extension?

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -177,6 +177,14 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     refute validator.valid?
   end
 
+  test 'does not validate a feed url for an unsupported type, e.g. a document collection' do
+    collection = create(:document_collection)
+    feed_url   = generic_url_maker.document_collection_url(collection)
+    validator  = FeedUrlValidator.new(feed_url)
+
+    refute validator.valid?
+  end
+
   test '#description does not fall over when the feed is bad' do
     assert_nil FeedUrlValidator.new('http://bad/feed').description
   end


### PR DESCRIPTION
We want to reject feeds for formats that we do not currently support, e.g. document collections. This is currently a source of exceptions (https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/538886340da11537fa000b55)
