### PR TITLE
Handle html attachment preview on non existent docs

### DIFF
--- a/app/controllers/html_attachments_controller.rb
+++ b/app/controllers/html_attachments_controller.rb
@@ -23,7 +23,7 @@ private
   def find_edition
     if previewing?
       @edition = Document.at_slug(document_class, slug_param).try(:latest_edition)
-      raise_not_found unless can_preview?(@edition)
+      render_not_found unless can_preview?(@edition)
     else
       @edition = document_class.published_as(slug_param)
     end
@@ -35,7 +35,7 @@ private
     if unpublishing = Unpublishing.from_slug(slug_param, document_class)
       redirect_to unpublishing.document_path
     else
-      raise_not_found
+      render_not_found
     end
   end
 
@@ -61,9 +61,5 @@ private
 
   def set_locale_from_attachment(&block)
     I18n.with_locale(@html_attachment.locale || I18n.default_locale, &block)
-  end
-
-  def raise_not_found
-    raise ActiveRecord::RecordNotFound, "could not find Edition with slug #{slug_param}"
   end
 end

--- a/test/functional/html_attachments_controller_test.rb
+++ b/test/functional/html_attachments_controller_test.rb
@@ -34,9 +34,8 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
   test '#show returns 404 if the edition is not published' do
     publication, attachment = create_edition_and_attachment(state: :draft)
 
-    assert_raise ActiveRecord::RecordNotFound do
-      get :show, publication_id: publication.document, id: attachment
-    end
+    get :show, publication_id: publication.document, id: attachment
+    assert_response :not_found
   end
 
   test '#show returns 404 if the attachment cannot be found' do
@@ -51,9 +50,8 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
     login_as create(:departmental_editor)
     attachment = create(:html_attachment)
 
-    assert_raise ActiveRecord::RecordNotFound do
-      get :show, publication_id: 'non-existent-slug', id: 'non-existent-attachment', preview: attachment.id
-    end
+    get :show, publication_id: 'non-existent-slug', id: 'non-existent-attachment', preview: attachment.id
+    assert_response :not_found
   end
 
   view_test '#show renders the HTML attachment (without caching) on draft edition if previewing' do
@@ -87,9 +85,8 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
     attachment = build(:html_attachment)
     publication = create(:draft_publication, access_limited: true, attachments: [attachment], organisations: [create(:organisation)])
 
-    assert_raise ActiveRecord::RecordNotFound do
-      get :show, publication_id: publication.document, id: attachment, preview: attachment.id
-    end
+    get :show, publication_id: publication.document, id: attachment, preview: attachment.id
+    assert_response :not_found
   end
 
   test '#show redirects to the edition if the edition has been unpublished' do


### PR DESCRIPTION
Some housekeeping to stop exceptions being raised when previewing HTML attachments on non-existent documents (https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/5386d40a0da11537fa000448). Also adds some extra checking to prevent the preview of HTML attachments on access-limited documents.
