### PR TITLE
Handle pdf-reader gem errors

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -124,12 +124,8 @@ class AttachmentData < ActiveRecord::Base
 
   def calculate_number_of_pages
     PDF::Reader.new(path).page_count
-  rescue Exception => e
-    if Rails.env.production?
-      Airbrake.notify_or_ignore(e,
-        error_message: 'Exception raised while calculating number of pages in PDF uploaded.')
-    end
-    nil
+  rescue PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError => e
+    return nil
   end
 
   def file_is_not_empty


### PR DESCRIPTION
The pdf-reader gem will not handle every single PDF. Here we rescue the two common errors caused by strange PDFs and carry on. There is little point reporting these errors to our exception tracking as there isn't much that we can do about malformed or unsupported PDFs.

See https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/538c79ec0da11537fa001282?notice=2
