### PR TITLE
Better scheduled publishing error reporting

### DIFF
--- a/app/services/scheduled_edition_publisher.rb
+++ b/app/services/scheduled_edition_publisher.rb
@@ -14,7 +14,7 @@ private
   rescue => e
     if Rails.env.production?
       Airbrake.notify_or_ignore(e,
-        error_message: 'Exception raised during scheduled publishing attempt',
+        error_message: "Exception raised during scheduled publishing attempt: '#{e.message}'",
         parameters: { edition_id: edition.id }
       )
     else


### PR DESCRIPTION
Currently much of the context around errors raised during scheduled publishing is lost because the error message of the exception raised is not reported.

See https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/53754a7f0da115fb25002439
