### PR TITLE
Disable stats announcement filter script when pushState unsupported

### DIFF
--- a/app/assets/javascripts/application/modules/remote_search_filter.js
+++ b/app/assets/javascripts/application/modules/remote_search_filter.js
@@ -3,6 +3,8 @@
   window.GOVUK = window.GOVUK || {};
 
   function RemoteSearchFilter(params) {
+    if (!GOVUK.support.history()) return;
+
     GOVUK.Proxifier.proxifyAllMethods(this);
 
     this.$form                  = $(params.form_element);

--- a/test/javascripts/unit/application/modules/remote_search_filter_test.js
+++ b/test/javascripts/unit/application/modules/remote_search_filter_test.js
@@ -220,3 +220,9 @@ test("the search results are reverted on history popstate", function() {
   equal($("input[name='a_text_field']").val(), "some filter text");
   equal($("select[name='a_select_field[]']").val(), "option_2");
 });
+
+test("RemoteSearchFilter ignores browsers which don't support history.pushState", function() {
+  this.stub(window.GOVUK.support, "history", function() { return false; });
+  new GOVUK.RemoteSearchFilter({form_element: 'form.filter-form'});
+  ok($('input[type=submit]').css('display') != 'none');
+});


### PR DESCRIPTION
It's more important for users to have the correct url for a search than
to have ajaxy updating search results.

Bug: https://www.pivotaltracker.com/story/show/72255634
