### PR TITLE
Add with_this_determiner helper and fix text on attachment preview

### DIFF
--- a/app/helpers/text_helper.rb
+++ b/app/helpers/text_helper.rb
@@ -1,0 +1,5 @@
+module TextHelper
+  def with_this_determiner(string)
+    (string == string.singularize) ? "this #{string}" : "these #{string}"
+  end
+end

--- a/app/views/attachments/preview.html.erb
+++ b/app/views/attachments/preview.html.erb
@@ -22,7 +22,7 @@
 
     <%- end -%>
     <div class="return">
-      <p><%= link_to "See more information about this #{@edition.display_type}", public_document_path(@edition) %></p>
+      <p><%= link_to "See more information about #{with_this_determiner(@edition.display_type.downcase)}", public_document_path(@edition) %></p>
     </div>
   </div>
 </div>

--- a/test/unit/helpers/text_helper_test.rb
+++ b/test/unit/helpers/text_helper_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class TextHelperTest < ActionView::TestCase
+  test "#with_this_determiner prefixes singular strings with 'this'" do
+    assert_equal with_this_determiner("dog"), "this dog"
+  end
+
+  test "#with_this_determiner prefixes plural strings with 'these'" do
+    assert_equal with_this_determiner("statistics"), "these statistics"
+  end
+end


### PR DESCRIPTION
Previously, the link text  would read: "See more information about this statistics".  This PR adds a helper to render this / these appropriately.
