### PR TITLE
Fix text size rendering issue on policy group pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_policy_groups.scss
+++ b/app/assets/stylesheets/frontend/views/_policy_groups.scss
@@ -37,9 +37,6 @@
 
   .description {
     padding-bottom: $gutter-half;
-    .govspeak p:first-child {
-      @include ig-core-24;
-    }
   }
 
   .policy {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/71824272

The overly broad CSS rule was targetting the first child p of any element, eg, LI, ADDRESS, etc. Causing
large text all over the shop. Regardless having chatted to a designer, the make-first-p behaviour is no longer required anyway, so remove it.
