### PR TITLE
Add a stronger test for topical event deletion

### DIFF
--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -180,4 +180,5 @@ Then /^I should be able to delete the topical event "([^"]*)"$/ do |name|
   visit admin_topical_event_path(topical_event)
   click_on 'Edit'
   click_button 'Delete'
+  refute TopicalEvent.exists?(topical_event)
 end


### PR DESCRIPTION
Instead of just checking we can click the 'Delete' button and don't get an error, we should check that the event actually gets deleted.

Originally spotted [in a previous pull request](https://github.com/alphagov/whitehall/pull/1508/files#r13178153).
