### PR TITLE
Add bottom padding to stats filter form

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_filter-form-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_filter-form-block.scss
@@ -3,7 +3,7 @@
   width: $one-third;
 
   form {
-    padding: 0;
+    padding: 0 0 $gutter 0;
 
     fieldset {
       position: relative;


### PR DESCRIPTION
With JS disabled, the "Help us improve" block would butt right up against
the bottom of the filter form. This fixes that.

See comments in https://www.pivotaltracker.com/story/show/72255634
