### PR TITLE
List of links to orgs are safe html

### DIFF
--- a/app/views/attachments/preview.html.erb
+++ b/app/views/attachments/preview.html.erb
@@ -17,7 +17,7 @@
       </div>
 
       <div class="other-organisations">
-        <%= array_of_links_to_organisations(other_organisations).to_sentence %>
+        <%= array_of_links_to_organisations(other_organisations).to_sentence.html_safe %>
       </div>
 
     <%- end -%>

--- a/app/views/organisations/_organisations_name_list.html.erb
+++ b/app/views/organisations/_organisations_name_list.html.erb
@@ -4,5 +4,5 @@
   show_hm_government = lead_organisations.length == 0
 %>
 <p class="js-hide-other-departments organisations-name-list">
-  <%= array_of_links_to_organisations(organisations).to_sentence %>
+  <%= array_of_links_to_organisations(organisations).to_sentence.html_safe %>
 </p>

--- a/app/views/statistics_announcements/show.html.erb
+++ b/app/views/statistics_announcements/show.html.erb
@@ -23,7 +23,7 @@
             <% if @announcement.organisations.any?  %>
               <dt><%= t('document.headings.organisations', count: @announcement.organisations.length) %>:</dt>
               <dd>
-                <%= array_of_links_to_organisations(@announcement.organisations).to_sentence %>
+                <%= array_of_links_to_organisations(@announcement.organisations).to_sentence.html_safe %>
               </dd>
             <% end %>
             <% if @announcement.topics.any?  %>

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -147,6 +147,22 @@ class AttachmentsControllerTest < ActionController::TestCase
     assert_select '.headings h1', attachment.title
   end
 
+  view_test "GET #preview for a CSV attachment on a public edition has links to document organiastions" do
+    org_1 = create(:organisation)
+    org_2 = create(:organisation)
+    org_3 = create(:organisation)
+    visible_edition = create(:published_publication, :with_file_attachment, attachments: [
+      attachment = build(:csv_attachment)
+    ], organisations: [org_1, org_2, org_3])
+    attachment_data = attachment.attachment_data
+
+    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+
+    assert_select 'a[href=?]', organisation_path(org_1)
+    assert_select 'a[href=?]', organisation_path(org_2)
+    assert_select 'a[href=?]', organisation_path(org_3)
+  end
+
   test "GET #preview for a CSV attachment on a non-public edition returns a not found response" do
     unpublished_edition = create(:draft_publication, :with_file_attachment, attachments: [build(:csv_attachment)])
     attachment_data = unpublished_edition.attachments.first.attachment_data

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -7,9 +7,10 @@ class TopicsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
   view_test "GET :shows lists the topic details, setting the expiry headers based on the scheduled editions" do
-    organisation = create(:organisation)
+    organisation_1 = create(:organisation)
+    organisation_2 = create(:organisation)
     policy = create(:draft_policy, :scheduled)
-    topic = create(:topic, organisations: [organisation], editions: [policy, create(:published_news_article)])
+    topic = create(:topic, organisations: [organisation_1, organisation_2], editions: [policy, create(:published_news_article)])
 
     controller.expects(:expire_on_next_scheduled_publication).with(topic.scheduled_editions)
 
@@ -18,7 +19,8 @@ class TopicsControllerTest < ActionController::TestCase
     assert_select "h1", text: topic.name
     assert_select ".govspeak", text: topic.description
     assert_equal topic.description, assigns(:meta_description)
-    assert_select "a[href=?]", organisation_path(organisation)
+    assert_select "a[href=?]", organisation_path(organisation_1)
+    assert_select "a[href=?]", organisation_path(organisation_2)
   end
 
   view_test "GET :show lists the published policies and their summaries" do


### PR DESCRIPTION
Currently if there is more than one organisation tagged to these formats
the sentence will be html escaped on and html will be shown to the user.
A single org would have been displayed fine as `to_sentence` just
returns the first element.

This fixes pages which are currently broken on preview like this page: https://www.preview.alphagov.co.uk/government/topics/borders-and-immigration
