### PR TITLE
Add support for GML filetype

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -88,6 +88,7 @@ module DocumentHelper
       "html" => file_abbr_tag('HTML', 'Hypertext Markup Language'),
       "ics" => file_abbr_tag('ICS', 'iCalendar file'),
       "eps"  => file_abbr_tag('EPS', 'Encapsulated PostScript'),
+      "gml"  => file_abbr_tag('GML', 'Geography Markup Language'),
       "jpg"  => "JPEG",
       "odp"  => file_abbr_tag('ODP', 'OpenDocument Presentation'),
       "ods"  => file_abbr_tag('ODS', 'OpenDocument Spreadsheet'),

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -9,7 +9,7 @@ class AttachmentUploader < WhitehallUploader
   INDEXABLE_TYPES = %w(csv doc docx ods odp odt pdf ppt pptx rdf rtf txt xls xlsx xml)
 
   FALLBACK_THUMBNAIL_PDF = File.expand_path("../../assets/images/pub-cover.png", __FILE__)
-  EXTENSION_WHITE_LIST = %w(csv doc docx dot dxf gif ics jpg kml ods odp odt pdf png eps ps ppt pptx rdf rtf txt xls xlsx xlt xlsm xml xsd zip)
+  EXTENSION_WHITE_LIST = %w(csv doc docx dot dxf gif gml ics jpg kml ods odp odt pdf png eps ps ppt pptx rdf rtf txt xls xlsx xlt xlsm xml xsd zip)
 
   process :set_content_type
   after :retrieve_from_cache, :set_content_type

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -26,3 +26,5 @@ Mime::Type.register "application/vnd.oasis.opendocument.spreadsheet", :ods
 Mime::Type.register "application/rdf+xml", :rdf
 
 Mime::Type.register "application/dxf", :dxf
+
+Mime::Type.register "application/gml+xml", :gml

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -7,7 +7,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
     graphics = %w(png gif jpg eps ps dxf)
     documents = %w(pdf rtf doc docx ppt pptx rdf txt odt odp ics)
     spreadsheets = %w(csv xls xlsx xlsm ods)
-    markup = %w(kml xml xsd)
+    markup = %w(gml kml xml xsd)
     containers = %w(zip)
     templates = %w(dot xlt)
 


### PR DESCRIPTION
GML is an XML-based markup language for laying out geographical features.

Required so we can support [Land Registry content](http://www.landregistry.gov.uk/market-trend-data/inspire/inspire-downloads).
