### PR TITLE
Stop special-casing sub-org about page URLs.

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -59,9 +59,9 @@ module PublicDocumentRoutesHelper
   def build_url_for_corporate_information_page(edition, options)
     org = edition.owning_organisation
     # About pages are actually shown on the CIP index for an Organisation.
-    # But sub-orgs and worldwide orgs show the about text on the org page itself.
+    # But worldwide orgs show the about text on the org page itself.
     if edition.about_page?
-      if org.is_a?(WorldwideOrganisation) || org.organisation_type.sub_organisation?
+      if org.is_a?(WorldwideOrganisation)
         polymorphic_url([org], options)
       else
         polymorphic_url([org, CorporateInformationPage], options)

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -61,7 +61,7 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     assert_equal organisation_corporate_information_pages_path(cip.organisation), public_document_path(cip)
 
     cip.organisation.organisation_type = OrganisationType::sub_organisation
-    assert_equal organisation_path(cip.organisation), public_document_path(cip)
+    assert_equal organisation_corporate_information_pages_path(cip.organisation), public_document_path(cip)
   end
 
   test 'returns public document URL including host in production environment' do


### PR DESCRIPTION
Sub-organisations no longer show their About Us content on their home page, so
this changes the public document helper to correctly return the /about URL for
these pages. Also fixes the issue that about pages were overwriting the org home
page in the search index.
