### PR TITLE
Describe relationship between sub-orgs and parents correctly

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -96,6 +96,8 @@ module OrganisationHelper
         "#{name} works with #{parents.to_sentence}."
       when 'non-ministerial department'
         "#{name} is #{relationship}."
+      when 'sub-organisation'
+        "#{name} is part of #{parents.to_sentence}."
       else
         "#{name} is #{relationship} of #{parents.to_sentence}."
       end

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -314,6 +314,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_relationship_type_is_described_as(:tribunal_ndpb, '{this_org_name} is a tribunal non-departmental public body of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:public_corporation, '{this_org_name} is a public corporation of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:independent_monitoring_body, '{this_org_name} is an independent monitoring body of the {parent_org_name}.')
+    assert_relationship_type_is_described_as(:sub_organisation, '{this_org_name} is part of the {parent_org_name}.')
     assert_relationship_type_is_described_as(:other, '{this_org_name} works with the {parent_org_name}.')
   end
 


### PR DESCRIPTION
'Sub-organisation' is internal jargon. We shouldn't be describing them
as such to users.

https://www.pivotaltracker.com/story/show/72888338
