### PR TITLE
Correct department counts on how-government-works page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,6 @@ class HomeController < PublicFacingController
   layout 'frontend'
 
   enable_request_formats feed: [:atom]
-  before_filter :load_ministerial_department_count, only: :how_government_works
 
   def feed
     @recently_updated = Edition.published.in_reverse_chronological_order.includes(:document).limit(10)
@@ -12,11 +11,12 @@ class HomeController < PublicFacingController
     sitewide_setting = load_reshuffle_setting
     @is_during_reshuffle = sitewide_setting.on if sitewide_setting
     @policy_count = Policy.published.count
-    @non_ministerial_department_count = Organisation.non_ministerial_departments.count
     sorter = MinisterSorter.new
     @cabinet_minister_count = sorter.cabinet_ministers.count - 1 # subtract one to discount PM
     @other_minister_count = sorter.other_ministers.count
     @all_ministers_count = @cabinet_minister_count + @other_minister_count + 1 # add one to put the PM back in
+    @ministerial_department_count = Organisation.listable.ministerial_departments.count
+    @non_ministerial_department_count = Organisation.listable.non_ministerial_departments.count
   end
 
   def get_involved
@@ -32,11 +32,5 @@ class HomeController < PublicFacingController
   end
 
   def history_lancaster_house
-  end
-
-  private
-
-  def load_ministerial_department_count
-    @ministerial_department_count = Organisation.ministerial_departments.count
   end
 end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -28,6 +28,10 @@ FactoryGirl.define do
     organisation_type_key :ministerial_department
   end
 
+  factory :non_ministerial_department, parent: :organisation do
+    organisation_type_key :non_ministerial_department
+  end
+
   factory :organisation_with_alternative_format_contact_email, parent: :organisation, aliases: [:alternative_format_provider] do
     alternative_format_contact_email "alternative@example.com"
   end

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -90,6 +90,26 @@ class HomeControllerTest < ActionController::TestCase
     assert_select '.all-ministers .count', '4'
   end
 
+  test "how_government_works should assign @ministerial_department_count to the count of active ministerial departments" do
+    create(:ministerial_department)
+    create(:ministerial_department)
+    create(:ministerial_department, :closed)
+
+    get :how_government_works
+
+    assert_equal 2, assigns[:ministerial_department_count]
+  end
+
+  test "how_government_works should assign @non_ministerial_department_count to the count of active non-ministerial departments" do
+    create(:non_ministerial_department)
+    create(:non_ministerial_department)
+    create(:non_ministerial_department, :closed)
+
+    get :how_government_works
+
+    assert_equal 2, assigns[:non_ministerial_department_count]
+  end
+
   test "get involved has counts of open and closed consultations" do
     old = create(:published_consultation, opening_at: 2.years.ago, closing_at: 1.year.ago - 2.day)
 


### PR DESCRIPTION
Before this, all departments were being included in the counts, including
closed ones.

The organisation index is supposed to be the official list of government
departments and that uses the Organisation.listable scope, we should
use that scope for the count.

Pivotal: https://www.pivotaltracker.com/story/show/71920686
