### PR TITLE
Display national statistics logo on stat announcement show page

### DIFF
--- a/app/assets/stylesheets/frontend/views/statistics_announcements/show.scss
+++ b/app/assets/stylesheets/frontend/views/statistics_announcements/show.scss
@@ -1,4 +1,8 @@
 .statistics-announcements-show {
+  .headings-block .heading-extra {
+    margin-top: $gutter * 1.5;
+  }
+
   .release-date-change-information {
     margin: $gutter 0;
 

--- a/app/models/frontend/statistics_announcement.rb
+++ b/app/models/frontend/statistics_announcement.rb
@@ -21,4 +21,8 @@ class Frontend::StatisticsAnnouncement < InflatableModel
   def to_param
     slug
   end
+
+  def national_statistic?
+    document_type == "Statistics - national statistics"
+  end
 end

--- a/app/views/statistics_announcements/show.html.erb
+++ b/app/views/statistics_announcements/show.html.erb
@@ -12,7 +12,11 @@
                  locals: { type: "Statistics release announcement",
                            heading: @announcement.title,
                            extra: true } %>
-
+      <div class="heading-extra">
+        <div class="inner-heading">
+          <%= national_statistics_logo(@announcement) %>
+        </div>
+      </div>
 
       <aside class="meta metadata-list">
         <div class="inner-heading">

--- a/test/unit/models/frontend/statistics_announcement_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_test.rb
@@ -24,4 +24,9 @@ class Frontend::StatisticsAnnouncementTest < ActiveSupport::TestCase
   test "it identifies by it's slug" do
     assert_equal 'a-slug', build_announcement(slug: 'a-slug').to_param
   end
+
+  test "#national_statistic? is true if the document_type is 'Statistics - national statistics'" do
+    assert build_announcement(document_type: "Statistics - national statistics").national_statistic?
+    refute build_announcement(document_type: "Statistics").national_statistic?
+  end
 end


### PR DESCRIPTION
National statistics are a very specific, accredited kind of statistic. We should display the "National Statistics" logo on the statistics announcement page as well as the statistics' actual show page.

https://www.pivotaltracker.com/story/show/71391810
