### PR TITLE
Typo ex chancellors page

### DIFF
--- a/app/views/historic_appointments/past_chancellors.html.erb
+++ b/app/views/historic_appointments/past_chancellors.html.erb
@@ -293,7 +293,7 @@
           <p class="term">1812 to 1823</p>
         </div></li>
         <li class="person person-excerpt"><div class="inner">
-          <h3 class="name">Spender Perceval</h3>
+          <h3 class="name">Spencer Perceval</h3>
           <p class="term">1807 to 1812</p>
         </div></li>
         <li class="person person-excerpt"><div class="inner">


### PR DESCRIPTION
Should say "Spencer" not "Spender"
https://www.pivotaltracker.com/story/show/72705330
