### PR TITLE
Add translation for document.headings.policies

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -13,6 +13,9 @@ ar:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         zero:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -122,6 +122,9 @@ az:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: dərc olunub
     read:
     speech:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -11,6 +11,9 @@ be:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Аб'ява

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -9,6 +9,9 @@ bg:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Съобщение

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -9,6 +9,9 @@ bn:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -10,6 +10,9 @@ cs:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Oznámení

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,6 +13,9 @@ cy:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         zero:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -9,6 +9,9 @@ de:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Meldung

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -9,6 +9,9 @@ dr:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: اعلان

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -9,6 +9,9 @@ el:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Ανακοίνωση

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,9 @@ en:
       attachments:
         one: Document
         other: Documents
+      policies:
+        one: Policy
+        other: Policies
     type:
       announcement:
         one: Announcement

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -9,6 +9,9 @@ es-419:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Novedades

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,6 +9,9 @@ es:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Anuncio

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -124,6 +124,9 @@ fa:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: منتشر شده
     read: مقاله  %{title} را بخوانید
     speech:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,6 +9,9 @@ fr:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Annonce

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -11,6 +11,9 @@ he:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: הודעה

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -9,6 +9,9 @@ hi:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: घोषणा

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -125,6 +125,9 @@ hu:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: közzététel dátuma
     read: 'Olvassa el a következő cikket: %{title}'
     speech:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -9,6 +9,9 @@ hy:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Հայտարարություն

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -124,6 +124,9 @@ id:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: Diterbitkan
     read: Baca artikel %{title}
     speech:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -9,6 +9,9 @@ it:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Annuncio

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -123,6 +123,9 @@ ja:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: 掲載日
     read: '%{title} の記事を読む'
     speech:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -122,6 +122,9 @@ ka:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published:
     read:
     speech:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -123,6 +123,9 @@ ko:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: 발행
     read: '%{title} 기사를 확인하세요'
     speech:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -10,6 +10,9 @@ lt:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Pranešimas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -9,6 +9,9 @@ lv:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Paziņojums

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -122,6 +122,9 @@ ms:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published:
     read:
     speech:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -11,6 +11,9 @@ pl:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Ogłoszenie

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -9,6 +9,9 @@ ps:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: خبرتیا

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -9,6 +9,9 @@ pt:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Anúncio

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -10,6 +10,9 @@ ro:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Știre

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -11,6 +11,9 @@ ru:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Объявление

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -9,6 +9,9 @@ si:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: නිවේදනය

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -10,6 +10,9 @@ sk:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -9,6 +9,9 @@ so:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Ogeysiis

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -9,6 +9,9 @@ sq:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Lajmerim

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -11,6 +11,9 @@ sr:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Najava

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -9,6 +9,9 @@ sw:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -9,6 +9,9 @@ ta:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: அறிவிப்பு

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -123,6 +123,9 @@ th:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: ตีพิมพ์
     read: อ่าน%{title}บทความ
     speech:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -9,6 +9,9 @@ tk:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -124,6 +124,9 @@ tr:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: Yayında
     read: '%{title} makalesini okuyunuz'
     speech:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -11,6 +11,9 @@ uk:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: Оголошення

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -9,6 +9,9 @@ ur:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: اعلان

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -9,6 +9,9 @@ uz:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     type:
       announcement:
         one: E'lon

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -124,6 +124,9 @@ vi:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: Đã xuất bản
     read: Đọc bài có  %{title}
     speech:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -122,6 +122,9 @@ zh-hk:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: 已發布
     read: 閱讀%{title}文章
     speech:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -122,6 +122,9 @@ zh-tw:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: 發行
     read: 閱讀%{title}文章
     speech:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -122,6 +122,9 @@ zh:
       from:
       location:
       part_of:
+      policies:
+        one:
+        other:
     published: 已发布
     read: 阅读%{title}文章
     speech:


### PR DESCRIPTION
policies/show.html.erb was referencing a missing key
Fix related to this Zendesk ticket: 
https://govuk.zendesk.com/agent/#/tickets/751553
(translation missing on policy page title)
