### PR TITLE
Assume english format when parsing dates on stats announcement filter

### DIFF
--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -22,7 +22,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   end
 
   def to_date=(date)
-    date = Chronic.parse(date, guess: :end) if date.is_a? String
+    date = Chronic.parse(date, guess: :end, endian_precedence: :little) if date.is_a? String
     @to_date = if date.present?
       (date - 1.seconds).to_date
     else
@@ -31,7 +31,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   end
 
   def from_date=(date)
-    date = Chronic.parse(date, guess: :begin) if date.is_a? String
+    date = Chronic.parse(date, guess: :begin, endian_precedence: :little) if date.is_a? String
     @from_date = if date.present?
       date.to_date
     else

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -13,6 +13,11 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     assert_equal Date.new(2010, 01, 01), build(from_date: "Jan 2010").from_date
   end
 
+  test "to_date= and from_date= assumes english date format when ambiguous" do
+    assert_equal Date.new(2010, 06, 12), build(to_date: "12/6/2010").to_date
+    assert_equal Date.new(2010, 06, 12), build(from_date: "12/6/2010").from_date
+  end
+
   test "#page= casts to integer" do
     assert build(page: '2').page.is_a? Integer
   end


### PR DESCRIPTION
Bug affected the stats announcement filter (https://www.gov.uk/government/statistics/announcements (yes, it's supposed to be empty, the feature's not in use yet and isn't discoverable)).

Previously, the date fields would assume an American date format when ambiguous, 
so entering "12/06/2010" would parse out as 6th December 2010.

I've taken a look to see if there's any way to configure Chronic site-wide, but that's a no-go.

Story: https://www.pivotaltracker.com/story/show/73205986
