### PR TITLE
Stats announcements index ordered by public_timestamp

### DIFF
--- a/app/providers/frontend/statistics_announcement_provider.rb
+++ b/app/providers/frontend/statistics_announcement_provider.rb
@@ -71,6 +71,7 @@ module Frontend
       params[:per_page] = params[:per_page].to_s
 
       params[:format] = "statistics_announcement"
+      params[:order] = {release_timestamp: "asc"}
 
       params
     end

--- a/test/unit/providers/frontend/statistics_announcement_provider_test.rb
+++ b/test/unit/providers/frontend/statistics_announcement_provider_test.rb
@@ -7,19 +7,35 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
   end
 
   test "#search: page and per_page params are converted to strings" do
-    @mock_source.expects(:advanced_search).with(page: '2', per_page: '10', format: 'statistics_announcement').returns({'total' => 0, 'results' => []})
+    @mock_source.expects(:advanced_search).with {|actual|
+      actual[:page] == '2' &&
+      actual[:per_page] == '10'
+    }.returns({'total' => 0, 'results' => []})
     Frontend::StatisticsAnnouncementProvider.search(page: 2, per_page: 10)
   end
 
   test "#search: from_date and to_date are moved to release_timestamp[:from] and release_timestamp[:to] and are formatted as iso8601" do
     from_date = 1.day.from_now
     to_date = 1.year.from_now
-    @mock_source.expects(:advanced_search).with(release_timestamp: {from: from_date.iso8601, to: to_date.iso8601}, page: '2', per_page: '10', format: 'statistics_announcement').returns({'total' => 0, 'results' => []})
+    @mock_source.expects(:advanced_search).with {|actual|
+      actual[:release_timestamp] == {from: from_date.iso8601, to: to_date.iso8601} &&
+      actual[:from_date].nil? &&
+      actual[:to_date].nil?
+    }.returns({'total' => 0, 'results' => []})
     Frontend::StatisticsAnnouncementProvider.search(from_date: from_date, to_date: to_date, page: 2, per_page: 10)
   end
 
   test "#search adds in the paramater format=statistics_announcement" do
-    @mock_source.expects(:advanced_search).with {|actual| actual[:format] == "statistics_announcement" }.returns({'total' => 0, 'results' => []})
+    @mock_source.expects(:advanced_search).with {|actual|
+      actual[:format] == "statistics_announcement"
+    }.returns({'total' => 0, 'results' => []})
+    Frontend::StatisticsAnnouncementProvider.search(page: 2, per_page: 10)
+  end
+
+  test "#search adds in the paramater order={release_timestamp: 'asc'" do
+    @mock_source.expects(:advanced_search).with {|actual|
+      actual[:order][:release_timestamp] == 'asc'
+    }.returns({'total' => 0, 'results' => []})
     Frontend::StatisticsAnnouncementProvider.search(page: 2, per_page: 10)
   end
 
@@ -61,7 +77,7 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
   end
 
   test "#search: results are returned in a CollectionPage with the correct total, page and per_page values" do
-    @mock_source.stubs(:advanced_search).with(page: '2', per_page: '10', format: 'statistics_announcement').returns('total' => 30, 'results' => 10.times.map {|n| {"title" => "A title", "metadata" => {}} })
+    @mock_source.stubs(:advanced_search).returns('total' => 30, 'results' => 10.times.map {|n| {"title" => "A title", "metadata" => {}} })
 
     results = Frontend::StatisticsAnnouncementProvider.search(page: 2, per_page: 10)
 


### PR DESCRIPTION
Stats announcements (https://whitehall-admin.preview.alphagov.co.uk/government/statistics/announcements) didn't have any explicit ordering before. This PR orders them by release_timestamp instead.

The visible announcement date is not the same as the announcement's timestamp, as in many cases the announcement has a displayed date range of up to two months instead of a discrete date.  The timestamp does reflect that date range however.

Also, make a few of the tests a little less brittle.

Story: https://www.pivotaltracker.com/story/show/73205062
