### PR TITLE
Report exceptions raised during edition workflow

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -9,17 +9,20 @@ class Admin::EditionWorkflowController < Admin::BaseController
   before_filter :set_minor_change_flag
   before_filter :ensure_reason_given_for_force_publishing, only: :force_publish
 
-  rescue_from ActiveRecord::StaleObjectError do
+  rescue_from ActiveRecord::StaleObjectError do |exception|
+    notify_airbrake(exception)
     redirect_to admin_edition_path(@edition), alert: "This document has been edited since you viewed it; you are now viewing the latest version"
   end
 
-  rescue_from ActiveRecord::RecordInvalid do
+  rescue_from ActiveRecord::RecordInvalid do |exception|
+    notify_airbrake(exception)
     redirect_to admin_edition_path(@edition),
       alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is invalid (#{@edition.errors.full_messages.to_sentence}). " +
              "Please edit it and try again."
   end
 
-  rescue_from Transitions::InvalidTransition do
+  rescue_from Transitions::InvalidTransition do |exception|
+    notify_airbrake(exception)
     redirect_to admin_edition_path(@edition),
       alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is not ready yet. Please try again."
   end


### PR DESCRIPTION
The fact that we are rescue these exceptions is a long-standing smell and a source of technical debt that we need to address. Work was started to extract all these workflow actions into self-contained and atomic
service objects such that we would no longer need to rescue these exceptions (see `EditionPublisher`, `EditionForcePublisher`, etc), but that work was not completed.

I propose we remove these `rescue_from` statements completely as they are masking all sorts of potential problems. Before we do, this change adds exception logging so that we can get a sense of the type and volume of exceptions we are currently silently handling. This will allow us to better asses the likely impact of removing them now instead of waiting until all workflow actions have had service objects extracted.
