### PR TITLE
Fix rel external for featured articles on org pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_featured_news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_featured_news.scss
@@ -33,7 +33,7 @@
           @include right-to-left {
             padding: $gutter-one-third 0 0 $gutter-half;
           }
-          @include media(tablet){
+          @include media(tablet) {
             padding: 0;
           }
 
@@ -48,7 +48,7 @@
         @include right-to-left {
           float: right;
         }
-        @include media(tablet){
+        @include media(tablet) {
           float: none;
           width: $full-width;
         }
@@ -63,6 +63,9 @@
           padding-top: 0;
           a {
             font-weight: bold;
+            &[rel=external] {
+              @include external-link-19-bold-no-hover;
+            }
           }
         }
         h3 {


### PR DESCRIPTION
Including the correct rel=external mixin to fix the lack of the space between external links for featured news on org homepages and the external link icon.

https://www.pivotaltracker.com/story/show/72420384
