### PR TITLE
Show publication history for published and archived documents

### DIFF
--- a/app/views/documents/_document_footer_meta.html.erb
+++ b/app/views/documents/_document_footer_meta.html.erb
@@ -7,11 +7,10 @@
   <div class="history">
     <dl class="primary-metadata">
       <dt><%= t('document.footer_meta.published') %>:</dt>
-      <% if document.state != 'published' %>
+      <% if document.pre_publication? %>
         <dd>Preview</dd>
       <% else %>
         <dd><%= absolute_date(history.last.public_timestamp) %></dd>
-
         <% unless history.newly_published? %>
           <dt><%= t('document.footer_meta.updated') %>:</dt>
           <dd><%= absolute_date(history.first.public_timestamp) %></dd>


### PR DESCRIPTION
The publication history for a document only used to display for documents with state 'published', all others would display "Preview" instead. This meant archived documents had "Preview" as their publication history. 
We now display "Preview" for documents that have not been published yet and the history for all others. 
https://www.pivotaltracker.com/story/show/66134198
