### PR TITLE
Fix rendering of inline images on about pages.

### DIFF
--- a/app/views/corporate_information_pages/index.html.erb
+++ b/app/views/corporate_information_pages/index.html.erb
@@ -45,7 +45,7 @@
                   <%= @document.summary %>
                 </p>
               </div>
-              <%= govspeak_to_html @document.body %>
+              <%= govspeak_edition_to_html @document %>
             </div>
           <% end %>
           <% if has_any_transparency_pages?(@organisation) %>


### PR DESCRIPTION
About pages (ie CIP indexes) were not using the correct govspeak helper to render inline attachments, so the raw markup was appearing on page.

https://www.agileplannerapp.com/boards/173808/cards/4226
