### PR TITLE
SPIKE for comment: speeding up edition edit forms [DO NOT MERGE]

### DIFF
--- a/app/helpers/admin/form_field_caching_helper.rb
+++ b/app/helpers/admin/form_field_caching_helper.rb
@@ -1,0 +1,38 @@
+module Admin::FormFieldCachingHelper
+
+  def cached_worldwide_priority_options
+    Rails.cache.fetch("edition_options/worldwide_priorities", expires_in: 30.minutes) do
+      WorldwidePriority.published.alphabetical.map {|wp| [wp.title, wp.id] }
+    end
+  end
+
+  def cached_world_location_options
+    Rails.cache.fetch("edition_options/world_locations", expires_in: 30.minutes) do
+      WorldLocation.ordered_by_name.map { |wl| [wl.name, wl.id] }
+    end
+  end
+
+  def cached_ministerial_appointment_options
+    Rails.cache.fetch("edition_options/ministerial_roles", expires_in: 30.minutes) do
+      ministerial_appointment_options
+    end
+  end
+
+  def cached_organisation_options
+    Rails.cache.fetch("edition_options/lead_organisations", expires_in: 30.minutes) do
+      organisations_for_edition_organisations_fields.map { |o| [o.select_name, o.id] }
+    end
+  end
+
+  def cached_related_policy_options
+    Rails.cache.fetch("edition_options/related_policies", expires_in: 30.minutes) do
+      related_policy_options
+    end
+  end
+
+  def cached_alternative_format_provider_options
+    Rails.cache.fetch("edition_options/alternative_format_providers", expires_in: 30.minutes) do
+      organisations_for_edition_organisations_fields.map {|o| ["#{o.name} (#{o.alternative_format_contact_email || "-"})", o.id]}
+    end
+  end
+end

--- a/app/helpers/admin/related_policies_helper.rb
+++ b/app/helpers/admin/related_policies_helper.rb
@@ -1,8 +1,8 @@
 module Admin::RelatedPoliciesHelper
-  def options_from_related_policy_options_for_select(related_policy_options, edition)
+  def related_policy_options_for_select(edition)
     selected_policy_ids = edition.related_policy_ids
     selected_policy_ids |= Array(params[:edition][:related_policy_ids]) if params[:edition]
 
-    options_from_collection_for_select(related_policy_options, :first, :last, selected_policy_ids)
+    options_for_select(cached_related_policy_options, selected_policy_ids)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,7 @@ module ApplicationHelper
 
   def role_appointment_options(filter = RoleAppointment)
     filter.includes(:person).with_translations_for(:organisations).with_translations_for(:role).alphabetical_by_person.map do |appointment|
-      [appointment.id, "#{appointment.person.name}, #{role_appointment(appointment)}, in #{appointment.organisations.map(&:name).to_sentence}"]
+      ["#{appointment.person.name}, #{role_appointment(appointment)}, in #{appointment.organisations.map(&:name).to_sentence}", appointment.id]
     end
   end
 
@@ -79,13 +79,13 @@ module ApplicationHelper
     Policy.latest_edition.with_translations.includes(:topics).active.map do |policy|
       parts = [policy.title]
       parts << "(#{policy.topics.map(&:name).to_sentence})" if policy.topics.any?
-      [policy.id, parts.join(" ")]
+      [parts.join(" "), policy.id]
     end
   end
 
   def related_policy_options_excluding(policies)
     related_policy_options.select do |po|
-      !policies.map(&:id).include?(po.first)
+      !policies.map(&:id).include?(po.last)
     end
   end
 

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -1,6 +1,6 @@
 <%= form.label :role_appointment_ids, 'Ministers' %>
 <%= form.select :role_appointment_ids,
-                options_from_collection_for_select(ministerial_appointment_options, :first, :last, edition.role_appointment_ids),
+                options_for_select(cached_ministerial_appointment_options, edition.role_appointment_ids),
                 { include_blank: true },
                 multiple: true,
                 class: 'chzn-select',

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,7 +1,7 @@
 <fieldset>
   <%= form.label :related_policy_ids, 'Related policies' %>
   <%= form.select :related_policy_ids,
-                  options_from_related_policy_options_for_select(related_policy_options, form.object),
+                  related_policy_options_for_select(form.object),
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select',

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -83,9 +83,9 @@
       <div class="row-fluid">
         <%= label_tag 'edition[related_policy_ids][]', 'Additional policies' %>
         <%= select_tag 'edition[related_policy_ids][]',
-          options_from_collection_for_select(
+          options_for_select(
             related_policy_options_excluding(policies_for_editions_organisations(@edition)),
-            :first, :last, @edition.related_policy_ids),
+            @edition.related_policy_ids),
           include_blank: true,
           multiple: true,
           class: 'chzn-select',

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -5,7 +5,7 @@
 <%= form.label :world_location_ids, "Select the world locations this #{edition.format_name.titleize.downcase} is about", mandatory: world_location_mandatory %>
 
 <%= form.select :world_location_ids,
-                options_from_collection_for_select(WorldLocation.ordered_by_name, 'id', 'name', edition.world_location_ids),
+                options_for_select(cached_world_location_options, edition.world_location_ids),
                 { include_blank: true },
                 multiple: true,
                 class: 'chzn-select',

--- a/app/views/admin/editions/_worldwide_priority_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_priority_fields.html.erb
@@ -1,6 +1,6 @@
 <%= form.label :worldwide_priority_ids, 'Worldwide priorities' %>
 <%= form.select :worldwide_priority_ids,
-                options_from_collection_for_select(WorldwidePriority.published.alphabetical, 'id', 'title', form.object.worldwide_priority_ids),
+                options_for_select(cached_worldwide_priority_options, form.object.worldwide_priority_ids),
                 {},
                 multiple: true,
                 class: 'chzn-select',

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="role_appointment">
   <%= form.label :role_appointment_id, 'Speaker' %>
-  <%= form.select :role_appointment_id, options_from_collection_for_select(role_appointment_options, :first, :last, edition.role_appointment_id), { include_blank: true }, class: 'chzn-select', data: { placeholder: "Choose a person..." } %>
+  <%= form.select :role_appointment_id, options_for_select(role_appointment_options, edition.role_appointment_id), { include_blank: true }, class: 'chzn-select', data: { placeholder: "Choose a person..." } %>
 </div>
 <div class="edition_person_override">
   <%= form.text_field :person_override, label_text: "Speaker" %>

--- a/app/views/admin/supporting_pages/_related_policy_fields.html.erb
+++ b/app/views/admin/supporting_pages/_related_policy_fields.html.erb
@@ -4,7 +4,7 @@
   should rarely choose more than one policy).</p>
 
   <%= form.select :related_policy_ids,
-                  options_from_related_policy_options_for_select(related_policy_options, form.object),
+                  related_policy_options_for_select(form.object),
                   { include_blank: true },
                   multiple: true,
                   class: "chzn-select",

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,8 @@ Whitehall::Application.configure do
   config.slimmer.asset_host = ENV['STATIC_DEV'] || Plek.new.find('static')
 
   # Disable cache in development
-  config.cache_store = :null_store
+  # config.cache_store = :null_store
+  config.cache_store = :memory_store, { size: 32.megabytes }
 
   if ENV['SHOW_PRODUCTION_IMAGES']
     orig_host = config.asset_host

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -34,9 +34,9 @@ class ApplicationHelperTest < ActionView::TestCase
     options = role_appointment_options
 
     assert_equal 3, options.length
-    assert options.include? [philip_hammond_appointment.id, "Philip Hammond, Secretary of State, in Ministry of Defence"]
-    assert options.include? [philip_hammond_home_secretary_appointment.id, "Philip Hammond, as Secretary of State (01 January 2010 to 01 January 2011), in Home Office"]
-    assert options.include? [theresa_may_appointment.id, "Theresa May, Secretary of State, in Home Office"]
+    assert options.include? ["Philip Hammond, Secretary of State, in Ministry of Defence", philip_hammond_appointment.id]
+    assert options.include? ["Philip Hammond, as Secretary of State (01 January 2010 to 01 January 2011), in Home Office", philip_hammond_home_secretary_appointment.id]
+    assert options.include? ["Theresa May, Secretary of State, in Home Office", theresa_may_appointment.id]
   end
 
   test "should supply options with IDs and descriptions for all the ministerial roles" do
@@ -65,7 +65,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
     options = role_appointment_options
     assert_equal 1, options.length
-    assert options.include? [appointment.id, "Joe Bloggs, Role, in Org"]
+    assert options.include? ["Joe Bloggs, Role, in Org", appointment.id]
   end
 
   test '#link_to_attachment returns nil when attachment is nil' do
@@ -225,7 +225,7 @@ class ApplicationHelperTest < ActionView::TestCase
     topic = build(:topic, name: "Topic")
     policy = create(:policy, title: "Policy title", topics: [topic])
     excluded = create(:policy, title: "Excluded", topics: [topic])
-    assert_equal [[policy.id, "Policy title (Topic)"]], related_policy_options_excluding([excluded])
+    assert_equal [["Policy title (Topic)", policy.id]], related_policy_options_excluding([excluded])
   end
 
   test "#policies_for_editions_organisations returns all active policies that map to an organisation the edition is in" do
@@ -241,7 +241,7 @@ class ApplicationHelperTest < ActionView::TestCase
     third_topic = build(:topic, name: "Third topic")
     policy = create(:policy, title: "Policy title", topics: [first_topic, second_topic, third_topic])
     options = related_policy_options
-    assert_equal [[policy.id, "Policy title (First topic, Second topic and Third topic)"]], related_policy_options
+    assert_equal [["Policy title (First topic, Second topic and Third topic)", policy.id]], related_policy_options
   end
 
   test "skips asset host for image paths if user signed in and image in uploads" do


### PR DESCRIPTION
Proof of concept of a potential technique to speed up the edit forms for editions. At present, these take several seconds to load, making for a pretty miserable user experience.

This commit demonstrates how using Rails caching to cache options for form select fields could yield some serious speed improvements. In almost all cases, the values in these options do not change very
often (e.g. lists of organisations, world locations, people, etc). This caching would have to be combined with an effective strategy for invalidating the caches when there are changes.

In this example, the news article form goes from loading in approximately 5 seconds to loading in less than a 1.3 seconds.
