### PR TITLE
Fix web_urls in api responses.

### DIFF
--- a/app/presenters/api/detailed_guide_presenter.rb
+++ b/app/presenters/api/detailed_guide_presenter.rb
@@ -26,7 +26,7 @@ class Api::DetailedGuidePresenter < Api::BasePresenter
       {
         title: org.name,
         id: context.organisation_url(org, format: :json),
-        web_url: context.organisation_url(org),
+        web_url: Whitehall.url_maker.organisation_url(org),
         details: {
           type: "organisation",
           short_description: org.acronym

--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -5,7 +5,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
       title: model.name,
       format: model.organisation_type.name,
       updated_at: model.updated_at,
-      web_url: context.organisation_url(model),
+      web_url: Whitehall.url_maker.organisation_url(model),
       details: {
         slug: model.slug,
         abbreviation: model.acronym,
@@ -31,7 +31,7 @@ private
     model.parent_organisations.map do |parent|
       {
         id: context.api_organisation_url(parent),
-        web_url: context.organisation_url(parent)
+        web_url: Whitehall.url_maker.organisation_url(parent)
       }
     end
   end
@@ -40,7 +40,7 @@ private
     model.child_organisations.map do |child|
       {
         id: context.api_organisation_url(child),
-        web_url: context.organisation_url(child)
+        web_url: Whitehall.url_maker.organisation_url(child)
       }
     end
   end

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -5,14 +5,14 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       title: model.name,
       format: model.display_type,
       updated_at: model.updated_at,
-      web_url: context.world_location_url(model),
+      web_url: Whitehall.url_maker.world_location_url(model),
       details: {
         slug: model.slug,
         iso2: model.iso2,
       },
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),
-        web_url: context.world_location_url(model, anchor: 'organisations'),
+        web_url: Whitehall.url_maker.world_location_url(model, anchor: 'organisations'),
       }
     }
   end

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -5,7 +5,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       title: model.name,
       format: 'Worldwide Organisation',
       updated_at: model.updated_at,
-      web_url: context.worldwide_organisation_url(model),
+      web_url: Whitehall.url_maker.worldwide_organisation_url(model),
       details: {
         slug: model.slug,
       },
@@ -27,7 +27,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
   def sponsor_as_json(sponsor)
     {
       title: sponsor.name,
-      web_url: context.organisation_url(sponsor),
+      web_url: Whitehall.url_maker.organisation_url(sponsor),
       details: {
         acronym: sponsor.acronym || ''
       }
@@ -46,7 +46,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       title: office_worldwide_organisation.contact.title,
       format: 'World Office',
       updated_at: office_worldwide_organisation.updated_at,
-      web_url: context.worldwide_organisation_worldwide_office_url(model, office_worldwide_organisation),
+      web_url: Whitehall.url_maker.worldwide_organisation_worldwide_office_url(model, office_worldwide_organisation),
       details: {
         email: office_worldwide_organisation.contact.email || '',
         description: office_worldwide_organisation.contact.comments || '',

--- a/test/unit/presenters/api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/api/detailed_guide_presenter_test.rb
@@ -64,7 +64,7 @@ class Api::DetailedGuidePresenterTest < PresenterTestCase
     guide_json = {
       title: @organisation.name,
       id: organisation_url(@organisation, format: :json),
-      web_url: organisation_url(@organisation),
+      web_url: Whitehall.url_maker.organisation_url(@organisation),
       details: {
         type: 'organisation',
         short_description: @organisation.acronym

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -69,20 +69,20 @@ class Api::OrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public organisation url as web_url" do
-    assert_equal organisation_url(@organisation), @presenter.as_json[:web_url]
+    assert_equal Whitehall.url_maker.organisation_url(@organisation), @presenter.as_json[:web_url]
   end
 
   test "json includes request-relative api parent organisations" do
     parent = stub_record(:organisation)
     @organisation.stubs(:parent_organisations).returns([parent])
     assert_equal api_organisation_url(parent), @presenter.as_json[:parent_organisations].first[:id]
-    assert_equal organisation_url(parent), @presenter.as_json[:parent_organisations].first[:web_url]
+    assert_equal Whitehall.url_maker.organisation_url(parent), @presenter.as_json[:parent_organisations].first[:web_url]
   end
 
   test "json includes request-relative api child organisations" do
     child = stub_record(:organisation)
     @organisation.stubs(:child_organisations).returns([child])
     assert_equal api_organisation_url(child), @presenter.as_json[:child_organisations].first[:id]
-    assert_equal organisation_url(child), @presenter.as_json[:child_organisations].first[:web_url]
+    assert_equal Whitehall.url_maker.organisation_url(child), @presenter.as_json[:child_organisations].first[:web_url]
   end
 end

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -58,7 +58,7 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url as web_url" do
-    assert_equal world_location_url(@location), @presenter.as_json[:web_url]
+    assert_equal Whitehall.url_maker.world_location_url(@location), @presenter.as_json[:web_url]
   end
 
   test "json includes request-relative api organisations url as organisations id" do
@@ -66,6 +66,6 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
   end
 
   test "json includes public location url (anchored on organisations) organisations web_url" do
-    assert_equal world_location_url(@location, anchor: 'organisations'), @presenter.as_json[:organisations][:web_url]
+    assert_equal Whitehall.url_maker.world_location_url(@location, anchor: 'organisations'), @presenter.as_json[:organisations][:web_url]
   end
 end

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -62,7 +62,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public world organisations url as web_url" do
-    assert_equal worldwide_organisation_url(@world_org), @presenter.as_json[:web_url]
+    assert_equal Whitehall.url_maker.worldwide_organisation_url(@world_org), @presenter.as_json[:web_url]
   end
 
   test 'json includes office sponsoring org name in sponsors array as title' do
@@ -76,7 +76,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test "json includes public organisations url for sponsor in sponsors array as web_url" do
-    assert_equal organisation_url(@main_sponsor), @presenter.as_json[:sponsors].first[:web_url]
+    assert_equal Whitehall.url_maker.organisation_url(@main_sponsor), @presenter.as_json[:sponsors].first[:web_url]
   end
 
   test 'json includes office contact title in offices as title' do
@@ -85,7 +85,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
   end
 
   test 'json includes public office url in offices as web_url' do
-    assert_equal worldwide_organisation_worldwide_office_url(@world_org, @office), @presenter.as_json[:offices][:main][:web_url]
+    assert_equal Whitehall.url_maker.worldwide_organisation_worldwide_office_url(@world_org, @office), @presenter.as_json[:offices][:main][:web_url]
   end
 
   test 'json includes office contact comments in offices as description' do


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/1563 introduced a bug whereby api requests would return request-relative URLs in the web_url field. This restores the original behaviour and returns public URLs (derived from `ENV['GOVUK_WEBSITE_ROOT']`) in these responses.
