### PR TITLE
Fix IE7 alignment/float issue for management list on org pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -559,6 +559,9 @@
           width: 75%;
           li {
             width: $one-third;
+            @include ie(7) {
+              height: 110px;
+            }
           }
         }
       }


### PR DESCRIPTION
I've added in a fixed height of 110px (min-height not IE7 compatible)
to fix alignment issue in IE7. This should be enough for allow longer
names listed and not too much to make the list items too tall and have
too much unecessary white space

https://www.pivotaltracker.com/story/show/70927282
