### PR TITLE
Repair count on stats announcement index

### DIFF
--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -82,7 +82,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   end
 
   def result_count
-    results.count
+    results.total
   end
 
   def next_page_params

--- a/features/step_definitions/statistics_announcement_steps.rb
+++ b/features/step_definitions/statistics_announcement_steps.rb
@@ -77,7 +77,9 @@ When(/^I click on the first statistics announcement$/) do
 end
 
 Then(/^I can see the first page of all the statistics announcements$/) do
-
+  within '.filter-results-summary' do
+    assert page.has_content? "43 release announcements"
+  end
   assert page.has_content? "Womble to Wombat population ratios"
   assert page.has_content? "2055 beard lengths"
   assert page.has_content? "Wombat population in Wimbledon Common 2063"


### PR DESCRIPTION
The count used to show the number of results _returned_, which would always
be 40 when looking at a result set >= 40 (because 40 per page). This fixes that.

Story: https://www.pivotaltracker.com/story/show/73954532
