### PR TITLE
Correct parent tag on mainstream category

### DIFF
--- a/db/data_migration/20140630131603_update_mainstream_categories.rb
+++ b/db/data_migration/20140630131603_update_mainstream_categories.rb
@@ -1,0 +1,1 @@
+MainstreamCategory.find_by_parent_tag('visas-immigration/sponsoring-workers-students').update_attribute(:parent_tag, 'visas-immigration/sponsor-workers-students')


### PR DESCRIPTION
The slugs for a set of visa-related browse pages were updated in panopticon (https://github.com/alphagov/panopticon/commit/ce57246d1c34eac4b37eee7d478535cdcdcc9fca)
but the whitehall mainstream categories were not updated accordingly, specifically the "Endorsing, sponsoring and supporting visa applicants" category that has the parent tag of "visas-immigration/sponsoring-workers-students". This has caused any detailed guides tagged to this category to generate broken links, for
example the link to the mainstream category in the meta data for this guide (https://www.gov.uk/apply-for-a-tier-4-sponsor-licence) is broken. This data migration updates the category's parent_tag to match the slug of the section in panopticon.

/cc @Shotclog
