### PR TITLE
Revert "Report exceptions raised during edition workflow"

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -9,20 +9,17 @@ class Admin::EditionWorkflowController < Admin::BaseController
   before_filter :set_minor_change_flag
   before_filter :ensure_reason_given_for_force_publishing, only: :force_publish
 
-  rescue_from ActiveRecord::StaleObjectError do |exception|
-    notify_airbrake(exception)
+  rescue_from ActiveRecord::StaleObjectError do
     redirect_to admin_edition_path(@edition), alert: "This document has been edited since you viewed it; you are now viewing the latest version"
   end
 
-  rescue_from ActiveRecord::RecordInvalid do |exception|
-    notify_airbrake(exception)
+  rescue_from ActiveRecord::RecordInvalid do
     redirect_to admin_edition_path(@edition),
       alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is invalid (#{@edition.errors.full_messages.to_sentence}). " +
              "Please edit it and try again."
   end
 
-  rescue_from Transitions::InvalidTransition do |exception|
-    notify_airbrake(exception)
+  rescue_from Transitions::InvalidTransition do
     redirect_to admin_edition_path(@edition),
       alert: "Unable to #{action_name_as_human_interaction(params[:action])} because it is not ready yet. Please try again."
   end


### PR DESCRIPTION
This reverts commit 4642a9d7f471f6b080c70e54bca6a9e5e4084ac0.

We've had these notifications running for almost two weeks now so have a handle on the kind of things we need to handle in these workflow actions.
