### PR TITLE
Style corp information page language links

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -48,6 +48,7 @@
   @import "helpers/_announcements.scss";
   @import "helpers/_archive-notice.scss";
   @import "helpers/_attachment.scss";
+  @import "helpers/_available_languages.scss";
   @import "helpers/_beta-notice.scss";
   @import "helpers/_browse.scss";
   @import "helpers/_change-notes.scss";
@@ -137,6 +138,7 @@
   @import "views/_worldwide_priorities.scss";
   @import "views/_take-part-pages.scss";
   @import "views/_topical-events.scss";
+  @import "views/corporate_information_pages/show.scss";
   @import "views/organisations/_transition_state_visualisation.scss";
   @import "views/statistics_announcements/index.scss";
   @import "views/statistics_announcements/show.scss";

--- a/app/assets/stylesheets/frontend/helpers/_available_languages.scss
+++ b/app/assets/stylesheets/frontend/helpers/_available_languages.scss
@@ -1,0 +1,39 @@
+.available-languages {
+  ul {
+    @extend %contain-floats;
+    list-style: none;
+    padding: $gutter-half 0 $gutter-one-sixth;
+    border-bottom: 1px solid $border-colour;
+
+    li {
+      float: left;
+      display: block;
+      border-right: 1px solid $border-colour;
+      padding: 0 $gutter-one-third 0 0;
+      height: 16px;
+      margin: 3px $gutter-one-third 2px 0;
+      @include right-to-left {
+        float: right;
+      }
+
+      &.last {
+        border-right: 0;
+      }
+
+      a, span {
+        display: block;
+        margin-top: -1px;
+        @include core-16;
+      }
+      @include right-to-left{
+        border-left: 1px solid $border-colour;
+        border-right: 0;
+        margin: 3px 0 2px $gutter-one-third;
+        padding: 0 0 0 $gutter-one-third;
+        &.last {
+          border-left: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/frontend/helpers/_headings.scss
+++ b/app/assets/stylesheets/frontend/helpers/_headings.scss
@@ -88,45 +88,6 @@
     }
   }
 
-  .available-languages {
-    ul {
-      @extend %contain-floats;
-      list-style: none;
-      padding: $gutter-half 0 $gutter-one-sixth;
-      border-bottom: 1px solid $border-colour;
-
-      li {
-        float: left;
-        display: block;
-        border-right: 1px solid $border-colour;
-        padding: 0 $gutter-one-third 0 0;
-        height: 16px;
-        margin: 3px $gutter-one-third 2px 0;
-        @include right-to-left {
-          float: right;
-        }
-
-        &.last {
-          border-right: 0;
-        }
-
-        a, span {
-          display: block;
-          margin-top: -1px;
-          @include core-16;
-        }
-        @include right-to-left{
-          border-left: 1px solid $border-colour;
-          border-right: 0;
-          margin: 3px 0 2px $gutter-one-third;
-          padding: 0 0 0 $gutter-one-third;
-          &.last {
-            border-left: 0;
-          }
-        }
-      }
-    }
-  }
   .organisations-icon-list {
     margin-top: $gutter*2;
   }

--- a/app/assets/stylesheets/frontend/views/corporate_information_pages/_show.scss
+++ b/app/assets/stylesheets/frontend/views/corporate_information_pages/_show.scss
@@ -1,0 +1,12 @@
+.corporate-information-pages-show {
+  .available-languages {
+    width: 50%;
+    float: right;
+    margin: 0 0 $gutter-half $gutter-half;
+
+    ul {
+      margin-left: $gutter-one-third;
+      padding-top: 0;
+    }
+  }
+}

--- a/app/views/corporate_information_pages/show.html.erb
+++ b/app/views/corporate_information_pages/show.html.erb
@@ -11,12 +11,10 @@
     </div>
     <div class="block-2">
       <div class="inner-block">
+        <%= render 'shared/available_languages', object: @corporate_information_page %>
         <%= content_tag :p, class: 'homepage-link' do %>
           <%= link_to "#{@organisation.name} homepage", organisation_path(@organisation) %>
         <% end %>
-        <aside class="organisation-top-tasks">
-          <%= render 'shared/available_languages', object: @corporate_information_page %>
-        </aside>
         <h1 class="main"><%= @corporate_information_page.title %></h1>
         <p class="description">
           <%= @corporate_information_page.summary %>


### PR DESCRIPTION
Previously, the alternative language links were unstyled in a bulleted list on corporate information pages. This fixes that by extracting the styling for .available-languages into a css helper, taking it out of the heading scope.

Screenshot after styling change: 

![screen shot 2014-07-03 at 15 10 48](https://cloud.githubusercontent.com/assets/110680/3470656/876637ea-02bc-11e4-874d-a354dc13bf9a.png)
