### PR TITLE
Fix atom feed where fractions are present in a publication

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -137,7 +137,7 @@ module GovspeakHelper
     return govspeak if govspeak.blank?
     govspeak.gsub(GovspeakHelper::FRACTION_REGEXP) do |match|
       if $1.present? && $2.present?
-        render(partial: 'shared/govspeak_fractions', locals: { numerator: $1, denominator: $2 })
+        render(partial: 'shared/govspeak_fractions.html.erb', locals: { numerator: $1, denominator: $2 })
       else
         ''
       end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -540,6 +540,21 @@ class PublicationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test '#index atom feed should render fractions' do
+    publication = create(:published_publication, body: "My favourite fraction is [Fraction:1/4].")
+
+    get :index, format: :atom
+
+    assert_select_atom_feed do
+      assert_select 'feed > entry' do
+        assert_select "content" do |content|
+          assert content[0].to_s.include?("1_4.png"), "publication body should render fractions"
+          assert content[0].to_s.include?("alt=\"1/4\""), "publication body should render fraction alt text"
+        end
+      end
+    end
+  end
+
   view_test '#index should show relevant document collection information' do
     editor = create(:departmental_editor)
     publication = create(:draft_publication)


### PR DESCRIPTION
The publications atom feed will error when fractions are present in a publication as the rendering expects `_govspeak_fractions.atom.erb` to exist. Updates the partial to specify the html partial for all rendering.
https://www.pivotaltracker.com/story/show/74222468
