### PR TITLE
Remove unoccupied role messaging

### DIFF
--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -30,9 +30,6 @@
           </dl>
         </div>
       </aside>
-      <% unless @ministerial_role.occupied? %>
-	<aside class="status-block"><h2>This is not a current government role</h2></aside>
-      <% end %>
     </div>
   </header>
 


### PR DESCRIPTION
This is more often confusing than helpful. Because of the way we model roles
it's possible for a role to have been replaced/superseded by a new role
with a slightly different name, which technically means the old role is no
longer occupied. 
