### PR TITLE
Correct radio button "checked" check

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -24,7 +24,7 @@
       showOrHideChangeNotes();
 
       function showOrHideChangeNotes() {
-        if ($minor_change_radio_button.attr('checked')){
+        if ($minor_change_radio_button.prop('checked')){
           $change_notes_section.slideUp(200);
         }
         else {


### PR DESCRIPTION
The "checked" attribute does not correspond to the "checked" property and as of jQuery 1.6, `attr('checked')` returns `undefined`. `prop` should be used instead to get the state of the radio button.
