### PR TITLE
Configure Sidekiq explicitly

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_keys
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,3 @@
+host: 127.0.0.1
+port: 6379
+namespace: whitehall


### PR DESCRIPTION
At the moment, the sidekiq.rb initializer gets overridden on deployment to set the correct redis server. This makes it hard to configure sidekiq with any other settings. This change allows us to override just the redis config without bludgeon the rest of the sidekiq config.
