### PR TITLE
Change the warning text on statistics announcements

### DIFF
--- a/app/views/admin/statistics_announcements/_warning.html.erb
+++ b/app/views/admin/statistics_announcements/_warning.html.erb
@@ -1,3 +1,3 @@
 <p class="warning">
-  Warning: This is an experimental feature. Do not create/modify statistics announcements unless you have authorisation to do so.
+Statistics announcements are only for official statistics governed by the UK Statistics Authority.
 </p>


### PR DESCRIPTION
Editors are posting the wrong documents as statistics announcements. This change is to the warning text on the Statistics Announcements page.
