### PR TITLE
Reduce sidekiq workers per box

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 :verbose: false
-:concurrency:  4
+:concurrency:  2
 :queues:
   - [imports, 2]
   - [router, 4]


### PR DESCRIPTION
This brings whitehall into line with the number of workers on other apps. It also will help prevent us DDOS-ing transitioning servers during importing of large numbers of documents/attachments.

Related story: https://www.agileplannerapp.com/boards/173808/cards/5058
