### PR TITLE
Fix JS in old IEs by removing trailing comma

### DIFF
--- a/app/assets/javascripts/vendor/jquery/jquery.highlighttextarea.js
+++ b/app/assets/javascripts/vendor/jquery/jquery.highlighttextarea.js
@@ -315,7 +315,7 @@
 
             // now make the textarea transparent to see the highlighter throught
             this.$textarea.css({
-                'background': 'none',
+                'background': 'none'
             });
 
             // display highlighter text for debuging


### PR DESCRIPTION
- Was fine on live because comma was stripped out
- Made it difficult to test new javascript features on IE7

Aside: This jQuery plugin has a few reported problems related to older versions of IE. The version after the one we're using is a "complete rewrite", without any real docs. https://github.com/mistic100/jquery-highlighttextarea/issues?page=1&state=closed
