### PR TITLE
Only allow safe govspeak in SitewideSettings

### DIFF
--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -2,6 +2,7 @@ class SitewideSetting < ActiveRecord::Base
   validates :govspeak, presence: true, if: :on
   validates :key, presence: true
   validates_uniqueness_of :key
+  validates_with SafeHtmlValidator
 
   def human_status
     on ? "On" : "Off"


### PR DESCRIPTION
This is the same validation used in Edition models and enforces a whitelist of supported elements.
