### PR TITLE
Retrieve the most recent Unpublishing

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -12,7 +12,7 @@ class Unpublishing < ActiveRecord::Base
   validate :redirect_not_circular
 
   def self.from_slug(slug, type)
-    where(slug: slug, document_type: type.to_s).first
+    where(slug: slug, document_type: type.to_s).last
   end
 
   def redirect?

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -69,6 +69,15 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal unpublishing, Unpublishing.from_slug('some-slug', 'CaseStudy')
   end
 
+  test 'Unpublishing.from_slug returns the most recent unpublishing' do
+    case_study          = create(:published_case_study)
+    first_unpublishing  = create(:unpublishing, edition: case_study, slug: case_study.slug)
+    new_edition         = case_study.create_draft(create(:user))
+    second_unpublishing = create(:unpublishing, edition: new_edition, slug: new_edition.slug)
+
+    assert_equal second_unpublishing, Unpublishing.from_slug(new_edition.slug, 'CaseStudy')
+  end
+
   test 'alternative_url is required if the reason is Consolidated' do
     unpublishing = build(:unpublishing, unpublishing_reason_id: UnpublishingReason::Consolidated.id, alternative_url: nil)
     refute unpublishing.valid?


### PR DESCRIPTION
Some documents have been unpublished more than once. We want to make sure we retrieve the most recent Unpublishing instance, otherwise we may not perform the correct action (i.e. the first unpublishing may be because the document was "published in error" whilst the most recent is a redirect)

Story: https://www.agileplannerapp.com/boards/173808/cards/5143
