### PR TITLE
Allow admin access to stats announcements.

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -57,12 +57,4 @@ class Admin::BaseController < ApplicationController
   end
   helper_method :typecast_for_attachable_routing
 
-  def user_can_see_stats_announcements?
-    current_user && (current_user.gds_editor? || current_user.organisation_slug == 'office-for-national-statistics')
-  end
-  helper_method :user_can_see_stats_announcements?
-
-  def restrict_access_to_gds_editors_and_ons_users
-    forbidden! unless user_can_see_stats_announcements?
-  end
 end

--- a/app/controllers/admin/statistics_announcement_date_changes_controller.rb
+++ b/app/controllers/admin/statistics_announcement_date_changes_controller.rb
@@ -1,5 +1,4 @@
 class Admin::StatisticsAnnouncementDateChangesController < Admin::BaseController
-  before_filter :restrict_access_to_gds_editors_and_ons_users
   before_filter :find_statistics_announcement
 
   def new

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -1,5 +1,4 @@
 class Admin::StatisticsAnnouncementsController < Admin::BaseController
-  before_filter :restrict_access_to_gds_editors_and_ons_users
   before_filter :find_statistics_announcement, only: [:show, :edit, :update, :destroy]
 
   def index

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -6,9 +6,7 @@ module Admin::UrlHelper
   end
 
   def admin_statistics_announcements_link
-    if user_can_see_stats_announcements?
-      admin_header_link "Statistics announcements", admin_statistics_announcements_path
-    end
+    admin_header_link "Statistics announcements", admin_statistics_announcements_path
   end
 
   def admin_topics_header_menu_link

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -56,7 +56,7 @@
           <%= document_creation_dropdown %>
         </li>
         <%= admin_documents_header_link %>
-        <%= admin_statistics_announcements_link if user_can_see_stats_announcements? %>
+        <%= admin_statistics_announcements_link %>
         <%= admin_featured_header_link %>
         <%= admin_user_organisation_header_link %>
         <li class="js-more-nav masthead-tab-item">

--- a/test/functional/admin/statistics_announcement_date_changes_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_date_changes_controller_test.rb
@@ -10,21 +10,6 @@ class Admin::StatisticsAnnouncementDateChangesControllerTest < ActionController:
     end
   end
 
-  test 'only gds editors and ONS users have access' do
-    login_as(:policy_writer)
-    get :new, statistics_announcement_id: @announcement
-    assert_response :forbidden
-
-    login_as(:gds_editor)
-    get :new, statistics_announcement_id: @announcement
-    assert_response :success
-
-    ons_user = create(:user, organisation: create(:organisation, name: 'Office for National Statistics'))
-    login_as(ons_user)
-    get :new, statistics_announcement_id: @announcement
-    assert_response :success
-  end
-
   view_test "GET :new renders a pre-filled announcement form" do
     get :new, statistics_announcement_id: @announcement
 

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -7,21 +7,6 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     @topic = create(:topic)
   end
 
-  test 'only gds editors and ONS users have access' do
-    login_as(:policy_writer)
-    get :index
-    assert_response :forbidden
-
-    login_as(:gds_editor)
-    get :index
-    assert_response :success
-
-    ons_user = create(:user, organisation: create(:organisation, name: 'Office for National Statistics'))
-    login_as(ons_user)
-    get :index
-    assert_response :success
-  end
-
   view_test "GET :new renders a new announcement form" do
     get :new
 


### PR DESCRIPTION
Removes the custom access control of gds editor or ONS dept user
allowing any whitehall admin to announce stats.
https://www.pivotaltracker.com/story/show/75338486
