### PR TITLE
Data migration to change detailed guide slugs

### DIFF
--- a/db/data_migration/20140724134114_change_slugs_on_detailed_guides.rb
+++ b/db/data_migration/20140724134114_change_slugs_on_detailed_guides.rb
@@ -1,0 +1,17 @@
+slug_changes = {
+  'electricity-meter-accuracy-and-billing-disputes' => 'electricity-meter-accuracy-and-disputes',
+  'gas-meter-accuracy-and-billing-disputes' => 'gas-meter-accuracy-and-disputes'
+}
+
+slug_changes.each do |old_slug, new_slug|
+  document = Document.where(slug: old_slug, document_type: 'DetailedGuide').first
+
+  if document
+    puts "Changing detailed guide slug #{old_slug} to #{new_slug}"
+    Whitehall::SearchIndex.delete(document.published_edition)
+    document.update_attribute(:slug, new_slug)
+    Whitehall::SearchIndex.add(document.published_edition)
+  else
+    puts "Warning: DetailedGuide with slug '#{old_slug}' not found"
+  end
+end


### PR DESCRIPTION
We remove them from the search index based on the original slug before updating the slug and re-indexing.

Story: https://www.agileplannerapp.com/boards/173808/cards/5152
