### PR TITLE
Fix find-in-admin bookmarklet

### DIFF
--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -47,7 +47,7 @@ function get_mapping() {
 
 function nav_to_backend() {
   var mapping = get_mapping();
-  if (mapping) window.location = "<%= Whitehall.admin_root %>/" + mapping.path_builder(mapping.id_finder());
+  if (mapping) window.location = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin/" + mapping.path_builder(mapping.id_finder());
 }
 
 nav_to_backend();


### PR DESCRIPTION
The generated URLs are not including the admin path prefix.
