### PR TITLE
Filter stats announcements in admin by title/slug

### DIFF
--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -2,10 +2,8 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
   before_filter :find_statistics_announcement, only: [:show, :edit, :update, :destroy]
 
   def index
-    @statistics_announcements = StatisticsAnnouncement.
-                                  includes(:current_release_date).
-                                  order(current_release_date: :release_date).
-                                  page(params[:page])
+    @filter = Admin::StatisticsAnnouncementFilter.new(filter_params)
+    @statistics_announcements = @filter.statistics_announcements
   end
 
   def new
@@ -58,5 +56,9 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
     params.require(:statistics_announcement).permit(
       :title, :summary, :organisation_id, :topic_id, :publication_type_id, :publication_id,
       current_release_date_attributes: [:id, :release_date, :precision, :confirmed])
+  end
+
+  def filter_params
+    params.slice(:title, :page, :per_page)
   end
 end

--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -1,0 +1,25 @@
+module Admin
+  class StatisticsAnnouncementFilter
+
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+
+    def statistics_announcements
+      results = unfiltered_results
+      results = results.with_title_containing(options[:title]) if options[:title]
+
+      results
+    end
+
+    private
+
+    def unfiltered_results
+      StatisticsAnnouncement.includes(:current_release_date)
+                            .order(current_release_date: :release_date)
+                            .page(options[:page])
+    end
+  end
+end

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -20,6 +20,11 @@ class StatisticsAnnouncement < ActiveRecord::Base
 
   accepts_nested_attributes_for :current_release_date, reject_if: :persisted?
 
+  scope :with_title_containing, -> *keywords {
+    pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
+    where("title REGEXP :pattern OR slug = :slug", pattern: pattern, slug: keywords)
+  }
+
   include Searchable
   searchable  title: :title,
               link: :public_path,

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -75,4 +75,3 @@
   <%= submit_tag "Search" %>
   <p><a href="?state=active">Reset all fields</a></p>
 </form>
-

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag admin_statistics_announcements_path, class: "filter-options", method: :get do %>
+  <h2>Search</h2>
+
+  <div class="filter-grouping">
+    <%= label_tag :search_title, 'Title or slug' %>
+    <div class="btn-enter-wrapper">
+      <%= search_field_tag :title, @filter.options[:title], id: 'search_title', placeholder: 'Search title' %>
+    </div>
+  </div>
+
+  <%= submit_tag "Search" %>
+  <p><%= link_to "Reset", admin_statistics_announcements_path %></p>
+<% end %>

--- a/app/views/admin/statistics_announcements/_search_results.html.erb
+++ b/app/views/admin/statistics_announcements/_search_results.html.erb
@@ -1,0 +1,35 @@
+<table class="statistics-announcements table table-striped">
+  <thead>
+    <tr>
+      <th>Announcement title</th>
+      <th>Document</th>
+      <th>Organisation</th>
+      <th>Topic</th>
+      <th>Display date</th>
+      <th>Release date</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @statistics_announcements.each do |statistics_announcement| %>
+      <%= content_tag_for :tr, statistics_announcement do %>
+        <td><%= link_to statistics_announcement.title, [:admin, statistics_announcement] %></td>
+        <td>
+          <% if publication = statistics_announcement.publication %>
+            <%= link_to(publication.title, [:admin, publication]) %>
+            (<%= publication.current_state %>)
+          <% else %>
+            (no document)
+          <% end %>
+        </td>
+        <td><%= statistics_announcement.organisation.name %></td>
+        <td><%= statistics_announcement.topic.name %></td>
+        <td>
+          <%= statistics_announcement.display_date %>
+          (<%= statistics_announcement.confirmed? ? 'confirmed' : 'provisional' %>)
+        </td>
+        <td><%= statistics_announcement.release_date.to_s(:long_ordinal) %></td>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @statistics_announcements, theme: 'twitter-bootstrap' %>

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -8,38 +8,11 @@
 
 <h1>Statistics announcement</h1>
 
-<table class="statistics-announcements table table-striped">
-  <thead>
-    <tr>
-      <th>Announcement title</th>
-      <th>Document</th>
-      <th>Organisation</th>
-      <th>Topic</th>
-      <th>Display date</th>
-      <th>Release date</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @statistics_announcements.each do |statistics_announcement| %>
-      <%= content_tag_for :tr, statistics_announcement do %>
-        <td><%= link_to statistics_announcement.title, [:admin, statistics_announcement] %></td>
-        <td>
-          <% if publication = statistics_announcement.publication %>
-            <%= link_to(publication.title, [:admin, publication]) %>
-            (<%= publication.current_state %>)
-          <% else %>
-            (no document)
-          <% end %>
-        </td>
-        <td><%= statistics_announcement.organisation.name %></td>
-        <td><%= statistics_announcement.topic.name %></td>
-        <td>
-          <%= statistics_announcement.display_date %>
-          (<%= statistics_announcement.confirmed? ? 'confirmed' : 'provisional' %>)
-        </td>
-        <td><%= statistics_announcement.release_date.to_s(:long_ordinal) %></td>
-      <% end %>
-    <% end %>
-  </tbody>
-</table>
-<%= paginate @statistics_announcements, theme: 'twitter-bootstrap' %>
+<div class="row-fluid">
+  <div class="span3 span3-responsive">
+    <%= render 'filter_options' %>
+  </div>
+  <div class="span9" id="search_results">
+    <%= render 'search_results' %>
+  </div>
+</div>

--- a/features/admin-announce-statistical-releases.feature
+++ b/features/admin-announce-statistical-releases.feature
@@ -23,6 +23,13 @@ Feature: Announcing a upcoming statistics release
     When I change the release date on the announcement
     Then the new date is reflected on the announcement
 
+  Scenario: searching for a statistics announcement
+    Given I am a GDS editor in the organisation "Department for Beards"
+    And a statistics announcement called "MQ5 statistics" exists
+    And a statistics announcement called "PQ3 statistics" exists
+    When I search for announcements containing "MQ5"
+    And I should only see a statistics announcement called "MQ5 statistics"
+
   @javascript
   Scenario: linking a document to a statistics announcement
     Given I am a GDS editor in the organisation "Department for Beards"

--- a/features/step_definitions/admin_announcing_statistics_steps.rb
+++ b/features/step_definitions/admin_announcing_statistics_steps.rb
@@ -59,6 +59,12 @@ When(/^I change the release date on the announcement$/) do
   click_on 'Change date'
 end
 
+When(/^I search for announcements containing "(.*?)"$/) do |keyword|
+  visit admin_statistics_announcements_path
+  fill_in 'Title or slug', with: keyword
+  click_on 'Search'
+end
+
 Then(/^the document fields are pre\-filled based on the announcement$/) do
   assert page.has_css?("input[id=edition_title][value='#{@statistics_announcement.title}']")
   assert page.has_css?("textarea[id=edition_summary]", text: @statistics_announcement.summary)
@@ -78,6 +84,11 @@ Then(/^I should see the announcement listed on the list of announcements$/) do
   ensure_path admin_statistics_announcements_path
 
   assert page.has_content?(announcement.title)
+end
+
+Then(/^I should (see|only see) a statistics announcement called "(.*?)"$/) do |single_or_multiple, title|
+  assert page.has_css?("tr.statistics_announcement", count: 1) if single_or_multiple == 'only see'
+  assert page.has_css?("tr.statistics_announcement", text: title)
 end
 
 Then(/^the new date is reflected on the announcement$/) do

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -45,14 +45,6 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     refute StatisticsAnnouncement.any?
   end
 
-  view_test "GET :index renders a table of statistics announcements" do
-    announcement = create(:statistics_announcement)
-    get :index
-
-    assert_response :success
-    assert_select 'table.statistics-announcements tr td a', text: announcement.title
-  end
-
   view_test "GET :show renders the details of the announcement" do
     announcement = create(:statistics_announcement)
     get :show, id: announcement

--- a/test/unit/admin/statistics_announcement_filter_test.rb
+++ b/test/unit/admin/statistics_announcement_filter_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
+  test "should filter by title" do
+    match = create(:statistics_announcement, title: "MQ5 statistics")
+    no_match = create(:statistics_announcement, title: "PQ5 statistics")
+
+    assert_equal [match], Admin::StatisticsAnnouncementFilter.new(title: "mq5").statistics_announcements
+  end
+end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -82,6 +82,13 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal ["type does not match: must be national statistics"], announcement.errors[:publication]
   end
 
+  test ".with_title_containing returns statistics announcements matching provided title" do
+    match = create(:statistics_announcement, title: "MQ5 statistics")
+    no_match = create(:statistics_announcement, title: "PQ6 statistics")
+
+    assert_equal [match], StatisticsAnnouncement.with_title_containing("mq5")
+  end
+
   test '#most_recent_change_note returns the most recent change note' do
     announcement    = create_announcement_with_changes
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5170

this is just a first-pass at getting a search and
filter interface in place for stats announcements.
editors have an immediate need to start searching
by title and slug, so we put in place that first.
