### PR TITLE
Fix missing organisation metadata

### DIFF
--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -18,13 +18,11 @@
       <aside class="meta metadata-list">
         <div class="inner-heading">
           <dl>
-            <% if @ministerial_role.organisations.any? %>
-              <dt><%= t('document.headings.organisations', count: @ministerial_role.organisations.count) %>:</dt>
-              <dd>
-                <%= render  partial: 'organisations/organisations_name_list',
-                            locals: { organisations: @ministerial_role.organisations } %>
-              </dd>
-            <% end %>
+            <dt><%= t('document.headings.organisations', count: @ministerial_role.organisations.count) %>:</dt>
+            <dd>
+              <%= render  partial: 'organisations/organisations_name_list',
+                          locals: { organisations: @ministerial_role.organisations } %>
+            </dd>
             <% if @ministerial_role.occupied? %>
               <dt><%= t('roles.headings.current_holder') %>:</dt>
               <dd><%= link_to @ministerial_role.current_person.name, @ministerial_role.current_person %></dd>

--- a/app/views/organisations/_organisations_name_list.html.erb
+++ b/app/views/organisations/_organisations_name_list.html.erb
@@ -1,7 +1,5 @@
 <%
-  lead_organisations ||= []
   organisations ||= []
-  show_hm_government = lead_organisations.length == 0
 %>
 <p class="js-hide-other-departments organisations-name-list">
   <%= array_of_links_to_organisations(organisations).to_sentence.html_safe %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -24,8 +24,7 @@
               <dt><%= t('document.headings.organisations', count: @classification.organisations.length) %>:</dt>
               <dd>
                 <%= render  partial: 'organisations/organisations_name_list',
-                            locals: { organisations: @classification.organisations,
-                                      lead_organisations: @classification.lead_organisations } %>
+                            locals: { organisations: @classification.organisations } %>
               </dd>
             </dl>
           </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -21,8 +21,7 @@
             <dt><%= t('document.headings.organisations', count: @classification.organisations.length) %>:</dt>
             <dd>
               <%= render  partial: 'organisations/organisations_name_list',
-                          locals: { organisations: @classification.organisations,
-                                    lead_organisations: @classification.lead_organisations } %>
+                          locals: { organisations: @classification.organisations } %>
             </dd>
             <% if @related_classifications.any? %>
               <dt>Related topics:</dt>


### PR DESCRIPTION
Example - https://www.gov.uk/government/ministers/foreign-secretary

• added code to include org meatadata
• wrapped in if statement to not show if a minister has no org

https://www.pivotaltracker.com/story/show/75507696
