### PR TITLE
Use the time now as a default from filter for upcoming announcements

### DIFF
--- a/app/providers/frontend/statistics_announcement_provider.rb
+++ b/app/providers/frontend/statistics_announcement_provider.rb
@@ -61,11 +61,10 @@ module Frontend
     def self.prepare_search_params(params)
       params = params.dup
 
-      release_timestamp_params = {
-        from: params.delete(:from_date).try(:iso8601),
+      params[:release_timestamp] = {
+        from: (params.delete(:from_date) || Time.zone.now).try(:iso8601),
         to: params.delete(:to_date).try(:iso8601)
       }.delete_if {|k, v| v.blank? }
-      params[:release_timestamp] = release_timestamp_params unless release_timestamp_params.empty?
 
       params[:page] = params[:page].to_s
       params[:per_page] = params[:per_page].to_s

--- a/test/functional/statistics_announcements_controller_test.rb
+++ b/test/functional/statistics_announcements_controller_test.rb
@@ -37,7 +37,19 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
                                                                                   precision: StatisticsAnnouncementDate::PRECISION[:exact],
                                                                                   confirmed: true)
 
+      old_announcement = create :statistics_announcement, title: "Average moustache lengths 2013",
+                                                          publication_type_id: PublicationType::NationalStatistics.id,
+                                                          organisation: organisation,
+                                                          topic: topic,
+                                                          current_release_date: build(:statistics_announcement_date,
+                                                                                      release_date: Time.zone.parse("2013-01-01 09:30:00"),
+                                                                                      precision: StatisticsAnnouncementDate::PRECISION[:exact],
+                                                                                      confirmed: true)
+
+
       get :index
+
+      assert_equal 1, assigns(:filter).results.size
 
       rendered = Nokogiri::HTML::Document.parse(response.body)
       list_item = rendered.css('.document-list li').first


### PR DESCRIPTION
Statistics announcements with publications are not being filtered from the present time automatically causing published statistics to appear in the 'Upcoming' filter. [Details here](https://www.pivotaltracker.com/story/show/75338234). Provides a default 'from right now' filter on upcoming statistics with (published) publications.
