### PR TITLE
Correct URL for static from external

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you are running whitehall with `bundle exec rails server` and don't want to
 run a local copy of `static`, you can tell the app to use assets served
 directly from the Preview environment by setting `STATIC_DEV`:
 
-  STATIC_DEV=https://static.preview.alphagov.co.uk bundle exec rails server
+  STATIC_DEV=https://assets-origin.preview.alphagov.co.uk bundle exec rails server
 
 If you are only working on the Whitehall admin interface, you don't need the
 assets available.

--- a/startup.sh
+++ b/startup.sh
@@ -10,7 +10,7 @@ else
   echo "Showing production images"
 fi
 # Serve static shared assets from preview so static doesn't need to be running
-export STATIC_DEV="https://static.preview.alphagov.co.uk"
+export STATIC_DEV="https://assets-origin.preview.alphagov.co.uk"
 echo
 bundle install
 bundle exec rails s thin -p 3020


### PR DESCRIPTION
I don't know what this file is for, but it's referencing a URL for
static that won't be available shortly. We should stop doing that.
