### PR TITLE
Avoid race condition in scheduled publications after data sync

### DIFF
--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -14,12 +14,11 @@ namespace :publishing do
       end
     end
 
-    desc "Queues missing jobs for any future-scheduled editions"
+    desc "Queues missing jobs for any scheduled editions (including overdue ones)"
     task :queue_missing_jobs => :environment do
-      scheduled_scope = Edition.scheduled.where(Edition.arel_table[:scheduled_publication].gteq(Time.zone.now))
       queued_ids      = ScheduledPublishingWorker.queued_edition_ids
-      missing_jobs    = scheduled_scope.select { |edition| !queued_ids.include?(edition.id) }
-      puts "#{scheduled_scope.count} editions scheduled for publication, of which #{missing_jobs.size} do not have a job."
+      missing_jobs    = Edition.scheduled.select { |edition| !queued_ids.include?(edition.id) }
+      puts "#{Edition.scheduled.count} editions scheduled for publication, of which #{missing_jobs.size} do not have a job."
 
       puts "Queueing missing jobs..."
       missing_jobs.each do |edition|


### PR DESCRIPTION
/cc @alext 

The nightly data sync from prod->staging takes a while and there's a
potential race condition whereby a document which is scheduled for
publication during this time would not get enqueued on the staging side.
That's because by the time the DataSyncComplete job runs on staging it
is now 'overdue' and so this task would not have enqueued it.

I checked the behaviour of `Sidekiq::Worker#perform_at`[1]. If you
schedule a task in the past then it will run it immediately, which seems
like a reasonable behaviour in this context.

This PR therefore removes the constraint that the `queue_missing_jobs`
rake task should only enqueue future scheduled documents. Instead it
enqueues all scheduled documents including overdue ones.

[1]
https://github.com/mperham/sidekiq/blob/a652117e2e78603450e65985e7061c133599803d/lib/sidekiq/worker.rb#L50-L51
