### PR TITLE
Revert stats filter date changes

### DIFF
--- a/app/providers/frontend/statistics_announcement_provider.rb
+++ b/app/providers/frontend/statistics_announcement_provider.rb
@@ -61,10 +61,11 @@ module Frontend
     def self.prepare_search_params(params)
       params = params.dup
 
-      params[:release_timestamp] = {
-        from: (params.delete(:from_date) || Time.zone.now).try(:iso8601),
+      release_timestamp_params = {
+        from: params.delete(:from_date).try(:iso8601),
         to: params.delete(:to_date).try(:iso8601)
       }.delete_if {|k, v| v.blank? }
+      params[:release_timestamp] = release_timestamp_params unless release_timestamp_params.empty?
 
       params[:page] = params[:page].to_s
       params[:per_page] = params[:per_page].to_s

--- a/test/functional/statistics_announcements_controller_test.rb
+++ b/test/functional/statistics_announcements_controller_test.rb
@@ -37,19 +37,7 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
                                                                                   precision: StatisticsAnnouncementDate::PRECISION[:exact],
                                                                                   confirmed: true)
 
-      old_announcement = create :statistics_announcement, title: "Average moustache lengths 2013",
-                                                          publication_type_id: PublicationType::NationalStatistics.id,
-                                                          organisation: organisation,
-                                                          topic: topic,
-                                                          current_release_date: build(:statistics_announcement_date,
-                                                                                      release_date: Time.zone.parse("2013-01-01 09:30:00"),
-                                                                                      precision: StatisticsAnnouncementDate::PRECISION[:exact],
-                                                                                      confirmed: true)
-
-
       get :index
-
-      assert_equal 1, assigns(:filter).results.size
 
       rendered = Nokogiri::HTML::Document.parse(response.body)
       list_item = rendered.css('.document-list li').first


### PR DESCRIPTION
This reverts the changes in 7085ad37260e5975b4b0e2215dee3b737708526f (pull request #1635).

This is currently breaking Whitehall on preview as the date format passed into the Rummager request is incorrect, causing Rummager to return errors.

Removing this out of master for now so that we can unblock deploys.
