### PR TITLE
Remove explicit sanitize dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'transitions', require: ['transitions', 'active_record/transitions']
 gem 'carrierwave', '0.9.0'
-gem 'govspeak', '~> 1.6.2'
+gem 'govspeak', '~> 2.0.0' 
 gem 'kramdown', '~> 0.13.8'
 gem 'validates_email_format_of'
 gem 'friendly_id', '4.0.9'
@@ -41,13 +41,6 @@ gem 'raindrops', '0.11.0'
 gem 'airbrake', '3.1.15'
 gem 'pdf-reader', '1.3.3'
 gem 'typhoeus', '0.6.8'
-
-# This sanitize fork branch fizes an issue with sanitize seeing colons in ids (when used as anchor tag references in an href)
-# as links with protocols. This has been fixed and merged in rgrove's Sanitize, but will only be released with version 2.1.
-# Once that version is released and govspeak's gemspec has been updated to require it, this requirement is no longer required.
-# https://github.com/rgrove/sanitize/commit/d7f34f72b82ff6bb6ea795e516125fb999c8f828
-# https://github.com/alphagov/govspeak/blob/master/Gemfile
-gem 'sanitize', github: 'alphagov/sanitize', branch: '2.0.6-plus-colons-in-anchor-hrefs'
 
 # Gems to smooth transition to Rails 4
 gem 'strong_parameters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: git://github.com/alphagov/sanitize.git
-  revision: d8c9015ce78c8ac2108ad632214463a5eed465d3
-  branch: 2.0.6-plus-colons-in-anchor-hrefs
-  specs:
-    sanitize (2.0.6)
-      nokogiri (>= 1.4.4)
-
-GIT
   remote: git://github.com/alphagov/test_track.git
   revision: 1f997082e2f1be94274d294c2f8d34ab0b21bb7f
   specs:
@@ -155,11 +147,11 @@ GEM
       warden-oauth2 (~> 0.0.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    govspeak (1.6.2)
+    govspeak (2.0.0)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       nokogiri (~> 1.5.10)
-      sanitize (~> 2.0.3)
+      sanitize (~> 2.1.0)
     govuk_frontend_toolkit (0.47.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -305,6 +297,8 @@ GEM
       null_logger
       rest-client
     safe_yaml (0.9.3)
+    sanitize (2.1.0)
+      nokogiri (>= 1.4.4)
     sass (3.2.8)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -406,7 +400,7 @@ DEPENDENCIES
   gds-api-adapters (= 12.4.2)
   gds-sso (= 9.3.0)
   globalize3!
-  govspeak (~> 1.6.2)
+  govspeak (~> 2.0.0)
   govuk_frontend_toolkit (= 0.47.0)
   invalid_utf8_rejector (~> 0.0.1)
   isbn_validation
@@ -436,7 +430,6 @@ DEPENDENCIES
   rake (= 10.1.0)
   rubocop
   rummageable (= 1.0.0)
-  sanitize!
   sass (= 3.2.8)
   sass-rails
   shared_mustache (~> 0.0.2)


### PR DESCRIPTION
Govspeak 2.0 upgrades the version of sanitize to 2.1.0. We no longer need to force a version of sanitize here because the changes included in the alphagov fork have been merged upstream.
