### PR TITLE
Use Ghostscript to generate PDF thumbnails

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -49,7 +49,7 @@ class AttachmentUploader < WhitehallUploader
   end
 
   def pdf_thumbnail_command(width, height)
-    %{convert -resize #{width}x#{height} "#{path}[0]" "#{path}" 2>&1}
+    %{gs -o #{path} -sDEVICE=pngalpha -dLastPage=1 -r72 -dDEVICEWIDTHPOINTS=#{width} -dDEVICEHEIGHTPOINTS=#{height} -dPDFFitPage #{path} 2>&1}
   end
 
   def extension_white_list


### PR DESCRIPTION
ImageMagick cannot convert PDF to images by itself and instead delegates
to Ghostscript. By bypassing ImageMagick and going to Ghostscript
directly, we see a big improvement in thumbnail generation speed:

```
Test file 1 with ImageMagick: 30.7 seconds
            with Ghostscript:  1.5 seconds
Test file 2 with ImageMagick: 30.7 seconds
            with Ghostscript:  1.2 seconds
Test file 3 with ImageMagick: 31.4 seconds
            with Ghostscript:  1.7 seconds
```
- [x] code review
- [x] PO acceptance

Story: https://www.agileplannerapp.com/boards/173808/cards/5258
