### PR TITLE
Ensures proper urls are formed for replacing unpublished content

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -14,7 +14,7 @@ class RegisterableEdition
     # to be consistent with Panopticon's slug format.
     panopticon_slug = Whitehall.url_maker.public_document_path(edition).sub(/\A\//, "")
     if edition.deleted?
-      panopticon_slug.sub!(%r{/deleted-([^/]+)$}, "/\1")
+      panopticon_slug.sub!(%r{/deleted-([^/]+)$}, '/\1')
     end
     panopticon_slug
   end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -44,7 +44,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
   end
 
   test "sets the correct slug for a deleted edition" do
-    publication = create(:publication)
+    publication = create(:publication, title: "Edition title")
 
     Whitehall.edition_services.deleter(publication).perform!
 
@@ -52,8 +52,8 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(publication)
 
-    assert_match /^deleted-/, whitehall_publication_slug
-    refute_match /deleted-/, registerable_edition.slug
+    assert_equal "deleted-edition-title", whitehall_publication_slug
+    assert_equal "government/publications/edition-title", registerable_edition.slug
   end
 
   test "sets the state to draft if the edition isn't published" do


### PR DESCRIPTION
Updates PR https://github.com/alphagov/whitehall/pull/1629

Removes 'deleted-' from the urls formed by RegisterableEdition so that
causes existing artefacts in Panopticon to be updated, instead of
creating an new artefact record
