### PR TITLE
Add a data migration to trim excessive slugs

### DIFF
--- a/db/data_migration/20140811124333_fix_too_long_slugs.rb
+++ b/db/data_migration/20140811124333_fix_too_long_slugs.rb
@@ -2,6 +2,8 @@ require 'gds_api/router'
 
 router = GdsApi::Router.new(Plek.current.find('router-api'))
 
+updated = false
+
 Document.find_by_sql("SELECT *, LENGTH(slug) AS slug_length FROM documents HAVING `slug_length` > 250;").each do |document|
   if published = document.published_edition
     old_slug = document.slug
@@ -12,5 +14,8 @@ Document.find_by_sql("SELECT *, LENGTH(slug) AS slug_length FROM documents HAVIN
     new_path = Whitehall.url_maker.document_path(published.reload)
     puts "Redirecting '#{old_path}' to '#{new_path}'"
     router.add_redirect_route(old_path, 'exact', new_path)
+    updated = true
   end
 end
+
+router.commit_routes if updated


### PR DESCRIPTION
We introduced a limit on slug length in ca28979, however documents created before this time don't conform to this validation, which breaks the crawler due to the invalid file name size it creates (also, the URLs are way too long).

This data migration cleans up the old slugs for published editions by updating their slugs to the new maximum length and redirecting the old URLs to the new URLs.
