### PR TITLE
Delete redundant feature flag code

### DIFF
--- a/app/helpers/country_helper.rb
+++ b/app/helpers/country_helper.rb
@@ -8,22 +8,14 @@ module CountryHelper
   end
 
   def array_of_links_to_world_locations(world_locations)
-    world_locations.map { |world_location|
-      if Whitehall.world_feature?
-        link_to world_location.name, world_location, class: 'world-location-link'
-      else
-        world_location.name
-      end
-    }
+    world_locations.map do |world_location|
+      link_to(world_location.name, world_location, class: 'world-location-link')
+    end
   end
 
   def array_of_links_to_worldwide_organisations(worldwide_organisations)
-    worldwide_organisations.map { |worldwide_organisation|
-      if Whitehall.world_feature?
-        link_to worldwide_organisation.name, worldwide_organisation, class: 'worldwide-organisation-link'
-      else
-        worldwide_organisation.name
-      end
-    }
+    worldwide_organisations.map do |worldwide_organisation|
+      link_to worldwide_organisation.name, worldwide_organisation, class: 'worldwide-organisation-link'
+    end
   end
 end

--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -49,20 +49,18 @@
           </div>
         <% end %>
 
-        <% if Whitehall.world_feature? %>
-          <% if filters.include? :locations %>
-            <div class="filter">
-              <%= label_tag "world_locations", t('document_filters.world_locations.label'), class: "title" %>
-              <%= select_tag "world_locations[]", locations_options(document_type, @filter.selected_locations), class: "single-row-select", id: "world_locations" %>
-            </div>
-          <% end %>
+        <% if filters.include? :locations %>
+          <div class="filter">
+            <%= label_tag "world_locations", t('document_filters.world_locations.label'), class: "title" %>
+            <%= select_tag "world_locations[]", locations_options(document_type, @filter.selected_locations), class: "single-row-select", id: "world_locations" %>
+          </div>
+        <% end %>
 
-          <% if filters.include? :include_world_location_news %>
-            <div class="filter checkbox-filter">
-              <%= label_tag "include_world_location_news", "Include local news from UK embassies and other world organisations" %>
-              <%= check_box_tag :include_world_location_news, '1', @filter.include_world_location_news %>
-            </div>
-          <% end %>
+        <% if filters.include? :include_world_location_news %>
+          <div class="filter checkbox-filter">
+            <%= label_tag "include_world_location_news", "Include local news from UK embassies and other world organisations" %>
+            <%= check_box_tag :include_world_location_news, '1', @filter.include_world_location_news %>
+          </div>
         <% end %>
 
         <% if filters.include? :date %>

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -156,7 +156,7 @@ module Whitehall
   end
 
   def self.searchable_classes
-    additional_classes = [
+    [
       Organisation,
       MinisterialRole,
       Person,
@@ -165,21 +165,10 @@ module Whitehall
       OperationalField,
       PolicyGroup,
       TakePartPage,
-      StatisticsAnnouncement
-    ]
-    not_yet_searchable_classes = []
-    if world_feature?
-      additional_classes += [
-        WorldLocation,
-        WorldwideOrganisation
-      ]
-    else
-      not_yet_searchable_classes += [
-        WorldLocationNewsArticle,
-        WorldwidePriority
-      ]
-    end
-    additional_classes + edition_classes - not_yet_searchable_classes
+      StatisticsAnnouncement,
+      WorldLocation,
+      WorldwideOrganisation,
+    ] + edition_classes
   end
 
   def self.edition_route_path_segments
@@ -200,14 +189,6 @@ module Whitehall
       news: "news",
       detailed_guidance: "detailed_guidance"
     }[format]
-  end
-
-  def self.local_government_features?
-    true
-  end
-
-  def self.world_feature?
-    true
   end
 
   def self.extract_text_feature?

--- a/test/integration/search_index_test.rb
+++ b/test/integration/search_index_test.rb
@@ -8,50 +8,22 @@ class SearchIndexTest < ActiveSupport::TestCase
     edition_types.each {|t| assert search_index.include?(t.name.to_sym)}
   end
 
-  test "Whitehall.government_search_index does not include WorldwidePriorities if the world_feature? is false" do
-    Whitehall.stubs(:world_feature?).returns(false)
-    WorldwidePriority.stubs(search_index: ['worldwide_priorities_index'])
-    refute Whitehall.government_search_index.include?('worldwide_priorities_index')
-  end
-
-  test "Whitehall.government_search_index does include WorldwidePriorities if the world_feature? is true" do
-    Whitehall.stubs(:world_feature?).returns(true)
+  test "Whitehall.government_search_index includes WorldwidePriorities" do
     WorldwidePriority.stubs(search_index: ['worldwide_priorities_index'])
     assert Whitehall.government_search_index.include?('worldwide_priorities_index')
   end
 
-  test "Whitehall.government_search_index does not include WorldLocationNewsArticles if the world_feature? is false" do
-    Whitehall.stubs(:world_feature?).returns(false)
-    WorldLocationNewsArticle.stubs(search_index: ['world_location_news_articles_index'])
-    refute Whitehall.government_search_index.include?('world_location_news_articles_index')
-  end
-
-  test "Whitehall.government_search_index does include WorldLocationNewsArticles if the world_feature? is true" do
-    Whitehall.stubs(:world_feature?).returns(true)
+  test "Whitehall.government_search_index includes WorldLocationNewsArticles" do
     WorldLocationNewsArticle.stubs(search_index: ['world_location_news_articles_index'])
     assert Whitehall.government_search_index.include?('world_location_news_articles_index')
   end
 
-  test "Whitehall.government_search_index does not include WorldLocations if the world_feature? is false" do
-    Whitehall.stubs(:world_feature?).returns(false)
-    WorldLocation.stubs(search_index: ['world_locations_index'])
-    refute Whitehall.government_search_index.include?('world_locations_index')
-  end
-
-  test "Whitehall.government_search_index does include WorldLocations if the world_feature? is true" do
-    Whitehall.stubs(:world_feature?).returns(true)
+  test "Whitehall.government_search_index includes WorldLocations" do
     WorldLocation.stubs(search_index: ['world_locations_index'])
     assert Whitehall.government_search_index.include?('world_locations_index')
   end
 
-  test "Whitehall.government_search_index does not include WorldwideOrganisations if the world_feature? is false" do
-    Whitehall.stubs(:world_feature?).returns(false)
-    WorldwideOrganisation.stubs(search_index: ['worldwide_organisations_index'])
-    refute Whitehall.government_search_index.include?('worldwide_organisations_index')
-  end
-
-  test "Whitehall.government_search_index does include WorldwideOrganisations if the world_feature? is true" do
-    Whitehall.stubs(:world_feature?).returns(true)
+  test "Whitehall.government_search_index includes WorldwideOrganisations" do
     WorldwideOrganisation.stubs(search_index: ['worldwide_organisations_index'])
     assert Whitehall.government_search_index.include?('worldwide_organisations_index')
   end


### PR DESCRIPTION
Both these features have been live for a long time now and no longer require feature-flags. The tests for Whitehall.government_search_index are questionable, but I've left them here for safety.
