### PR TITLE
Improve role date selection

### DIFF
--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -9,7 +9,7 @@
                 disabled: !form.object.new_record? %>
 
 <% if form.object.new_record? %>
-  <p>Once an appointment has been created the person cannot be changed, to preserve this person's relationship to any associated speeches.</p>
+  <p>Once an appointment has been created the person cannot be changed. This preserves a person’s relationship to associated speeches.</p>
 <% end %>
 
 <%= form.label :started_at %>


### PR DESCRIPTION
- Starting from 1700 and having to scroll all the way down to 2014, or even 2019, is painful
- Restrict date entries to current year rather than current year + 5 which seemed to be the default
- Refine copy about why roles cannot be changed later
