### PR TITLE
Increase sidekiq redis timeout

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,5 +6,5 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_config
+  config.redis = redis_config.merge({ timeout: 2 })
 end


### PR DESCRIPTION
We've been seeing timeouts recently on the healthcheck requests. Traced back to the redis query made by `ScheduledPublishingWorker.queue_size`. This will generally respond instantaneously, but occasionally takes longer than a second to respond (or at least it is since we upgraded redis).

See https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/53e9fbd50da1159146003f49
