### PR TITLE
Change cucumber default output to be `progress`

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features


### PR DESCRIPTION
Only show dots when tests pass rather than pages of text.
