### PR TITLE
Data migration to fix publication unpublishing

### DIFF
--- a/db/data_migration/20140821165929_change_unpublishing_type_on_publication.rb
+++ b/db/data_migration/20140821165929_change_unpublishing_type_on_publication.rb
@@ -1,0 +1,12 @@
+publication  = Publication.find(373322)
+unpublishing = publication.unpublishing
+redirect_url = "#{Whitehall.public_root}/government/publications/review-of-radiation-dose-issues-from-the-use-of-ct-in-the-uk"
+
+puts "Updating the unpublishing reason and setting up a redirect to #{redirect_url}"
+unpublishing.unpublishing_reason_id = UnpublishingReason::Consolidated.id
+unpublishing.redirect = true
+unpublishing.alternative_url = redirect_url
+unpublishing.save!
+
+puts "Resetting the publication back to draft so that it's no longer \"archived\" and is instead \"unpublished\""
+publication.update_attribute(:state, 'draft')


### PR DESCRIPTION
This publication was mistakenly set to "archived" instead of being "unpublished". This data migration corrects the unpublishing, setting up the redirect, and also sets the edition state back to "draft", completing the unpublishing process.

Story: https://www.agileplannerapp.com/boards/173808/cards/5665
