### PR TITLE
Fix a document 404ing with a redirect

### DIFF
--- a/db/data_migration/20140822081728_slug_change_for_vat_notice_7002.rb
+++ b/db/data_migration/20140822081728_slug_change_for_vat_notice_7002.rb
@@ -1,0 +1,10 @@
+require 'gds_api/router'
+
+router = GdsApi::Router.new(Plek.current.find('router-api'))
+
+not_found_slug = "/government/publications/vat-notice-7002-group-and-divisional-registration/vat-notice-7002-group-and-divisional-registration"
+content_at_slug = "/government/publications/vat-notice-7002-group-and-divisional-registration/vat-notice-7002-group-and-divisional-registration--2"
+
+puts "registering redirect #{not_found_slug} -> #{content_at_slug}"
+router.add_redirect_route(not_found_slug, 'exact', content_at_slug)
+puts "done registering redirect"


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5678

it seems 2 editors started working on separate drafts for the same content, hence there were duplicate documents. the content lives at the url that contains the slug with a sequence number. hence redirecting to that location.

PR for router-data: https://github.gds/gds/router-data/pull/145
