### PR TITLE
Allow removal of deleted announcements from index

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -41,7 +41,7 @@ class StatisticsAnnouncement < ActiveRecord::Base
               metadata: :search_metadata
 
   delegate  :release_date, :display_date, :confirmed?,
-              to: :current_release_date
+              to: :current_release_date, allow_nil: true
 
 
   def self.without_published_publication

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -65,6 +65,13 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement.destroy
   end
 
+  test 'a destroyed announcement can still generate a searchable link so it can be removed from the search index' do
+    announcement = create(:statistics_announcement)
+    announcement.reload.destroy
+
+    assert_equal Whitehall.url_maker.statistics_announcement_path(announcement), announcement.search_index['link']
+  end
+
   test 'only valid when associated publication is of a matching type' do
     statistics          = create(:draft_statistics)
     national_statistics = create(:draft_national_statistics)


### PR DESCRIPTION
Destroying statistics announcements raises an exception with real rummager because it cannot generate the link to remove it from the index. This is because the :statistics_announcement_dates association is now a dependent and gets destroyed when the announcement is destroyed, but the current announcement date is delegated to when generating the searchable content to get the link.

This is a follow up to https://github.com/alphagov/whitehall/pull/1678
