### PR TITLE
Nest CSS class correctly

### DIFF
--- a/app/assets/stylesheets/frontend/views/_detailed_guides.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides.scss
@@ -273,8 +273,8 @@
       }
     }
   }
-}
 
-.heading-extra {
-  padding-top: 45px;
+  .heading-extra {
+    padding-top: 45px;
+  }
 }


### PR DESCRIPTION
A change to detailed guides stylesheet caused a bug in other document types with translations. This change nests the detailed guides css correctly.
