### PR TITLE
Add MIT licence, owned by HMG/GDS

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (C) 2014 HM Government (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This mirrors the licences used in [many](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/LICENCE) [of](https://github.com/alphagov/frontend/blob/master/LICENCE.txt) [our](https://github.com/alphagov/static/blob/master/LICENCE) [other](https://github.com/alphagov/smart-answers/blob/master/LICENSE.md) [repositories](https://github.com/alphagov/router/blob/master/LICENSE).

Fixes #1683
