### PR TITLE
Fix report-a-problem form alignment with new static

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -356,7 +356,6 @@
   }
   .report-a-problem-container {
     margin-left: 0;
-    max-width: 33em;
   }
 
   @include right-to-left {

--- a/app/assets/stylesheets/frontend/views/_layouts.scss
+++ b/app/assets/stylesheets/frontend/views/_layouts.scss
@@ -32,7 +32,3 @@ p.report-a-problem-toggle {
     text-decoration: underline;
   }
 }
-
-.report-a-problem-container {
-  max-width: 33em;
-}


### PR DESCRIPTION
On a version of `static` that includes the [report-a-problem improvements](https://github.com/alphagov/static/pull/441),
the report-a-problem form is misaligned:

![image](https://cloud.githubusercontent.com/assets/23801/4057147/d97148f8-2dc4-11e4-8956-de4e9f9fde1e.png)

This change fixes that issue, while not really
breaking anything when `whitehall` runs against the old version of `static`.

/cc @edds @dsingleton 
