### PR TITLE
Use govspeak version with fix for address markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'transitions', require: ['transitions', 'active_record/transitions']
 gem 'carrierwave', '0.9.0'
-gem 'govspeak', '~> 2.0'
+gem 'govspeak', '~> 3.0', '>= 3.1.1'
 gem 'validates_email_format_of'
 gem 'friendly_id', '4.0.9'
 gem 'babosa'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       warden-oauth2 (~> 0.0.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    govspeak (2.0.2)
+    govspeak (3.1.1)
       htmlentities (~> 4)
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
@@ -403,7 +403,7 @@ DEPENDENCIES
   gds-api-adapters (= 12.4.2)
   gds-sso (= 9.3.0)
   globalize3!
-  govspeak (~> 2.0)
+  govspeak (~> 3.0, >= 3.1.1)
   govuk_frontend_toolkit (= 0.47.0)
   invalid_utf8_rejector (~> 0.0.1)
   isbn_validation


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5680

the address markdown ($A) required an extra blank line preceding it for preview toggle to format addresses as expected. this was confusing for the editors. this change fixed the issue: https://github.com/alphagov/govspeak/pull/43
