### PR TITLE
Add script for removing sectors.

### DIFF
--- a/lib/data_hygiene/specialist_sector_cleanup.rb
+++ b/lib/data_hygiene/specialist_sector_cleanup.rb
@@ -1,0 +1,41 @@
+class SpecialistSectorCleanup
+  def initialize(slug)
+    @slug = slug
+  end
+
+  def any_taggings?
+    taggings.any?
+  end
+
+  def any_published_taggings?
+    taggings.map(&:edition).any? do |edition|
+      edition.document.ever_published_editions.any?
+    end
+  end
+
+  def remove_taggings(add_note: true)
+    taggings.each do |tagging|
+      edition = tagging.edition
+
+      puts "Removing tagging to edition ##{edition.id}"
+
+      tagging.destroy
+
+      if add_note
+        puts "Adding an editorial note from the GDS user"
+
+        gds_user = User.find_by_email("govuk-whitehall@digital.cabinet-office.gov.uk")
+        edition.editorial_remarks.create!(
+          author: gds_user,
+          body: "Automatically untagged from old sector '#{@slug}'"
+        )
+      end
+    end
+  end
+
+private
+
+  def taggings
+    SpecialistSector.where(tag: @slug)
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -21,3 +21,40 @@ task :supporting_page_cleanup => :environment do
     end
   end
 end
+
+task :specialist_sector_cleanup => :environment do
+  require "data_hygiene/specialist_sector_cleanup"
+
+  puts "Which specialist sector is being deleted?"
+  slug = STDIN.gets.chomp
+
+  cleanup = SpecialistSectorCleanup.new(slug)
+
+  if cleanup.any_taggings?
+    puts "Some editions are tagged to #{slug}"
+
+    if cleanup.any_published_taggings?
+      puts "WARNING! Some documents have been published.  You will need to remove the sector from ElasticSearch"; puts
+    end
+
+    puts "What would you like to do?"
+    puts "1. Untag the editions from the sector, adding an editorial note"
+    puts "2. Untag the editions from the sector, no note"
+    puts "3. Do nothing [default]"
+
+    case STDIN.gets.chomp
+    when "1"
+      cleanup.remove_taggings(add_note: true)
+    when "2"
+      cleanup.remove_taggings(add_note: false)
+    when "3", ""
+      puts "Doing nothing"
+      exit
+    else
+      puts "Invalid option"
+      exit
+    end
+  else
+    puts "The sector '#{slug}' has not been tagged to any editions"
+  end
+end

--- a/test/factories/specialist_sector.rb
+++ b/test/factories/specialist_sector.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :specialist_sector do
+  end
+end

--- a/test/unit/data_hygiene/specialist_sector_cleanup_test.rb
+++ b/test/unit/data_hygiene/specialist_sector_cleanup_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+require 'data_hygiene/specialist_sector_cleanup'
+
+class SpecialistSectorCleanupTest < ActiveSupport::TestCase
+  include DataHygiene
+
+  setup do
+    @published_edition = create(:published_edition)
+    @draft_edition = create(:draft_edition)
+    @gds_user = create(:user, email: 'govuk-whitehall@digital.cabinet-office.gov.uk')
+  end
+
+  test "#any_taggings? is true if any content is tagged to the sector" do
+    cleanup = SpecialistSectorCleanup.new('oil-and-gas/offshore')
+    refute cleanup.any_taggings?
+
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+    assert cleanup.any_taggings?
+  end
+
+  test "#any_published_taggings? is true if any published content is tagged to the sector" do
+    cleanup = SpecialistSectorCleanup.new('oil-and-gas/offshore')
+    refute cleanup.any_published_taggings?
+
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    refute cleanup.any_published_taggings?
+
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+    assert cleanup.any_published_taggings?
+  end
+
+  test "#remove_taggings(add_note: false) removes the taggings without adding notes" do
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+
+    SpecialistSectorCleanup.new('oil-and-gas/offshore').remove_taggings(add_note: false)
+
+    assert_equal 0, SpecialistSector.count
+    assert_equal 0, EditorialRemark.count
+  end
+
+  test "#remove_taggings(add_note: true) removes the taggings and adds notes" do
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+
+    SpecialistSectorCleanup.new('oil-and-gas/offshore').remove_taggings(add_note: true)
+
+    assert_equal 0, SpecialistSector.count
+
+    [@published_edition, @draft_edition].each do |edition|
+      edition.reload
+      assert edition.editorial_remarks.any?
+    end
+  end
+end


### PR DESCRIPTION
Provides a repeatable script for untagging sectors from editions and adding editorial notes.

Warns the user if they are untagging published documents so appropriate changes can be made in the elasticsearch index.

https://www.pivotaltracker.com/story/show/76471004
