### PR TITLE
Stop incorrect date initialisation at month end

### DIFF
--- a/app/assets/javascripts/admin/views/statistics_announcement_dates/_form.js
+++ b/app/assets/javascripts/admin/views/statistics_announcement_dates/_form.js
@@ -46,31 +46,35 @@
     },
 
     getDateFromRecentDateFields: function() {
-      var date = new Date();
+      var year,
+          month,
+          day,
+          hours,
+          minutes;
 
       StatisticsAnnouncementDateForm.$releaseDateInputs.each(function(i) {
         var value = parseInt($(this).val(), 10);
 
         switch(i) {
           case 0:
-            date.setFullYear(value);
+            year = value;
             break;
           case 1:
-            date.setMonth(value - 1);
+            month = value - 1;
             break;
           case 2:
-            date.setDate(value);
+            day = value;
             break;
           case 3:
-            date.setHours(value);
+            hours = value;
             break;
           case 4:
-            date.setMinutes(value);
+            minutes = value;
             break;
         }
       });
 
-      return date;
+      return new Date(year, month, day, hours, minutes);
     },
 
     updateExampleDates: function(date, status) {


### PR DESCRIPTION
Bug manifested as a failing test on Aug 29, the tests use February as an example. The JavaScript was creating a date, using today, then going through and setting each of the properties, eg year, month etc. On August 29, setting the month to February would try and create a date “February 29” (non-leap year) which is not a valid date, so JavaScript switches the month to March.
- Avoid bug by creating variables from each date input then creating a date all at once

![screen shot 2014-08-29 at 12 30 08](https://cloud.githubusercontent.com/assets/319055/4089664/74450e80-2f70-11e4-89c5-2b1d87c2d99f.png)
