### PR TITLE
Unscope SpecialistSector relation to Edition

### DIFF
--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -14,6 +14,10 @@ class SpecialistSector < ActiveRecord::Base
     end
   end
 
+  def edition
+    Edition.unscoped { super }
+  end
+
 private
   def self.nested_sectors
     fetch_sectors.select(&:parent).group_by(&:parent)


### PR DESCRIPTION
Each SpecialistSector belongs to an edition. However, if the edition is deleted, requesting the relation returns nil as the default scope for the Edition model is to exclude deleted editions.

By overriding the relation to be unscoped, we can still perform operations on Editions related to SpecialistSectors regardless of their state.

This specific change will make it possible to use the script added in #1688 to remove the `working-sea/fishing` sector tag, which is tagged to several 'deleted' editions.

This is based on prior art in [app/models/classification_membership.rb](https://github.com/alphagov/whitehall/blob/ec83c2ea/app/models/classification_membership.rb#L25).
