### PR TITLE
Script for cleaning up duplicate announcements

### DIFF
--- a/lib/data_hygiene/duplicate_statistics_announcement.rb
+++ b/lib/data_hygiene/duplicate_statistics_announcement.rb
@@ -1,0 +1,50 @@
+require 'gds_api/router'
+
+module DataHygiene
+  class DuplicateStatisticsAnnouncement
+    attr_reader :logger
+
+    def initialize(duplicate, logger=Rails.logger, noop=false)
+      @duplicate = duplicate
+      @logger = logger
+      @noop = noop
+    end
+
+    def destroy_and_redirect_to(authoritative_announcement)
+      register_redirect_to(authoritative_announcement)
+
+      log "Destroying duplicate announcement with slug #{@duplicate.slug}"
+      unless noop?
+        @duplicate.destroy
+      end
+    end
+
+  private
+
+    def log(message)
+      @logger.info message
+    end
+
+    def noop?
+      @noop
+    end
+
+    def register_redirect_to(announcement)
+      announcement_path = Whitehall.url_maker.statistics_announcement_path(announcement)
+
+      log "Registering redirect: #{path} => #{announcement_path}"
+      unless noop?
+        router.add_redirect_route(path, :exact, announcement_path)
+        router.commit_routes
+      end
+    end
+
+    def path
+      Whitehall.url_maker.statistics_announcement_path(@duplicate)
+    end
+
+    def router
+      @router ||= GdsApi::Router.new(Plek.current.find('router-api'))
+    end
+  end
+end

--- a/script/dedupe_stats_announcement
+++ b/script/dedupe_stats_announcement
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+require 'optparse'
+
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: ./script/dedupe_stats_announcement duplicate-announcement-slug authoritative-announcement-slug"
+  opts.separator ""
+  opts.separator <<-EOS
+Destroys the duplicate statistics announcement matching the duplicate slug
+and registers a redirect to the statistics announcement matching the
+authoritative slug.
+  EOS
+  opts.separator ""
+  opts.separator "Specific options:"
+
+  opts.on('-n', '--noop', 'Output actions without invoking them') do
+    options[:noop]    = true
+    options[:verbose] = true
+  end
+end
+parser.parse!
+
+duplicate_slug, authoritative_slug = ARGV
+
+unless duplicate_slug && authoritative_slug
+  puts parser.help
+  exit(-1)
+end
+
+puts "Performing operation as NOOP" if options[:noop]
+
+require File.expand_path('../../config/application',  __FILE__)
+Rails.application.require_environment!
+
+duplicate_announcement = StatisticsAnnouncement.find(duplicate_slug)
+authoritative_announcement = StatisticsAnnouncement.find(authoritative_slug)
+logger = Logger.new(STDOUT)
+
+DataHygiene::DuplicateStatisticsAnnouncement.new(duplicate_announcement, logger, options[:noop]).destroy_and_redirect_to(authoritative_announcement)
+
+puts "For completeness, the above redirect should also be added to router-data"

--- a/test/unit/data_hygiene/duplicate_statistics_announcement_test.rb
+++ b/test/unit/data_hygiene/duplicate_statistics_announcement_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'gds_api/test_helpers/router'
+
+module DataHygiene
+  class DuplicateStatisticsAnnouncementTest < ActiveSupport::TestCase
+    include GdsApi::TestHelpers::Router
+
+    test "#destroy_and_redirect_to registers a redirect and destroys the announcement" do
+      announcement = create(:statistics_announcement)
+      duplicate    = create(:statistics_announcement, title: announcement.title, organisation: announcement.organisation)
+
+      announcement_path = Whitehall.url_maker.statistics_announcement_path(announcement)
+      duplicate_path    = Whitehall.url_maker.statistics_announcement_path(duplicate)
+
+      registration_request, commit_request = stub_redirect_registration(duplicate_path, :exact, announcement_path, "permanent")
+
+      DuplicateStatisticsAnnouncement.new(duplicate).destroy_and_redirect_to(announcement)
+
+      assert_requested(registration_request)
+      assert_requested(commit_request)
+
+      refute StatisticsAnnouncement.exists?(duplicate)
+      assert StatisticsAnnouncement.exists?(announcement)
+    end
+  end
+end


### PR DESCRIPTION
Some code that will make it easier to delete and redirect duplicate statistics announcements in future. It registers a redirect from a duplicated announcement to an authoritative one and destroys the
duplicate. The script can be run from the command line:

```
$  ./script/dedupe_stats_announcement dupe_slug authoritative_slug
```

The script also accepts a "-n" option to call the command as NOOP.

Story: https://www.agileplannerapp.com/boards/173808/cards/5804
