### PR TITLE
Remove international development fund categories

### DIFF
--- a/db/data_migration/20140902100317_remove_international_development_fund_detailed_guides.rb
+++ b/db/data_migration/20140902100317_remove_international_development_fund_detailed_guides.rb
@@ -1,9 +1,18 @@
+require 'gds_api/router'
+router_api = GdsApi::Router.new(Plek.current.find('router-api'))
+
+REDIRECT_TO = "/international-development-funding"
+
 categories = MainstreamCategory.where(parent_tag: "citizenship/international-development")
 
 categories.each do |category|
   old_path = Whitehall.url_maker.mainstream_category_path(category)
   puts "removing category: #{category.title}"
   guides = category.detailed_guides
+
+  puts "\t registering redirect: #{old_path} => #{REDIRECT_TO}"
+  router_api.add_redirect_route(old_path, 'exact', REDIRECT_TO)
+
   puts "\t removing association to category from #{guides.count} guides"
   guides.each do |guide|
     if guide.primary_mainstream_category_id == category.id
@@ -13,8 +22,12 @@ categories.each do |category|
       guide.update_attribute :other_mainstream_category_ids, new_ids
     end
   end
+
   puts "\t destroying category: \t #{old_path} 💥🔫"
   category.destroy
 end
+
+puts "committing redirects"
+router_api.commit_routes
 
 puts "\nDon't forget to add the above redirects to router-data!"


### PR DESCRIPTION
International development funds are moving from whitehall to
specialist-publisher/specialist-frontend. Therefore we want to remove
them from collections browse and redirect the categories to the new
international development fund finder.
