### PR TITLE
Redirect to filtered search results after publish

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -61,7 +61,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
   def publish
     edition_publisher = Whitehall.edition_services.publisher(@edition)
     if edition_publisher.perform!
-      redirect_to admin_editions_path(state: :published), notice: "The document #{@edition.title} has been published"
+      redirect_to admin_editions_path(session_filters || { state: :published }),
+        notice: "The document #{@edition.title} has been published"
     else
       redirect_to admin_edition_path(@edition), alert: edition_publisher.failure_reason
     end

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -7,11 +7,13 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     @user = login_as(:departmental_editor)
   end
 
-  test 'publish publishes the given edition on behalf of the current user' do
+  test 'publish publishes the given edition on behalf of the current user and redirects back to filtered search view' do
+    session[:document_filters] = session_filters = {"type"=>"policy", "state"=>"submitted", "page"=>"3" }
+
     stub_panopticon_registration(submitted_edition)
     post :publish, id: submitted_edition, lock_version: submitted_edition.lock_version
 
-    assert_redirected_to admin_editions_path(state: :published)
+    assert_redirected_to admin_editions_path(session_filters)
     assert_equal "The document #{submitted_edition.title} has been published", flash[:notice]
     assert submitted_edition.reload.published?
     assert_equal @user, submitted_edition.published_by


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5164

Currently when an editor publishes an edition,
we redirect them back to the editions results
with the filter reset to all published editions.

Following research, editors preferred to go back
to the filtered search results they were last at.
If they had not chosen search filters, we should
redirect them to their organisations published
editions.
