### PR TITLE
High profile groups display on organisation index

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -21,7 +21,7 @@ module Organisation::OrganisationTypeConcern
     }
 
     scope :listable, -> {
-      excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'")
+      excluding_govuk_status_closed.with_translations
     }
 
     scope :allowed_promotional, -> {

--- a/app/presenters/organisations_index_presenter.rb
+++ b/app/presenters/organisations_index_presenter.rb
@@ -25,6 +25,10 @@ class OrganisationsIndexPresenter < Array
     self.class.new(grouped_organisations[:devolved_administration] || [])
   end
 
+  def high_profile_groups
+    self.class.new(grouped_organisations[:high_profile_group] || [])
+  end
+
   def live_count
     @live_count ||= count(&:live?)
   end
@@ -43,6 +47,8 @@ class OrganisationsIndexPresenter < Array
     @grouped_organisations ||= group_by { |org|
       if org.type.agency_or_public_body?
         :agencies_and_government_bodies
+      elsif org.type.sub_organisation?
+        :high_profile_group
       else
         org.type.key
       end

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -44,6 +44,12 @@
                                   show_govuk_status:  false,
                                   show_transition_state: Whitehall::organisations_transition_visualisation_feature_enabled %>
 
+      <%= render 'index_section', organisations:      @organisations.high_profile_groups,
+                                  header_text:        'High profile groups',
+                                  block_id:           'high-profile-groups',
+                                  list_item_partial:  'index_item_plain',
+                                  show_govuk_status:  false %>
+
       <%= render 'index_section', organisations:      @organisations.public_corporations,
                                   header_text:        'Public corporations',
                                   block_id:           'public-corporations',

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -150,6 +150,7 @@ Scenario: Viewing the organisations index and seeing organisations grouped into 
   And I should see the agencies and government bodies listed with count
   And I should see the public corporations listed with count
   And I should see the devolved administrations listed with count
+  And I should see the high profile groups listed with count
 
 Scenario: Viewing the organisations index and seeing a visualisation of the number of agencies and public bodies live on govuk
   Given 1 live, 1 transitioning and 1 exempt executive agencies

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -107,6 +107,7 @@ Given(/^some organisations of every type exist$/) do
   @independent_monitoring_body =  create :organisation, organisation_type_key: :independent_monitoring_body
   @adhoc_advisory_group =         create :organisation, organisation_type_key: :adhoc_advisory_group
   @devolved_administration =      create :organisation, organisation_type_key: :devolved_administration, govuk_status: "exempt"
+  @sub_organisation =             create :organisation, organisation_type_key: :sub_organisation, parent_organisations: [@ministerial_department]
   @other_organisation =           create :organisation, organisation_type_key: :other
 
   @child_org_1 = create :organisation, parent_organisations: [@ministerial_department]
@@ -299,6 +300,15 @@ end
 Then(/^I should see the devolved administrations listed with count$/) do
   within "#devolved-administrations" do
     assert page.has_link?(@devolved_administration.name, href: organisation_path(@devolved_administration))
+    within "header" do
+      assert page.has_content? "1"
+    end
+  end
+end
+
+Then(/^I should see the high profile groups listed with count$/) do
+  within "#high-profile-groups" do
+    assert page.has_link?(@sub_organisation.name, href: organisation_path(@sub_organisation))
     within "header" do
       assert page.has_content? "1"
     end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -17,14 +17,6 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_equal :some_presented_organisations, assigns(:organisations)
   end
 
-  view_test "index shouldn't include sub-organisations" do
-    sub_organisation = create(:sub_organisation)
-
-    get :index
-
-    refute_select_object(sub_organisation)
-  end
-
   view_test "should include a rel='alternate' link to JSON representation of organisations" do
     get :index
 

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -60,16 +60,12 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     end
   end
 
-  test "listable should return all organisations which are not sub organisations" do
-    top_level_org = create(:organisation, organisation_type_key: :executive_office)
-    sub_org = create(:sub_organisation)
-
-    assert Organisation.listable.include?(top_level_org)
-    refute Organisation.listable.include?(sub_org)
-  end
-
-  test "listable should also exclude organisations which have govuk_status of 'closed'" do
+  test "listable should return all organisations which are not 'closed'" do
+    ministerial_department = create(:ministerial_department)
+    sub_organisation = create(:sub_organisation)
     closed_org = create(:closed_organisation)
+    assert Organisation.listable.include?(ministerial_department)
+    assert Organisation.listable.include?(sub_organisation)
     refute Organisation.listable.include?(closed_org)
   end
 

--- a/test/unit/presenters/organisations_index_presenter_test.rb
+++ b/test/unit/presenters/organisations_index_presenter_test.rb
@@ -67,6 +67,18 @@ class OrganisationsIndexPresenterTest < ActiveSupport::TestCase
     assert subject.agencies_and_government_bodies.is_a? OrganisationsIndexPresenter
   end
 
+  test "#high_profile_groups should return all organisations whose type is sub_organisation" do
+    ministerial_department = build(:ministerial_department)
+    high_profile_group = build(:sub_organisation, parent_organisations: [ministerial_department])
+
+    subject = OrganisationsIndexPresenter.new([high_profile_group, ministerial_department])
+
+    assert subject.high_profile_groups.include?(high_profile_group)
+    refute subject.high_profile_groups.include?(ministerial_department)
+
+    assert subject.high_profile_groups.is_a?(OrganisationsIndexPresenter)
+  end
+
   def status_variety_pack
     [build(:organisation, govuk_status: 'live'),
       build(:organisation, govuk_status: 'live'),


### PR DESCRIPTION
Story: https://www.agileplannerapp.com/boards/105200/cards/4629

Many users are attempting to use the organisations index at www.gov.uk/government/organisations to find high profile groups which are not in their own right organisations. An example of this would be UKVI, where 8% of users landing on that page search for either 'visas' or 'immigration'. This adds high profile groups to the organisations index to satisfy this user need.

There are plans to re-think the design of that page / how users find organisations and this is only meant to be a quick-fix to satisfy current needs.
- [x] Passed product review
