### PR TITLE
Script to move content from one topic to another

### DIFF
--- a/lib/data_hygiene/topic_retagger.rb
+++ b/lib/data_hygiene/topic_retagger.rb
@@ -1,0 +1,93 @@
+class TopicRetagger
+  attr_reader :source_topic_id, :destination_topic_id
+
+  def initialize(source_topic_id, destination_topic_id)
+    @source_topic_id = source_topic_id
+    @destination_topic_id = destination_topic_id
+  end
+
+  def retag
+    # Grab the list of published editions before we make any changes to the
+    # tags.  We'll need to re-register these after the re-tagging is done.
+    taggings, published_editions = get_taggings_and_editions(source_topic_id)
+
+    log "Updating #{taggings.count} taggings of editions (#{published_editions.count} published) to change #{source_topic_id} to #{destination_topic_id}"
+
+    update_taggings(taggings)
+    register_editions(published_editions)
+  end
+
+private
+
+  def update_taggings(taggings)
+    taggings.reject { |tagging| tagging.edition.nil? }.each do |tagging|
+      if tagging.edition.specialist_sector_tags.include? destination_topic_id
+        remove_tagging(tagging)
+      else
+        change_tagging(tagging)
+      end
+    end
+  end
+
+  def get_taggings_and_editions(topic_id)
+    taggings = SpecialistSector.where(tag: topic_id)
+
+    published_editions = taggings.map { |tagging|
+      tagging.edition.try(:document).try(:published_edition)
+    }.compact.uniq
+
+    [taggings, published_editions]
+  end
+
+  def register_editions(editions)
+    editions.each do |edition|
+      log "registering '#{edition.slug}'"
+      registerable_edition = RegisterableEdition.new(edition)
+      registerer           = Whitehall.panopticon_registerer_for(registerable_edition)
+      registerer.register(registerable_edition)
+    end
+  end
+
+  def remove_tagging(tagging)
+    edition = tagging.edition
+    log "removing tagging on '#{edition.slug}' edition #{edition.id}"
+    tagging.destroy
+
+    add_editorial_remark(edition,
+      "Bulk retagging from topic '#{source_topic_id}' to '#{destination_topic_id}' resulted in duplicate tag - removed it"
+    )
+  end
+
+  def change_tagging(tagging)
+    edition = tagging.edition
+    log "tagging '#{edition.slug}' edition #{edition.id}"
+    tagging.tag = destination_topic_id
+    tagging.save!
+
+    add_editorial_remark(edition,
+      "Bulk retagging from topic '#{source_topic_id}' to '#{destination_topic_id}' changed tag"
+    )
+  end
+
+  def add_editorial_remark(edition, message)
+    if edition.nil?
+      log " - no edition (probably deleted)"
+    elsif Edition::FROZEN_STATES.include?(edition.state)
+      log " - edition is frozen; skipping editorial remarks"
+    else
+      log " - adding editorial remark"
+      edition.editorial_remarks.create!(
+        author: gds_user,
+        body: message
+      )
+    end
+  end
+
+  def gds_user
+    @gds_user ||= User.find_by_email("govuk-whitehall@digital.cabinet-office.gov.uk")
+  end
+
+  def log(message)
+    puts message
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -58,3 +58,18 @@ task :specialist_sector_cleanup => :environment do
     puts "The sector '#{slug}' has not been tagged to any editions"
   end
 end
+
+desc "Move content from one topic to another"
+task :move_content_to_new_topic => :environment do
+  require "data_hygiene/topic_retagger"
+
+  source_topic_id = ENV['SOURCE']
+  destination_topic_id = ENV['DESTINATION']
+
+  if source_topic_id == destination_topic_id
+    puts "Source and destination topics are the same"
+    exit
+  end
+
+  TopicRetagger.new(source_topic_id, destination_topic_id).retag
+end

--- a/test/unit/data_hygiene/topic_retagger_test.rb
+++ b/test/unit/data_hygiene/topic_retagger_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+require 'data_hygiene/topic_retagger'
+
+class TopicRetaggerTest < ActiveSupport::TestCase
+  include DataHygiene
+
+  setup do
+    @published_edition = create(:published_edition)
+    @draft_edition = create(:draft_edition)
+    @gds_user = create(:user, email: 'govuk-whitehall@digital.cabinet-office.gov.uk')
+  end
+
+  # Replace the `log` method on a TopicTagger with one that appends the logged
+  # messages to an array.  Return the array.
+  def stub_logging(tagger)
+    def tagger.log(message)
+      @logs ||= []
+      @logs << message
+    end
+    def tagger.logs
+      @logs
+    end
+  end
+
+  test "#retag updates the taggings" do
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+    stub_panopticon_registration(@published_edition)
+
+    tagger = TopicRetagger.new('oil-and-gas/offshore', 'oil-and-gas/really-far-out')
+    stub_logging(tagger)
+    tagger.retag
+
+    [@published_edition, @draft_edition].each do |edition|
+      edition.reload
+      assert edition.editorial_remarks.any?
+      assert edition.specialist_sectors.map(&:tag) == ['oil-and-gas/really-far-out']
+    end
+
+    expected_logs = [
+      %{Updating 2 taggings of editions (1 published) to change oil-and-gas/offshore to oil-and-gas/really-far-out},
+      %{tagging '#{@draft_edition.title}' edition #{@draft_edition.id}},
+      %{ - adding editorial remark},
+      %{tagging '#{@published_edition.title}' edition #{@published_edition.id}},
+      %{ - adding editorial remark},
+      %{registering '#{@published_edition.title}'},
+    ]
+    assert tagger.logs == expected_logs
+  end
+end


### PR DESCRIPTION
This is part of https://www.pivotaltracker.com/story/show/76471962

All editions tagged with the source topic are retagged replacing the
source topic with the destination topic.

I decided to apply this to all editions including old ones since this
script is expected to be used when doing bulk re-assignment of topics;
we'll be likely to delete the source topic using the existing
specialist_sector_cleanup task after running this, so any old editions
where we didn't re-assign the topic would just lose their topic.
