### PR TITLE
Emails for contacts without postal addresses do not float

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -658,14 +658,12 @@
       .comment {
         margin-bottom: $gutter-half;
       }
-      .adr, .email-url-number {
+      .adr {
+        margin: 0 0 $gutter-one-third;
         @include media(tablet) {
           float: left;
           width: 40%;
         }
-      }
-      .adr {
-        margin: 0 0 $gutter-one-third;
         span {
           display: block;
           padding-right: $gutter-half;
@@ -688,6 +686,7 @@
       &.postal-address {
         .email-url-number {
           @include media(tablet){
+            float: left;
             width: 60%;
           }
         }


### PR DESCRIPTION
This was causing issues where the comment text would display oddly
next to the email address, and caused additional issues in IE.

Related Zendesk ticket: https://govuk.zendesk.com/agent/#/tickets/821859
