### PR TITLE
Disable the text extraction feature

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -192,7 +192,7 @@ module Whitehall
   end
 
   def self.extract_text_feature?
-    (ENV['WHITEHALL_EXTRACT_TEXT_FEATURE'] || true).to_s =~ /^(1|true)$/
+    false
   end
 
   def self.rummager_work_queue_name

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -174,6 +174,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
   end
 
   test "should return extracted_text if text file present" do
+    Whitehall.stubs(:extract_text_feature?).returns(true)
     test_pdf = fixture_file_upload('simple.pdf', 'application/pdf')
     attachment = build(:attachment_data, file: test_pdf)
     attachment.stubs(:read_extracted_text).returns "\nThis is a test pdf.\n\n\n"


### PR DESCRIPTION
Since we removed the initialiser override from our deployment code which disables this feature in production, this will default to enabling the feature, which may start sending extracted attachment bodies to Rummager. Since this feature was never completed, we've not fully tested it, and we're planning to remove it in its current form, we shouldn't inadvertently enable it.
