### PR TITLE
Ensure UrlMaker can be found during lookup

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -3,6 +3,7 @@ module Whitehall
   autoload :RandomKey, 'whitehall/random_key'
   autoload :FormBuilder, 'whitehall/form_builder'
   autoload :Uploader, 'whitehall/uploader'
+  autoload :UrlMaker, 'whitehall/url_maker'
 
   mattr_accessor :search_backend
   mattr_accessor :government_search_client


### PR DESCRIPTION
We get occasional uninitialized constant exceptions in sidekiq workers because the
Whitehall::UrlMaker class cannot be found. This adds the class to its
parent module such that it can be found regardless of the execution path
of the code. See http://urbanautomaton.com/blog/2013/08/27/rails-autoloading-hell/
for more details about constant lookup and Rails autoload.
