### PR TITLE
Add 3 more orgs to services-information whitelist

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -420,6 +420,9 @@ class Organisation < ActiveRecord::Base
 
   def organisations_with_services_and_information_link
     [
+      'charity-commission',
+      'environment-agency',
+      'marine-management-organisation',
       'maritime-and-coastguard-agency',
     ]
   end


### PR DESCRIPTION
The Environment Agency, Marine Management Organisation and Charity
Commission all now have their content tagged correctly so can have a
services and information link added.

https://www.pivotaltracker.com/story/show/78455338
