### PR TITLE
Remove the template handler when rendering govspeak partials

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -139,7 +139,7 @@ module GovspeakHelper
     return govspeak if govspeak.blank?
     govspeak.gsub(GovspeakHelper::FRACTION_REGEXP) do |match|
       if $1.present? && $2.present?
-        render(partial: 'shared/govspeak_fractions.html.erb', locals: { numerator: $1, denominator: $2 })
+        render(partial: 'shared/govspeak_fractions', formats: [:html], locals: { numerator: $1, denominator: $2 })
       else
         ''
       end


### PR DESCRIPTION
This removes the following warning:

`DEPRECATION WARNING: Passing a template handler in the template name
is deprecated.`
