### PR TITLE
Set cache-control for replacement attachment redirects

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -28,6 +28,7 @@ private
     if edition = attachment_visibility.unpublished_edition
       redirect_to public_document_path(edition, id: edition.unpublishing.slug)
     elsif replacement = attachment_data.replaced_by
+      expires_headers
       redirect_to replacement.url, status: 301
     else
       super

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -28,6 +28,8 @@ class AttachmentsControllerTest < ActionController::TestCase
 
     assert_redirected_to replacement.url
     assert_equal 301, response.status
+    assert_cache_control("max-age=#{Whitehall.uploads_cache_max_age}")
+    assert_cache_control("public")
   end
 
   test 'document attachments that are visible are sent to the browser inline with default caching' do

--- a/test/support/cache_control_test_helpers.rb
+++ b/test/support/cache_control_test_helpers.rb
@@ -1,6 +1,7 @@
 module CacheControlTestHelpers
   def assert_cache_control(expected_directive)
     cache_control_header = response.headers['Cache-Control']
+    assert cache_control_header, "No Cache-Control header set in response"
     assignments, directives = cache_control_header.split(/, */).partition {|stmt| stmt.include?("=")}
     if expected_directive.include?("=")
       expected_name, expected_value = expected_directive.split("=")


### PR DESCRIPTION
These currently return a 301 with Cache-Control set to private (because
that's the default unless otherwise specified).  This means that these
requests can't be cached in the CDN etc.

This sets a cache-control header to the default `uploads_cache_max_age`.
