### PR TITLE
Remove locality when displaying a country with a remote office

### DIFF
--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -24,9 +24,10 @@
           <ul>
 
           <% if embassy.remote_services_country -%>
+            <% organisation = embassy.consular_services_organisations.first -%>
             <li>
-              <p><%= embassy.name %> doesn't have consular services, you need to go to the <%= embassy.offices.first.title %> in <%= embassy.remote_services_country %>.</p>
-              <%= link_to(embassy.offices.first.title, worldwide_organisation_path(embassy.offices.first.slug)) %>
+              <p><%= embassy.name %> doesn't have consular services, you need to go to the <%= organisation.name %> in <%= embassy.remote_services_country %>.</p>
+              <%= link_to(organisation.name, worldwide_organisation_path(organisation.slug)) %>
             </li>
 
           <% else -%>

--- a/test/functional/embassies_controller_test.rb
+++ b/test/functional/embassies_controller_test.rb
@@ -16,7 +16,8 @@ class EmbassiesControllerTest < ActionController::TestCase
     aruba = create(:world_location, :with_worldwide_organisations, name: "Aruba")
     netherlands = create(:world_location, name: "Netherlands")
     aruban_org = aruba.worldwide_organisations.first
-    aruban_contact = create(:contact, title: "British Consulate General Amsterdam", street_address: "...", country: netherlands)
+    aruban_contact = create(:contact, street_address: "...", country: netherlands)
+    aruban_org.update_attribute(:name, "British Consulate General Amsterdam")
     aruban_org.main_office = create(:worldwide_office,
                                     contact: aruban_contact,
                                     worldwide_organisation: aruban_org,


### PR DESCRIPTION
Displaying a locality (city name) is more misleading than useful in the context of a remote country.
Fix link to remote consular service org page.
