### PR TITLE
Removing summary paragraphs after policies and announcement headings

### DIFF
--- a/app/helpers/ministerial_roles_helper.rb
+++ b/app/helpers/ministerial_roles_helper.rb
@@ -13,11 +13,4 @@ module MinisterialRolesHelper
     end
   end
 
-  def policies_responsible(person, role)
-    if person.present?
-      t('roles.policies_responsible_with_person', person: person.name, role: role.name)
-    else
-      t('roles.policies_responsible', role: role.name)
-    end
-  end
 end

--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -98,7 +98,6 @@
       <% if @ministerial_role.published_policies.any? %>
         <section class="policy" id="policies">
           <h1><%= t('policies.heading') %></h1>
-          <p><%= policies_responsible(@ministerial_role.current_person, @ministerial_role) %></p>
 
           <%= render 'ministerial_roles/policies', role: @ministerial_role %>
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -95,7 +95,6 @@
             <% if role.published_policies.any? %>
               <section class="policy">
                 <h1><%= t('policies.heading') %></h1>
-                <p><%= policies_responsible(@person, role) %></p>
 
                 <%= render partial: 'ministerial_roles/policies',
                            locals: { role: role } %>

--- a/app/views/shared/_announcement_list.html.erb
+++ b/app/views/shared/_announcement_list.html.erb
@@ -3,7 +3,6 @@
 <% if announcer.announcements.any? %>
   <section class="announcements" id="announcements">
     <h1><%= t('announcements.heading') %></h1>
-    <p>by <%= announcer.name %></p>
 
     <%= render 'shared/feeds', atom_url: atom_feed_url_for(announcer) %>
 

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -550,7 +550,6 @@ ar:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -549,7 +549,6 @@ az:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -432,7 +432,6 @@ be:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -315,7 +315,6 @@ bg:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -314,7 +314,6 @@ bn:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -373,7 +373,6 @@ cs:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -552,7 +552,6 @@ cy:
       previous_holders: 'Cyn-ddeiliaid '
       responsibilities: Cyfrifoldebau
     ministerial: Rôl Gweinidogol
-    policies_responsible: dan gyfrifoldeb %{role}
     policies_responsible_with_person: dan gyfrifoldeb %{person} fel %{role}
     previous_holders: Cyn-ddeiliaid y rôl yma
     read_more: Mwy am y rôl yma

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -314,7 +314,6 @@ de:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -314,7 +314,6 @@ dr:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -315,7 +315,6 @@ el:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -504,7 +504,6 @@ en:
     ministerial: Ministerial role
     read_more: More about this role
     previous_holders: Previous holders of this role
-    policies_responsible: under the responsibility of %{role}
     policies_responsible_with_person: under the responsibility of %{person} as %{role}
     headings:
       responsibilities: Responsibilities

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -314,7 +314,6 @@ es-419:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -314,7 +314,6 @@ es:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -552,7 +552,6 @@ fa:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -314,7 +314,6 @@ fr:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -432,7 +432,6 @@ he:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -314,7 +314,6 @@ hi:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -553,7 +553,6 @@ hu:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -314,7 +314,6 @@ hy:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -552,7 +552,6 @@ id:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -314,7 +314,6 @@ it:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -550,7 +550,6 @@ ja:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -549,7 +549,6 @@ ka:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -550,7 +550,6 @@ ko:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -373,7 +373,6 @@ lt:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -314,7 +314,6 @@ lv:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -549,7 +549,6 @@ ms:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -432,7 +432,6 @@ pl:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -316,7 +316,6 @@ ps:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -314,7 +314,6 @@ pt:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -374,7 +374,6 @@ ro:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -432,7 +432,6 @@ ru:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -315,7 +315,6 @@ si:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -373,7 +373,6 @@ sk:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -314,7 +314,6 @@ so:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -314,7 +314,6 @@ sq:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -436,7 +436,6 @@ sr:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -314,7 +314,6 @@ sw:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -314,7 +314,6 @@ ta:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -550,7 +550,6 @@ th:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -314,7 +314,6 @@ tk:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -551,7 +551,6 @@ tr:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -432,7 +432,6 @@ uk:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -314,7 +314,6 @@ ur:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -314,7 +314,6 @@ uz:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -552,7 +552,6 @@ vi:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -549,7 +549,6 @@ zh-hk:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -549,7 +549,6 @@ zh-tw:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -549,7 +549,6 @@ zh:
       previous_holders:
       responsibilities:
     ministerial:
-    policies_responsible:
     policies_responsible_with_person:
     previous_holders:
     read_more:


### PR DESCRIPTION
Removing summary paragraphs after policies and announcement headings on people and minister pages

• these summary sentences only appear on people and minister pages so have removed them from there
• as a result I remove the def from the helper too as it's now unused
• and removed it from the translation files too

https://www.agileplannerapp.com/boards/105200/cards/5558
