### PR TITLE
Modify organisation_state in search index for closed and devolved organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -161,7 +161,7 @@ class Organisation < ActiveRecord::Base
              description: :summary,
              boost_phrases: :acronym,
              slug: :slug,
-             organisation_state: :govuk_status
+             organisation_state: :searchable_govuk_status
 
   extend FriendlyId
   friendly_id
@@ -263,6 +263,14 @@ class Organisation < ActiveRecord::Base
 
   def sub_organisations
     child_organisations.where(organisation_type_key: :sub_organisation)
+  end
+
+  def searchable_govuk_status
+    if closed? && devolved?
+      'devolved'
+    else
+      govuk_status
+    end
   end
 
   def live?

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -381,10 +381,12 @@ class OrganisationTest < ActiveSupport::TestCase
     create(:published_corporate_information_page, corporate_information_page_type: about_type, summary: 'Taxing.', organisation: hmrc)
     mod = create(:organisation, name: 'Ministry of Defence', acronym: 'mod')
     create(:published_corporate_information_page, corporate_information_page_type: about_type, summary: 'Defensive.', organisation: mod)
+    superseding_organisation = create(:devolved_administration, name: 'Devolved administration')
+    create(:organisation, name: 'Devolved organisation', acronym: 'dev', govuk_status: 'closed', govuk_closed_status: 'devolved', superseding_organisations: [superseding_organisation])
 
     results = Organisation.search_index.to_a
 
-    assert_equal 4, results.length
+    assert_equal 6, results.length
     assert_equal({'title' => 'Department for Culture and Sports',
                   'link' => '/government/organisations/department-for-culture-and-sports',
                   'slug' => 'department-for-culture-and-sports',
@@ -417,6 +419,14 @@ class OrganisationTest < ActiveSupport::TestCase
                   'boost_phrases' => 'mod',
                   'description' => 'Defensive.',
                   'organisation_state' => 'live'}, results[3])
+    assert_equal({'title' => 'Devolved organisation',
+                  'acronym' => 'dev',
+                  'link' => '/government/organisations/devolved-organisation',
+                  'slug' => 'devolved-organisation',
+                  'indexable_content' => '',
+                  'format' => 'organisation',
+                  'boost_phrases' => 'dev',
+                  'organisation_state' => 'devolved'}, results[5])
   end
 
   test '#published_announcements returns published news or speeches' do


### PR DESCRIPTION
We want to hide the [closed organisation] text in search results for organisations marked as closed and devolved. In order to so, we return "live" if an organisation is closed and devolved. A fix involving properly modelling devolved status is planned in the future. 

Please see: https://www.agileplannerapp.com/boards/105200/cards/6007 for more background of the story. 
