### PR TITLE
Warn about similar slugs

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -307,9 +307,7 @@ module Admin::EditionsHelper
     nil
   end
 
-  def similar_slugs_warning(edition)
-    if !edition.document.published? && edition.document.has_similar_slug?
-      "This title is already used on GOV.UK. Please create a unique title."
-    end
+  def show_similar_slugs_warning?(edition)
+    !edition.document.published? && edition.document.similar_slug_exists?
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,7 +46,7 @@ class Document < ActiveRecord::Base
     where(document_type: document_types, slug: slug).first
   end
 
-  def has_similar_slug?
+  def similar_slug_exists?
     scope = Document.where(document_type: document_type)
     sequence_separator = friendly_id_config.sequence_separator
     slug_without_sequence = slug.split(sequence_separator).first

--- a/app/views/admin/editions/_similar_slug_warning.html.erb
+++ b/app/views/admin/editions/_similar_slug_warning.html.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-warning">
+  <p>This title is already used on GOV.UK. Please create a unique title.</p>
+</div>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -25,12 +25,7 @@
     <section>
       <h1><%= edition_edit_headline(@edition) %></h1>
 
-      <% if warning = similar_slugs_warning(@edition) %>
-        <div class="alert alert-warning">
-          <p><%= warning %></p>
-        </div>
-      <% end %>
-
+      <%= render('similar_slug_warning') if show_similar_slugs_warning?(@edition) %>
       <%= render "recent_openings", edition: @edition, recent_openings: @recent_openings %>
       <%= render "form", edition: @edition %>
     </section>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -43,11 +43,7 @@
       <% end %>
     </section>
 
-    <% if warning = similar_slugs_warning(@edition) %>
-      <section class="alert alert-warning">
-        <p><%= warning %></p>
-      </section>
-    <% end %>
+    <%= render('similar_slug_warning') if show_similar_slugs_warning?(@edition) %>
 
     <% if @edition.scheduled_publication %>
       <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -127,20 +127,20 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal "document collection", build(:document, document_type: "DocumentCollection").humanized_document_type
   end
 
-  test "checks for similar slugs" do
+  test "#similar_slug_exists? returns true if a document with a similar slug exists" do
     existing = create(:news_article, title: "Latest news")
     draft = create(:news_article, title: "Latest news")
 
-    assert draft.document.has_similar_slug?
+    assert draft.document.similar_slug_exists?
 
     distinct_draft = create(:news_article, title: "Latest news from the crime scene")
-    refute distinct_draft.document.has_similar_slug?
+    refute distinct_draft.document.similar_slug_exists?
   end
 
-  test "respects document_type scope while checking for similar slugs" do
+  test "#similar_slug_exists? scopes to documents of the same type" do
     existing = create(:news_article, title: "UK prospers")
     draft = create(:speech, title: "UK prospers")
 
-    refute draft.document.has_similar_slug?
+    refute draft.document.similar_slug_exists?
   end
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5403

As a department editor
When creating a document in Whitehall Publisher
I want be warned of possible title duplicates
So that I can create unique titles and avoid ugly --2, --3 slugs

This warning appears in 2 places:
- on the edit form
- on the edition show page, below the submit / publish action buttons
