### PR TITLE
Add row wrapping div to fix IE7 float bug

### DIFF
--- a/app/views/services_and_information/_collection_group.html.erb
+++ b/app/views/services_and_information/_collection_group.html.erb
@@ -1,15 +1,17 @@
-<div class="head-section">
-  <h2><%= collection_group.title %></h2>
-</div>
+<div class="collection-group">
+  <div class="head-section">
+    <h2><%= collection_group.title %></h2>
+  </div>
 
-<div class="content">
-  <ol>
-    <% collection_group.examples.each_with_index do |example, index| -%>
-      <li><%= link_to collection_group.title_for_example_at(index), collection_group.link_for_example_at(index) %></li>
-    <% end %>
+  <div class="content">
+    <ol>
+      <% collection_group.examples.each_with_index do |example, index| -%>
+        <li><%= link_to collection_group.title_for_example_at(index), collection_group.link_for_example_at(index) %></li>
+      <% end %>
 
-    <% if collection_group.more_documents? %>
-      <li><%= link_to "See more", collection_group.subsector_link, class: "other" %></li>
-    <% end %>
-  </ol>
+      <% if collection_group.more_documents? %>
+        <li><%= link_to "See more", collection_group.subsector_link, class: "other" %></li>
+      <% end %>
+    </ol>
+  </div>
 </div>


### PR DESCRIPTION
IE7 doesn't quite understand floating and clearing elements so doesn't
position the headers next to the list of links they are associated to.
Instead the headers float up to the list above the one it is intended
for.

This adds a wrapping div to each list of links which forces the heading
to clear the previous list and sit next to the list it is intended for.

Before:
![screen shot 2014-10-01 at 12 03 07](https://cloud.githubusercontent.com/assets/35035/4474088/5942f570-495b-11e4-964b-6969b9dd3140.png)

After:
![screen shot 2014-10-01 at 12 02 43](https://cloud.githubusercontent.com/assets/35035/4474130/de9b0d98-495b-11e4-9f95-bd803eaf0c2b.png)
- [x] Product review
- [x] Dev review
