### PR TITLE
Rake task to requeue all scheduled publishing jobs.

### DIFF
--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -16,6 +16,11 @@ class ScheduledPublishingWorker
     end.map(&:delete)
   end
 
+  # Only used by the publishing:scheduled:requeue_all_jobs rake task.
+  def self.dequeue_all
+    queued_jobs.map(&:delete)
+  end
+
   def self.queue_size
     queued_jobs.size
   end

--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -26,6 +26,18 @@ namespace :publishing do
         puts "#{edition.id} queued"
       end
     end
+
+    desc "Clears all jobs then requeues all scheduled editions (intended for use after a db restore)"
+    task :requeue_all_jobs => :environment do
+      ScheduledPublishingWorker.dequeue_all
+
+      puts "Queueing #{Edition.scheduled.count} jobs"
+      Edition.scheduled.each do |edition|
+        ScheduledPublishingWorker.queue(edition)
+        print "."
+      end
+      puts ""
+    end
   end
 
   namespace :overdue do

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -67,6 +67,22 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
     end
   end
 
+  test '.dequeue_all removes all scheduled publishing jobs' do
+    edition1 = create(:scheduled_edition)
+    edition2 = create(:scheduled_edition)
+
+    with_real_sidekiq do
+      ScheduledPublishingWorker.queue(edition1)
+      ScheduledPublishingWorker.queue(edition2)
+
+      assert_equal 2, Sidekiq::ScheduledSet.new.size
+
+      ScheduledPublishingWorker.dequeue_all
+
+      assert_equal 0, Sidekiq::ScheduledSet.new.size
+    end
+  end
+
   test '.queue_size returns the number of queued ScheduledPublishingWorker jobs' do
     with_real_sidekiq do
       ScheduledPublishingWorker.perform_at(1.day.from_now, 'null')


### PR DESCRIPTION
At the moment, after a database restore (ie after a data sync to staging or preview), the list of scheduled editions does not match the list of sidekiq jobs in redis.  There is an existing task to add jobs for any editions that have mising jobs.  This works for some cases, however it fails to account for editions that are no longer
scheduled (orphaned sidekiq jobs), or editions that have have their scheduled time changed.

To address this, we therefore delete all sidekiq jobs for the `ScheduledPublishingWorker` and then re-queue all editions that are scheduled for publication.

https://www.pivotaltracker.com/story/show/79398610
