### PR TITLE
Remove organisation_id from StatisticAnnouncement

### DIFF
--- a/db/migrate/20141003083550_drop_organisation_id_from_statistics_announcements.rb
+++ b/db/migrate/20141003083550_drop_organisation_id_from_statistics_announcements.rb
@@ -1,0 +1,9 @@
+class DropOrganisationIdFromStatisticsAnnouncements < ActiveRecord::Migration
+  def up
+    remove_column :statistics_announcements, :organisation_id
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1109,7 +1109,6 @@ ActiveRecord::Schema.define(:version => 20141009101445) do
     t.string   "slug"
     t.text     "summary"
     t.integer  "publication_type_id"
-    t.integer  "organisation_id"
     t.integer  "topic_id"
     t.integer  "creator_id"
     t.datetime "created_at",          :null => false
@@ -1122,7 +1121,6 @@ ActiveRecord::Schema.define(:version => 20141009101445) do
 
   add_index "statistics_announcements", ["cancelled_by_id"], :name => "index_statistics_announcements_on_cancelled_by_id"
   add_index "statistics_announcements", ["creator_id"], :name => "index_statistics_announcements_on_creator_id"
-  add_index "statistics_announcements", ["organisation_id"], :name => "index_statistics_announcements_on_organisation_id"
   add_index "statistics_announcements", ["publication_id"], :name => "index_statistics_announcements_on_publication_id"
   add_index "statistics_announcements", ["slug"], :name => "index_statistics_announcements_on_slug"
   add_index "statistics_announcements", ["title"], :name => "index_statistics_announcements_on_title"


### PR DESCRIPTION
**WARNING: Don not merge until https://github.com/alphagov/whitehall/pull/1751 is successfully deployed to production:**

the change above introduces a join table to store M-M relations between statistics announcements and organisations. hence this column is not required.
