### PR TITLE
Publish Organisations to the Publishing API

### DIFF
--- a/app/services/service_listeners/organisation_publishing_api_registrar.rb
+++ b/app/services/service_listeners/organisation_publishing_api_registrar.rb
@@ -1,0 +1,11 @@
+module ServiceListeners
+  class OrganisationPublishingApiRegistrar
+    def initialize(organisation)
+      @organisation = organisation
+    end
+
+    def register!
+      PublishingApiRegisterOrganisationWorker.perform_async(@organisation.id)
+    end
+  end
+end

--- a/app/workers/publishing_api_register_organisation_worker.rb
+++ b/app/workers/publishing_api_register_organisation_worker.rb
@@ -1,0 +1,17 @@
+class PublishingApiRegisterOrganisationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :publishing_api
+
+  def perform(organisation_id, options = {})
+    organisation = Organisation.find(organisation_id)
+
+    if organisation.present?
+      registerable_org = organisation
+      Whitehall.publishing_api_client.put_content_item(
+        registerable_org.base_path,
+        registerable_org.attributes_for_publishing_api
+      )
+    end
+  end
+
+end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -799,4 +799,34 @@ class OrganisationTest < ActiveSupport::TestCase
     assert organisation.valid?
     assert_equal 'http://jobs.com/', organisation.jobs_url
   end
+
+  test "it creates an attributes hash for the publishing api" do
+    organisation = create(:organisation)
+
+    expected_attributes_for_publishing_api_hash = {
+      title: organisation.name,
+      base_path: "/government/#{organisation.slug}",
+      description: organisation.summary,
+      format: "placeholder",
+      need_ids: [],
+      public_updated_at: organisation.updated_at,
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      routes: [ { path: "/government/#{organisation.slug}", type: "exact" }],
+      redirects: [],
+      update_type: "minor",
+      details: {
+        abbreviation: organisation.acronym,
+        logo_formatted_name: organisation.logo_formatted_name,
+        organisation_brand_colour_class_name: organisation.organisation_brand_colour.try(:class_name),
+        organisation_logo_type_class_name: organisation.organisation_logo_type.try(:class_name),
+        closed_at: organisation.closed_at,
+        govuk_status: organisation.govuk_status,
+        parent_organisations: organisation.parent_organisations,
+        child_organisations: organisation.child_organisations,
+      }
+    }
+
+    assert_equal expected_attributes_for_publishing_api_hash, organisation.attributes_for_publishing_api
+  end
 end

--- a/test/unit/services/listeners/organisation_publication_api_registrar_test.rb
+++ b/test/unit/services/listeners/organisation_publication_api_registrar_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ServiceListeners::OrganisationPublishingApiRegistrarTest < ActiveSupport::TestCase
+
+  test "registers an organisation with the publishing api" do
+    organisation = create(:organisation)
+    PublishingApiRegisterOrganisationWorker.expects(:perform_async).with(organisation.id).once
+    ServiceListeners::OrganisationPublishingApiRegistrar.new(organisation).register!
+  end
+
+end

--- a/test/unit/workers/publishing_api_register_organisation_worker_test.rb
+++ b/test/unit/workers/publishing_api_register_organisation_worker_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api'
+
+class PublishingApiRegisterOrganisationWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApi
+
+  test "registers an organisagtion with the publishing api" do
+    organisation = create(:organisation)
+    stub_publishing_api_put_item(organisation.base_path, organisation.attributes_for_publishing_api)
+
+    PublishingApiRegisterOrganisationWorker.new.perform(organisation.id)
+
+    assert_publishing_api_put_item(organisation.base_path,
+      JSON.parse(organisation.attributes_for_publishing_api.to_json))
+  end
+end


### PR DESCRIPTION
As part of the work of moving other Applications to rely on the Content Store we need access to Organisations. This work sent the Organisation to the Publishing API after save.
