### PR TITLE
Don't deprecate columns too soon.

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -1,7 +1,4 @@
 class HtmlAttachment < Attachment
-  extend DeprecatedColumns
-  deprecated_columns :body, :manually_numbered_headings
-
   extend FriendlyId
   friendly_id :sluggable_string
 


### PR DESCRIPTION
We still need these columns for both the data migration and as the fall back
that is used during the interim period when the code has been deployed but the
data migration has not completed.

Part of https://www.agileplannerapp.com/boards/173808/cards/6159
