### PR TITLE
Cleanup deprecated HtmlAttachment attributes

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -38,7 +38,7 @@ module GovspeakHelper
   end
 
   def html_attachment_govspeak_headers(attachment)
-    govspeak_headers(attachment.body).tap do |headers|
+    govspeak_headers(attachment.govspeak_content_body).tap do |headers|
       if attachment.manually_numbered_headings?
         headers.each { |header| header.text = header.text.gsub(/^(\d+.?\d*\s*)/, '') }
       end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -9,23 +9,11 @@ class HtmlAttachment < Attachment
   validates :govspeak_content, presence: true
 
   accepts_nested_attributes_for :govspeak_content
-  delegate :body_html, :headers_html, :manually_numbered_headings?,
+  delegate :body, :body_html, :headers_html,
             to: :govspeak_content, allow_nil: true, prefix: true
 
-  # Note: temporary setter to deal with the form submissions made with the old
-  # code. To be cleaned up post-deploy.
-  def body=(govspeak)
-    (govspeak_content || self.build_govspeak_content).body = govspeak
-  end
-
-  # NOTE: temporary getter to make sure we still return body content before the
-  # data has been migrated to the new delegated model
-  def body
-    govspeak_content.try(:body) || attributes['body']
-  end
-
   def manually_numbered_headings?
-    govspeak_content.try(:manually_numbered_headings?) || attributes['manually_numbered_headings']
+    govspeak_content.manually_numbered_headings?
   end
 
   def accessible?
@@ -70,7 +58,7 @@ class HtmlAttachment < Attachment
   end
 
   def extracted_text
-    Govspeak::Document.new(body).to_text
+    Govspeak::Document.new(govspeak_content_body).to_text
   end
 
   def should_generate_new_friendly_id?
@@ -86,11 +74,7 @@ class HtmlAttachment < Attachment
 
   def deep_clone
     super.tap do |clone|
-      if govspeak_content.present?
-        clone.govspeak_content = govspeak_content.dup
-      else
-        clone.build_govspeak_content(body: body, manually_numbered_headings: manually_numbered_headings)
-      end
+      clone.govspeak_content = govspeak_content.dup
     end
   end
 

--- a/app/views/html_attachments/show.html.erb
+++ b/app/views/html_attachments/show.html.erb
@@ -33,7 +33,7 @@
 </header>
 <div class="block publication-content">
   <div class="inner-block floated-children">
-    <%= @html_attachment.govspeak_content_body_html || govspeak_to_html(@html_attachment.body, @edition.images, govspeak_options_for_html_attachment(@html_attachment)) %>
+    <%= @html_attachment.govspeak_content_body_html || govspeak_to_html(@html_attachment.govspeak_content_body, @edition.images, govspeak_options_for_html_attachment(@html_attachment)) %>
   </div>
 </div>
 <div class="js-back-to-content back-to-content">

--- a/db/migrate/20141007105706_remove_body_from_attachements.rb
+++ b/db/migrate/20141007105706_remove_body_from_attachements.rb
@@ -1,0 +1,5 @@
+class RemoveBodyFromAttachements < ActiveRecord::Migration
+  def change
+    remove_columns :attachments, :body, :manually_numbered_headings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(:version => 20141009101445) do
     t.string   "order_url"
     t.integer  "price_in_pence"
     t.integer  "attachment_data_id"
-    t.integer  "ordering",                                         :null => false
+    t.integer  "ordering",                 :null => false
     t.string   "hoc_paper_number"
     t.string   "parliamentary_session"
     t.boolean  "unnumbered_command_paper"
@@ -72,8 +72,6 @@ ActiveRecord::Schema.define(:version => 20141009101445) do
     t.string   "attachable_type"
     t.string   "type"
     t.string   "slug"
-    t.text     "body",                       :limit => 2147483647
-    t.boolean  "manually_numbered_headings"
     t.string   "locale"
   end
 

--- a/features/step_definitions/import_steps.rb
+++ b/features/step_definitions/import_steps.rb
@@ -45,7 +45,7 @@ Then /^the imported publication has an html attachment with the title "([^"]*)" 
   publication = Import.last.editions.last
   attachment = publication.attachments.first
   assert_equal html_title, attachment.title
-  assert_equal html_body, attachment.body
+  assert_equal html_body, attachment.govspeak_content_body
 end
 
 Then /^the import succeeds, creating (\d+) imported speech(?:es)? with "([^"]*)" speech type and with no deliverer set$/ do |edition_count, speech_type_slug|

--- a/lib/whitehall/uploader/publication_row.rb
+++ b/lib/whitehall/uploader/publication_row.rb
@@ -63,7 +63,7 @@ module Whitehall::Uploader
     end
 
     def html_attachment_attributes
-      { title: html_title, body: html_body }
+      { title: html_title, govspeak_content_attributes: { body: html_body } }
     end
 
   protected

--- a/script/scrub-database
+++ b/script/scrub-database
@@ -87,7 +87,7 @@ run_mysql_command "UPDATE attachments SET title='${lorem_ipsum_line}' WHERE atta
 echo "Done"
 
 echo "Anonymising html attachment data for latest access limited drafts..."
-run_mysql_command "UPDATE attachments SET body='${lorem_ipsum_paragraphs}', slug=concat('${lorem_ipsum_slug}-', id) WHERE attachable_type = 'Edition' AND attachable_id IN (${access_limited_edition_ids})" 1> /dev/null
+run_mysql_command "UPDATE attachments SET slug=concat('${lorem_ipsum_slug}-', id) WHERE attachable_type = 'Edition' AND attachable_id IN (${access_limited_edition_ids})" 1> /dev/null
 echo "Done"
 
 echo "Anonymising file names for attachments on latest access limited drafts..."

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -100,7 +100,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_equal 1, @edition.reload.attachments.size
     assert_equal 'Attachment title', @edition.attachments.first.title
-    assert_equal 'Some **govspeak** body', @edition.attachments.first.body
+    assert_equal 'Some **govspeak** body', @edition.attachments.first.govspeak_content_body
   end
 
   test 'POST :create ignores html attachments when attachable does not allow them' do
@@ -200,7 +200,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
       govspeak_content_attributes: { body: 'New body', id: attachment.govspeak_content.id }
     }
     assert_equal 'New title', attachment.reload.title
-    assert_equal 'New body', attachment.reload.body
+    assert_equal 'New body', attachment.reload.govspeak_content_body
   end
 
   test "PUT :update with empty file payload changes attachment metadata, but not the attachment data" do

--- a/test/integration/sanitise_db_test.rb
+++ b/test/integration/sanitise_db_test.rb
@@ -58,12 +58,12 @@ class SanitiseDBTest < ActiveSupport::TestCase
 
     good_attachment.reload
     assert_equal "Good title", good_attachment.title
-    assert_equal "Good body", good_attachment.body
+    assert_equal "Good body", good_attachment.govspeak_content_body
     assert_equal "good-title", good_attachment.slug
 
     bad_attachment.reload
     refute bad_attachment.title =~ /Bad title/, "Expected title to be sanitised"
-    refute bad_attachment.body =~ /Bad body/, "Expected body to be sanitised"
+    refute bad_attachment.govspeak_content_body =~ /Bad body/, "Expected body to be sanitised"
     refute bad_attachment.slug =~ /bad-title/, "Expected slug to be sanitised"
   end
 

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -142,7 +142,7 @@ class AttachableTest < ActiveSupport::TestCase
       attachment_2 = build(:html_attachment, title: "Test HTML attachment"),
     ])
 
-    attachment_3 = HtmlAttachment.new(title: 'Title', body: "Testing")
+    attachment_3 = build(:html_attachment, title: 'Title', body: "Testing")
     publication.attachments << attachment_3
 
     assert_equal [attachment_2, attachment_3], publication.html_attachments(true)
@@ -195,7 +195,7 @@ class AttachableTest < ActiveSupport::TestCase
     attachment_2 = draft.attachments[1]
     assert attachment_2.persisted?
     assert html_attachment.id != attachment_2.id
-    assert_equal html_attachment.body, attachment_2.body
+    assert_equal html_attachment.govspeak_content.body, attachment_2.govspeak_content.body
     assert_equal html_attachment.title, attachment_2.title
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -19,20 +19,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert attachment.id != clone.id
     assert clone.new_record?
     assert_equal attachment.title, clone.title
-    assert_equal attachment.body, clone.body
-  end
-
-  test '#deep_clone temporarily handles attachments without a GovspeakContent instance' do
-    attachment = create(:html_attachment)
-    attachment.govspeak_content.destroy
-
-    clone = attachment.reload.deep_clone
-
-    assert attachment.id != clone.id
-    assert clone.new_record?
-    assert clone.govspeak_content.present?
-    assert_equal attachment.title, clone.title
-    assert_equal attachment.body, clone.body
+    assert_equal attachment.govspeak_content_body, clone.govspeak_content_body
   end
 
   test '#url returns absolute path' do

--- a/test/unit/uploader/publication_row_test.rb
+++ b/test/unit/uploader/publication_row_test.rb
@@ -77,7 +77,7 @@ module Whitehall::Uploader
       assert_nil new_publication_row.html_body
 
       row = new_publication_row({'html_body' => 'body', 'html_body_1' => ' part 1', 'html_body_2' => ' part 2'})
-      assert_equal 'body part 1 part 2', row.attributes[:html_attachment_attributes][:body]
+      assert_equal 'body part 1 part 2', row.attributes[:html_attachment_attributes][:govspeak_content_attributes][:body]
     end
 
     test "returns the HTML title if present" do
@@ -90,7 +90,7 @@ module Whitehall::Uploader
     test "sets title and body for an HTML attachment if present" do
       row_with_html_attachment = new_publication_row({'html_title' => 'HTML title', 'html_body' => 'HTML body'})
       assert_equal 'HTML title', row_with_html_attachment.attributes[:html_attachment_attributes][:title]
-      assert_equal 'HTML body', row_with_html_attachment.attributes[:html_attachment_attributes][:body]
+      assert_equal 'HTML body', row_with_html_attachment.attributes[:html_attachment_attributes][:govspeak_content_attributes][:body]
     end
 
     test "finds ministers specified by slug in minister 1 and minister 2 columns" do

--- a/test/unit/workers/import_row_worker_test.rb
+++ b/test/unit/workers/import_row_worker_test.rb
@@ -40,7 +40,7 @@ class ImportRowWorkerTest < ActiveSupport::TestCase
 
       html_attachment = publication.attachments.last
       assert_equal 'HTML title', html_attachment.title
-      assert_equal 'body', html_attachment.body
+      assert_equal 'body', html_attachment.govspeak_content_body
 
       file_attachment = publication.attachments.first
       assert_equal 'File title', file_attachment.title


### PR DESCRIPTION
This completes the work that extracted govspeak content out of `HtmlAttachment` and into a separate `GovspeakContent` model.
- [x] [Main story](https://www.agileplannerapp.com/boards/173808/cards/6159) successfully deployed to production
- [x] Code review
- [x] PO accepted

Story: https://www.agileplannerapp.com/boards/173808/cards/6223
