### PR TITLE
Add more organisations to scoped search list

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -441,7 +441,9 @@ class Organisation < ActiveRecord::Base
 
   def organisations_with_scoped_search
     [
+      'environment-agency',
       'land-registry',
+      'legal-aid-agency',
     ]
   end
 


### PR DESCRIPTION
Based on feedback and analytics, we believe that most searches performed
from pages with a primary organisation of either the Environment Agency
or the Legal Aid Agency will be improved by scoping the search results
for those agencies.  We checked the top 20 searches from such content
manually, as part of considering this, and they all either have very
similar results, or look much more likely to satisfy users with scoping
turned on.

This change simply adds the EA and LAA organisations to the whitelist to
turn such scoping on.

Story at: https://www.pivotaltracker.com/story/show/78720082
- [x] Product approval
- [x] Tech approval
