### PR TITLE
Delay queueing of GovspeakContentWorker job

### DIFF
--- a/app/models/govspeak_content.rb
+++ b/app/models/govspeak_content.rb
@@ -16,8 +16,14 @@ class GovspeakContent < ActiveRecord::Base
 
 private
 
+  # NOTE: we delay the processing of the govspeak so as to ensure that the
+  # GovspeakContent record actually exists in the database. This is necessary
+  # because the re-editioning process (which clones HtmlAttachments, and thus
+  # GovspeakContent) takes a while, meaning the transaction may not have
+  # completed before the job is picked up, causing ActiveRecord::RecordNotFound
+  # errors.
   def queue_html_compute_job
-    GovspeakContentWorker.perform_async(self.id)
+    GovspeakContentWorker.perform_in(10.seconds, self.id)
   end
 
   def body_or_numbering_scheme_changed?


### PR DESCRIPTION
We delay the processing of the govspeak so as to ensure that the GovspeakContent
record actually exists in the database. This is necessary because the
re-editioning process (which clones HtmlAttachments, and thus GovspeakContent)
takes a while and the transaction this happens in may not have completed before
the job is picked up, resulting in ActiveRecord::RecordNotFound errors.

Follow up to: https://www.agileplannerapp.com/boards/173808/cards/6159
