### PR TITLE
Make dedupe_stats_announcement more idiotproof

### DIFF
--- a/script/dedupe_stats_announcement
+++ b/script/dedupe_stats_announcement
@@ -38,4 +38,4 @@ logger = Logger.new(STDOUT)
 
 DataHygiene::DuplicateStatisticsAnnouncement.new(duplicate_announcement, logger, options[:noop]).destroy_and_redirect_to(authoritative_announcement)
 
-puts "For completeness, the above redirect should also be added to router-data"
+puts "For completeness, the above redirect should also be added to router-data/data/slug-changes.csv"


### PR DESCRIPTION
I had to go raking around in router-data to find where the redirect
should go.  So I thought I'd help the next person.
