### PR TITLE
Make related_policy_ids method more robust

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -17,7 +17,9 @@ module Edition::RelatedPolicies
   end
 
   def related_policy_ids
-    related_documents.map {|d| d.latest_edition.id }
+    related_documents.
+      find_all {|d| d.document_type == Policy.name }.
+      map {|d| d.latest_edition.try(:id) }.compact
   end
 
   def can_be_related_to_policies?

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -41,4 +41,19 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
 
     assert_equal [policy.id], edition.related_policy_ids
   end
+
+  test '#related_policy_ids does not include non-policies' do
+    policy = create(:policy)
+    edition = create(:news_article,
+      related_documents: [policy.document, create(:detailed_guide).document])
+
+    assert_equal [policy.id], edition.related_policy_ids
+  end
+
+  test '#related_policy_ids does not fall over with deleted documents' do
+    policy = create(:deleted_policy)
+    edition = create(:news_article, related_documents: [policy.document])
+
+    assert_equal [], edition.related_policy_ids
+  end
 end


### PR DESCRIPTION
Two things this method was doing wrong:
- It was returning non-policies
- It fell over if the related document had been deleted

This was causing issues when trying to edit an edition that was related to "deleted" documents.

Story: https://www.agileplannerapp.com/boards/173808/cards/6176
