### PR TITLE
Stats announcement filter handles nil organisations

### DIFF
--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -41,7 +41,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   end
 
   def organisations=(organisations)
-    @organisations = organisations.map { |org|
+    @organisations = Array(organisations).map { |org|
       org.is_a?(Organisation) ? org : Organisation.find_by_slug(org)
     }.compact
   end

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -31,6 +31,10 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     assert_equal [org_1, org_2], build(organisations: [org_1.slug, org_2]).organisations
   end
 
+  test "organisations= handles nil" do
+    assert_equal [], build(organisations: nil).organisations
+  end
+
   test "organisation_slugs returns slugs of organisations" do
     organisation = create(:organisation)
     assert_equal [organisation.slug], build(organisations: [organisation]).organisation_slugs


### PR DESCRIPTION
We're seeing exceptions being raised when the `organisations` parameter is `nil`.

Story: https://www.agileplannerapp.com/boards/173808/cards/6279
