### PR TITLE
Properly duplicate specialist sectors on re-edition.

### DIFF
--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -14,7 +14,9 @@ module Edition::SpecialistSectors
 
     add_trait do
       def process_associations_before_save(edition)
-        edition.specialist_sectors = @edition.specialist_sectors
+        @edition.specialist_sectors.each do |sector|
+          edition.specialist_sectors << sector.dup
+        end
       end
     end
   end

--- a/test/unit/edition/specialist_sectors_test.rb
+++ b/test/unit/edition/specialist_sectors_test.rb
@@ -6,10 +6,13 @@ class Edition::SpecialistSectorsTest < ActiveSupport::TestCase
     expected_secondary_tags = ['oil-and-gas/taxation', 'tax/corporation-tax']
     edition = create(:published_policy, primary_specialist_sector_tag: expected_primary_tag, secondary_specialist_sector_tags: expected_secondary_tags)
 
+    assert_equal 3, SpecialistSector.count
+
     draft = edition.create_draft(create(:policy_writer))
 
     assert_equal expected_primary_tag, draft.primary_specialist_sector_tag
     assert_equal expected_secondary_tags, draft.secondary_specialist_sector_tags
+    assert_equal 6, SpecialistSector.count
   end
 
   test "#specialist_sector_tags should return tags ordered from primary to secondary" do


### PR DESCRIPTION
They are currently merely repointed, losing history and potentially causing bugs.

https://www.pivotaltracker.com/story/show/80295454

Dev to accept:
- [x] dev acceptance
