### PR TITLE
Clear computed govspeak when content changes

### DIFF
--- a/app/models/govspeak_content.rb
+++ b/app/models/govspeak_content.rb
@@ -4,7 +4,7 @@ class GovspeakContent < ActiveRecord::Base
   validates :body, :html_attachment, presence: true
   validates_with SafeHtmlValidator
 
-  after_validation :reset_computed_html, if: :body_or_numbering_scheme_changed?
+  before_save :reset_computed_html, if: :body_or_numbering_scheme_changed?
   after_save :queue_html_compute_job, if: :body_or_numbering_scheme_changed?
 
   def body_html


### PR DESCRIPTION
Since the code that pre-computes HTML from govspeak on HTML attachments went out yesterday, we've had a couple support tickets from users who are seeing out-of-date versions of their HTML attachments. To prevent this happening, we clear the computed values when changes are made. This prevents out-of-date HTML being shown in the period before the job to re-compute it has had time to complete. This means that users will always see the latest version of their HTML Attachment, as it gets generated on-the-fly when a pre-computed version is not yet available.
