### PR TITLE
Handle nil topics in stats announcements filter

### DIFF
--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -55,7 +55,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   end
 
   def topics=(topics)
-    @topics = topics.map { |topic|
+    @topics = Array(topics).map { |topic|
       topic.is_a?(Topic) ? topic : Topic.find_by_slug(topic)
     }.compact
   end

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -45,6 +45,10 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     assert_equal [topic_1, topic_2], build(topics: [topic_1.slug, topic_2]).topics
   end
 
+  test "topics= handles nil" do
+    assert_equal [], build(topics: nil).topics
+  end
+
   test "topic_slugs returns slugs of topics" do
     topic = create(:topic)
     assert_equal [topic.slug], build(topics: [topic]).topic_slugs


### PR DESCRIPTION
More Errbit exception squashing. Requests are coming in with the `topics` param set to nil: https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/542accec0da115f3290009cb?notice=4
