### PR TITLE
Publish Organisations to the Publishing API

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -141,6 +141,7 @@ class Organisation < ActiveRecord::Base
   validates :govuk_closed_status, inclusion: {in: %w{no_longer_exists replaced split merged changed_name left_gov devolved}}, presence: true, if: :closed?
   validates :organisation_logo_type_id, presence: true
   validates :logo, presence: true, if: :custom_logo_selected?
+  validates :content_id, presence: true
 
   validate :exactly_one_superseding_organisation, if: Proc.new { |organisation| organisation.replaced? || organisation.merged? || organisation.changed_name? }
   validate :at_least_two_superseding_organisations, if: :split?
@@ -169,8 +170,10 @@ class Organisation < ActiveRecord::Base
   extend FriendlyId
   friendly_id
 
+  before_validation :generate_content_id, on: :create
   before_destroy { |r| r.destroyable? }
   after_save :ensure_analytics_identifier
+  after_save :publish_to_publishing_api
 
   def custom_logo_selected?
     organisation_logo_type_id == OrganisationLogoType::CustomLogo.id
@@ -224,6 +227,10 @@ class Organisation < ActiveRecord::Base
     unless analytics_identifier.present?
       update_column(:analytics_identifier, organisation_type.analytics_prefix + self.id.to_s)
     end
+  end
+
+  def publish_to_publishing_api
+    PublishingApiRegisterOrganisationWorker.perform_async(self.id)
   end
 
   def organisation_logo_type
@@ -430,6 +437,33 @@ class Organisation < ActiveRecord::Base
 
   def to_s
     name
+  end
+
+  def base_path
+    Whitehall.url_maker.organisation_path(self)
+  end
+
+  def attributes_for_publishing_api
+    {
+      content_id: content_id,
+      title: name,
+      base_path: base_path,
+      format: "placeholder", # This will be updated once Whitehall uses the Content Store permanently,
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: updated_at,
+      routes: [
+        {
+          path: base_path,
+          type: "exact"
+        }
+      ],
+      update_type: "major",
+    }
+  end
+
+  def generate_content_id
+    self.content_id ||= SecureRandom.uuid
   end
 
   private

--- a/app/workers/publishing_api_register_organisation_worker.rb
+++ b/app/workers/publishing_api_register_organisation_worker.rb
@@ -1,0 +1,14 @@
+class PublishingApiRegisterOrganisationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :publishing_api
+
+  def perform(organisation_id, options = {})
+    organisation = Organisation.find(organisation_id)
+
+    Whitehall.publishing_api_client.put_content_item(
+      organisation.base_path,
+      organisation.attributes_for_publishing_api
+    )
+  end
+
+end

--- a/db/data_migration/20141010105113_add_content_id_to_organisations.rb
+++ b/db/data_migration/20141010105113_add_content_id_to_organisations.rb
@@ -1,0 +1,8 @@
+Organisation.where(content_id: "").each do |org|
+  org.content_id = SecureRandom.uuid
+  if org.save
+    puts "Added content_id to #{org.name}"
+  else
+    puts "Couldn't save #{org.name} because #{org.errors.full_messages}"
+  end
+end

--- a/db/migrate/20141009101445_add_content_id_to_organisation.rb
+++ b/db/migrate/20141009101445_add_content_id_to_organisation.rb
@@ -1,0 +1,6 @@
+class AddContentIdToOrganisation < ActiveRecord::Migration
+  def change
+    add_column :organisations, :content_id, :string, null: false
+    add_index :organisations, :content_id, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141006110852) do
+ActiveRecord::Schema.define(:version => 20141009101445) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -887,6 +887,7 @@ ActiveRecord::Schema.define(:version => 20141006110852) do
     t.string   "organisation_chart_url"
     t.string   "govuk_closed_status"
     t.string   "custom_jobs_url"
+    t.string   "content_id",                                                  :null => false
   end
 
   add_index "organisations", ["default_news_organisation_image_data_id"], :name => "index_organisations_on_default_news_organisation_image_data_id"
@@ -1099,6 +1100,7 @@ ActiveRecord::Schema.define(:version => 20141006110852) do
     t.datetime "updated_at",                 :null => false
   end
 
+  add_index "statistics_announcement_organisations", ["organisation_id"], :name => "index_statistics_announcement_organisations_on_organisation_id"
   add_index "statistics_announcement_organisations", ["statistics_announcement_id", "organisation_id"], :name => "index_on_statistics_announcement_id_and_organisation_id"
 
   create_table "statistics_announcements", :force => true do |t|
@@ -1106,6 +1108,7 @@ ActiveRecord::Schema.define(:version => 20141006110852) do
     t.string   "slug"
     t.text     "summary"
     t.integer  "publication_type_id"
+    t.integer  "organisation_id"
     t.integer  "topic_id"
     t.integer  "creator_id"
     t.datetime "created_at",          :null => false
@@ -1114,11 +1117,11 @@ ActiveRecord::Schema.define(:version => 20141006110852) do
     t.text     "cancellation_reason"
     t.datetime "cancelled_at"
     t.integer  "cancelled_by_id"
-    t.integer  "organisation_id"
   end
 
   add_index "statistics_announcements", ["cancelled_by_id"], :name => "index_statistics_announcements_on_cancelled_by_id"
   add_index "statistics_announcements", ["creator_id"], :name => "index_statistics_announcements_on_creator_id"
+  add_index "statistics_announcements", ["organisation_id"], :name => "index_statistics_announcements_on_organisation_id"
   add_index "statistics_announcements", ["publication_id"], :name => "index_statistics_announcements_on_publication_id"
   add_index "statistics_announcements", ["slug"], :name => "index_statistics_announcements_on_slug"
   add_index "statistics_announcements", ["title"], :name => "index_statistics_announcements_on_title"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,7 @@ class ActiveSupport::TestCase
     Whitehall.search_backend = Whitehall::DocumentFilter::FakeSearch
     VirusScanHelpers.erase_test_files
     Sidekiq::Worker.clear_all
+    stub_default_publishing_api_put
   end
 
   teardown do

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -806,4 +806,35 @@ class OrganisationTest < ActiveSupport::TestCase
 
     assert_equal organisation.statistics_announcements, StatisticsAnnouncementOrganisation.all.map(&:statistics_announcement)
   end
+
+  test "generating a content_id" do
+    SecureRandom.stubs(:uuid).returns("a random UUID")
+    organisation = create(:organisation)
+
+    assert organisation.valid?
+    assert_equal organisation.content_id, "a random UUID"
+  end
+
+  test "it creates an attributes hash for the publishing api" do
+    organisation = create(:organisation)
+
+    expected_attributes_for_publishing_api_hash = {
+      content_id: organisation.content_id,
+      title: organisation.name,
+      base_path: "/government/organisations/#{organisation.slug}",
+      format: "placeholder",
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: organisation.updated_at,
+      routes: [
+        {
+          path: organisation.base_path,
+          type: "exact"
+        }
+      ],
+      update_type: "major",
+    }
+
+    assert_equal expected_attributes_for_publishing_api_hash, organisation.attributes_for_publishing_api
+  end
 end

--- a/test/unit/workers/publishing_api_register_organisation_worker_test.rb
+++ b/test/unit/workers/publishing_api_register_organisation_worker_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api'
+
+class PublishingApiRegisterOrganisationWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApi
+
+  test "sends an organisation to the publishing api" do
+    organisation = create(:organisation)
+
+    assert_publishing_api_put_item(organisation.base_path,
+      JSON.parse(organisation.attributes_for_publishing_api.to_json))
+  end
+end


### PR DESCRIPTION
As part of the work of moving other Applications to rely on the Content Store we need access to Organisations. This work sends the Organisation to the Publishing API after save which kicks off a worker and queues it up to send to the publishing API.

This commit adds the content_id to the Organisation table. This is generated and used by the content store as a UUID. It generates this on a before_validation callback.

Work was based off the work in 63e4f7c. [Ticket](https://trello.com/c/MUqfVwLp/358-getting-orgs-from-whitehall-into-content-store).
