### PR TITLE
Icon-step images are in a folder

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -725,10 +725,10 @@
 
         @for $i from 1 through 14 {
           &:nth-child(#{$i}) {
-            background-image: image-url("icon-step-#{$i}.png");
+            background-image: image-url("icon-steps/icon-step-#{$i}.png");
 
             @include device-pixel-ratio() {
-              background-image: image-url("icon-step-#{$i}-2x.png");
+              background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
               background-size: 24px 24px;
             }
           }


### PR DESCRIPTION
The icon-step images were [moved into a folder](https://github.com/alphagov/govuk_frontend_toolkit/commit/e523d51536482f3f300b798883c348e9d41bf2da). Update the Sass to look
for them in that folder.
