### PR TITLE
Remove IPO from the services & info page whitelist

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -438,7 +438,6 @@ class Organisation < ActiveRecord::Base
     %w{
       charity-commission
       environment-agency
-      intellectual-property-office
       marine-management-organisation
       maritime-and-coastguard-agency
       natural-england


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/80463772

Due to some content issues, we're removing the link to the Services & Information Page from the homepage of the Intellectual Property Office at the current time.
