### PR TITLE
Reinstate keyword-filter identifier.

### DIFF
--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -8,7 +8,7 @@
         <legend class="visuallyhidden">Filter <%= document_type_plural %></legend>
 
         <% if filters.include? :keyword %>
-          <div class="filter">
+          <div id="keyword-filter" class="filter">
             <%= label_tag "keywords", "Contains", class: 'title' %>
             <%= text_field_tag :keywords, @filter.keywords, placeholder: "keywords" %>
           </div>


### PR DESCRIPTION
Removed in a previous cleanup the containing element for the keywords
field on all document filtering needs to have a filter specific
elementId.
See:
https://github.com/alphagov/whitehall/commit/4c682d099fa0f77f042d01bcd39c5dd9d44f317d#diff-08e4a107c3401662ebf39b86de38b01cL11
