### PR TITLE
Fix add_content_id_to_orgs migration

### DIFF
--- a/db/data_migration/20141010105113_add_content_id_to_organisations.rb
+++ b/db/data_migration/20141010105113_add_content_id_to_organisations.rb
@@ -1,4 +1,4 @@
-Organisation.where(content_id: "").each do |org|
+Organisation.where(content_id: nil).each do |org|
   org.content_id = SecureRandom.uuid
   if org.save
     puts "Added content_id to #{org.name}"

--- a/db/migrate/20141009101445_add_content_id_to_organisation.rb
+++ b/db/migrate/20141009101445_add_content_id_to_organisation.rb
@@ -1,6 +1,6 @@
 class AddContentIdToOrganisation < ActiveRecord::Migration
   def change
-    add_column :organisations, :content_id, :string, null: false
-    add_index :organisations, :content_id, :unique => true
+    add_column :organisations, :content_id, :string
+    add_index :organisations, :content_id, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -887,9 +887,10 @@ ActiveRecord::Schema.define(:version => 20141009101445) do
     t.string   "organisation_chart_url"
     t.string   "govuk_closed_status"
     t.string   "custom_jobs_url"
-    t.string   "content_id",                                                  :null => false
+    t.string   "content_id"
   end
 
+  add_index "organisations", ["content_id"], :name => "index_organisations_on_content_id", :unique => true
   add_index "organisations", ["default_news_organisation_image_data_id"], :name => "index_organisations_on_default_news_organisation_image_data_id"
   add_index "organisations", ["organisation_logo_type_id"], :name => "index_organisations_on_organisation_logo_type_id"
   add_index "organisations", ["organisation_type_key"], :name => "index_organisations_on_organisation_type_key"


### PR DESCRIPTION
With the migration added in ba5a421 there was both a `null:false` and index on the new `content_id` column. This prevented the migration from running as when it came to add the index all the rows in the column were blank strings.

This commit changes the existing migration to add the `content_id` column without the null constraint and updates the data migration to look for Orgs with nil `content_id` fields instead of empty strings. 

Since the original migration half ran I'll manually drop the `content_id` column before merging.
- [x] dropped `content_id` column 
