### PR TITLE
Fix SSL issue with phantomjs loading assets.

### DIFF
--- a/features/support/javascript.rb
+++ b/features/support/javascript.rb
@@ -1,7 +1,7 @@
 require 'capybara/poltergeist'
 # static.preview SSL certificate is causing errors in Cucumber tests, # so we're ignoring SSL errors for now.
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ignore-ssl-errors=yes']})
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1', '--ignore-ssl-errors=yes']})
 end
 Capybara.javascript_driver = :poltergeist
 


### PR DESCRIPTION
phantomjs defaults to using SSLv3, which has now been disabled
everywhere.  The protocol used can be changed with an option:

> --ssl-protocol=<val>                 Sets the SSL protocol
>   (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')

This PR makes poltergeist set this option when invoking phantomjs.
