### PR TITLE
Ebola response topical event slug change.

### DIFF
--- a/db/data_migration/20141015122422_ebola_response_slug_change.rb
+++ b/db/data_migration/20141015122422_ebola_response_slug_change.rb
@@ -1,0 +1,13 @@
+ebola_response = TopicalEvent.find('ebola-government-response')
+
+old_url = ebola_response.search_link
+ebola_response.remove_from_search_index
+
+ebola_response.update_attribute(:slug, 'ebola-virus-government-response')
+
+ebola_response.update_in_search_index
+new_url = ebola_response.search_link
+
+require 'gds_api/router'
+router = GdsApi::Router.new(Plek.find('router-api'))
+router.add_redirect_route(old_url, 'exact', new_url)


### PR DESCRIPTION
Topical events are not held in Panopticon, so no update needed there.

https://govuk.zendesk.com/agent/tickets/850192
