### PR TITLE
Use an en dash to separate title and sector name

### DIFF
--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -2,7 +2,7 @@ module SpecialistSectorHelper
 
   def add_sector_name(title, sector_tag)
     if sector_tag
-      "#{link_to(sector_tag.title, sector_tag.web_url)} - #{title.downcase}".html_safe
+      "#{link_to(sector_tag.title, sector_tag.web_url)} &ndash; #{title.downcase}".html_safe
     else
       title
     end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -53,7 +53,7 @@ module SpecialistSectorHelper
   end
 
   def check_for_primary_sector_in_heading
-    assert has_content?("Oil and gas - guidance")
+    assert find("article header").has_content?("Oil and gas")
   end
 
   def check_for_sectors_and_subsectors_in_metadata


### PR DESCRIPTION
A dash makes more typographical sense than a hyphen here, and elsewhere on GOV.UK we tend to use an en dash surrounded by spaces, rather than an em dash without spaces (or with hair spaces).
