### PR TITLE
Bring back basic logging for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-# At the time of committing, our full test suite generated 17MB of logs.  Disabling logging
-# decreased the time taken to run all tests by around 20 seconds on my machine.
-ENV["DISABLE_LOGGING_IN_TEST"] = "true"
+# Our test suite generates ~17MB of logs at log level :info, switching
+# to log level :warn reduces logging and increases execution speed.
+ENV["LOG_LEVEL"] = "warn"
 
 ENV['GOVUK_APP_DOMAIN'] = 'dev.gov.uk' unless ENV['GOVUK_APP_DOMAIN']
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,12 +33,7 @@ Whitehall::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  if ENV["DISABLE_LOGGING_IN_TEST"]
-    File.open(Rails.root.join("log", "test.log"), "a") do |file|
-      file.puts "\n*NOTE* Disabling logging in an attempt to speed up the tests.\n\n"
-    end
-    config.logger = Logger.new(nil)
-  end
+  config.log_level = (ENV["LOG_LEVEL"].presence || :debug).to_sym
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,


### PR DESCRIPTION
Having no logging in tests masks certain errors and warnings, which should not be ignored and can help in debugging unexpected test failures; especially with errors that arise only when running entire test suites.

Bringing back this minimal logging has not made any difference to the [branch build time](https://ci-new.alphagov.co.uk/job/govuk_whitehall_branches/buildTimeTrend).
