### PR TITLE
Welsh translations for static text on CIPs

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -636,25 +636,25 @@ cy:
     email: E-bost
   corporate_information_page:
     type:
-      about:
-      about_our_services:
-      access_and_opening:
-      complaints_procedure:
-      equality_and_diversity:
-      media_enquiries:
-      membership:
-      our_energy_use:
-      our_governance:
-      personal_information_charter: Nod gwybodaeth bersonol
-      petitions_and_campaigns:
-      procurement:
+      about: Amdanom ni
+      about_our_services: Gwybodaeth am ein gwasanaethau
+      access_and_opening: Mynediad i'n swyddfeydd ac amseroedd agor
+      complaints_procedure: Trefn gwyno
+      equality_and_diversity: Cydraddoldeb ac amrywiaeth
+      media_enquiries: Ymholiadau'r cyfryngau
+      membership: Aelodaeth
+      our_energy_use: Ein defnydd o egni
+      our_governance: Ein trefn lywodraethu
+      personal_information_charter: Siarter gwybodaeth bersonol
+      petitions_and_campaigns: Deisebau ac ymgyrchoedd
+      procurement: Caffael yn %{organisation_name}
       publication_scheme: Cynllun cyhoeddi
-      recruitment:
-      research:
-      social_media_use:
-      staff_update:
-      statistics:
-      terms_of_reference:
+      recruitment: Yn gweithio i %{organisation_name}
+      research: Ymchwil yn %{organisation_name}
+      social_media_use: Defnydd o gyfryngau cymdeithasol
+      staff_update: Gwybodaeth a newyddion staff
+      statistics: Ystadegau yn %{organisation_name}
+      terms_of_reference: Cylch gorchwyl
       welsh_language_scheme: Cynllun iaith Gymraeg
   date:
     formats:
@@ -763,12 +763,12 @@ cy:
       long_ordinal: '%e %B %Y %H:%M'
   worldwide_organisation:
     corporate_information:
-      about_our_services_html:
+      about_our_services_html: Canfod %{link}
       personal_information_charter_html: Mae ein %{link} yn egluro sut rydym yn trin
         eich gwybodaeth bersonol.
       publication_scheme_html: Darllenwch am y mathau o wybodaeth rydym yn eu cyhoeddi'n
         rheolaidd yn ein %{link}.
-      social_media_use_html:
+      social_media_use_html: Darllenwch ein polisi ar %{link}
       welsh_language_scheme_html: Dysgwch am ein hymrwymiad i gyhoeddi yn y %{link}.
     find_out_more: Gweld proffil llawn a'r holl fanylion cyswllt
     headings:


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5962
https://govuk.zendesk.com/agent/#/tickets/817849

[/government/organisations/land-registry/about.cy](https://www.gov.uk/government/organisations/land-registry/about.cy) had missing Welsh translations for some static text.
