### PR TITLE
Include sidekiq job parameters in errbit reports

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,9 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
-  config.error_handlers << Proc.new {|ex, context_hash| Airbrake.notify(ex, context_hash) }
+  config.error_handlers << lambda do |exception, context|
+     Airbrake.notify(ex, parameters: context)
+   end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
The context hash (containing the parameters of the failed job) where not being correctly passed to Airbrake, so were not appearing in exception reports.
