### PR TITLE
Correct typo in sidekiq airbrake error handling

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,7 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_
 Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.error_handlers << lambda do |exception, context|
-     Airbrake.notify(ex, parameters: context)
+     Airbrake.notify(exception, parameters: context)
    end
 end
 


### PR DESCRIPTION
I made a mistake with my previous pull request and misspelt the local variable...
