### PR TITLE
Migration for updating parent_tag for 'housing' detailed guides

### DIFF
--- a/db/data_migration/20141021160613_rename_housing_parent_tags.rb
+++ b/db/data_migration/20141021160613_rename_housing_parent_tags.rb
@@ -1,0 +1,15 @@
+category_changes = [
+  ["housing/local-councils","housing-local-services/local-councils"],
+  ["housing/recycling-rubbish","housing-local-services/recycling-rubbish"],
+  ["housing/safety-environment","housing-local-services/safety-environment"],
+  ["housing/council-tax","housing-local-services/council-tax"],
+]
+
+category_changes.each do |old_category, new_category|
+  puts "updating #{old_category} to #{new_category}"
+
+  MainstreamCategory.where(:parent_tag => old_category).each do |category|
+    puts "\t Category is #{category.title}"
+    category.update_attribute(:parent_tag, new_category)
+  end
+end


### PR DESCRIPTION
The housing tag is being replaced with housing-local-services, this updates the detailed guides.

This should be merged and deployed after this Panaopticon PR - https://github.com/alphagov/panopticon/pull/222.

The browse category slugs are redirceted in this router-data PR - https://github.gds/gds/router-data/pull/198.
