### PR TITLE
admin:statistics_announcements/index handles nil org

### DIFF
--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -72,6 +72,6 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
 
   def filter_params
     params.slice(:title, :page, :per_page, :organisation_id).
-      reverse_merge(organisation_id: current_user.organisation.id)
+      reverse_merge(organisation_id: current_user.organisation.try(:id))
   end
 end

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -23,6 +23,13 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     assert_equal [@organsation_announcement], assigns(:statistics_announcements)
   end
 
+  test "GET :index handles users without an organisation" do
+    login_as create(:gds_editor, organisation: nil)
+    get :index
+
+    assert_response :success
+  end
+
   test "POST :create saves the announcement to the database and redirects to the dashboard" do
     post :create, statistics_announcement: {
                     title: 'Beard stats 2014',


### PR DESCRIPTION
Users without an organisation viewing the statistics announcement index page should not raise an exception.
