### PR TITLE
Fix data migration to clear rails cache

### DIFF
--- a/db/data_migration/20141020093354_clear_rails_cache_for_taggable_ministerial_role_appointments.rb
+++ b/db/data_migration/20141020093354_clear_rails_cache_for_taggable_ministerial_role_appointments.rb
@@ -1,3 +1,9 @@
-include Admin::TaggableContentHelper
+class TaggableContentCacheCleaner
+  include Admin::TaggableContentHelper
 
-Rails.cache.delete(taggable_ministerial_role_appointments_cache_digest)
+  def do
+    Rails.cache.delete(taggable_ministerial_role_appointments_cache_digest)
+  end
+end
+
+TaggableContentCacheCleaner.new.do


### PR DESCRIPTION
the previous version was giving a `undefined method 'include'` error, because it done from within a class.
