### PR TITLE
Remove duplicate method implementation that exists on inherited class

### DIFF
--- a/lib/whitehall/uploader/publication_row.rb
+++ b/lib/whitehall/uploader/publication_row.rb
@@ -99,13 +99,6 @@ module Whitehall::Uploader
       end
     end
 
-    def attachments_from_columns
-      1.upto(Row::ATTACHMENT_LIMIT).map do |number|
-        next unless row["attachment_#{number}_title"] || row["attachment_#{number}_url"]
-        Builders::AttachmentBuilder.build({title: row["attachment_#{number}_title"]}, row["attachment_#{number}_url"], @attachment_cache, @logger, @line_number)
-      end.compact
-    end
-
     def apply_meta_data_to_attachment(attachment)
       attachment.order_url = row["order_url"]
       attachment.isbn = row["isbn"]


### PR DESCRIPTION
Found this method while trying to understand how uploads work. It
looks like it's a clear duplicate of the same code that exists in the
`Row::attachments_from_columns` implementation[1].

[1]  https://github.com/alphagov/whitehall/blob/7db851b66dcc6a144443ee281c5c03ae32d54253/lib/whitehall/uploader/row.rb#L136-141
