### PR TITLE
Remove faulty data migration

### DIFF
--- a/db/data_migration/20141020093354_clear_rails_cache_for_taggable_ministerial_role_appointments.rb
+++ b/db/data_migration/20141020093354_clear_rails_cache_for_taggable_ministerial_role_appointments.rb
@@ -1,9 +1,0 @@
-class TaggableContentCacheCleaner
-  include Admin::TaggableContentHelper
-
-  def do
-    Rails.cache.delete(taggable_ministerial_role_appointments_cache_digest)
-  end
-end
-
-TaggableContentCacheCleaner.new.do


### PR DESCRIPTION
This migration runs only on one machine in production hence doesn't clear cache from all nodes, as we'd want.
