### PR TITLE
Fix ODF highlighting include ODS

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -17,7 +17,7 @@ class AttachmentData < ActiveRecord::Base
   validate :cant_be_replaced_by_self
   after_save :handle_to_replace_id
 
-  OPENDOCUMENT_EXTENSIONS = %w(ODT ODP ODF).freeze
+  OPENDOCUMENT_EXTENSIONS = %w(ODT ODP ODS).freeze
 
   def filename
     url && File.basename(url)


### PR DESCRIPTION
ODF is the format group, ODS is the spreadsheet format, which was missing.

https://www.agileplannerapp.com/boards/105200/cards/5626
