### PR TITLE
Fix GillSans font stack

### DIFF
--- a/app/assets/stylesheets/admin/layout.scss
+++ b/app/assets/stylesheets/admin/layout.scss
@@ -56,7 +56,7 @@ $collapse-tabs-width: 710px;
   background-repeat: no-repeat;
   background-position: 0 15px;
   color: #fff;
-  font-family: "GillSans", "Gill Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "GillSans", "Gill Sans MT", "Gill Sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 20px;
   margin-left: 10px;
   padding: $default-vertical-padding 10px 0 2.3em;


### PR DESCRIPTION
- On IE neither GillSans nor Gill Sans were matching
- In Chrome on windows, Chrome has been known to pick “Gill Sans Ultra Bold” instead

Applying fix from admin template:
https://github.com/alphagov/govuk_admin_template/pull/41
