### PR TITLE
Cleanup old constant references

### DIFF
--- a/app/workers/publishing_api_register_artefact_worker.rb
+++ b/app/workers/publishing_api_register_artefact_worker.rb
@@ -1,4 +1,0 @@
-# FIXME: This is a temporary constant here to allow any existing queued jobs to
-# be processed by sidekiq. Once the queue has had a reasonable time to be worked
-# through, this file can be deleted.
-PublishingApiRegisterArtefactWorker = PublishingApiEditionWorker

--- a/app/workers/publishing_api_register_organisation_worker.rb
+++ b/app/workers/publishing_api_register_organisation_worker.rb
@@ -1,4 +1,0 @@
-# FIXME: This is a temporary constant here to allow any existing queued jobs to
-# be processed by sidekiq. Once the queue has had a reasonable time to be worked
-# through, this file can be deleted.
-PublishingApiRegisterOrganisationWorker = PublishingApiOrganisationWorker


### PR DESCRIPTION
**WARNING: Do not merge until https://github.com/alphagov/whitehall/pull/1794 has been deployed and given enough time to run down the job queue**

Once the code that renames and reworkes these workers has been deployed and the queue has had adequate time to run down, we can get rid of these temporary references to the old workers.
- [x] Peer review
- [x] https://github.com/alphagov/whitehall/pull/1794 has been deployed
- [x] The sidekiq monitor has been checked to ensure there are no longer any `PublishingApiRegisterArtefactWorker` or `PublishingApiRegisterOrganisationWorker` jobs remaining
