### PR TITLE
Correct passive form for departments on the main edition filter

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -177,7 +177,7 @@ module Admin
       elsif organisation && organisation == @current_user.organisation
         "My department’s"
       elsif organisation
-        "#{organisation.name}’s"
+        organisation.name.possessive
       else
         "Everyone’s"
       end

--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -50,15 +50,7 @@ module Admin
       elsif user.try(:organisation) == organisation
         "My organisation’s"
       else
-        possessive(organisation.name)
-      end
-    end
-
-    def possessive(thing_name)
-      if thing_name.ends_with?("s")
-        "#{thing_name}’"
-      else
-        "#{thing_name}’s"
+        organisation.name.possessive
       end
     end
 

--- a/lib/patches/string.rb
+++ b/lib/patches/string.rb
@@ -1,0 +1,15 @@
+class String
+
+  # Returns the possessive form of a string.
+  # For example, "Bill".possessive returns "Bill’s", whereas "Years".possessive
+  # returns "Years’"
+  def possessive
+    return self if empty?
+
+    if self.ends_with?("s")
+      self + "’"
+    else
+      self + "’s"
+    end
+  end
+end


### PR DESCRIPTION
After discussion with folk in the content team, the verdict was that the possessive form for things ending in "s" should not have the extra "s".

Before:

![screen shot 2014-10-29 at 12 44 15](https://cloud.githubusercontent.com/assets/3687/4825819/6de83872-5f69-11e4-9078-c968898189f5.png)

After:

![screen shot 2014-10-29 at 12 43 41](https://cloud.githubusercontent.com/assets/3687/4825821/757913ea-5f69-11e4-9809-d4942f156390.png)
