### PR TITLE
Re-enable phantomJS SSL error reporting in tests.

### DIFF
--- a/features/support/javascript.rb
+++ b/features/support/javascript.rb
@@ -1,7 +1,7 @@
 require 'capybara/poltergeist'
-# static.preview SSL certificate is causing errors in Cucumber tests, # so we're ignoring SSL errors for now.
+# PhamtomJS 1.9.x defaults to SSLv3 which has been disabled since POODLE, so we have to override the default.
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1', '--ignore-ssl-errors=yes']})
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1']})
 end
 Capybara.javascript_driver = :poltergeist
 


### PR DESCRIPTION
This was disabled when preview didn't have a valid SSL cert. This is on
longer an issue because 1. preview has a valid SSL cert, and 2. The
tests no longer point at preview[1].

This will hopefully reveal some more meaningful errors when loading
assets fails.

[1] https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_templates/header_footer_only.html#L19-L21
