### PR TITLE
Prevent test from failing due to timing issue

### DIFF
--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -118,7 +118,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     form         = create(:publication, publication_type: PublicationType::Form)
     policy_paper = create(:publication, publication_type: PublicationType::PolicyPaper)
 
-    assert_equal [form, policy_paper],
+    assert_same_elements [form, policy_paper],
       Admin::EditionFilter.new(Edition, @current_user, type: "publication",
                                subtypes: [PublicationType::PolicyPaper.id, PublicationType::Form.id]).editions
 


### PR DESCRIPTION
The test here is not concerned with the order these editions are returned in, just the fact that the correct ones are returned. By using `assert_same_elements`, we don't have to worry about the nondeterministic order they may be returned in because they are created at the same time (time is frozen in the test suite).
