### PR TITLE
Deleting document deletes collection memberships

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,7 +27,7 @@ class Document < ActiveRecord::Base
                AND e2.state <> 'deleted'))
 
   has_many :document_sources, dependent: :destroy
-  has_many :document_collection_group_memberships
+  has_many :document_collection_group_memberships, dependent: :delete_all
   has_many :document_collection_groups, through: :document_collection_group_memberships
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document

--- a/db/data_migration/20141105130948_delete_document_collection_group_memberships_for_deleted_documents.rb
+++ b/db/data_migration/20141105130948_delete_document_collection_group_memberships_for_deleted_documents.rb
@@ -1,0 +1,3 @@
+puts "Deleting all DocumentCollectionGroupMembership records that reference deleted documents"
+count = DocumentCollectionGroupMembership.where('document_id NOT IN (?)', Document.pluck(:id)).delete_all
+puts "Deleted #{count} DocumentCollectionGroupMemberships that referenced deleted documents"

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -89,6 +89,15 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal nil, DocumentSource.find_by_id(document_source.id)
   end
 
+  test "#destroy also destroys document collection group memberships" do
+    published_edition = create(:published_edition)
+    document_collection = create(:published_document_collection,
+      groups: [ build(:document_collection_group, documents: [published_edition.document]) ])
+
+    published_edition.document.destroy
+    assert_empty DocumentCollectionGroupMembership.where(document_id: published_edition.document.id)
+  end
+
   test "should list a single change history when sole published edition is marked as a minor change" do
     edition = create(:published_policy, minor_change: true, change_note: nil)
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8071
resolves: https://govuk.zendesk.com/tickets/866860

a document collection cannot be re-editioned if its groups contain deleted documents. if we destroy all `DocumentCollectionGroupMembership` when a `Document` is destroyed, this issue will not occur, and will also make sure references to documents are valid.

these deleted document memberships don't surface up in admin or on the public site because we use [`DocumentCollectionGroup#latest_editions`](https://github.com/alphagov/whitehall/blob/master/app/views/admin/document_collection_groups/index.html.erb#L72) and [`DocumentCollectionGroup#published_editions`](https://github.com/alphagov/whitehall/blob/master/app/controllers/document_collections_controller.rb#L7) which filter out these dangling records.

also includes a data migration to delete ~230 dangling `DocumentCollectionGroupMembership` records referring to deleted documents, which were created in absence of `dependent: delete_all`.
