### PR TITLE
Add non-english translations paths

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -21,7 +21,7 @@ class RegisterableEdition
 
   def paths
     if kind == "detailed_guide"
-      ["/#{slug}"]
+      detailed_guide_paths
     else
       []
     end
@@ -82,5 +82,9 @@ private
 
   def published?
     edition.state == "published"
+  end
+
+  def detailed_guide_paths
+    ["/#{slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" }
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -20,6 +20,19 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal [], registerable_edition.prefixes
   end
 
+  test "prepares a translated detailed guide for registration with Panopticon" do
+    edition = create(:published_detailed_guide, translated_into: [:cy, :fr],
+                     title: "Edition title",
+                     summary: "Edition summary")
+
+    slug = edition.document.slug
+
+    registerable_edition = RegisterableEdition.new(edition)
+
+    assert_same_elements ["/#{slug}", "/#{slug}.cy", "/#{slug}.fr"], registerable_edition.paths
+  end
+
+
   test "does not set any routes for other formats" do
     edition = create(:published_publication,
                      title: "Edition title",


### PR DESCRIPTION
Where an Edition has translations ensure that RegisterableEdition
returns the appropriate paths for the non-english translations.
https://www.agileplannerapp.com/boards/173808/cards/8081
