### PR TITLE
Silently handle GovspeakContent that has gone

### DIFF
--- a/app/workers/govspeak_content_worker.rb
+++ b/app/workers/govspeak_content_worker.rb
@@ -2,7 +2,8 @@ class GovspeakContentWorker
   include Sidekiq::Worker
 
   def perform(id)
-    govspeak_content = GovspeakContent.find(id)
+    return unless govspeak_content = GovspeakContent.find_by_id(id)
+
     govspeak_content.computed_body_html = generate_govspeak(govspeak_content)
     govspeak_content.computed_headers_html = generate_headers(govspeak_content)
     govspeak_content.save!

--- a/test/unit/workers/govspeak_content_worker_test.rb
+++ b/test/unit/workers/govspeak_content_worker_test.rb
@@ -76,6 +76,10 @@ class GovspeakContentWorkerTest < ActiveSupport::TestCase
       govspeak_content.computed_headers_html
   end
 
+  test "silently handles non-existant GovspeakContent" do
+    GovspeakContentWorker.new.perform(non_existant_id = 123)
+  end
+
 private
 
   def example_govspeak


### PR DESCRIPTION
If an HtmlAttachment is deleted before the job is processed, the job will fail and keep getting retried. Better to silently handle this situation.

Story: https://www.agileplannerapp.com/boards/173808/cards/7959
