### PR TITLE
Change Ofqual slug to match search term

### DIFF
--- a/db/data_migration/20141106151406_change_ofqual_slug_to_match_search_term.rb
+++ b/db/data_migration/20141106151406_change_ofqual_slug_to_match_search_term.rb
@@ -1,0 +1,35 @@
+require 'gds_api/router'
+
+router = GdsApi::Router.new(Plek.current.find('router-api'))
+
+old_slug = 'office-of-qualifications-and-examinations-regulation'
+new_slug = 'ofqual'
+
+if (org = Organisation.find_by_slug(old_slug))
+  puts "Changing org slug from #{old_slug} to #{new_slug}"
+
+  # Remove document at old slug from search
+  org.remove_from_search_index
+
+  Organisation.transaction do
+    org.slug = new_slug
+    org.save!
+
+    User.where(:organisation_slug => old_slug).update_all(:organisation_slug => new_slug)
+  end
+
+  # Index at new slug.
+  org.update_in_search_index
+
+  puts "Creating redirect for old org URL in router"
+  router.add_redirect_route("/government/organisations/#{old_slug}",
+                            "exact",
+                            "/government/organisations/#{new_slug}")
+
+  puts "Re-registering #{new_slug} published editions in search"
+  org.editions.published.each do |edition|
+    edition.update_in_search_index
+  end
+else
+  puts "No organisation found with slug #{old_slug}.  Skipping..."
+end


### PR DESCRIPTION
Ofqual was initially created as the unabbreviated version but the title is Ofqual, and that's what people think of it as and search for.

This commit adds a data migration which updates the slug, along with all of Ofquals Users and Editions which they've published.

This will also require a bunch of changes in Production environments which I don't have access to.

[Ticket](https://www.pivotaltracker.com/story/show/80284724).

When deploying:
- [ ] update the Org tag in Panopticon
- [ ] update the Org slug in Signon
- [ ] update the Org in the Need API
- [ ] clear the cache in Maslow
- [ ] update the Org in Contacts
- [ ] update the Org in Transition and Redirector
- [ ] tell Search and Browse about the change
- [ ] add the organisation redirect to router-data
