### PR TITLE
Allow additional ArcGIS file format to be uploaded

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -122,9 +122,8 @@ class AttachmentUploader < WhitehallUploader
     end
 
     class ArcGISShapefileExaminer < Examiner
-      REQUIRED_EXTS = ['shp', 'shx', 'dbf']
-      OPTIONAL_EXTS = ['prj', 'sbn', 'sbx', 'fbn', 'fbx', 'ain', 'aih',
-                       'ixs', 'mxs', 'atx', 'shp.xml', 'cpg']
+      REQUIRED_EXTS = %w(shp shx dbf)
+      OPTIONAL_EXTS = %w(aih ain atx avl cpg fbn fbx ixs mxs prj sbn sbx shp.xml)
       ALLOWED_EXTS = REQUIRED_EXTS + OPTIONAL_EXTS
       EXT_MATCHER = /\.(#{ALLOWED_EXTS.map { |e| Regexp.escape(e)}.join('|') })\Z/
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -132,28 +132,25 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   def required_arcgis_file_list
-    [
-      'london.shp',
-      'london.shx',
-      'london.dbf'
-    ]
+    %w(london.shp london.shx london.dbf)
   end
 
   def optional_argis_file_list
-    [
-      'london.prj',
-      'london.sbn',
-      'london.sbx',
-      'london.fbn',
-      'london.fbx',
-      'london.ain',
-      'london.aih',
-      'london.ixs',
-      'london.mxs',
-      'london.atx',
-      'london.shp.xml',
-      'london.cpg'
-    ]
+    %w(
+      london.aih
+      london.ain
+      london.atx
+      london.avl
+      london.cpg
+      london.fbn
+      london.fbx
+      london.ixs
+      london.mxs
+      london.prj
+      london.sbn
+      london.sbx
+      london.shp.xml
+    )
   end
 
   def comprehensive_arcgis_file_list


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8154
fixes: https://govuk.zendesk.com/agent/tickets/868015

permit files with ArcGIS file extension `.avl` to be uploaded as part of collections. `.avl` are ArcView 3 legend files.

whilst working on that area, i've just reformatted and sorted the arrays to be more compact and easier to update.
