### PR TITLE
Better CSRF handling

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -57,4 +57,9 @@ class Admin::BaseController < ApplicationController
   end
   helper_method :typecast_for_attachable_routing
 
+  # Override the default Rails behaviour to raise an exception when receiving
+  # unverified requests instead of nullifying the session
+  def handle_unverified_request
+    raise ActionController::InvalidAuthenticityToken
+  end
 end

--- a/test/integration/csrf_test.rb
+++ b/test/integration/csrf_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class CsrfTest < ActionController::TestCase
+  class TestAdminController < Admin::BaseController
+    def create
+      render text: 'OK'
+    end
+  end
+  tests TestAdminController
+
+  setup do
+    ActionController::Base.allow_forgery_protection = true
+    login_as_admin
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  test "raises an InvalidAuthenticityToken exception without a valid CSRF token" do
+    with_test_routes do
+      assert_raises ActionController::InvalidAuthenticityToken do
+        post :create
+      end
+    end
+  end
+
+  test "does not raise an exception with a valid CSRF token" do
+    with_test_routes do
+      session["_csrf_token"] = SecureRandom.base64(32)
+      post :create, authenticity_token: session["_csrf_token"]
+    end
+  end
+
+  def with_test_routes(&block)
+    with_routing do |map|
+      map.draw do
+        post '/post_csrf', to: 'csrf_test/test_admin#create'
+      end
+      yield block
+    end
+  end
+end


### PR DESCRIPTION
Instead of nullifying the session (which is the default Rails behaviour), raise
an exception when an unverified request is received.
