### PR TITLE
Collection cache max age should be 5m

### DIFF
--- a/app/controllers/document_collections_controller.rb
+++ b/app/controllers/document_collections_controller.rb
@@ -1,5 +1,6 @@
 class DocumentCollectionsController < DocumentsController
   def show
+    cache_max_age(Whitehall.document_collections_cache_max_age)
     expire_on_next_scheduled_publication(@document.editions)
     @document_collection = @document
     set_meta_description(@document_collection.summary)

--- a/app/helpers/cache_control_helper.rb
+++ b/app/helpers/cache_control_helper.rb
@@ -1,7 +1,7 @@
 module CacheControlHelper
 
-  def cache_max_age
-    @cache_max_age ||= Whitehall.default_cache_max_age
+  def cache_max_age(cache_max_age = Whitehall.default_cache_max_age)
+    @cache_max_age ||= cache_max_age
   end
 
   def expire_on_next_scheduled_publication(scheduled_editions)

--- a/config/initializers/cache_max_age.rb
+++ b/config/initializers/cache_max_age.rb
@@ -1,2 +1,3 @@
 Whitehall.default_cache_max_age = 15.minutes
 Whitehall.uploads_cache_max_age = 4.hours
+Whitehall.document_collections_cache_max_age = 5.minutes

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -18,6 +18,7 @@ module Whitehall
   mattr_accessor :maslow
   mattr_accessor :default_cache_max_age
   mattr_accessor :uploads_cache_max_age
+  mattr_accessor :document_collections_cache_max_age
   mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8023

HMRC need to publish a collection page which needs to reflect the latest changes in no longer than 5m.

made a change to the `CacheControlHelper` to allow overriding the `cache_max_age` from the controller, so that we can set a max age of 5m for collections.
