### PR TITLE
Handle 99 body columns during import

### DIFF
--- a/features/importing-new-editions.feature
+++ b/features/importing-new-editions.feature
@@ -35,7 +35,7 @@ Feature: Importing new editions
   - title: required
   - summary: optional
   - body: required
-  - body_1..9: optional - allows long bodies to be split across multiple columns. body + body_1..9 are concatinated to form the complete body
+  - body_1..99: optional - allows long bodies to be split across multiple columns. body + body_1..99 are concatenated to form the complete body
   - organisation: required, ideally default blank to SELECTED, reject anything that is non-blank that can't be found
 
   Publications:

--- a/lib/whitehall/uploader/row.rb
+++ b/lib/whitehall/uploader/row.rb
@@ -18,7 +18,7 @@ module Whitehall::Uploader
     def self.validator
       HeadingValidator.new
         .required(%w{old_url title summary body organisation})
-        .multiple("body_#", 0..9)
+        .multiple("body_#", 0..99)
     end
 
     def title

--- a/test/unit/uploader/row_test.rb
+++ b/test/unit/uploader/row_test.rb
@@ -66,6 +66,8 @@ module Whitehall::Uploader
         "body_7" => "body7\n",
         "body_8" => "body8\n",
         "body_9" => "body9\n"
+        "body_10" => "body10\n"
+        "body_11" => "body11\n"
       }
       row = build_row(csv_data)
       row.stubs(:organisation).returns(stubbed_organisation)


### PR DESCRIPTION
A few upcoming imports contain much copy, and lend themselves to the natural concatenation feature already present in whitehall. 

This pull request attempts to extend the number of body columns in an imported CSV from 9 to 99. 
