### PR TITLE
Remove title separator line for freedom of information addresses

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -776,6 +776,11 @@
         clear: both;
         padding: $gutter 0 $gutter-half 0;
       }
+      .contact {
+        h2 {
+          border-top: none;
+        }
+      }
     }
 
     .see-legislation {


### PR DESCRIPTION
Linked to Zendesk ticket: https://govuk.zendesk.com/agent/tickets/873595

Before:

![screen shot 2014-11-14 at 12 32 24](https://cloud.githubusercontent.com/assets/5455804/5046701/748df934-6c05-11e4-8261-1cbd14a6c408.png)

After:

![screen shot 2014-11-14 at 13 34 58](https://cloud.githubusercontent.com/assets/5455804/5046716/a5e61e6c-6c05-11e4-8adb-3b42dda76179.png)
