### PR TITLE
Document filter message for no results

### DIFF
--- a/app/assets/javascripts/admin/modules/document_finder.js
+++ b/app/assets/javascripts/admin/modules/document_finder.js
@@ -12,8 +12,10 @@
     // store the selected document's id (with a name attribute of
     // 'document_id') or edition's id (with a name attribute of 'edition_id').
 
-    init: function(filter_params) {
-      this.additional_filter_params = filter_params;
+    init: function(params) {
+      this.no_results_message = params.no_results_message || 'No results matching search criteria';
+      delete params.no_results_message;
+      this.additional_filter_params = params;
       this.latest_results = null;
       this.search_term_content = '';
       this.$search_term = $('input#title');
@@ -76,11 +78,15 @@
 
     showSearchResults: function(results) {
       this.latest_results = results;
+      var no_results_message = this.no_results_message;
 
       var formatResults = function(data) {
         var results = [];
         $.each(data, function(i, result) { results.push(result.title) });
-        return results;
+        if (results.length)
+          return results;
+        else
+          return [no_results_message];
       };
 
       this.$search_term.autocomplete('option', 'source', formatResults(results));

--- a/app/views/admin/statistics_announcements/_document_linker.html.erb
+++ b/app/views/admin/statistics_announcements/_document_linker.html.erb
@@ -1,4 +1,5 @@
-<% initialise_script 'GOVUK.documentFinder', type: 'publication', subtypes: [statistics_announcement.publication_type_id], state: 'not_published' %>
+<% initialise_script 'GOVUK.documentFinder', type: 'publication', subtypes: [statistics_announcement.publication_type_id], state: 'not_published',
+    no_results_message: "Couldn't find a matching draft publication of type '#{statistics_announcement.publication_type.singular_name}'" %>
 <% initialise_script 'GOVUK.statisticsAnnouncementLinker' %>
 
 <%= form_for [:admin, statistics_announcement], html: { style: 'display:none' } do |form| %>


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8672
addresses: https://govuk.zendesk.com/tickets/869065

In its current version the document filter shows a loader image when the search is being performed and doesn't provide any feedback if results are not found.

Editors can get confused if they're searching for a publication to link to a Statistics Announcement and no results are returned. It may seem as if the filter is not functioning.

I've added a suitable message which reminds editors that the lookup is scoped by publication type which is same as the type of the statistics announcement, and, publication state being not published.

![screen shot 2014-11-17 at 14 22 58](https://cloud.githubusercontent.com/assets/230074/5067284/3a7b3582-6e66-11e4-812c-76cc6950220e.png)
