### PR TITLE
Fix expiry for collections with nothing scheduled

### DIFF
--- a/app/controllers/document_collections_controller.rb
+++ b/app/controllers/document_collections_controller.rb
@@ -1,7 +1,9 @@
 class DocumentCollectionsController < DocumentsController
+
   def show
     cache_max_age(Whitehall.document_collections_cache_max_age)
     expire_on_next_scheduled_publication(@document.editions)
+
     @document_collection = @document
     set_meta_description(@document_collection.summary)
     @groups = @document_collection.groups.visible.map do |group|
@@ -11,6 +13,11 @@ class DocumentCollectionsController < DocumentsController
   end
 
 private
+
+  def set_cache_control_headers
+    expires_in Whitehall.document_collections_cache_max_age, public: true
+  end
+
   def document_class
     DocumentCollection
   end

--- a/test/functional/document_collections_controller_test.rb
+++ b/test/functional/document_collections_controller_test.rb
@@ -74,7 +74,15 @@ class DocumentCollectionsControllerTest < ActionController::TestCase
     collection.groups.first.documents << publication.document
 
     get :show, id: collection.slug
+    assert_cache_control("max-age=#{Whitehall.document_collections_cache_max_age}")
+  end
 
+  test "GET #show sets Cache-Control: max-age to Whitehall.document_collections_cache_max_age if nothing in the collection is scheduled to publish ever" do
+    collection = create(:published_document_collection, :with_group)
+    publication = create(:publication)
+    collection.groups.first.documents << publication.document
+
+    get :show, id: collection.slug
     assert_cache_control("max-age=#{Whitehall.document_collections_cache_max_age}")
   end
 end


### PR DESCRIPTION
following-up on: https://github.com/alphagov/whitehall/pull/1837

missed handling one scenario where document collections with none of its items scheduled for publishing still set a max-age of 15.mins.

that's because `expire_on_next_scheduled_publication` doesn't change the expires header if nothing in the collection is scheduled to publish.

i've overridden the `set_cache_control_headers` in this controller to use `documents_collection_cache_max_age` which fixes this.
