### PR TITLE
Don't register with panopticon when changing slug

### DIFF
--- a/lib/whitehall/organisation_slug_changer.rb
+++ b/lib/whitehall/organisation_slug_changer.rb
@@ -29,10 +29,9 @@ class Whitehall::OrganisationSlugChanger
                               "exact",
                               "/government/organisations/#{new_slug}")
 
-    logger.info "Re-registering #{new_slug} published editions in search and panopticon"
+    logger.info "Re-registering #{new_slug} published editions in search"
     organisation.editions.published.find_each do |edition|
       ServiceListeners::SearchIndexer.new(edition).index!
-      ServiceListeners::PanopticonRegistrar.new(edition).register!
     end
   end
 

--- a/test/unit/whitehall/organisation_slug_changer_test.rb
+++ b/test/unit/whitehall/organisation_slug_changer_test.rb
@@ -9,7 +9,6 @@ module Whitehall
       @new_slug = 'new-slug'
       @slug_changer = OrganisationSlugChanger.new(@organisation, @new_slug, router: @router)
       ServiceListeners::SearchIndexer.any_instance.stubs(:index!)
-      ServiceListeners::PanopticonRegistrar.any_instance.stubs(:register!)
     end
 
     test 'it removes the org from search index' do
@@ -53,16 +52,6 @@ module Whitehall
       indexer = mock("indexer")
       indexer.expects(:index!)
       ServiceListeners::SearchIndexer.expects(:new).with(edition).returns(indexer)
-
-      @slug_changer.call
-    end
-
-    test 're-registers in panopticon any published editions associated with the organisation' do
-      edition = create(:published_publication, organisations: [@organisation])
-
-      registerer = mock("registerer")
-      registerer.expects(:register!)
-      ServiceListeners::PanopticonRegistrar.expects(:new).with(edition).returns(registerer)
 
       @slug_changer.call
     end


### PR DESCRIPTION
Artefacts in panopticon will be updated by a rake task run directly in
panopticon, therefore we don't need to re-register content with
panopticon. The direct rake task will be much more efficient.
Re-registering with panopticon is a potentially costly operation.
