### PR TITLE
Add change_history to case study API presenter.

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -14,7 +14,11 @@ module PublishingApiPresenters
     end
 
     def details
-      super.merge({body: body, first_public_at: edition.first_public_at}).tap do |json|
+      super.merge({
+        body: body,
+        first_public_at: edition.first_public_at,
+        change_history: edition.change_history.as_json,
+      }).tap do |json|
         json[:image] = image_details if image_available?
       end
     end

--- a/lib/govuk_content_schemas/case_study.json
+++ b/lib/govuk_content_schemas/case_study.json
@@ -96,6 +96,26 @@
             { "type": null }
           ]
         },
+        "change_history": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "public_timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "note": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "public_timestamp",
+              "note"
+            ]
+          }
+        },
         "tags": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
This creates some duplication since the top change note within the change_history hash will be the same as the existing change_note attribute. However, the latter is already being used by the email alerts service; it would probably be good to change that app to use change_history instead.
