### PR TITLE
Don't send draft sector tags out to Rummager.

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -288,7 +288,7 @@ class Edition < ActiveRecord::Base
     search_format_types: :search_format_types,
     attachments: nil,
     operational_field: nil,
-    specialist_sectors: :specialist_sector_tags,
+    specialist_sectors: :live_specialist_sector_tags,
     latest_change_note: :most_recent_change_note,
   )
 

--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -38,7 +38,13 @@ module Edition::SpecialistSectors
   end
 
   def specialist_sector_tags
-    searchable_specialist_sector_tags
+    Array(primary_specialist_sector_tag) + secondary_specialist_sector_tags
+  end
+
+  def live_specialist_sector_tags
+    specialist_sector_tags.select do |tag|
+      live_specialist_sector_tag_slugs.include?(tag)
+    end
   end
 
 private
@@ -56,7 +62,7 @@ private
     self.public_send("#{relation}=", sectors)
   end
 
-  def searchable_specialist_sector_tags
-    Array(primary_specialist_sector_tag).concat(secondary_specialist_sector_tags)
+  def live_specialist_sector_tag_slugs
+    @live_specialist_sector_tag_slugs ||= SpecialistSector.live_subsectors.map(&:slug)
   end
 end

--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -6,12 +6,12 @@ class SpecialistSector < ActiveRecord::Base
 
   def self.grouped_sector_topics
     nested_sectors.map do |sector_tag, topic_tags|
-      OpenStruct.new(
-        slug: slug_for_sector_tag(sector_tag),
-        title: sector_tag.title,
-        topics: topic_tags.map { |tag| sector_topic_from_tag(tag) }
-      )
+      sector_topic_from_tag(sector_tag, topic_tags.map { |tag| sector_topic_from_tag(tag) })
     end
+  end
+
+  def self.live_subsectors
+    find_subsectors(fetch_live_sectors).map {|sector_tag| sector_topic_from_tag(sector_tag) }
   end
 
   def edition
@@ -20,7 +20,11 @@ class SpecialistSector < ActiveRecord::Base
 
 private
   def self.nested_sectors
-    fetch_sectors.select(&:parent).group_by(&:parent).sort_by {|parent, _| parent.title }
+    find_subsectors(fetch_sectors).group_by(&:parent).sort_by {|parent, _| parent.title }
+  end
+
+  def self.find_subsectors(sectors)
+    sectors.select(&:parent)
   end
 
   def self.fetch_sectors
@@ -29,8 +33,14 @@ private
     raise DataUnavailable.new
   end
 
-  def self.sector_topic_from_tag(tag)
-    OpenStruct.new(slug: slug_for_sector_tag(tag), title: tag.title, draft?: (tag.state == 'draft'))
+  def self.fetch_live_sectors
+    Whitehall.content_api.tags('specialist_sector', draft: false)
+  rescue
+    raise DataUnavailable.new
+  end
+
+  def self.sector_topic_from_tag(tag, topics = [])
+    OpenStruct.new(slug: slug_for_sector_tag(tag), title: tag.title, topics: topics, draft?: (tag.state == 'draft'))
   end
 
   def self.slug_for_sector_tag(tag)

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -6,13 +6,14 @@ Feature: Tagging content with specialist sectors
   @real_content_api
   Scenario: writer can tag documents with specialist sectors
     Given I am a writer
-      And there are some specialist sectors
+    And there are some specialist sectors
     When I start editing a draft document
     Then I can tag it to some specialist sectors
 
   @real_content_api
   Scenario: sectors are shown on tagged content
-    Given there is a document tagged to specialist sectors
+    Given there are some specialist sectors
+    And there is a document tagged to specialist sectors
     When I view the document
     Then I should see the specialist sub-sector and its parent sector
     And I should not see draft specialist sectors

--- a/test/unit/edition/searchable_test.rb
+++ b/test/unit/edition/searchable_test.rb
@@ -11,7 +11,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
     assert_equal "generic_edition", edition.search_index["format"]
     assert_equal edition.summary, edition.search_index["description"]
     assert_equal edition.id, edition.search_index["id"]
-    assert_equal edition.specialist_sector_tags, edition.search_index["specialist_sectors"]
+    assert_equal edition.live_specialist_sector_tags, edition.search_index["specialist_sectors"]
     assert_equal edition.most_recent_change_note, edition.search_index["latest_change_note"]
     assert_equal nil, edition.search_index["organisations"]
     assert_equal nil, edition.search_index["people"]

--- a/test/unit/edition/specialist_sectors_test.rb
+++ b/test/unit/edition/specialist_sectors_test.rb
@@ -42,6 +42,24 @@ class Edition::SpecialistSectorsTest < ActiveSupport::TestCase
     assert_equal [], edition_without_specialist_sectors.specialist_sector_tags
   end
 
+  test "#live_specialist_sector_tags should filter out draft tags" do
+    live_tag = stub(
+      title: 'Live subsector',
+      slug: 'live_super/live_primary',
+      draft?: false,
+      topics: []
+    )
+
+    edition = create(:edition,
+      primary_specialist_sector_tag: 'live_super/live_primary',
+      secondary_specialist_sector_tags: ['live_super/draft_secondary'],
+    )
+
+    SpecialistSector.stubs(:live_subsectors).returns([live_tag])
+
+    assert_equal ['live_super/live_primary'], edition.live_specialist_sector_tags
+  end
+
   test "moving a secondary tag to the primary tag doesn't fail" do
     tag = "environmental-management/waste"
     publication = create(:publication, secondary_specialist_sector_tags: [tag])

--- a/test/unit/specialist_sector_test.rb
+++ b/test/unit/specialist_sector_test.rb
@@ -6,6 +6,59 @@ class SpecialistSectorTest < ActiveSupport::TestCase
 
   setup do
     use_real_content_api
+
+    oil_and_gas = { slug: 'oil-and-gas', title: 'Oil and Gas', draft: false }
+    tax = { slug: 'tax', title: 'Tax', draft: false }
+    environmental_management = { slug: 'environmental-management', title: 'Environmental management', draft: true }
+
+    draft_sector_tags = [
+      { slug: 'tax/capital-gains-tax', title: 'Capital Gains Tax', parent: tax, draft: true },
+      { slug: 'oil-and-gas/wells', title: 'Wells', parent: oil_and_gas, draft: true },
+      environmental_management
+    ]
+
+    live_sector_tags = [
+      tax,
+      { slug: 'tax/income-tax', title: 'Income Tax', parent: tax, draft: false },
+      oil_and_gas,
+      { slug: 'oil-and-gas/fields', title: 'Fields', parent: oil_and_gas, draft: false }
+    ]
+
+    content_api_has_draft_and_live_tags(type: 'specialist_sector', draft: draft_sector_tags, live: live_sector_tags)
+
+
+    @wells = OpenStruct.new(slug: 'oil-and-gas/wells', title: 'Wells', draft?: true, topics: [])
+    @fields = OpenStruct.new(slug: 'oil-and-gas/fields', title: 'Fields', draft?: false, topics: [])
+
+    @oil_and_gas = OpenStruct.new(
+      slug: 'oil-and-gas',
+      title: 'Oil and Gas',
+      draft?: false,
+      topics: [
+        @fields,
+        @wells
+      ]
+    )
+
+    @income_tax = OpenStruct.new(slug: 'tax/income-tax', title: 'Income Tax', draft?: false, topics: [])
+    @capital_gains = OpenStruct.new(slug: 'tax/capital-gains-tax', title: 'Capital Gains Tax', draft?: true, topics: [])
+
+    @tax = OpenStruct.new(
+      slug: 'tax',
+      title: 'Tax',
+      draft?: false,
+      topics: [
+        @income_tax,
+        @capital_gains
+      ]
+    )
+
+    @environmental_management = OpenStruct.new(
+      slug: 'environmental-management',
+      title: 'Environmental management',
+      draft?: true,
+      topics: []
+    )
   end
 
   teardown do
@@ -13,39 +66,7 @@ class SpecialistSectorTest < ActiveSupport::TestCase
   end
 
   test '.grouped_sector_topics should return specialist sector tags grouped under sorted parents' do
-    oil_and_gas = { slug: 'oil-and-gas', title: 'Oil and Gas' }
-    tax = { slug: 'tax', title: 'Tax' }
-
-    sector_tags = [
-      tax,
-      { slug: 'tax/income-tax', title: 'Income Tax', parent: tax },
-      { slug: 'tax/capital-gains-tax', title: 'Capital Gains Tax', parent: tax },
-      oil_and_gas,
-      { slug: 'oil-and-gas/wells', title: 'Wells', parent: oil_and_gas },
-      { slug: 'oil-and-gas/fields', title: 'Fields', parent: oil_and_gas },
-    ]
-
-    content_api_has_tags('specialist_sector', sector_tags)
-
-    oil_and_gas = OpenStruct.new(
-      slug: 'oil-and-gas',
-      title: 'Oil and Gas',
-      topics: [
-        OpenStruct.new(slug: 'oil-and-gas/wells', title: 'Wells', draft?: false),
-        OpenStruct.new(slug: 'oil-and-gas/fields', title: 'Fields', draft?: false)
-      ]
-    )
-
-    tax = OpenStruct.new(
-      slug: 'tax',
-      title: 'Tax',
-      topics: [
-        OpenStruct.new(slug: 'tax/income-tax', title: 'Income Tax', draft?: false),
-        OpenStruct.new(slug: 'tax/capital-gains-tax', title: 'Capital Gains Tax', draft?: false)
-      ]
-    )
-
-    assert_equal [oil_and_gas, tax], SpecialistSector.grouped_sector_topics
+    assert_equal [@oil_and_gas, @tax], SpecialistSector.grouped_sector_topics
   end
 
   test '.grouped_sector_topics should raise a DataUnavailable error when the content API is unavailable' do
@@ -54,6 +75,10 @@ class SpecialistSectorTest < ActiveSupport::TestCase
     assert_raise SpecialistSector::DataUnavailable do
       SpecialistSector.grouped_sector_topics
     end
+  end
+
+  test '.live_subsectors should return only live subsectors' do
+    assert_equal [@income_tax, @fields], SpecialistSector.live_subsectors
   end
 
 private


### PR DESCRIPTION
It's OK for us to send these into the content store as it's impossible to subscribe to a draft tag and in the future the draft tags will be stripped by the content store once they're moved to the `links` hash.

https://www.pivotaltracker.com/story/show/82664682
