### PR TITLE
Make organisations no longer accessible by id

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -102,7 +102,7 @@ private
   end
 
   def load_organisation
-    @organisation = Organisation.with_translations(I18n.locale).find(params[:id])
+    @organisation = Organisation.with_translations(I18n.locale).find_by_slug(params[:id])
   end
 
   def set_cache_max_age


### PR DESCRIPTION
Bug originally found by noticing that the URL
gov.uk/government/organisations/10downingstreet
was redirecting to organisation with ID 10 in our database

Organisations should only be accessible via their slug url, not ID.
