### PR TITLE
Managing Editor permissions for managing featured links

### DIFF
--- a/lib/whitehall/authority/rules/organisation_rules.rb
+++ b/lib/whitehall/authority/rules/organisation_rules.rb
@@ -2,15 +2,20 @@ module Whitehall::Authority::Rules
   class OrganisationRules < Struct.new(:actor, :subject)
     def can?(action)
       case action
-      when :manage_featured_links
-        actor.gds_admin? || actor.gds_editor? || (actor.managing_editor? && actor.organisation == subject)
       when :create
         actor.gds_admin?
       when :edit
-        actor.gds_admin? || actor.organisation == subject || actor.organisation.try(:has_child_organisation?, subject)
+        actor.gds_admin? || actor_is_from_organisation_or_parent?(actor, subject)
+      when :manage_featured_links
+        actor.gds_admin? || actor.gds_editor? || (actor.managing_editor? && actor_is_from_organisation_or_parent?(actor, subject))
       else
         false
       end
+    end
+
+    private
+    def actor_is_from_organisation_or_parent?(actor, organisation)
+      actor.organisation == organisation || actor.organisation.try(:has_child_organisation?, organisation)
     end
   end
 end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -156,13 +156,15 @@ class ManagingEditorTest < ActiveSupport::TestCase
     refute enforcer_for(managing_editor, :sitewide_settings_section).can?(:administer)
   end
 
-  test 'can manage featured links for their organisation' do
+  test 'can manage featured links for their organisation and child organisation' do
     user = managing_editor
 
     editors_org = user.organisation
+    child_org = create(:organisation, parent_organisations: [editors_org])
     other_org = build(:organisation)
 
     assert enforcer_for(user, editors_org).can?(:manage_featured_links)
+    assert enforcer_for(user, child_org).can?(:manage_featured_links)
     refute enforcer_for(user, other_org).can?(:manage_featured_links)
   end
 end


### PR DESCRIPTION
Allows Managing Editors to add and edit featured links on an organisation's homepage, when they are a member of that organisation or a parent organisation.

https://www.agileplannerapp.com/boards/173808/cards/8685
