### PR TITLE
Add a data migration to redirect phillip-marsden to philip-marsden

### DIFF
--- a/db/data_migration/20141124104930_change_phillip_marsden_slug_to_philip_marsden.rb
+++ b/db/data_migration/20141124104930_change_phillip_marsden_slug_to_philip_marsden.rb
@@ -1,0 +1,12 @@
+require 'gds_api/router'
+
+router = GdsApi::Router.new(Plek.find('router-api'))
+
+person = Person.find_by_slug('phillip-marsden')
+person.slug = 'philip-marsden'
+person.save!
+
+router.add_redirect_route("/government/people/phillip-marsden",
+                          'exact',
+                          "/government/people/philip-marsden")
+router.commit_routes


### PR DESCRIPTION
- Someone added a ticket to the second-line backlog to rename this
  person's slug due to a typo when it was first created. After a chat
  with Tekin, this was deemed the easiest way. This fixes, in this
  case, the bad spelling of Philip.
