### PR TITLE
Fix casualty fields duplication

### DIFF
--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -22,7 +22,6 @@
       <%= form.fields_for :fatality_notice_casualties do |casualty_form| %>
         <div class="js-duplicate-fields-set well">
           <%= casualty_form.text_area :personal_details, horizontal: true, rows: 2 %>
-          <%= casualty_form.hidden_field :_destroy, class: 'js-hidden-destroy' %>
         </div>
       <% end %>
     </fieldset>

--- a/features/fatalities.feature
+++ b/features/fatalities.feature
@@ -50,6 +50,11 @@ Feature: Fatalities
     When I link the minister "Nick Smith" to the fatality notice
     Then I should see the minister's name listed at the top
 
+  Scenario: Writer manages casualty entries for a fatality shown on the field of operation page
+    Given there is a fatality notice titled "Death of Joe" in the field "Iraq"
+    When I add a casualty to the fatality notice
+    Then I should see a casualty listed on the field of operation page for "Iraq"
+
   Scenario: Citizen looks at field of operations information
     Given there is a fatality notice titled "Death of Joe and Jim" in the field "Iraq"
     When I look at the fatality notice titled "Death of Joe and Jim"

--- a/features/step_definitions/fatalities_steps.rb
+++ b/features/step_definitions/fatalities_steps.rb
@@ -60,3 +60,18 @@ end
 Then /^I can create a fatality notice$/ do
   draft_fatality_notice("Fatality Notice", "Iraq")
 end
+
+When(/^I add a casualty to the fatality notice$/) do
+  begin_new_draft_document FatalityNotice.last.title
+  fill_in "Personal details", with: "Causualty"
+  choose "edition_minor_change_true"
+  click_button "Save"
+end
+
+Then(/^I should see a casualty listed on the field of operation page for "(.*?)"$/) do |field|
+  visit operational_field_path(OperationalField.find_by_name(field))
+
+  within '.fatality_notice ul.casualties' do
+    assert page.has_content?(FatalityNotice.last.title, count: 1)
+  end
+end


### PR DESCRIPTION
http://www.agileplannerapp.com/boards/173808/cards/8196
fixes: https://govuk.zendesk.com/agent/tickets/872828

casualty entries on fatality notices were being duplicated because of duplicate `_destroy` inputs on the form, which was causing the 'Remove' button to not work as expected. seemingly, a result of [this refactoring](https://github.com/alphagov/whitehall/commit/3b8145).
