### PR TITLE
Correct data migrations

### DIFF
--- a/db/data_migration/20141113141441_push_case_studies_to_publishing_api.rb
+++ b/db/data_migration/20141113141441_push_case_studies_to_publishing_api.rb
@@ -1,5 +1,5 @@
-puts "Pushing case studies to publishing API"
-CaseStudy.find_each do |case_study|
+puts "Pushing published case studies to publishing API"
+CaseStudy.published.find_each do |case_study|
   print '.'
   PublishingApiEditionWorker.perform_async(case_study.id)
 end

--- a/db/data_migration/20141119171625_push_case_studies_again.rb
+++ b/db/data_migration/20141119171625_push_case_studies_again.rb
@@ -1,5 +1,5 @@
-puts "Pushing case studies to publishing API"
-CaseStudy.find_each do |case_study|
+puts "Pushing published case studies to publishing API"
+CaseStudy.published.find_each do |case_study|
   print '.'
   PublishingApiEditionWorker.perform_async(case_study.id)
 end


### PR DESCRIPTION
These data migrations incorrectly pushed all case studies (not just published ones) to the content store. They have been run now, but I'm correcting them here to be safe in case folk use them as a reference in future.
