### PR TITLE
Add CSV permission for all departmental editors

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -102,7 +102,7 @@ module Whitehall::Authority::Rules
 
     def can_with_a_class?(action)
       if [:export, :confirm_export].include? action
-        actor.gds_editor? || actor.gds_admin?
+        actor.gds_admin? || actor.gds_editor? || actor.managing_editor? || actor.departmental_editor?
       else
         [:create, :see].include? action
       end

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -158,4 +158,8 @@ class DepartmentEditorTest < ActiveSupport::TestCase
     refute enforcer_for(user, editors_org).can?(:manage_featured_links)
     refute enforcer_for(user, other_org).can?(:manage_featured_links)
   end
+
+  test 'can export editions' do
+    assert enforcer_for(department_editor, Edition).can?(:export)
+  end
 end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -167,4 +167,8 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(user, child_org).can?(:manage_featured_links)
     refute enforcer_for(user, other_org).can?(:manage_featured_links)
   end
+
+  test 'can export editions' do
+    assert enforcer_for(managing_editor, Edition).can?(:export)
+  end
 end


### PR DESCRIPTION
Allow all departmental editors to export the document list as a CSV.

https://www.agileplannerapp.com/boards/173808/cards/8668
