### PR TITLE
Add an admin API for reindexing sector editions.

### DIFF
--- a/app/controllers/admin/api/search_controller.rb
+++ b/app/controllers/admin/api/search_controller.rb
@@ -1,0 +1,12 @@
+class Admin::Api::SearchController < Admin::BaseController
+  skip_before_filter :verify_authenticity_token, only: [:reindex_specialist_sector_editions]
+
+  def reindex_specialist_sector_editions
+    published_and_tagged_editions = Edition.published.joins(:specialist_sectors).where(specialist_sectors: {tag: params[:slug]})
+    published_and_tagged_editions.each do |edition|
+      edition.update_in_search_index
+    end
+
+    render json: {result: 'ok', count: published_and_tagged_editions.count}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,10 @@ Whitehall::Application.routes.draw do
       namespace :admin do
         root to: 'dashboard#index', via: :get
 
+        namespace :api do
+          post 'reindex-specialist-sector-editions/*slug', to: 'search#reindex_specialist_sector_editions', as: 'reindex_specialist_sector_editions'
+        end
+
         get 'find-in-admin-bookmarklet' => 'find_in_admin_bookmarklet#index', as: :find_in_admin_bookmarklet_instructions_index
         get 'find-in-admin-bookmarklet/:browser' => 'find_in_admin_bookmarklet#show', as: :find_in_admin_bookmarklet_instructions
 

--- a/test/functional/admin/api/search_controller_test.rb
+++ b/test/functional/admin/api/search_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class Admin::Api::SearchControllerTest < ActionController::TestCase
+  def setup
+    login_as :user
+
+    @relevant_editions = [
+      # Published with correct primary tag
+      FactoryGirl.create(:publication, :published, primary_specialist_sector_tag: 'oil-and-gas/licensing'),
+      # Published with correct secondary tag
+      FactoryGirl.create(:detailed_guide, :published, secondary_specialist_sector_tags: ['oil-and-gas/licensing'])
+    ]
+
+    @irrelevant_editions = [
+      # Correct tag, but draft
+      FactoryGirl.create(:publication, :draft, primary_specialist_sector_tag: 'oil-and-gas/licensing'),
+      # Correct tag, but archived
+      FactoryGirl.create(:publication, :archived, primary_specialist_sector_tag: 'oil-and-gas/licensing'),
+      # Published, but incorrect tag
+      FactoryGirl.create(:publication, :published, secondary_specialist_sector_tags: ['environmental-management/boating']),
+      # Published, but no tag
+      FactoryGirl.create(:publication, :published)
+    ]
+  end
+
+  test "#reindex_specialist_sector reindexes all published editions tagged to the specialist sector" do
+    @relevant_editions.each do |edition|
+      Whitehall::SearchIndex.expects(:add).with(edition).once
+    end
+
+    @irrelevant_editions.each do |edition|
+      Whitehall::SearchIndex.expects(:add).with(edition).never
+    end
+
+    post :reindex_specialist_sector_editions,
+      {slug: 'oil-and-gas/licensing'},
+      {'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'}
+  end
+end


### PR DESCRIPTION
In order to get tag information for published
editions into Rummager (and thence to the services
and information page, among others) when a draft
specialist sector is published, we need to notify
Whitehall so it can resubmit all published editions
tagged with that specialist sector.

https://www.pivotaltracker.com/story/show/83216078
