### PR TITLE
Add unarchiving task

### DIFF
--- a/lib/data_hygiene/edition_unarchiver.rb
+++ b/lib/data_hygiene/edition_unarchiver.rb
@@ -1,0 +1,34 @@
+module DataHygiene
+  class EditionUnarchiver
+    attr_reader :edition, :user, :logger
+
+    GDS_INSIDE_GOV_USER_ID = 406
+
+    def initialize(edition_id, logger=Rails.logger)
+      @edition = Edition.find(edition_id)
+      raise "Cannot unarchive an edition with state '#{@edition.state}'" unless @edition.archived?
+      @user = User.find(GDS_INSIDE_GOV_USER_ID)
+      @logger = logger
+    end
+
+    def unarchive
+      Edition.transaction do
+        # The archived edition have state 'published' to create a draft.
+        edition.update_attribute(:state, :published)
+        edition.reload
+        draft = edition.create_draft(user)
+        draft.minor_change = true
+        draft.editorial_remarks << EditorialRemark.create(author: @user, edition: @edition, body: "Unarchived")
+
+        Edition::AuditTrail.acting_as(user) do
+          EditionForcePublisher.new(draft).perform!
+        end
+
+        draft.reload
+        logger.info("Unarchived Edition #{edition.id}, this has now been superseded.")
+        logger.info("Created and published draft #{draft.id}.")
+        draft
+      end
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -73,3 +73,8 @@ task :move_content_to_new_topic => :environment do
 
   TopicRetagger.new(source_topic_id, destination_topic_id).retag
 end
+
+desc "Unarchive an edition (creates and publishes a draft with audit trail)"
+task :unarchive_edition, [:edition_id] => :environment do |t,args|
+  DataHygiene::EditionUnarchiver.new(args[:edition_id], Logger.new(STDOUT)).unarchive
+end

--- a/test/unit/data_hygiene/edition_unarchiver_test.rb
+++ b/test/unit/data_hygiene/edition_unarchiver_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+module DataHygiene
+  class EditionUnarchiverTest < ActiveSupport::TestCase
+    setup do
+      @edition = FactoryGirl.create(:published_edition)
+      @edition.archive!
+      @user = FactoryGirl.create(:user, id: 406)
+    end
+
+    test "initialize with a non-existent edition id errors" do
+      assert_raises ActiveRecord::RecordNotFound do
+        EditionUnarchiver.new(123)
+      end
+    end
+
+    test "initialize with an existing edition id finds the edition" do
+      assert_equal @edition, EditionUnarchiver.new(@edition.id).edition
+    end
+
+    test "initialize finds the correct user for unarchiving" do
+      assert_equal @user, EditionUnarchiver.new(@edition.id).user
+    end
+
+    test "initialize raises an error unless the edition is archived" do
+      @edition.update_attribute(:state, "published")
+      assert_raises RuntimeError do
+        EditionUnarchiver.new(@edition.id)
+      end
+    end
+
+    test "unarchive performs steps in a transaction" do
+      EditionForcePublisher.any_instance.stubs(:perform!).raises("Something bad happened here.")
+
+      assert_raises RuntimeError do
+        EditionUnarchiver.new(@edition.id).unarchive
+      end
+      @edition.reload
+
+      assert_equal "archived", @edition.state
+    end
+
+    test "unarchive updates the state of the original edition to superceded" do
+      EditionUnarchiver.new(@edition.id).unarchive
+      @edition.reload
+      assert_equal "superseded", @edition.state
+    end
+
+    test "unarchive publishes a draft of the archived edition" do
+      unarchived = EditionUnarchiver.new(@edition.id).unarchive
+      assert unarchived.published?
+      assert unarchived.minor_change
+      assert_equal @edition.document, unarchived.document
+      assert_equal @user, unarchived.editorial_remarks.first.author
+      assert_equal "Unarchived", unarchived.editorial_remarks.first.body
+    end
+  end
+end


### PR DESCRIPTION
(https://cloud.githubusercontent.com/assets/93511/5201656/12bc7c8c-756d-11e4-91ff-fb817ab01e4e.png)
https://www.agileplannerapp.com/boards/173808/cards/8018

Provides a simple way to 'unarchive' Editions by creating a draft version and force publishing it.
See discussion here https://www.agileplannerapp.com/boards/173808/discussions/2428 for more background.

![screenshot - 261114 - 13 06 14](https://cloud.githubusercontent.com/assets/93511/5201674/43635c52-756d-11e4-85a4-515e426b8237.png)
