### PR TITLE
Add a data migration to rename a gambling duties document collection

### DIFF
--- a/db/data_migration/20141124175243_change_gambling_duties_notices_slug_to_not_include_forms.rb
+++ b/db/data_migration/20141124175243_change_gambling_duties_notices_slug_to_not_include_forms.rb
@@ -1,8 +1,8 @@
-require 'gds-api/router'
+require 'gds_api/router'
 
 router = GdsApi::Router.new(Plek.find('router-api'))
 
-collection = DocumentCollection.find_by_slug('gambling-duty-forms-and-notices')
+collection = Document.where(slug: 'gambling-duty-forms-and-notices', document_type: 'DocumentCollection').first
 collection.slug = 'gambling-duty-notices'
 collection.save!
 


### PR DESCRIPTION
- There was a ticket in the second-line backlog about renaming this
  document collection because it referenced "forms", which the page no
  longer housed. Now it only references "notices". It was decided that
  this data migration approach was the most sensible, following on from
  #1861.
- In this data migration, I've also added a line to remove the old
  collection from the search index, so the same titled document won't
  appear twice - thanks Tekin.
