### PR TITLE
Enable all services to be deselected for a WWO

### DIFF
--- a/app/views/admin/worldwide_offices/_form.html.erb
+++ b/app/views/admin/worldwide_offices/_form.html.erb
@@ -33,15 +33,19 @@
 
       <fieldset class="services">
         <legend>Services</legend>
+        <% # without this hidden field, once a service has been selected and saved, all services cannot be de-selected.
+           # http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha %>
+        <%= hidden_field_tag 'worldwide_office[service_ids][]', nil %>
         <% WorldwideService.all.group_by{|ws| ws.service_type}.each do |service_type, services| %>
           <div class="control-group">
             <p class="control-label"><%= service_type.name %></p>
             <div class="controls">
               <% services.each do |service| %>
-                <label class="checkbox">
-                  <%= check_box_tag 'worldwide_office[service_ids][]', service.id, office_form.object.services.include?(service) %>
+                <%= label_tag "worldwide_office_service_ids_#{service.id}", class: "checkbox" do %>
+                  <%= check_box_tag 'worldwide_office[service_ids][]', service.id,
+                    office_form.object.services.include?(service), id: "worldwide_office_service_ids_#{service.id}" %>
                   <%= service.name %>
-                </label>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -120,6 +120,16 @@ Then /^the "([^"]*)" office details should be shown on the public website$/ do |
   end
 end
 
+Then(/^I should be able to remove all services from the "(.*?)" office$/) do |description|
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: description }).first
+  visit edit_admin_worldwide_organisation_worldwide_office_path(worldwide_organisation_id: WorldwideOrganisation.last.id, id: worldwide_office.id)
+  available_services = worldwide_office.services.each { |service| uncheck "worldwide_office_service_ids_#{service.id}" }
+  click_on "Save"
+
+  visit edit_admin_worldwide_organisation_worldwide_office_path(worldwide_organisation_id: WorldwideOrganisation.last.id, id: worldwide_office.id)
+  available_services.each { |service| assert page.has_unchecked_field? "worldwide_office_service_ids_#{service.id}" }
+end
+
 Given /^that the world location "([^"]*)" exists$/ do |country_name|
   create(:world_location, name: country_name)
 end

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -39,6 +39,7 @@ Feature: Administering worldwide organisation
     Given a worldwide organisation "Department of Beards in France"
     When I add an "Hair division" office for the home page with address, phone number, and some services
     Then the "Hair division" office details should be shown on the public website
+    And I should be able to remove all services from the "Hair division" office
 
   Scenario: Creating a worldwide organisation in a particular world location
     Given that the world location "France" exists


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8045
fixes: https://govuk.zendesk.com/agent/tickets/802017

adding a hidden field for the check box group for services for a worldwide organisation, which enables deselection of all services. applying a fix similar to [the one used by rails](http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha).
