### PR TITLE
Make organisation slug changer commit routes.

### DIFF
--- a/lib/whitehall/organisation_slug_changer.rb
+++ b/lib/whitehall/organisation_slug_changer.rb
@@ -28,6 +28,7 @@ class Whitehall::OrganisationSlugChanger
     router.add_redirect_route("/government/organisations/#{old_slug}",
                               "exact",
                               "/government/organisations/#{new_slug}")
+    router.commit_routes
 
     logger.info "Re-registering #{new_slug} published editions in search"
     organisation.editions.published.find_each do |edition|

--- a/test/unit/whitehall/organisation_slug_changer_test.rb
+++ b/test/unit/whitehall/organisation_slug_changer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Whitehall
   class OrganisationSlugChangerTest < ActiveSupport::TestCase
     setup do
-      @router = stub("router", add_redirect_route: nil)
+      @router = stub("router", add_redirect_route: nil, commit_routes: nil)
       @organisation = create(:organisation)
       @organisation.stubs(:remove_from_search_index)
       @new_slug = 'new-slug'
@@ -38,11 +38,15 @@ module Whitehall
     end
 
     test 'adds redirect route' do
+      order = sequence('order')
+
       @router.expects(:add_redirect_route).with(
         "/government/organisations/#{@organisation.slug}",
         "exact",
         "/government/organisations/#{@new_slug}"
-      )
+      ).in_sequence(order)
+      @router.expects(:commit_routes).in_sequence(order)
+
       @slug_changer.call
     end
 


### PR DESCRIPTION
Without this, the redirect won't be live until something else commits
the routes.  There's no guarantee on when that will happen.
