### PR TITLE
DataHygiene::PublishingApiRepublisher handles all

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,7 +14,7 @@ class Document < ActiveRecord::Base
   has_one  :published_edition,
            class_name: 'Edition',
            inverse_of: :document,
-           conditions: { state: %w(published archived) }
+           conditions: { state: Edition::PUBLICLY_VISIBLE_STATES }
 
   has_one  :latest_edition,
            class_name: 'Edition',

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -41,6 +41,7 @@ class Edition < ActiveRecord::Base
   FROZEN_STATES = %w(superseded deleted).freeze
   PRE_PUBLICATION_STATES = %w(imported draft submitted rejected scheduled).freeze
   POST_PUBLICATION_STATES = %w(published superseded archived).freeze
+  PUBLICLY_VISIBLE_STATES = %w(published archived).freeze
 
   scope :with_title_or_summary_containing, -> *keywords {
     pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
@@ -66,7 +67,7 @@ class Edition < ActiveRecord::Base
   scope :corporate_publications,        -> { where(publication_type_id: PublicationType::CorporateReport.id) }
   scope :worldwide_priorities,          -> { where(type: "WorldwidePriority") }
   scope :corporate_information_pages,   -> { where(type: "CorporateInformationPage") }
-  scope :publicly_visible,              -> { where(state: ['published', 'archived']) }
+  scope :publicly_visible,              -> { where(state: PUBLICALLY_VISIBLE_STATES) }
 
   # @!group Callbacks
   before_save :set_public_timestamp
@@ -327,6 +328,10 @@ class Edition < ActiveRecord::Base
     else
       raise "author can only be set on new records"
     end
+  end
+
+  def publicly_visible?
+    PUBLICLY_VISIBLE_STATES.include?(state)
   end
 
   # @group Overwritable permission methods

--- a/test/unit/data_hygiene/publishing_api_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_republisher_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class DataHygiene::PublishingApiRepublisherTest < ActiveSupport::TestCase
+  test "republishes a model to the Publishing API" do
+    organisation     = create(:organisation)
+    scope            = Organisation.where(id: organisation.id)
+    presenter        = PublishingApiPresenters::Organisation.new(organisation)
+    WebMock.reset!
+
+    expected_request = stub_publishing_api_put_item(presenter.base_path, presenter.as_json)
+
+    DataHygiene::PublishingApiRepublisher.new(scope, NullLogger.instance).perform
+
+    assert_requested expected_request
+  end
+
+  test "skips editions that are not publically visible" do
+    draft     = create(:draft_edition)
+    published = create(:published_edition)
+    archived  = create(:published_edition, state: 'archived')
+
+    draft_payload = PublishingApiPresenters::Edition.new(draft).as_json
+    published_payload = PublishingApiPresenters::Edition.new(published).as_json
+    archived_payload  = PublishingApiPresenters::Edition.new(archived).as_json
+
+    draft_request     = stub_publishing_api_put_item(draft_payload[:base_path], draft_payload)
+    published_request = stub_publishing_api_put_item(published_payload[:base_path], published_payload)
+    archived_request  = stub_publishing_api_put_item(archived_payload[:base_path], archived_payload)
+
+    DataHygiene::PublishingApiRepublisher.new(Edition.where(true), NullLogger.instance).perform
+
+    assert_requested published_request
+    assert_requested archived_request
+    assert_not_requested draft_request
+  end
+end


### PR DESCRIPTION
The changes to skip non-published things broke the republisher for non-`Edition` models. This makes it work for non-`Edition` instances, and also adds some tests
