### PR TITLE
Fix bug with supporting page url generation

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -68,7 +68,8 @@ module PublicDocumentRoutesHelper
   end
 
   def build_url_for_supporting_page(edition, options)
-    options.merge!(policy_id: edition.related_policies.first.document, id: edition.document)
+    options = options.merge(id: edition.document)
+    options[:policy_id] ||= edition.related_policies.first.document
     polymorphic_url('policy_supporting_page', options)
   end
 

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -54,6 +54,13 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     assert_equal policy_supporting_page_path(policy.document, supporting_page.document), public_document_path(supporting_page)
   end
 
+  test 'returns the policy_supporting_page path for SupportingPage instances for the specified policy' do
+    first_policy = create(:policy)
+    second_policy = create(:policy)
+    supporting_page = create(:supporting_page, related_policies: [first_policy, second_policy])
+    assert_equal policy_supporting_page_path(second_policy.document, supporting_page.document), public_document_path(supporting_page, policy_id: second_policy.document)
+  end
+
   test 'returns the correct path for CorporateInformationPage instances' do
     cip = create(:corporate_information_page)
     assert_equal organisation_corporate_information_page_path(cip.organisation, cip.slug), public_document_path(cip)


### PR DESCRIPTION
There was an issue with generating URLs for supporting pages that belong
to more than one policy.  The [code in the controller](https://github.com/alphagov/whitehall/blob/build-11392/app/controllers/supporting_pages_controller.rb#L10-L11) specifies the
policy to generate the URL for.  However, this option was being
overridden in the url helper.

This updates the URL helper to only set the policy if one hasn't been
given.

Pivotal: https://www.pivotaltracker.com/story/show/83388244
