### PR TITLE
Fix case study export migration.

### DIFF
--- a/db/data_migration/20141126112655_republish_case_studies_to_content_store.rb
+++ b/db/data_migration/20141126112655_republish_case_studies_to_content_store.rb
@@ -1,1 +1,1 @@
-DataHygiene::PublishingApiPublisher.new(CaseStudy.published).perform
+DataHygiene::PublishingApiRepublisher.new(CaseStudy.published).perform


### PR DESCRIPTION
Publisher class was renamed but migration referenced the old class.
