### PR TITLE
Add WorldwideOrganisations to content_store.

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -32,6 +32,8 @@ class WorldwideOrganisation < ActiveRecord::Base
   validates_with SafeHtmlValidator
   validates :name, presence: true
 
+  include PublishesToPublishingApi
+
   extend FriendlyId
   friendly_id
 

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -9,7 +9,8 @@ private
     {
       lead_organisations: edition.lead_organisations.map(&:content_id),
       supporting_organisations: edition.supporting_organisations.map(&:content_id),
-      world_locations: edition.world_locations.map(&:content_id)
+      world_locations: edition.world_locations.map(&:content_id),
+      worldwide_organisations: edition.worldwide_organisations.map(&:content_id)
     }
   end
 

--- a/db/data_migration/20141127125300_set_worldwide_org_content_ids.rb
+++ b/db/data_migration/20141127125300_set_worldwide_org_content_ids.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.connection.execute 'UPDATE worldwide_organisations SET content_id=UUID() where content_id IS NULL'

--- a/db/data_migration/20141127125955_publish_worldwide_orgs_to_content_store.rb
+++ b/db/data_migration/20141127125955_publish_worldwide_orgs_to_content_store.rb
@@ -1,0 +1,1 @@
+DataHygiene::PublishingApiRepublisher.new(WorldwideOrganisation).perform

--- a/db/migrate/20141127124535_add_content_id_to_worldwide_organisation.rb
+++ b/db/migrate/20141127124535_add_content_id_to_worldwide_organisation.rb
@@ -1,0 +1,5 @@
+class AddContentIdToWorldwideOrganisation < ActiveRecord::Migration
+  def change
+    add_column :worldwide_organisations, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141126143003) do
+ActiveRecord::Schema.define(:version => 20141127124535) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -1309,6 +1309,7 @@ ActiveRecord::Schema.define(:version => 20141126143003) do
     t.integer  "main_office_id"
     t.integer  "default_news_organisation_image_data_id"
     t.string   "analytics_identifier"
+    t.string   "content_id"
   end
 
   add_index "worldwide_organisations", ["default_news_organisation_image_data_id"], :name => "index_worldwide_organisations_on_image_data_id"

--- a/lib/govuk_content_schemas/case_study.json
+++ b/lib/govuk_content_schemas/case_study.json
@@ -158,6 +158,9 @@
         },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     }

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -52,7 +52,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       links: {
         lead_organisations: [case_study.lead_organisations.first.content_id],
         supporting_organisations: [],
-        world_locations: []
+        world_locations: [],
+        worldwide_organisations: []
       }
     }
     presented_hash = present(case_study)
@@ -111,7 +112,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     expected_links_hash = {
       lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
       supporting_organisations: [supporting_org.content_id],
-      world_locations: []
+      world_locations: [],
+      worldwide_organisations: []
     }
 
     assert_valid_against_schema('case_study', presented_hash.to_json)
@@ -142,6 +144,14 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     assert_equal [location.content_id], presented_hash[:links][:world_locations]
   end
 
+  test "links hash includes worldwide organisations" do
+    wworg = create(:worldwide_organisation)
+    case_study = create(:published_case_study,
+                        worldwide_organisations: [wworg])
+    presented_hash = present(case_study)
+    assert_valid_against_schema('case_study', presented_hash.to_json)
+    assert_equal [wworg.content_id], presented_hash[:links][:worldwide_organisations]
+  end
 private
 
   def assert_equal_hash(expected, actual)

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -25,6 +25,26 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     assert_equal expected_hash, present(organisation)
   end
 
+  test 'presents a Worldwide Organisation ready for adding to the publishing API' do
+    worldwide_org = create(:worldwide_organisation, name: 'Locationia Embassy')
+    public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)
+
+    expected_hash = {
+      content_id: worldwide_org.content_id,
+      title: "Locationia Embassy",
+      base_path: public_path,
+      format: "placeholder_worldwide_organisation",
+      locale: 'en',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: worldwide_org.updated_at,
+      routes: [ { path: public_path, type: "exact" } ],
+      update_type: "major",
+    }
+
+    assert_equal expected_hash, present(worldwide_org)
+  end
+
   test 'presents a World Location ready for adding to the publishing API' do
     world_location = create(:world_location, name: 'Locationia')
     public_path = Whitehall.url_maker.world_location_path(world_location)


### PR DESCRIPTION
Add content_ids to worldwide orgs, push them to the content store, and reference them from the CaseStudy links hash.
