### PR TITLE
Delete erroneously synced users

### DIFF
--- a/db/data_migration/20141128080155_fix_erroneously_synced_users_with_empty_permissions.rb
+++ b/db/data_migration/20141128080155_fix_erroneously_synced_users_with_empty_permissions.rb
@@ -1,0 +1,6 @@
+puts "Cleaning-up erroneously synced users who do not have not accessed Whitehall in the past."
+
+users_to_delete = User.where("created_at >= ?", Time.zone.parse('27-Nov-2014 10:50')).select { |user| user.permissions.blank? }
+number_of_users_deleted = User.delete_all(id: users_to_delete.map(&:id))
+
+puts "Done. Deleted #{number_of_users_deleted} users."


### PR DESCRIPTION
Signon push update rake task pushed information of users who had never used Publisher, so cleaning that up. see related: https://github.com/alphagov/signonotron2/pull/290
