### PR TITLE
Permit :id for nested attribute fatality notices

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -220,7 +220,7 @@ class Admin::EditionsController < Admin::BaseController
       nation_inapplicabilities_attributes: [
         :id, :nation_id, :alternative_url, :excluded
       ],
-      fatality_notice_casualties_attributes: [:personal_details, :_destroy],
+      fatality_notice_casualties_attributes: [:id, :personal_details, :_destroy],
       need_ids: []
     ]
   end


### PR DESCRIPTION
Following-up on: https://github.com/alphagov/whitehall/pull/1862

I missed adding this important bit of the fix, which permits the `:id` of the nested attribute to be destroyed, allowing rails to retrieve the correct associated record and destroy it.

The earlier PR already contains an integration test to test this behaviour.
