### PR TITLE
Revise grammar of organisation closed page

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -42,9 +42,9 @@ module OrganisationHelper
   def organisation_closed_govuk_status_description(organisation)
     if organisation.no_longer_exists?
       if organisation.closed_at.present?
-        "#{organisation.name} closed down in #{organisation.closed_at.to_s(:one_month_precision)}"
+        "#{organisation.name} closed in #{organisation.closed_at.to_s(:one_month_precision)}"
       else
-        "#{organisation.name} has closed down"
+        "#{organisation.name} has closed"
       end
     elsif organisation.replaced? || organisation.split?
       if organisation.closed_at.present?

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -116,14 +116,14 @@ class OrganisationHelperTest < ActionView::TestCase
   test '#organisation_govuk_status_description describes an organisation that no longer exists' do
     organisation = build(:closed_organisation, name: 'Beard Ministry')
 
-    assert_equal "Beard Ministry has closed down", organisation_govuk_status_description(organisation)
+    assert_equal "Beard Ministry has closed", organisation_govuk_status_description(organisation)
   end
 
   test '#organisation_govuk_status_description for an organisation that no longer exists includes the closed date if available' do
     closed_time = 1.day.ago
     organisation = build(:closed_organisation, name: 'Beard Ministry', closed_at: closed_time)
 
-    assert_equal "Beard Ministry closed down in November 2011", organisation_govuk_status_description(organisation)
+    assert_equal "Beard Ministry closed in November 2011", organisation_govuk_status_description(organisation)
   end
 
   test '#organisation_govuk_status_description describes an organisation that has been replaced' do


### PR DESCRIPTION
Does it close up? Or sideways? I make this pull request because the two most important pieces of information are Org Name, and whether it's closed or not....and my eye gets confused by the word "down".

Reference GOV.UK [content guidance](https://www.gov.uk/design-principles/style-guide/writing-for-the-web)....or TL;DR, shorter and to the pointer is gooder. 
