### PR TITLE
Fix topic changes test

### DIFF
--- a/test/integration/data_hygiene/tag_changes_processor_test.rb
+++ b/test/integration/data_hygiene/tag_changes_processor_test.rb
@@ -46,7 +46,7 @@ class TopicChangesProcessorTest < ActiveSupport::TestCase
 
   def publishing_worker_expects(editions)
     editions.each do |edition|
-      PublishingApiWorker.expects(:perform_async).with(edition.class.name, edition.id, 'republish').once
+      PublishingApiWorker.expects(:perform_async).with(edition.class.name, edition.id, 'republish', edition.locale.to_sym).once
     end
   end
 


### PR DESCRIPTION
The addition of a `locale` key to the PublishingApiWorker invocation broke the TopicChangesProcessor test. Add it to the expectation in the test.
