### PR TITLE
Bust ContentAPI cache when requesting live tags.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '14.5.0'
+gem 'gds-api-adapters', '17.0.1'
 gem 'whenever', '0.9.0', require: false
 gem 'mini_magick'
 gem 'shared_mustache', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.0)
     friendly_id (4.0.9)
-    gds-api-adapters (14.5.0)
+    gds-api-adapters (17.0.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -406,7 +406,7 @@ DEPENDENCIES
   equivalent-xml (= 0.3.0)
   factory_girl
   friendly_id (= 4.0.9)
-  gds-api-adapters (= 14.5.0)
+  gds-api-adapters (= 17.0.1)
   gds-sso (~> 10.0)
   globalize3!
   govspeak (~> 3.2.0)

--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -34,7 +34,7 @@ private
   end
 
   def self.fetch_live_sectors
-    Whitehall.content_api.tags('specialist_sector', draft: false)
+    Whitehall.content_api.tags('specialist_sector', draft: false, bust_cache: true)
   rescue
     raise DataUnavailable.new
   end

--- a/test/unit/specialist_sector_test.rb
+++ b/test/unit/specialist_sector_test.rb
@@ -81,6 +81,12 @@ class SpecialistSectorTest < ActiveSupport::TestCase
     assert_equal [@income_tax, @fields], SpecialistSector.live_subsectors
   end
 
+  test '.live_subsectors should cache bust the Content API request' do
+    SpecialistSector.live_subsectors
+
+    assert_requested :get, Regexp.new("#{Plek.find('content_api')}.*\\?(.*&)?cachebust=")
+  end
+
 private
   def use_real_content_api
     Whitehall.content_api = GdsApi::ContentApi.new(Plek.find('content_api'))


### PR DESCRIPTION
This prevents Whitehall endpoints using old data
when triggered by Panopticon immediately after
publishing a tag.

Followup to https://www.pivotaltracker.com/story/show/83216144
- [x] Tech review
- [x] Product review
