### PR TITLE
PublishingApiWorker handles deleted models

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -2,7 +2,9 @@ class PublishingApiWorker
   include Sidekiq::Worker
 
   def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
-    model     = class_for(model_name).find(id)
+    model     = class_for(model_name).find_by_id(id)
+    return unless model
+
     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)
 
     I18n.with_locale(locale) do

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -42,6 +42,10 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     )
   end
 
+  test "fails gracefully if the model cannot be found" do
+    PublishingApiWorker.new.perform('Edition', non_existant_id = 12)
+  end
+
   test "passes the update_type option to the presenter" do
     update_type = "republish"
 


### PR DESCRIPTION
Instead of raising an exception and retrying the job for the next 25 days, the worker should end gracefully if the model does not exist for whatever reason (usually because they've been deleted - see https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/547729b20da115b5cf00098e)
