### PR TITLE
Fix redirects on existing Unpublishings.

### DIFF
--- a/db/data_migration/20141204114251_convert_unpublishing_reasons_and_urls.rb
+++ b/db/data_migration/20141204114251_convert_unpublishing_reasons_and_urls.rb
@@ -18,6 +18,11 @@ Unpublishing.where('alternative_url like "https://whitehall-admin%"').each do |u
   unp.update_column(:alternative_url, new_url)
 end
 
+# Fix any alternative urls that have stray whitespace
+Unpublishing.where("alternative_url LIKE ' %'").each do |unpubishing|
+  unpubishing.update_column(:alternative_url, unpubishing.alternative_url.strip)
+end
+
 # Now fix deprecated unpublishing reasons. If they currently (after above fix)
 # redirect to a page on gov.uk, keep that redirect with reason 4 (consolidated
 # into another page), otherwise turn off redirect and use reason 1 (published in


### PR DESCRIPTION
Tidy up old Unpublishings that no longer validate according to current rules.
- Fix alternative_urls that point to whitehall-admin instead of gov.uk;
- Change instances of deprecated unpublishing_reason_ids 2 and 3 to currently valid 1 or 4, and change automatic redirect as necessary.
