### PR TITLE
Render archiving explanations as govspeak.

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -38,13 +38,17 @@ private
 
   def archive_notice
     {
-      explanation: edition.unpublishing.explanation,
+      explanation: unpublishing_explanation,
       archived_at: edition.updated_at
     }
   end
 
   def body
     Whitehall::EditionGovspeakRenderer.new(edition).body
+  end
+
+  def unpublishing_explanation
+    Whitehall::EditionGovspeakRenderer.new(edition).unpublishing_explanation
   end
 
   def image_available?

--- a/lib/whitehall/edition_govspeak_renderer.rb
+++ b/lib/whitehall/edition_govspeak_renderer.rb
@@ -11,6 +11,10 @@ module Whitehall
       helpers.govspeak_edition_to_html(edition)
     end
 
+    def unpublishing_explanation
+      helpers.govspeak_to_html(edition.unpublishing.explanation) if edition.unpublishing.try(:explanation).present?
+    end
+
   private
 
     # Because the govspeak helpers in whitehall rely on rendering partials, we

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -184,7 +184,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     case_study.unpublishing.save!
 
     archive_notice = {
-      explanation: "No longer relevant",
+      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
       archived_at: case_study.updated_at
     }
 

--- a/test/unit/whitehall/edition_govspeak_renderer_test.rb
+++ b/test/unit/whitehall/edition_govspeak_renderer_test.rb
@@ -5,7 +5,7 @@ class Whitehall::EditionGovspeakRendererTest < ActiveSupport::TestCase
     edition = build(:edition, body: 'Some content')
 
     assert_equivalent_html '<div class="govspeak"><p>Some content</p></div>',
-      render_govspeak(edition)
+      render_govspeak(edition).body
   end
 
   test "interpolates images into rendered HTML" do
@@ -14,7 +14,7 @@ class Whitehall::EditionGovspeakRendererTest < ActiveSupport::TestCase
     edition.stubs(:images).returns([image])
 
     assert_equivalent_html govspeak_with_image_html(image),
-      render_govspeak(edition)
+      render_govspeak(edition).body
   end
 
   test "converts inline attachments" do
@@ -23,13 +23,20 @@ class Whitehall::EditionGovspeakRendererTest < ActiveSupport::TestCase
       attachment_1 = build(:file_attachment, id: 1),
       attachment_2 = build(:file_attachment, id: 2)
     ])
-    html = render_govspeak(edition)
+    html = render_govspeak(edition).body
     assert_select_within_html html, "#attachment_#{attachment_1.id}"
     assert_select_within_html html, "#attachment_#{attachment_2.id}"
   end
 
+  test "renders govspeak in archiving_explanation" do
+    edition = build(:edition, body: 'Some content')
+    edition.unpublishing = build(:unpublishing, edition: edition, explanation: 'Some explanation')
+    assert_equivalent_html '<div class="govspeak"><p>Some explanation</p></div>',
+      render_govspeak(edition).unpublishing_explanation
+  end
+
   def render_govspeak(edition)
-    Whitehall::EditionGovspeakRenderer.new(edition).body
+    Whitehall::EditionGovspeakRenderer.new(edition)
   end
 
 private


### PR DESCRIPTION
We allow govspeak in the unpublishing/archiving explanation box, so this needs to be rendered on publishing to content-store.
