### PR TITLE
Feedback when no editions are found

### DIFF
--- a/app/views/admin/classification_featurings/_featured_documents.html.erb
+++ b/app/views/admin/classification_featurings/_featured_documents.html.erb
@@ -1,32 +1,38 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th>Type</th>
-      <th>Title</th>
-      <th>Published</th>
-      <th></th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @tagged_editions.each do |edition| %>
-      <%= content_tag_for :tr, edition do %>
-        <td class="type"><%= edition.type.titleize %></td>
-        <td><%= link_to edition.title, admin_edition_path(edition) %></td>
-        <td><%=localize edition.major_change_published_at.to_date %></td>
-        <% featuring = @classification.featuring_of(edition) %>
-        <td><%= "Featured" if featuring %></td>
-        <td>
-          <% if featuring %>
-            <%= form_for([:admin, @classification, featuring], method: :delete, html: {class: "button_to"}) do |f| %>
-              <%= f.submit "Unfeature", class: "btn btn-danger" %>
-            <% end %>
-          <% else %>
-            <%= link_to "Feature", polymorphic_path([:new, :admin, @classification, :classification_featuring], edition_id: edition.id), class: "btn" %>
+<% if @tagged_editions.present? %>
+  <table class="table table-striped">
+    <thead>
+      <tr class="table-header">
+        <th>Type</th>
+        <th>Title</th>
+        <th>Published</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+        <% @tagged_editions.each do |edition| %>
+          <%= content_tag_for :tr, edition do %>
+            <td class="type"><%= edition.type.titleize %></td>
+            <td><%= link_to edition.title, admin_edition_path(edition) %></td>
+            <td><%=localize edition.major_change_published_at.to_date %></td>
+            <% featuring = @classification.featuring_of(edition) %>
+            <td><%= "Featured" if featuring %></td>
+            <td>
+              <% if featuring %>
+                <%= form_for([:admin, @classification, featuring], method: :delete, html: {class: "button_to"}) do |f| %>
+                  <%= f.submit "Unfeature", class: "btn btn-danger" %>
+                <% end %>
+              <% else %>
+                <%= link_to "Feature", polymorphic_path([:new, :admin, @classification, :classification_featuring], edition_id: edition.id), class: "btn" %>
+              <% end %>
+            </td>
           <% end %>
-        </td>
-      <% end %>
-    <% end %>
-  </tbody>
-</table>
-<%= paginate @tagged_editions, theme: 'twitter-bootstrap' %>
+        <% end %>
+    </tbody>
+  </table>
+  <%= paginate @tagged_editions, theme: 'twitter-bootstrap' %>
+<% else %>
+  <div class="add-top-margin no-content no-content-bordered">
+    No documents found
+  </div>
+<% end %>

--- a/app/views/admin/classification_featurings/index.html.erb
+++ b/app/views/admin/classification_featurings/index.html.erb
@@ -26,7 +26,7 @@
   <% end %>
 
   <hr />
-  <h2 class="feature-title add-bottom-margin">Feature new documents</h2>
+  <h2 class="feature-title add-bottom-margin">Feature new documents tagged with ‘<%= @classification.name %>’</h2>
 
   <div class="row-fluid">
     <div class="span3">

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -68,6 +68,16 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     assert_equal [news_article], tagged_editions
   end
 
+  view_test "GET :index contains a message when no results matching search criteria were found" do
+    create(:published_news_article, topics: [@topic])
+    news_article = create(:published_news_article, topics: [@topic])
+
+    get :index, topic_id: create(:topic)
+
+    assert_equal 0, assigns(:tagged_editions).count
+    assert_match 'No documents found', response.body
+  end
+
   test "PUT :order saves the new order of featurings" do
     feature1 = create(:classification_featuring, classification: @topic)
     feature2 = create(:classification_featuring, classification: @topic)


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8827

editors are getting confused and think that editions filter is not working. also, updated the search results title to include the classification scope that would be applied.

![screen shot 2014-12-08 at 17 12 18](https://cloud.githubusercontent.com/assets/230074/5338969/49810c64-7f00-11e4-926c-f3bcb26513bd.png)
