### PR TITLE
Correct `dependent: :destroy` for CIPs

### DIFF
--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -2,7 +2,10 @@ module HasCorporateInformationPages
   extend ActiveSupport::Concern
 
   included do
-    has_many :corporate_information_pages, dependent: :destroy, through: "edition_#{table_name}".to_sym, source: :edition, class_name: "CorporateInformationPage"
+    has_many :corporate_information_pages, through: "edition_#{table_name}".to_sym, source: :edition, class_name: "CorporateInformationPage"
+    before_destroy do |record|
+      record.corporate_information_pages.map { |cip| cip.document.destroy }
+    end
   end
 
   def summary

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,6 +2,7 @@ class Organisation < ActiveRecord::Base
   include PublishesToPublishingApi
   include Searchable
   include Organisation::OrganisationTypeConcern
+  include HasCorporateInformationPages
 
   DEFAULT_JOBS_URL = 'https://www.civilservicejobs.service.gov.uk/csr'
 
@@ -119,8 +120,6 @@ class Organisation < ActiveRecord::Base
   has_many :featured_links, as: :linkable, dependent: :destroy, order: :created_at
   accepts_nested_attributes_for :featured_links, reject_if: -> attributes { attributes['url'].blank? }, allow_destroy: true
   validates :homepage_type, inclusion: {in: %w{news service}}
-
-  include HasCorporateInformationPages
 
   accepts_nested_attributes_for :default_news_image, reject_if: :all_blank
   accepts_nested_attributes_for :organisation_roles

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -1,4 +1,6 @@
 class WorldwideOrganisation < ActiveRecord::Base
+  include HasCorporateInformationPages
+
   PRIMARY_ROLES = [AmbassadorRole, HighCommissionerRole, GovernorRole]
 
   has_many :worldwide_organisation_world_locations, dependent: :destroy
@@ -18,8 +20,6 @@ class WorldwideOrganisation < ActiveRecord::Base
   accepts_nested_attributes_for :default_news_image, reject_if: :all_blank
 
   scope :ordered_by_name, ->() { with_translations(I18n.default_locale).order(translation_class.arel_table[:name]) }
-
-  include HasCorporateInformationPages
 
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = 'WO'

--- a/db/data_migration/20141209072457_destroy_orphaned_corporate_information_pages.rb
+++ b/db/data_migration/20141209072457_destroy_orphaned_corporate_information_pages.rb
@@ -1,0 +1,9 @@
+puts "Destroying corporate information pages without an owning organisation"
+
+orphaned_cip_ids = CorporateInformationPage.pluck(:id) -
+                    CorporateInformationPage.joins(:organisation).pluck(:id) -
+                    CorporateInformationPage.joins(:worldwide_organisation).pluck(:id)
+
+CorporateInformationPage.where(id: orphaned_cip_ids).map { |cip| cip.document.destroy } # also deletes editions
+
+puts "Deleted #{orphaned_cip_ids.count} orphaned corporate information page editions having ids: #{orphaned_cip_ids.to_sentence}"

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -512,6 +512,13 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_nil user.reload.organisation_slug
   end
 
+  test 'destroys associated corporate information page documents and editions' do
+    organisation = create(:corporate_information_page).organisation
+    assert_difference %w(Organisation.count Document.count CorporateInformationPage.count), -1 do
+      organisation.destroy
+    end
+  end
+
   test 'should use full name as display_name if acronym is an empty string' do
     assert_equal 'Blah blah', build(:organisation, acronym: '', name: 'Blah blah').display_name
   end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -65,6 +65,15 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     refute AccessAndOpeningTimes.exists?(office_access_info)
   end
 
+  test 'destroys associated corporate information page documents and editions' do
+    worldwide_organisation = create(:worldwide_organisation)
+    create(:corporate_information_page, worldwide_organisation: worldwide_organisation, organisation: nil)
+
+    assert_difference %w(WorldwideOrganisation.count Document.count CorporateInformationPage.count), -1 do
+      worldwide_organisation.destroy
+    end
+  end
+
   test "has an overridable default main office" do
     worldwide_organisation = create(:worldwide_organisation)
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8853

there's a `dependent: destroy` on organisations to destroy associated corporate information pages when the organisation is deleted. in spite of that few orphaned CIPs exist: 336462, 336498, 363483. included data migration gets rid of these orphaned corporate information page editions and documents.

there are changes in 2 places to fix this issue:
1. `dependent: :destroy` on `corporate_information_pages` association only destroys the record in the join table and not the corporate information page edition. so the fix is to have an explicit `before_destroy` to clean corporate information editions and documents.
2. callbacks are invoked in the order in which they're declared. if the `before_destroy` to destroy corporate information gets registered before the `:edition_organisation, dependent: :destroy` this will work. else, when the callback tries to destroy related corporate information pages it won't be able to fetch the related corporate information editions because the linking record is gone.
