### PR TITLE
Check for markup equivalence, not string match

### DIFF
--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -183,13 +183,11 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
     case_study.unpublishing.save!
 
-    archive_notice = {
-      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
-      archived_at: case_study.updated_at
-    }
-
     assert_valid_against_schema('case_study', present(case_study).to_json)
-    assert_equal archive_notice, present(case_study)[:details][:archive_notice]
+    assert_equal case_study.updated_at,
+      present(case_study)[:details][:archive_notice][:archived_at]
+    assert_equivalent_html "<div class=\"govspeak\"><p>No longer relevant</p></div>",
+      present(case_study)[:details][:archive_notice][:explanation]
   end
 
 private


### PR DESCRIPTION
This gets around the issue of different versions of libxml generating subtly
different whitespace/newline output.
