### PR TITLE
Add more links to services and information pages

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -458,7 +458,11 @@ class Organisation < ActiveRecord::Base
   def organisations_with_services_and_information_link
     %w{
       charity-commission
+      department-for-education
+      driver-and-vehicle-standards-agency
       environment-agency
+      high-speed-two-limited
+      hm-revenue-customs
       marine-management-organisation
       maritime-and-coastguard-agency
       natural-england


### PR DESCRIPTION
This commit turns on the link for the HMRC services and information
page: this is a time-critical change which needs to go out on Wednesday
10th December - and HMRC will need to be informed so that they can
remove a duplicate link from their organisation page when it has been
deployed.

It also adds links for several other organisations (DfE, HS2, DVSA);
these ones are not time-critical.
- [x] Tech review
- [x] Product review
