### PR TITLE
More unpublishing repairs

### DIFF
--- a/db/data_migration/20141209152607_do_not_auto_redirect_non_gov_uk_links.rb
+++ b/db/data_migration/20141209152607_do_not_auto_redirect_non_gov_uk_links.rb
@@ -1,0 +1,13 @@
+auto_redirects_with_non_govuk_url = Unpublishing.where(redirect: true).
+                                       where("alternative_url NOT LIKE ? AND alternative_url NOT LIKE ?",
+                                        'https://www.gov.uk%', 'http://www.dev.gov.uk%' )
+number = auto_redirects_with_non_govuk_url.count
+
+puts "Fixing auto-redirects for non-GOVUK urls"
+auto_redirects_with_non_govuk_url.each do |unpublishing|
+  puts "ID: #{unpublishing.id}, URL: #{unpublishing.alternative_url}"
+  unpublishing.unpublishing_reason_id = UnpublishingReason::PublishedInError.id
+  unpublishing.redirect = false
+  unpublishing.save(validate: false)
+end
+puts "#{number} unpublishings that no longer auto-redirect"


### PR DESCRIPTION
This converts a bunch of auto-redirecting unpublishings so that they do not
automatically redirect as they are not on GOV.UK. Instead, a splash page will be
shown. This is because the Publishing 2.0 stack does not support non-GOVUK
redirects at present, and whitehall Unpublishings are not valid without a GOVUK
alternative URL.

Follow up to this story: https://trello.com/c/nqvBhUVg/83-clean-up-existing-unpublishings
