### PR TITLE
Add id to join tables to support dependent destroy

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -22,7 +22,7 @@ class Organisation < ActiveRecord::Base
   has_many :edition_organisations, dependent: :destroy
   has_many :editions, through: :edition_organisations
 
-  has_many :statistics_announcement_organisations, dependent: :delete_all
+  has_many :statistics_announcement_organisations, dependent: :destroy
   has_many :statistics_announcements, through: :statistics_announcement_organisations
 
   has_many :organisation_roles

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -9,10 +9,10 @@ class StatisticsAnnouncement < ActiveRecord::Base
   has_one  :current_release_date, class_name: 'StatisticsAnnouncementDate', order: 'created_at DESC', inverse_of: :statistics_announcement
   has_many :statistics_announcement_dates, dependent: :destroy
 
-  has_many :statistics_announcement_topics, dependent: :delete_all
+  has_many :statistics_announcement_topics, dependent: :destroy
   has_many :topics, through: :statistics_announcement_topics
 
-  has_many :statistics_announcement_organisations, dependent: :delete_all
+  has_many :statistics_announcement_organisations, dependent: :destroy
   has_many :organisations, through: :statistics_announcement_organisations
 
   validate  :publication_is_matching_type, if: :publication

--- a/db/migrate/20141210091101_add_id_to_statistics_announcement_organisations.rb
+++ b/db/migrate/20141210091101_add_id_to_statistics_announcement_organisations.rb
@@ -1,0 +1,5 @@
+class AddIdToStatisticsAnnouncementOrganisations < ActiveRecord::Migration
+  def change
+    add_column :statistics_announcement_organisations, :id, :primary_key
+  end
+end

--- a/db/migrate/20141210093620_add_id_to_statistics_announcement_topics.rb
+++ b/db/migrate/20141210093620_add_id_to_statistics_announcement_topics.rb
@@ -1,0 +1,5 @@
+class AddIdToStatisticsAnnouncementTopics < ActiveRecord::Migration
+  def change
+    add_column :statistics_announcement_topics, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141209093141) do
+ActiveRecord::Schema.define(:version => 20141210093620) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -1070,7 +1070,7 @@ ActiveRecord::Schema.define(:version => 20141209093141) do
   add_index "statistics_announcement_dates", ["creator_id"], :name => "index_statistics_announcement_dates_on_creator_id"
   add_index "statistics_announcement_dates", ["statistics_announcement_id", "created_at"], :name => "statistics_announcement_release_date"
 
-  create_table "statistics_announcement_organisations", :id => false, :force => true do |t|
+  create_table "statistics_announcement_organisations", :force => true do |t|
     t.integer  "statistics_announcement_id"
     t.integer  "organisation_id"
     t.datetime "created_at",                 :null => false
@@ -1080,7 +1080,7 @@ ActiveRecord::Schema.define(:version => 20141209093141) do
   add_index "statistics_announcement_organisations", ["organisation_id"], :name => "index_statistics_announcement_organisations_on_organisation_id"
   add_index "statistics_announcement_organisations", ["statistics_announcement_id", "organisation_id"], :name => "index_on_statistics_announcement_id_and_organisation_id"
 
-  create_table "statistics_announcement_topics", :id => false, :force => true do |t|
+  create_table "statistics_announcement_topics", :force => true do |t|
     t.integer  "statistics_announcement_id"
     t.integer  "topic_id"
     t.datetime "created_at",                 :null => false

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -202,6 +202,20 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_includes announcement.reload.organisations, organisation
   end
 
+  test '#destroy destroys organisation associations' do
+    statistics_announcement = create(:statistics_announcement)
+    assert_difference %w(StatisticsAnnouncement.count StatisticsAnnouncementOrganisation.count), -1 do
+      statistics_announcement.destroy
+    end
+  end
+
+  test '#destroy destroys topic associations' do
+    statistics_announcement = create(:statistics_announcement)
+    assert_difference %w(StatisticsAnnouncement.count StatisticsAnnouncementTopic.count), -1 do
+      statistics_announcement.destroy
+    end
+  end
+
   test 'StatisticsAnnouncement.with_topics scope returns announcements with matching topics' do
     topic1 = create(:topic)
     topic2 = create(:topic)


### PR DESCRIPTION
we use `dependent: :destroy` in most places to get rid of associated records when the parent record is destroyed.

`statistics_announcement_topics` and `statistics_announcement_organisations` join tables didn't have an `id` primary key because of which we can't `dependent: :destroy` them. rails requires the `id` primary key for cascade destroys to work. going forward if we add any callback to the association objects they will get missed when a cascade destroy happens.

this change adds the `id` column to these tables to prevent that.