### PR TITLE
Change schools colleges policy slug

### DIFF
--- a/db/data_migration/20141210090358_change_slug_for_schools_colleges_policy_document.rb
+++ b/db/data_migration/20141210090358_change_slug_for_schools_colleges_policy_document.rb
@@ -9,10 +9,10 @@ policy = Policy.published_as(slug)
 supporting_pages = policy.published_supporting_pages
 
 # remove the old versions from the search index
-Whitehall::SearchIndex.for(:government).delete(policy)
+Whitehall::SearchIndex.delete(policy)
 
 supporting_pages.each do |supporting_page|
-  Whitehall::SearchIndex.for(:government).delete(supporting_page)
+  Whitehall::SearchIndex.delete(supporting_page)
 end
 
 # change the slug on the parent document
@@ -20,14 +20,14 @@ policy.document.slug = new_slug
 policy.document.save!
 
 # re-index the new versions
-Whitehall::SearchIndex.for(:government).add(policy)
+Whitehall::SearchIndex.add(policy)
 
 supporting_pages.each do |supporting_page|
-  Whitehall::SearchIndex.for(:government).add(supporting_page)
+  Whitehall::SearchIndex.add(supporting_page)
 end
 
 # set the redirect
-router.add_redirect_route("/government/policy/#{slug}",
-                          'exact',
-                          "/government/policy/#{new_slug}")
+router.add_redirect_route("/government/policies/#{slug}",
+                          'prefix',
+                          "/government/policies/#{new_slug}")
 router.commit_routes


### PR DESCRIPTION
This is a rework of this pull request: #1893
- This should remove the policy and its supporting pages from the search index
- Update the policy slug
- Re-add the policy and its supporting pages to the search index
- Add a prefix redirect to the router to redirect both the policy and the supporting pages to the new location

Requested in: https://www.pivotaltracker.com/story/show/83664248

Do I also need add a matching redirect to router data?
