### PR TITLE
Re-index statistics announcements on org changes

### DIFF
--- a/lib/whitehall/organisation_slug_changer.rb
+++ b/lib/whitehall/organisation_slug_changer.rb
@@ -46,6 +46,12 @@ class Whitehall::OrganisationSlugChanger
     organisation.editions.published.find_each do |edition|
       ServiceListeners::SearchIndexer.new(edition).index!
     end
+
+    logger.info "Re-registering #{new_slug} statistics announcements without publications in search"
+    organisation.statistics_announcements.without_published_publication.find_each do |statistics_announcement|
+      ServiceListeners::SearchIndexer.new(statistics_announcement).index!
+    end
+
     logger.info "Complete.\n\nThe following entries should be added to router-data:\n"
     logger.info router_data_csv_lines
   end

--- a/test/unit/whitehall/organisation_slug_changer_test.rb
+++ b/test/unit/whitehall/organisation_slug_changer_test.rb
@@ -90,5 +90,15 @@ module Whitehall
 
       @slug_changer.call
     end
+
+    test 're-registers in search any statistics announcements with published publications associated with the organisation' do
+      statistics_announcement = create(:statistics_announcement, organisations: [@organisation])
+
+      indexer = mock("indexer")
+      indexer.expects(:index!)
+      ServiceListeners::SearchIndexer.expects(:new).with(statistics_announcement).returns(indexer)
+
+      @slug_changer.call
+    end
   end
 end


### PR DESCRIPTION
When an organisation changes its slug we also need to re-index the
statistics announcements as they store the organisation slugs in the
search index. They are like editions in many ways but aren't actually a
type of edition so weren't picked up the first time around.

This was noticed because some Ofqual announcements aren't listed
in the right index: https://www.pivotaltracker.com/story/show/84297826
