### PR TITLE
Show unpublishing information on drafts

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -119,7 +119,7 @@ module Admin
     end
 
     def editions_with_translations(locale = nil)
-      editions_without_translations = unpaginated_editions.includes(:last_author).order("editions.updated_at DESC")
+      editions_without_translations = unpaginated_editions.includes(:last_author, :unpublishing).order("editions.updated_at DESC")
 
       if locale
         editions_without_translations.with_translations(locale)

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -56,6 +56,10 @@
             <% if edition.non_english_edition? %>
               (<%= edition.locale %>)
             <% end %>
+            <% # TODO: remove unpublishing information once we have a separate state for unpublished editions
+              if edition.unpublishing.present? %>
+              unpublished <%= time_ago_in_words(edition.unpublishing.created_at) %> ago
+            <% end %>
             <% if edition.force_published? %>
               <span class="force_published label label-important">not reviewed</span>
             <% end %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -5,7 +5,12 @@
     <dt>Type of document:</dt>
     <dd><%= edition_type(@edition) %></dd>
     <dt>Status:</dt>
-    <dd><%= @edition.state.capitalize %></dd>
+    <dd>
+      <% status_text = [@edition.state.capitalize]
+         # TODO: remove unpublishing information once we have a separate state for unpublished editions
+         status_text << "unpublished #{time_ago_in_words(@edition.unpublishing.created_at)} ago" if @edition.unpublishing.present? %>
+      <%= status_text.join(', ') %>
+    </dd>
     <dt>Change type:</dt>
     <dd><%= @edition.minor_change? ? 'Minor' : 'Major' %></dd>
     <% if @edition.respond_to?(:organisations) %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -33,7 +33,8 @@
       <% end %>
 
       <%= reject_edition_button(@edition) if @edition.can_reject? && can?(:reject, @edition) %>
-      <%= delete_edition_button(@edition) if @edition.can_delete? %>
+      <%= # TODO: remove condition based on unpublishing once we have a separate state for unpublished editions
+        delete_edition_button(@edition) if @edition.can_delete? && @edition.unpublishing.nil? %>
       <% if can?(:unpublish, @edition) %>
         <% if @edition.can_unpublish? %>
           <%= link_to 'Archive or unpublish', confirm_unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version), class: "btn btn-danger" %>

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -98,3 +98,9 @@ Then /^I should be redirected to the new url when I view the document on the pub
   visit public_document_path(edition)
   assert_current_url edition.unpublishing.alternative_url
 end
+
+Then /^I should not be able to discard the draft resulting from the unpublishing$/ do
+  visit admin_edition_path(Edition.last)
+  refute page.has_button?('Discard draft')
+end
+

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -18,6 +18,12 @@ Feature: Unpublishing published documents
     When I unpublish the document because it was published in error
     Then I should see that the document was published in error at the original url
 
+  Scenario: Draft resulting from an unpublishing should not be deletable
+    Given I am a managing editor
+    And a published document exists with a slug that does not match the title
+    When I unpublish the document because it was published in error
+    Then I should not be able to discard the draft resulting from the unpublishing
+
   Scenario: Unpublishing a document and redirecting
     Given I am a managing editor
     And a published document "Published by accident" exists

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -52,6 +52,14 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_match "Everyone’s documents", response_html.children[0].text()
   end
 
+  view_test '#index should show unpublishing information' do
+    edition = create(:unpublished_edition)
+    xhr :get, :index, state: :active
+
+    assert_select 'td.title', text: /edition.title/
+    assert_select 'td.title', text: /unpublished less than a minute ago/
+  end
+
   test "diffing against a previous version" do
     policy = create(:draft_policy)
     editor = create(:departmental_editor)
@@ -298,6 +306,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_template :show
     assert_equal 'News article', imported_news_article.reload.title
   end
+
 
   def stub_edition_filter(attributes = {})
     default_attributes = {


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8902

content designers need to know when a draft is a fresh draft as opposed to a draft that resulted from an unpublishing. this is a temporary fix whilst we create a state called 'unpublished' to represent such editions.

![screen shot 2014-12-15 at 15 52 36](https://cloud.githubusercontent.com/assets/319055/5438743/77ffa43e-8472-11e4-90cf-b141c064dda2.png)
![screen shot 2014-12-15 at 15 52 48](https://cloud.githubusercontent.com/assets/319055/5438744/78006f36-8472-11e4-887f-1a8af1321465.png)
