### PR TITLE
Fix currently broken data migration

### DIFF
--- a/db/data_migration/20141209072457_destroy_orphaned_corporate_information_pages.rb
+++ b/db/data_migration/20141209072457_destroy_orphaned_corporate_information_pages.rb
@@ -4,6 +4,6 @@ orphaned_cip_ids = CorporateInformationPage.pluck(:id) -
                     CorporateInformationPage.joins(:organisation).pluck(:id) -
                     CorporateInformationPage.joins(:worldwide_organisation).pluck(:id)
 
-CorporateInformationPage.where(id: orphaned_cip_ids).map { |cip| cip.document.destroy } # also deletes editions
+CorporateInformationPage.where(id: orphaned_cip_ids).map { |cip| cip.document.try(:destroy) } # also deletes editions
 
 puts "Deleted #{orphaned_cip_ids.count} orphaned corporate information page editions having ids: #{orphaned_cip_ids.to_sentence}"


### PR DESCRIPTION
Because the orphan CIP pages may belong to the same document, the document might not exist as it may have been destroyed already in a previous iteration.
