### PR TITLE
Turn scoped search on for the CMA

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -470,6 +470,7 @@ class Organisation < ActiveRecord::Base
 
   def organisations_with_scoped_search
     [
+      'competition-and-markets-authority',
       'environment-agency',
       'land-registry',
       'legal-aid-agency',


### PR DESCRIPTION
Tara's analysis indicates that it's likely to be an improvement to turn
scoped search on for the CMA, though it's not as clear as for other
organisations we've turned this on for.  We'll watch this closely; it
may be that we need to filter to a group of organisations, rather than
just to CMA content.
- [x] Tech review
- [x] Product review
