### PR TITLE
Update all service and info styling

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -246,6 +246,14 @@
       @include media(tablet) {
         margin-bottom: $gutter;
       }
+      .see-all {
+        @include bold-16;
+        margin-top: $gutter-one-sixth;
+
+        @include media(tablet) {
+          margin-left: $gutter-two-thirds;
+        }
+      }
     }
 
     &.service-priority {


### PR DESCRIPTION
So that it doesn't look out of place on the page. We didn't do this the
first time round because there were no examples of orgs with news
priority links but with a service and info link so it got forgotten.

Old:

![screen shot 2014-12-17 at 11 19 07](https://cloud.githubusercontent.com/assets/35035/5470392/f7acc79e-85de-11e4-825e-1195ba0d1bf8.png)

New:

![screen shot 2014-12-17 at 11 19 13](https://cloud.githubusercontent.com/assets/35035/5470394/fa39da9c-85de-11e4-8308-fd08a2f0f065.png)
