### PR TITLE
Support query params and fragment in redirect URL

### DIFF
--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -56,7 +56,12 @@ private
   end
 
   def alternative_path
-    URI.parse(unpublishing.alternative_url).path
+    uri = URI.parse(unpublishing.alternative_url)
+    URI::Generic.build(
+      path: uri.path,
+      query: uri.query,
+      fragment: uri.fragment
+    ).to_s
   end
 
   def details

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -193,4 +193,15 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     assert_equal expected_hash, presenter.as_json
     assert_valid_against_schema(presenter.as_json, 'redirect')
   end
+
+  test 'redirect representations can contain query paramters and anchor tags' do
+    alternative_path = '/page?param=1#subheading'
+    unpublishing     = create(:redirect_unpublishing,
+      alternative_url: Whitehall.public_root + alternative_path)
+
+    presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
+    presented_hash = presenter.as_json
+
+    assert_equal alternative_path, presented_hash[:redirects][0][:destination]
+  end
 end


### PR DESCRIPTION
Content store has now been changed to [support anchor fragments and query parameters](https://github.com/alphagov/content-store/pull/93).

However the Unpublishing presenter currently [strips these off when sending them to content store](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api_presenters/unpublishing.rb#L59).

This change ensures that the anchor fragment and query parameters are preserved.

We use URI::Generic.build to compose the pieces of the URI, rather than trying to do anything too clever with regexps.

Trello story:
https://trello.com/c/sMBwhDUN/98-alternate-url-of-unpublishings-should-support-anchor-fragment-and-query-parameters
