### PR TITLE
Move details section from bottom to top of document page

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -72,7 +72,7 @@
     @include ig-core-19;
     margin: $gutter-one-sixth 0 $gutter-one-sixth $gutter-two-thirds;
     @include media (tablet) {
-      margin: $gutter-one-third 0 $gutter-one-third $gutter-two-thirds;
+      margin: $gutter-one-third 0 $gutter-one-third 0;
     }
     ul, ol {
       margin: 0 0 0 $gutter-two-thirds;
@@ -86,7 +86,7 @@
     @include right-to-left {
       margin: $gutter-one-sixth $gutter-two-thirds $gutter-one-sixth 0;
       @include media (tablet) {
-        margin: $gutter-one-third $gutter-two-thirds $gutter-one-third 0;
+        margin: $gutter-one-third 0 $gutter-one-third 0;
       }
       ul, ol {
         margin: 0 $gutter-two-thirds 0 0;
@@ -108,7 +108,7 @@
     @include ig-core-19;
     margin: $gutter-one-sixth 0 $gutter-one-sixth $gutter-two-thirds;
     @include media (tablet) {
-      margin: $gutter-one-third 0 $gutter-one-third $gutter-two-thirds;
+      margin: $gutter-one-third 0 $gutter-one-third 0;
     }
     ul, ol {
       margin: 0 0 0 $gutter-two-thirds;
@@ -122,7 +122,7 @@
     @include right-to-left {
       margin: $gutter-one-sixth $gutter-two-thirds $gutter-one-sixth 0;
       @include media (tablet) {
-        margin: $gutter-one-third $gutter-two-thirds $gutter-one-third 0;
+        margin: $gutter-one-third 0 $gutter-one-third 0;
       }
       ul, ol {
         margin: 0 $gutter-two-thirds 0 0;

--- a/app/assets/stylesheets/frontend/views/_new-document-page.scss
+++ b/app/assets/stylesheets/frontend/views/_new-document-page.scss
@@ -20,14 +20,23 @@
     }
   }
 
+  #details {
+    margin-bottom: $gutter*2;
+    .govspeak {
+      ul {
+        margin-left: 0;
+      }
+    }
+  }
+
   .summary {
     padding-bottom: $gutter-two-thirds;
     @include media(tablet) {
-      padding-bottom: $gutter + $gutter-half;
+      padding-bottom: $gutter;
     }
 
     p {
-      @include ig-core-24;
+      @include core-24;
     }
   }
 

--- a/app/assets/stylesheets/frontend/views/_new-document-page.scss
+++ b/app/assets/stylesheets/frontend/views/_new-document-page.scss
@@ -22,9 +22,9 @@
 
   #details {
     margin-bottom: $gutter*2;
-    .govspeak {
-      ul {
-        margin-left: 0;
+    @include media(tablet) {
+      .govspeak {
+        max-width: $two-thirds;
       }
     }
   }

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -16,6 +16,10 @@
   <div>
     <div class="inner-block">
       <%= render partial: "document_summary", locals: { document: @document } %>
+
+      <section id="details">
+              <%= govspeak_edition_to_html @document %>
+      </section>
     </div>
   </div>
 
@@ -23,23 +27,6 @@
     <div class="inner-block">
       <%= render partial: "documents/attachment_full_width",
                  locals: { document: @document } %>
-    </div>
-  </div>
-
-  <div class="block-3 heading-block">
-    <div class="inner-block">
-      <section id="details">
-        <div class="head-section">
-          <h1><%= t('publications.headings.detail') %></h1>
-        </div>
-        <div class="content">
-          <article>
-            <div class="body">
-              <%= govspeak_edition_to_html @document %>
-            </div>
-          </article>
-        </div>
-      </section>
     </div>
   </div>
 

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -17,9 +17,9 @@
     <div class="inner-block">
       <%= render partial: "document_summary", locals: { document: @document } %>
 
-      <section id="details">
-              <%= govspeak_edition_to_html @document %>
-      </section>
+      <div id="details">
+        <%= govspeak_edition_to_html @document %>
+      </div>
     </div>
   </div>
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -45,7 +45,7 @@ class PublicationsControllerTest < ActionController::TestCase
       get :show, id: publication.document
     end
 
-    assert_select ".body", text: "body-in-html"
+    assert_select ".govspeak", text: "body-in-html"
   end
 
   view_test "#show should not explicitly say that publication applies to the whole of the UK" do


### PR DESCRIPTION
• move markup
• remove details heading
• remove unneeded markup
• update styling to match new design (spacing mainly)

https://www.agileplannerapp.com/boards/105200/cards/8943

Screenshots of before and after
![screen shot 2014-12-18 at 11 14 01](https://cloud.githubusercontent.com/assets/1692222/5487216/19fc8a50-86a7-11e4-99d8-f78769c729b1.png)
![screen shot 2014-12-18 at 11 13 29](https://cloud.githubusercontent.com/assets/1692222/5487217/19fc8e24-86a7-11e4-881c-7db883b17b8f.png)
