### PR TITLE
Add "UK and the Commonwealth" international delegation.

### DIFF
--- a/db/data_migration/20141218113852_add_uk_commonwealth_international_delegation.rb
+++ b/db/data_migration/20141218113852_add_uk_commonwealth_international_delegation.rb
@@ -1,0 +1,5 @@
+WorldLocation.create!(
+  :name => "UK and the Commonwealth",
+  :title => "UK and the Commonwealth",
+  :world_location_type => WorldLocationType::InternationalDelegation
+)


### PR DESCRIPTION
A data migration to add the new international delegation.

There's deliberatly no UI for adding world locations (which delegations are modelled as a type of) due to the sensitive nature of this content.  This therefore has to be done as a migration.

Ticket: https://www.agileplannerapp.com/boards/173808/cards/8993
