### PR TITLE
Avoid hard-coding year in cucumber features

### DIFF
--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -114,7 +114,7 @@ When(/^I change the release date on the announcement$/) do
   visit admin_statistics_announcement_path(@statistics_announcement)
   click_on 'Change release date'
 
-  select_datetime '14-Dec-2014 09:30', from: 'Release date'
+  select_datetime "14-Dec-#{Date.today.year.next} 09:30", from: 'Release date'
   check 'Confirmed date?'
   choose 'Exact'
   click_on 'Publish change of date'
@@ -184,7 +184,7 @@ Then(/^I should (see|only see) a statistics announcement called "(.*?)"$/) do |s
 end
 
 Then(/^the new date is reflected on the announcement$/) do
-  assert page.has_content?('14 December 2014 9:30am')
+  assert page.has_content?("14 December #{Date.today.year.next} 9:30am")
 end
 
 Then(/^I should be able to filter both past and future announcements$/) do


### PR DESCRIPTION
[This test](https://github.com/alphagov/whitehall/blob/master/features/admin-statistics-announcements.feature#L20-L25) tries to fill in a release date for a stats announcement which must be in the future and can go up to 5 years in the future.

Changed it to be a year in the future, instead of the hard-coded value of 2014 which is in the past.