### PR TITLE
Restore unpublishings for news articles and publications

### DIFF
--- a/db/data_migration/20150106070706_restore_unpublishings_for_editions.rb
+++ b/db/data_migration/20150106070706_restore_unpublishings_for_editions.rb
@@ -1,0 +1,22 @@
+[ 400612, 403646, 407080, 409918, 403691, 407085, 407171, 409867, 403708, 403688,
+  406620, 409891, 403706, 407151, 409876, 403683, 406383, 407228, 403704, 407077,
+  409923, 403695, 407179, 407079, 403102, 400399, 403710, 406608, 419802, 420932,
+  420936, 398547, 386766 ].each do |id|
+  if edition = Edition.where(id: id).first
+    if edition.archived?
+      if edition.unpublishing.present?
+        puts "#{id}: Unpublishing already exists; skipping"
+      else
+        unpublishing = edition.build_unpublishing(
+                        unpublishing_reason_id: UnpublishingReason::Archived.id,
+                        explanation: 'This content is no longer current.')
+        unpublishing.save!
+        puts "#{id}: Unpublishing created"
+      end
+    else
+      puts "#{id}: Not archived; skipping"
+    end
+  else
+    puts "Couldn't find Edition with id: #{id}"
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8158

missing unpublishings for news articles and publications are causing them to [blow-up](https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/5433e5830da115cbfe000522). these editions have been identified from the latest data synced on Preview using this query:

`Edition.archived.includes(:unpublishing).select {|e| e.unpublishing.nil? }.map(&:id)`

content designers have confirmed that the reason for these editions being unpublished is because they should be archived as the content is no longer current.