### PR TITLE
Add whitespace between footer metadata items to improve readability

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_footer_meta.scss
@@ -40,6 +40,7 @@
       }
     }
     dd {
+      margin-top: 5px;
       @include bold-24;
       // some bits of metadata are included inside of other tags which have a 
       // default style of font-weight: normal


### PR DESCRIPTION
Fixes #1839, and brings it into sync with the GOV.UK component
version, which has the same margin: https://github.com/alphagov/static/blob/master/app/assets/stylesheets/govuk-component/_document-footer.scss#L36

Longer term the footer in WH should be replaced with the component
but in the mean time this improves readbility.

Before:
![screenshot 2015-01-08 15 40 02](https://cloud.githubusercontent.com/assets/63201/5664977/b57b145a-974c-11e4-9873-fa134d8fbef0.png)

After:
![screenshot 2015-01-08 15 39 58](https://cloud.githubusercontent.com/assets/63201/5664973/a6459e1a-974c-11e4-8de9-bb23aea47c43.png)