### PR TITLE
Extract entities from abbreviations

### DIFF
--- a/lib/whitehall/abbreviation_extractor.rb
+++ b/lib/whitehall/abbreviation_extractor.rb
@@ -1,0 +1,43 @@
+module Whitehall
+  class AbbreviationExtractor
+    def initialize(edition)
+      @edition = edition
+    end
+
+    def extract
+      abbr_tags.map do |abbr_tag|
+        {
+          terms: [
+            abbr_tag.attr('title'),
+            abbr_tag.inner_text
+          ],
+          type: "abbreviation"
+        }
+      end.uniq
+    end
+
+  private
+    def abbr_tags
+      Nokogiri::HTML(edition_html).css("abbr")
+    end
+
+    def edition_html
+      helpers.govspeak_to_html(
+        @edition.body,
+        [],
+        { heading_numbering: :manual, contact_heading_tag: 'h4' }
+      )
+    end
+
+    # Because the govspeak helpers in whitehall rely on rendering partials, we
+    # need to make sure the view paths are set, otherwise the helpers can't find
+    # the partials.
+    def helpers
+      @helpers ||= begin
+        helpers = ApplicationController.helpers
+        helpers.view_paths = ApplicationController.view_paths
+        helpers
+      end
+    end
+  end
+end

--- a/script/export_abbreviation_entities
+++ b/script/export_abbreviation_entities
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.dirname(__FILE__) + "/../lib"
+require File.dirname(__FILE__) + '/../config/environment'
+require 'whitehall/abbreviation_extractor'
+
+Edition.published.find_each do |edition|
+  entities = Whitehall::AbbreviationExtractor.new(edition).extract
+  if entities.any?
+    entities.each do |entity|
+      puts entity.to_json
+    end
+  end
+end

--- a/test/unit/whitehall/abbreviation_extractor_test.rb
+++ b/test/unit/whitehall/abbreviation_extractor_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class AbbreviationExtractorTest < ActiveSupport::TestCase
+  test "extracts a single abbreviation couple from an edition" do
+    edition = create(:edition, body:
+      "This is the DVLA\n\n" +
+      "*[DVLA]:Driver and Vehicle Licensing Agency"
+    )
+
+    abbreviations = Whitehall::AbbreviationExtractor.new(edition).extract
+
+    assert_equal [{terms: ["Driver and Vehicle Licensing Agency", "DVLA"], type: "abbreviation"}], abbreviations
+  end
+
+  test "extracts multiple abbreviation couples from an edition" do
+    edition = create(:edition, body:
+      "This is the MOD\n\n" +
+      "This is the MOJ\n\n" +
+      "*[MOD]:Ministry of Defence\n" +
+      "*[MOJ]:Ministry of Justice"
+    )
+
+    abbreviations = Whitehall::AbbreviationExtractor.new(edition).extract
+
+    assert_equal [
+      {terms: ["Ministry of Defence", "MOD"], type: "abbreviation"},
+      {terms: ["Ministry of Justice", "MOJ"], type: "abbreviation"}
+    ], abbreviations
+  end
+
+  test "only extracts unique abbreviations" do
+    edition = create(:edition, body:
+      "This is the MOD\n\n" +
+      "This is the MOD\n\n" +
+      "*[MOD]:Ministry of Defence\n"
+    )
+
+    abbreviations = Whitehall::AbbreviationExtractor.new(edition).extract
+
+    assert_equal [
+      {terms: ["Ministry of Defence", "MOD"], type: "abbreviation"}
+    ], abbreviations
+  end
+end


### PR DESCRIPTION
As part of our 'GOV.UK Search and Navigation improvement' [Firebreak project](/https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=20185307) we need to extract 'abbreviations' from Editions.

Together with @heathd I created an extractor and a script that runs it through all the editions present in Whitehall. The script also outputs all the pairs in newline separated json.

ie:

{"terms":["Government digital service","GDS"],"type":"abbreviation"}
{"terms":["Ministry of Justice","MoJ"],"type":"abbreviation"}


