### PR TITLE
Update ruby version specified in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ user-friendly manner. Documention can be found on [rdoc](http://rdoc.info/github
 
 ### Pre-requisites
 
-* Ruby >= 1.9.3
+* Ruby 2.1.4
 * Rubygems and Bundler
 * Mysql
 * Imagemagick and Ghostscript (for generating thumbnails of uploaded


### PR DESCRIPTION
In 4e4638b84b3a6ff2a4517f28133aef308be44140 .ruby-version was changed to specify 2.1.4 (cc @tekin).