### PR TITLE
Handle featuring of undated topical events

### DIFF
--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -57,4 +57,11 @@ module Admin::OrganisationHelper
       'hidden'
     end
   end
+
+  def topical_event_dates_string(topical_event)
+    [
+      topical_event.start_date.try(:to_date),
+      topical_event.end_date.try(:to_date)
+    ].compact.map { |date| l(date) }.join(' to ')
+  end
 end

--- a/app/views/admin/feature_lists/_current_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_current_feature_list.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <%= form_for feature_list, url: reorder_admin_feature_list_path(feature_list), method: :post do |form| %>
     <fieldset class="sortable">
-      <% @feature_list.features.current.each do |feature| %>
+      <% feature_list.features.current.each do |feature| %>
         <div class="well feature-list">
           <%= label_tag "ordering-#{feature.id}" do %>
             <div class="icon"><i class="icon-align-justify"></i></div>
@@ -25,7 +25,7 @@
             <% elsif feature.topical_event %>
               <div class="title"><%= link_to feature.topical_event, edit_admin_topical_event_path(feature.topical_event) %></div>
               <div class="type">Topical Event</div>
-              <div class="date"><%= l feature.topical_event.start_date.to_date %> to <%= l feature.topical_event.end_date.to_date %></div>
+              <div class="date"><%= topical_event_dates_string(feature.topical_event) %></div>
               <%= content_tag_for :div, feature.topical_event, class: "button" do %>
                 <%= link_to('Unfeature', unfeature_admin_feature_list_feature_path(feature_list, feature), confirm: "Unfeature '#{feature}'?", method: :post, class: "btn btn-danger") %>
               <% end %>

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -407,4 +407,16 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  view_test "GET :features copes with topical events that have no dates" do
+    topical_event = create(:topical_event)
+    organisation = create(:organisation)
+    feature_list = organisation.load_or_create_feature_list('en')
+    feature_list.features.create!(topical_event: topical_event,
+                                  image: image_fixture_file,
+                                  alt_text: 'Image alternative text')
+
+
+    get :features, id: organisation, locale: 'en'
+    assert_response :success
+  end
 end

--- a/test/unit/helpers/admin/organisation_helper_test.rb
+++ b/test/unit/helpers/admin/organisation_helper_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class Admin::OrganisationHelperTest < ActionView::TestCase
+
+  test '#topical_event_dates_string handles a topical event with a start date but no end date' do
+    topical_event = create(:topical_event, start_date: Date.today)
+
+    assert_equal '11 November 2011', topical_event_dates_string(topical_event)
+  end
+
+  test '#topical_event_dates_string handles a topical event with start and end dates' do
+    topical_event = create(:topical_event, start_date: Date.today, end_date: Date.today + 1.week)
+
+    assert_equal '11 November 2011 to 18 November 2011', topical_event_dates_string(topical_event)
+  end
+
+  test '#topical_event_dates_string handles a topical event with no dates' do
+    topical_event = create(:topical_event)
+
+    assert_equal '', topical_event_dates_string(topical_event)
+  end
+end


### PR DESCRIPTION
Topical events can be created without a start and end date, but the organisation featurings page in admin assumes that any featured topical events have these dates set. This updates the view code to handle topical events that don't have a start and end date, and also those that only have a start date.

Story: https://www.agileplannerapp.com/boards/173808/cards/9131