### PR TITLE
Expose content id for Orgs in API

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -14,6 +14,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
         organisation_logo_type_class_name: model.organisation_logo_type.try(:class_name),
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
+        content_id: model.content_id,
       },
       parent_organisations: parent_organisations,
       child_organisations: child_organisations,


### PR DESCRIPTION
As we want to query the content ID for Organisations we need to expose them from the API in Whitehall. This commit adds it to the Api::OrganisationsPresenter.