### PR TITLE
Only show services-info examples from the org

### DIFF
--- a/app/models/services_and_information_finder.rb
+++ b/app/models/services_and_information_finder.rb
@@ -20,7 +20,7 @@ private
     {
       count: "0",
       filter_organisations: [organisation.slug],
-      facet_specialist_sectors: "1000,examples:4,example_scope:global,order:value.title",
+      facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
     }
   end
 end

--- a/test/unit/services_and_information_finder_test.rb
+++ b/test/unit/services_and_information_finder_test.rb
@@ -7,7 +7,7 @@ class ServicesAndInformationFinderTest < ActiveSupport::TestCase
     expected_search_query = {
       count: "0",
       filter_organisations: [organisation.slug],
-      facet_specialist_sectors: "1000,examples:4,example_scope:global,order:value.title",
+      facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
     }
 
     finder = ServicesAndInformationFinder.new(organisation, search_client)


### PR DESCRIPTION
On the services and information pages for an organisation, we were
previously showing the most popular examples for each sub-topic
regardless of whether they were tagged to the organisation.  Instead,
only show examples which are tagged to the organisation.  This helps on
pages like the HMRC services and information page, where some sub-topics
(such as "Maritime safety") were showing no examples which were to do
with HMRC.

Before:

![screen shot 2015-01-15 at 08 06 24](https://cloud.githubusercontent.com/assets/73564/5754218/71fe77a8-9c8d-11e4-9424-5ac3c7f5a21f.png)

After:

![screen shot 2015-01-15 at 08 06 06](https://cloud.githubusercontent.com/assets/73564/5754220/783e3202-9c8d-11e4-9fac-8fd4836fac24.png)

 * [x] Product review
 * [x] Tech review