### PR TITLE
Different email signup for MHRA

### DIFF
--- a/app/controllers/email_signup_information_controller.rb
+++ b/app/controllers/email_signup_information_controller.rb
@@ -21,6 +21,6 @@ private
   end
 
   def email_signup_pages
-    EmailSignupPagesFinder.find(organisation)
+    EmailSignupPagesFinder.signup_page_for_atom_url("#{organisation.slug}.atom").signup_pages
   end
 end

--- a/app/controllers/email_signup_information_controller.rb
+++ b/app/controllers/email_signup_information_controller.rb
@@ -21,6 +21,6 @@ private
   end
 
   def email_signup_pages
-    EmailSignupPagesFinder.signup_page_for_atom_url("#{organisation.slug}.atom").signup_pages
+    EmailSignupPagesFinder.find(organisation)
   end
 end

--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -1,0 +1,13 @@
+module EmailSignupHelper
+
+  def email_signup_path(atom_url)
+    signup_page = EmailSignupPagesFinder.signup_page_for_atom_url(atom_url)
+
+    if signup_page
+      signup_page.email_signup_path
+    else
+      new_email_signups_path(email_signup: {feed: atom_url})
+    end
+  end
+
+end

--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -1,13 +1,20 @@
 module EmailSignupHelper
 
-  def email_signup_path(atom_url)
-    signup_page = EmailSignupPagesFinder.signup_page_for_atom_url(atom_url)
-
-    if signup_page
-      signup_page.email_signup_path
+  def email_signup_path(atom_feed_url)
+    if EmailSignupPagesFinder.exists_for_atom_feed?(atom_feed_url)
+      organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
     else
-      new_email_signups_path(email_signup: {feed: atom_url})
+      new_email_signups_path(email_signup: {feed: atom_feed_url})
     end
   end
 
+private
+
+  def organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
+    organisation_email_signup_information_path extract_slug_from_atom_feed(atom_feed_url)
+  end
+
+  def extract_slug_from_atom_feed(atom_feed_url)
+    /\/([\w-]+).atom$/.match(atom_feed_url)[1]
+  end
 end

--- a/app/models/email_signup_pages_finder.rb
+++ b/app/models/email_signup_pages_finder.rb
@@ -1,3 +1,8 @@
+# Utility class used to identify and return the information for an
+# organisation's custom email signup page.
+#
+# Only the MHRA has such a page at present and the class is hardcoded with this
+# knowledge.
 class EmailSignupPagesFinder
   def self.find(organisation)
     if organisation.slug == mhra_slug

--- a/app/models/email_signup_pages_finder.rb
+++ b/app/models/email_signup_pages_finder.rb
@@ -1,34 +1,29 @@
 class EmailSignupPagesFinder
-
-  def self.signup_page_for_atom_url(atom_url)
-    special_cases.find { |c| atom_url.match(c.regex) }
+  def self.find(organisation)
+    case organisation.slug
+    when "medicines-and-healthcare-products-regulatory-agency"
+      mhra_email_signup_pages
+    end
   end
 
-private
+  def self.exists_for_atom_feed?(atom_feed_url)
+    atom_feed_url.ends_with?("medicines-and-healthcare-products-regulatory-agency.atom")
+  end
 
-  def self.special_cases
+  def self.mhra_email_signup_pages
     [
       OpenStruct.new(
-        regex: /medicines-and-healthcare-products-regulatory-agency.atom$/,
-        email_signup_path: self.route_helpers.organisation_email_signup_information_path("medicines-and-healthcare-products-regulatory-agency"),
-        signup_pages: [
-          OpenStruct.new(
-            text: "Drug alerts and medical device alerts",
-            description: "Subscribe to <a href='/drug-device-alerts/email-signup'>MHRA's alerts and recalls for drugs and medical devices</a>.".html_safe,
-          ),
-          OpenStruct.new(
-            text: "Drug Safety Update",
-            description: "Subscribe to the <a href='/drug-safety-update/email-signup'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
-          ),
-          OpenStruct.new(
-            text: "News and publications from the MHRA",
-            description: "Subscribe to <a href='/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fmedicines-and-healthcare-products-regulatory-agency.atom'>MHRA's new publications, statistics, consultations and announcements</a>.".html_safe,
-          ),
-        ]
-      )
+        text: "Drug alerts and medical device alerts",
+        description: "Subscribe to <a href='/drug-device-alerts/email-signup'>MHRA's alerts and recalls for drugs and medical devices</a>.".html_safe,
+      ),
+      OpenStruct.new(
+        text: "Drug Safety Update",
+        description: "Subscribe to the <a href='/drug-safety-update/email-signup'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
+      ),
+      OpenStruct.new(
+        text: "News and publications from the MHRA",
+        description: "Subscribe to <a href='/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fmedicines-and-healthcare-products-regulatory-agency.atom'>MHRA's new publications, statistics, consultations and announcements</a>.".html_safe,
+      ),
     ]
   end
-
-  def self.route_helpers; Rails.application.routes.url_helpers; end
-
 end

--- a/app/models/email_signup_pages_finder.rb
+++ b/app/models/email_signup_pages_finder.rb
@@ -1,13 +1,16 @@
 class EmailSignupPagesFinder
   def self.find(organisation)
-    case organisation.slug
-    when "medicines-and-healthcare-products-regulatory-agency"
+    if organisation.slug == mhra_slug
       mhra_email_signup_pages
     end
   end
 
   def self.exists_for_atom_feed?(atom_feed_url)
-    atom_feed_url.ends_with?("medicines-and-healthcare-products-regulatory-agency.atom")
+    atom_feed_url.ends_with?(mhra_slug + ".atom")
+  end
+
+  def self.mhra_slug
+    "medicines-and-healthcare-products-regulatory-agency"
   end
 
   def self.mhra_email_signup_pages

--- a/app/models/email_signup_pages_finder.rb
+++ b/app/models/email_signup_pages_finder.rb
@@ -1,25 +1,34 @@
 class EmailSignupPagesFinder
-  def self.find(organisation)
-    case organisation.slug
-    when "medicines-and-healthcare-products-regulatory-agency"
-      mhra_email_signup_pages
-    end
+
+  def self.signup_page_for_atom_url(atom_url)
+    special_cases.find { |c| atom_url.match(c.regex) }
   end
 
-  def self.mhra_email_signup_pages
+private
+
+  def self.special_cases
     [
       OpenStruct.new(
-        text: "Drug alerts and medical device alerts",
-        description: "Subscribe to <a href='/drug-device-alerts/email-signup'>MHRA's alerts and recalls for drugs and medical devices</a>.".html_safe,
-      ),
-      OpenStruct.new(
-        text: "Drug Safety Update",
-        description: "Subscribe to the <a href='/drug-safety-update/email-signup'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
-      ),
-      OpenStruct.new(
-        text: "News and publications from the MHRA",
-        description: "Subscribe to <a href='/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fmedicines-and-healthcare-products-regulatory-agency.atom'>MHRA's new publications, statistics, consultations and announcements</a>.".html_safe,
-      ),
+        regex: /medicines-and-healthcare-products-regulatory-agency.atom$/,
+        email_signup_path: self.route_helpers.organisation_email_signup_information_path("medicines-and-healthcare-products-regulatory-agency"),
+        signup_pages: [
+          OpenStruct.new(
+            text: "Drug alerts and medical device alerts",
+            description: "Subscribe to <a href='/drug-device-alerts/email-signup'>MHRA's alerts and recalls for drugs and medical devices</a>.".html_safe,
+          ),
+          OpenStruct.new(
+            text: "Drug Safety Update",
+            description: "Subscribe to the <a href='/drug-safety-update/email-signup'>Drug Safety Update</a>, the monthly newsletter for healthcare professionals, with clinical advice on the safe use of medicines.".html_safe,
+          ),
+          OpenStruct.new(
+            text: "News and publications from the MHRA",
+            description: "Subscribe to <a href='/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fmedicines-and-healthcare-products-regulatory-agency.atom'>MHRA's new publications, statistics, consultations and announcements</a>.".html_safe,
+          ),
+        ]
+      )
     ]
   end
+
+  def self.route_helpers; Rails.application.routes.url_helpers; end
+
 end

--- a/app/views/shared/_feeds.html.erb
+++ b/app/views/shared/_feeds.html.erb
@@ -1,7 +1,7 @@
 <% unless atom_url.blank? %>
   <div class="feeds">
     <span><%= t("feeds.get_updates_to_this_list") %></span>
-    <%= link_to t('feeds.email'), new_email_signups_path(email_signup: {feed: atom_url}), class: 'govdelivery' %>&nbsp;<%= link_to t("feeds.feed"), atom_url, class: "feed js-feed" %>
+    <%= link_to t('feeds.email'), email_signup_path(atom_url), class: 'govdelivery' %>&nbsp;<%= link_to t("feeds.feed"), atom_url, class: "feed js-feed" %>
     <div class="feed-panel js-feed-panel">
       <h3>Copy and paste this URL in to your feed reader</h3>
       <input value="<%= atom_url %>">

--- a/features/email-signup-information-for-organisations.feature
+++ b/features/email-signup-information-for-organisations.feature
@@ -1,6 +1,11 @@
 Feature: Email signup information for organisations
+  The MHRA has a need for more specialised email alerts and as such, has a
+  custom email signup page where uses can sign up for specific drug alerts. The
+  organisation home page links to this custom page rather than the standard
+  atom-based email signup page.
 
-  Scenario: Signing up to organisation alerts
-    Given the organisation "Medicines and healthcare products regulatory agency" exists
-    When I visit the "Medicines and healthcare products regulatory agency" organisation email signup information page
+  Scenario: Signing up to custom organisation email alerts for the MHRA
+    Given the organisation "Medicines and healthcare products regulatory agency" exists with a featured article
+    When I visit the "Medicines and healthcare products regulatory agency" organisation
+    And click the link for the latest email alerts
     Then I should see email signup information for "Medicines and healthcare products regulatory agency"

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -87,8 +87,10 @@ Then(/^no govuk_delivery notifications should have been sent yet$/) do
   mock_govuk_delivery_client.refute_method_called(:notify)
 end
 
-When(/^I visit the "(.*?)" organisation email signup information page$/) do |org_name|
-  visit_organisation_email_signup_information_page(org_name)
+When(/^click the link for the latest email alerts$/) do
+  within '.feeds' do
+    click_on 'email'
+  end
 end
 
 Then(/^I should see email signup information for "(.*?)"$/) do |organisation_name|

--- a/test/unit/models/email_signup_pages_finder_test.rb
+++ b/test/unit/models/email_signup_pages_finder_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class EmailSignupPagesFinderTest < ActiveSupport::TestCase
+
+  test "returns correct OpenStruct" do
+    @signup_page = EmailSignupPagesFinder.signup_page_for_atom_url("medicines-and-healthcare-products-regulatory-agency.atom")
+
+    assert_equal @signup_page.email_signup_path, "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup"
+    assert_equal @signup_page.signup_pages.length, 3
+  end
+
+  test "doesn't match other URLs" do
+    @signup_page = EmailSignupPagesFinder.signup_page_for_atom_url("ministry-of-silly-walks.atom")
+
+    assert_equal @signup_page, nil
+  end
+
+end

--- a/test/unit/models/email_signup_pages_finder_test.rb
+++ b/test/unit/models/email_signup_pages_finder_test.rb
@@ -2,17 +2,36 @@ require "test_helper"
 
 class EmailSignupPagesFinderTest < ActiveSupport::TestCase
 
-  test "returns correct OpenStruct" do
-    @signup_page = EmailSignupPagesFinder.signup_page_for_atom_url("medicines-and-healthcare-products-regulatory-agency.atom")
+  test 'EmailSignupPagesFinder.find returns a data structure representing the email signup pages for the MHRA' do
+    signup_page = EmailSignupPagesFinder.find(mhra)
 
-    assert_equal @signup_page.email_signup_path, "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup"
-    assert_equal @signup_page.signup_pages.length, 3
+    assert_equal signup_page.map {|p| p[:text] },
+      [
+        'Drug alerts and medical device alerts',
+        'Drug Safety Update',
+        'News and publications from the MHRA',
+      ]
   end
 
-  test "doesn't match other URLs" do
-    @signup_page = EmailSignupPagesFinder.signup_page_for_atom_url("ministry-of-silly-walks.atom")
-
-    assert_equal @signup_page, nil
+  test 'EmailSignupPagesFinder.find returns nil for a non-matching organisations' do
+    another_org = create(:organisation, name: 'Org without custom signup page')
+    refute EmailSignupPagesFinder.find(another_org)
   end
 
+  test 'EmailSignupPagesFinder.exists_for_atom_feed? returns true for the MHRA atom feed' do
+    mhra_atom_feed = Whitehall.atom_feed_maker.organisation_url(mhra)
+
+    assert EmailSignupPagesFinder.exists_for_atom_feed?(mhra_atom_feed)
+  end
+
+  test 'EmailSignupPagesFinder.exists_for_atom_feed? returns false for other atom feeds' do
+    non_matching_atom_feed = Whitehall.atom_feed_maker.organisation_url(create(:organisation))
+    refute EmailSignupPagesFinder.exists_for_atom_feed?(non_matching_atom_feed)
+  end
+
+private
+
+  def mhra
+    @mhra ||= create(:organisation, name: 'Medicines and Healthcare Products Regulatory Agency')
+  end
 end


### PR DESCRIPTION
MHRA is a special case in that Users have a strong connection with the brand so it needs a different URL for the signup page so they can also sign up for drug safety updates or drug and device alerts.

I've done this by calling a helper from the feed and passing in the `atom_url` which is in turn passed to `EmailSignupPagesFinder` which does a lookup in an array of OpenStructs to find a matching regex. This also includes the Rails Route helpers in order to build the path in a sane way.

[Ticket](https://trello.com/c/nmljEkL1/508-mhra-email-sign-up-routes).