### PR TITLE
Html pub heading numbering

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -80,7 +80,11 @@
   .in-page-navigation {
     color: $white;
     margin: 0 0 $gutter+$gutter-one-third;
-    width: 70%;
+    width: 100%;
+    @include media(desktop) {
+      width: 70%;
+    }
+
     h2 {
       font-weight: bold;
     }
@@ -99,6 +103,21 @@
         padding-left: 0;
         li {
           list-style: none;
+          &.numbered {
+            margin-left: $gutter-two-thirds;
+            @include media(desktop) {
+              margin-left: $gutter;              
+            }
+            a {
+              .heading-number {
+                @include bold-19($tabular-numbers: true);
+                margin-left: -18px;
+                @include media(desktop) {
+                  margin-left: -20px;
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -40,7 +40,9 @@ module GovspeakHelper
   def html_attachment_govspeak_headers(attachment)
     govspeak_headers(attachment.govspeak_content_body).tap do |headers|
       if attachment.manually_numbered_headings?
-        headers.each { |header| header.text = header.text.gsub(/^(\d+.?\d*\s*)/, '') }
+        headers.each { |header|
+          header.text = header.text.gsub(/^(\d+.?\d*)\s*/, '<span class="heading-number">\1</span> ').html_safe
+        }
       end
     end
   end
@@ -48,9 +50,14 @@ module GovspeakHelper
   def html_attachment_govspeak_headers_html(attachment)
     content_tag(:ol, class: ('unnumbered' if attachment.manually_numbered_headings?)) do
       html_attachment_govspeak_headers(attachment).reduce('') do |html, header|
-        html << content_tag(:li ,link_to(header.text, "##{header.id}"))
+        css_class = header_contains_manual_numbering?(header) ? 'numbered' : ''
+        html << content_tag(:li ,link_to(header.text, "##{header.id}"), class: css_class)
       end.html_safe
     end
+  end
+
+  def header_contains_manual_numbering?(header)
+    header.text.include?('<span class="heading-number">')
   end
 
   def govspeak_embedded_contacts(govspeak)

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -50,7 +50,7 @@ module GovspeakHelper
   def html_attachment_govspeak_headers_html(attachment)
     content_tag(:ol, class: ('unnumbered' if attachment.manually_numbered_headings?)) do
       html_attachment_govspeak_headers(attachment).reduce('') do |html, header|
-        css_class = header_contains_manual_numbering?(header) ? 'numbered' : ''
+        css_class = header_contains_manual_numbering?(header) ? 'numbered' : nil
         html << content_tag(:li ,link_to(header.text, "##{header.id}"), class: css_class)
       end.html_safe
     end

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -93,13 +93,13 @@ class GovspeakHelperTest < ActionView::TestCase
     ], headers
   end
 
-  test "#html_attachment_govspeak_headers strips numbers from manually numbered HTML attachments" do
+  test "#html_attachment_govspeak_headers add number markup for manually numbered HTML attachments" do
     attachment = build(:html_attachment,
       body: "## 1. First\n\n## 2. Second\n\n### 2.1 Sub",
       manually_numbered_headings: true
     )
-    expected_headings = [Govspeak::Header.new("First", 2, "first"),
-                         Govspeak::Header.new("Second", 2, "second")]
+    expected_headings = [Govspeak::Header.new("<span class=\"heading-number\">1.</span> First", 2, "first"),
+                         Govspeak::Header.new("<span class=\"heading-number\">2.</span> Second", 2, "second")]
 
     assert_equal expected_headings, html_attachment_govspeak_headers(attachment)
   end

--- a/test/unit/workers/govspeak_content_worker_test.rb
+++ b/test/unit/workers/govspeak_content_worker_test.rb
@@ -126,7 +126,7 @@ private
   def example_headers_html
     <<-END
       <ol>
-        <li><a href="#heading">Heading</a></li>
+        <li class=""><a href="#heading">Heading</a></li>
       </ol>
     END
   end
@@ -134,7 +134,7 @@ private
   def example_manually_numbered_headers_html
     <<-END
       <ol class="unnumbered">
-        <li><a href="#heading">Heading</a></li>
+        <li class=""><a href="#heading">Heading</a></li>
       </ol>
     END
   end

--- a/test/unit/workers/govspeak_content_worker_test.rb
+++ b/test/unit/workers/govspeak_content_worker_test.rb
@@ -126,7 +126,7 @@ private
   def example_headers_html
     <<-END
       <ol>
-        <li class=""><a href="#heading">Heading</a></li>
+        <li><a href="#heading">Heading</a></li>
       </ol>
     END
   end
@@ -134,7 +134,7 @@ private
   def example_manually_numbered_headers_html
     <<-END
       <ol class="unnumbered">
-        <li class=""><a href="#heading">Heading</a></li>
+        <li><a href="#heading">Heading</a></li>
       </ol>
     END
   end


### PR DESCRIPTION
make headings links consistent/match contents headings

• update helper to include matching numbering and add class to parent
li for manually numbered list items
• add styling for the numbers

https://www.agileplannerapp.com/boards/105200/cards/8667

Before and after screenshots
![after](https://cloud.githubusercontent.com/assets/1692222/5802047/105c773e-9fe9-11e4-8627-77206751fc35.png)
![before](https://cloud.githubusercontent.com/assets/1692222/5802046/10586946-9fe9-11e4-888b-66db88d3eb05.png)


Comment from Camille -

> The data migration throws some errors on some attachments:
> `Validation failed: Body can't be blank undefined methodcaptures' for nil:NilClass`
>
> Would like to discuss with a Whitehall-team person when someone's available :)