### PR TITLE
Restore organisation logo border on mobile

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_organisations.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisations.scss
@@ -506,7 +506,10 @@ img.organisation-logo-custom {
 
 // Non-cornforming Medium
 .organisation-logo-no-identity-medium {
-  border-left: 0;
+  // No-op attribute to stop `.organisation-logo-no-identity-medium` not being
+  // extendable, as it technically contains no attributes (as the MQ is hoisted)
+  z-index: auto;
+
   @include media(tablet){
     font-size: 18px;
     line-height: 20px;


### PR DESCRIPTION
You can't extend empty selectors (as SASS ignores them) and
this selector is treated as empty because the MQ is hoisted out

z-index seems like the least offensive attribute to use, and less
likely to conflict with a real property.

Removing the removal of the border will bring that back on mobile-
size org pages, which is the desired behaviour

CC @edds and @tekin 