### PR TITLE
Include contents list for html publications when printing

### DIFF
--- a/app/assets/stylesheets/frontend/print/_html-publication.scss
+++ b/app/assets/stylesheets/frontend/print/_html-publication.scss
@@ -1,0 +1,21 @@
+.html-publications-show {
+  nav.in-page-navigation {
+    display: block!important;
+  }
+  .unnumbered {
+    list-style: none;
+    li {
+      margin-left: 0;
+      padding: 0 0 $gutter-one-sixth 0;
+      .heading-number {
+        font-weight: bold;
+      }
+    }
+  }
+  // I may move this to static after a bigger review of print stylesheets
+  ul {
+    li {
+      margin-left: $gutter-two-thirds;
+    } 
+  }
+}


### PR DESCRIPTION
... So that users are more confident about what's in the document and it's structure when they read it offline.

• display: block!important declaration used to override the !important declaration set on hiding the body nav
• remove unneccessary margins for better alignment
• bold the numbering to match desktop styles
• reduce padding around nav li's to reduce wasted printed vertical space but maintain clarity

https://www.agileplannerapp.com/boards/105200/cards/8667