### PR TITLE
Ensure document export doesn't consume all memory

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -27,12 +27,10 @@ module Admin
       ).page(options[:page])
     end
 
-    def editions_for_csv(locale = nil)
-      @editions_for_csv ||= {}
-      return @editions_for_csv[locale] if @editions_for_csv[locale]
-
-      requested_editions = editions_with_translations(locale)
-      @editions_for_csv[locale] = permitted_only(requested_editions)
+    def each_edition_for_csv(locale = nil)
+      editions_with_translations(locale).find_each do |edition|
+        yield edition if Whitehall::Authority::Enforcer.new(@current_user, edition).can?(:see)
+      end
     end
 
     def page_title

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -21,7 +21,7 @@ private
   def generate_csv(filter)
     CSV.generate do |csv|
       csv << DocumentListExportPresenter.header_row
-      filter.editions_for_csv.each do |edition|
+      filter.each_edition_for_csv do |edition|
         presenter = DocumentListExportPresenter.new(edition)
         csv << presenter.row
       end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -259,7 +259,9 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   test "editions_for_csv should not be paginated" do
     3.times { create(:policy) }
     filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
-    assert_equal 3, filter.editions_for_csv.count
+    count = 0
+    filter.each_edition_for_csv { |unused| count += 1}
+    assert_equal 3, count
   end
 
 end

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -14,7 +14,9 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   end
 
   test 'generate_csv calls presenter once for each edition' do
-    @worker.stubs(:create_filter).returns(stub(editions_for_csv: [1, 2, 3]))
+    filter = mock()
+    filter.expects(:each_edition_for_csv).multiple_yields(1, 2, 3)
+    @worker.stubs(:create_filter).returns(filter)
     @worker.stubs(:send_mail)
     DocumentListExportPresenter.expects(:new).returns(stub(row: [])).times(3)
     @worker.perform({"state" =>"draft"}, @user.id)


### PR DESCRIPTION
When called from the document export worker, the edition filter was attempting to load all editions into memory before filtering those the user is allowed to export; this was causing the process to use all available memory. Instead, rewrite to filter inside `find_each` and return an iterator to the worker.