### PR TITLE
Resetting the font to sans-serif for all things print

### DIFF
--- a/app/assets/stylesheets/frontend/print/_print.scss
+++ b/app/assets/stylesheets/frontend/print/_print.scss
@@ -1,3 +1,7 @@
+* {
+  font-family: $Print-reset;
+}
+
 a {
   text-decoration: none;
 }

--- a/app/assets/stylesheets/frontend/styleguide/_font-stacks.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_font-stacks.scss
@@ -92,3 +92,8 @@ $NTA-Black:
 $Helvetica-Regular:
     "GDS-Logo",
     sans-serif;
+
+
+// Font reset for print
+
+$Print-reset: sans-serif;


### PR DESCRIPTION
This fixes an odd character bug in some printers unable to print transport font.