### PR TITLE
Hide "more like this" when there are none

### DIFF
--- a/app/helpers/detailed_guides_helper.rb
+++ b/app/helpers/detailed_guides_helper.rb
@@ -1,0 +1,5 @@
+module DetailedGuidesHelper
+  def has_more_like_this?
+    @categories.any? or @document.part_of_published_collection? or @document.published_related_detailed_guides.any?
+  end
+end

--- a/app/views/detailed_guides/_document_contextual.html.erb
+++ b/app/views/detailed_guides/_document_contextual.html.erb
@@ -9,9 +9,11 @@
             <%= link_to header_record.text, "##{header_record.id}" %>
           </li>
         <% end %>
-        <li class="more-like-this">
-          <%= link_to t('detailed_guidance.see_more_like_this'), "#more-like-this" %>
-        </li>
+        <% if has_more_like_this? %>
+          <li class="more-like-this">
+            <%= link_to t('detailed_guidance.see_more_like_this'), "#more-like-this" %>
+          </li>
+        <% end %>
       </ol>
     </nav>
   <% end %>

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -56,49 +56,51 @@
         <a href="#page-navigation"><%= t('detailed_guidance.back_to_contents') %></a>
       </div>
       <%= render partial: 'documents/document_footer_meta', locals: { document: @document, policies: @related_policies } %>
-      <aside id="more-like-this" class="aside-more-like-this">
-        <h1><%= t('detailed_guidance.more') %></h1>
-        <% if @categories.any? %>
-          <section id="guide-categories" class="categories">
-            <div class="inner">
-              <h2><%= t('detailed_guidance.categories') %></h2>
-              <ul>
-                <% @categories.each do |category| %>
-                  <%= content_tag_for(:li, category) do %>
-                    <%= link_to category.title, mainstream_category_path(category) %>
+      <% if has_more_like_this? %>
+        <aside id="more-like-this" class="aside-more-like-this">
+          <h1><%= t('detailed_guidance.more') %></h1>
+          <% if @categories.any? %>
+            <section id="guide-categories" class="categories">
+              <div class="inner">
+                <h2><%= t('detailed_guidance.categories') %></h2>
+                <ul>
+                  <% @categories.each do |category| %>
+                    <%= content_tag_for(:li, category) do %>
+                      <%= link_to category.title, mainstream_category_path(category) %>
+                    <% end %>
                   <% end %>
-                <% end %>
-              </ul>
-            </div>
-          </section>
-        <% end %>
+                </ul>
+              </div>
+            </section>
+          <% end %>
 
-        <% if @document.part_of_published_collection? %>
-          <section id="document-collection" class="document-collection">
-            <div class="inner">
-              <h2><%= t('detailed_guidance.part_of_published_collection') %></h2>
-              <ul>
-                <%= list_of_li_links_to_document_collections(@document) %>
-              </ul>
-            </div>
-          </section>
-        <% end %>
+          <% if @document.part_of_published_collection? %>
+            <section id="document-collection" class="document-collection">
+              <div class="inner">
+                <h2><%= t('detailed_guidance.part_of_published_collection') %></h2>
+                <ul>
+                  <%= list_of_li_links_to_document_collections(@document) %>
+                </ul>
+              </div>
+            </section>
+          <% end %>
 
-        <% if @document.published_related_detailed_guides.any? %>
-          <section class="related-guidance">
-            <div class="inner">
-              <h2><%= t('detailed_guidance.published_related_detailed_guides') %></h2>
-              <ul class="related-detailed-guides">
-                <% @document.published_related_detailed_guides.each do |detailed_guide| %>
-                  <%= content_tag_for(:li, detailed_guide) do %>
-                    <%= link_to detailed_guide.title, public_document_path(detailed_guide), title: "View #{detailed_guide.title}" %>
+          <% if @document.published_related_detailed_guides.any? %>
+            <section class="related-guidance">
+              <div class="inner">
+                <h2><%= t('detailed_guidance.published_related_detailed_guides') %></h2>
+                <ul class="related-detailed-guides">
+                  <% @document.published_related_detailed_guides.each do |detailed_guide| %>
+                    <%= content_tag_for(:li, detailed_guide) do %>
+                      <%= link_to detailed_guide.title, public_document_path(detailed_guide), title: "View #{detailed_guide.title}" %>
+                    <% end %>
                   <% end %>
-                <% end %>
-              </ul>
-            </div>
-          </section>
-        <% end %>
-      </aside>
+                </ul>
+              </div>
+            </section>
+          <% end %>
+        </aside>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -107,6 +107,14 @@ That's all
     assert_select ".category-#{category.slug}"
   end
 
+  view_test "guides show more like this when there are categories" do
+    category = create(:mainstream_category)
+    guide = create(:published_detailed_guide, primary_mainstream_category: category)
+    get :show, id: guide.document
+
+    assert_select "#more-like-this"
+  end
+
   view_test "detailed guides without a mainstream category are successfully rendered" do
     guide = create(:published_detailed_guide, primary_mainstream_category: nil)
     get :show, id: guide.document


### PR DESCRIPTION
Remove the link to the footer and the blue “more like this” header when there is nothing like this, eg no categories, not in a collection and no related guides.

Example:
https://www.gov.uk/genomic-research-unit

Use `?w=1` when reviewing.