### PR TITLE
Remove link to the product development backlog

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -15,7 +15,6 @@
     <h3>Product development</h3>
     <ul>
       <li><a href="https://insidegovuk.blog.gov.uk/">Inside GOV.UK blog</a></li>
-      <li><a href="https://www.agileplannerapp.com/boards/105200/planning">Development backlog (Agile Planner)</a></li>
     </ul>
   </div>
   <div class="span4">


### PR DESCRIPTION
The development on this project is currently split between multiple teams, so linking to any single team's backlog could confuse publishers looking for a feature they've been told "the team" is working on.