### PR TITLE
Propagate unpublishing updates to content-store

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -11,6 +11,8 @@ class Unpublishing < ActiveRecord::Base
     allow_blank: true
   validate :redirect_not_circular
 
+  after_update :publish_to_publishing_api
+
   def self.from_slug(slug, type)
     where(slug: slug, document_type: type.to_s).last
   end
@@ -60,5 +62,9 @@ private
     URI.parse(alternative_url).path
   rescue URI::InvalidURIError
     nil
+  end
+
+  def publish_to_publishing_api
+    Whitehall::PublishingApi.publish(self)
   end
 end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -65,6 +65,6 @@ private
   end
 
   def publish_to_publishing_api
-    Whitehall::PublishingApi.publish(self)
+    Whitehall::PublishingApi.publish(self, 'minor')
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -10,8 +10,8 @@ module Whitehall
   class UnpublishableInstanceError < StandardError; end
 
   class PublishingApi
-    def self.publish(model_instance)
-      do_action(model_instance)
+    def self.publish(model_instance, update_type_override=nil)
+      do_action(model_instance, update_type_override)
     end
 
     def self.republish(model_instance)

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -134,11 +134,11 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal [:en, :es], unpublishing.translated_locales
   end
 
-  test 'updates are propogated to publishing api' do
+  test 'updates are propogated to publishing API as a minor update' do
     unpublishing = create(:unpublishing, unpublishing_reason_id: UnpublishingReason::Archived.id, explanation: 'Needs more work.')
 
     new_explanation = 'This publication will be ready for publishing next week.'
-    Whitehall::PublishingApi.expects(:publish).with(responds_with(:explanation, new_explanation)).once
+    Whitehall::PublishingApi.expects(:publish).with(responds_with(:explanation, new_explanation), 'minor').once
 
     unpublishing.update_attribute(:explanation, new_explanation)
   end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -134,6 +134,15 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal [:en, :es], unpublishing.translated_locales
   end
 
+  test 'updates are propogated to publishing api' do
+    unpublishing = create(:unpublishing, unpublishing_reason_id: UnpublishingReason::Archived.id, explanation: 'Needs more work.')
+
+    new_explanation = 'This publication will be ready for publishing next week.'
+    Whitehall::PublishingApi.expects(:publish).with(responds_with(:explanation, new_explanation)).once
+
+    unpublishing.update_attribute(:explanation, new_explanation)
+  end
+
   def reason
     UnpublishingReason::PublishedInError
   end


### PR DESCRIPTION
https://trello.com/c/H7tPyTil

Users are able to edit the "explanation" on an unpublishing outside of normal document workflow. At present, these edits do not get reflected in the "unpublishing" in content store.

Whitehall needs to be updated such that when the explanation on an unpublishing is made, the "unpublishing" in content store is also updated.

The only change that's allowed to an unpublishing is updating the explanation text, which is a minor change. Hence these changes are marked as `minor`.