### PR TITLE
Warn stats publishers that they must also edit publication release dates

### DIFF
--- a/app/views/admin/statistics_announcement_date_changes/new.html.erb
+++ b/app/views/admin/statistics_announcement_date_changes/new.html.erb
@@ -19,6 +19,11 @@
         <%= form.text_area :change_note, required: true, rows: 5, class: 'form-control', label_text: 'Public change note' %>
       <% end %>
     </div>
+    <% if @statistics_announcement.publication %>
+      <div class="alert">
+        <span>Don’t forget to change the release date of the <%= link_to "attached publication", [:admin, @statistics_announcement.publication] %> as well.</span>
+      </div>
+    <% end %>
     <%= form.save_or_cancel_buttons buttons: { save: 'Publish change of date' }, cancel: [:admin, @statistics_announcement] %>
   <% end %>
 </div>


### PR DESCRIPTION
- This is in relation to the statistics announcements, and clarifies
  that they should take care to edit not just the publish date of the
  announcement, but of the publication of the actual statistics.
- This small copy change is intended to be a quick solution to lessen
  the frequency with which the unintended publication of statistics
  ahead of their announcement happens. The work to make announcements
  linked to publications in a way that updates the date for all
  associations when one is updated is considerably more involved.
- https://www.pivotaltracker.com/story/show/87453112.

![screen shot 2015-02-05 at 14 16 05](https://cloud.githubusercontent.com/assets/355033/6061683/92c35354-ad41-11e4-94aa-d4484592b4dc.png)