### PR TITLE
Implements new layouts of publication show pages and attachments

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -140,6 +140,7 @@
   @import "views/corporate_information_pages/show.scss";
   @import "views/organisations/_transition_state_visualisation.scss";
   @import "views/publications/_index.scss";
+  @import "views/publications/_show.scss";
   @import "views/statistics/_index.scss";
   @import "views/statistics_announcements/_index.scss";
   @import "views/statistics_announcements/_show.scss";

--- a/app/assets/stylesheets/frontend/views/publications/_show.scss
+++ b/app/assets/stylesheets/frontend/views/publications/_show.scss
@@ -1,0 +1,120 @@
+.publications-show-page {
+  p {
+    @include core-19;
+  }
+  .govspeak ul {
+    margin-left:0px;
+  }
+
+  .heading-block {
+    h1 {
+      @include media(tablet) {
+        padding-left: $gutter-half;
+        margin-bottom: $gutter-two-thirds;
+      }
+    }
+    .document-type {
+      @include core-19;
+      float: left;
+      margin-right: 5px;
+      @include media(tablet) {
+        @include bold-24;
+        float: none;
+      }
+    }
+    .document-size {
+      @include core-19($tabular-numbers: true);
+      float: left;
+      @include media(tablet) {
+        float: none;
+      }
+    }
+    .changed{
+      display: block;
+    }
+  }
+
+  .attachment {
+
+    padding: $gutter-one-third 0 0 0;
+
+    @include media(tablet) {
+      padding: $gutter-half 0 0 0;
+      @include right-to-left {
+        padding: $gutter-half 0 0 0;
+      }
+    }
+
+    .attachment-details {
+
+      @include grid-column( 2/3 );
+
+      h1, h2, h3 {
+        @include bold-24;
+      }
+
+      .references {
+        display: block;
+        @include media ( tablet ) {
+          display: inline;
+        }
+      }
+      .references,
+      .price {
+        color: $secondary-text-colour;
+      }
+      .order_url {
+        @include media ( tablet ) {
+          margin-left: $gutter-one-third;
+        }
+      }
+      .unnumbered-paper {
+         display: block;
+      }
+    }
+
+    .title a,
+    .govspeak a,
+    .toggler {
+      text-decoration: none;
+      &:hover,
+      &:focus {
+        outline: none;
+        text-decoration: underline;
+    }
+
+    .attachment-details,
+    .metadata {
+      padding: 0;
+      @include media(tablet) {
+        padding: 0 $gutter-half;
+      }
+    }
+  }
+
+  .metadata {
+    @include grid-column( 1/3 );
+    @include core-14;
+    .opendocument-help {
+      clear: both;
+      margin: 0;
+      a {
+        @include external-link-14;
+      }
+    }
+  }
+
+    // This ensure these elements have font-size 14px on all formats
+    // Breaks the font mixins standards but is better for design and layout
+    .accessibility-warning,
+    .references,
+    .opendocument-help,
+    .order_url,
+    .price {
+      @include core-16;
+      @include media(tablet) {
+        @include core-14;
+       }
+    }
+  }
+}

--- a/app/assets/stylesheets/frontend/views/publications/_show.scss
+++ b/app/assets/stylesheets/frontend/views/publications/_show.scss
@@ -11,6 +11,9 @@
       @include media(tablet) {
         padding-left: $gutter-half;
         margin-bottom: $gutter-two-thirds;
+        @include right-to-left {
+          padding: 0 $gutter-half 0 0;
+        }
       }
     }
     .document-type {
@@ -18,7 +21,7 @@
       float: left;
       margin-right: 5px;
       @include media(tablet) {
-        @include bold-24;
+        font-weight: bold;
         float: none;
       }
     }
@@ -40,16 +43,12 @@
 
     @include media(tablet) {
       padding: $gutter-half 0 0 0;
-      @include right-to-left {
-        padding: $gutter-half 0 0 0;
-      }
     }
 
     .attachment-details {
-
       @include grid-column( 2/3 );
 
-      h1, h2, h3 {
+      h2 {
         @include bold-24;
       }
 
@@ -81,6 +80,7 @@
       &:focus {
         outline: none;
         text-decoration: underline;
+      }
     }
 
     .attachment-details,
@@ -104,17 +104,16 @@
     }
   }
 
-    // This ensure these elements have font-size 14px on all formats
-    // Breaks the font mixins standards but is better for design and layout
-    .accessibility-warning,
-    .references,
-    .opendocument-help,
-    .order_url,
-    .price {
-      @include core-16;
-      @include media(tablet) {
-        @include core-14;
-       }
-    }
+  // This ensure these elements have font-size 14px on all formats
+  // Breaks the font mixins standards but is better for design and layout
+  .accessibility-warning,
+  .references,
+  .opendocument-help,
+  .order_url,
+  .price {
+    @include core-16;
+    @include media(tablet) {
+      @include core-14;
+     }
   }
 }

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -33,6 +33,10 @@ class HtmlAttachment < Attachment
     false
   end
 
+  def file_extension
+    "html"
+  end
+
   # Is in OpenDocument format? (see http://en.wikipedia.org/wiki/OpenDocument)
   def opendocument?
     false

--- a/app/views/documents/_attachment_attributes.html.erb
+++ b/app/views/documents/_attachment_attributes.html.erb
@@ -1,0 +1,24 @@
+<h3 class='document-type'><%= humanized_content_type(attachment.file_extension) %></h3>
+<span class='document-size'>
+  <%= number_to_human_size(attachment.file_size)%><% if attachment.number_of_pages.present? %>, <%= pluralize(attachment.number_of_pages, 'page')%><% end %>
+</span>
+
+<% if attachment.opendocument? %>
+  <p class="opendocument-help">
+    <%= t('attachment.opendocument.help_html') %>
+  </p>
+<% end %>
+
+<% unless attachment.accessible? %>
+  <div class="accessibility-warning js-toggle-accessibility-warning" id="<%= help_block_id %>">
+    <h2><%= t('attachment.accessibility.heading') %>
+      <span class="toggler"><%= t('attachment.accessibility.request_a_different_format') %></span>
+    </h2>
+    <p class="help-block">
+      <%= t('attachment.accessibility.full_help_html',
+        email: alertnative_order_email,
+        title: attachment.title,
+        references: attachment_references(attachment)) %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/documents/_attachment_attributes.html.erb
+++ b/app/views/documents/_attachment_attributes.html.erb
@@ -1,7 +1,9 @@
 <h3 class='document-type'><%= humanized_content_type(attachment.file_extension) %></h3>
-<span class='document-size'>
-  <%= number_to_human_size(attachment.file_size)%><% if attachment.number_of_pages.present? %>, <%= pluralize(attachment.number_of_pages, 'page')%><% end %>
-</span>
+<% if attachment.respond_to?(:file_size) && attachment.respond_to?(:number_of_pages) %>
+  <span class='document-size'>
+    <%= number_to_human_size(attachment.file_size)%><% if attachment.number_of_pages.present? %>, <%= pluralize(attachment.  number_of_pages, 'page')%><% end %>
+  </span>
+<% end %>
 
 <% if attachment.opendocument? %>
   <p class="opendocument-help">

--- a/app/views/documents/_publication_attachment.html.erb
+++ b/app/views/documents/_publication_attachment.html.erb
@@ -1,0 +1,70 @@
+<%
+  extra_description ||= ""
+  published_on ||= ""
+  help_block_id = "attachment-#{attachment.id}-accessibility-help"
+  attachment_link_options = attachment.accessible? ? {} : { "aria-describedby" => help_block_id }
+  attachment_link_options['rel'] = 'external' if attachment.external?
+%>
+<%= content_tag_for(:section, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded") do %>
+  <div class="attachment-details govspeak">
+    <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), attachment_link_options %></h2>
+
+    <% unless extra_description.empty? %>
+      <p class="extra-description"><%= extra_description %></p>
+    <% end %>
+
+    <% if previewable?(attachment) %>
+      <span class="preview">
+        <strong>
+          <%= link_to "View online", preview_path_for_attachment(attachment) %>
+        </strong>
+      </span>
+      <span class="download">
+        <%= link_to attachment.url(preview: params[:preview]) do %>
+          <strong>Download</strong>
+        <% end %>
+      </span>
+    <% end %>
+
+    <!-- Publishing/Changes information -->
+    <% unless published_on.blank? %>
+      <span class="changed"><%= t('attachment.headings.published') %>: <%= absolute_date(published_on) %></span>
+    <% end %>
+
+    <% if attachment.isbn.present? or attachment.unique_reference.present? or attachment.command_paper_number.present? or attachment.hoc_paper_number.present? %>
+      <span class="references">
+        <%= t('attachment.headings.reference') %>: <%= attachment_reference(attachment) %>
+      </span>
+    <% end %>
+
+    <% if attachment.order_url.present? %>
+      <%= link_to t('attachment.headings.order_a_copy'), attachment.order_url,
+          class: "order_url", title: t('attachment.headings.order_a_copy_full') %>
+      <% if attachment.price %>
+        <span class="price">(<%= number_to_currency(attachment.price, unit: "&pound;".html_safe) %>)</span>
+      <% end %>
+    <% end %>
+
+    <% if attachment.unnumbered_command_paper? || attachment.unnumbered_hoc_paper? %>
+      <span class="unnumbered-paper">
+        <% if attachment.unnumbered_command_paper? %>
+          <%= t('attachment.headings.unnumbered_command_paper') %>
+        <% else %>
+          <%= t('attachment.headings.unnumbered_hoc_paper') %>
+        <% end %>
+      </span>
+    <% end %>
+
+  </div>
+
+  <div class="metadata">
+    <%= render partial: "documents/attachment_attributes",
+      locals: {
+        attachment: attachment,
+        help_block_id: help_block_id,
+        alertnative_order_email: alternative_format_order_link(attachment, alternative_format_contact_email)
+      }
+    %>
+  </div>
+
+<% end %>

--- a/app/views/documents/_publication_attachment.html.erb
+++ b/app/views/documents/_publication_attachment.html.erb
@@ -5,7 +5,7 @@
   attachment_link_options = attachment.accessible? ? {} : { "aria-describedby" => help_block_id }
   attachment_link_options['rel'] = 'external' if attachment.external?
 %>
-<%= content_tag_for(:section, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded") do %>
+<%= content_tag_for(:div, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded") do %>
   <div class="attachment-details govspeak">
     <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), attachment_link_options %></h2>
 

--- a/app/views/documents/_publication_attachments.html.erb
+++ b/app/views/documents/_publication_attachments.html.erb
@@ -1,0 +1,19 @@
+<%
+  attachments = document.attachments.for_current_locale
+  title = t('document.headings.attachments', count: attachments.size) unless local_assigns.include?(:title)
+  published_on = '' unless local_assigns.include?(:published_on)
+%>
+<section class="publications-attachments">
+  <h1><%= title %></h1>
+  <article>
+    <% attachments.each do |attachment| %>
+      <%= render partial: "documents/publication_attachment",
+        locals: {
+          attachment: attachment,
+          alternative_format_contact_email: document.alternative_format_contact_email,
+          published_on: published_on
+        }
+      %>
+    <% end %>
+  </article>
+</section>

--- a/app/views/documents/_publication_attachments.html.erb
+++ b/app/views/documents/_publication_attachments.html.erb
@@ -3,7 +3,7 @@
   title = t('document.headings.attachments', count: attachments.size) unless local_assigns.include?(:title)
   published_on = '' unless local_assigns.include?(:published_on)
 %>
-<section class="publications-attachments">
+<div class="publications-attachments">
   <h1><%= title %></h1>
   <article>
     <% attachments.each do |attachment| %>
@@ -16,4 +16,4 @@
       %>
     <% end %>
   </article>
-</section>
+</div>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -20,29 +20,16 @@
     </div>
   </div>
 
+  <section id="details" class="inner-block">
+    <%= govspeak_edition_to_html @document %>
+  </section>
+
   <div class="block-2 heading-block">
     <div class="inner-block">
       <%= render partial: "documents/publication_attachments",
                  locals: {
                   document: @document
                  } %>
-    </div>
-  </div>
-
-  <div class="block-3 heading-block">
-    <div class="inner-block">
-      <section id="details">
-        <div class="head-section">
-          <h1><%= t('publications.headings.detail') %></h1>
-        </div>
-        <div class="content">
-          <article>
-            <div class="body">
-              <%= govspeak_edition_to_html @document %>
-            </div>
-          </article>
-        </div>
-      </section>
     </div>
   </div>
 

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,3 +1,4 @@
+<% page_class "publications-show-page" %>
 <% page_title edition_page_title(@document), t('publications.heading') %>
 
 <%= content_tag_for :article, @document, nil, class: "document-page #{@document.type.downcase}" do %>
@@ -21,8 +22,10 @@
 
   <div class="block-2 heading-block">
     <div class="inner-block">
-      <%= render partial: "documents/attachment_full_width",
-                 locals: { document: @document } %>
+      <%= render partial: "documents/publication_attachments",
+                 locals: {
+                  document: @document
+                 } %>
     </div>
   </div>
 

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -20,16 +20,30 @@
     </div>
   </div>
 
-  <section id="details" class="inner-block">
-    <%= govspeak_edition_to_html @document %>
-  </section>
-
   <div class="block-2 heading-block">
     <div class="inner-block">
       <%= render partial: "documents/publication_attachments",
                  locals: {
                   document: @document
                  } %>
+    </div>
+  </div>
+
+
+  <div class="block-3 heading-block">
+    <div class="inner-block">
+      <section id="details">
+        <div class="head-section">
+          <h1><%= t('publications.headings.detail') %></h1>
+        </div>
+        <div class="content">
+          <article>
+            <div class="body">
+              <%= govspeak_edition_to_html @document %>
+            </div>
+          </article>
+        </div>
+      </section>
     </div>
   </div>
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -45,7 +45,7 @@ class PublicationsControllerTest < ActionController::TestCase
       get :show, id: publication.document
     end
 
-    assert_select ".body", text: "body-in-html"
+    assert_select "#details", text: "body-in-html"
   end
 
   view_test "#show should not explicitly say that publication applies to the whole of the UK" do

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -45,7 +45,7 @@ class PublicationsControllerTest < ActionController::TestCase
       get :show, id: publication.document
     end
 
-    assert_select "#details", text: "body-in-html"
+    assert_select ".body", text: "body-in-html"
   end
 
   view_test "#show should not explicitly say that publication applies to the whole of the UK" do


### PR DESCRIPTION
• new design should be limited to publications pages only
• adds new attachment attributes partial
• splits metadata into separate column
• details sections to the top of publication show pages

Before -
![before](https://cloud.githubusercontent.com/assets/1692222/6103973/264fd866-b041-11e4-8a28-2d331adc1132.png)

After -
![after](https://cloud.githubusercontent.com/assets/1692222/6103975/2deec762-b041-11e4-89e0-9ab46355fb0b.png)


New pull request created from https://github.com/alphagov/whitehall/pull/1944 and fixes made in response to feedback and some other changes made.