### PR TITLE
Remove specialist browse category

### DIFF
--- a/app/models/edition/has_mainstream_categories.rb
+++ b/app/models/edition/has_mainstream_categories.rb
@@ -31,6 +31,15 @@ module Edition::HasMainstreamCategories
     true
   end
 
+  def remove_mainstream_category(category)
+    if self.primary_mainstream_category_id == category.id
+      self.update_attribute :primary_mainstream_category_id, nil
+    elsif self.other_mainstream_category_ids.include? category.id
+      new_ids = self.other_mainstream_category_ids.reject { |id| id == category.id }
+      self.update_attribute :other_mainstream_category_ids, new_ids
+    end
+  end
+
   private
 
   def avoid_duplication_between_primary_and_other_mainstream_categories

--- a/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
+++ b/db/data_migration/20150209134053_remove_self_assessment_detailed_guide_category.rb
@@ -1,0 +1,26 @@
+require 'gds_api/router'
+router_api = GdsApi::Router.new(Plek.current.find('router-api'))
+
+REDIRECT_TO = "/government/organisations/hm-revenue-customs"
+
+categories = MainstreamCategory.where(parent_tag: "tax/self-assessment")
+
+categories.each do |category|
+  old_path = Whitehall.url_maker.mainstream_category_path(category)
+  puts "removing category: #{category.title}"
+  guides = category.detailed_guides
+
+  puts "\t registering redirect: #{old_path} => #{REDIRECT_TO}"
+  router_api.add_redirect_route(old_path, 'exact', REDIRECT_TO)
+
+  puts "\t removing association to category from #{guides.count} guides"
+  guides.each { |guide| guide.remove_mainstream_category(category) }
+
+  puts "\t destroying category: \t #{old_path}"
+  category.destroy
+end
+
+puts "committing redirects"
+router_api.commit_routes
+
+puts "\nDon't forget to add the above redirects to router-data!"

--- a/test/unit/edition/has_mainstream_categories_test.rb
+++ b/test/unit/edition/has_mainstream_categories_test.rb
@@ -36,4 +36,20 @@ class Edition::HasMainstreamCategoriesTest < ActiveSupport::TestCase
     edition.destroy
     refute EditionMainstreamCategory.find_by_id(relation.id)
   end
+
+  test "can be dissociated from a mainstream category e.g. if we delete the category" do
+    primary_mainstream_category = create(:mainstream_category)
+    other_mainstream_category = create(:mainstream_category)
+    published_guide = create(:published_detailed_guide,
+                             primary_mainstream_category: primary_mainstream_category,
+                             other_mainstream_categories: [other_mainstream_category])
+
+
+    published_guide.remove_mainstream_category(primary_mainstream_category)
+    published_guide.remove_mainstream_category(other_mainstream_category)
+
+    assert_nil published_guide.primary_mainstream_category_id
+    assert published_guide.other_mainstream_category_ids.empty?
+
+  end
 end


### PR DESCRIPTION
Remove the detailed guide for tax advisers and agents.

This PR is based off of the work done in this: https://github.com/alphagov/whitehall/pull/1698 to do something similar.

https://www.pivotaltracker.com/n/projects/780127/stories/87918708 (pivotal)

After this is merged the following redirect should also be added to router-data (I think?): `browse/tax/self-assessment/guidance-for-tax-advisers-and-agents,/government/organisations/hm-revenue-customs`