### PR TITLE
Add `remove_mainstream_category` method

### DIFF
--- a/app/models/edition/has_mainstream_categories.rb
+++ b/app/models/edition/has_mainstream_categories.rb
@@ -31,6 +31,22 @@ module Edition::HasMainstreamCategories
     true
   end
 
+  # The main utility of this method is in data migrations
+  # when a mainstream category is no longer needed.
+  # Because this uses `update_attribute`, it's possible to
+  # bring the data into an inconsistent state (eg no primary
+  # mainstream category but other mainstream categories).
+  #
+  # Use with caution!
+  def remove_mainstream_category!(category)
+    if self.primary_mainstream_category_id == category.id
+      self.update_attribute :primary_mainstream_category_id, nil
+    elsif self.other_mainstream_category_ids.include? category.id
+      new_ids = self.other_mainstream_category_ids.reject { |id| id == category.id }
+      self.update_attribute :other_mainstream_category_ids, new_ids
+    end
+  end
+
   private
 
   def avoid_duplication_between_primary_and_other_mainstream_categories

--- a/test/unit/edition/has_mainstream_categories_test.rb
+++ b/test/unit/edition/has_mainstream_categories_test.rb
@@ -36,4 +36,20 @@ class Edition::HasMainstreamCategoriesTest < ActiveSupport::TestCase
     edition.destroy
     refute EditionMainstreamCategory.find_by_id(relation.id)
   end
+
+  test "can be dissociated from a mainstream category e.g. if we delete the category" do
+    primary_mainstream_category = create(:mainstream_category)
+    other_mainstream_category = create(:mainstream_category)
+    published_guide = create(:published_detailed_guide,
+                             primary_mainstream_category: primary_mainstream_category,
+                             other_mainstream_categories: [other_mainstream_category])
+
+
+    published_guide.remove_mainstream_category!(primary_mainstream_category)
+    published_guide.remove_mainstream_category!(other_mainstream_category)
+
+    assert_nil published_guide.primary_mainstream_category_id
+    assert published_guide.other_mainstream_category_ids.empty?
+
+  end
 end


### PR DESCRIPTION
It's come up twice now(https://github.com/alphagov/whitehall/pull/1967 and https://github.com/alphagov/whitehall/pull/1698) that we've had to make a migration to remove a mainstream category, these migrations would have benefitted from a `remove_mainstream_category` method on `has_mainstream_categories` so this commit adds it and adds a test.

/cc @evilstreak 