### PR TITLE
Solve the curious case of the mystery unpublishings

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -19,6 +19,7 @@ module Whitehall
     end
 
     def self.schedule(edition)
+      return unless served_from_content_store?(edition)
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
@@ -30,6 +31,7 @@ module Whitehall
     end
 
     def self.unschedule(edition)
+      return unless served_from_content_store?(edition)
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)
@@ -54,9 +56,13 @@ module Whitehall
       end
     end
 
+    def self.served_from_content_store?(edition)
+      edition.kind_of?(CaseStudy)
+    end
+
     def self.should_publish?(instance)
       if instance.kind_of?(Unpublishing)
-        instance.edition.kind_of?(CaseStudy)
+        served_from_content_store?(instance.edition)
       else
         true
       end

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -20,7 +20,7 @@ class SchedulingTest < ActiveSupport::TestCase
   end
 
   test "scheduling a subsequent edition publishes a publish intent to the Publishing API" do
-    published_edition = create(:published_edition)
+    published_edition = create(:published_case_study)
     new_draft = published_edition.create_draft(published_edition.creator)
     new_draft.change_note = 'changed'
     new_draft.scheduled_publication = 1.day.from_now
@@ -52,7 +52,7 @@ class SchedulingTest < ActiveSupport::TestCase
   end
 
   test "unscheduling a scheduled first-edition removes the publish intent and replaces the 'coming_soon' with a 'gone' item" do
-    scheduled_edition = create(:scheduled_edition)
+    scheduled_edition = create(:scheduled_case_study)
     unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
     base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
 
@@ -65,8 +65,8 @@ class SchedulingTest < ActiveSupport::TestCase
   end
 
   test "unscheduling a scheduled subsequent edition removes the publish intent but doesn't publish a 'gone' item" do
-    published_edition = create(:published_edition)
-    scheduled_edition = create(:scheduled_edition, document: published_edition.document)
+    published_edition = create(:published_case_study)
+    scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
 
     unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
     base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)


### PR DESCRIPTION
Since early January we have had various reports of documents being
published which appear to be immediately unpublished. 'gone' routes
were found to have made their way into the router database, and after
they were manually deleted by 2nd line everything worked as expected.

We found that these cases involved not-yet-published documents of various
formats that had been scheduled, then unscheduled, then published.

Since https://github.com/alphagov/whitehall/pull/1921 scheduling and
unscheduling have been going through the Publishing API for all formats. For
an initial publishing:

- scheduling created a publish intent and a 'coming soon' content item in the
  content store, both of which registered the same route
- unscheduling deleted the publish intent (which did not modify routes any
  further) and put a 'gone' content item in the content store, which updated
  the route to a 'gone' route
- publishing the document put a 'placeholder' content item in the content
  store unless it was a case study; this did not modify routes

This left the 'gone' route in place for non-case-study documents, which made
it look as if the item had been unpublished immediately.

This commit stops sending updates to the Publishing API when
scheduling/unscheduling, except for case studies. For all other formats, the
only thing we send to the content store now is a placeholder when they are
published.

This assumes that Whitehall is able to show 'coming soon' pages and adjust
cache headers for scheduled publications, which otherwise we wanted publish
intents and content store 'coming soon' items for.