### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -23,7 +23,6 @@ class PublishingApiPresenters::ComingSoon
 
   def as_json
     {
-      base_path: base_path,
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',
       format: 'coming_soon',

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -19,7 +19,6 @@ module PublishingApiPresenters
       {
         content_id: edition.content_id,
         title: edition.title,
-        base_path: base_path,
         description: edition.summary,
         format: "placeholder",
         locale: I18n.locale.to_s,

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -18,7 +18,6 @@ class PublishingApiPresenters::Placeholder
     {
       content_id: item.content_id,
       title: item.name,
-      base_path: base_path,
       format: format,
       locale: I18n.locale.to_s,
       publishing_app: 'whitehall',

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -22,7 +22,6 @@ private
 
   def redirect_hash
     {
-      base_path: base_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       redirects: [
@@ -36,7 +35,6 @@ private
     {
       content_id: edition.content_id,
       title: edition.title,
-      base_path: base_path,
       description: edition.summary,
       format: 'unpublishing',
       locale: I18n.locale.to_s,

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -9,7 +9,6 @@ private
 
   def gone_item_for(base_path)
     {
-      base_path: base_path,
       format: 'gone',
       publishing_app: 'whitehall',
       update_type: 'major',

--- a/app/workers/publishing_api_schedule_worker.rb
+++ b/app/workers/publishing_api_schedule_worker.rb
@@ -9,7 +9,6 @@ class PublishingApiScheduleWorker
 
   def build_publish_intent(base_path, publish_timestamp)
     {
-      base_path: base_path,
       publish_time: publish_timestamp,
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -17,7 +17,6 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       content_id: case_study.document.content_id,
       title: 'Case study title',
       description: 'The summary',
-      base_path: public_path,
       format: 'case_study',
       locale: 'en',
       need_ids: [],

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -8,7 +8,6 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
     publish_timestamp = 1.day.from_now
 
     expected_hash = {
-      base_path: base_path,
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',
       format: 'coming_soon',

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -19,7 +19,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
       content_id: edition.document.content_id,
       title: 'The title',
       description: 'The summary',
-      base_path: public_path,
       format: 'placeholder',
       locale: 'en',
       need_ids: [],
@@ -81,7 +80,7 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
       assert_equal 'ur', presented_hash[:locale]
       assert_equal 'Urdu title', presented_hash[:title]
       assert_equal Whitehall.url_maker.public_document_path(edition, locale: :ur),
-        presented_hash[:base_path]
+        presented_hash[:routes].first[:path]
 
     end
   end

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -12,7 +12,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     expected_hash = {
       content_id: ministerial_role.content_id,
       title: "Secretary of State for Silly Walks",
-      base_path: public_path,
       format: "placeholder_ministerial_role",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -32,7 +31,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     expected_hash = {
       content_id: organisation.content_id,
       title: "Organisation of Things",
-      base_path: public_path,
       format: "placeholder_organisation",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -52,7 +50,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     expected_hash = {
       content_id: person.content_id,
       title: "Winston",
-      base_path: public_path,
       format: "placeholder_person",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -72,7 +69,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     expected_hash = {
       content_id: worldwide_org.content_id,
       title: "Locationia Embassy",
-      base_path: public_path,
       format: "placeholder_worldwide_organisation",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -92,7 +88,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     expected_hash = {
       content_id: world_location.content_id,
       title: "Locationia",
-      base_path: public_path,
       format: "placeholder_world_location",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -123,7 +118,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       assert_equal 'fr', presented_hash[:locale]
       assert_equal 'French name', presented_hash[:title]
       assert_equal Whitehall.url_maker.organisation_path(organisation, locale: :fr),
-        presented_hash[:base_path]
+        presented_hash[:routes].first[:path]
 
     end
   end

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -10,7 +10,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       content_id: edition.content_id,
       title: edition.title,
       description: edition.summary,
-      base_path: public_path,
       format: 'unpublishing',
       locale: 'en',
       need_ids: [],
@@ -91,7 +90,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
 
       presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
 
-      assert_equal french_base_path, presenter.as_json[:base_path]
+      assert_equal french_base_path, presenter.as_json[:routes].first[:path]
       assert_valid_against_schema(presenter.as_json, 'unpublishing')
     end
   end
@@ -104,7 +103,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       content_id: edition.content_id,
       title: edition.title,
       description: edition.summary,
-      base_path: public_path,
       format: 'unpublishing',
       locale: 'en',
       need_ids: [],
@@ -147,7 +145,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     I18n.with_locale(:fr) do
       presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
 
-      assert_equal french_base_path, presenter.as_json[:base_path]
+      assert_equal french_base_path, presenter.as_json[:routes].first[:path]
       assert_equal 'fr', presenter.as_json[:locale]
       assert_valid_against_schema(presenter.as_json, 'unpublishing')
     end
@@ -158,7 +156,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     public_path      = unpublishing.document_path
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
-      base_path: public_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',
@@ -179,7 +176,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     public_path      = unpublishing.document_path
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
-      base_path: public_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -79,9 +79,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     published_payload = PublishingApiPresenters.presenter_for(published, update_type: "republish").as_json
     archived_payload  = PublishingApiPresenters.presenter_for(archived, update_type: "republish").as_json
 
-    draft_request     = stub_publishing_api_put_item(draft_payload[:base_path], draft_payload)
-    published_request = stub_publishing_api_put_item(published_payload[:base_path], published_payload)
-    archived_request  = stub_publishing_api_put_item(archived_payload[:base_path], archived_payload)
+    draft_request     = stub_publishing_api_put_item(draft.search_link, draft_payload)
+    published_request = stub_publishing_api_put_item(published.search_link, published_payload)
+    archived_request  = stub_publishing_api_put_item(archived.search_link, archived_payload)
 
     Whitehall::PublishingApi.republish(published)
     Whitehall::PublishingApi.republish(archived)
@@ -97,7 +97,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   test "republishes an unpublishing" do
     unpublishing = create(:unpublishing)
     payload      = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish").as_json
-    request      = stub_publishing_api_put_item(payload[:base_path], payload)
+    request      = stub_publishing_api_put_item(unpublishing.document_path, payload)
 
     Whitehall::PublishingApi.republish(unpublishing)
     assert_requested request
@@ -106,7 +106,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   test "publishes a redirect unpublishing" do
     unpublishing = create(:redirect_unpublishing)
     payload      = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish").as_json
-    request      = stub_publishing_api_put_item(payload[:base_path], payload)
+    request      = stub_publishing_api_put_item(unpublishing.document_path, payload)
 
     Whitehall::PublishingApi.republish(unpublishing)
     assert_requested request
@@ -116,7 +116,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     unpublishing    = create(:unpublishing)
     edition         = unpublishing.edition
     english_payload = PublishingApiPresenters::Unpublishing.new(unpublishing).as_json
-    english_request = stub_publishing_api_put_item(english_payload[:base_path], english_payload)
+    english_request = stub_publishing_api_put_item(unpublishing.document_path, english_payload)
 
     german_payload, german_request = nil
     I18n.with_locale(:de) do
@@ -124,7 +124,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       edition.save!
 
       german_payload = PublishingApiPresenters::Unpublishing.new(unpublishing).as_json
-      german_request = stub_publishing_api_put_item(german_payload[:base_path], german_payload)
+      german_request = stub_publishing_api_put_item(unpublishing.document_path, german_payload)
     end
 
     Whitehall::PublishingApi.publish(unpublishing)

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -7,7 +7,6 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
     locale       = 'fr'
 
     expected_payload = {
-      base_path: base_path,
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',
       format: 'coming_soon',

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -5,7 +5,6 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
     base_path = '/government/this-never-existed-honest'
 
     gone_payload = {
-      base_path: base_path,
       format: 'gone',
       publishing_app: 'whitehall',
       update_type: 'major',

--- a/test/unit/workers/publishing_api_schedule_worker_test.rb
+++ b/test/unit/workers/publishing_api_schedule_worker_test.rb
@@ -6,7 +6,6 @@ class PublishingApiScheduleWorkerTest < ActiveSupport::TestCase
     publish_time = 2.days.from_now
 
     expected_payload = {
-      base_path: base_path,
       publish_time: publish_time,
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

For more context: https://github.com/alphagov/content-store/pull/104