### PR TITLE
Add political flag to organisations

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -96,7 +96,7 @@ class Admin::OrganisationsController < Admin::BaseController
       :govuk_status, :govuk_closed_status, :closed_at, :organisation_chart_url,
       :foi_exempt, :ocpa_regulated, :public_meetings, :public_minutes,
       :regulatory_function, :important_board_members, :custom_jobs_url,
-      :homepage_type,
+      :homepage_type, :political,
       superseding_organisation_ids: [],
       default_news_image_attributes: [:file, :file_cache],
       organisation_roles_attributes: [:id, :ordering],

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -59,6 +59,11 @@
     <p>
       <%= organisation_form.text_field :custom_jobs_url  %>
     </p>
+    <% if current_user.gds_editor? %>
+      <label class="checkbox political-status">
+        <%= organisation_form.check_box :political, label_text: "Organisation publishes content associated with the current government" %>
+      </label>
+    <% end %>
   </fieldset>
   <fieldset>
     <legend>Associations</legend>

--- a/db/migrate/20150217154454_add_policital_to_organisations.rb
+++ b/db/migrate/20150217154454_add_policital_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddPolicitalToOrganisations < ActiveRecord::Migration
+  def change
+    add_column :organisations, :political, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -879,6 +879,7 @@ ActiveRecord::Schema.define(version: 20150219115527) do
     t.string   "custom_jobs_url"
     t.string   "content_id"
     t.string   "homepage_type",                           default: "news"
+    t.boolean  "political",                               default: false
   end
 
   add_index "organisations", ["content_id"], name: "index_organisations_on_content_id", unique: true, using: :btree

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -419,4 +419,23 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     get :features, id: organisation, locale: 'en'
     assert_response :success
   end
+
+  view_test "GDS Editors can set political status" do
+    organisation = create(:organisation)
+    policy_writer = create(:policy_writer, organisation: organisation)
+    login_as(policy_writer)
+
+    get :edit, id: organisation
+    refute_select ".political-status"
+
+    managing_editor = create(:managing_editor, organisation: organisation)
+    login_as(managing_editor)
+    get :edit, id: organisation
+    refute_select ".political-status"
+
+    gds_editor = create(:gds_editor, organisation: organisation)
+    login_as(gds_editor)
+    get :edit, id: organisation
+    assert_select ".political-status"
+  end
 end


### PR DESCRIPTION
So that we can correctly flag content which may contain content which is
not the opinion of the current government, we need to be able to tell if
an organisation publishes content associated to the current government.
This adds a flag to organisations which can manually be set in the admin
by GDS editors.

Added a basic test to assert that the checkbox doesn't get displayed for
other users.

- [x] Tech review
- [x] Product review