### PR TITLE
Perforance improvements to document searches controller

### DIFF
--- a/app/controllers/admin/document_searches_controller.rb
+++ b/app/controllers/admin/document_searches_controller.rb
@@ -21,6 +21,7 @@ class Admin::DocumentSearchesController < Admin::BaseController
         .with_translations(I18n.locale)
         .limit(10)
     end
+
   private
     def filters_for(params)
       filters = []
@@ -38,7 +39,7 @@ class Admin::DocumentSearchesController < Admin::BaseController
         end
       end
 
-      filters << ->(editions) { editions.public_send(params[:state] || 'active' ) }
+      filters << ->(editions) { editions.in_state(params[:state] || 'active') }
 
       filters
     end

--- a/app/controllers/admin/document_searches_controller.rb
+++ b/app/controllers/admin/document_searches_controller.rb
@@ -1,6 +1,54 @@
 class Admin::DocumentSearchesController < Admin::BaseController
   def show
-    filter_options = params.slice(:title, :type, :subtypes, :state).reverse_merge(state: 'active', per_page: 10)
-    @filter = Admin::EditionFilter.new(Edition, current_user, filter_options)
+    @editions = Filterer.new(params).editions
+  end
+
+  class Filterer
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+    def editions
+      filters_for(params).inject(edition_scope) do |editions, filter|
+        filter.call(editions)
+      end
+    end
+
+    def edition_scope
+      Edition
+        .with_translations(I18n.locale)
+        .limit(10)
+    end
+  private
+    def filters_for(params)
+      filters = []
+
+      if params[:title]
+        filters << ->(editions) { editions.with_title_containing(params[:title]) }
+      end
+
+      type = find_type(params[:type])
+      if type
+        filters << ->(editions) { editions.by_type(type) }
+
+        if params[:subtypes]
+          filters << ->(editions) { editions.by_subtypes(type, params[:subtypes]) }
+        end
+      end
+
+      filters << ->(editions) { editions.public_send(params[:state] || 'active' ) }
+
+      filters
+    end
+
+    def find_type(type_name)
+      if type_name
+        Whitehall.edition_classes.find do |klass|
+          klass.to_s == type_name.classify
+        end
+      end
+    end
   end
 end

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -91,10 +91,6 @@ module Admin
       end
     end
 
-    def valid_scopes
-      %w(active imported draft submitted rejected published scheduled force_published archived not_published)
-    end
-
     private
 
     def unpaginated_editions
@@ -104,7 +100,7 @@ module Admin
       editions = editions.by_type(type) if type
       editions = editions.by_subtype(type, subtype) if subtype
       editions = editions.by_subtypes(type, subtype_ids) if type && subtype_ids
-      editions = editions.public_send(state) if state
+      editions = editions.in_state(state) if state
       editions = editions.authored_by(author) if author
       editions = editions.in_organisation(organisation) if organisation
       editions = editions.with_classification(classification) if classification
@@ -133,7 +129,7 @@ module Admin
     end
 
     def state
-      options[:state] if valid_scopes.include?(options[:state])
+      options[:state] if Edition.valid_state?(options[:state])
     end
 
     def title

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -5,6 +5,14 @@ module Edition::Workflow
     def active
       where(arel_table[:state].not_eq('superseded'))
     end
+
+    def in_state(state)
+      valid_state?(state) && public_send(state)
+    end
+
+    def valid_state?(state)
+      %w(active imported draft submitted rejected published scheduled force_published archived not_published).include?(state)
+    end
   end
 
   included do

--- a/app/views/admin/document_searches/show.json.jbuilder
+++ b/app/views/admin/document_searches/show.json.jbuilder
@@ -1,6 +1,6 @@
-json.results_any? @filter.editions.any?
+json.results_any? @editions.any?
 json.set! :results do
-  json.array! @filter.editions do |edition|
+  json.array! @editions do |edition|
     json.extract!     edition, :id, :document_id, :title, :display_type
     json.type         edition.type.underscore
     json.url          admin_edition_path(edition)

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -6,11 +6,6 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     @current_user = build(:gds_editor)
   end
 
-  test "knows which states/scopes are valid for filtering" do
-    expected_scopes = %w(imported draft submitted rejected scheduled published archived active force_published not_published)
-    assert_same_elements expected_scopes, Admin::EditionFilter.new(Edition, @current_user).valid_scopes
-  end
-
   test "ignores invalid state scopes" do
     policy = create(:draft_policy)
 


### PR DESCRIPTION
We've been seeing reports of timeouts when querying performing operations which hit the `DocumentSearchesController`. This is used when adding a document to a document collection e.g.:

![screen shot 2015-02-17 at 19 10 28](https://cloud.githubusercontent.com/assets/61065/6235205/b3277184-b6d8-11e4-8c63-60b3559ccbed.png)

It's also used in part of the workflow in statistical releases, when attaching an existing document to a statistical announcement.

The underlying problem is that these queries rely on searching through all editions using a naive text search in mysql. There are around 350k records in the `edition_translations` table. A better solution would be to use a proper full text search index to allow searching for documents in admin, but for now we need some stop-gap to improve performance.

These changes should achieve an approx 4x speedup by:

- avoiding the 'count' query which is triggered by kaminari pagination
- using `LIKE` instead of `REGEXP` to perform the string-comparisons in the title matching in mysql

https://www.pivotaltracker.com/story/show/88310928