### PR TITLE
Fix the copyright notice

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (C) 2014 HM Government (Government Digital Service)
+Copyright (C) 2011 Crown copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Works made by civil servants come under Crown Copyright, according to the Copyright, Designs and Patents Act 1988: see an [explanation and link to the legislation](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright/crown-copyright/) on The National Archives.

The copyright year is supposed to be the date the work was created, which in this case dates back to the original commit in 2011: 8fa277204b3859131640df556c2346cafcf57a8f.