### PR TITLE
Preemptively add primary_locale to editions

### DIFF
--- a/db/migrate/20150209053237_add_primary_locale_to_editions.rb
+++ b/db/migrate/20150209053237_add_primary_locale_to_editions.rb
@@ -1,0 +1,12 @@
+class AddPrimaryLocaleToEditions < ActiveRecord::Migration
+  def up
+    add_column :editions, :primary_locale, :string, default: 'en', null: false
+
+    Edition.reset_column_information
+    Edition.update_all('primary_locale = locale')
+  end
+
+  def down
+    remove_column :editions, :primary_locale
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141210093620) do
+ActiveRecord::Schema.define(:version => 20150209053237) do
 
   create_table "about_pages", :force => true do |t|
     t.integer  "topical_event_id"
@@ -434,6 +434,7 @@ ActiveRecord::Schema.define(:version => 20141210093620) do
     t.datetime "closing_at"
     t.integer  "corporate_information_page_type_id"
     t.string   "need_ids"
+    t.string   "primary_locale",                              :default => "en",    :null => false
   end
 
   add_index "editions", ["alternative_format_provider_id"], :name => "index_editions_on_alternative_format_provider_id"


### PR DESCRIPTION
this is to avoid a race condition when deploying the rails 4 upgrade.

I noticed errors when deploying to preview which I think occured because the
whitehall-frontend apps restarted before the schema change had propogated to
the mysql slave. So the frontend apps saw the old schema and thought that Editions
did not have a `primary_locale` attribute.

We can pre-emptively add and populate this field.

A migration included in the rails 4 branch will update the field to ensure that
it contains the latest data at the time of switchover. Adding it pre-emptively
to the database schema avoids the race condition.