### PR TITLE
Fix order of Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,11 +267,11 @@ GEM
       sprockets-rails (~> 2.0)
     rails-i18n (0.7.3)
       i18n (~> 0.5)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     rails_translation_manager (0.0.1)
       activesupport
       rails-i18n
-    rails-observers (0.1.2)
-      activemodel (~> 4.0)
     railties (4.0.13)
       actionpack (= 4.0.13)
       activesupport (= 4.0.13)
@@ -439,8 +439,8 @@ DEPENDENCIES
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.0.13)
   rails-i18n
-  rails_translation_manager (= 0.0.1)
   rails-observers
+  rails_translation_manager (= 0.0.1)
   raindrops (= 0.11.0)
   rake (= 10.1.0)
   rubocop


### PR DESCRIPTION
This commit is the order that Bundler decided the gems should be in.