### PR TITLE
Add association to current Government when creating Documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,6 +39,7 @@ class Document < ActiveRecord::Base
   delegate :topics, to: :latest_edition
 
   after_create :ensure_document_has_a_slug
+  after_create :set_current_government
 
   attr_accessor :sluggable_string
 
@@ -110,5 +111,9 @@ class Document < ActiveRecord::Base
     if slug.blank?
       update_column(:slug, id.to_s)
     end
+  end
+
+  def set_current_government
+    update_column(:government_id, Government.current.id) if Government.current.present?
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,7 +39,6 @@ class Document < ActiveRecord::Base
   delegate :topics, to: :latest_edition
 
   after_create :ensure_document_has_a_slug
-  after_create :set_current_government
 
   attr_accessor :sluggable_string
 
@@ -101,6 +100,12 @@ class Document < ActiveRecord::Base
     document_type.underscore.gsub('_', ' ')
   end
 
+  def ensure_document_has_government
+    if Government.current.present? and government.nil?
+      update_column(:government_id, Government.current.id)
+    end
+  end
+
   private
 
   def destroy_all_editions
@@ -111,9 +116,5 @@ class Document < ActiveRecord::Base
     if slug.blank?
       update_column(:slug, id.to_s)
     end
-  end
-
-  def set_current_government
-    update_column(:government_id, Government.current.id) if Government.current.present?
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,6 +11,8 @@ class Document < ActiveRecord::Base
   has_many :editions, inverse_of: :document
   has_many :edition_relations, dependent: :destroy, inverse_of: :document
 
+  belongs_to :government
+
   has_one  :published_edition,
            -> { where(state: Edition::PUBLICLY_VISIBLE_STATES) },
            class_name: 'Edition',

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -3,6 +3,8 @@ class Government < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :start_date, presence: true
 
+  has_many :documents
+
   before_validation on: :create do |government|
     government.slug = government.name.to_s.parameterize
   end

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -8,4 +8,6 @@ class Government < ActiveRecord::Base
   before_validation on: :create do |government|
     government.slug = government.name.to_s.parameterize
   end
+
+  scope :current, -> { order(start_date: :desc).first }
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -32,6 +32,7 @@ private
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number
+    edition.document.ensure_document_has_government
   end
 
   def fire_transition!

--- a/db/migrate/20150219165949_add_column_government_to_document.rb
+++ b/db/migrate/20150219165949_add_column_government_to_document.rb
@@ -1,0 +1,5 @@
+class AddColumnGovernmentToDocument < ActiveRecord::Migration
+  def change
+    add_column :documents, :government_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150219115527) do
+ActiveRecord::Schema.define(version: 20150219165949) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 20150219115527) do
     t.string   "slug"
     t.string   "document_type"
     t.string   "content_id"
+    t.integer  "government_id"
   end
 
   add_index "documents", ["document_type"], name: "index_documents_on_document_type", using: :btree

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -152,4 +152,10 @@ class DocumentTest < ActiveSupport::TestCase
 
     refute draft.document.similar_slug_exists?
   end
+
+  test "current government is set on creation" do
+    current_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
+    document = create(:document)
+    assert_equal current_government, document.government
+  end
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -153,9 +153,18 @@ class DocumentTest < ActiveSupport::TestCase
     refute draft.document.similar_slug_exists?
   end
 
-  test "current government is set on creation" do
-    current_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
+  test "#ensure_document_has_government does not change existing government association" do
     document = create(:document)
-    assert_equal current_government, document.government
+    initial_government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
+    Government.stubs(:current).returns(initial_government)
+    document.ensure_document_has_government
+
+    assert_equal initial_government, document.government
+
+    new_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
+    Government.stubs(:current).returns(new_government)
+    document.ensure_document_has_government
+
+    assert_equal initial_government, document.government
   end
 end

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -48,4 +48,11 @@ class GovernmentTest < ActiveSupport::TestCase
 
     refute labour_government_duplicating_original_name.valid?
   end
+
+  test "knows the correct current government" do
+    current_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
+    previous_government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
+
+    assert_equal current_government, Government.current
+  end
 end

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -65,6 +65,18 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_equal 1.week.ago, edition.major_change_published_at
   end
 
+  test '#perform! with a unpublished edition sets the government association' do
+    government = create(:government)
+    edition = create(:submitted_edition)
+
+    refute edition.document.government
+
+    publisher = EditionPublisher.new(edition)
+
+    assert publisher.perform!
+    assert_equal government, edition.document.government
+  end
+
   test '#perform! supersedes all previous editions' do
     published_edition = create(:published_edition)
     edition = published_edition.create_draft(create(:policy_writer))


### PR DESCRIPTION
Adds a relationship between documents and a government, defaulting to the current government. After discussion with @edds we agreed that it OK to assume that this would be the government with the most recent start date, as no speculative/future governments should exist. 

This only sets the association at the point of publication for a document, there will be separate work to retroactive apply government associations to documents. Also the association won't be exposed in the UI yet.

Setting the government at the point of publication means we avoid 2 edge cases;

1. A document is created and scheduled on a future date under a new government, but would still be attached to the old government via the document creation
2. A document is created/draft under one government and published under a new government, but is still attached to the original government when the draft was created.

https://trello.com/c/049aghPo/43-add-government-relation-to-future-documents

- [x] Code review
- [x] Product review 