### PR TITLE
Ministers in content store

### DIFF
--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -1,5 +1,6 @@
 class MinisterialRole < Role
   include Searchable
+  include PublishesToPublishingApi
 
   has_many :edition_ministerial_roles
   has_many :editions, through: :edition_ministerial_roles

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,5 @@
 class Person < ActiveRecord::Base
+  include PublishesToPublishingApi
 
   def self.columns
     # This is here to enable us to gracefully remove the biography column

--- a/db/data_migration/20150223113328_set_role_content_ids.rb
+++ b/db/data_migration/20150223113328_set_role_content_ids.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.connection.execute 'UPDATE roles SET content_id=UUID() where content_id IS NULL'

--- a/db/data_migration/20150223113420_publish_ministerial_roles_to_content_store.rb
+++ b/db/data_migration/20150223113420_publish_ministerial_roles_to_content_store.rb
@@ -1,0 +1,1 @@
+DataHygiene::PublishingApiRepublisher.new(MinisterialRole).perform

--- a/db/data_migration/20150223160956_set_person_content_ids.rb
+++ b/db/data_migration/20150223160956_set_person_content_ids.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.connection.execute 'UPDATE people SET content_id=UUID() where content_id IS NULL'

--- a/db/data_migration/20150223161232_publish_people_to_content_store.rb
+++ b/db/data_migration/20150223161232_publish_people_to_content_store.rb
@@ -1,0 +1,1 @@
+DataHygiene::PublishingApiRepublisher.new(Person).perform

--- a/db/migrate/20150218111253_add_content_id_to_roles.rb
+++ b/db/migrate/20150218111253_add_content_id_to_roles.rb
@@ -1,0 +1,5 @@
+class AddContentIdToRoles < ActiveRecord::Migration
+  def change
+    add_column :roles, :content_id, :string
+  end
+end

--- a/db/migrate/20150223160728_add_content_id_to_people.rb
+++ b/db/migrate/20150223160728_add_content_id_to_people.rb
@@ -1,0 +1,5 @@
+class AddContentIdToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -585,8 +585,8 @@ ActiveRecord::Schema.define(version: 20150219165949) do
     t.string   "name"
     t.date     "start_date"
     t.date     "end_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "governments", ["end_date"], name: "index_governments_on_end_date", using: :btree
@@ -1019,6 +1019,7 @@ ActiveRecord::Schema.define(version: 20150219165949) do
     t.integer  "role_payment_type_id"
     t.boolean  "supports_historical_accounts", default: false, null: false
     t.integer  "whip_ordering",                default: 100
+    t.string   "content_id"
   end
 
   add_index "roles", ["attends_cabinet_type_id"], name: "index_roles_on_attends_cabinet_type_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150219165949) do
+ActiveRecord::Schema.define(version: 20150223160728) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -899,6 +899,7 @@ ActiveRecord::Schema.define(version: 20150219165949) do
     t.string   "carrierwave_image"
     t.string   "slug"
     t.boolean  "privy_counsellor",  default: false
+    t.string   "content_id"
   end
 
   add_index "people", ["slug"], name: "index_people_on_slug", unique: true, using: :btree

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -34,7 +34,7 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test "should be valid if legacy image isn't 960x640px" do
-    person = build(:person, slug: 'stubbed', image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
+    person = build(:person, slug: 'stubbed', image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')), content_id: "a-content-id")
     person.save(validate: false)
     assert person.reload.valid?
   end

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -1,8 +1,28 @@
 require 'test_helper'
 
 class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
-  def present(organisation, options = {})
-    PublishingApiPresenters::Placeholder.new(organisation, options).as_json
+  def present(model_instance, options = {})
+    PublishingApiPresenters::Placeholder.new(model_instance, options).as_json
+  end
+
+  test 'presents a Ministerial Role ready for adding to the publishing API' do
+    ministerial_role = create(:ministerial_role, name: "Secretary of State for Silly Walks")
+    public_path = Whitehall.url_maker.ministerial_role_path(ministerial_role)
+
+    expected_hash = {
+      content_id: ministerial_role.content_id,
+      title: "Secretary of State for Silly Walks",
+      base_path: public_path,
+      format: "placeholder_ministerial_role",
+      locale: 'en',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: ministerial_role.updated_at,
+      routes: [ { path: public_path, type: "exact" } ],
+      update_type: "major",
+    }
+
+    assert_equal expected_hash, present(ministerial_role)
   end
 
   test 'presents an Organisation ready for adding to the publishing API' do

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -45,6 +45,26 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     assert_equal expected_hash, present(organisation)
   end
 
+  test 'presents a Person ready for adding to the publishing API' do
+    person = create(:person, forename: "Winston")
+    public_path = Whitehall.url_maker.person_path(person)
+
+    expected_hash = {
+      content_id: person.content_id,
+      title: "Winston",
+      base_path: public_path,
+      format: "placeholder_person",
+      locale: 'en',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: person.updated_at,
+      routes: [ { path: public_path, type: "exact" } ],
+      update_type: "major",
+    }
+
+    assert_equal expected_hash, present(person)
+  end
+
   test 'presents a Worldwide Organisation ready for adding to the publishing API' do
     worldwide_org = create(:worldwide_organisation, name: 'Locationia Embassy')
     public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)


### PR DESCRIPTION
As part of the work to move Policies to exist in the Content Store (as Finders) we need to push certain formats into the Content Store which correctly don't exist in there. This PR includes the work for pushing Ministerial Roles and People into the Content Store.

- [x] code review