### PR TITLE
Ensure deprecated columns are inherited

### DIFF
--- a/lib/deprecated_columns.rb
+++ b/lib/deprecated_columns.rb
@@ -4,10 +4,12 @@ module DeprecatedColumns
   # in a future commit, *after* the code marking the column
   # as deprecated has been deployed
   def deprecated_columns(*names)
-    cattr_accessor :deprecated_column_list do
-      # default value
-      names.map(&:to_s)
+    unless self.respond_to?(:deprecated_column_list)
+      class_attribute :deprecated_column_list
+      self.deprecated_column_list = []
     end
+
+    self.deprecated_column_list += names.map(&:to_s)
 
     def columns
       super().reject { |column| deprecated_column_list.include?(column.name) }


### PR DESCRIPTION
It's important that deprecated columns are inherited because if a column
is deprecated in the base class then it would also need to be deprecated
in any derived class (if using Rails STI).

We have a specific issue because `Policy` deprecates
`published_related_publication_count` and Edition deprecates `locale`.
There were errors being raised inside ActiveRecord in some edge cases
because the `locale` column was not deprecated for `Policy`.

https://trello.com/c/ZUlRft6V/53-rails-4-upgrade-deprecated-columns-helper-error