### PR TITLE
Fix data migration generator

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -6,7 +6,7 @@ class DataMigrationGenerator < Rails::Generators::NamedBase
     Time.zone.now.utc.strftime("%Y%m%d%H%M%S")
   end
 
-  def create_migration
-    migration_template "data_migration.rb", Rails.root.join("db/data_migration", file_name)
+  def create_data_migration
+    migration_template "data_migration.rb", Rails.root.join("db/data_migration", "#{file_name}.rb")
   end
 end


### PR DESCRIPTION
the api had changed in Rails 4.

In rails/rails@9541434 a new method `create_migration` had been added to the
`Rails::Generators::Migration` module which this uses. That new method
clashed with out one, so we just need to rename it.