### PR TITLE
Data migration to backfill political content flag.

### DIFF
--- a/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
+++ b/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
@@ -1,0 +1,92 @@
+# As per https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1412V79VMtpfZWNMYJhV7A2QFDKvUdseRtnA35bm-gmY/edit#gid=1194852478
+#
+# Exceptions at time of writing:
+# - Blog posts are not stored in Whitehall
+# - Annual reports are covered under corporate reports
+# - Government responses, press releases and news stories are covered under news articles
+
+POLITICAL_PUBLICATION_TYPES = [
+  PublicationType::ImpactAssessment,
+  PublicationType::InternationalTreaty,
+  PublicationType::PolicyPaper,
+  PublicationType::ResearchAndAnalysis,
+  PublicationType::CorporateReport
+].freeze
+
+POLITICAL_ORGS = %w[
+  attorney-generals-office
+  cabinet-office
+  department-for-business-enterprise-and-regulatory-reform
+  department-for-business-innovation-skills
+  department-for-children-schools-and-families
+  department-for-communities-and-local-government
+  department-for-constitutional-affairs
+  department-for-culture-media-sport
+  department-for-education
+  department-for-education-and-skills
+  department-for-environment-food-rural-affairs
+  department-for-innovation-universities-and-skills
+  department-for-international-development
+  department-for-transport
+  department-for-work-pensions
+  department-of-constitutional-affairs
+  department-of-energy-climate-change
+  department-of-health
+  department-of-inland-revenue
+  department-of-national-heritage
+  department-of-social-security
+  department-of-the-environment-transport-and-the-regions
+  department-of-trade-and-industry
+  exchequer-and-audit-department
+  foreign-commonwealth-office
+  hm-treasury
+  home-office
+  law-officers-departments
+  lord-chancellors-department
+  ministry-of-defence
+  ministry-of-justice
+  northern-ireland-office
+  office-of-the-advocate-general-for-scotland
+  the-office-of-the-leader-of-the-house-of-commons
+  office-of-the-leader-of-the-house-of-lords
+  prime-ministers-office-10-downing-street
+  scotland-office
+  scottish-office
+  uk-export-finance
+  wales-office
+].freeze
+
+def has_minister?(edition)
+  (edition.can_be_associated_with_ministers? && edition.ministerial_roles.any?) ||
+    edition.try(:role_appointment).try(:role).is_a?(MinisterialRole)
+end
+
+def political_format?(edition)
+  case edition
+  when Consultation, Speech, NewsArticle, WorldLocationNewsArticle
+    true
+  when Publication
+    POLITICAL_PUBLICATION_TYPES.include?(edition.publication_type)
+  else
+    false
+  end
+end
+
+def has_political_org?(edition)
+  edition.can_be_related_to_organisations? &&
+    edition.organisations.where(slug: POLITICAL_ORGS).any?
+end
+
+index = 0
+edition_scope = Edition.where(state: ["published","draft","archived"])
+edition_count = edition_scope.count
+
+edition_scope.find_each do |edition|
+  if has_minister?(edition) || (political_format?(edition) && has_political_org?(edition))
+    edition.update_attribute(:political, true)
+  end
+
+  index += 1
+
+  Rails.logger.info("Processed #{index} of #{edition_count} editions (#{(index.to_f/edition_count.to_f)*100}%)") if index % 1000 == 0
+end

--- a/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
+++ b/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
@@ -33,7 +33,6 @@ POLITICAL_ORGS = %w[
   department-of-constitutional-affairs
   department-of-energy-climate-change
   department-of-health
-  department-of-inland-revenue
   department-of-national-heritage
   department-of-social-security
   department-of-the-environment-transport-and-the-regions

--- a/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
+++ b/db/data_migration/20150224084313_backfill_political_flag_on_editions.rb
@@ -15,6 +15,7 @@ POLITICAL_PUBLICATION_TYPES = [
 
 POLITICAL_ORGS = %w[
   attorney-generals-office
+  better-regulation-delivery-office
   cabinet-office
   department-for-business-enterprise-and-regulatory-reform
   department-for-business-innovation-skills
@@ -37,23 +38,34 @@ POLITICAL_ORGS = %w[
   department-of-social-security
   department-of-the-environment-transport-and-the-regions
   department-of-trade-and-industry
-  exchequer-and-audit-department
+  deputy-prime-ministers-office
+  english-partnerships
   foreign-commonwealth-office
+  government-equalities-office
   hm-treasury
   home-office
+  homes-and-communities-agency
+  housing-corporation
+  immigration-enforcement
+  infrastructure-uk
   law-officers-departments
   lord-chancellors-department
   ministry-of-defence
   ministry-of-justice
   northern-ireland-office
+  office-for-low-emission-vehicles
   office-of-the-advocate-general-for-scotland
   the-office-of-the-leader-of-the-house-of-commons
   office-of-the-leader-of-the-house-of-lords
+  open-public-services
   prime-ministers-office-10-downing-street
+  renewable-fuels-agency
   scotland-office
   scottish-office
+  the-shareholder-executive
   uk-export-finance
   wales-office
+  welsh-office
 ].freeze
 
 def has_minister?(edition)

--- a/db/migrate/20150224083732_add_political_flag_to_edition.rb
+++ b/db/migrate/20150224083732_add_political_flag_to_edition.rb
@@ -1,0 +1,5 @@
+class AddPoliticalFlagToEdition < ActiveRecord::Migration
+  def change
+    add_column :editions, :political, :boolean, null:false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150219165949) do
+ActiveRecord::Schema.define(version: 20150224083732) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -436,6 +436,7 @@ ActiveRecord::Schema.define(version: 20150219165949) do
     t.integer  "corporate_information_page_type_id"
     t.string   "need_ids"
     t.string   "primary_locale",                              default: "en",    null: false
+    t.boolean  "political",                                   default: false,   null: false
   end
 
   add_index "editions", ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree


### PR DESCRIPTION
Adjusts all published, draft, and archived editions.

This enables signposting of political documents associated with previous governments.

The intended behaviour is to tag all editions which are either a) associated with a minister or b) from a "political organisation" AND are of a "political format".

https://trello.com/c/M4VrdeQc/41-back-fill-political-flag-for-relevant-documents

- [x] Get sign-off from @bmwelby and Alex Jackson for "political organisations" list
- [x] Get sign-off from @bmwelby and Alex Jackson for "political formats" list
- [x] Get local/preview sign-off from @bmwelby or Alex Jackson on results of migration
- [x] Rebase onto master
- [ ] Refactor this PR to use code from here: https://github.com/alphagov/whitehall/pull/1995