### PR TITLE
Add political checkbox to editions

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -189,6 +189,7 @@ class Admin::EditionsController < Admin::BaseController
       :additional_related_mainstream_content_title,
       :primary_specialist_sector_tag,
       :corporate_information_page_type_id,
+      :political,
       secondary_specialist_sector_tags: [],
       ministerial_role_ids: [],
       lead_organisation_ids: [],

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -14,6 +14,12 @@
   <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: form.object.body_required? %>
 
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
+
+  <% if (edition.document and edition.document.published?) and can?(:mark_political, edition) %>
+    <label class="checkbox political-status">
+      <%= form.check_box :political, label_text: "Document should be labelled as associated with the government of the time" %>
+    </label>
+  <% end %>
 <% end %>
 
 <%= render partial: 'first_published_at', locals: { form: form, edition: edition } %>

--- a/db/migrate/20150220133345_add_political_to_editions.rb
+++ b/db/migrate/20150220133345_add_political_to_editions.rb
@@ -1,0 +1,5 @@
+class AddPoliticalToEditions < ActiveRecord::Migration
+  def change
+    add_column :editions, :political, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -436,6 +436,7 @@ ActiveRecord::Schema.define(version: 20150223160728) do
     t.integer  "corporate_information_page_type_id"
     t.string   "need_ids"
     t.string   "primary_locale",                              default: "en",    null: false
+    t.boolean  "political",                                   default: false
   end
 
   add_index "editions", ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -6,7 +6,8 @@ module Whitehall::Authority::Rules
         :approve, :publish, :force_publish,
         :reject, :make_fact_check, :review_fact_check,
         :make_editorial_remark, :review_editorial_remark,
-        :limit_access, :unpublish, :export, :confirm_export
+        :limit_access, :unpublish, :export, :confirm_export,
+        :mark_political
       ]
     end
 
@@ -39,7 +40,9 @@ module Whitehall::Authority::Rules
       elsif action == :unpublish && actor.managing_editor?
         return true
       else
-        if actor.gds_editor?
+        if actor.gds_admin?
+          gds_admin_can?(action)
+        elsif actor.gds_editor?
           gds_editor_can?(action)
         elsif actor.departmental_editor?
           departmental_editor_can?(action)
@@ -55,6 +58,10 @@ module Whitehall::Authority::Rules
           departmental_writer_can?(action)
         end
       end
+    end
+
+    def gds_admin_can?(action)
+      gds_editor_can?(action)
     end
 
     def gds_editor_can?(action)
@@ -132,7 +139,7 @@ module Whitehall::Authority::Rules
         can_publish?
       when :force_publish
         can_force_publish?
-      when :unpublish
+      when :unpublish, :mark_political
         false
       else
         true
@@ -140,7 +147,12 @@ module Whitehall::Authority::Rules
     end
 
     def managing_editor_can?(action)
-      departmental_editor_can?(action)
+      case action
+      when :mark_political
+        true
+      else
+        departmental_editor_can?(action)
+      end
     end
 
     def world_editor_can?(action)
@@ -149,7 +161,7 @@ module Whitehall::Authority::Rules
 
     def departmental_writer_can?(action)
       case action
-      when :approve, :publish, :unpublish, :force_publish, :reject
+      when :approve, :publish, :unpublish, :force_publish, :reject, :mark_political
         false
       else
         true

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController::TestCase
+  tests Admin::NewsArticlesController
+
+  setup do
+    login_as :policy_writer
+  end
+
+  view_test "displays the political checkbox for privileged users " do
+    login_as :managing_editor
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+    get :edit, id: new_draft
+    assert_select '.political-status', count: 1
+  end
+
+  view_test "doesn't display the political checkbox for non-privileged users " do
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+    get :edit, id: new_draft
+    assert_select '.political-status', count: 0
+  end
+
+  view_test "doesn't display the political checkbox on creation" do
+    login_as :managing_editor
+    get :new
+    assert_select '.political-status', count: 0
+  end
+end

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -162,4 +162,8 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   test 'can export editions' do
     assert enforcer_for(department_editor, Edition).can?(:export)
   end
+
+  test 'cannot mark editions as political' do
+    refute enforcer_for(department_editor, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/department_writer_test.rb
+++ b/test/unit/whitehall/authority/department_writer_test.rb
@@ -138,4 +138,8 @@ class DepartmentWriterTest < ActiveSupport::TestCase
   test 'cannot administer the sitewide_settings section' do
     refute enforcer_for(department_writer, :sitewide_settings_section).can?(:administer)
   end
+
+  test 'cannot mark editions as political' do
+    refute enforcer_for(department_writer, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/whitehall/authority/gds_admin_test.rb
@@ -31,4 +31,8 @@ class GDSAdminTest < ActiveSupport::TestCase
     refute enforcer_for(non_gds_admin, government).can?(:edit)
     refute enforcer_for(non_gds_admin, Government).can?(:create)
   end
+
+  test 'can mark editions as political' do
+    assert enforcer_for(gds_admin, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/whitehall/authority/gds_editor_test.rb
@@ -172,4 +172,8 @@ class GDSEditorTest < ActiveSupport::TestCase
     assert enforcer_for(user, editors_org).can?(:manage_featured_links)
     assert enforcer_for(user, other_org).can?(:manage_featured_links)
   end
+
+  test 'can mark editions as political' do
+    assert enforcer_for(gds_editor, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -171,4 +171,8 @@ class ManagingEditorTest < ActiveSupport::TestCase
   test 'can export editions' do
     assert enforcer_for(managing_editor, Edition).can?(:export)
   end
+
+  test 'can mark editions as political' do
+    assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/world_editor_test.rb
+++ b/test/unit/whitehall/authority/world_editor_test.rb
@@ -199,4 +199,9 @@ class WorldEditorTest < ActiveSupport::TestCase
     user = world_editor(['hat land', 'tie land'])
     refute enforcer_for(user, :sitewide_settings_section).can?(:administer)
   end
+
+  test 'cannot mark editions as political' do
+    user = world_editor(['hat land', 'tie land'])
+    refute enforcer_for(user, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/whitehall/authority/world_writer_test.rb
+++ b/test/unit/whitehall/authority/world_writer_test.rb
@@ -195,4 +195,9 @@ class WorldWriterTest < ActiveSupport::TestCase
     user = world_writer(['hat land', 'tie land'])
     refute enforcer_for(user, :sitewide_settings_section).can?(:administer)
   end
+
+  test 'cannot mark editions as political' do
+    user = world_writer(['hat land', 'tie land'])
+    refute enforcer_for(user, normal_edition).can?(:mark_political)
+  end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -93,26 +93,15 @@ class WorldLocationTest < ActiveSupport::TestCase
     end
   end
 
-  test "all_by_type should group world locations by type sorting the types by their sort order" do
+  test "all_by_type should group world locations by type sorting the types by their sort order and locations by their name" do
     world_location_type = WorldLocationType::WorldLocation
     delegation_type = WorldLocationType::InternationalDelegation
 
-    location_1 = create(:world_location, world_location_type: world_location_type)
-    location_2 = create(:world_location, world_location_type: delegation_type)
-    location_3 = create(:world_location, world_location_type: delegation_type)
-
-    assert_equal [[world_location_type, [location_1]] , [delegation_type, [location_2, location_3]]], WorldLocation.all_by_type
-  end
-
-  test "all_by_type should group world locations by type sorting the locations by their name" do
-    world_location_type = WorldLocationType::WorldLocation
-    delegation_type = WorldLocationType::InternationalDelegation
-
-    location_1 = create(:world_location, world_location_type: delegation_type, name: 'Neverland')
-    location_2 = create(:world_location, world_location_type: world_location_type, name: 'Narnia')
+    location_1 = create(:world_location, world_location_type: world_location_type, name: 'Narnia')
+    location_2 = create(:world_location, world_location_type: delegation_type, name: 'Neverland')
     location_3 = create(:world_location, world_location_type: world_location_type, name: 'Middle Earth')
 
-    assert_equal [[world_location_type, [location_3, location_2]] , [delegation_type, [location_1]]], WorldLocation.all_by_type
+    assert_equal [[world_location_type, [location_3, location_1]] , [delegation_type, [location_2]]], WorldLocation.all_by_type
   end
 
   test "#feature_list_for_locale should return the feature list for the given locale, or build one if not" do


### PR DESCRIPTION
So that we can manually change the political state of an edition add a
checkbox to the admin. This will be useful if, for example, a document
which doesn't meet the standard criteria for being political is noticed
to be political. Only managing editors and GDS staff should be able to
change the state of the political flag. The political checkbox should
only be shown after the document has been published for the first time.
This is so that we can automatically set it on first publish. If it was
editable before the first publish and editor changed it our automatic
political marking would overwrite what the editor had set.

![screen shot 2015-03-03 at 14 05 05](https://cloud.githubusercontent.com/assets/35035/6464878/35d57ed2-c1b5-11e4-849c-3fb5a0d493f2.png)

---

This still needs the words next to the checkbox checking and either this
or https://github.com/alphagov/whitehall/pull/1991 need to remove the database migration depending on which gets
merged first