### PR TITLE
Backfill Government on historic Documents

### DIFF
--- a/db/data_migration/20150220140246_set_government_for_historic_documents.rb
+++ b/db/data_migration/20150220140246_set_government_for_historic_documents.rb
@@ -1,0 +1,27 @@
+# We only to update content that has been published, having some kind of publish
+# date, and that is not irrecoverably unpublished (eg, not deleted or superseded)
+updatable_edition_states = Edition::PUBLICLY_VISIBLE_STATES
+
+Document.where(government_id: nil).find_each do | document |
+  edition = Edition.where(document_id: document.id, state: updatable_edition_states)
+            .order(created_at: :desc).first
+
+  # Some document won't have any editions in `updatable_edition_states`
+  unless edition
+    puts "Skipping '#{document.id}', no edition"
+    next
+  end
+
+  # Most documents have `first_public_at`, which maps to `first_published_at`
+  # but some `Speech` rows are missing it, so use `delivered_on` instead
+  unless publication_date = edition.first_public_at || edition.delivered_on
+    puts "Skipping '#{document.id}' (#{edition.state.upcase}), missing publication date"
+    next
+  end
+
+  government = Government.on_date(publication_date)
+  puts "Setting '#{document.id}' to '#{government.slug}'"
+
+  document.update_attribute(:government, government)
+
+end


### PR DESCRIPTION
The government field was added to Document in #1984, and is
set when a document is published for the first time (though this
is likely to change shortly).

This migration backfills government for Documents that have
already been published. The government of a document should
be based on the point when the document itself was first
published - distinct from when the Model was created.

This date is derived from `first_public_at` date on edition,
which reflects the historic creation date of a document.
(There is an exception for speeches, which use a different
field, but has the same intent).

From that date the government at the time can be found, and
can be set on Document. 

- [x] Code review
- [x] Product review
- [x] #1984 is deployed, so new documents have a Government
- [x] Government date ranges are double checked, and updated if needed (Done in https://github.com/alphagov/whitehall/pull/1999)
- [x] https://github.com/alphagov/whitehall/pull/2003 is merged, and rebased into these changes
