### PR TITLE
Bugfix: cannot redirect to params hash on export

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -39,7 +39,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def index
     if filter && filter.valid?
-      session[:document_filters] = params_filters.to_hash
+      session[:document_filters] = params_filters
       if request.xhr?
         render partial: 'search_results'
       else
@@ -159,7 +159,7 @@ class Admin::EditionsController < Admin::BaseController
     previous_document = import.document_imported_before(@edition.document) if import
     return admin_edition_path(previous_document.latest_edition) if previous_document
 
-    admin_editions_path(session_filters.merge(state: :imported))
+    admin_editions_path(session_filters.merge('state' => :imported))
   end
 
   def fetch_version_and_remark_trails
@@ -309,15 +309,15 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date).to_hash
   end
 
   def params_filters_with_default_state
-    params_filters.reverse_merge(state: 'active')
+    params_filters.reverse_merge('state' => 'active')
   end
 
   def filter
-    @filter ||= Admin::EditionFilter.new(edition_class, current_user, params_filters_with_default_state) if params_filters.any?
+    @filter ||= Admin::EditionFilter.new(edition_class, current_user, params_filters_with_default_state.symbolize_keys) if params_filters.any?
   end
 
   def detect_other_active_editors

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -12,21 +12,21 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   test 'should pass filter parameters to an edition filter' do
     stub_filter = stub_edition_filter
-    Admin::EditionFilter.expects(:new).with(anything, anything, has_entries("state" => "draft", "type" => "policy")).returns(stub_filter)
+    Admin::EditionFilter.expects(:new).with(anything, anything, has_entries(state: "draft", type: "policy")).returns(stub_filter)
 
     get :index, state: :draft, type: :policy
   end
 
   test "should not pass blank parameters to the edition filter" do
     stub_filter = stub_edition_filter
-    Admin::EditionFilter.expects(:new).with(anything, anything, Not(has_key("author"))).returns(stub_filter)
+    Admin::EditionFilter.expects(:new).with(anything, anything, Not(has_key(:author))).returns(stub_filter)
 
     get :index, state: :draft, author: ""
   end
 
   test 'should add state param set to "active" if none is supplied' do
     stub_filter = stub_edition_filter
-    Admin::EditionFilter.expects(:new).with(anything, anything, has_entry("state" => "active")).returns(stub_filter)
+    Admin::EditionFilter.expects(:new).with(anything, anything, has_entry(state: "active")).returns(stub_filter)
 
     get :index, type: :policy
   end
@@ -163,8 +163,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   test "index should redirect to remembered filtered options if selected filter is invalid" do
     organisation = create(:organisation)
-    session[:document_filters] = { state: :submitted, author: current_user.to_param, organisation: organisation.to_param }
-    stub_edition_filter valid?: false
+    session[:document_filters] = { 'state' => 'submitted', 'author' => current_user.to_param, 'organisation' => organisation.to_param }
     get :index, author: 'invalid'
     assert_redirected_to admin_editions_path(state: :submitted, author: current_user, organisation: organisation)
   end


### PR DESCRIPTION
When exporting a CSV list of documents there would be an error 'cannot
redirect to params hash'.

The values returned from `params_filters` have a limited set of keys which
are safe to use in redirects. So always convert this to a plain hash
(with symbol keys).