### PR TITLE
Flag political content on publish

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -427,6 +427,10 @@ class Edition < ActiveRecord::Base
     false
   end
 
+  def is_associated_with_a_minister?
+    false
+  end
+
   # @!endgroup
 
   def create_draft(user)

--- a/app/models/edition/appointment.rb
+++ b/app/models/edition/appointment.rb
@@ -10,6 +10,10 @@ module Edition::Appointment
 
   end
 
+  def is_associated_with_a_minister?
+    role_appointment && role.is_a?(MinisterialRole)
+  end
+
   def person
     if person_override?
       person_override

--- a/app/models/edition/ministers.rb
+++ b/app/models/edition/ministers.rb
@@ -17,4 +17,8 @@ module Edition::Ministers
   def can_be_associated_with_ministers?
     true
   end
+
+  def is_associated_with_a_minister?
+    ministerial_roles.any?
+  end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -55,7 +55,7 @@ private
   end
 
   def flag_if_political_content!
-    return if edition.previously_published
+    return if edition.document.published?
 
     edition.political = PoliticalContentIdentifier.political?(edition)
   end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -28,7 +28,7 @@ class EditionPublisher < EditionService
 private
 
   def prepare_edition
-    edition.access_limited  = false
+    edition.access_limited = false
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -28,6 +28,7 @@ class EditionPublisher < EditionService
 private
 
   def prepare_edition
+    flag_if_political_content!
     edition.access_limited = false
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
@@ -51,5 +52,11 @@ private
   def scheduled_for_publication?
     # Just using edition.scheduled? misses submitted editions
     edition.scheduled_publication.present?
+  end
+
+  def flag_if_political_content!
+    return if edition.previously_published
+
+    edition.political = PoliticalContentIdentifier.political?(edition)
   end
 end

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -7,13 +7,26 @@ class PoliticalContentIdentifier
     PublicationType::ResearchAndAnalysis,
   ].freeze
 
+  attr_reader :edition
+  def initialize(edition)
+    @edition = edition
+  end
+
   def self.political?(edition)
-    edition.is_associated_with_a_minister? || (is_political_format?(edition) && has_political_org?(edition))
+    new(edition).political?
+  end
+
+  def political?
+    is_associated_with_a_minister? || (is_political_format? && has_political_org?)
   end
 
 private
 
-  def self.is_political_format?(edition)
+  def is_associated_with_a_minister?
+    edition.is_associated_with_a_minister?
+  end
+
+  def is_political_format?
     case edition
     when Consultation, Speech, NewsArticle, WorldLocationNewsArticle
       true
@@ -24,7 +37,7 @@ private
     end
   end
 
-  def self.has_political_org?(edition)
+  def has_political_org?
     edition.can_be_related_to_organisations? &&
       edition.organisations.where(political: true).any?
   end

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -1,0 +1,36 @@
+class PoliticalContentIdentifier
+  POLITICAL_PUBLICATION_TYPES = [
+    PublicationType::CorporateReport,
+    PublicationType::ImpactAssessment,
+    PublicationType::InternationalTreaty,
+    PublicationType::PolicyPaper,
+    PublicationType::ResearchAndAnalysis,
+  ].freeze
+
+  def self.political?(edition)
+    has_minister?(edition) || (is_political_format?(edition) && has_political_org?(edition))
+  end
+
+private
+
+  def self.has_minister?(edition)
+    (edition.can_be_associated_with_ministers? && edition.ministerial_roles.any?) ||
+      edition.try(:role_appointment).try(:role).is_a?(MinisterialRole)
+  end
+
+  def self.is_political_format?(edition)
+    case edition
+    when Consultation, Speech, NewsArticle, WorldLocationNewsArticle
+      true
+    when Publication
+      POLITICAL_PUBLICATION_TYPES.include?(edition.publication_type)
+    else
+      false
+    end
+  end
+
+  def self.has_political_org?(edition)
+    edition.can_be_related_to_organisations? &&
+      edition.organisations.where(political: true).any?
+  end
+end

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -8,15 +8,10 @@ class PoliticalContentIdentifier
   ].freeze
 
   def self.political?(edition)
-    has_minister?(edition) || (is_political_format?(edition) && has_political_org?(edition))
+    edition.is_associated_with_a_minister? || (is_political_format?(edition) && has_political_org?(edition))
   end
 
 private
-
-  def self.has_minister?(edition)
-    (edition.can_be_associated_with_ministers? && edition.ministerial_roles.any?) ||
-      edition.try(:role_appointment).try(:role).is_a?(MinisterialRole)
-  end
 
   def self.is_political_format?(edition)
     case edition

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -20,6 +20,14 @@ FactoryGirl.define do
     trait(:with_alternative_format_contact_email) {
       sequence(:alternative_format_contact_email) { |n| "organisation-#{n}@example.com" }
     }
+
+    trait(:political) do
+      political true
+    end
+
+    trait(:non_political) do
+      political false
+    end
   end
 
   factory :closed_organisation, parent: :organisation, traits: [:closed]

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class PoliticalContentIdentifierTest < ActiveSupport::TestCase
+  test '#political?(edition) is true if content is tagged to a minister' do
+    edition = create(:speech, role_appointment: create(:ministerial_role_appointment))
+
+    assert PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is true if content is from a political org and is a political format' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:consultation, lead_organisations: [political_organisation])
+
+    assert PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is true if content is from a political org and is a political subformat' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:publication, :policy_paper, lead_organisations: [political_organisation])
+
+    assert PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is false if content is from a political org but not a political format' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:detailed_guide, lead_organisations: [political_organisation])
+
+    refute PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is false if content is from a political org but not a political subformat' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:publication, :statistics, lead_organisations: [political_organisation])
+
+    refute PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is true if content is not from a political org, is a non-political Publication type, but is associated with a minister' do
+    non_political_organisation = create(:organisation, :non_political)
+    edition = create(:publication, :statistics,
+      lead_organisations: [non_political_organisation],
+      ministerial_roles: [create(:ministerial_role)]
+    )
+
+    assert PoliticalContentIdentifier.political?(edition)
+  end
+
+  test '#political?(edition) is false if content is a political format but not from a political org' do
+    non_political_organisation = create(:organisation, :non_political)
+    edition = create(:consultation, lead_organisations: [non_political_organisation])
+
+    refute PoliticalContentIdentifier.political?(edition)
+  end
+end

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -76,7 +76,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert published_edition.reload.superseded?, "expected previous edition to be superseded but it's #{published_edition.state}"
   end
 
-  test '#perform! does not choke if previoues editions are invalid' do
+  test '#perform! does not choke if previous editions are invalid' do
     published_edition = create(:published_edition)
     edition = published_edition.create_draft(create(:policy_writer))
     edition.minor_change = true

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class EditionPublisherTest < ActiveSupport::TestCase
-
   test '#perform! with a valid submitted edition publishes the edition, setting the publishing timestamps and version' do
     edition   = create(:submitted_edition)
 

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -156,4 +156,18 @@ class EditionPublisherTest < ActiveSupport::TestCase
     edition.reload
     refute edition.political?
   end
+
+  test '#perform! sets a political flag on political content that has a first_published_at set' do
+    edition = create(:submitted_edition, first_published_at: 3.weeks.ago)
+
+    refute edition.political?
+
+    PoliticalContentIdentifier.stubs(:political?).with(edition).returns(true)
+
+    publisher = EditionPublisher.new(edition)
+
+    assert publisher.perform!
+    edition.reload
+    assert edition.political?
+  end
 end


### PR DESCRIPTION
Occurs on publish, if being published for the first time.  Does not get overridden by later editions.

https://trello.com/c/wRNF77pJ/40-set-up-political-flag-for-future-published-documents

Tests will fail until this is rebased onto a branch containing the migration to add the `political` column to `Edition`.  I recommend we merge https://github.com/alphagov/whitehall/pull/1992 first, then this, then refactor https://github.com/alphagov/whitehall/pull/1991 to flag the appropriate political organisations and make use of the code introduced here.

- [x] Code review
- [x] Product review (uses same code as https://github.com/alphagov/whitehall/pull/1991 which has been signed off)
- [x] Merge https://github.com/alphagov/whitehall/pull/1992
- [x] Rebase onto master