### PR TITLE
Update the sign-off wording in the edition published/rejected email

### DIFF
--- a/app/views/notifications/edition_published.text.erb
+++ b/app/views/notifications/edition_published.text.erb
@@ -4,4 +4,4 @@ The <%= @edition.format_name %> '<%= @edition.title %>' has now been published. 
 
 All the best,
 
-IG Admin
+GOV.UK Admin

--- a/app/views/notifications/edition_rejected.text.erb
+++ b/app/views/notifications/edition_rejected.text.erb
@@ -4,4 +4,4 @@ The <%= @edition.class.model_name.human.downcase %> '<%= @edition.title %>' was 
 
 All the best,
 
-IG Admin
+GOV.UK Admin


### PR DESCRIPTION
- Inside Government hasn't existed for ages, so "IG Admin" was
  misleading. Change it to say "GOV.UK Admin" instead.