### PR TITLE
Send analytics event through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/application/filter-list-items.js
+++ b/app/assets/javascripts/application/filter-list-items.js
@@ -40,7 +40,7 @@
       filter._trackTimeout = root.setTimeout(function(){
         var pagePath = window.location.pathname.split('/').pop();
         if(pagePath){
-          window._gaq && _gaq.push(['_trackEvent', 'searchBoxFilter', search, pagePath, 0, true]);
+          GOVUK.analytics.trackEvent('searchBoxFilter', search, {label: pagePath, nonInteraction: true});
         }
       }, 1000);
     },


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1261204/stories/88175032

This change wraps the GA event in the [newly introduced](https://github.com/alphagov/static/pull/549)
analytics API. This will aid in the migration from GA Classic to Universal Analytics, while
remaining functionally equivalent during the migration.

/cc @fofr 