### PR TITLE
Track social media shares in Universal

### DIFF
--- a/app/assets/javascripts/application/document-share-links.js
+++ b/app/assets/javascripts/application/document-share-links.js
@@ -3,21 +3,19 @@
   window.GOVUK = window.GOVUK || {};
 
   function DocumentShareLinks(options) {
-    this.$el = $(options.el);
-    this.$el.find('.facebook').click($.proxy(function() {
-      this.submitEvent('facebook');
-    }, this));
-    this.$el.find('.twitter').click($.proxy(function() {
-      this.submitEvent('twitter');
-    }, this));
-  }
+    var $el = $(options.el);
 
-  DocumentShareLinks.prototype.submitEvent = function(network) {
-    if (window._gaq) {
-      // opt_target is set to location.pathname to clean up query strings, etc.
-      window._gaq.push(['_trackSocial', network, 'share', location.pathname]);
+    $el.on('click', '.facebook', trackFacebook);
+    $el.on('click', '.twitter', trackTwitter);
+
+    function trackFacebook() {
+      GOVUK.analytics.trackShare('facebook');
     }
-  };
+
+    function trackTwitter() {
+      GOVUK.analytics.trackShare('twitter');
+    }
+  }
 
   GOVUK.DocumentShareLinks = DocumentShareLinks;
 }());

--- a/test/javascripts/unit/document-share-links_test.js
+++ b/test/javascripts/unit/document-share-links_test.js
@@ -1,27 +1,21 @@
 module("document-share-links", {
   setup: function() {
-    window._gaq = [];
-
-    this.$el = $('<div class="document-share-links"></div>');
-    this.$el.append('<a href="https://www.facebook.com/sharer/sharer.php?u=https://www.gov.uk" target="_blank" class="facebook"><span class="connect">Share on</span> Facebook</span></a>');
-    this.$el.append('<a href="https://twitter.com/share?url=https://www.gov.uk" target="_blank" class="twitter"><span class="connect">Share on</span> Twitter</span></a>');
+    GOVUK.analytics = {trackShare: function() {}};
+    this.$el = $('<div></div>');
+    this.$el.append('<a href="#" class="facebook">Facebook</a>');
+    this.$el.append('<a href="#" class="twitter">Twitter</a>');
     this.shareLinks = new window.GOVUK.DocumentShareLinks({el: this.$el});
   }
 });
 
 test("should send GA event when clicking facebook button", function() {
-  equal(window._gaq.length, 0);
+  var spy = this.spy(GOVUK.analytics, "trackShare");
   this.$el.find('.facebook').click();
-  equal(window._gaq[0][0], '_trackSocial');
-  equal(window._gaq[0][1], 'facebook');
-  equal(window._gaq[0][2], 'share');
+  sinon.assert.calledWith(spy, 'facebook');
 });
 
 test("should send GA event when clicking twitter button", function() {
-  equal(window._gaq.length, 0);
+  var spy = this.spy(GOVUK.analytics, "trackShare");
   this.$el.find('.twitter').click();
-  equal(window._gaq[0][0], '_trackSocial');
-  equal(window._gaq[0][1], 'twitter');
-  equal(window._gaq[0][2], 'share');
+  sinon.assert.calledWith(spy, 'twitter');
 });
-


### PR DESCRIPTION
Update to using `GOVUK.analytics.trackShare` method instead of using the Google Analytics API directly. This will send the social media event to both classic and universal.

See also:
https://github.com/alphagov/static/pull/550

https://www.pivotaltracker.com/story/show/88174796

cc @benilovj 