### PR TITLE
Send virtual pageview through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -43,7 +43,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
       history.pushState(documentFilter.currentPageState(), null, url);
     },
     updateTracking: function(url) {
-      window._gaq && _gaq.push(['_trackPageview', url]);
+      GOVUK.analytics.trackPageview(url);
     },
     submitFilters: function(e){
       e.preventDefault();

--- a/test/javascripts/unit/document_filter_test.js
+++ b/test/javascripts/unit/document_filter_test.js
@@ -162,9 +162,9 @@ test("should render results based on successful ajax response", function() {
 
 test("should fire analytics on successful ajax response", function() {
   this.filterForm.enableDocumentFilter();
-  window._gaq = [];
+  GOVUK.analytics = { trackPageview: function() {} };
 
-  var analytics = this.spy(_gaq, "push");
+  var analytics = this.spy(GOVUK.analytics, "trackPageview");
   var server = this.sandbox.useFakeServer();
   server.respondWith(JSON.stringify(this.ajaxData));
 
@@ -399,5 +399,3 @@ test("#_pluralize pluralizes words ending in y", function() {
   equal(GOVUK.documentFilter._pluralize("fly", 1), "fly");
   equal(GOVUK.documentFilter._pluralize("fly", 2), "flies");
 });
-
-


### PR DESCRIPTION
This change wraps the GA event in the newly introduced
analytics API. This will aid in the migration from GA Classic to
Universal Analytics, while remaining functionally equivalent
during the migration.

https://www.pivotaltracker.com/story/show/87738926