### PR TITLE
Update the Government association for Document during publish

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -100,12 +100,6 @@ class Document < ActiveRecord::Base
     document_type.underscore.gsub('_', ' ')
   end
 
-  def ensure_document_has_government
-    if Government.current.present? and government.nil?
-      update_column(:government_id, Government.current.id)
-    end
-  end
-
   private
 
   def destroy_all_editions

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -10,4 +10,9 @@ class Government < ActiveRecord::Base
   end
 
   scope :current, -> { order(start_date: :desc).first }
+
+  def self.on_date(date)
+    return nil if date.to_date > Date.today
+    self.where('start_date <= ?', date).order(start_date: :desc).first
+  end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -32,12 +32,12 @@ private
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number
-    edition.document.ensure_document_has_government
   end
 
   def fire_transition!
     super
     supersede_previous_editions!
+    update_government!
   end
 
   def supersede_previous_editions!
@@ -52,5 +52,9 @@ private
   def scheduled_for_publication?
     # Just using edition.scheduled? misses submitted editions
     edition.scheduled_publication.present?
+  end
+
+  def update_government!
+    edition.document.update_attribute(:government, Government.on_date(edition.first_public_at))
   end
 end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -153,18 +153,4 @@ class DocumentTest < ActiveSupport::TestCase
     refute draft.document.similar_slug_exists?
   end
 
-  test "#ensure_document_has_government does not change existing government association" do
-    document = create(:document)
-    initial_government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
-    Government.stubs(:current).returns(initial_government)
-    document.ensure_document_has_government
-
-    assert_equal initial_government, document.government
-
-    new_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
-    Government.stubs(:current).returns(new_government)
-    document.ensure_document_has_government
-
-    assert_equal initial_government, document.government
-  end
 end

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -55,4 +55,19 @@ class GovernmentTest < ActiveSupport::TestCase
 
     assert_equal current_government, Government.current
   end
+
+  test "knows the active government at a date" do
+    government_current = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2010-05-12')
+    government_in_2005 = FactoryGirl.create(:government, name: "2005 to 2010 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
+    FactoryGirl.create(:government, name: "2001 to 2005 Labour government", start_date: "2001-06-08", end_date: "2005-05-05")
+
+    assert_equal government_in_2005, Government.on_date(Date.parse("2006-01-01")), "non-current government"
+    assert_equal government_in_2005, Government.on_date(Date.parse("2010-05-11")), "last day of government"
+    assert_equal government_current, Government.on_date(Date.parse("2010-05-12")), "first day of government"
+
+    assert_nil Government.on_date(Date.parse("1900-05-12")), "non existant past government"
+    assert_nil Government.on_date(Date.parse("2020-05-12")), "future date"
+    assert_nil Government.on_date(Date.tomorrow), "tomorrow"
+    assert_equal government_current, Government.on_date(Date.today), "today (not the future)"
+  end
 end

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -65,15 +65,11 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_equal 1.week.ago, edition.major_change_published_at
   end
 
-  test '#perform! with a unpublished edition sets the government association' do
-    government = create(:government)
-    edition = create(:submitted_edition)
+  test '#perform! sets a government association for the document' do
+    government = FactoryGirl.create(:government, name: "A current government", start_date: 2.years.ago, end_date: 2.years.from_now)
+    edition    = create(:submitted_edition, first_published_at: Time.zone.now)
 
-    refute edition.document.government
-
-    publisher = EditionPublisher.new(edition)
-
-    assert publisher.perform!
+    assert EditionPublisher.new(edition).perform!
     assert_equal government, edition.document.government
   end
 


### PR DESCRIPTION
The associated Government should be based on the `first_public_at` date,
which can be edited as part of edition metadata, so the associated
Government needs to be updated when the edition is.

This is done after the Edition itself has been saved, in case the
edition update fails.

This also removes the old implementation/tests, which set the
Government once (and only once) during the first publish