### PR TITLE
Update sprockets and sprockets-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'dalli'
 gem 'json-schema', '2.5.0'
 gem 'rails_translation_manager', '0.0.1'
 gem 'rails-observers'
+gem 'sprockets', '3.0.0.beta.8'
 
 if ENV['GLOBALIZE_DEV']
   gem 'globalize', path: '../globalize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,6 @@ GEM
       sass (>= 3.2.0)
     hashery (2.1.1)
     hashie (3.2.0)
-    hike (1.2.3)
     hitimes (1.2.2)
     htmlentities (4.3.2)
     i18n (0.7.0)
@@ -339,12 +338,9 @@ GEM
       rack (>= 1.3.5)
       rest-client
     slop (3.6.0)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.0.0.beta.8)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.2)
+    sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -365,7 +361,7 @@ GEM
     ttfunk (1.1.1)
     typhoeus (0.6.9)
       ethon (>= 0.7.1)
-    tzinfo (0.3.42)
+    tzinfo (0.3.43)
     uglifier (2.6.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -454,6 +450,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   slimmer (= 6.0.0)
+  sprockets (= 3.0.0.beta.8)
   statsd-ruby (~> 1.2.1)
   test-queue
   test_track (~> 0.1.0)!

--- a/app/assets/stylesheets/frontend/print.scss
+++ b/app/assets/stylesheets/frontend/print.scss
@@ -38,6 +38,12 @@ html {
 // Styles for comment page elements
 
 #whitehall-wrapper {
-  @import "print/*";
+  @import "print/document.scss";
+  @import "print/documents-index.scss";
+  @import "print/heading-block.scss";
+  @import "print/html-publication.scss";
+  @import "print/index-list.scss";
+  @import "print/ministerial-roles.scss";
+  @import "print/organisations.scss";
+  @import "print/print.scss";
 }
-


### PR DESCRIPTION
Whitehall is experiencing intermittent test failures on parallel builds due to
an issue in the sprockets gem[1]. This is fixed in master, but not in a final
release yet. This updates sprockets to the latest 3.0 beta release to get
around the issue.

Importing a folder of SCSS partials using "/*" isn't working with these versions
of sprockets and sprockets-rails. Being explicit with the order that the CSS is
loaded is better as it leaves no ambiguity with the load order/cascade.

[1] https://github.com/sstephenson/sprockets/pull/545