### PR TITLE
Better context message for contract tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -7,7 +7,7 @@ env
 function github_status {
   STATUS="$1"
   MESSAGE="$2"
-  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "content_schemas contract tests" >/dev/null
+  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "whitehall contract tests" >/dev/null
 }
 
 function error_handler {


### PR DESCRIPTION
It needs to mention the name of the app in which the contract tests were
run, so that it makes sense in the context of a pull request of
govuk-content-schemas.