### PR TITLE
Derive Government from Edition at run-time, rather than persisting on Document

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,8 @@
 # All {Edition}s have one document, this model contains the slug and
 # handles the logic for slug regeneration.
 class Document < ActiveRecord::Base
+  extend DeprecatedColumns
+  deprecated_columns :government_id
 
   extend FriendlyId
 
@@ -10,8 +12,6 @@ class Document < ActiveRecord::Base
 
   has_many :editions, inverse_of: :document
   has_many :edition_relations, dependent: :destroy, inverse_of: :document
-
-  belongs_to :government
 
   has_one  :published_edition,
            -> { where(state: Edition::PUBLICLY_VISIBLE_STATES) },

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -654,11 +654,15 @@ class Edition < ActiveRecord::Base
     end
   end
 
-  def date_for_government
-   first_public_at.to_date
+  def government
+    Government.on_date(date_for_government) unless date_for_government.nil?
   end
 
 private
+
+  def date_for_government
+    first_public_at.try(:to_date)
+  end
 
   def enforcer(user)
     Whitehall::Authority::Enforcer.new(user, self)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -654,6 +654,10 @@ class Edition < ActiveRecord::Base
     end
   end
 
+  def date_for_government
+   first_public_at.to_date
+  end
+
 private
 
   def enforcer(user)

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -3,8 +3,6 @@ class Government < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :start_date, presence: true
 
-  has_many :documents
-
   before_validation on: :create do |government|
     government.slug = government.name.to_s.parameterize
   end

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -7,10 +7,13 @@ class Government < ActiveRecord::Base
     government.slug = government.name.to_s.parameterize
   end
 
-  scope :current, -> { order(start_date: :desc).first }
+  def self.current
+    order(start_date: :desc).first
+  end
 
   def self.on_date(date)
-    return nil if date.to_date > Date.today
-    self.where('start_date <= ?', date).order(start_date: :desc).first
+    return if date.to_date > Date.today
+
+    where('start_date <= ?', date).order(start_date: :desc).first
   end
 end

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -49,11 +49,11 @@ class Speech < Announcement
     role_appointment && role_appointment.role && role_appointment.role.ministerial?
   end
 
-  def date_for_government
-    delivered_on.to_date
-  end
-
 private
+
+  def date_for_government
+    delivered_on.try(:to_date)
+  end
 
   def skip_organisation_validation?
     can_have_some_invalid_data? || person_override.present?

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -49,7 +49,11 @@ class Speech < Announcement
     role_appointment && role_appointment.role && role_appointment.role.ministerial?
   end
 
-  private
+  def date_for_government
+    delivered_on.to_date
+  end
+
+private
 
   def skip_organisation_validation?
     can_have_some_invalid_data? || person_override.present?

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -55,7 +55,6 @@ private
   end
 
   def update_government!
-    government = Government.on_date(edition.date_for_government)
-    edition.document.update_attribute(:government, government)
+    edition.document.update_attribute(:government, edition.government)
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -55,6 +55,7 @@ private
   end
 
   def update_government!
-    edition.document.update_attribute(:government, Government.on_date(edition.first_public_at))
+    government = Government.on_date(edition.date_for_government)
+    edition.document.update_attribute(:government, government)
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -37,7 +37,6 @@ private
   def fire_transition!
     super
     supersede_previous_editions!
-    update_government!
   end
 
   def supersede_previous_editions!
@@ -52,9 +51,5 @@ private
   def scheduled_for_publication?
     # Just using edition.scheduled? misses submitted editions
     edition.scheduled_publication.present?
-  end
-
-  def update_government!
-    edition.document.update_attribute(:government, edition.government)
   end
 end

--- a/db/pending_migration_cleanups/20150303164154_drop_government_id_from_documents.rb
+++ b/db/pending_migration_cleanups/20150303164154_drop_government_id_from_documents.rb
@@ -1,0 +1,5 @@
+class DropGovernmentIdFromDocuments < ActiveRecord::Migration
+  def change
+    remove_column :documents, :government_id
+  end
+end

--- a/test/factories/governments.rb
+++ b/test/factories/governments.rb
@@ -3,4 +3,13 @@ FactoryGirl.define do
     sequence(:name) { |index| "Government #{index}" }
     start_date "2010-05-06"
   end
+
+  factory :current_government, parent: :government do
+    start_date { 2.years.ago + 1.day }
+  end
+
+  factory :previous_government, parent: :government do
+     start_date { 6.years.ago }
+     end_date { 2.years.ago }
+  end
 end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -356,8 +356,11 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal true, consultation_with_command_paper_outcome.search_index[:has_act_paper]
   end
 
-  test "#date_for_government returns first_public_at as date" do
-    consultation = create(:consultation)
-    assert_equal consultation.date_for_government, consultation.first_public_at.to_date
+  test "#government returns the government active on the opening_at date" do
+    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
+    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    consultation = create(:consultation, opening_at: 4.years.ago)
+
+    assert_equal historic_government, consultation.government
   end
 end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -355,4 +355,9 @@ class ConsultationTest < ActiveSupport::TestCase
     consultation_with_command_paper_outcome.outcome.stubs(:has_act_paper?).returns(true)
     assert_equal true, consultation_with_command_paper_outcome.search_index[:has_act_paper]
   end
+
+  test "#date_for_government returns first_public_at as date" do
+    consultation = create(:consultation)
+    assert_equal consultation.date_for_government, consultation.first_public_at.to_date
+  end
 end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -357,10 +357,10 @@ class ConsultationTest < ActiveSupport::TestCase
   end
 
   test "#government returns the government active on the opening_at date" do
-    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
-    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    create(:current_government)
+    previous_government = create(:previous_government)
     consultation = create(:consultation, opening_at: 4.years.ago)
 
-    assert_equal historic_government, consultation.government
+    assert_equal previous_government, consultation.government
   end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -903,9 +903,22 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test '#date_for_government returns first_public_at as a date' do
-    edition = create(:published_edition)
-    assert_equal edition.date_for_government, edition.first_public_at.to_date
+  test '#government returns the current government for a newly published edition' do
+    government = create(:government, start_date: 2.years.ago)
+    edition = create(:edition, first_published_at: Time.zone.now)
+    assert_equal government, edition.government
+  end
+
+  test '#government returns the historic government for a previously published edition' do
+    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
+    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    edition = create(:edition, first_published_at: 4.years.ago)
+    assert_equal historic_government, edition.government
+  end
+
+  test '#government returns nil for an edition without a first_published_at' do
+    edition = create(:edition, first_published_at: nil)
+    assert_nil edition.government
   end
 
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -904,16 +904,16 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test '#government returns the current government for a newly published edition' do
-    government = create(:government, start_date: 2.years.ago)
+    government = create(:current_government)
     edition = create(:edition, first_published_at: Time.zone.now)
     assert_equal government, edition.government
   end
 
   test '#government returns the historic government for a previously published edition' do
-    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
-    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    previous_government = create(:previous_government)
+    create(:current_government)
     edition = create(:edition, first_published_at: 4.years.ago)
-    assert_equal historic_government, edition.government
+    assert_equal previous_government, edition.government
   end
 
   test '#government returns nil for an edition without a first_published_at' do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -903,4 +903,9 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
+  test '#date_for_government returns first_public_at as a date' do
+    edition = create(:published_edition)
+    assert_equal edition.date_for_government, edition.first_public_at.to_date
+  end
+
 end

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 class GovernmentTest < ActiveSupport::TestCase
   test "automatically adds a slug on creation" do
-    government = FactoryGirl.create(:government, name: "2005 to 2010 Labour government")
+    government = create(:government, name: "2005 to 2010 Labour government")
 
     assert_equal "2005-to-2010-labour-government", government.slug
   end
 
   test "doesn't change the slug when the name changes" do
-    government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government")
+    government = create(:government, name: "2004 to 2009 Labour government")
 
     government.name = "2004 to 2009 Labour government"
     government.save!
@@ -17,57 +17,64 @@ class GovernmentTest < ActiveSupport::TestCase
   end
 
   test "doesn't permit blank names" do
-    blank_government = FactoryGirl.build(:government, name: '')
-    nil_government = FactoryGirl.build(:government, name: nil)
+    blank_government = build(:government, name: '')
+    nil_government = build(:government, name: nil)
 
     refute blank_government.valid?
     refute nil_government.valid?
   end
 
   test "doesn't permit blank start_date" do
-    blank_government = FactoryGirl.build(:government, start_date: '')
-    nil_government = FactoryGirl.build(:government, start_date: nil)
+    blank_government = build(:government, start_date: '')
+    nil_government = build(:government, start_date: nil)
 
     refute blank_government.valid?
     refute nil_government.valid?
   end
 
   test "enforces unique names" do
-    FactoryGirl.create(:government, name: "2005 to 2010 Labour government")
-    duplicate_government = FactoryGirl.build(:government, name: "2005 to 2010 Labour government")
+    create(:government, name: "2005 to 2010 Labour government")
+    duplicate_government = build(:government, name: "2005 to 2010 Labour government")
 
     refute duplicate_government.valid?
   end
 
   test "enforces unique slugs" do
-    labour_government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government")
+    labour_government = create(:government, name: "2004 to 2009 Labour government")
     labour_government.name = "2005 to 2010 Labour government"
     labour_government.save!
 
-    labour_government_duplicating_original_name = FactoryGirl.build(:government, name: "2004 to 2009 Labour government")
+    labour_government_duplicating_original_name = build(:government, name: "2004 to 2009 Labour government")
 
     refute labour_government_duplicating_original_name.valid?
   end
+end
+
+class GovernmentOnDateTest < ActiveSupport::TestCase
+  setup do
+    @current_government = create(:current_government)
+    @previous_government = create(:previous_government)
+    @even_earlier_government = create(:government,
+                                start_date: @previous_government.start_date - 4.years,
+                                end_date: @previous_government.end_date - 1.day)
+  end
 
   test "knows the correct current government" do
-    current_government = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2012-05-12')
-    previous_government = FactoryGirl.create(:government, name: "2004 to 2009 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
-
-    assert_equal current_government, Government.current
+    assert_equal @current_government, Government.current
   end
 
   test "knows the active government at a date" do
-    government_current = FactoryGirl.create(:government, name: "2010 to 2015 Conservative and Liberal democrat coalition government", start_date: '2010-05-12')
-    government_in_2005 = FactoryGirl.create(:government, name: "2005 to 2010 Labour government", start_date: '2005-05-06', end_date: '2010-05-11')
-    FactoryGirl.create(:government, name: "2001 to 2005 Labour government", start_date: "2001-06-08", end_date: "2005-05-05")
+    assert_equal @current_government, Government.on_date(Date.today)
+    assert_equal @previous_government, Government.on_date(4.years.ago)
+    assert_equal @previous_government, Government.on_date(@previous_government.end_date)
+    assert_equal @current_government, Government.on_date(@current_government.start_date)
+  end
 
-    assert_equal government_in_2005, Government.on_date(Date.parse("2006-01-01")), "non-current government"
-    assert_equal government_in_2005, Government.on_date(Date.parse("2010-05-11")), "last day of government"
-    assert_equal government_current, Government.on_date(Date.parse("2010-05-12")), "first day of government"
+  test "#on_date returns nil for date when no government exist" do
+    assert_nil Government.on_date(@even_earlier_government.start_date - 1.day)
+  end
 
-    assert_nil Government.on_date(Date.parse("1900-05-12")), "non existant past government"
-    assert_nil Government.on_date(Date.parse("2020-05-12")), "future date"
+  test "#on_date returns nil for future dates" do
     assert_nil Government.on_date(Date.tomorrow), "tomorrow"
-    assert_equal government_current, Government.on_date(Date.today), "today (not the future)"
   end
 end

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -65,32 +65,6 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_equal 1.week.ago, edition.major_change_published_at
   end
 
-  test '#perform! sets a government association for the document based on first published timestamp' do
-    government = create(:government)
-    edition    = create(:submitted_edition, first_published_at: Time.zone.now)
-
-    assert EditionPublisher.new(edition).perform!
-    assert_equal government, edition.document.government
-  end
-
-  test '#perform! sets a government association for a speech based on delivered_on timestamp' do
-    old_government = create(:government, start_date: 2.years.ago, end_date: 1.day.ago)
-    current_government = create(:government, start_date: Date.today)
-    edition = create(:submitted_speech, first_published_at: Time.zone.now, delivered_on: 1.day.ago)
-
-    assert EditionPublisher.new(edition).perform!
-    assert_equal old_government, edition.document.government
-  end
-
-  test '#perform! sets a government association for a consultation based on opening_at timestamp' do
-    old_government = create(:government, start_date: 2.years.ago, end_date: 1.day.ago)
-    current_government = create(:government, start_date: Date.today)
-    edition = create(:submitted_consultation, opening_at: 1.day.ago)
-
-    assert EditionPublisher.new(edition).perform!
-    assert_equal old_government, edition.document.government
-  end
-
   test '#perform! supersedes all previous editions' do
     published_edition = create(:published_edition)
     edition = published_edition.create_draft(create(:policy_writer))

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -175,17 +175,16 @@ class SpeechTest < ActiveSupport::TestCase
   end
 
   test "#government returns the government active on the delivered_on date" do
-    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
-    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    create(:current_government)
+    previous_government = create(:previous_government)
     speech = create(:speech, first_published_at: 1.day.ago, delivered_on: 4.years.ago)
 
-    assert_equal historic_government, speech.government
+    assert_equal previous_government, speech.government
   end
 
   test '#government returns nil for an speech without a delivered_on' do
     speech = create(:imported_speech, delivered_on: nil)
     assert_nil speech.government
   end
-
 
 end

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -173,4 +173,9 @@ class SpeechTest < ActiveSupport::TestCase
   test "is not translatable when non-English" do
     refute build(:speech, primary_locale: :es).translatable?
   end
+
+  test "#date_for_government returns delivered_on as date" do
+    speech = create(:speech)
+    assert_equal speech.date_for_government, speech.delivered_on.to_date
+  end
 end

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -174,8 +174,18 @@ class SpeechTest < ActiveSupport::TestCase
     refute build(:speech, primary_locale: :es).translatable?
   end
 
-  test "#date_for_government returns delivered_on as date" do
-    speech = create(:speech)
-    assert_equal speech.date_for_government, speech.delivered_on.to_date
+  test "#government returns the government active on the delivered_on date" do
+    historic_government = create(:government, start_date: 6.years.ago, end_date: 2.years.ago)
+    current_government = create(:government, start_date: 2.years.ago + 1.day)
+    speech = create(:speech, first_published_at: 1.day.ago, delivered_on: 4.years.ago)
+
+    assert_equal historic_government, speech.government
   end
+
+  test '#government returns nil for an speech without a delivered_on' do
+    speech = create(:imported_speech, delivered_on: nil)
+    assert_nil speech.government
+  end
+
+
 end


### PR DESCRIPTION
Taking this approach  simplifies the code significantly, keeping the relationship to `Government` encapsulated in `Edition`, and there's not a need to de-normalise onto `Document` yet, and if becomes needed it can be added and backfilled then.

**Changes:**
 - Gets the right government for `Speech`, using the `delivered_on` in preference to `first_published_at`, as there are many examples where `delivered_on` is much earlier.
 - Government is now exposed by `Edition#government`, and derived at run-time, rather than being set during publishing.
 - Removes the `Document.government` field - which isn't used anywhere yet.
 - Adds factories for tests creating `Government`s and refactors the tests to be more readable.

**This supports:**
- [Add government relation to future documents](https://trello.com/c/049aghPo/43-add-government-relation-to-future-documents)
- [Back fill government relation on previous documents](https://trello.com/c/lC333N5T/44-back-fill-government-relation-on-previous-documents) - the new implementation means no backfill is required, as `Government` is derived at 

Paired with @tekin