### PR TITLE
Republish edition when dependencies change

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -132,7 +132,7 @@ module GovspeakHelper
   def render_embedded_contacts(govspeak, heading_tag)
     return govspeak if govspeak.blank?
     heading_tag ||= 'h3'
-    govspeak.gsub(Govspeak::EMBEDDED_CONTACT_REGEXP) do
+    govspeak.gsub(Contact::EMBEDDED_CONTACT_REGEXP) do
       if contact = Contact.find_by(id: $1)
         render(partial: 'contacts/contact', locals: { contact: contact, heading_tag: heading_tag }, formats: ["html"])
       else

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -13,6 +13,8 @@ class Contact < ActiveRecord::Base
   validates :street_address, :country_id, presence: true, if: -> r { r.has_postal_address? }
   accepts_nested_attributes_for :contact_numbers, allow_destroy: true, reject_if: :all_blank
 
+  after_update :republish_dependant_editions
+
   include TranslatableModel
   translates :title, :comments, :recipient, :street_address, :locality,
              :region, :email, :contact_form_url
@@ -68,4 +70,11 @@ class Contact < ActiveRecord::Base
   def missing_translations
     super & contactable.non_english_translated_locales
   end
+
+private
+
+  def republish_dependant_editions
+    dependant_editions.each { |e| Whitehall::PublishingApi.republish(e) }
+  end
+
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,7 +4,7 @@ class Contact < ActiveRecord::Base
   belongs_to :contactable, polymorphic: true
   has_many   :contact_numbers, dependent: :destroy
   has_many   :edition_dependencies, as: :dependable, dependent: :destroy
-  has_many   :dependant_editions, through: :edition_dependencies, source: :dependant
+  has_many   :dependant_editions, through: :edition_dependencies, source: :edition
   belongs_to :country,
              -> { where("world_locations.world_location_type_id" => WorldLocationType::WorldLocation.id) },
              class_name: "WorldLocation",

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,7 +4,7 @@ class Contact < ActiveRecord::Base
   belongs_to :contactable, polymorphic: true
   has_many   :contact_numbers, dependent: :destroy
   has_many   :edition_dependencies, as: :dependable, dependent: :destroy
-  has_many   :dependant_editions, through: :edition_dependencies, source: :edition
+  has_many   :dependent_editions, through: :edition_dependencies, source: :edition
   belongs_to :country,
              -> { where("world_locations.world_location_type_id" => WorldLocationType::WorldLocation.id) },
              class_name: "WorldLocation",
@@ -15,7 +15,7 @@ class Contact < ActiveRecord::Base
   validates :street_address, :country_id, presence: true, if: -> r { r.has_postal_address? }
   accepts_nested_attributes_for :contact_numbers, allow_destroy: true, reject_if: :all_blank
 
-  after_update :republish_dependant_editions
+  after_update :republish_dependent_editions
 
   include TranslatableModel
   translates :title, :comments, :recipient, :street_address, :locality,
@@ -75,8 +75,8 @@ class Contact < ActiveRecord::Base
 
 private
 
-  def republish_dependant_editions
-    dependant_editions.each { |e| Whitehall::PublishingApi.republish(e) }
+  def republish_dependent_editions
+    dependent_editions.each { |e| Whitehall::PublishingApi.republish(e) }
   end
 
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,6 @@
 class Contact < ActiveRecord::Base
+  EMBEDDED_CONTACT_REGEXP = /\[Contact\:([0-9]+)\]/
+
   belongs_to :contactable, polymorphic: true
   has_many   :contact_numbers, dependent: :destroy
   has_many   :edition_dependencies, as: :dependable, dependent: :destroy

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,8 @@
 class Contact < ActiveRecord::Base
   belongs_to :contactable, polymorphic: true
   has_many   :contact_numbers, dependent: :destroy
+  has_many   :edition_dependencies, as: :dependable, dependent: :destroy
+  has_many   :dependant_editions, through: :edition_dependencies, source: :dependant
   belongs_to :country,
              -> { where("world_locations.world_location_type_id" => WorldLocationType::WorldLocation.id) },
              class_name: "WorldLocation",

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -30,6 +30,9 @@ class Edition < ActiveRecord::Base
   has_many :classification_featurings, inverse_of: :edition
   has_many :links_reports, as: :link_reportable
 
+  has_many :dependencies, class_name: 'EditionDependency', dependent: :destroy
+  has_many :contact_dependencies, through: :dependencies, source: :dependable, source_type: 'Contact'
+
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -30,8 +30,8 @@ class Edition < ActiveRecord::Base
   has_many :classification_featurings, inverse_of: :edition
   has_many :links_reports, as: :link_reportable
 
-  has_many :dependencies, class_name: 'EditionDependency', dependent: :destroy
-  has_many :contact_dependencies, through: :dependencies, source: :dependable, source_type: 'Contact'
+  has_many :edition_dependencies, dependent: :destroy
+  has_many :depended_upon_contacts, through: :edition_dependencies, source: :dependable, source_type: 'Contact'
 
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -67,11 +67,11 @@ module Edition::Workflow
         transitions from: :scheduled, to: :submitted
       end
 
-      event :publish do
+      event :publish, success: :populate_dependencies do
         transitions from: [:submitted, :scheduled], to: :published
       end
 
-      event :force_publish do
+      event :force_publish, success: :populate_dependencies do
         transitions from: [:draft, :submitted], to: :published
       end
 
@@ -112,5 +112,11 @@ module Edition::Workflow
     if existing_edition = document.non_published_edition
       errors.add(:base, "There is already an active #{existing_edition.state} edition for this document")
     end
+  end
+
+private
+
+  def populate_dependencies
+    EditionDependenciesPopulator.new(self).populate!
   end
 end

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -67,11 +67,11 @@ module Edition::Workflow
         transitions from: :scheduled, to: :submitted
       end
 
-      event :publish, success: :populate_dependencies do
+      event :publish do
         transitions from: [:submitted, :scheduled], to: :published
       end
 
-      event :force_publish, success: :populate_dependencies do
+      event :force_publish do
         transitions from: [:draft, :submitted], to: :published
       end
 
@@ -114,9 +114,4 @@ module Edition::Workflow
     end
   end
 
-private
-
-  def populate_dependencies
-    EditionDependenciesPopulator.new(self).populate!
-  end
 end

--- a/app/models/edition_dependency.rb
+++ b/app/models/edition_dependency.rb
@@ -1,6 +1,4 @@
 class EditionDependency < ActiveRecord::Base
   belongs_to :dependant, class_name: 'Edition'
   belongs_to :dependable, polymorphic: true
-
-  scope :contacts, -> { where(dependable_type: 'Contact') }
 end

--- a/app/models/edition_dependency.rb
+++ b/app/models/edition_dependency.rb
@@ -1,0 +1,6 @@
+class EditionDependency < ActiveRecord::Base
+  belongs_to :dependant, class_name: 'Edition'
+  belongs_to :dependable, polymorphic: true
+
+  scope :contacts, -> { where(dependable_type: 'Contact') }
+end

--- a/app/models/edition_dependency.rb
+++ b/app/models/edition_dependency.rb
@@ -1,4 +1,4 @@
 class EditionDependency < ActiveRecord::Base
-  belongs_to :dependant, class_name: 'Edition'
+  belongs_to :edition
   belongs_to :dependable, polymorphic: true
 end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -6,6 +6,7 @@ Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |_, edition,
 Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).index! }
 Whitehall.edition_services.subscribe("unpublish") { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |_, edition, _| Whitehall::PublishingApi.publish(edition) }
+Whitehall.edition_services.subscribe(/^(force_publish|publish)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }
 Whitehall.edition_services.subscribe(/^(archive)$/) { |_, edition, _| Whitehall::PublishingApi.republish(edition) }
 Whitehall.edition_services.subscribe(/^(unpublish)$/) { |_, edition, _| Whitehall::PublishingApi.publish(edition.unpublishing) }
 Whitehall.edition_services.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule(edition) }

--- a/db/migrate/20150303113958_create_edition_dependencies.rb
+++ b/db/migrate/20150303113958_create_edition_dependencies.rb
@@ -1,0 +1,11 @@
+class CreateEditionDependencies < ActiveRecord::Migration
+  def change
+    create_table :edition_dependencies do |t|
+      t.references :dependant
+      t.references :dependable, polymorphic: true
+    end
+
+    add_index :edition_dependencies, [:dependant_id, :dependable_id, :dependable_type],
+      unique: true, name: 'index_edition_dependencies_on_dependant_and_dependable'
+  end
+end

--- a/db/migrate/20150303113958_create_edition_dependencies.rb
+++ b/db/migrate/20150303113958_create_edition_dependencies.rb
@@ -1,11 +1,11 @@
 class CreateEditionDependencies < ActiveRecord::Migration
   def change
     create_table :edition_dependencies do |t|
-      t.references :dependant
+      t.references :edition
       t.references :dependable, polymorphic: true
     end
 
-    add_index :edition_dependencies, [:dependable_id, :dependable_type, :dependant_id],
-      unique: true, name: 'index_edition_dependencies_on_dependable_and_dependant'
+    add_index :edition_dependencies, [:dependable_id, :dependable_type, :edition_id],
+      unique: true, name: 'index_edition_dependencies_on_dependable_and_edition'
   end
 end

--- a/db/migrate/20150303113958_create_edition_dependencies.rb
+++ b/db/migrate/20150303113958_create_edition_dependencies.rb
@@ -5,7 +5,7 @@ class CreateEditionDependencies < ActiveRecord::Migration
       t.references :dependable, polymorphic: true
     end
 
-    add_index :edition_dependencies, [:dependant_id, :dependable_id, :dependable_type],
-      unique: true, name: 'index_edition_dependencies_on_dependant_and_dependable'
+    add_index :edition_dependencies, [:dependable_id, :dependable_type, :dependant_id],
+      unique: true, name: 'index_edition_dependencies_on_dependable_and_dependant'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150223160728) do
+ActiveRecord::Schema.define(version: 20150303113958) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -285,6 +285,14 @@ ActiveRecord::Schema.define(version: 20150223160728) do
 
   add_index "edition_authors", ["edition_id"], name: "index_edition_authors_on_edition_id", using: :btree
   add_index "edition_authors", ["user_id"], name: "index_edition_authors_on_user_id", using: :btree
+
+  create_table "edition_dependencies", force: true do |t|
+    t.integer "dependant_id"
+    t.integer "dependable_id"
+    t.string  "dependable_type"
+  end
+
+  add_index "edition_dependencies", ["dependant_id", "dependable_id", "dependable_type"], name: "index_edition_dependencies_on_dependant_and_dependable", unique: true, using: :btree
 
   create_table "edition_mainstream_categories", force: true do |t|
     t.integer  "edition_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -287,12 +287,12 @@ ActiveRecord::Schema.define(version: 20150303113958) do
   add_index "edition_authors", ["user_id"], name: "index_edition_authors_on_user_id", using: :btree
 
   create_table "edition_dependencies", force: true do |t|
-    t.integer "dependant_id"
+    t.integer "edition_id"
     t.integer "dependable_id"
     t.string  "dependable_type"
   end
 
-  add_index "edition_dependencies", ["dependant_id", "dependable_id", "dependable_type"], name: "index_edition_dependencies_on_dependant_and_dependable", unique: true, using: :btree
+  add_index "edition_dependencies", ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true, using: :btree
 
   create_table "edition_mainstream_categories", force: true do |t|
     t.integer  "edition_id"

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -1,11 +1,11 @@
 class EditionDependenciesPopulator
 
-  def initialize(dependant)
-    @dependant = dependant
+  def initialize(edition)
+    @edition = edition
   end
 
   def populate!
-    @dependant.contact_dependencies = Govspeak::ContactsExtractor.new(@dependant.body).contacts
+    @edition.contact_dependencies = Govspeak::ContactsExtractor.new(@edition.body).contacts
   end
 
 end

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -1,0 +1,20 @@
+class EditionDependenciesPopulator
+
+  def initialize(dependant)
+    @dependant = dependant
+  end
+
+  def populate!
+    populate Govspeak::ContactsExtractor.new(@dependant.body).contacts
+  end
+
+private
+
+  def populate(dependables)
+    existing_dependables = @dependant.dependencies.includes(:dependable).map(&:dependable)
+    dependencies_attributes = (dependables - existing_dependables).inject([]) do |attributes, dependable|
+      attributes << { dependant: @dependant, dependable: dependable }
+    end
+    EditionDependency.create!(dependencies_attributes) if dependencies_attributes.present?
+  end
+end

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -5,16 +5,7 @@ class EditionDependenciesPopulator
   end
 
   def populate!
-    populate Govspeak::ContactsExtractor.new(@dependant.body).contacts
+    @dependant.contact_dependencies = Govspeak::ContactsExtractor.new(@dependant.body).contacts
   end
 
-private
-
-  def populate(dependables)
-    existing_dependables = @dependant.dependencies.includes(:dependable).map(&:dependable)
-    dependencies_attributes = (dependables - existing_dependables).inject([]) do |attributes, dependable|
-      attributes << { dependant: @dependant, dependable: dependable }
-    end
-    EditionDependency.create!(dependencies_attributes) if dependencies_attributes.present?
-  end
 end

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -5,7 +5,7 @@ class EditionDependenciesPopulator
   end
 
   def populate!
-    @edition.contact_dependencies = Govspeak::ContactsExtractor.new(@edition.body).contacts
+    @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts
   end
 
 end

--- a/lib/govspeak/contacts_extractor.rb
+++ b/lib/govspeak/contacts_extractor.rb
@@ -1,0 +1,19 @@
+module Govspeak
+  EMBEDDED_CONTACT_REGEXP = /\[Contact\:([0-9]+)\]/
+
+  class ContactsExtractor
+    def initialize(govspeak)
+      @govspeak = govspeak
+    end
+
+    def contacts
+      return [] if @govspeak.blank?
+      # scan yields an array of capture groups for each match
+      # so "[Contact:1] is now [Contact:2]" => [["1"], ["2"]]
+      @govspeak.scan(Govspeak::EMBEDDED_CONTACT_REGEXP).map { |capture|
+        contact_id = capture.first
+        Contact.find_by(id: contact_id)
+      }.compact
+    end
+  end
+end

--- a/lib/govspeak/contacts_extractor.rb
+++ b/lib/govspeak/contacts_extractor.rb
@@ -1,6 +1,4 @@
 module Govspeak
-  EMBEDDED_CONTACT_REGEXP = /\[Contact\:([0-9]+)\]/
-
   class ContactsExtractor
     def initialize(govspeak)
       @govspeak = govspeak
@@ -10,7 +8,7 @@ module Govspeak
       return [] if @govspeak.blank?
       # scan yields an array of capture groups for each match
       # so "[Contact:1] is now [Contact:2]" => [["1"], ["2"]]
-      @govspeak.scan(Govspeak::EMBEDDED_CONTACT_REGEXP).map { |capture|
+      @govspeak.scan(Contact::EMBEDDED_CONTACT_REGEXP).map { |capture|
         contact_id = capture.first
         Contact.find_by(id: contact_id)
       }.compact

--- a/lib/govspeak/contacts_extractor_helpers.rb
+++ b/lib/govspeak/contacts_extractor_helpers.rb
@@ -1,0 +1,7 @@
+module Govspeak
+  module ContactsExtractorHelpers
+    def govspeak_embedded_contacts(govspeak)
+      ContactsExtractor.new(govspeak).contacts
+    end
+  end
+end

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -110,4 +110,25 @@ class ContactTest < ActiveSupport::TestCase
     expected_locales = [:de, :fr].map { |l| Locale.new(l) }
     assert_equal expected_locales, contact.missing_translations
   end
+
+  test "republishes dependant editions after update" do
+    contact = create(:contact)
+    news_article = create(:published_news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
+    corp_info_page = create(:published_corporate_information_page, body: "For free advice, please visit our office: [Contact:#{contact.id}]")
+    EditionDependenciesPopulator.new(news_article).populate!
+    EditionDependenciesPopulator.new(corp_info_page).populate!
+
+    expect_republishing(news_article, corp_info_page)
+
+    contact.update_attributes(title: "Changed contact title")
+  end
+
+  def expect_republishing(*editions)
+    editions.each do |edition|
+      Whitehall.publishing_api_client.expects(:put_content_item)
+        .with(Whitehall.url_maker.public_document_path(edition),
+          has_entries(content_id: edition.content_id, update_type: 'republish'))
+    end
+  end
+
 end

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -111,7 +111,7 @@ class ContactTest < ActiveSupport::TestCase
     assert_equal expected_locales, contact.missing_translations
   end
 
-  test "republishes dependant editions after update" do
+  test "republishes dependent editions after update" do
     contact = create(:contact)
     news_article = create(:published_news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
     corp_info_page = create(:published_corporate_information_page, body: "For free advice, please visit our office: [Contact:#{contact.id}]")

--- a/test/unit/edition/workflow_test.rb
+++ b/test/unit/edition/workflow_test.rb
@@ -77,6 +77,18 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     end
   end
 
+  [:publish, :force_publish].each do |event|
+    test "##{event} populates edition's dependencies" do
+      contacts = create_list(:contact, 2)
+      news_article = create(:submitted_news_article, body: "For more information, get in touch at:
+        [Contact:#{contacts[0].id}] or [Contact:#{contacts[1].id}]")
+
+      news_article.send(event)
+
+      assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
+    end
+  end
+
   test "should be able to change major_change_published_at and first_published_at when scheduled" do
     edition = create(:edition, :scheduled)
     edition.first_published_at = Time.zone.now

--- a/test/unit/edition/workflow_test.rb
+++ b/test/unit/edition/workflow_test.rb
@@ -77,18 +77,6 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     end
   end
 
-  [:publish, :force_publish].each do |event|
-    test "##{event} populates edition's dependencies" do
-      contacts = create_list(:contact, 2)
-      news_article = create(:submitted_news_article, body: "For more information, get in touch at:
-        [Contact:#{contacts[0].id}] or [Contact:#{contacts[1].id}]")
-
-      news_article.send(event)
-
-      assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
-    end
-  end
-
   test "should be able to change major_change_published_at and first_published_at when scheduled" do
     edition = create(:edition, :scheduled)
     edition.first_published_at = Time.zone.now

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
-  test "populates contacts extracted from dependant editions' govspeak" do
+  test "populates contacts extracted from dependent editions' govspeak" do
     contacts = create_list(:contact, 2)
     news_article = create(:news_article, body: "For more information, get in touch at:
       [Contact:#{contacts[0].id}] or [Contact:#{contacts[1].id}]")

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -8,15 +8,16 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
 
     EditionDependenciesPopulator.new(news_article).populate!
 
-    assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
+    assert_same_elements contacts, news_article.contact_dependencies.reload
   end
 
   test "ignores duplicate dependencies" do
     contact = create(:contact)
     news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
-    EditionDependency.create!(dependant: news_article, dependable: contact)
+    EditionDependency.create!(dependant: news_article, dependable: contact) # dependency is populated already
 
-    assert_nothing_raised { EditionDependenciesPopulator.new(news_article).populate! }
-    # would otherwise raise ActiveRecord::RecordNotUnique
+    EditionDependenciesPopulator.new(news_article).populate!
+
+    assert_same_elements [contact], news_article.contact_dependencies.reload
   end
 end

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
+  test "populates contacts extracted from dependant editions' govspeak" do
+    contacts = create_list(:contact, 2)
+    news_article = create(:news_article, body: "For more information, get in touch at:
+      [Contact:#{contacts[0].id}] or [Contact:#{contacts[1].id}]")
+
+    EditionDependenciesPopulator.new(news_article).populate!
+
+    assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
+  end
+
+  test "ignores duplicate dependencies" do
+    contact = create(:contact)
+    news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
+    EditionDependency.create!(dependant: news_article, dependable: contact)
+
+    assert_nothing_raised { EditionDependenciesPopulator.new(news_article).populate! }
+    # would otherwise raise ActiveRecord::RecordNotUnique
+  end
+end

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -8,16 +8,16 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
 
     EditionDependenciesPopulator.new(news_article).populate!
 
-    assert_same_elements contacts, news_article.contact_dependencies.reload
+    assert_same_elements contacts, news_article.depended_upon_contacts.reload
   end
 
   test "ignores duplicate dependencies" do
     contact = create(:contact)
     news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
-    news_article.contact_dependencies << contact # dependency is populated already
+    news_article.depended_upon_contacts << contact # dependency is populated already
 
     EditionDependenciesPopulator.new(news_article).populate!
 
-    assert_same_elements [contact], news_article.contact_dependencies.reload
+    assert_same_elements [contact], news_article.depended_upon_contacts.reload
   end
 end

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -14,7 +14,7 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
   test "ignores duplicate dependencies" do
     contact = create(:contact)
     news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
-    EditionDependency.create!(dependant: news_article, dependable: contact) # dependency is populated already
+    news_article.contact_dependencies << contact # dependency is populated already
 
     EditionDependenciesPopulator.new(news_article).populate!
 

--- a/test/unit/govspeak/contacts_extractor_test.rb
+++ b/test/unit/govspeak/contacts_extractor_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ContactsExtractorTest < ActiveSupport::TestCase
+  test 'can collect all the embedded contacts into a list of Contacts in order' do
+    contact_1 = build(:contact)
+    contact_2 = build(:contact)
+    Contact.stubs(:find_by).with(id: '1').returns(contact_1)
+    Contact.stubs(:find_by).with(id: '2').returns(contact_2)
+
+    input = 'We have an office at [Contact:2] but deliveries go to [Contact:1]'
+
+    embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
+    assert_equal [contact_2, contact_1], embedded_contacts
+  end
+
+  test 'will not remove duplicate contacts' do
+    contact_1 = build(:contact)
+    Contact.stubs(:find_by).with(id: '1').returns(contact_1)
+
+    input = 'Our office at [Contact:1] is brilliant, you should come for a cup of tea. Remeber the address is [Contact:1]'
+
+    embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
+    assert_equal [contact_1, contact_1], embedded_contacts
+  end
+
+  test 'will silently remove contact references that do not resolve to a Contact' do
+    Contact.stubs(:find_by).with(id: '1').returns(nil)
+
+    input = 'Our office used to be at [Contact:1] but we moved'
+
+    embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
+    assert_equal [], embedded_contacts
+  end
+end

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -297,31 +297,6 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_equivalent_html "<div class=\"govspeak\"></div>", output
   end
 
-  test 'can collect all the embedded contacts into a list of Contacts in order' do
-    contact_1 = build(:contact)
-    contact_2 = build(:contact)
-    Contact.stubs(:find_by).with(id: '1').returns(contact_1)
-    Contact.stubs(:find_by).with(id: '2').returns(contact_2)
-    input = 'We have an office at [Contact:2] but deliveries go to [Contact:1]'
-    embedded_contacts = govspeak_embedded_contacts(input)
-    assert_equal [contact_2, contact_1], embedded_contacts
-  end
-
-  test 'will not remove duplicate contacts' do
-    contact_1 = build(:contact)
-    Contact.stubs(:find_by).with(id: '1').returns(contact_1)
-    input = 'Our office at [Contact:1] is brilliant, you should come for a cup of tea. Remeber the address is [Contact:1]'
-    embedded_contacts = govspeak_embedded_contacts(input)
-    assert_equal [contact_1, contact_1], embedded_contacts
-  end
-
-  test 'will silently remove contact references that do not resolve to a Contact' do
-    Contact.stubs(:find_by).with(id: '1').returns(nil)
-    input = 'Our office used to be at [Contact:1] but we moved'
-    embedded_contacts = govspeak_embedded_contacts(input)
-    assert_equal [], embedded_contacts
-  end
-
   test 'will use the html version of the contact partial, even if the view context is for a different format' do
     contact = build(:contact)
     Contact.stubs(:find_by).with(id: '1').returns(contact)

--- a/test/unit/services/listeners/edition_dependencies_populator_test.rb
+++ b/test/unit/services/listeners/edition_dependencies_populator_test.rb
@@ -11,7 +11,7 @@ class ServiceListeners::EditionDependenciesPopulatorTest < ActiveSupport::TestCa
       stub_panopticon_registration(news_article)
 
       assert Whitehall.edition_services.send(service_name, news_article).perform!
-      assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
+      assert_same_elements contacts, news_article.contact_dependencies
     end
   end
 

--- a/test/unit/services/listeners/edition_dependencies_populator_test.rb
+++ b/test/unit/services/listeners/edition_dependencies_populator_test.rb
@@ -11,7 +11,7 @@ class ServiceListeners::EditionDependenciesPopulatorTest < ActiveSupport::TestCa
       stub_panopticon_registration(news_article)
 
       assert Whitehall.edition_services.send(service_name, news_article).perform!
-      assert_same_elements contacts, news_article.contact_dependencies
+      assert_same_elements contacts, news_article.depended_upon_contacts
     end
   end
 

--- a/test/unit/services/listeners/edition_dependencies_populator_test.rb
+++ b/test/unit/services/listeners/edition_dependencies_populator_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ServiceListeners::EditionDependenciesPopulatorTest < ActiveSupport::TestCase
+
+  [:publisher, :force_publisher].each do |service_name|
+    test "Whitehall.edition_services.#{service_name} populates edition's dependencies" do
+      contacts = create_list(:contact, 2)
+      news_article = create(:submitted_news_article, body: "For more information, get in touch at:
+        [Contact:#{contacts[0].id}] or [Contact:#{contacts[1].id}]", major_change_published_at: Time.zone.now)
+
+      stub_panopticon_registration(news_article)
+
+      assert Whitehall.edition_services.send(service_name, news_article).perform!
+      assert_equal contacts, news_article.dependencies.contacts.map(&:dependable)
+    end
+  end
+
+end


### PR DESCRIPTION
https://trello.com/c/ibAvwvH7

### Problem

Content Store has editions with govspeak fields like contacts already expanded. So whenever the embedded contact changes, we need to republish the edition with the govspeak field expansion updated.

Based on [Proposal: How to handle dynamic govspeak elements](https://gov-uk.atlassian.net/wiki/x/n4ASAQ), this PR first addresses handling changes in contacts embedded within an edition. There will be a follow-up PR for:

0. doing the same for admin links, and
0. running a data migration to populate the dependencies for already published editions.

### Solution

0. create `edition_dependencies` table to track dependencies between editions and contacts that it embeds. it is a polymorphic that caters to the dependency being either a contact or another edition because we know that very soon we have to repeat the same for admin links as well.
0. create `EditionDependencyPopulator` which scans for contacts present in the edition body and saves those in `edition_dependencies`.
0. run `EditionDependencyPopulator` on an edition when it gets published.
0. queue-up jobs in `PublishingApiWorker` for republishing a contact's dependent editions whenever a contact is updated.