### PR TITLE
Remove political checkbox for managing editors

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -149,7 +149,7 @@ module Whitehall::Authority::Rules
     def managing_editor_can?(action)
       case action
       when :mark_political
-        true
+        false
       else
         departmental_editor_can?(action)
       end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -8,7 +8,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   view_test "displays the political checkbox for privileged users " do
-    login_as :managing_editor
+    login_as :gds_editor
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     get :edit, id: new_draft
@@ -23,7 +23,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   view_test "doesn't display the political checkbox on creation" do
-    login_as :managing_editor
+    login_as :gds_editor
     get :new
     assert_select '.political-status', count: 0
   end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -173,6 +173,6 @@ class ManagingEditorTest < ActiveSupport::TestCase
   end
 
   test 'can mark editions as political' do
-    assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
+    refute enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 end


### PR DESCRIPTION
Until the guidance exists on how to use the checkbox remove it from view
for managing editors. We will swap this back when the guidance is
published.