### PR TITLE
Data migration to backfill political flag on editions

### DIFF
--- a/db/data_migration/20150304163010_backfill_political_editions.rb
+++ b/db/data_migration/20150304163010_backfill_political_editions.rb
@@ -1,0 +1,15 @@
+index = 0
+
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+edition_scope = Edition.where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+edition_count = edition_scope.count
+
+edition_scope.find_each do |edition|
+  if PoliticalContentIdentifier.political?(edition)
+    edition.update_column(:political, true)
+  end
+
+  index += 1
+
+  puts "Processed #{index} of #{edition_count} editions (#{(index.to_f/edition_count.to_f)*100}%)" if index % 1000 == 0
+end


### PR DESCRIPTION
This will set the political flag to true on any editions identified as being political using `PoliticalContentIdentifier`.

https://trello.com/c/M4VrdeQc/41-back-fill-political-flag-for-relevant-documents

On my local machine, it takes 8 minutes and 30 seconds to run, which may or may not be acceptable.