### PR TITLE
Revert removal of deprecated_columns

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,6 +1,9 @@
 # The base class for all editoral content. It configures the searchable options and callbacks.
 # @abstract Using STI should not create editions directly.
 class Edition < ActiveRecord::Base
+  extend DeprecatedColumns
+  deprecated_columns :locale
+
   include Edition::Traits
 
   include Edition::NullImages

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -10,6 +10,11 @@ class Policy < Edition
   include Edition::WorldLocations
   include Edition::WorldwidePriorities
 
+
+  extend DeprecatedColumns
+  # FIXME: Pending migration in db/pending_migration_cleanups to remove this column
+  deprecated_columns :published_related_publication_count
+
   has_many :edition_relations, through: :document
   has_many :related_editions, through: :edition_relations, source: :edition
   has_many :published_related_editions,


### PR DESCRIPTION
Reverts part of alphagov/whitehall#2007.

We believe the slave mysql databases still have this column due to replication lag. Add these `deprecated_columns` statements back in will make the app ignore them until they've been dropped.