### PR TITLE
Add a history-mode column to Document export CSVs

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -27,6 +27,7 @@ class DocumentListExportPresenter
       'Policies',
       'Specialist sectors',
       'Collections',
+      'Affected by history-mode',
     ]
   end
 
@@ -47,7 +48,8 @@ class DocumentListExportPresenter
       attachment_types,
       policies,
       specialist_sectors,
-      collections
+      collections,
+      edition.political?,
     ]
   end
 

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -130,6 +130,10 @@ class DocumentListExportPresenter
       when Time
         # YYYY-MM-DD hh:mm:ss, which seems to be best understood by spreadsheets.
         elem.to_formatted_s(:db)
+      when true
+        'yes'
+      when false
+        'no'
       else
         elem
       end

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -36,10 +36,10 @@ class DocumentListExportPresenterTest < PresenterTestCase
     assert_equal(['greenpaper.pdf', 'An HTML attachment', 'http://www.example.com'], pr.attachment_types)
   end
 
-  test '#format_elements formats arrays and dates but leaves strings alone' do
+  test '#format_elements formats arrays, dates and booleans but leaves strings alone' do
     pr = DocumentListExportPresenter.new('')
-    data = [%w(list of elements), Time.new(2014, 10, 5, 10, 15), 'normal string']
-    assert_equal(['list, of, elements', '2014-10-05 10:15:00', 'normal string'], pr.format_elements(data))
+    data = [%w(list of elements), Time.new(2014, 10, 5, 10, 15), 'normal string', true, false]
+    assert_equal(['list, of, elements', '2014-10-05 10:15:00', 'normal string', 'yes', 'no',], pr.format_elements(data))
   end
 
   test '#lead_organisations returns list of lead org names' do


### PR DESCRIPTION
This will be used by Departmental Editors to see what content will be
affected by history-mode, eg, content that is 'political' and that
belongs to a previous government will be marked as historical.

This allows Editors to see which of their documents will be marked
as historic when the government changes.

https://trello.com/c/3QRDCMOG/59-departmental-editors-can-see-the-history-mode-state-of-content

- [x] Product review
- [ ] Technical review