### PR TITLE
Let an Edition mark itself as being in history-mode

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -659,6 +659,10 @@ class Edition < ActiveRecord::Base
     Government.on_date(date_for_government) unless date_for_government.nil?
   end
 
+  def historic?
+    political? && !government.current?
+  end
+
 private
 
   def date_for_government

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -16,4 +16,8 @@ class Government < ActiveRecord::Base
 
     where('start_date <= ?', date).order(start_date: :desc).first
   end
+
+  def current?
+    self == Government.current
+  end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -921,4 +921,27 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil edition.government
   end
 
+  test '#historic? is true when political and from a previous government' do
+    create(:current_government)
+    previous_government = create(:previous_government)
+
+    edition = create(:edition, political: true, first_published_at: previous_government.start_date)
+    assert edition.historic?
+  end
+
+  test '#historic? is false for when not political or from the current government' do
+    current_government = create(:current_government)
+
+    previous_government = create(:previous_government)
+
+    edition = create(:edition, political: false, first_published_at: previous_government.start_date)
+    refute edition.historic?
+
+    edition = create(:edition, political: false, first_published_at: current_government.start_date)
+    refute edition.historic?
+
+    edition = create(:edition, political: true, first_published_at: current_government.start_date)
+    refute edition.historic?
+  end
+
 end

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -77,4 +77,12 @@ class GovernmentOnDateTest < ActiveSupport::TestCase
   test "#on_date returns nil for future dates" do
     assert_nil Government.on_date(Date.tomorrow), "tomorrow"
   end
+
+  test '#current? is true for the current government' do
+    assert @current_government.current?
+  end
+
+  test '#current? is false for previous governments' do
+    refute @previous_government.current?
+  end
 end


### PR DESCRIPTION
Adds `historic?`, based on agreed rule that something should be in
history-mode if it is political and does not belong to the current
Government.

This adds `current?` on Government and uses `Edition.political?`,
which already exists. Note,`political?` isn't fully populated yet.

This was written for https://github.com/alphagov/whitehall/pull/2014 but which only needed `Edition.political?` 
in the end. I've split it out as it'll still be used in future work (like https://trello.com/c/lowbsjJK/80-spike-history-mode-on-document-pages), so getting it reviewed early.