### PR TITLE
Add basic Government API

### DIFF
--- a/app/controllers/api/governments_controller.rb
+++ b/app/controllers/api/governments_controller.rb
@@ -1,0 +1,24 @@
+class Api::GovernmentsController < PublicFacingController
+  skip_before_filter :restrict_request_formats
+  respond_to :json
+
+  self.responder = Api::Responder
+
+  def index
+    respond_with Api::GovernmentPresenter.paginate(Government.order(start_date: :desc), view_context)
+  end
+
+  def show
+    @government = Government.find_by(slug: params[:id])
+    if @government
+      respond_with Api::GovernmentPresenter.new(@government, view_context)
+    else
+      respond_with_not_found
+    end
+  end
+
+private
+  def respond_with_not_found
+    respond_with Hash.new, status: :not_found
+  end
+end

--- a/app/presenters/api/government_presenter.rb
+++ b/app/presenters/api/government_presenter.rb
@@ -1,0 +1,19 @@
+class Api::GovernmentPresenter < Api::BasePresenter
+  def as_json(options = {})
+    {
+      id: context.api_government_url(model.slug),
+      title: model.name,
+      slug: model.slug,
+      details: {
+        start_date: model.start_date,
+        end_date: model.end_date,
+      },
+    }
+  end
+
+  def links
+    [
+      [context.api_government_url(model.slug), {'rel' => 'self'}]
+    ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Whitehall::Application.routes.draw do
         get :tags
       end
     end
+    resources :governments, only: [:index, :show], defaults: { format: :json }
     resources :organisations, only: [:index, :show], defaults: { format: :json }
     resources :world_locations, path: 'world-locations', only: [:index, :show], defaults: { format: :json } do
       resources :worldwide_organisations, path: 'organisations', only: [:index], defaults: { format: :json }

--- a/test/functional/api/governments_controller_test.rb
+++ b/test/functional/api/governments_controller_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class Api::GovernmentsControllerTest < ActionController::TestCase
+  disable_database_queries
+  should_be_a_public_facing_controller
+
+  view_test "index paginates governments" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    Government.stubs(:order).returns([])
+    Api::GovernmentPresenter.stubs(:paginate).with(Government.order(start_date: :desc), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert_equal 'representation', json_response['paged']
+  end
+
+  view_test "index includes _response_info in response" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    Government.stubs(:order).returns([])
+    Api::GovernmentPresenter.stubs(:paginate).with(Government.order(start_date: :desc), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert_equal 'ok', json_response['_response_info']['status']
+  end
+
+  view_test "show responds with JSON representation of found government" do
+    government = stub_record(:government, slug: 'old-gov')
+    government.stubs(:to_param).returns('old-gov')
+    Government.stubs(:find_by).with(slug: government.slug).returns(government)
+    presenter = Api::GovernmentPresenter.new(government, controller.view_context)
+    presenter.stubs(:as_json).returns(foo: :bar)
+    Api::GovernmentPresenter.stubs(:new).with(government, anything).returns(presenter)
+
+    get :show, id: government.slug, format: 'json'
+    assert_equal 'bar', json_response['foo']
+  end
+
+  view_test "show includes _response_info in response" do
+    government = stub_record(:government, slug: 'old-gov')
+    government.stubs(:to_param).returns('old-gov')
+    Government.stubs(:find_by).with(slug: government.slug).returns(government)
+    presenter = Api::GovernmentPresenter.new(government, controller.view_context)
+    presenter.stubs(:as_json).returns(foo: :bar)
+    Api::GovernmentPresenter.stubs(:new).with(government, anything).returns(presenter)
+
+    get :show, id: government.slug, format: 'json'
+    assert_equal 'ok', json_response['_response_info']['status']
+  end
+
+  view_test "show responds with 404 if government is not found" do
+    Government.stubs(:find_by).with(slug: 'unknown').returns nil
+    get :show, id: 'unknown', format: 'json'
+    assert_response :not_found
+    assert_equal 'not found', json_response['_response_info']['status']
+  end
+end

--- a/test/unit/presenters/api/government_presenter_test.rb
+++ b/test/unit/presenters/api/government_presenter_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class Api::GovernmentPresenterTest < PresenterTestCase
+  setup do
+    @government = stub_record(:government, slug: 'old-gov')
+    @presenter = Api::GovernmentPresenter.new(@government, @view_context)
+    stubs_helper_method(:params).returns(format: :json)
+  end
+
+  test ".paginate returns a page presenter for the correct page of presented governments" do
+    stubs_helper_method(:params).returns(page: 1)
+    page = [@government]
+    Api::Paginator.stubs(:paginate).with([@government], page: 1).returns(page)
+
+    paginated = Api::GovernmentPresenter.paginate([@government], @view_context)
+
+    assert_equal Api::PagePresenter, paginated.class
+    assert_equal 1, paginated.page.size
+    assert_equal Api::GovernmentPresenter, paginated.page.first.class
+    assert_equal @government, paginated.page.first.model
+  end
+
+  test 'links has a self link, pointing to the request-relative api government url' do
+    self_link = @presenter.links.detect { |(url, attrs)| attrs['rel'] == 'self'}
+    assert self_link
+    url, attrs = *self_link
+    assert_equal api_government_url(@government.slug), url
+  end
+
+  test "json includes request-relative api government url as id" do
+    assert_equal api_government_url(@government.slug), @presenter.as_json[:id]
+  end
+
+  test "json includes government name as title" do
+    @government.stubs(:name).returns('government-name')
+    assert_equal 'government-name', @presenter.as_json[:title]
+  end
+
+  test "json includes government start_date and end_date in details hash" do
+    end_date = Time.current.to_date
+    start_date = (Time.current - 2.days).to_date
+    @government.stubs(:start_date).returns(start_date)
+    @government.stubs(:end_date).returns(end_date)
+    assert_equal start_date, @presenter.as_json[:details][:start_date]
+    assert_equal end_date, @presenter.as_json[:details][:end_date]
+  end
+end


### PR DESCRIPTION
Copying the approach and most of the code from the organisation API. 
Creates both a paginated index and a show method for each government.
Currently the only details on each government are start and end dates.

This is a sample of what the data looks like:

![screen shot 2015-03-06 at 14 10 32](https://cloud.githubusercontent.com/assets/35035/6526519/9e394736-c40a-11e4-9e2c-780249325b55.png)
