### PR TITLE
Statistics announcement unpublisher

### DIFF
--- a/lib/data_hygiene/statistics_announcement_unpublisher.rb
+++ b/lib/data_hygiene/statistics_announcement_unpublisher.rb
@@ -1,0 +1,48 @@
+require 'gds_api/router'
+
+module DataHygiene
+  class StatisticsAnnouncementUnpublisher
+    def initialize(announcement_slug:, logger:)
+      @announcement_slug = announcement_slug
+      @logger = logger
+    end
+
+    def call
+      if announcement
+        register_gone_route
+        destroy_announcement
+      else
+        logger.error(
+          %(Could not find StatisticsAnnouncement with slug "#{announcement_slug}")
+        )
+      end
+    end
+
+  private
+    attr_reader :announcement_slug, :logger
+
+    def announcement
+      @announcement ||= StatisticsAnnouncement.find_by(slug: announcement_slug)
+    end
+
+    def register_gone_route
+      route = announcement.public_path
+
+      logger.info(%(Registering GONE route for "#{route}"))
+
+      router_api.add_gone_route(route, :exact, commit: true)
+    end
+
+    def destroy_announcement
+      logger.info(
+        %(Deleting StatisticsAnnouncement with slug "#{announcement_slug}")
+      )
+
+      announcement.destroy
+    end
+
+    def router_api
+      @router_api ||= GdsApi::Router.new(Plek.new.find("router-api"))
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -113,3 +113,11 @@ desc "Unarchive an edition (creates and publishes a draft with audit trail)"
 task :unarchive_edition, [:edition_id] => :environment do |t,args|
   DataHygiene::EditionUnarchiver.new(args[:edition_id], Logger.new(STDOUT)).unarchive
 end
+
+desc "Unpublish a statistics announcement and register a 410 GONE route for it"
+task :unpublish_statistics_announcement, [:slug] => :environment do |t, args|
+  DataHygiene::StatisticsAnnouncementUnpublisher.new(
+    announcement_slug: args[:slug],
+    logger: Logger.new(STDOUT),
+  ).call
+end

--- a/test/unit/data_hygiene/statistics_announcement_unpublisher_test.rb
+++ b/test/unit/data_hygiene/statistics_announcement_unpublisher_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'gds_api/test_helpers/router'
+
+module DataHygiene
+  class StatisticsAnnouncementUnpublisherTest < ActiveSupport::TestCase
+    include GdsApi::TestHelpers::Router
+
+    setup do
+      @fake_logger = NullLogger.instance
+      @announcement = create(:statistics_announcement)
+    end
+
+    test "reports an error when given a non-existent slug" do
+      unpublisher = StatisticsAnnouncementUnpublisher.new(
+        announcement_slug: "not-a-real-slug",
+        logger: @fake_logger,
+      )
+
+      @fake_logger.expects(:error).once.with(regexp_matches(/not-a-real-slug/))
+
+      unpublisher.call
+    end
+
+    test "destroys the announcement and registers a 'Gone' route when given a valid slug" do
+      unpublisher = StatisticsAnnouncementUnpublisher.new(
+        announcement_slug: @announcement.slug,
+        logger: @fake_logger,
+      )
+
+      register_request, commit_request = stub_gone_route_registration(@announcement.public_path, :exact)
+
+      unpublisher.call
+
+      refute StatisticsAnnouncement.exists?(@announcement)
+
+      assert_requested(register_request)
+      assert_requested(commit_request)
+    end
+  end
+end


### PR DESCRIPTION
Add a rake task to unpublish statistics announcements. They don't have any workflow, so after discussion with @marksheldonGDS we agreed the best way to handle it would be to delete the records and register a GONE route for them.

Here are a couple of tickets with details of announcements that need unpublishing:

- https://www.pivotaltracker.com/story/show/89716404
- https://www.pivotaltracker.com/story/show/89094234