### PR TITLE
Specify locale for Organisations.listable scope

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -21,7 +21,7 @@ module Organisation::OrganisationTypeConcern
     }
 
     scope :listable, -> {
-      excluding_govuk_status_closed.with_translations
+      excluding_govuk_status_closed.with_translations(I18n.locale)
     }
 
     scope :allowed_promotional, -> {


### PR DESCRIPTION
Eager loading the translations without specifying the locale means we get two copies of the wales-office organisation in the results, one for the English translation and one for the Welsh translation.

This stops Wales Office appearing twice on https://www.gov.uk/government/organisations

Ticket: https://www.pivotaltracker.com/story/show/89589862