### PR TITLE
Don't reference versions in admin editions filter

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -114,8 +114,7 @@ module Admin
 
     def editions_with_translations(locale = nil)
       editions_without_translations = unpaginated_editions.
-                                        includes(:last_author, :unpublishing).
-                                        references(:versions).
+                                        includes(:unpublishing).
                                         order("editions.updated_at DESC")
 
       if locale

--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -16,11 +16,10 @@ module Edition::AuditTrail
     has_many :versions, -> { order("created_at ASC, id ASC") }, as: :item
 
     has_one :most_recent_version,
-            -> { order('created_at DESC, id DESC') },
+            -> { order('versions.created_at DESC, versions.id DESC') },
             class_name: 'Version',
             as: :item
     has_one :last_author,
-            -> { order('versions.created_at DESC, versions.id DESC') },
             through: :most_recent_version,
             source: :user
 


### PR DESCRIPTION
This was added to get around an issue during the Rails 4.1 upgrade that meant
ActiveRecord wasn't able to generate a valid query when trying to eager load the
`last_author`s on a collection of editions. Unfortunately, this resulted in a
highly inefficient queries that required a lot of writing to disk and was causing 
problems with the MySQL server.

To get around the issue whilst we investigate further, the eager-loading of
`last_author` is being removed. This makes the page n+1 (where n is 50) as it now
loads each `last_author` with an individual query, but the additional impact to
users is fairly minimal on this already-slow page.

The root problem is that ActiveRecord doesn't seem to be able to eager-load the
`last_author` association correctly. This association is a has_one that is
through another has_one association (`most_recent_version`) that also has an
order clause to determine the precise one.