### PR TITLE
Proposal: Cleanup publication_type_id on non-Publication editions

### DIFF
--- a/db/data_migration/20150310165123_remove_publication_type_id_on_consultations.rb
+++ b/db/data_migration/20150310165123_remove_publication_type_id_on_consultations.rb
@@ -1,0 +1,1 @@
+Edition.where('type <> "Publication" AND publication_type_id IS NOT NULL').update_all(publication_type_id: nil)


### PR DESCRIPTION
It's set on quite a few other publication types, when
it shouldn't be:

Consultation => 3622
NewsArticle => 6
Policy => 46
Speech => 5
