### PR TITLE
[#90025978] Statistics redirects belong in data/statistics.csv

### DIFF
--- a/script/dedupe_stats_announcement
+++ b/script/dedupe_stats_announcement
@@ -38,4 +38,4 @@ logger = Logger.new(STDOUT)
 
 DataHygiene::DuplicateStatisticsAnnouncement.new(duplicate_announcement, logger, options[:noop]).destroy_and_redirect_to(authoritative_announcement)
 
-puts "For completeness, the above redirect should also be added to router-data/data/slug-changes.csv"
+puts "For completeness, the above redirect should also be added to router-data/data/statistics.csv"


### PR DESCRIPTION
The [OpsManual instructions][] say that redirected stats announcements
should be added to `router-data/data/statistics.csv`. Update the message
here for consistency.

[OpsManual instructions]: https://github.gds/pages/gds/opsmanual/2nd-line/applications/whitehall.html#de-duplicating-whitehall-statistics-announcements