### PR TITLE
Set missing content ids for organisations

### DIFF
--- a/db/data_migration/20150311142732_add_missing_content_id_for_organisation.rb
+++ b/db/data_migration/20150311142732_add_missing_content_id_for_organisation.rb
@@ -1,0 +1,5 @@
+Organisation.where(content_id: nil).each do |organisation|
+  organisation.content_id = SecureRandom.uuid
+  organisation.save(validate: false)
+  puts "Setting content_id for #{organisation.name}"
+end


### PR DESCRIPTION
The [previous data migration](https://github.com/alphagov/whitehall/blob/master/db/data_migration/20141010105113_add_content_id_to_organisations.rb) skipped over any organisations that failed validation. This meant that at least one (FCO Services) was left without a content_id as it failed validation due to not having an alternative format provider email address.