### PR TITLE
Fix case study image caption validity in terms of content schema

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -24,7 +24,7 @@ module LeadImagePresenterHelper
   def lead_image_caption
     if images.first
       caption = images.first.caption && images.first.caption.strip
-      caption.present? && caption
+      caption.present? ? caption : nil
     end
   end
 

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -80,6 +80,21 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     assert_equal expected_hash, presented_hash[:details][:image]
   end
 
+  test "returns case study image caption as nil (not false) when it is blank" do
+    image = build(:image, alt_text: 'Image alt text', caption: '')
+    case_study = create(:published_case_study, images: [image])
+
+    expected_hash = {
+      url: (Whitehall.asset_root + image.url(:s300)),
+      alt_text: image.alt_text,
+      caption: nil
+    }
+    presented_hash = present(case_study)
+
+    assert_valid_against_schema(presented_hash, 'case_study')
+    assert_equal expected_hash, presented_hash[:details][:image]
+  end
+
   test "falls back to the organisation's default news image when there is no image" do
     organisation_image = DefaultNewsOrganisationImageData.new(file: image_fixture_file)
     organisation = create(:organisation, default_news_image: organisation_image)


### PR DESCRIPTION
When `caption` was a blank string, or null, it was returning `false`, but the
schema specified that it should a string or null.

Strictly speaking, I think we should republish all case studies now that we've
changed the way that they are generated.