### PR TITLE
Add a history mode notice on document pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_status-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_status-block.scss
@@ -22,3 +22,21 @@
     padding: $gutter-two-thirds;
   }
 }
+
+.history-status-block {
+  clear: both;
+  margin: $gutter-half;
+
+  @include media(desktop) {
+    margin-bottom: $gutter;
+  }
+
+  h2 {
+    @include heading-24;
+    font-weight: bold;
+  }
+
+  p {
+    @include heading-24;
+  }
+}

--- a/app/assets/stylesheets/frontend/helpers/_status-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_status-block.scss
@@ -25,10 +25,15 @@
 
 .history-status-block {
   clear: both;
-  margin: $gutter-half;
+  margin: $gutter-half 0;
+  padding: $gutter-half;
+
+  color: $white;
+  background: $govuk-blue;
 
   @include media(desktop) {
-    margin-bottom: $gutter;
+    margin: $gutter $gutter-half;
+    padding: $gutter-two-thirds $gutter;
   }
 
   h2 {

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -663,6 +663,8 @@ class Edition < ActiveRecord::Base
   end
 
   def historic?
+    return false unless government
+
     political? && !government.current?
   end
 

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -24,3 +24,8 @@
                                  topics: topics,
                                  primary_mainstream_category: primary_mainstream_category,
                                  specialist_tag_finder: specialist_tag_finder %>
+
+<% if document.historic? %>
+<%= render('documents/history_notice', type: document.format_name,
+                                       government_name: document.government.try(:name)) %>
+<% end %>

--- a/app/views/documents/_history_notice.html.erb
+++ b/app/views/documents/_history_notice.html.erb
@@ -1,0 +1,6 @@
+<div class="history-status-block">
+  <h2>This <%= type.downcase %> is from a previous government</h2>
+  <% if government_name %>
+  <p>It was published under the <%= government_name %></p>
+  <% end %>
+</div>

--- a/features/history-mode.feature
+++ b/features/history-mode.feature
@@ -1,0 +1,9 @@
+Feature: history-mode
+  As a member of the public
+  I want to know when a document was published under a previous government
+  So that I know it does not reflect the view of the current government
+
+Scenario: reading a political document from a previous government
+  Given there is a current government
+  And there is a political document from a previous government
+  Then it should be publicly marked as belonging to the previous government

--- a/features/step_definitions/government_steps.rb
+++ b/features/step_definitions/government_steps.rb
@@ -20,3 +20,7 @@ When(/^I edit the government called "(.*?)" to have dates "(.*?)" and "(.*?)"$/)
     end_date: end_date
   })
 end
+
+Given(/^there is a current government$/) do
+  FactoryGirl.create(:current_government)
+end

--- a/features/step_definitions/history_mode_steps.rb
+++ b/features/step_definitions/history_mode_steps.rb
@@ -1,0 +1,9 @@
+Given(/^there is a political document from a previous government$/) do
+  @previous_government = FactoryGirl.create(:previous_government)
+  @edition = FactoryGirl.create(:published_publication, political: true, first_published_at: @previous_government.start_date)
+end
+
+Then(/^it should be publicly marked as belonging to the previous government$/) do
+  visit public_document_path(@edition)
+  assert page.has_css?(".history-status-block", text: @previous_government.name)
+end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -944,4 +944,12 @@ class EditionTest < ActiveSupport::TestCase
     refute edition.historic?
   end
 
+  test '#historic? is false when the document has no government' do
+    edition = create(:edition, political: true, first_published_at: nil)
+    refute edition.historic?
+
+    edition = create(:edition, political: false, first_published_at: nil)
+    refute edition.historic?
+  end
+
 end


### PR DESCRIPTION
History mode applies to political documents published under a previous government

We want to show that the document is not associated with the current administration
and show which administration it was published under.

**Previews:**
![image](https://cloud.githubusercontent.com/assets/63201/6643256/d42ade52-c9a2-11e4-9d5a-282ce81fde0a.png)

![image](https://cloud.githubusercontent.com/assets/63201/6643279/025cd33e-c9a3-11e4-9967-f7ed97ac6502.png)
