### PR TITLE
Use https for wikipedia link describing ODF

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -43,7 +43,7 @@ class AttachmentData < ActiveRecord::Base
     file_extension == "csv"
   end
 
-  # Is in OpenDocument format? (see http://en.wikipedia.org/wiki/OpenDocument)
+  # Is in OpenDocument format? (see https://en.wikipedia.org/wiki/OpenDocument)
   def opendocument?
     OPENDOCUMENT_EXTENSIONS.include? file_extension.upcase
   end

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -17,7 +17,7 @@ class ExternalAttachment < Attachment
     false
   end
 
-  # Is in OpenDocument format? (see http://en.wikipedia.org/wiki/OpenDocument)
+  # Is in OpenDocument format? (see https://en.wikipedia.org/wiki/OpenDocument)
   def opendocument?
     false
   end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -33,7 +33,7 @@ class HtmlAttachment < Attachment
     false
   end
 
-  # Is in OpenDocument format? (see http://en.wikipedia.org/wiki/OpenDocument)
+  # Is in OpenDocument format? (see https://en.wikipedia.org/wiki/OpenDocument)
   def opendocument?
     false
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,7 +489,7 @@ en:
         %{email}.
         Please tell us what format you need. It will help us if you say what assistive technology you use.
     opendocument:
-      help_html: This file is in an <a rel="external" href="http://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a> format
+      help_html: This file is in an <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a> format
     see_more: See more information about this %{document_type}
   detailed_guidance:
     back_to_contents: Back to contents

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -366,7 +366,7 @@ et:
       unnumbered_command_paper:
       unnumbered_hoc_paper: Nummerdamata eelnõu dokument
     opendocument:
-      help_html: See fail on <a rel="external" href="http://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a>
+      help_html: See fail on <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a>
         formaadis
     see_more: 'Loe lähemalt: %{document_type}'
   change_notes:


### PR DESCRIPTION
Use https link because it's better for security/privacy and for HTTP/2.0 upgrade