### PR TITLE
Render case studies in government-frontend

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -11,6 +11,10 @@ class CaseStudy < Edition
 
   validates :first_published_at, presence: true, if: -> e { e.trying_to_convert_to_draft == true }
 
+  def rendering_app
+    "government-frontend"
+  end
+
   def display_type_key
     "case_study"
   end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -12,7 +12,7 @@ class CaseStudy < Edition
   validates :first_published_at, presence: true, if: -> e { e.trying_to_convert_to_draft == true }
 
   def rendering_app
-    "government-frontend"
+    Whitehall.case_study_publishing_api_rendering_app
   end
 
   def display_type_key

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -548,6 +548,10 @@ class Edition < ActiveRecord::Base
     end
   end
 
+  def rendering_app
+    "whitehall-frontend"
+  end
+
   def format_name
     self.class.format_name
   end

--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -19,6 +19,10 @@ class RegisterableEdition
     panopticon_slug
   end
 
+  def rendering_app
+    edition.rendering_app
+  end
+
   def paths
     if kind == "detailed_guide"
       detailed_guide_paths

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -1,6 +1,6 @@
 class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
   def as_json
-    super.merge(format: "case_study", links: links)
+    super.merge(format: "case_study", rendering_app: "government-frontend", links: links)
   end
 
 private

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -1,6 +1,10 @@
 class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
   def as_json
-    super.merge(format: "case_study", rendering_app: "government-frontend", links: links)
+    super.merge(
+      format: "case_study",
+      rendering_app: edition.rendering_app,
+      links: links
+    )
   end
 
 private

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -13,24 +13,28 @@
 # Note this format becomes redundant once the caching infrasture is able to
 # honour caching headers on upstream 404 responses.
 class PublishingApiPresenters::ComingSoon
-  attr_reader :base_path, :publishing_timestamp, :locale
+  attr_reader :edition, :locale
 
-  def initialize(base_path, publishing_timestamp, locale)
-    @base_path = base_path
-    @publishing_timestamp = publishing_timestamp
+  def initialize(edition, locale)
+    @edition = edition
     @locale = locale
   end
 
   def as_json
     {
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: edition.rendering_app,
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,
       update_type: 'major',
-      details: { publish_time: publishing_timestamp },
+      details: { publish_time: edition.scheduled_publication.as_json },
       routes: [ { path: base_path, type: "exact" } ]
     }
+  end
+
+private
+  def base_path
+    Whitehall.url_maker.public_document_path(edition, locale: locale)
   end
 end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -26,6 +26,8 @@ module PublishingApiPresenters
         public_updated_at: edition.public_timestamp,
         update_type: update_type,
         publishing_app: "whitehall",
+        # We're not using edition.rendering_app because we're defaulting to a
+        # placeholder and placeholders only exist because they are rendered by whitehall
         rendering_app: "whitehall-frontend",
         routes: [ { path: base_path, type: "exact" } ],
         redirects: [],

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -42,7 +42,7 @@ private
       public_updated_at: edition.public_timestamp,
       update_type: update_type,
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: edition.rendering_app,
       routes: [ { path: base_path, type: 'exact' } ],
       redirects: [],
       details: details,

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,9 +1,11 @@
 class PublishingApiComingSoonWorker
   include Sidekiq::Worker
 
-  def perform(base_path, publish_timestamp, locale)
-    coming_soon = PublishingApiPresenters::ComingSoon.new(base_path, publish_timestamp, locale)
+  def perform(edition_id, locale)
+    edition = Edition.find(edition_id)
+    coming_soon = PublishingApiPresenters::ComingSoon.new(edition, locale)
 
+    base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
     Whitehall.publishing_api_client.put_content_item(base_path, coming_soon.as_json)
   end
 end

--- a/config/initializers/publishing_api_rendering_app.rb
+++ b/config/initializers/publishing_api_rendering_app.rb
@@ -1,0 +1,1 @@
+Whitehall.case_study_publishing_api_rendering_app = 'whitehall-frontend'

--- a/db/data_migration/20150317165803_republish_case_studies_to_render_on_government_frontend.rb
+++ b/db/data_migration/20150317165803_republish_case_studies_to_render_on_government_frontend.rb
@@ -1,0 +1,3 @@
+# Unpublished case studies
+DataHygiene::PublishingApiRepublisher.new(CaseStudy.archived).perform
+DataHygiene::PublishingApiRepublisher.new(CaseStudy.publicly_visible).perform

--- a/db/data_migration/20150317165803_republish_case_studies_to_render_on_government_frontend.rb
+++ b/db/data_migration/20150317165803_republish_case_studies_to_render_on_government_frontend.rb
@@ -1,3 +1,6 @@
 # Unpublished case studies
 DataHygiene::PublishingApiRepublisher.new(CaseStudy.archived).perform
 DataHygiene::PublishingApiRepublisher.new(CaseStudy.publicly_visible).perform
+
+case_study_unpublishings = Unpublishing.joins(:edition).where(editions: { type: CaseStudy })
+DataHygiene::PublishingApiRepublisher.new(case_study_unpublishings).perform

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -216,7 +216,7 @@ module Whitehall
   end
 
   def self.panopticon_registerer_for(registerable_edition)
-    GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: registerable_edition.kind)
+    GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: registerable_edition.rendering_app, kind: registerable_edition.kind)
   end
 
   def self.load_secrets

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -23,6 +23,7 @@ module Whitehall
   mattr_accessor :document_collections_cache_max_age
   mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
+  mattr_accessor :case_study_publishing_api_rendering_app
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -25,7 +25,8 @@ module Whitehall
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiScheduleWorker.perform_async(base_path, publish_timestamp)
         unless edition.document.published?
-          PublishingApiComingSoonWorker.perform_async(base_path, publish_timestamp, locale)
+          PublishingApiComingSoonWorker.perform_async(edition.id, locale)
+                                      # perform_async(base_path, publish_timestamp, locale)
         end
       end
     end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -23,7 +23,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       public_updated_at: case_study.public_timestamp,
       update_type: 'major',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       routes: [
         { path: public_path, type: 'exact' }
       ],

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -23,7 +23,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       public_updated_at: case_study.public_timestamp,
       update_type: 'major',
       publishing_app: 'whitehall',
-      rendering_app: 'government-frontend',
+      rendering_app: 'whitehall-frontend',
       routes: [
         { path: public_path, type: 'exact' }
       ],
@@ -65,6 +65,19 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
     assert_equal expected_hash[:details], presented_hash[:details]
   end
+
+
+  test "uses value of case_study_publishing_api_rendering_app to set rendering_app" do
+    Whitehall.stubs(:case_study_publishing_api_rendering_app).returns('government-frontend')
+    case_study = create(:published_case_study,
+                    title: 'Case study title',
+                    summary: 'The summary',
+                    body: 'Some content')
+    presented_hash = present(case_study)
+
+    assert_equal 'government-frontend', presented_hash[:rendering_app]
+  end
+
 
   test "includes details of the case study image if present" do
     image = build(:image, alt_text: 'Image alt text', caption: 'A caption')

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -3,22 +3,26 @@ require 'test_helper'
 class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
 
   test 'presents a valid "coming_soon" content item' do
-    base_path         = '/some/path'
     locale            = 'en'
     publish_timestamp = 1.day.from_now
+    edition           = create(:scheduled_case_study,
+                                title: 'Case study title',
+                                summary: 'The summary',
+                                body: 'Some content',
+                                scheduled_publication: publish_timestamp)
 
     expected_hash = {
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,
       update_type: 'major',
       details: { publish_time: publish_timestamp },
-      routes: [ { path: base_path, type: 'exact' } ]
+      routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ]
     }
 
-    presenter = PublishingApiPresenters::ComingSoon.new(base_path, publish_timestamp, locale)
+    presenter = PublishingApiPresenters::ComingSoon.new(edition, locale)
 
     assert_equal expected_hash, presenter.as_json
     assert_valid_against_schema(presenter.as_json, 'coming_soon')

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -13,7 +13,7 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
 
     expected_hash = {
       publishing_app: 'whitehall',
-      rendering_app: 'government-frontend',
+      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -14,7 +14,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [
@@ -107,7 +107,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -14,7 +14,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: 'government-frontend',
+      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [
@@ -107,7 +107,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: 'government-frontend',
+      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -163,8 +163,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       assert_equal [english_path, timestamp], PublishingApiScheduleWorker.jobs[0]['args']
       assert_equal [french_path, timestamp], PublishingApiScheduleWorker.jobs[1]['args']
 
-      assert_equal [english_path, timestamp, 'en'], PublishingApiComingSoonWorker.jobs[0]['args']
-      assert_equal [french_path, timestamp, 'fr'], PublishingApiComingSoonWorker.jobs[1]['args']
+      assert_equal [edition.id, 'en'], PublishingApiComingSoonWorker.jobs[0]['args']
+      assert_equal [edition.id, 'fr'], PublishingApiComingSoonWorker.jobs[1]['args']
     end
   end
 

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -2,23 +2,29 @@ require 'test_helper'
 
 class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
   test 'publishes a "coming_soon" format to the Publishing API' do
-    base_path    = '/base_path/for/content.fr'
+    base_path    = '/government/case-studies/case-study-title.fr'
     publish_time = 2.days.from_now
     locale       = 'fr'
+    edition      = create(:scheduled_case_study,
+                           title: 'Case study title',
+                           summary: 'The summary',
+                           body: 'Some content',
+                           scheduled_publication: publish_time)
 
     expected_payload = {
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,
       update_type: 'major',
       details: { publish_time: publish_time },
-      routes: [ { path: base_path, type: 'exact'} ]
+      routes: [ { path: base_path, type: 'exact' } ]
     }
+
     expected_request = stub_publishing_api_put_item(base_path, expected_payload)
 
-    PublishingApiComingSoonWorker.new.perform(base_path, publish_time.as_json, locale)
+    PublishingApiComingSoonWorker.new.perform(edition, locale)
 
     assert_requested expected_request
   end

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -13,7 +13,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
 
     expected_payload = {
       publishing_app: 'whitehall',
-      rendering_app: 'government-frontend',
+      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,


### PR DESCRIPTION
DON'T MERGE YET, but please do review.

We have been publishing case studies to publishing-api for some time, and
government-frontend is now ready to handle case studies we can finally use it
to render them in production.

The migration is required to republish all existing case studies to
publishing-api with the updated rendering_app. publishing-api will send this on
to router-api/router so that it routes requests for the URLs to
government-frontend instead of whitehall-frontend.

*Note* The data migration will queue around 930 case studies for republishing. On preview, it was taking ~3 seconds for a worker to republish, so given two nodes, the time taken was around 23 minutes, though this should be quicker on staging/production.