### PR TITLE
Hardcode the asset manifest file

### DIFF
--- a/config/environments/benchmark.rb
+++ b/config/environments/benchmark.rb
@@ -25,7 +25,8 @@ Whitehall::Application.configure do
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.suppress_app_log = true
 
-  # Defaults to Rails.root.join("public/assets")
+  # Defaults to a file named manifest-<random>.json in the config.assets.prefix
+  # directory within the public folder.
   # config.assets.manifest = YOUR_PATH
 
   # Specifies the header that your server uses for sending files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Whitehall::Application.configure do
   config.logstasher.suppress_app_log = true
 
   # Defaults to Rails.root.join("public/assets")
-  # config.assets.manifest = YOUR_PATH
+  config.assets.manifest = Rails.root.join("public/government/assets/assets-manifest.json")
 
   # Specifies the header that your server uses for sending files
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,8 @@ Whitehall::Application.configure do
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.suppress_app_log = true
 
-  # Defaults to Rails.root.join("public/assets")
+  # Defaults to a file named manifest-<random>.json in the config.assets.prefix
+  # directory within the public folder.
   config.assets.manifest = Rails.root.join("public/government/assets/assets-manifest.json")
 
   # Specifies the header that your server uses for sending files


### PR DESCRIPTION
**TL;DR**: The upgrade to Rails 4 introduced a subtle bug that is causing non-deterministic assets to be served across the servers. This ensures that all boxes will serve the same assets.

The sprockets gem  behaves slightly differently in Rails 4 land - pre-Rails 4, it would generate a `public/assets/manifest.yml` file that mapped all the asset file paths to their compiled versions (e.g. mapped "application.css" to the latest compiled version that would look like "application-DIGEST-OF-COMPILED-FILE.css"). Rails would then use this manifest file to include the latest/correct compiled asset in the markup. In Rails 4, the manifest file is now generated with a different filename - it is generated as
`"manifest-#{SecureRandom.hex(16)}.json"` [1]. This same manifest file is meant to be reused on each re-compilation (i.e. updated to point to the new assets that have been compiled), and the sprockets code assumes there is only one. If there is more than one, then sprockets loads a matching manifest file at random[2]. And because of the "special" way Whitehall compiles and syncs assets on deploy[3], it always generates a fresh manifest file (with a different hex digest), meaning there is now more than one! This results in different boxes showing different asset files based on the particular manifest-HEX.json file that it happened to load when the Rails process boots.

By explicitly configuring the filepath of the asset manifest file, we force sprockets to always use the same filename and thus ensure that each server is using the same manifest.

Note that this is a temporary fix to unblock whitehall deploys. Separate work is being done to make whitehall less of a "special snowflake" and have it compile assets on the servers instead of compiling locally and rsync-ing.

[1] This change was made to make the manifest file harder to find in the public directory, revealing the filename and location of all assets on the server.

[2] The Dir glob on the following line returns results in a non-deterministic order, which means choosing the first result will more than likely give you a different file on different machines:
https://github.com/rails/sprockets/blob/v3.0.0.beta.8/lib/sprockets/manifest.rb#L48

[3] Instead of doing things the "Rails Way" and having each box compile their own assets, Whitehall's deploy script takes care of compiling the assets locally before rsync-ing them to the boxes. But because the deploy build is performed on a clean workspace, there are no existing assets, and thus no
existing manifest file, so it *always* generates a fresh manifest file with a different randomly generated filename: https://github.gds/gds/alphagov-deployment/blob/master/whitehall/config/deploy.rb#L49-L50. This was introduced at a time when we were having problems compiling assets on the frontend boxes - it would often timeout and fail, forcing us to roll back deploys. As stated above, it's likely this is no longer necessary and work is being done separately to make whitehall deploys more "normal".