### PR TITLE
Fix translated child organisations appearing twice

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -45,7 +45,7 @@ module Organisation::OrganisationTypeConcern
 
   def active_child_organisations_excluding_sub_organisations
     @active_child_organisations_excluding_sub_organisations ||=
-      child_organisations.excluding_govuk_status_closed.with_translations.where("organisation_type_key != 'sub_organisation'").ordered_by_name_ignoring_prefix
+      child_organisations.excluding_govuk_status_closed.with_translations(I18n.locale).where("organisation_type_key != 'sub_organisation'").ordered_by_name_ignoring_prefix
   end
 
   def active_child_organisations_excluding_sub_organisations_grouped_by_type


### PR DESCRIPTION
If a parent organisation (as defined by its relationship to `child_organisations`) had a child that was translated, it would appear on the `Organisations#index` page once per translation.

The real life result of this bug is that HMCTS, which also has a Welsh version, appears twice under MoJ.

The applied fix is basically the same as in ec3979c1308a3f576cfe531d775283bf863d724d.