### PR TITLE
Statistical publications should never be political

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -128,6 +128,10 @@ class Publication < Publicationesque
     end
   end
 
+  def political?
+    !statistics? && super
+  end
+
   private
 
   def attachment_required_before_moving_out_of_draft

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -67,6 +67,10 @@ class PublicationType
     [Statistics, NationalStatistics]
   end
 
+  def self.non_statistical
+    all - statistical
+  end
+
   def slug
     plural_name.downcase.gsub(/[^a-z]+/, "-")
   end

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -208,4 +208,16 @@ class PublicationsInTopicsTest < ActiveSupport::TestCase
 
     assert_equal publication, statistics_announcement.reload.publication
   end
+
+  test 'statistics publications are never political' do
+    PublicationType.statistical.each do |type|
+      refute build(:publication, publication_type_id: type.id, political: true).political?
+      refute build(:publication, publication_type_id: type.id, political: false).political?
+    end
+
+    PublicationType.non_statistical.each do |type|
+      assert build(:publication, publication_type_id: type.id, political: true).political?
+      refute build(:publication, publication_type_id: type.id, political: false).political?
+    end
+  end
 end


### PR DESCRIPTION
Statistics publications should never be political, even if they have been associated with a role/minister or a political organisation.

Trello: https://trello.com/c/jQLfihxc/104-prevent-statistics-being-placed-in-history-mode