### PR TITLE
Editions with minsterial role appts are political

### DIFF
--- a/app/models/edition/role_appointments.rb
+++ b/app/models/edition/role_appointments.rb
@@ -21,4 +21,11 @@ module Edition::RoleAppointments
   def search_index
     super.merge("people" => role_appointments.map(&:slug))
   end
+
+  def is_associated_with_a_minister?
+    role_appointments.any? do |role_appointment|
+      role_appointment.role.is_a?(MinisterialRole)
+    end
+  end
+
 end

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -7,6 +7,12 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     assert PoliticalContentIdentifier.political?(edition)
   end
 
+  test '#political?(edition) is true if content is tagged to one or more ministers' do
+    edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
+
+    assert PoliticalContentIdentifier.political?(edition)
+  end
+
   test '#political?(edition) is true if content is from a political org and is a political format' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])


### PR DESCRIPTION
Editions linked to a single ministerial role appointment are
already considered political, this adds the same behaviour for
an edition with many ministerial role appointments.