### PR TITLE
Tweak logging in publishing_api_republisher

### DIFF
--- a/lib/data_hygiene/publishing_api_republisher.rb
+++ b/lib/data_hygiene/publishing_api_republisher.rb
@@ -21,11 +21,11 @@ module DataHygiene
     end
 
     def perform
-      logger.info "Pushing #{scope.count} #{scope.model_name} instances to the Publishing API"
+      logger.info "Queuing #{scope.count} #{scope.model_name} instances for republishing to the Publishing API"
 
       scope.find_each { |instance| republish(instance) }
 
-      logger.info("Republished #{republished} instances")
+      logger.info("Queued #{republished} instances for repulishing")
     end
 
   private


### PR DESCRIPTION
Make it clear that the items haven't been republished, they've been queued to
be republished. This confused me because the data hadn't (yet) been changed in
content-store/router-api even though it seemed they had been republished
already.