### PR TITLE
Fix specialist sector deletion script

### DIFF
--- a/lib/data_hygiene/specialist_sector_cleanup.rb
+++ b/lib/data_hygiene/specialist_sector_cleanup.rb
@@ -7,33 +7,70 @@ class SpecialistSectorCleanup
     taggings.any?
   end
 
-  def any_published_taggings?
-    taggings.map(&:edition).any? do |edition|
-      edition.document.ever_published_editions.any?
-    end
-  end
-
-  def remove_taggings(add_note: true)
+  def remove_taggings
     taggings.each do |tagging|
       edition = tagging.edition
 
-      puts "Removing tagging to edition ##{edition.id}"
+      if edition
+        puts "Removing tagging to edition ##{edition.id}"
+      else
+        puts "Removing tagging where edition was nil"
+      end
 
       tagging.destroy
 
-      if add_note
-        puts "Adding an editorial note from the GDS user"
+      if edition.nil?
+        puts "no edition (probably deleted)"
+      else
+        add_remark(edition)
 
-        gds_user = User.find_by(email: "govuk-whitehall@digital.cabinet-office.gov.uk")
-        edition.editorial_remarks.create!(
-          author: gds_user,
-          body: "Automatically untagged from old sector '#{@slug}'"
-        )
+        if edition.state == 'published'
+          register_edition(edition)
+        end
       end
     end
   end
 
 private
+
+  def add_remark(edition)
+    if Edition::FROZEN_STATES.include?(edition.state)
+      puts "edition is frozen; not adding editorial remark"
+    else
+      puts "adding an editorial remark"
+
+      edition.editorial_remarks.create!(
+        author: gds_user,
+        body: "Automatically untagged from old sector '#{@slug}'"
+      )
+    end
+  end
+
+  def register_edition(edition)
+    puts "registering '#{edition.slug}' (id #{edition.id})"
+    edition.reload
+    register_with_panopticon(edition)
+    register_with_publishing_api(edition)
+    register_with_search(edition)
+  end
+
+  def register_with_panopticon(edition)
+    registerable_edition = RegisterableEdition.new(edition)
+    registerer           = Whitehall.panopticon_registerer_for(registerable_edition)
+    registerer.register(registerable_edition)
+  end
+
+  def register_with_publishing_api(edition)
+    Whitehall::PublishingApi.republish(edition)
+  end
+
+  def register_with_search(edition)
+    edition.update_in_search_index
+  end
+
+  def gds_user
+    @gds_user ||= User.find_by(email: "govuk-whitehall@digital.cabinet-office.gov.uk")
+  end
 
   def taggings
     SpecialistSector.where(tag: @slug)

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -22,38 +22,18 @@ task :supporting_page_cleanup => :environment do
   end
 end
 
-task :specialist_sector_cleanup => :environment do
+task :specialist_sector_cleanup, [:slug] => :environment do |_task, args|
   require "data_hygiene/specialist_sector_cleanup"
 
-  puts "Which specialist sector is being deleted?"
-  slug = STDIN.gets.chomp
+  slug = args[:slug]
+  if slug.nil?
+    raise "slug not specified"
+  end
 
   cleanup = SpecialistSectorCleanup.new(slug)
 
   if cleanup.any_taggings?
-    puts "Some editions are tagged to #{slug}"
-
-    if cleanup.any_published_taggings?
-      puts "WARNING! Some documents have been published.  You will need to remove the sector from ElasticSearch"; puts
-    end
-
-    puts "What would you like to do?"
-    puts "1. Untag the editions from the sector, adding an editorial note"
-    puts "2. Untag the editions from the sector, no note"
-    puts "3. Do nothing [default]"
-
-    case STDIN.gets.chomp
-    when "1"
-      cleanup.remove_taggings(add_note: true)
-    when "2"
-      cleanup.remove_taggings(add_note: false)
-    when "3", ""
-      puts "Doing nothing"
-      exit
-    else
-      puts "Invalid option"
-      exit
-    end
+    cleanup.remove_taggings
   else
     puts "The sector '#{slug}' has not been tagged to any editions"
   end


### PR DESCRIPTION
The specialist sector script was failing with editions which had been
deleted.  Additionally, it was an interactive script, meaning that we
couldn't usefully script it from fabric.  Finally, it didn't re-register
the content that was changed with panopticon, rummager or content-store.

Update the script to:
 - handle deleted editions
 - to be non-interactive
 - to always attempt to add a note on the edition for editors so that
   they can see a tag was removed automatically.  The is skipped for
   frozen editions, but done for all others.
 - to register the changed content appropriately.