### PR TITLE
Statistical publications and fatality notices should never political

### DIFF
--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,12 +1,6 @@
 require 'test_helper'
 
 class PoliticalContentIdentifierTest < ActiveSupport::TestCase
-  test 'editions tagged to a minister are political' do
-    edition = create(:speech, role_appointment: create(:ministerial_role_appointment))
-
-    assert political?(edition)
-  end
-
   test 'editions of a political format associated with one or more ministers is political' do
     edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
 

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,12 +1,6 @@
 require 'test_helper'
 
 class PoliticalContentIdentifierTest < ActiveSupport::TestCase
-  test 'political formats associated with ministerial role appointments are political' do
-    edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
-
-    assert political?(edition)
-  end
-
   test 'political formats associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])
@@ -40,6 +34,12 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     edition = create(:publication, :statistics, lead_organisations: [political_organisation])
 
     refute political?(edition)
+  end
+
+  test 'political formats associated with ministerial role appointments are political' do
+    edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
+
+    assert political?(edition)
   end
 
   test 'formats associated with a minister are always political, regardless of format and any other associations' do

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -14,11 +14,11 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     assert political?(edition)
   end
 
-  test 'publications that are of a political sub-type associated with political orgs are political' do
-    political_organisation = create(:organisation, :political)
-    edition = create(:publication, :policy_paper, lead_organisations: [political_organisation])
+  test 'editions of a political format not associated with political orgs are not political' do
+    non_political_organisation = create(:organisation, :non_political)
+    edition = create(:consultation, lead_organisations: [non_political_organisation])
 
-    assert political?(edition)
+    refute political?(edition)
   end
 
   test 'editions of a non-political format associated with political orgs are not political' do
@@ -26,6 +26,13 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     edition = create(:detailed_guide, lead_organisations: [political_organisation])
 
     refute political?(edition)
+  end
+
+  test 'publications that are of a political sub-type associated with political orgs are political' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:publication, :policy_paper, lead_organisations: [political_organisation])
+
+    assert political?(edition)
   end
 
   test 'publications of a non-political sub-type not associated with political orgs are not political' do
@@ -43,13 +50,6 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     )
 
     assert political?(edition)
-  end
-
-  test 'editions of a political format not associated with political orgs are not political' do
-    non_political_organisation = create(:organisation, :non_political)
-    edition = create(:consultation, lead_organisations: [non_political_organisation])
-
-    refute political?(edition)
   end
 
 private

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,6 +1,22 @@
 require 'test_helper'
 
 class PoliticalContentIdentifierTest < ActiveSupport::TestCase
+  test 'fatality notices are never political, even when associated with a minister' do
+    fatality_notice = create(:fatality_notice,
+      role_appointments: [create(:ministerial_role_appointment)]
+    )
+
+    refute political?(fatality_notice)
+  end
+
+  test 'statistics publications are never political, even when associated with a minister' do
+    statistics_publication = create(:publication, :statistics,
+      ministerial_roles: [create(:ministerial_role)]
+    )
+
+    refute political?(statistics_publication)
+  end
+
   test 'political formats associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])
@@ -31,23 +47,13 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
 
   test 'publications of a non-political sub-type associated with political orgs are not political' do
     political_organisation = create(:organisation, :political)
-    edition = create(:publication, :statistics, lead_organisations: [political_organisation])
+    edition = create(:publication, :guidance, lead_organisations: [political_organisation])
 
     refute political?(edition)
   end
 
   test 'political formats associated with ministerial role appointments are political' do
     edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
-
-    assert political?(edition)
-  end
-
-  test 'formats associated with a minister are always political, regardless of format and any other associations' do
-    non_political_organisation = create(:organisation, :non_political)
-    edition = create(:publication, :statistics,
-      lead_organisations: [non_political_organisation],
-      ministerial_roles: [create(:ministerial_role)]
-    )
 
     assert political?(edition)
   end

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,48 +1,48 @@
 require 'test_helper'
 
 class PoliticalContentIdentifierTest < ActiveSupport::TestCase
-  test 'editions of a political format associated with one or more ministers is political' do
+  test 'political formats associated with ministerial role appointments are political' do
     edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
 
-    assert PoliticalContentIdentifier.political?(edition)
+    assert political?(edition)
   end
 
-  test 'editions of a political format associated with a political orgs are political' do
+  test 'political formats associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])
 
     assert political?(edition)
   end
 
-  test 'editions of a political format not associated with political orgs are not political' do
+  test 'political formats not associated with political orgs are not political' do
     non_political_organisation = create(:organisation, :non_political)
     edition = create(:consultation, lead_organisations: [non_political_organisation])
 
     refute political?(edition)
   end
 
-  test 'editions of a non-political format associated with political orgs are not political' do
+  test 'non-political formats associated with political orgs are not political' do
     political_organisation = create(:organisation, :political)
     edition = create(:detailed_guide, lead_organisations: [political_organisation])
 
     refute political?(edition)
   end
 
-  test 'publications that are of a political sub-type associated with political orgs are political' do
+  test 'publications of a political sub-type associated with political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:publication, :policy_paper, lead_organisations: [political_organisation])
 
     assert political?(edition)
   end
 
-  test 'publications of a non-political sub-type not associated with political orgs are not political' do
+  test 'publications of a non-political sub-type associated with political orgs are not political' do
     political_organisation = create(:organisation, :political)
     edition = create(:publication, :statistics, lead_organisations: [political_organisation])
 
     refute political?(edition)
   end
 
-  test 'editions associated with a minister are political, even if not from a political organisation and not of a political format' do
+  test 'formats associated with a minister are always political, regardless of format and any other associations' do
     non_political_organisation = create(:organisation, :non_political)
     edition = create(:publication, :statistics,
       lead_organisations: [non_political_organisation],

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -1,60 +1,66 @@
 require 'test_helper'
 
 class PoliticalContentIdentifierTest < ActiveSupport::TestCase
-  test '#political?(edition) is true if content is tagged to a minister' do
+  test 'editions tagged to a minister are political' do
     edition = create(:speech, role_appointment: create(:ministerial_role_appointment))
 
-    assert PoliticalContentIdentifier.political?(edition)
+    assert political?(edition)
   end
 
-  test '#political?(edition) is true if content is tagged to one or more ministers' do
+  test 'editions of a political format associated with one or more ministers is political' do
     edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
 
     assert PoliticalContentIdentifier.political?(edition)
   end
 
-  test '#political?(edition) is true if content is from a political org and is a political format' do
+  test 'editions of a political format associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])
 
-    assert PoliticalContentIdentifier.political?(edition)
+    assert political?(edition)
   end
 
-  test '#political?(edition) is true if content is from a political org and is a political subformat' do
+  test 'publications that are of a political sub-type associated with political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:publication, :policy_paper, lead_organisations: [political_organisation])
 
-    assert PoliticalContentIdentifier.political?(edition)
+    assert political?(edition)
   end
 
-  test '#political?(edition) is false if content is from a political org but not a political format' do
+  test 'editions of a non-political format associated with political orgs are not political' do
     political_organisation = create(:organisation, :political)
     edition = create(:detailed_guide, lead_organisations: [political_organisation])
 
-    refute PoliticalContentIdentifier.political?(edition)
+    refute political?(edition)
   end
 
-  test '#political?(edition) is false if content is from a political org but not a political subformat' do
+  test 'publications of a non-political sub-type not associated with political orgs are not political' do
     political_organisation = create(:organisation, :political)
     edition = create(:publication, :statistics, lead_organisations: [political_organisation])
 
-    refute PoliticalContentIdentifier.political?(edition)
+    refute political?(edition)
   end
 
-  test '#political?(edition) is true if content is not from a political org, is a non-political Publication type, but is associated with a minister' do
+  test 'editions associated with a minister are political, even if not from a political organisation and not of a political format' do
     non_political_organisation = create(:organisation, :non_political)
     edition = create(:publication, :statistics,
       lead_organisations: [non_political_organisation],
       ministerial_roles: [create(:ministerial_role)]
     )
 
-    assert PoliticalContentIdentifier.political?(edition)
+    assert political?(edition)
   end
 
-  test '#political?(edition) is false if content is a political format but not from a political org' do
+  test 'editions of a political format not associated with political orgs are not political' do
     non_political_organisation = create(:organisation, :non_political)
     edition = create(:consultation, lead_organisations: [non_political_organisation])
 
-    refute PoliticalContentIdentifier.political?(edition)
+    refute political?(edition)
+  end
+
+private
+
+  def political?(edition)
+    PoliticalContentIdentifier.political?(edition)
   end
 end


### PR DESCRIPTION
I re-organised the tests a fair bit here to try and make it clearer what the desired behaviour is. The coverage is almost exactly the same as the changes are mostly renaming and re-ordering to make things easier to follow. Hopefully the separate commits should make it easier to see that coverage hasn't been lost (although a couple of now-redundant tests have been removed). The meat of the change is in the final commit.

Trello: https://trello.com/c/jQLfihxc/104-statistics-and-fatality-notices-should-never-be-identified-as-political