### PR TITLE
Prevent uses of unsafe MySQL functions

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -48,7 +48,6 @@ class Classification < ActiveRecord::Base
   has_many :offsite_links, as: :parent
 
   scope :alphabetical, -> { order("name ASC") }
-  scope :randomized,   -> { order('RAND()') }
 
   mount_uploader :logo, ImageUploader, mount_on: :carrierwave_image
 

--- a/db/data_migration/20141125162430_ensure_all_documents_have_content_id.rb
+++ b/db/data_migration/20141125162430_ensure_all_documents_have_content_id.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.connection.execute 'UPDATE documents SET content_id=UUID() where content_id IS NULL'
+Document.where(content_id: nil).find_each do |document|
+  document.update_attribute(:content_id, SecureRandom.uuid)
+end

--- a/db/data_migration/20141126145501_set_world_location_content_ids.rb
+++ b/db/data_migration/20141126145501_set_world_location_content_ids.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.connection.execute 'UPDATE world_locations SET content_id=UUID() where content_id IS NULL'
+WorldLocations.where(content_id: nil).find_each do |world_location|
+  world_location.update_attribute(:content_id, SecureRandom.uuid)
+end

--- a/db/data_migration/20141127125300_set_worldwide_org_content_ids.rb
+++ b/db/data_migration/20141127125300_set_worldwide_org_content_ids.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.connection.execute 'UPDATE worldwide_organisations SET content_id=UUID() where content_id IS NULL'
+WorldwideOrganisations.where(content_id: nil).find_each do |worldwide_organisation|
+  worldwide_organisation.update_attribute(:content_id, SecureRandom.uuid)
+end

--- a/db/data_migration/20150223113328_set_role_content_ids.rb
+++ b/db/data_migration/20150223113328_set_role_content_ids.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.connection.execute 'UPDATE roles SET content_id=UUID() where content_id IS NULL'
+Role.where(content_id: nil).find_each do |role|
+  role.update_attribute(:content_id, SecureRandom.uuid)
+end

--- a/db/data_migration/20150223160956_set_person_content_ids.rb
+++ b/db/data_migration/20150223160956_set_person_content_ids.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.connection.execute 'UPDATE people SET content_id=UUID() where content_id IS NULL'
+People.where(content_id: nil).find_each do |people|
+  people.update_attribute(:content_id, SecureRandom.uuid)
+end

--- a/test/unit/unsafe_mysql_functions_test.rb
+++ b/test/unit/unsafe_mysql_functions_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class UnsafeMySQLFunctionsTest < ActiveSupport::TestCase
+
+  def unsafe_functions
+    %w{
+      FOUND_ROWS()
+      GET_LOCK()
+      IS_FREE_LOCK()
+      IS_USED_LOCK()
+      LOAD_FILE()
+      MASTER_POS_WAIT()
+      RAND()
+      RELEASE_LOCK()
+      ROW_COUNT()
+      SESSION_USER()
+      SLEEP()
+      SYSDATE()
+      SYSTEM_USER()
+      USER()
+      UUID()
+      UUID_SHORT()
+    }
+  end
+
+  def unsafe_function_regex
+    escaped_functions = unsafe_functions.map { |function| Regexp.escape(function) }
+    Regexp.new(
+      "(" +
+        escaped_functions.join("|") +
+      ")",
+      Regexp::IGNORECASE
+    )
+  end
+
+  test "no (suspected) uses of MySQL functions which are unsafe with statement-based replication" do
+    files = Dir.glob(File.join(Rails.root, '**', '*.rb'))
+    bad_files = files.select do |filename|
+      next if filename == File.expand_path(__FILE__)
+
+      match = false
+      File.open(filename) do |file|
+        match = file.grep(unsafe_function_regex).any?
+      end
+      match
+    end
+
+    # This test is case insensitive so has the potential to return false
+    # positives. If it does return a false positive, you might:
+    #
+    #   * remove the parentheses from the Ruby method call
+    #   * tweak this test - eg we're unlikely to call MySQL's USER() function,
+    #     but we might call current_user() in our code
+    #
+    # For more details: http://dev.mysql.com/doc/refman/5.5/en/replication-rbr-safe-unsafe.html
+    message = "Found suspected calls to MySQL functions which are unsafe with statement-based replication."
+    assert_equal [], bad_files, message
+  end
+end


### PR DESCRIPTION
We replicate our data from master to slaves using MySQL's statement-based
replication. This means that SQL statements are relayed to the slave where it
runs them again. If a non-deterministic function call is part of the statement,
it will therefore save different data on the master and each slave. This
happened with the content IDs set in these migrations.

I removed the `randomized` scope from Classification as it failed the test but
hasn't been used since: 33a3b4c0976c83706c2191a29c69e0792470d558

Whilst we won't run these migrations again, I needed to change them so that the
test would pass and so that the unsafe examples aren't copied.

Setting each value in Ruby rather than single SQL statement will be much much
slower, especially for the 160,000 Document records, but we shouldn't ever run
these migrations again.

I based the code on TimeZoneTest.