### PR TITLE
History mode analytics

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -296,4 +296,11 @@ Please tell us:
     return 'non-political' unless edition.political?
     edition.historic? ? 'historic' : 'political'
   end
+
+  def publishing_government_analytics_tag(edition)
+    return unless edition.government
+    tag :meta,
+      name: 'govuk:publishing-government',
+      content: edition.government.slug
+  end
 end

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -285,4 +285,15 @@ Please tell us:
 
     from
   end
+
+  def political_state_analytics_tag(edition)
+    tag :meta,
+      name: 'govuk:political-status',
+      content: political_state_analytics_value(edition)
+  end
+
+  def political_state_analytics_value(edition)
+    return 'non-political' unless edition.political?
+    edition.historic? ? 'historic' : 'political'
+  end
 end

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -1,3 +1,7 @@
+<%# The <meta> tags will be hoisted into <head> by Slimmer %>
+<%= political_state_analytics_tag(document) %>
+<%= publishing_government_analytics_tag(document) %>
+
 <%
   header_title ||= ""
   policies ||= nil

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -23,7 +23,10 @@
     <%= stylesheet_link_tag "frontend/print.css", media: "print" %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
-    <%= political_state_analytics_tag(@document) if @document %>
+    <% if @document %>
+      <%= political_state_analytics_tag(@document) %>
+      <%= publishing_government_analytics_tag(@document) %>
+    <% end %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -23,6 +23,7 @@
     <%= stylesheet_link_tag "frontend/print.css", media: "print" %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
+    <%= political_state_analytics_tag(@document) if @document %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -23,10 +23,6 @@
     <%= stylesheet_link_tag "frontend/print.css", media: "print" %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
-    <% if @document %>
-      <%= political_state_analytics_tag(@document) %>
-      <%= publishing_government_analytics_tag(@document) %>
-    <% end %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -665,26 +665,29 @@ class PublicationsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test '#show has political state for historic documents' do
+  view_test '#show has political state and government for historic documents' do
     current_government = create(:current_government)
     previous_government = create(:previous_government)
     edition = create(:published_publication, political: true, first_published_at: previous_government.start_date)
     get :show, id: edition.document
     assert_has_meta_tag 'govuk:political-status', 'historic'
+    assert_has_meta_tag 'govuk:publishing-government', previous_government.slug
   end
 
-  view_test '#show has political state for political documents' do
+  view_test '#show has political state and government for political documents' do
     previous_government = create(:previous_government)
     edition = create(:published_publication, political: true, first_published_at: previous_government.start_date)
     get :show, id: edition.document
     assert_has_meta_tag 'govuk:political-status', 'political'
+    assert_has_meta_tag 'govuk:publishing-government', previous_government.slug
   end
 
-  view_test '#show has political state for non-political documents' do
+  view_test '#show has political state and government for non-political documents' do
     current_government = create(:current_government)
     edition = create(:published_publication, political: false, first_published_at: current_government.start_date)
     get :show, id: edition.document
     assert_has_meta_tag 'govuk:political-status', 'non-political'
+    assert_has_meta_tag 'govuk:publishing-government', current_government.slug
   end
 
   view_test "should show links to other available translations of the edition" do

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -665,6 +665,27 @@ class PublicationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test '#show has political state for historic documents' do
+    current_government = create(:current_government)
+    previous_government = create(:previous_government)
+    edition = create(:published_publication, political: true, first_published_at: previous_government.start_date)
+    get :show, id: edition.document
+    assert_has_meta_tag 'govuk:political-status', 'historic'
+  end
+
+  view_test '#show has political state for political documents' do
+    previous_government = create(:previous_government)
+    edition = create(:published_publication, political: true, first_published_at: previous_government.start_date)
+    get :show, id: edition.document
+    assert_has_meta_tag 'govuk:political-status', 'political'
+  end
+
+  view_test '#show has political state for non-political documents' do
+    current_government = create(:current_government)
+    edition = create(:published_publication, political: false, first_published_at: current_government.start_date)
+    get :show, id: edition.document
+    assert_has_meta_tag 'govuk:political-status', 'non-political'
+  end
 
   view_test "should show links to other available translations of the edition" do
     edition = build(:draft_publication)

--- a/test/support/html_assertions.rb
+++ b/test/support/html_assertions.rb
@@ -46,4 +46,8 @@ module HtmlAssertions
   def assert_has_link(expected_text, expected_href, html_fragment)
     assert html_fragment.at_xpath(".//a[.='#{expected_text}'][@href='#{expected_href}']").present?, "Expected\n#{html_fragment.to_s} to include a link with text \"#{expected_text}\" and href \"#{expected_href}\"."
   end
+
+  def assert_has_meta_tag(name, content)
+    assert_select %{meta[name="#{name}"][content="#{content}"]}
+  end
 end


### PR DESCRIPTION
This will allow us to track pages;
 - in history mode already
 - that would go into history mode with a government change
 - that would never be in history mode

Also which government they were published under.

https://trello.com/c/fednKEAR/105-add-analytics-for-history-mode

Corresponding analytics changes: https://github.com/alphagov/static/pull/561