### PR TITLE
Add script to fix UUIDs in MySQL replication

### DIFF
--- a/script/fix-content-id-replication
+++ b/script/fix-content-id-replication
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+# Fix UUIDs that are incorrectly replicated
+
+# Bare calls to `uuid` in MySQL aren't safe across replication, as the generated
+# UUIDs will be different per server, see:
+# http://dev.mysql.com/doc/refman/5.1/en/replication-rbr-safe-unsafe.html
+
+# This migration works by capturing the UUID from the database in Ruby-land,
+# then updating the database as a string value. This `UPDATE` statement will
+# replicate to the slaves and fix the discrepancy, even though it won't change
+# the actual data on the master machine, where it's run.
+
+def fix_content_id(record)
+  content_id = record.content_id
+  record.update_columns(content_id: content_id)
+  record
+end
+
+puts "Fixing Document..."
+Document.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Fixing Organisation..."
+Organisation.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Fixing Person..."
+Person.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Fixing Role..."
+Role.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Fixing WorldLocation..."
+WorldLocation.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Fixing WorldwideOrganisation..."
+WorldwideOrganisation.find_each do |d|
+  fix_content_id(d)
+end
+
+puts "Done"


### PR DESCRIPTION
The bare `uuid` function call in MySQL isn't replication safe when
performing STATEMENT-level binary replication:

http://dev.mysql.com/doc/refman/5.1/en/replication-rbr-safe-unsafe.html

In a previous migration, we batch-updated several models using this
function to insert `content_id` values. When these migrations replicated
to our backup and read-only slaves, the UUIDs became wrong because of
the replication safety issue.

This means that currently our backups aren't current with production as
the `content_id` values differ.

This commit fixes that by adding a script to be run on the master
machine which:

1. Grabs the `content_id` in Ruby-land, avoiding replication issues
2. Forcing an `UPDATE` statement to run using `update_columns` call
3. Once this has run, the `UPDATE` statements will replicate to the
   slaves containing the correct strings, which will synchronise the
   slave values with the master.

The migrations themselves were future-proofed in
4864e94.

The command should be run with `rails r` - we chose this path over a
data migration because we don't want this script to run inside a
transaction (it takes over 90 seconds to run).