### PR TITLE
Stop Parser warning us about Ruby 2.1.4 syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development do
   gem 'thin', '1.6.3'
   gem 'newrelic_rpm'
   gem 'quiet_assets'
-  gem 'rubocop'
+  gem 'rubocop', require: false
 end
 
 group :test do


### PR DESCRIPTION
Rubocop requires Parser, which warns about mythical Ruby versions when
running any scripts in development:

```
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.5-compliant syntax, but you are running 2.1.4.
```

Making the Rubocop Gem load only when explicitly asked means we don't
see these warnings anymore.

This also [follows Rubocop's guidelines for installation](https://github.com/bbatsov/rubocop#installation)