### PR TITLE
Remove MP from MP's names

### DIFF
--- a/db/data_migration/20150323153536_remove_mp_from_mps.rb
+++ b/db/data_migration/20150323153536_remove_mp_from_mps.rb
@@ -1,0 +1,8 @@
+puts "Removing MP from MP's letters:"
+Person.where('letters LIKE "%MP%"').each do |person|
+  new_letters = person.letters.gsub(/(^|\s)MP(\s|$)/, '')
+  if person.letters != new_letters
+    puts "\tUpdating '#{person.letters}' to '#{new_letters}' for #{person.slug}"
+    person.update_attribute(:letters, new_letters)
+  end
+end


### PR DESCRIPTION
**This shouldn't be merged till after the last deploy before the 30th March deploy**

As a person interested in government I need to know that as of 30/03/15
MP's elected in 2010 are no longer officially MP's so that that I am not
confused.

As a MP I need GOV.UK to reflect the fact that I am no longer a MP so
that I am not accused of impropriety.