### PR TITLE
Update which publication sub-types can be political

### DIFF
--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -9,9 +9,7 @@ class PoliticalContentIdentifier
   POLITICAL_PUBLICATION_TYPES = [
     PublicationType::CorporateReport,
     PublicationType::ImpactAssessment,
-    PublicationType::InternationalTreaty,
     PublicationType::PolicyPaper,
-    PublicationType::ResearchAndAnalysis,
   ].freeze
 
   attr_reader :edition


### PR DESCRIPTION
"Research And Analysis" and "International Treaties" were initially
marked as political formats, but aren't anymore.

https://trello.com/c/rlJkchwi/124-remove-international-treaties-and-research-and-analysis-from-history-mode

This will require a reprocessing of political content, to apply
these new rules, which will happen separately (and after some
other changes to the rules for politicality of content).

Note: I've not updated any tests with this change. The tests assert
the behaviour of `political_publication_type`, rather than specific
publication types in `POLITICAL_PUBLICATION_TYPES` - so this change
passes the existing tests.