### PR TITLE
Revert hide political checkboxes and add guidance

### DIFF
--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -16,9 +16,8 @@
   <%= render partial: "additional_significant_fields", locals: {form: form, edition: form.object} %>
 
   <% if (edition.document and edition.document.published?) and can?(:mark_political, edition) %>
-    <label class="checkbox political-status">
-      <%= form.check_box :political, label_text: "Document should be labelled as associated with the government of the time" %>
-    </label>
+    <%= form.check_box :political, label_text: "Associate with government of the time (currently set to #{edition.government.name}).", class: 'political-status' %>
+    <p><a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode'>Read the history mode guidance</a> for more information as to what this means.</p>
   <% end %>
 <% end %>
 

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -149,7 +149,7 @@ module Whitehall::Authority::Rules
     def managing_editor_can?(action)
       case action
       when :mark_political
-        false
+        true
       else
         departmental_editor_can?(action)
       end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -8,9 +8,10 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   view_test "displays the political checkbox for privileged users " do
+    government = create(:current_government)
     login_as :managing_editor
-    published_edition = create(:published_news_article)
-    new_draft = create(:news_article, document: published_edition.document)
+    published_edition = create(:published_news_article, first_published_at: 2.days.ago)
+    new_draft = create(:news_article, document: published_edition.document, first_published_at: 2.days.ago)
     get :edit, id: new_draft
     assert_select '.political-status', count: 1
   end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -8,7 +8,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   view_test "displays the political checkbox for privileged users " do
-    login_as :gds_editor
+    login_as :managing_editor
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     get :edit, id: new_draft
@@ -23,7 +23,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   view_test "doesn't display the political checkbox on creation" do
-    login_as :gds_editor
+    login_as :managing_editor
     get :new
     assert_select '.political-status', count: 0
   end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -173,6 +173,6 @@ class ManagingEditorTest < ActiveSupport::TestCase
   end
 
   test 'can mark editions as political' do
-    refute enforcer_for(managing_editor, normal_edition).can?(:mark_political)
+    assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 end


### PR DESCRIPTION
Show the checkboxes for managing editors and show a link to the guidance on how to use the checkbox.

![screen shot 2015-03-24 at 13 57 19](https://cloud.githubusercontent.com/assets/35035/6803164/b7d01a04-d22d-11e4-91a1-8a1098e79134.png)


https://trello.com/c/fhJ4IXM0/150-make-history-mode-checkbox-available-for-managing-editors