### PR TITLE
Autoclose ministerial appointments

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -1,6 +1,5 @@
 class Admin::GovernmentsController < Admin::BaseController
-  before_filter :enforce_create_permissions!, only: [:new, :create]
-  before_filter :enforce_edit_permissions!, only: [:edit, :update, :prepare_to_close, :close]
+  before_filter :enforce_permissions!, except: :index
 
   def index
     @governments = Government.order(start_date: :desc)
@@ -52,12 +51,8 @@ private
     params.require(:government).permit(:name, :start_date, :end_date)
   end
 
-  def enforce_create_permissions!
-    enforce_permission!(:create, Government)
-  end
-
-  def enforce_edit_permissions!
-    enforce_permission!(:create, Government.find(params[:id]))
+  def enforce_permissions!
+    enforce_permission!(:manage, Government)
   end
 
   def current_active_ministerial_appointments

--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -42,7 +42,7 @@ class Admin::GovernmentsController < Admin::BaseController
       appointment.update_attribute(:ended_at, Time.zone.now)
     end
 
-    redirect_to edit_admin_government_path(government)
+    redirect_to edit_admin_government_path(government), notice: "Government closed"
   end
 
 private

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -8,5 +8,5 @@
     Warning: changes to government information will appear instantly on the live site.
   </p>
 
-  <%= government_form.save_or_cancel(cancel: admin_organisations_path) %>
+  <%= government_form.save_or_cancel(cancel: admin_governments_path) %>
 <% end %>

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -2,7 +2,14 @@
   <%= government_form.errors %>
   <p><%= government_form.text_field :name, {placeholder: "eg 2005 to 2010 Labour government"} %></p>
   <p><%= government_form.text_field :start_date, {placeholder: "eg 2005-05-06"} %></p>
-  <p><%= government_form.text_field :end_date, {placeholder: "eg 2010-05-11"} %></p>
+
+  <% if government.end_date.present? %>
+    <p><%= government_form.text_field :end_date, {placeholder: "eg 2010-05-11"} %></p>
+  <% elsif government.persisted? %>
+    <p>
+      <%= link_to "Prepare to close this government", prepare_to_close_admin_government_path(government) %>
+    </p>
+  <% end %>
 
   <p class="warning">
     Warning: changes to government information will appear instantly on the live site.

--- a/app/views/admin/governments/index.html.erb
+++ b/app/views/admin/governments/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Governments" %>
 <h1>Governments</h1>
 
-<% if can?(:create, Government) %>
+<% if can?(:manage, Government) %>
   <p>
     <%= link_to "Create a government", new_admin_government_path %>
   </p>
@@ -20,7 +20,7 @@
     <% @governments.each do |government| %>
       <%= content_tag_for(:tr, government) do %>
         <td>
-          <% if can?(:edit, government) %>
+          <% if can?(:manage, Government) %>
             <%= link_to government.name, edit_admin_government_path(government) %>
           <% else %>
             <%= government.name %>

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -1,0 +1,22 @@
+<% page_title "Prepare to close this government" %>
+<h1>Prepare to close this government</h1>
+
+<p>
+  Closing this government will unappoint the following ministerial roles, are you sure?
+</p>
+
+<ul>
+  <% current_active_ministerial_appointments.each do |appointment| %>
+    <li><%= appointment.role.name %>: <%= appointment.person.name %></li>
+  <% end %>
+</ul>
+
+<div class="form-actions">
+  <%= form_tag close_admin_government_path(@government) do %>
+    <button type="submit" class="btn btn-danger btn-large">Yes, close this government</button>
+  <% end %>
+
+  <span class="or_cancel">
+    <%= link_to "No! Don't do that! Noooo!", edit_admin_government_path(@government) %>
+  </span>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,7 +373,12 @@ Whitehall::Application.routes.draw do
           end
         end
 
-        resources :governments, except: [:destroy]
+        resources :governments, except: [:destroy] do
+          member do
+            get :prepare_to_close, path: "prepare-to-close"
+            post :close
+          end
+        end
 
         post "preview" => "preview#preview"
 

--- a/features/governments.feature
+++ b/features/governments.feature
@@ -9,6 +9,13 @@ Scenario: creating a government
   When I create a government called "2005 to 2010 Labour government" starting on "06/05/2005"
   Then there should be a government called "2005 to 2010 Labour government" starting on "2005-05-06"
 
+Scenario: ending a government
+  Given there is a current government
+  And two cabinet ministers "Alice" and "Ben"
+  And I am a GDS admin
+  When I close the current government
+  Then there should be no active ministerial role appointments
+
 Scenario: editing a government's start and end dates
   Given a government exists called "2005 to 2010 Labour government" between dates "06/05/2004" and "11/05/2009"
   And I am a GDS admin

--- a/features/step_definitions/government_steps.rb
+++ b/features/step_definitions/government_steps.rb
@@ -14,6 +14,10 @@ Given(/^a government exists called "(.*?)" between dates "(.*?)" and "(.*?)"$/) 
   FactoryGirl.create(:government, name: government_name, start_date: start_date, end_date: end_date)
 end
 
+Given(/^a government exists called "(.*?)" starting on "(.*?)"$/) do |government_name, start_date|
+  FactoryGirl.create(:government, name: government_name, start_date: start_date)
+end
+
 When(/^I edit the government called "(.*?)" to have dates "(.*?)" and "(.*?)"$/) do |government_name, start_date, end_date|
   edit_government(name: government_name, attributes: {
     start_date: start_date,
@@ -23,4 +27,12 @@ end
 
 Given(/^there is a current government$/) do
   FactoryGirl.create(:current_government)
+end
+
+When(/^I close the current government$/) do
+  close_government(name: Government.current.name)
+end
+
+Then(/^there should be no active ministerial role appointments$/) do
+  assert_equal 0, count_active_ministerial_role_appointments
 end

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -34,6 +34,19 @@ module GovernmentsHelper
       assert page.has_content?(end_date) if end_date
     end
   end
+
+  def close_government(name:)
+    visit admin_governments_path
+
+    click_on name
+
+    click_on "Prepare to close this government"
+    click_on "Yes, close this government"
+  end
+
+  def count_active_ministerial_role_appointments
+    RoleAppointment.current.for_ministerial_roles.count
+  end
 end
 
 World(GovernmentsHelper)

--- a/lib/whitehall/authority/rules/government_rules.rb
+++ b/lib/whitehall/authority/rules/government_rules.rb
@@ -2,7 +2,7 @@ module Whitehall::Authority::Rules
   class GovernmentRules < Struct.new(:actor, :subject)
     def can?(action)
       case action
-      when :create, :edit
+      when :manage
         actor.gds_admin?
       else
         false

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -7,7 +7,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
-  [:new, :edit].each do |action_method|
+  [:new, :edit, :prepare_to_close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
       login_as :gds_editor
       get action_method, id: @government.id
@@ -15,7 +15,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     end
   end
 
-  [:create, :update].each do |action_method|
+  [:create, :update, :close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
       login_as :gds_editor
       post action_method, id: @government.id

--- a/test/unit/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/whitehall/authority/gds_admin_test.rb
@@ -23,13 +23,11 @@ class GDSAdminTest < ActiveSupport::TestCase
     assert enforcer_for(gds_admin, Edition).can?(:export)
   end
 
-  test 'can create and edit governments' do
+  test 'can manage governments' do
     government = Government.new
-    assert enforcer_for(gds_admin, government).can?(:edit)
-    assert enforcer_for(gds_admin, Government).can?(:create)
+    assert enforcer_for(gds_admin, Government).can?(:manage)
 
-    refute enforcer_for(non_gds_admin, government).can?(:edit)
-    refute enforcer_for(non_gds_admin, Government).can?(:create)
+    refute enforcer_for(non_gds_admin, Government).can?(:manage)
   end
 
   test 'can mark editions as political' do


### PR DESCRIPTION
When a government is closed all ministers no longer
hold their roles.  This change saves lots of time
when closing the government and marks the act of
closing a government accordingly dire and protected.

This also prevents the setting of an end date when
creating a new government.

Flow is as follows.

Closed governments remain the same:
![screenshot 2015-03-24 15 27 09](https://cloud.githubusercontent.com/assets/109225/6805469/09a03654-d23b-11e4-92dc-361fc6948c6d.png)

Open governments gain a link to "Prepare for closing this government":
![screenshot 2015-03-24 15 28 09](https://cloud.githubusercontent.com/assets/109225/6805483/2303577a-d23b-11e4-8fc9-18fac972bc8c.png)

This link leads to a page explaining that all ministerial role appointments will be removed, and listing the appointments for review:
![screenshot 2015-03-24 15 28 31](https://cloud.githubusercontent.com/assets/109225/6805503/369b2a74-d23b-11e4-8f5f-23f1fc008044.png)

[.. cut ..]

![screenshot 2015-03-24 15 28 41](https://cloud.githubusercontent.com/assets/109225/6805504/3f0abc24-d23b-11e4-9b9b-fb2e3615dc8c.png)

Pushing the big red button makes it happen.

https://trello.com/c/xylhahXO/134-when-a-current-government-ends-all-ministerial-appointments-should-do-too

While I was at it I also fixed the return path of the "Cancel" link when editing a government, which is this ticket: https://trello.com/c/wnKFWhip/137-bug-cancel-button-on-create-a-gov-returns-to-wrong-page