### PR TITLE
Fix nondeterministic test

### DIFF
--- a/lib/data_hygiene/tag_changes_processor.rb
+++ b/lib/data_hygiene/tag_changes_processor.rb
@@ -1,7 +1,8 @@
 class TagChangesProcessor
 
-  def initialize(csv_location)
+  def initialize(csv_location, logger: Logger.new(nil))
     @csv_location = csv_location
+    @logger = logger
   end
 
   def process
@@ -113,6 +114,6 @@ private
   end
 
   def log(message)
-    puts message
+    @logger.info message
   end
 end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -106,7 +106,7 @@ task process_topic_retagging_csv: :environment do
     exit 1
   end
 
-  TagChangesProcessor.new(csv_location).process
+  TagChangesProcessor.new(csv_location, logger: Logger.new(STDOUT)).process
 end
 
 desc "Unarchive an edition (creates and publishes a draft with audit trail)"

--- a/test/integration/data_hygiene/tag_changes_processor_test.rb
+++ b/test/integration/data_hygiene/tag_changes_processor_test.rb
@@ -23,18 +23,6 @@ class TopicChangesProcessorTest < ActiveSupport::TestCase
     @csv_file.unlink
   end
 
-  # Replace the `log` method on a TopicTagger with one that appends the logged
-  # messages to an array.  Return the array.
-  def stub_logging(processor)
-    def processor.log(message)
-      @logs ||= []
-      @logs << message
-    end
-    def processor.logs
-      @logs
-    end
-  end
-
   def stub_registration(edition, sectors)
     registerable = RegisterableEdition.new(edition)
     stub_artefact_registration(
@@ -75,7 +63,6 @@ class TopicChangesProcessorTest < ActiveSupport::TestCase
 
     processor = TagChangesProcessor.new(@csv_file.path)
 
-    stub_logging(processor)
     processor.process
 
     assert_requested panopticon_published_edition
@@ -84,26 +71,5 @@ class TopicChangesProcessorTest < ActiveSupport::TestCase
     assert_requested panopticon_draft_edition2
 
     assert_edition_retagging([@published_edition, @published_edition2, @draft_edition, @draft_edition2])
-
-    expected_logs = [
-      %{Updating 1 taggings to change #{@old_tag} to #{@new_tag}},
-      %{tagging '#{@published_edition.title}' edition #{@published_edition.id}},
-      %{ - adding editorial remark},
-      %{registering '#{@published_edition.title}'},
-      %{Updating 1 taggings to change #{@old_tag} to #{@new_tag}},
-      %{tagging '#{@draft_edition.title}' edition #{@draft_edition.id}},
-      %{ - adding editorial remark},
-      %{registering '#{@draft_edition.title}'},
-      %{Updating 1 taggings to change #{@old_tag} to #{@new_tag}},
-      %{tagging '#{@published_edition2.title}' edition #{@published_edition2.id}},
-      %{ - adding editorial remark},
-      %{registering '#{@published_edition2.title}'},
-      %{Updating 1 taggings to change #{@old_tag} to #{@new_tag}},
-      %{tagging '#{@draft_edition2.title}' edition #{@draft_edition2.id}},
-      %{ - adding editorial remark},
-      %{registering '#{@draft_edition2.title}'},
-    ]
-    assert processor.logs == expected_logs
   end
-
 end


### PR DESCRIPTION
This test was failing intermittently[0]. I think the assertion was relying on the
implementation pulling records from the database in the order in which they were
inserted, but the implementation didn't specify an ordering. Whilst we could
write an assertion that the lines for each TagChange appeared in the right order
relative to each other, but in any order within the overall set of lines, we
feel that the assertion can be dropped as it wasn't adding much value anyway.

[0] https://ci-new.alphagov.co.uk/view/Whitehall/job/govuk_whitehall/11582/console