### PR TITLE
Add politicalness and government to search index

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -298,6 +298,8 @@ class Edition < ActiveRecord::Base
     operational_field: nil,
     specialist_sectors: :live_specialist_sector_tags,
     latest_change_note: :most_recent_change_note,
+    is_political: :political?,
+    government: :search_government
   )
 
   def search_title
@@ -664,6 +666,10 @@ class Edition < ActiveRecord::Base
 
   def government
     Government.on_date(date_for_government) unless date_for_government.nil?
+  end
+
+  def search_government
+    government.slug if government
   end
 
   def historic?

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -11,7 +11,8 @@ module Searchable
     :slug, :search_format_types, :world_locations,
     :attachments, :operational_field, :organisation_state,
     :release_timestamp, :metadata, :specialist_sectors,
-    :statistics_announcement_state, :latest_change_note
+    :statistics_announcement_state, :latest_change_note,
+    :is_political, :government
   ]
 
   included do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -444,7 +444,8 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should return search index suitable for Rummageable" do
-    policy = create(:published_policy, title: "policy-title")
+    government = create(:current_government)
+    policy = create(:published_policy, title: "policy-title", political: true, first_published_at: government.start_date)
     slug = policy.document.slug
     summary = policy.summary
 
@@ -453,6 +454,8 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal policy.body, policy.search_index["indexable_content"]
     assert_equal "policy", policy.search_index["format"]
     assert_equal summary, policy.search_index["description"]
+    assert_equal policy.political?, policy.search_index["is_political"]
+    assert_equal government.slug, policy.search_index["government"]
   end
 
   test 'search_format_types tags the edtion as an edition' do


### PR DESCRIPTION
Companion Rummager change, with new fields:
 - https://github.com/alphagov/rummager/pull/378

- government: slug/id, of the Government that first published the document
- is_political: boolean, true if the content is considered political

These fields will be used to mark some search results as being under
history mode, where political content from previous governments will
be marked as such. This will need to know if a government is current
and the name (not slug) needs to be displayed in the UI,

Government will be expanded from the slug via the Government API [1],
which will be done by Rummager, or the Frontend.

Indexing is_political and government, rather than is_historic,
means that when a government ends it's results will be updated
without needing to reindex all political documents.

[1] https://www.gov.uk/api/governments