### PR TITLE
Append _async to Whitehall::PublishingApi methods

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -65,6 +65,6 @@ private
   end
 
   def publish_to_publishing_api
-    Whitehall::PublishingApi.publish(self, 'minor')
+    Whitehall::PublishingApi.publish_async(self, 'minor')
   end
 end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -10,11 +10,11 @@ Whitehall.edition_services.tap do |es|
   es.subscribe("unpublish")                 { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 
   # publishing API
-  es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish(edition) }
-  es.subscribe("archive")                     { |_, edition, _| Whitehall::PublishingApi.republish(edition) }
-  es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish(edition.unpublishing) }
-  es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule(edition) }
-  es.subscribe("unschedule")                  { |_, edition, _| Whitehall::PublishingApi.unschedule(edition) }
+  es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition) }
+  es.subscribe("archive")                     { |_, edition, _| Whitehall::PublishingApi.republish_async(edition) }
+  es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
+  es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }
+  es.subscribe("unschedule")                  { |_, edition, _| Whitehall::PublishingApi.unschedule_async(edition) }
 
   # handling edition's dependency on other content
   es.subscribe(/^(force_publish|publish)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }

--- a/lib/data_hygiene/publishing_api_republisher.rb
+++ b/lib/data_hygiene/publishing_api_republisher.rb
@@ -31,7 +31,7 @@ module DataHygiene
   private
 
     def republish(instance)
-      Whitehall::PublishingApi.republish(instance)
+      Whitehall::PublishingApi.republish_async(instance)
       logger << '.'
       @republished +=1
     end

--- a/lib/data_hygiene/tag_changes_processor.rb
+++ b/lib/data_hygiene/tag_changes_processor.rb
@@ -88,7 +88,7 @@ private
   end
 
   def register_with_publishing_api(edition)
-    Whitehall::PublishingApi.republish(edition)
+    Whitehall::PublishingApi.republish_async(edition)
   end
 
   def register_with_search(edition)

--- a/lib/dependable.rb
+++ b/lib/dependable.rb
@@ -7,6 +7,6 @@ module Dependable
   end
 
   def republish_dependent_editions
-    dependent_editions.each { |e| Whitehall::PublishingApi.republish(e) }
+    dependent_editions.each { |e| Whitehall::PublishingApi.republish_async(e) }
   end
 end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -13,6 +13,6 @@ module PublishesToPublishingApi
   end
 
   def publish_to_publishing_api
-    Whitehall::PublishingApi.publish(self)
+    Whitehall::PublishingApi.publish_async(self)
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -10,15 +10,15 @@ module Whitehall
   class UnpublishableInstanceError < StandardError; end
 
   class PublishingApi
-    def self.publish(model_instance, update_type_override=nil)
+    def self.publish_async(model_instance, update_type_override=nil)
       do_action(model_instance, update_type_override)
     end
 
-    def self.republish(model_instance)
+    def self.republish_async(model_instance)
       do_action(model_instance, 'republish')
     end
 
-    def self.schedule(edition)
+    def self.schedule_async(edition)
       return unless served_from_content_store?(edition)
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
@@ -30,7 +30,7 @@ module Whitehall
       end
     end
 
-    def self.unschedule(edition)
+    def self.unschedule_async(edition)
       return unless served_from_content_store?(edition)
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)

--- a/test/integration/data_hygiene/tag_changes_processor_test.rb
+++ b/test/integration/data_hygiene/tag_changes_processor_test.rb
@@ -34,7 +34,7 @@ class TopicChangesProcessorTest < ActiveSupport::TestCase
 
   def publishing_worker_expects(editions)
     editions.each do |edition|
-      Whitehall::PublishingApi.expects(:republish).with(edition).once
+      Whitehall::PublishingApi.expects(:republish_async).with(edition).once
     end
   end
 

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -24,13 +24,13 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "create publishes to Publishing API" do
     organisation = build(:organisation)
-    Whitehall::PublishingApi.expects(:publish).with(organisation)
+    Whitehall::PublishingApi.expects(:publish_async).with(organisation)
     organisation.save
   end
 
   test "update publishes to Publishing API" do
     organisation = create(:organisation)
-    Whitehall::PublishingApi.expects(:publish).with(organisation)
+    Whitehall::PublishingApi.expects(:publish_async).with(organisation)
     organisation.update_attribute(:name, 'Edited org')
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -138,7 +138,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = create(:unpublishing, unpublishing_reason_id: UnpublishingReason::Archived.id, explanation: 'Needs more work.')
 
     new_explanation = 'This publication will be ready for publishing next week.'
-    Whitehall::PublishingApi.expects(:publish).with(responds_with(:explanation, new_explanation), 'minor').once
+    Whitehall::PublishingApi.expects(:publish_async).with(responds_with(:explanation, new_explanation), 'minor').once
 
     unpublishing.update_attribute(:explanation, new_explanation)
   end


### PR DESCRIPTION
across WH code wherever `Whitehall::PublishingApi` is referenced, it is not apparent that methods on it perform operations async'ly. this rename makes it explicit that we're sending an edition to a queue to be processed async.