### PR TITLE
Add history mode fields to Edition search index

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -298,6 +298,9 @@ class Edition < ActiveRecord::Base
     operational_field: nil,
     specialist_sectors: :live_specialist_sector_tags,
     latest_change_note: :most_recent_change_note,
+    is_political: :political?,
+    is_historic: :historic?,
+    government: :search_government_name
   )
 
   def search_title
@@ -664,6 +667,10 @@ class Edition < ActiveRecord::Base
 
   def government
     Government.on_date(date_for_government) unless date_for_government.nil?
+  end
+
+  def search_government_name
+    government.name if government
   end
 
   def historic?

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -11,7 +11,8 @@ module Searchable
     :slug, :search_format_types, :world_locations,
     :attachments, :operational_field, :organisation_state,
     :release_timestamp, :metadata, :specialist_sectors,
-    :statistics_announcement_state, :latest_change_note
+    :statistics_announcement_state, :latest_change_note,
+    :is_political, :is_historic, :government
   ]
 
   included do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -444,7 +444,8 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should return search index suitable for Rummageable" do
-    policy = create(:published_policy, title: "policy-title")
+    government = create(:current_government)
+    policy = create(:published_policy, title: "policy-title", political: true, first_published_at: government.start_date)
     slug = policy.document.slug
     summary = policy.summary
 
@@ -453,6 +454,9 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal policy.body, policy.search_index["indexable_content"]
     assert_equal "policy", policy.search_index["format"]
     assert_equal summary, policy.search_index["description"]
+    assert_equal policy.political?, policy.search_index["is_political"]
+    assert_equal policy.historic?, policy.search_index["is_historic"]
+    assert_equal government.name, policy.search_index["government"]
   end
 
   test 'search_format_types tags the edtion as an edition' do


### PR DESCRIPTION
These fields will be used to mark some search results as being under
history mode, where political content from previous governments will
displayed in the UI as associtated to the government that published
it.

Companion Rummager change, adding new fields:
 - https://github.com/alphagov/rummager/pull/378

**New fields:**
- `is_political`: _boolean_
  - If the content is considered political in nature, relfecting
  views of the government it was published under
- `is_historic`: _boolean_
  - If the content is political and published by a previous
  government, it is considered historic and not relfective of the
  current government and can be marked as such.
- `government_name`: _unsearchable_text_
  - The name of the Government that first published
  this document, eg, "1970 to 1974 Conservative government"

**Notes**

`government_name` is stored as text, rather than an identifier, and
not normalised, but storing the identifier would require either
Rummager or the frontend to perform expansion from identifier to
name and governments are not repsented in content store, yet.

If a government name is edited then content associated to that
government will need to be reindexed for the updated name to be
reflected in search results. This isn't something we expect to happen
very often, and are happy running a manual reindex if required.

When a government is ended all political documents will need to
be re-index, to set `is_historic` in search. This is a once every ~5
year change, and we're happy running a reindex task in this instance.

It's possible the updates for a government endeding could be done as
an async task that happens as a result of the government being ended
in the publishing tool. We'll look at that as follow up work, for now
this gets the right fields into search.

As discussed with @edds and @rboulton this morning.