### PR TITLE
Fix government_name in Edition search_index

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -300,7 +300,7 @@ class Edition < ActiveRecord::Base
     latest_change_note: :most_recent_change_note,
     is_political: :political?,
     is_historic: :historic?,
-    government: :search_government_name
+    government_name: :search_government_name
   )
 
   def search_title

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -12,7 +12,7 @@ module Searchable
     :attachments, :operational_field, :organisation_state,
     :release_timestamp, :metadata, :specialist_sectors,
     :statistics_announcement_state, :latest_change_note,
-    :is_political, :is_historic, :government
+    :is_political, :is_historic, :government_name
   ]
 
   included do

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -456,7 +456,7 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal summary, policy.search_index["description"]
     assert_equal policy.political?, policy.search_index["is_political"]
     assert_equal policy.historic?, policy.search_index["is_historic"]
-    assert_equal government.name, policy.search_index["government"]
+    assert_equal government.name, policy.search_index["government_name"]
   end
 
   test 'search_format_types tags the edtion as an edition' do


### PR DESCRIPTION
This should be `government_name` as in:
 - https://github.com/alphagov/rummager/blob/master/config/schema/document_types/edition.json#L33

Introduced in https://github.com/alphagov/whitehall/pull/2054/
but with the wrong name, even in the tests (especially in the tests)

:-1: 