### PR TITLE
Hide info on person page if they don't have a current role

### DIFF
--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -60,4 +60,8 @@ class PersonPresenter < Whitehall::Decorators::Decorator
     img = image_url(:s216) || 'blank-person.png'
     context.image_tag img, alt: name
   end
+
+  def in_current_role?
+    current_role_appointments.any?
+  end
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -42,7 +42,11 @@ class PersonPresenter < Whitehall::Decorators::Decorator
   end
 
   def biography
-    context.govspeak_to_html model.biography
+    if in_current_role?
+      context.govspeak_to_html model.biography
+    else
+      context.govspeak_to_html truncated_biography if model.biography
+    end
   end
 
   def link(options = {})
@@ -63,5 +67,11 @@ class PersonPresenter < Whitehall::Decorators::Decorator
 
   def in_current_role?
     current_role_appointments.any?
+  end
+
+private
+
+  def truncated_biography
+    model.biography.split(/\n/).first
   end
 end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -19,16 +19,20 @@
   <div class="block-2 ">
     <div class="inner-block js-stick-at-top-when-scrolling">
       <section class="contextual-info in-page-navigation ">
-        <div class="image">
-          <figure class="img">
-            <%= @person.image %>
-          </figure>
-        </div>
+        <% if @person.in_current_role? %>
+          <div class="image">
+            <figure class="img">
+              <%= @person.image %>
+            </figure>
+          </div>
+        <% end %>
         <h1><%= t('document.contents') %></h1>
         <nav role="navigation">
           <ul>
             <li><%= link_to t('people.biography'), '#biography' %></li>
-            <li><%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %></li>
+            <% if @person.in_current_role? %>
+              <li><%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %></li>
+            <% end %>
             <% if @person.previous_role_appointments.any? %>
               <li><%= link_to t('people.previous_roles'), "#previous-roles" %></li>
             <% end %>

--- a/features/people.feature
+++ b/features/people.feature
@@ -13,8 +13,8 @@ Scenario: Viewing all people
   Then I should see that "Johnny Macaroon" is listed under "m"
   And I should see that "Fred Bloggs" is listed under "b"
 
-Scenario: Viewing the person page for a minister
-  Given "Benjamin Disraeli" is a minister with a history
+Scenario: Viewing the person page for a person
+  Given a person called "Benjamin Disraeli"
   When I visit the person page for "Benjamin Disraeli"
   Then I should see information about the person "Benjamin Disraeli"
 

--- a/features/people.feature
+++ b/features/people.feature
@@ -66,3 +66,8 @@ Scenario: Images are virus-checked before publication
   Then the image will be quarantined for virus checking
   When the image has been virus-checked
   Then the virus checked image will be available for viewing
+
+Scenario: Viewing a person that previously had a role
+  Given "Dale Cooper" is a minister with a history
+  When I visit the person page for "Dale Cooper"
+  Then I should see limited information about the person "Dale Cooper"

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -18,13 +18,13 @@ Given /^a person called "([^"]*)" exists in the role of "([^"]*)"$/ do |name, ro
 end
 
 Given /^"([^"]*)" is a minister with a history$/ do |name|
-  person = create_person(name)
+  person = create_person(name, biography: "This is the first paragraph of the biography.\n\nThis is the second paragraph.")
   role = create(:ministerial_role)
   create(:ministerial_department, ministerial_roles: [role])
   create(:role_appointment, role: role, person: person, started_at: 2.years.ago, ended_at: 1.year.ago)
   role = create(:ministerial_role)
   create(:ministerial_department, ministerial_roles: [role])
-  create(:role_appointment, role: role, person: person, started_at: 1.year.ago, ended_at: nil)
+  create(:role_appointment, role: role, person: person, started_at: 1.year.ago, ended_at: 6.months.ago)
 end
 
 When /^I visit the person page for "([^"]*)"$/ do |name|
@@ -113,4 +113,11 @@ Then /^I should see that "([^"]*)" is listed under "([^"]*)"$/ do |name, letter|
   within("#people_#{letter}") do
     assert page.has_content?(name)
   end
+end
+
+Then(/^I should see limited information about the person "(.*?)"$/) do |name|
+  assert page.has_css?('.biography', text: "This is the first paragraph of the biography."), "Biography wasn't present"
+  assert page.has_no_content?("This is the second paragraph.")
+  assert page.has_no_css?('a[href="#current-roles"]')
+  assert page.has_no_css?('figure.img')
 end

--- a/test/unit/presenters/person_presenter_test.rb
+++ b/test/unit/presenters/person_presenter_test.rb
@@ -31,6 +31,12 @@ class PersonPresenterTest < ActionView::TestCase
     assert_select_from @presenter.biography, '.govspeak h2', text: 'Hello'
   end
 
+  test 'biography is truncated for people without a current role' do
+    @person.stubs(:biography).returns("This is the first paragraph.\r\n\r\nThis is the second paragraph")
+    @presenter.stubs(:in_current_role?).returns(false)
+    assert_no_match /This is the second paragraph./, @presenter.biography
+  end
+
   test "#announcements returns decorated published speeches and news articles available in the current locale in descending date" do
     speech_1 = build(:published_speech, first_published_at: 1.day.ago)
     speech_2 = build(:published_speech, first_published_at: 30.days.ago, translated_into: :cy)


### PR DESCRIPTION
This PR makes changes to the `person#show` page along with the presenter in order to hide certain information if the person doesn't currently hold any role. This includes hiding the image, truncating the biography at the end of the first paragraph and hiding the link to `Role` from the left hand nav. [Ticket](https://trello.com/c/bLzBWF8F/132-people-without-current-roles-should-have-limited-biographies).

Commits:
- hide image and link to Role in nav
- truncate biography at the end of the first paragraph for people without a current role
- modify an existing test as it was creating a Person with a previously held role but wasn't testing anything specific to this
- testing the changes to the person page with a feature test

Screenshot of the page of a person with no current role:

![screen shot 2015-03-26 at 16 29 57](https://cloud.githubusercontent.com/assets/449004/6851200/710fce80-d3d5-11e4-87b7-19b72a4e116b.png)