### PR TITLE
Tagging to new-world policies

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -199,6 +199,7 @@ class Admin::EditionsController < Admin::BaseController
       worldwide_organisation_ids: [],
       worldwide_priority_ids: [],
       related_policy_ids: [],
+      policy_content_ids: [],
       other_mainstream_category_ids: [],
       topic_ids: [],
       topical_event_ids: [],
@@ -333,6 +334,7 @@ class Admin::EditionsController < Admin::BaseController
   def clean_edition_parameters
     params[:edition][:title].strip! if params[:edition] && params[:edition][:title]
     params[:edition].delete(:primary_locale) if params[:edition] && params[:edition][:primary_locale].blank?
+    params[:edition][:policy_content_ids].reject!(&:blank?) if params[:edition] && params[:edition][:policy_content_ids]
   end
 
   def clear_scheduled_publication_if_not_activated

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -310,4 +310,8 @@ module Admin::EditionsHelper
   def show_similar_slugs_warning?(edition)
     !edition.document.published? && edition.document.similar_slug_exists?
   end
+
+  def future_policies_enabled?
+    ENV["ENABLE_FUTURE_POLICIES"]
+  end
 end

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -6,9 +6,7 @@ module Admin::TaggableContentHelper
   # policies. Each element of the array consists of two values: the name and
   # the content id of the policy
   def taggable_policy_content_ids_container
-    Whitehall.content_register.
-      entries('policy').
-      map { |policy| [policy['title'], policy['content_id']]}
+    Future::Policy.all.map { |policy| [policy.title, policy.content_id]}
   end
 
   # Returns an Array that represents the current set of taggable topics.

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -2,6 +2,15 @@
 # content, e.g. topics, organisations, etc.
 module Admin::TaggableContentHelper
 
+  # Returns an Array that represents the curret set of taggable (new-world)
+  # policies. Each element of the array consists of two values: the name and
+  # the content id of the policy
+  def taggable_policy_content_ids_container
+    Whitehall.content_register.
+      entries('policy').
+      map { |policy| [policy['title'], policy['content_id']]}
+  end
+
   # Returns an Array that represents the current set of taggable topics.
   # Each element of the array consists of two values: the name and ID of the
   # topic.

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -6,6 +6,7 @@ module Edition::RelatedPolicies
   included do
     has_many :related_policies, through: :related_documents, source: :latest_edition, class_name: 'Policy'
     has_many :published_related_policies, through: :related_documents, source: :published_edition, class_name: 'Policy'
+    has_many :edition_policies, foreign_key: :edition_id
   end
 
   # Ensure that when we set policy ids we don't remove other types of edition from the array
@@ -20,6 +21,16 @@ module Edition::RelatedPolicies
     related_documents.
       find_all {|d| d.document_type == Policy.name }.
       map {|d| d.latest_edition.try(:id) }.compact
+  end
+
+  def policy_content_ids
+    edition_policies.pluck(:policy_content_id)
+  end
+
+  def policy_content_ids=(content_ids)
+    self.edition_policies = content_ids.map do |content_id|
+      EditionPolicy.new(policy_content_id: content_id)
+    end
   end
 
   def can_be_related_to_policies?

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -33,7 +33,24 @@ module Edition::RelatedPolicies
     end
   end
 
+  def search_index
+    super.merge(policies: policy_slugs)
+  end
+
   def can_be_related_to_policies?
     true
+  end
+
+private
+
+  def policy_slugs
+    policy_content_ids.map do |content_id|
+      match = Whitehall.content_register.entries("policy").find { |p| p["content_id"] == content_id }
+      match ? extract_slug_from_path(match["base_path"]) : nil
+    end.compact
+  end
+
+  def extract_slug_from_path(path)
+    path.split('/').last
   end
 end

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -31,7 +31,7 @@ module Edition::RelatedPolicies
   end
 
   def policy_content_ids
-    edition_policies.pluck(:policy_content_id)
+    edition_policies.map(&:policy_content_id)
   end
 
   def policy_content_ids=(content_ids)

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -3,10 +3,17 @@ module Edition::RelatedPolicies
 
   include Edition::RelatedDocuments
 
+  class Trait < Edition::Traits::Trait
+    def process_associations_after_save(edition)
+      edition.policy_content_ids = @edition.policy_content_ids
+    end
+  end
+
   included do
     has_many :related_policies, through: :related_documents, source: :latest_edition, class_name: 'Policy'
     has_many :published_related_policies, through: :related_documents, source: :published_edition, class_name: 'Policy'
     has_many :edition_policies, foreign_key: :edition_id
+    add_trait Trait
   end
 
   # Ensure that when we set policy ids we don't remove other types of edition from the array

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -33,24 +33,15 @@ module Edition::RelatedPolicies
     end
   end
 
+  def policies
+    Future::Policy.from_content_ids(policy_content_ids)
+  end
+
   def search_index
-    super.merge(policies: policy_slugs)
+    super.merge(policies: policies.map(&:slug))
   end
 
   def can_be_related_to_policies?
     true
-  end
-
-private
-
-  def policy_slugs
-    policy_content_ids.map do |content_id|
-      match = Whitehall.content_register.entries("policy").find { |p| p["content_id"] == content_id }
-      match ? extract_slug_from_path(match["base_path"]) : nil
-    end.compact
-  end
-
-  def extract_slug_from_path(path)
-    path.split('/').last
   end
 end

--- a/app/models/edition_policy.rb
+++ b/app/models/edition_policy.rb
@@ -1,0 +1,2 @@
+class EditionPolicy < ActiveRecord::Base
+end

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -1,0 +1,31 @@
+# A model to represent new-world policies that are published by policy-publisher
+# and stored in the content-store.
+module Future
+  class Policy
+    attr_reader :base_path, :content_id, :slug, :title
+
+    def initialize(attributes)
+      @base_path = attributes["base_path"]
+      @content_id = attributes["content_id"]
+      @title = attributes["title"]
+      @slug = extract_slug
+    end
+
+    def self.all
+      Whitehall.content_register.entries('policy').map {|attrs| new(attrs.to_hash) }
+    end
+
+    def self.from_content_ids(content_ids)
+      content_ids.map do |content_id|
+        if match = Whitehall.content_register.entries("policy").find { |p| p["content_id"] == content_id }
+          new(match)
+        end
+      end.compact
+    end
+
+  private
+    def extract_slug
+      base_path.split('/').last
+    end
+  end
+end

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -8,13 +8,17 @@
                   data: { placeholder: "Choose related policies..."} %>
 </fieldset>
 
-<fieldset>
-  <p>These new policy fields are experimental.  Please do not use them unless requested</p>
-  <%= form.label :policy_content_ids, "Policies" %>
-  <%= form.select :policy_content_ids,
-                  taggable_policy_content_ids_container,
-                  { include_blank: true },
-                  multiple: true,
-                  class: 'chzn-select',
-                  data: { placeholder: "Choose policies..."} %>
-</fieldset>
+<% if future_policies_enabled? %>
+  <fieldset>
+    <%= form.label :policy_content_ids, "Policies" %>
+    <%= form.select :policy_content_ids,
+                    taggable_policy_content_ids_container,
+                    { include_blank: true },
+                    multiple: true,
+                    class: 'chzn-select',
+                    data: { placeholder: "Choose policies..."} %>
+    <p class="help-block"><em>
+      Note: This new policy field is experimental. Please do not use it unless requested.
+    </em></p>
+  </fieldset>
+<% end %>

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -7,3 +7,14 @@
                   class: 'chzn-select',
                   data: { placeholder: "Choose related policies..."} %>
 </fieldset>
+
+<fieldset>
+  <p>These new policy fields are experimental.  Please do not use them unless requested</p>
+  <%= form.label :policy_content_ids, "Policies" %>
+  <%= form.select :policy_content_ids,
+                  taggable_policy_content_ids_container,
+                  { include_blank: true },
+                  multiple: true,
+                  class: 'chzn-select',
+                  data: { placeholder: "Choose policies..."} %>
+</fieldset>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,9 @@ Whitehall::Application.configure do
   # them here means we don't have to explicitly set them just ro run tests.
   ENV['GOVUK_APP_DOMAIN'] ||= 'test.alphagov.co.uk'
   ENV['GOVUK_ASSET_ROOT'] ||= 'http://static.test.alphagov.co.uk'
+
+  # Turn on temporary feature-flag for future-policies feature during tests
+  ENV['ENABLE_FUTURE_POLICIES'] = 'true'
 end
 
 require Rails.root.join("test/support/skip_slimmer")

--- a/db/migrate/20150323155555_create_edition_policies.rb
+++ b/db/migrate/20150323155555_create_edition_policies.rb
@@ -1,0 +1,12 @@
+class CreateEditionPolicies < ActiveRecord::Migration
+  def change
+    create_table :edition_policies do |t|
+      t.references :edition
+      t.string :policy_content_id
+      t.timestamps
+    end
+
+    add_index :edition_policies, :edition_id
+    add_index :edition_policies, :policy_content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150303113958) do
+ActiveRecord::Schema.define(version: 20150323155555) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -325,6 +325,16 @@ ActiveRecord::Schema.define(version: 20150303113958) do
 
   add_index "edition_organisations", ["edition_id", "organisation_id"], name: "index_edition_organisations_on_edition_id_and_organisation_id", unique: true, using: :btree
   add_index "edition_organisations", ["organisation_id"], name: "index_edition_organisations_on_organisation_id", using: :btree
+
+  create_table "edition_policies", force: true do |t|
+    t.integer  "edition_id"
+    t.string   "policy_content_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "edition_policies", ["edition_id"], name: "index_edition_policies_on_edition_id", using: :btree
+  add_index "edition_policies", ["policy_content_id"], name: "index_edition_policies_on_policy_content_id", using: :btree
 
   create_table "edition_policy_groups", force: true do |t|
     t.integer "edition_id"

--- a/features/admin-policy-tagging.feature
+++ b/features/admin-policy-tagging.feature
@@ -1,0 +1,13 @@
+Feature: Tagging content with policies
+  As a departmental content editor
+  In order to make content available to users interested in a related policy
+  I want to be able to tag content to one or more policy areas or programmes
+
+  This feature relates to the new-world policy programes and policy areas that
+  are created and managed in policy-publisher and stored in the content store.
+  These policies will eventually replace the Policy format here in whitehall.
+
+  Scenario: a writer can tag a document to a policy
+    Given I am a writer
+    When I start editing a draft document
+    Then I can tag it to some policies

--- a/features/step_definitions/admin_policy_tagging_steps.rb
+++ b/features/step_definitions/admin_policy_tagging_steps.rb
@@ -1,8 +1,4 @@
 Then(/^I can tag it to some policies$/) do
-  select policy_1["title"], from: 'Policies'
-  click_button 'Save'
-  publication = Publication.last
-
-  assert_path admin_publication_path(publication)
-  assert_equal [policy_1["content_id"]], publication.policy_content_ids
+  tag_to_policies(policies: [policy_1])
+  check_edition_is_tagged_to_policies(edition: Publication.last, policies: [policy_1])
 end

--- a/features/step_definitions/admin_policy_tagging_steps.rb
+++ b/features/step_definitions/admin_policy_tagging_steps.rb
@@ -1,0 +1,8 @@
+Then(/^I can tag it to some policies$/) do
+  select policy_1["title"], from: 'Policies'
+  click_button 'Save'
+  publication = Publication.last
+
+  assert_path admin_publication_path(publication)
+  assert_equal [policy_1["content_id"]], publication.policy_content_ids
+end

--- a/features/support/admin_policy_tagging_helper.rb
+++ b/features/support/admin_policy_tagging_helper.rb
@@ -1,0 +1,16 @@
+module AdminPolicyTaggingHelper
+  def tag_to_policies(policies:)
+    policies.each do |policy|
+      select policy["title"], from: "Policies"
+      click_button "Save"
+    end
+  end
+
+  def check_edition_is_tagged_to_policies(edition:, policies:)
+    assert_path admin_publication_path(edition)
+    policy_content_ids = policies.map {|policy| policy["content_id"] }
+    assert_equal policy_content_ids, edition.policy_content_ids
+  end
+end
+
+World(AdminPolicyTaggingHelper)

--- a/features/support/content_register.rb
+++ b/features/support/content_register.rb
@@ -1,7 +1,7 @@
 require_relative '../../test/support/content_register_helpers'
 
 Before do
-  stub_content_register
+  stub_content_register_policies
 end
 
 World(ContentRegisterHelpers)

--- a/features/support/content_register.rb
+++ b/features/support/content_register.rb
@@ -1,33 +1,7 @@
-require 'gds_api/test_helpers/content_register'
+require_relative '../../test/support/content_register_helpers'
 
 Before do
-  mock_content_register
-end
-
-module ContentRegisterHelpers
-  include GdsApi::TestHelpers::ContentRegister
-
-  def mock_content_register
-    stub_content_register_entries("policy", [policy_1, policy_2])
-  end
-
-  def policy_1
-    @policy_1 ||= {
-        "content_id" => SecureRandom.uuid,
-        "format" => "policy",
-        "title" => "Policy 1",
-        "base_path" => "/government/policies/policy-1",
-      }
-  end
-
-  def policy_2
-    @policy_2 ||= {
-        "content_id" => SecureRandom.uuid,
-        "format" => "policy",
-        "title" => "Policy 2",
-        "base_path" => "/government/policies/policy-2",
-      }
-  end
+  stub_content_register
 end
 
 World(ContentRegisterHelpers)

--- a/features/support/content_register.rb
+++ b/features/support/content_register.rb
@@ -1,0 +1,33 @@
+require 'gds_api/test_helpers/content_register'
+
+Before do
+  mock_content_register
+end
+
+module ContentRegisterHelpers
+  include GdsApi::TestHelpers::ContentRegister
+
+  def mock_content_register
+    stub_content_register_entries("policy", [policy_1, policy_2])
+  end
+
+  def policy_1
+    @policy_1 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 1",
+        "base_path" => "/government/policies/policy-1",
+      }
+  end
+
+  def policy_2
+    @policy_2 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 2",
+        "base_path" => "/government/policies/policy-2",
+      }
+  end
+end
+
+World(ContentRegisterHelpers)

--- a/test/support/content_register_helpers.rb
+++ b/test/support/content_register_helpers.rb
@@ -3,7 +3,7 @@ require 'gds_api/test_helpers/content_register'
 module ContentRegisterHelpers
   include GdsApi::TestHelpers::ContentRegister
 
-  def stub_content_register
+  def stub_content_register_policies
     stub_content_register_entries("policy", [policy_1, policy_2])
   end
 

--- a/test/support/content_register_helpers.rb
+++ b/test/support/content_register_helpers.rb
@@ -1,0 +1,27 @@
+require 'gds_api/test_helpers/content_register'
+
+module ContentRegisterHelpers
+  include GdsApi::TestHelpers::ContentRegister
+
+  def stub_content_register
+    stub_content_register_entries("policy", [policy_1, policy_2])
+  end
+
+  def policy_1
+    @policy_1 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 1",
+        "base_path" => "/government/policies/policy-1",
+      }
+  end
+
+  def policy_2
+    @policy_2 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 2",
+        "base_path" => "/government/policies/policy-2",
+      }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,7 +168,7 @@ class ActionController::TestCase
 
   setup do
     request.env['warden'] = stub(authenticate!: false, authenticated?: false, user: nil)
-    stub_content_register
+    stub_content_register_policies
   end
 
   def login_as(role_or_user)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -159,6 +159,7 @@ class ActionController::TestCase
   include AtomTestHelpers
   include CacheControlTestHelpers
   include ViewRendering
+  include ContentRegisterHelpers
 
   include PublicDocumentRoutesHelper
   include Admin::EditionRoutesHelper
@@ -167,6 +168,7 @@ class ActionController::TestCase
 
   setup do
     request.env['warden'] = stub(authenticate!: false, authenticated?: false, user: nil)
+    stub_content_register
   end
 
   def login_as(role_or_user)

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require 'gds_api/test_helpers/content_register'
 
 class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentRegister
+
   test "#destroy should also remove the relationship to existing policies" do
     edition = create(:draft_consultation, related_editions: [create(:draft_policy)])
     relation = edition.outbound_edition_relations.first
@@ -55,5 +58,25 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     edition = create(:news_article, related_documents: [policy.document])
 
     assert_equal [], edition.related_policy_ids
+  end
+
+  test 'can assign, save and read content_ids for related policies' do
+    content_id = SecureRandom.uuid
+    edition = create(:news_article)
+    edition.policy_content_ids = [content_id]
+
+    assert_equal [content_id], edition.reload.policy_content_ids
+  end
+
+  test 're-assigning already-assigned content_ids does not create duplicates' do
+    content_id_1 = SecureRandom.uuid
+    content_id_2 = SecureRandom.uuid
+    edition = create(:news_article, policy_content_ids: [content_id_1])
+
+    assert_equal [content_id_1], edition.policy_content_ids
+
+    edition.policy_content_ids = [content_id_1, content_id_2]
+
+    assert_equal [content_id_1, content_id_2], edition.reload.policy_content_ids
   end
 end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -97,4 +97,14 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     edition = create(:news_article, policy_content_ids: [SecureRandom.uuid, policy_2['content_id']])
     assert_equal ['policy-2'], edition.search_index[:policies]
   end
+
+  test 're-editioned documents maintain related policies' do
+    stub_content_register_policies
+
+    content_id = SecureRandom.uuid
+    edition = create(:published_news_article, policy_content_ids: [content_id])
+    new_edition = edition.create_draft(create(:policy_writer))
+
+    assert_equal [content_id], new_edition.policy_content_ids
+  end
 end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -82,7 +82,7 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
   end
 
   test 'includes linked policies in search index data' do
-    stub_content_register
+    stub_content_register_policies
 
     edition = create(:news_article)
     assert_equal [], edition.search_index[:policies]
@@ -92,7 +92,7 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
   end
 
   test 'ignores non-existant content_ids' do
-    stub_content_register
+    stub_content_register_policies
 
     edition = create(:news_article, policy_content_ids: [SecureRandom.uuid, policy_2['content_id']])
     assert_equal ['policy-2'], edition.search_index[:policies]

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -98,6 +98,13 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     assert_equal ['policy-2'], edition.search_index[:policies]
   end
 
+  test '#policy_content_ids returns content_ids on an unsaved instance' do
+    stub_content_register_policies
+
+    edition = NewsArticle.new(policy_content_ids: [policy_2['content_id']])
+    assert_equal [policy_2['content_id']], edition.policy_content_ids
+  end
+
   test 're-editioned documents maintain related policies' do
     stub_content_register_policies
 


### PR DESCRIPTION
This adds the ability to tag whitehall documents to the new-world policies that are being created by policy-publisher and stored in content store.

![screen shot 2015-03-26 at 16 36 18](https://cloud.githubusercontent.com/assets/3687/6851293/18af05ac-d3d6-11e4-8049-36a142bf3a1d.png)

The new form field is feature-flagged such that it will only appear if the environment variable `ENABLE_FUTURE_POLICIES` is set. This will allow us to control where and when the form field is exposed whilst we road-test the feature. Initially it will be turned on in preview only. We do not expect this to be enable in preview before the start of purdah. We do not expect to enable this feature in production. Instead, the new field will simply replace the old one once we are happy that all the existing policies have been recreated and the existing relationships have been migrated. This should mean there is no confusion or disruption for editors.
 
Trello: https://trello.com/c/h2t4VlGE/31-allow-documents-in-whitehall-to-be-tagged-to-new-policy-areas