### PR TITLE
Improve history notice visibility on document page

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_status-block.scss
+++ b/app/assets/stylesheets/frontend/helpers/_status-block.scss
@@ -37,11 +37,13 @@
   }
 
   h2 {
-    @include heading-24;
+    @include heading-36;
     font-weight: bold;
-  }
 
-  p {
-    @include heading-24;
+    @include media(desktop) {
+      .government {
+        display: block;
+      }
+    }
   }
 }

--- a/app/views/documents/_history_notice.html.erb
+++ b/app/views/documents/_history_notice.html.erb
@@ -1,6 +1,10 @@
 <div class="history-status-block">
-  <h2>This <%= type.downcase %> is from a previous government</h2>
-  <% if government_name %>
-  <p>It was published under the <%= government_name %></p>
-  <% end %>
+  <h2>
+    This <%= type.downcase %> was published under
+    <% if government_name %>
+      the <span class="government"><%= government_name %></span>
+    <% else %>
+      a previous government
+    <% end %>
+  </h2>
 </div>


### PR DESCRIPTION
Reduce the length of the copy and make the text larger.

Most users of these pages are specialists, rather than mainstream
users, and need less sign-positing that the content is from a
previous government. We think they'll be more interested in
the particular government.

This allows us to reduce the copy significantly, giving us space
to increase the font-size to match the page title. This should
be more impactful and more visible.

It also breaks the sentence on the government name, meaning the
second line will always lead with the XXXX to YYYY date part of
the government, which we think will be more visible and more
easily scanned, hopefully reducing banner-blindness and making
the history notice more visible overall.

Note: we're only breaking the government name on larger screen
sizes, to avoid orphan words and taking up too much space on
a smaller screen

| :eyes: | Before | After |
|---|---|---|
| :iphone: | ![mobile-old](https://cloud.githubusercontent.com/assets/63201/6853557/d14c6cb4-d3e3-11e4-81e3-0f1e64b95708.png) | ![mobile-new](https://cloud.githubusercontent.com/assets/63201/6853558/d14d7c4e-d3e3-11e4-9cd8-ee487f26f18f.png) |
| :computer:  | ![desktop-old](https://cloud.githubusercontent.com/assets/63201/6853308/70f97a6a-d3e2-11e4-97bc-741bc9258710.png) | ![desktop-new] (https://cloud.githubusercontent.com/assets/63201/6853311/70fce11e-d3e2-11e4-9ccb-0680d1ea7b58.png) |


**Review**
- [x] Design (paired with @futurefabric)
- [x] Product
- [x] Code