### PR TITLE
Send drafts to publishing-api on save

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '18.1.0'
+gem 'gds-api-adapters', '18.2.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (18.1.0)
+    gds-api-adapters (18.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -411,7 +411,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 18.1.0)
+  gds-api-adapters (= 18.2.0)
   gds-sso (~> 10.0)
   globalize!
   govspeak (~> 3.2.0)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -71,6 +71,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def create
     if @edition.save
+      updater.perform!
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
       flash.now[:alert] = "There are some problems with the document"
@@ -88,6 +89,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def update
     if @edition.edit_as(current_user, edition_params)
+      updater.perform!
 
       if @edition.links_reports.last
         LinksReport.queue_for!(@edition)
@@ -350,6 +352,10 @@ class Admin::EditionsController < Admin::BaseController
     if params[:controller] == 'admin/editions'
       redirect_to admin_edition_path(@edition)
     end
+  end
+
+  def updater
+    @updater ||= Whitehall.edition_services.draft_updater(@edition)
   end
 
   def publisher

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -1,0 +1,16 @@
+class DraftEditionUpdater < EditionService
+
+  def perform!
+    if can_perform?
+      notify!
+      true
+    end
+  end
+
+  def failure_reason
+    if !edition.valid?
+      "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
+    end
+  end
+
+end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -8,7 +8,9 @@ class DraftEditionUpdater < EditionService
   end
 
   def failure_reason
-    if !edition.valid?
+    if !edition.draft?
+      "This edition is not draft."
+    elsif !edition.valid?
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end
   end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -13,4 +13,7 @@ class DraftEditionUpdater < EditionService
     end
   end
 
+  def verb
+    'update_draft'
+  end
 end

--- a/app/services/edition_service_coordinator.rb
+++ b/app/services/edition_service_coordinator.rb
@@ -15,6 +15,10 @@ class EditionServiceCoordinator
     ::EditionForcePublisher.new(edition, options.merge(notifier: self))
   end
 
+  def draft_updater(edition, options = {})
+    ::DraftEditionUpdater.new(edition, options.merge(notifier: self))
+  end
+
   def scheduler(edition, options = {})
     ::EditionScheduler.new(edition, options.merge(notifier: self))
   end

--- a/app/workers/publishing_api_draft_worker.rb
+++ b/app/workers/publishing_api_draft_worker.rb
@@ -1,0 +1,5 @@
+class PublishingApiDraftWorker < PublishingApiWorker
+  def send_item(base_path, content)
+    Whitehall.publishing_api_client.put_draft_content_item(base_path, content)
+  end
+end

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -7,13 +7,17 @@ class PublishingApiWorker
     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)
 
     I18n.with_locale(locale) do
-      Whitehall.publishing_api_client.put_content_item(
-        presenter.base_path,
-        presenter.as_json)
+      send_item(presenter.base_path, presenter.as_json)
     end
   end
 
+  private
+
   def class_for(model_name)
     model_name.constantize
+  end
+
+  def send_item(base_path, content)
+    Whitehall.publishing_api_client.put_content_item(base_path, content)
   end
 end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -11,7 +11,7 @@ Whitehall.edition_services.tap do |es|
 
   # publishing API
   es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition) }
-  es.subscribe("update_draft")                { |_, edition, _| Whitehall::PublishingApi.publish_draft(edition) }
+  es.subscribe("update_draft")                { |_, edition, _| Whitehall::PublishingApi.publish_draft_async(edition) }
   es.subscribe("archive")                     { |_, edition, _| Whitehall::PublishingApi.republish_async(edition) }
   es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
   es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -11,6 +11,7 @@ Whitehall.edition_services.tap do |es|
 
   # publishing API
   es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition) }
+  es.subscribe("update_draft")                { |_, edition, _| Whitehall::PublishingApi.publish_draft(edition) }
   es.subscribe("archive")                     { |_, edition, _| Whitehall::PublishingApi.republish_async(edition) }
   es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
   es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }

--- a/features/support/publishing_api.rb
+++ b/features/support/publishing_api.rb
@@ -2,4 +2,5 @@ require 'gds_api/publishing_api'
 
 Before do
   GdsApi::PublishingApi.any_instance.stubs(:put_content_item)
+  GdsApi::PublishingApi.any_instance.stubs(:put_draft_content_item)
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -14,7 +14,7 @@ module Whitehall
       do_action(model_instance, update_type_override)
     end
 
-    def self.publish_draft(model_instance, update_type_override=nil)
+    def self.publish_draft_async(model_instance, update_type_override=nil)
       return unless should_publish?(model_instance)
       locales_for(model_instance).each do |locale|
         PublishingApiDraftWorker.perform_async(model_instance.class.name, model_instance.id, update_type_override, locale)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -14,6 +14,13 @@ module Whitehall
       do_action(model_instance, update_type_override)
     end
 
+    def self.publish_draft(model_instance, update_type_override=nil)
+      return unless should_publish?(model_instance)
+      locales_for(model_instance).each do |locale|
+        PublishingApiDraftWorker.perform_async(model_instance.class.name, model_instance.id, update_type_override, locale)
+      end
+    end
+
     def self.republish_async(model_instance)
       do_action(model_instance, 'republish')
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,7 @@ class ActiveSupport::TestCase
     VirusScanHelpers.erase_test_files
     Sidekiq::Worker.clear_all
     stub_default_publishing_api_put
+    stub_default_publishing_api_put_draft
   end
 
   teardown do

--- a/test/unit/services/draft_edition_updater_test.rb
+++ b/test/unit/services/draft_edition_updater_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class DraftEditionUpdaterTest < ActiveSupport::TestCase
+
+  test "#perform! calls notify! without modifying the edition" do
+    edition = create(:draft_edition)
+    edition.freeze
+    updater = DraftEditionUpdater.new(edition)
+    updater.expects(:notify!).once
+
+    updater.perform!
+  end
+end

--- a/test/unit/services/draft_edition_updater_test.rb
+++ b/test/unit/services/draft_edition_updater_test.rb
@@ -10,4 +10,20 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
     updater.perform!
   end
+
+  test "cannot perform if edition is invalid" do
+    edition = Edition.new
+    updater = DraftEditionUpdater.new(edition)
+    updater.expects(:notify!).never
+
+    updater.perform!
+  end
+
+  test "cannot perform if edition is not draft" do
+    edition = create(:published_edition)
+    updater = DraftEditionUpdater.new(edition)
+    updater.expects(:notify!).never
+
+    updater.perform!
+  end
 end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -70,7 +70,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested english_request
   end
 
-  test "raises error for editions that are not publicly visible" do
+  test "#republish raises error for editions that are not publicly visible" do
     draft     = create(:draft_edition)
     published = create(:published_edition)
     archived  = create(:published_edition, state: 'archived')
@@ -244,5 +244,15 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
       assert_equal [], PublishingApiGoneWorker.jobs
     end
+  end
+
+  test "#publish_draft publishes a draft edition" do
+    draft_edition = create(:draft_case_study)
+    presenter = PublishingApiPresenters.presenter_for(draft_edition)
+    request = stub_publishing_api_put_draft_item(presenter.base_path, presenter.as_json)
+
+    Whitehall::PublishingApi.publish_draft(draft_edition)
+
+    assert_requested request
   end
 end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -246,12 +246,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "#publish_draft publishes a draft edition" do
+  test "#publish_draft_async publishes a draft edition" do
     draft_edition = create(:draft_case_study)
     presenter = PublishingApiPresenters.presenter_for(draft_edition)
     request = stub_publishing_api_put_draft_item(presenter.base_path, presenter.as_json)
 
-    Whitehall::PublishingApi.publish_draft(draft_edition)
+    Whitehall::PublishingApi.publish_draft_async(draft_edition)
 
     assert_requested request
   end

--- a/test/unit/workers/publishing_api_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_draft_worker_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api'
+
+class PublishingApiWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApi
+
+  test "registers a draft edition with the publishing api" do
+    edition   = create(:draft_case_study)
+    presenter = PublishingApiPresenters.presenter_for(edition)
+    request   = stub_publishing_api_put_draft_item(presenter.base_path, presenter.as_json)
+
+    PublishingApiDraftWorker.new.perform(edition.class.name, edition.id)
+
+    assert_requested request
+  end
+end


### PR DESCRIPTION
Adds a new edition service, `DraftEditionUpdater`, which does nothing except send notifications to its subscribers. This is called from `AdminEditionsController#create` and `#update`.

The service is subscribed to by a new `Whitehall::PublishingApi.publish_draft` method, which calls `PublishingApiDraftWorker` to send content to the publishing API draft endpoint.