### PR TITLE
Destroy dependencies for superseded editions

### DIFF
--- a/db/data_migration/20150330081423_destroy_dependencies_for_superseded_editions.rb
+++ b/db/data_migration/20150330081423_destroy_dependencies_for_superseded_editions.rb
@@ -1,0 +1,6 @@
+puts "Destroying dependencies for superseded editions"
+
+dependencies_for_superseded_editions = EditionDependency.includes(:edition).all.select {|ed| ed.edition.superseded? }
+EditionDependency.where(id: dependencies_for_superseded_editions.map(&:id)).destroy_all
+
+puts "Done."


### PR DESCRIPTION
https://trello.com/c/ibAvwvH7
https://trello.com/c/oYy2udbc

edition's dependencies are extracted when it's published, and are destroyed when it's superseded. these 2 callbacks were split across 2 PRs and deployments. there was a considerable gap between the deploy times of the 2 PRs. as a result, edition's dependencies were created on publish, but not destroyed when they were superseded.

this data migration fixes the invalid data that was created in the meantime. from Preview:

```sh
> EditionDependency.all.map {|ed| ed.edition.state}.inject(Hash.new(0)) {|h, e| h[e] += 1; h}
=> {published=>176, superseded=>61}
```

as a result of running this data migration, the 61(+) dependency records of superseded editions should get destroyed.