### PR TITLE
Data migration to index post political changes

### DIFF
--- a/db/data_migration/20150327160257_reindex_content_for_new_political_changes.rb
+++ b/db/data_migration/20150327160257_reindex_content_for_new_political_changes.rb
@@ -1,0 +1,39 @@
+POLITICAL_ORG_SLUGS = %w[
+  office-for-disability-issues
+  uk-export-finance
+]
+
+puts "Setting political flag on the following organisations:"
+POLITICAL_ORG_SLUGS.each do |slug|
+  organsation = Organisation.find_by(slug: slug)
+  puts "\t#{organsation.name}"
+  organsation.update_attribute(:political, true)
+end
+
+APOLITICAL_ORG_SLUGS = %w[
+  standards-and-testing-agency
+  third-party-campaigning-review
+]
+
+puts "Unsetting political flag on the following organisations:"
+APOLITICAL_ORG_SLUGS.each do |slug|
+  organsation = Organisation.find_by(slug: slug)
+  puts "\t#{organsation.name}"
+  organsation.update_attribute(:political, false)
+end
+
+index = 0
+
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+edition_scope = Edition.where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+edition_count = edition_scope.count
+
+edition_scope.find_each do |edition|
+  if PoliticalContentIdentifier.political?(edition)
+    edition.update_column(:political, true)
+  end
+
+  index += 1
+
+  puts "Processed #{index} of #{edition_count} editions (#{(index.to_f/edition_count.to_f)*100}%)" if index % 1000 == 0
+end


### PR DESCRIPTION
Some changes were made to the list of Political Orgs and which formats were political. This commit adds a migration which updates the Political Orgs and then reruns the PoliticalContentIdentifier over all the editions. [Ticket](https://trello.com/c/di1qVkrV/121-reindex-content-based-on-changes-to-fatality-notices-stats-publications-organisations-and-formats).