### PR TITLE
Reindex editions to populate history mode fields

### DIFF
--- a/db/data_migration/20150330134123_reindex_editions.rb
+++ b/db/data_migration/20150330134123_reindex_editions.rb
@@ -1,0 +1,2 @@
+puts "Re-indexing editions"
+Edition.reindex_all


### PR DESCRIPTION
Indexable fields for government_name, is_political and is_historic
were added and need populating in search, see:
- https://github.com/alphagov/whitehall/pull/2054