### PR TITLE
Update all documents political status

### DIFF
--- a/db/data_migration/20150327160257_reindex_content_for_new_political_changes.rb
+++ b/db/data_migration/20150327160257_reindex_content_for_new_political_changes.rb
@@ -29,9 +29,7 @@ edition_scope = Edition.where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
 edition_count = edition_scope.count
 
 edition_scope.find_each do |edition|
-  if PoliticalContentIdentifier.political?(edition)
-    edition.update_column(:political, true)
-  end
+  edition.update_column(:political, PoliticalContentIdentifier.political?(edition))
 
   index += 1
 


### PR DESCRIPTION
Rather than just documents which are now political update all the
editions. This is because some documents which were political will no
longer be considered political.