### PR TITLE
Revert "Reindex editions to populate history mode fields"

### DIFF
--- a/db/data_migration/20150330134123_reindex_editions.rb
+++ b/db/data_migration/20150330134123_reindex_editions.rb
@@ -1,2 +1,0 @@
-puts "Re-indexing editions"
-Edition.reindex_all


### PR DESCRIPTION
Reverts alphagov/whitehall#2064

After discussions with @rboulton @elliotcm @dsingleton we concluded that it would be better to perform the re-indexing using the bulk [dump](script/rummager_export.rb) and [load](https://github.com/alphagov/rummager/blob/master/bin/bulk_load) mechanism which allows for a seamless, reliable and efficient re-indexing of the full whitehall database.