### PR TITLE
Add migration to set political status of editions

### DIFF
--- a/db/data_migration/20150331121734_reindex_content_for_new_political_changes.rb
+++ b/db/data_migration/20150331121734_reindex_content_for_new_political_changes.rb
@@ -1,0 +1,13 @@
+index = 0
+
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+edition_scope = Edition.where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+edition_count = edition_scope.count
+
+edition_scope.find_each do |edition|
+  edition.update_column(:political, PoliticalContentIdentifier.political?(edition))
+
+  index += 1
+
+  puts "Processed #{index} of #{edition_count} editions (#{(index.to_f/edition_count.to_f)*100}%)" if index % 1000 == 0
+end


### PR DESCRIPTION
Update the political status of all editions based on the newly updated
political rules. Previously we only added political status this will
also remove political from no-longer political documents.