### PR TITLE
Remove custom GC from rummager dump script.

### DIFF
--- a/script/rummager_export.rb
+++ b/script/rummager_export.rb
@@ -27,7 +27,6 @@ end
 
 total_count = counts_by_class.values.inject(&:+)
 
-GC.disable
 start = Time.zone.now
 done = 0
 classes_to_index.each do |klass|
@@ -54,9 +53,6 @@ classes_to_index.each do |klass|
     puts s.to_json
     if i > 0 and i % 1000 == 0
       logger.info " .. #{i}"
-      GC.enable
-      GC.start
-      GC.disable
     end
     done += 1
     i += 1


### PR DESCRIPTION
The preview system was encountering high memory
usage issues.  Locally I could not reproduce
the same levels of RAM usage (2.5GB rather than
6.5GB) but removing the custom GC control kept
approximately the same local runtime and reduced
typical RAM usage to 380MB.

We're attributing these improvements to the Ruby
upgrades we've undergone since this script was
written.