### PR TITLE
Order previous role appointments most recent first

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -10,7 +10,7 @@ class Role < ActiveRecord::Base
     super.reject { |column| ['name', 'responsibilities'].include?(column.name) }
   end
 
-  has_many :role_appointments, -> { order('started_at') }
+  has_many :role_appointments, -> { order(started_at: :desc) }
   has_many :people, through: :role_appointments
 
   has_many :current_role_appointments,

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -11,9 +11,9 @@
   <%= sidebar_tabs appointments: "Appointments", govspeak_help: "Help" do |tabs| %>
     <%= tabs.pane id: "appointments" do %>
       <h1>Appointments</h1>
-      <p><%= link_to "Add previous appointment", new_admin_role_role_appointment_path(@role), class: "btn" %></p>
-      <%= render partial: "admin/role_appointments/list", locals: {role_appointments: @role.role_appointments} %>
       <p><%= link_to "New appointment", new_admin_role_role_appointment_path(@role, make_current: true), class: "btn" %></p>
+      <%= render partial: "admin/role_appointments/list", locals: {role_appointments: @role.role_appointments} %>
+      <p><%= link_to "Add previous appointment", new_admin_role_role_appointment_path(@role), class: "btn" %></p>  
     <% end %>
     <%= tabs.pane class: "govspeak_help", id: "govspeak_help" do %>
       <%= render partial: "admin/editions/govspeak_help" %>

--- a/test/unit/helpers/historic_appointments_helper_test.rb
+++ b/test/unit/helpers/historic_appointments_helper_test.rb
@@ -19,6 +19,6 @@ class HistoricAppointmentsHelperTest < ActionView::TestCase
   test '#previous_dates_in_office returns comma separated year ranges when the person has been appointed to that role multiple times' do
     ra1 = create(:role_appointment, started_at: Time.zone.parse("2001-01-01 00:00:00"), ended_at: Time.zone.parse("2005-01-01 00:00:00"))
     ra2 = create(:role_appointment, role: ra1.role, person: ra1.person, started_at: Time.zone.parse("2008-01-01 00:00:00"), ended_at: Time.zone.parse("2011-01-01 00:00:00"))
-    assert_equal "2001 to 2005, 2008 to 2011", previous_dates_in_office(ra1.role, ra1.person)
+    assert_equal "2008 to 2011, 2001 to 2005", previous_dates_in_office(ra1.role, ra1.person)
   end
 end


### PR DESCRIPTION
A couple of small workflow improvements around roles in WH admin.

It's more useful to have the most recent appointees to a role first,
for example prime ministers, which we have dating back to ~1800, where
a Whitehall admin would be more interested in modern holders of the role.

It's more likely for someone to add a new role appointment
rather than add a previous one, so switch the order to make
add new at the top and add previous to the bottom.

**"New appointment" and "add previous appointment" positions swapped**:
![screenshot 2015-03-31 17 43 13](https://cloud.githubusercontent.com/assets/63201/6924011/6e198724-d7cd-11e4-86f5-6b34ee44020d.png)

**List of previous appointments is most-recent first**:
![screenshot 2015-03-31 17 42 43](https://cloud.githubusercontent.com/assets/63201/6923992/5d335d90-d7cd-11e4-813a-f69beb9d1147.png)


