### PR TITLE
Sensible default for RoleAppointment and Government start dates

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -6,7 +6,7 @@ class Admin::GovernmentsController < Admin::BaseController
   end
 
   def new
-    @government = Government.new
+    @government = Government.new(start_date: Date.today)
   end
 
   def edit

--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -3,7 +3,7 @@ class Admin::RoleAppointmentsController < Admin::BaseController
 
   def new
     role = Role.find(params[:role_id])
-    @role_appointment = role.role_appointments.build
+    @role_appointment = role.role_appointments.build(started_at: Date.today)
   end
 
   def create

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -22,4 +22,10 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
       assert_response 403
     end
   end
+
+  view_test "new should have the default start date of today" do
+    login_as :gds_admin
+    get :new
+    assert_select "input[name='government[start_date]'][value='#{Date.today}']"
+  end
 end

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -21,6 +21,17 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "new should display a form for creating new an appoint, with started_at set to today, if make_current is set" do
+    role = create(:role)
+    get :new, role_id: role.id, make_current: true
+    assert_select 'form[action=?]', admin_role_role_appointments_path(role) do
+      assert_select "input[name='role_appointment[make_current]']"
+      assert_select "select[name='role_appointment[started_at(1i)]'] option[value='#{Date.today.year}'][selected='selected']"
+      assert_select "select[name='role_appointment[started_at(2i)]'] option[value='#{Date.today.month}'][selected='selected']"
+      assert_select "select[name='role_appointment[started_at(3i)]'] option[value='#{Date.today.day}'][selected='selected']"
+    end
+  end
+
   view_test "new should display a form for creating a historical appointment if make_current is not set" do
     role = create(:role)
     get :new, role_id: role.id


### PR DESCRIPTION
1. The common use-case is adding a new role appointment at the time
they appointment is made, and it makes more sense to set the
default started_at date to be today. For historic role appointments, 
the default is left blank.

2. When creating a new government the common case is a modern
government that has just come to power. Set the default
value for government start_date to be today, so someone
adding a new government in the common case has less
work to do.

https://trello.com/c/7IVzcDP6/147-when-creating-new-roles-and-governments-set-the-default-date-to-today

No screenshots as they'd be pretty dull.