### PR TITLE
Fix `rows` attribute on form textareas

### DIFF
--- a/app/views/admin/person_translations/edit.html.erb
+++ b/app/views/admin/person_translations/edit.html.erb
@@ -5,7 +5,7 @@
 <%= form_for @translated_person, url: admin_person_translation_path(@translated_person, translation_locale), method: :put do |form| %>
   <%= form.errors %>
 
-  <%= form.translated_text_area :biography, row: 20 %>
+  <%= form.translated_text_area :biography, rows: 20 %>
 
   <%= form.save_or_cancel cancel: admin_person_translations_path(@translated_person) %>
 <% end %>

--- a/app/views/admin/policy_groups/_form.html.erb
+++ b/app/views/admin/policy_groups/_form.html.erb
@@ -4,8 +4,8 @@
   <fieldset>
     <%= policy_group_form.text_field :name %>
     <%= policy_group_form.text_field :email %>
-    <%= policy_group_form.text_area :summary, row: 20 %>
-    <%= policy_group_form.text_area :description, row: 20, class: "previewable" %>
+    <%= policy_group_form.text_area :summary, rows: 20 %>
+    <%= policy_group_form.text_area :description, rows: 20, class: "previewable" %>
   </fieldset>
 
   <h3>Attachments</h3>

--- a/app/views/admin/responses/_form.html.erb
+++ b/app/views/admin/responses/_form.html.erb
@@ -5,7 +5,7 @@
 
   <%= form.label :published_on %>
   <%= form.date_select :published_on, { include_blank: true, start_year: 1997, end_year: Date.today.year + 5 }, { class: 'date' } %>
-  <%= form.text_area :summary, row: 20, label_text: 'Detail/Summary', class: "previewable" %>
+  <%= form.text_area :summary, rows: 20, label_text: 'Detail/Summary', class: "previewable" %>
 
   <%= form.save_or_cancel cancel: [:admin, consultation, consultation_response.singular_routing_symbol] %>
 <% end %>

--- a/app/views/admin/role_translations/edit.html.erb
+++ b/app/views/admin/role_translations/edit.html.erb
@@ -6,7 +6,7 @@
   <%= form.errors %>
 
   <%= form.translated_text_field :name %>
-  <%= form.translated_text_area :responsibilities, row: 20 %>
+  <%= form.translated_text_area :responsibilities, rows: 20 %>
 
   <%= form.save_or_cancel cancel: admin_role_translations_path(@translated_role) %>
 <% end %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -24,7 +24,7 @@
   </fieldset>
 
   <fieldset>
-    <%= form.text_area :responsibilities, row: 20, class: "previewable" %>
+    <%= form.text_area :responsibilities, rows: 20, class: "previewable" %>
   </fieldset>
   <p class="warning">
     <% if show_instantly_live_warning %>

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -9,7 +9,7 @@
       <%= form.text_field :title %>
       <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
       <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
-      <%= form.text_area :body, row: 20, class: "previewable", required: true %>
+      <%= form.text_area :body, rows: 20, class: "previewable", required: true %>
       <%= form.upload :image, horizontal: true %>
       <%= form.text_field :image_alt_text, horizontal: true, label_text: "Image description (alt text)" %>
       <%= form.save_or_cancel cancel: admin_take_part_pages_path %>

--- a/app/views/admin/world_location_translations/edit.html.erb
+++ b/app/views/admin/world_location_translations/edit.html.erb
@@ -7,7 +7,7 @@
 
   <%= form.translated_text_field :name %>
   <%= form.translated_text_field :title %>
-  <%= form.translated_text_area :mission_statement, row: 20 %>
+  <%= form.translated_text_area :mission_statement, rows: 20 %>
 
   <%= form.save_or_cancel cancel: admin_world_location_translations_path(@translated_world_location) %>
 <% end %>

--- a/app/views/admin/world_locations/edit.html.erb
+++ b/app/views/admin/world_locations/edit.html.erb
@@ -10,7 +10,7 @@
 
       <%= form.text_field :title %>
 
-      <%= form.text_area :mission_statement, row: 20, class: "previewable" %>
+      <%= form.text_area :mission_statement, rows: 20, class: "previewable" %>
 
       <%= form.check_box :active,
                 label_text: "Active (can visitors click through from the world location list?)" %>


### PR DESCRIPTION
This attribute changed in Rails 4, which meant all our textareas collapsed.

Fix the attribute so they display as intended.

Before:

![screen shot 2015-04-01 at 23 21 25](https://cloud.githubusercontent.com/assets/1516/6954054/d8d31a32-d8c5-11e4-8561-aeee57369e9e.png)

After:

![screen shot 2015-04-01 at 23 20 34](https://cloud.githubusercontent.com/assets/1516/6954047/ce08662a-d8c5-11e4-916e-8031d252ef82.png)

Fixes http://govuk.zendesk.com/tickets/996979