### PR TITLE
Ignore duplicate dependencies extracted

### DIFF
--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -5,8 +5,8 @@ class EditionDependenciesPopulator
   end
 
   def populate!
-    @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts
-    @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions
+    @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts.uniq
+    @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions.uniq
   end
 
 end

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -5,8 +5,11 @@ class EditionDependenciesPopulator
   end
 
   def populate!
-    @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts.uniq
-    @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions.uniq
+    # ensure that another process doesn't simultaneously modify the association
+    Edition.transaction do
+      @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts.uniq
+      @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions.uniq
+    end
   end
 
 end

--- a/lib/edition_dependencies_populator.rb
+++ b/lib/edition_dependencies_populator.rb
@@ -7,8 +7,8 @@ class EditionDependenciesPopulator
   def populate!
     # ensure that another process doesn't simultaneously modify the association
     Edition.transaction do
-      @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts.uniq
-      @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions.uniq
+      @edition.depended_upon_contacts = Govspeak::ContactsExtractor.new(@edition.body).contacts
+      @edition.depended_upon_editions = Govspeak::DependableEditionsExtractor.new(@edition.body).editions
     end
   end
 

--- a/lib/govspeak/contacts_extractor.rb
+++ b/lib/govspeak/contacts_extractor.rb
@@ -11,7 +11,7 @@ module Govspeak
       @govspeak.scan(EmbeddedContentPatterns::CONTACT).map { |capture|
         contact_id = capture.first
         Contact.find_by(id: contact_id)
-      }.compact
+      }.compact.uniq
     end
   end
 end

--- a/lib/govspeak/dependable_editions_extractor.rb
+++ b/lib/govspeak/dependable_editions_extractor.rb
@@ -18,7 +18,7 @@ module Govspeak
           editions << Edition.in_pre_publication_state.find_by(id: capture[capture_index])
         end
       end
-      editions.compact
+      editions.compact.uniq
     end
   end
 end

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -41,24 +41,4 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
 
     assert_same_elements [speech], news_article.depended_upon_editions.reload
   end
-
-  test "ignores duplicate contact dependencies" do
-    contact = create(:contact)
-    news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}].
-                                                  I repeat, [Contact:#{contact.id}].")
-
-    EditionDependenciesPopulator.new(news_article).populate!
-
-    assert_same_elements [contact], news_article.depended_upon_contacts.reload
-  end
-
-  test "ignores duplicate edition dependencies" do
-    speech = create(:speech)
-    news_article = create(:news_article, body: "Governor's [new speech](/government/admin/speeches/#{speech.id})
-                                                  is same as the [old speech](/government/admin/speeches/#{speech.id})")
-
-    EditionDependenciesPopulator.new(news_article).populate!
-
-    assert_same_elements [speech], news_article.depended_upon_editions.reload
-  end
 end

--- a/test/unit/edition_dependencies_populator_test.rb
+++ b/test/unit/edition_dependencies_populator_test.rb
@@ -22,7 +22,7 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
     assert_same_elements speeches, news_article.depended_upon_editions.reload
   end
 
-  test "ignores duplicate contact dependencies" do
+  test "doesn't try to re-create an existing contact dependency" do
     contact = create(:contact)
     news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}]")
     news_article.depended_upon_contacts << contact # dependency is populated already
@@ -32,10 +32,30 @@ class EditionDependenciesPopulatorTest < ActiveSupport::TestCase
     assert_same_elements [contact], news_article.depended_upon_contacts.reload
   end
 
-  test "ignores duplicate edition dependencies" do
+  test "doesn't try to re-create an existing edition dependency" do
     speech = create(:speech)
     news_article = create(:news_article, body: "Governor's new [speech](/government/admin/speeches/#{speech.id})")
     news_article.depended_upon_editions << speech # dependency is populated already
+
+    EditionDependenciesPopulator.new(news_article).populate!
+
+    assert_same_elements [speech], news_article.depended_upon_editions.reload
+  end
+
+  test "ignores duplicate contact dependencies" do
+    contact = create(:contact)
+    news_article = create(:news_article, body: "For more information, get in touch at: [Contact:#{contact.id}].
+                                                  I repeat, [Contact:#{contact.id}].")
+
+    EditionDependenciesPopulator.new(news_article).populate!
+
+    assert_same_elements [contact], news_article.depended_upon_contacts.reload
+  end
+
+  test "ignores duplicate edition dependencies" do
+    speech = create(:speech)
+    news_article = create(:news_article, body: "Governor's [new speech](/government/admin/speeches/#{speech.id})
+                                                  is same as the [old speech](/government/admin/speeches/#{speech.id})")
 
     EditionDependenciesPopulator.new(news_article).populate!
 

--- a/test/unit/govspeak/contacts_extractor_test.rb
+++ b/test/unit/govspeak/contacts_extractor_test.rb
@@ -13,14 +13,14 @@ class ContactsExtractorTest < ActiveSupport::TestCase
     assert_equal [contact_2, contact_1], embedded_contacts
   end
 
-  test 'will not remove duplicate contacts' do
+  test 'will remove duplicate contacts' do
     contact_1 = build(:contact)
     Contact.stubs(:find_by).with(id: '1').returns(contact_1)
 
     input = 'Our office at [Contact:1] is brilliant, you should come for a cup of tea. Remeber the address is [Contact:1]'
 
     embedded_contacts = Govspeak::ContactsExtractor.new(input).contacts
-    assert_equal [contact_1, contact_1], embedded_contacts
+    assert_equal [contact_1], embedded_contacts
   end
 
   test 'will silently remove contact references that do not resolve to a Contact' do

--- a/test/unit/govspeak/dependable_editions_extractor_test.rb
+++ b/test/unit/govspeak/dependable_editions_extractor_test.rb
@@ -50,11 +50,11 @@ class Govspeak::DependableEditionsExtractorTest < ActiveSupport::TestCase
     assert_empty Govspeak::DependableEditionsExtractor.new(govspeak).editions
   end
 
-  test "will not remove duplicate dependable editions" do
+  test "will remove duplicate dependable editions" do
     speech = create(:speech)
     govspeak = "[old speech](/government/admin/speeches/#{speech.id})
                   [same speech](/government/admin/speeches/#{speech.id})"
 
-    assert_equal [speech, speech], Govspeak::DependableEditionsExtractor.new(govspeak).editions
+    assert_equal [speech], Govspeak::DependableEditionsExtractor.new(govspeak).editions
   end
 end

--- a/test/unit/govspeak/dependable_editions_extractor_test.rb
+++ b/test/unit/govspeak/dependable_editions_extractor_test.rb
@@ -49,4 +49,12 @@ class Govspeak::DependableEditionsExtractorTest < ActiveSupport::TestCase
 
     assert_empty Govspeak::DependableEditionsExtractor.new(govspeak).editions
   end
+
+  test "will not remove duplicate dependable editions" do
+    speech = create(:speech)
+    govspeak = "[old speech](/government/admin/speeches/#{speech.id})
+                  [same speech](/government/admin/speeches/#{speech.id})"
+
+    assert_equal [speech, speech], Govspeak::DependableEditionsExtractor.new(govspeak).editions
+  end
 end


### PR DESCRIPTION
https://trello.com/c/LRY96KGc
related errbits: [1](https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/551b2a9e0da115ee6c000c4c), [2](https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/551937680da115b0360007c7), [3](https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/5514253b0da115cdc6000949) and many more.

for the contacts extractor or editions extractor it is OK to return duplicates to give an idea of how many times that dependency is mentioned in the body. however, the dependency populator should filter out duplicates before saving, otherwise the unique index causes errors.