### PR TITLE
improve edition published email text

### DIFF
--- a/app/views/notifications/edition_published.text.erb
+++ b/app/views/notifications/edition_published.text.erb
@@ -1,6 +1,8 @@
-Hi,
+Hello,
 
-The <%= @edition.format_name %> '<%= @edition.title %>' has now been published.  It is now available at the following url: <%= @public_url %>.
+The <%= @edition.format_name %> '<%= @edition.title %>' is published. It's now available at the following url: <%= @public_url %>
+
+New content will be live immediately, changes to previously published content can <a href="https://insidegovuk.blog.gov.uk/2014/11/05/how-soon-do-users-see-content-after-youve-pressed-publish/">take up to 15 minutes</a>. 
 
 All the best,
 

--- a/app/views/notifications/edition_published.text.erb
+++ b/app/views/notifications/edition_published.text.erb
@@ -2,7 +2,7 @@ Hello,
 
 The <%= @edition.format_name %> '<%= @edition.title %>' is published. It's now available at the following url: <%= @public_url %>
 
-New content will be live immediately, changes to previously published content can <a href="https://insidegovuk.blog.gov.uk/2014/11/05/how-soon-do-users-see-content-after-youve-pressed-publish/">take up to 15 minutes</a>. 
+New content will be live immediately, changes to previously published content can take up to 15 minutes. A blog post that explains more is at the following url: https://insidegovuk.blog.gov.uk/2014/11/05/how-soon-do-users-see-content-after-youve-pressed-publish
 
 All the best,
 


### PR DESCRIPTION
Users can report surprise at how long it appears to take for updates to content to be visible on the site. Experimenting whether changing the email can clarify the process and reduce confusion.