### PR TITLE
Highlight historic documents in Document Filters

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_document_list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_list.scss
@@ -15,6 +15,8 @@
     }
 
     ul {
+      @extend %contain-floats;
+
       li {
         @include core-14;
         float: left;
@@ -28,6 +30,12 @@
           padding: 0 0 0 $gutter;
         }
       }
+    }
+
+    p.historic {
+      @include core-14;
+      padding: 0 0 3px;
+      color: $secondary-text-colour;
     }
   }
 }

--- a/app/presenters/edition_presenter_helper.rb
+++ b/app/presenters/edition_presenter_helper.rb
@@ -8,7 +8,9 @@ module EditionPresenterHelper
       url: url,
       organisations: display_organisations.html_safe,
       display_date_microformat: display_date_microformat,
-      public_timestamp: model.public_timestamp
+      public_timestamp: model.public_timestamp,
+      historic?: model.historic?,
+      government_name: model.search_government_name,
     }
   end
 

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -17,6 +17,13 @@
             <li class="document-collections">{{{publication_collections}}}</li>
           {{/publication_collections}}
         </ul>
+        {{#historic?}}
+          {{#government_name}}
+            <p class="historic">
+            First published during the {{government_name}}
+            </p>
+          {{/government_name}}
+        {{/historic?}}
       </li>
     {{/results}}
   </ol>

--- a/lib/whitehall/document_filter/result.rb
+++ b/lib/whitehall/document_filter/result.rb
@@ -17,6 +17,14 @@ module Whitehall::DocumentFilter
       format
     end
 
+    def search_government_name
+      @doc['government_name']
+    end
+
+    def historic?
+      @doc['is_historic']
+    end
+
     def public_timestamp
       Time.zone.parse(@doc['public_timestamp'])
     end

--- a/test/unit/presenters/document_filter_presenter_test.rb
+++ b/test/unit/presenters/document_filter_presenter_test.rb
@@ -74,7 +74,9 @@ class DocumentFilterPresenterTest < PresenterTestCase
       "organisations" => "Ministry of Silly",
       "display_date_microformat" => "<abbr class=\"public_timestamp\" title=\"2011-11-08T11:11:11+00:00\"> 8 November 2011</abbr>",
       "public_timestamp" => 3.days.ago.as_json,
-      "publication_collections" => nil
+      "historic?" => false,
+      "government_name" => nil,
+      "publication_collections" => nil,
       }, json['results'].first)
   end
 


### PR DESCRIPTION
Only applies to historic (political and published by a previous
government), highlighting the publishing government within the
document filter results list.

![screenshot 2015-04-07 15 03 48](https://cloud.githubusercontent.com/assets/63201/7026922/9fe09a8c-dd44-11e4-93d0-6dca86e11f1d.png)


Expose `historic?` and `government_name` to the view.

https://trello.com/c/MxdqoXSB/149-implement-visual-presentation-of-history-mode-appearance-in-whitehall-document-filter-pages