### PR TITLE
Allow queue to be specified when enqueuing a job

### DIFF
--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -1,5 +1,4 @@
-class DocumentListExportWorker
-  include Sidekiq::Worker
+class DocumentListExportWorker < WorkerBase
 
   def perform(filter_options, user_id)
     user = User.find(user_id)

--- a/app/workers/govspeak_content_worker.rb
+++ b/app/workers/govspeak_content_worker.rb
@@ -1,5 +1,4 @@
-class GovspeakContentWorker
-  include Sidekiq::Worker
+class GovspeakContentWorker < WorkerBase
 
   def perform(id)
     return unless govspeak_content = GovspeakContent.find_by(id: id)

--- a/app/workers/import_force_publication_attempt_worker.rb
+++ b/app/workers/import_force_publication_attempt_worker.rb
@@ -1,5 +1,4 @@
-class ImportForcePublicationAttemptWorker
-  include Sidekiq::Worker
+class ImportForcePublicationAttemptWorker < WorkerBase
   sidekiq_options queue: :imports
 
   attr_reader :id

--- a/app/workers/import_row_worker.rb
+++ b/app/workers/import_row_worker.rb
@@ -1,6 +1,12 @@
-class ImportRowWorker < Struct.new(:import_id, :row_hash, :row_number)
-  include Sidekiq::Worker
+class ImportRowWorker < WorkerBase
   sidekiq_options queue: :imports
+  attr_reader :import_id, :row_hash, :row_number
+
+  def initialize(import_id = nil, row_hash = nil, row_number = nil)
+    @import_id = import_id
+    @row_hash = row_hash
+    @row_number = row_number
+  end
 
   def perform(*args)
     ImportRowWorker.new(*args).run

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -1,5 +1,4 @@
-class ImportWorker
-  include Sidekiq::Worker
+class ImportWorker < WorkerBase
   sidekiq_options queue: :imports
 
   def perform(id, options = {})

--- a/app/workers/links_report_worker.rb
+++ b/app/workers/links_report_worker.rb
@@ -1,5 +1,4 @@
-class LinksReportWorker
-  include Sidekiq::Worker
+class LinksReportWorker < WorkerBase
 
   def perform(id)
     links_report = LinksReport.find(id)

--- a/app/workers/panopticon_register_artefact_worker.rb
+++ b/app/workers/panopticon_register_artefact_worker.rb
@@ -1,8 +1,7 @@
 require 'plek'
 require 'gds_api/panopticon'
 
-class PanopticonRegisterArtefactWorker
-  include Sidekiq::Worker
+class PanopticonRegisterArtefactWorker < WorkerBase
   sidekiq_options queue: :panopticon
 
   def perform(edition_id, options = {})

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,5 +1,4 @@
-class PublishingApiComingSoonWorker
-  include Sidekiq::Worker
+class PublishingApiComingSoonWorker < WorkerBase
 
   def perform(base_path, publish_timestamp, locale)
     coming_soon = PublishingApiPresenters::ComingSoon.new(base_path, publish_timestamp, locale)

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,4 +1,5 @@
 class PublishingApiComingSoonWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(base_path, publish_timestamp, locale)
     coming_soon = PublishingApiPresenters::ComingSoon.new(base_path, publish_timestamp, locale)

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,4 +1,5 @@
 class PublishingApiGoneWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(base_path)
     Whitehall.publishing_api_client.put_content_item(base_path, gone_item_for(base_path))

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,4 @@
-class PublishingApiGoneWorker
-  include Sidekiq::Worker
+class PublishingApiGoneWorker < WorkerBase
 
   def perform(base_path)
     Whitehall.publishing_api_client.put_content_item(base_path, gone_item_for(base_path))

--- a/app/workers/publishing_api_organisation_worker.rb
+++ b/app/workers/publishing_api_organisation_worker.rb
@@ -1,6 +1,5 @@
 # FIXME: This will be redundant once the existing jobs have been worked off
-class PublishingApiOrganisationWorker
-  include Sidekiq::Worker
+class PublishingApiOrganisationWorker < WorkerBase
 
   def perform(organisation_id, options = {})
     organisation = Organisation.find(organisation_id)

--- a/app/workers/publishing_api_organisation_worker.rb
+++ b/app/workers/publishing_api_organisation_worker.rb
@@ -1,5 +1,6 @@
 # FIXME: This will be redundant once the existing jobs have been worked off
 class PublishingApiOrganisationWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(organisation_id, options = {})
     organisation = Organisation.find(organisation_id)

--- a/app/workers/publishing_api_schedule_worker.rb
+++ b/app/workers/publishing_api_schedule_worker.rb
@@ -1,4 +1,5 @@
 class PublishingApiScheduleWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(base_path, publish_timestamp)
     publish_intent = build_publish_intent(base_path, publish_timestamp)

--- a/app/workers/publishing_api_schedule_worker.rb
+++ b/app/workers/publishing_api_schedule_worker.rb
@@ -1,5 +1,4 @@
-class PublishingApiScheduleWorker
-  include Sidekiq::Worker
+class PublishingApiScheduleWorker < WorkerBase
 
   def perform(base_path, publish_timestamp)
     publish_intent = build_publish_intent(base_path, publish_timestamp)

--- a/app/workers/publishing_api_unschedule_worker.rb
+++ b/app/workers/publishing_api_unschedule_worker.rb
@@ -1,5 +1,5 @@
-class PublishingApiUnscheduleWorker
-  include Sidekiq::Worker
+class PublishingApiUnscheduleWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(base_path)
     Whitehall.publishing_api_client.destroy_intent(base_path)

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -1,4 +1,5 @@
 class PublishingApiWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
 
   def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
     return unless model = class_for(model_name).find_by(id: id)

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -1,5 +1,4 @@
-class PublishingApiWorker
-  include Sidekiq::Worker
+class PublishingApiWorker < WorkerBase
 
   def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
     return unless model = class_for(model_name).find_by(id: id)

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -1,9 +1,8 @@
 require 'sidekiq/api'
 
-class ScheduledPublishingWorker
+class ScheduledPublishingWorker < WorkerBase
   class ScheduledPublishingFailure < StandardError; end
 
-  include Sidekiq::Worker
   sidekiq_options queue: :scheduled_publishing
 
   def self.queue(edition)

--- a/app/workers/search_index_add_worker.rb
+++ b/app/workers/search_index_add_worker.rb
@@ -1,5 +1,4 @@
-class SearchIndexAddWorker
-  include Sidekiq::Worker
+class SearchIndexAddWorker < WorkerBase
 
   attr_reader :id, :class_name
 

--- a/app/workers/search_index_delete_worker.rb
+++ b/app/workers/search_index_delete_worker.rb
@@ -1,5 +1,4 @@
-class SearchIndexDeleteWorker
-  include Sidekiq::Worker
+class SearchIndexDeleteWorker < WorkerBase
 
   attr_reader :link, :index
 

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -1,0 +1,7 @@
+class WorkerBase
+  include Sidekiq::Worker
+
+  def self.perform_async_in_queue(queue, *args)
+    client_push('class' => self, 'args' => args, 'queue' => queue)
+  end
+end

--- a/test/unit/workers/worker_base_test.rb
+++ b/test/unit/workers/worker_base_test.rb
@@ -1,0 +1,27 @@
+class WorkerBaseTest < ActiveSupport::TestCase
+  def self.worker_has_run!
+  end
+
+  class MyWorker < WorkerBase
+    def perform
+      WorkerBaseTest.worker_has_run!
+    end
+  end
+
+  test ".perform_async runs the job" do
+    self.class.expects(:worker_has_run!)
+    MyWorker.perform_async
+  end
+
+  test ".perform_async_in_queue runs the job in the specified queue" do
+    example_arg = stub("example arg")
+    WorkerBase.expects(:client_push).with(
+      'class' => WorkerBaseTest::MyWorker,
+      'args' => [example_arg],
+      'queue' => 'test_queue'
+    )
+    MyWorker.perform_async_in_queue('test_queue', example_arg)
+  end
+
+end
+


### PR DESCRIPTION
We want to be able to run bulk jobs such as republishing all editions in a lower-priority queue so that they do not block normal publishing operations. Sidekiq does not provide a method for enqueueing jobs with a specified queue, so this adds such a method.