### PR TITLE
Set `X-Frame-Options` header to `ALLOWALL`

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -3,6 +3,7 @@ class PublicFacingController < ApplicationController
 
   before_filter :set_cache_control_headers
   before_filter :restrict_request_formats
+  before_filter :set_x_frame_options
 
   around_filter :set_locale
 
@@ -103,5 +104,9 @@ class PublicFacingController < ApplicationController
 
   def load_reshuffle_setting
     SitewideSetting.find_by(key: :minister_reshuffle_mode)
+  end
+
+  def set_x_frame_options
+    response.headers['X-Frame-Options'] = 'ALLOWALL'
   end
 end

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -180,6 +180,13 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
   end
 
+  test "public facing controllers explicitly set X-FRAME-OPTIONS header" do
+    with_routing_for_test_controller do
+      get :test
+      assert response.headers["X-Frame-Options"] == 'ALLOWALL'
+    end
+  end
+
   def with_routing_for_test_controller(&block)
     with_routing do |map|
       map.draw do


### PR DESCRIPTION
Rails 4 starts setting a default `X-Frame-Options` policy of `SAMEORIGIN` which prevents this application from being displayed in an iframe outside of GOV.UK, for example in the side-by-side browser.

As this application only contains information pages and nothing transactional, we have decided to allow it to be included in iframes on external sites.

- [Pivotal](https://www.pivotaltracker.com/n/projects/780127/stories/92019798)
- [Zendesk](https://govuk.zendesk.com/tickets/1001074)