### PR TITLE
Add data migration to reformat old policies.

### DIFF
--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -67,7 +67,7 @@ end
 gds_user = User.find_by!(name: "GDS Inside Government Team")
 url_maker = Whitehall.url_maker
 
-Policy.published.with_translations.each do |policy|
+Policy.publicly_visible.with_translations.each do |policy|
   puts %{Creating policy paper from policy ##{policy.id}}
 
   title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -63,7 +63,7 @@ $CTA
 end
 
 gds_user = User.find_by!(name: "GDS Inside Government Team")
-url_maker = UrlMaker.new
+url_maker = Whitehall.url_maker
 
 Policy.published.with_translations.each do |policy|
   puts %{Creating policy paper from policy ##{policy.id}}

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -65,13 +65,13 @@ end
 gds_user = User.find_by!(name: "GDS Inside Government Team")
 url_maker = UrlMaker.new
 
-Policy.published.each do |policy|
+Policy.published.with_translations.each do |policy|
   puts %{Creating policy paper from policy ##{policy.id}}
 
   title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
   short_title = "2010 to 2015 coalition policy: #{policy.title}"
 
-  supporting_pages = policy.supporting_pages.published
+  supporting_pages = policy.supporting_pages.published.with_translations
 
   alternative_format_provider = policy.lead_organisations.first
 

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -3,8 +3,8 @@ module PolicyMigrationHelpers
     callout = %|
 $CTA
 This is a copy of a document that stated a policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
-The previous URL of this page was [#{url_maker.public_document_url(policy)}](#{url_maker.public_document_path(policy)})
-Current policies can be found at the GOV.UK [policies list](/government/policies).
+The previous URL of this page was [#{url_maker.public_document_url(policy)}](#{url_maker.public_document_url(policy)})
+Current policies can be found at the GOV.UK [policies list](#{url_maker.policies_url}).
 $CTA
 
 |
@@ -86,7 +86,7 @@ Policy.published.with_translations.each do |policy|
 
   policy_paper_body = "This policy paper shows the policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
 
-Find out about the [current government’s policies](/government/policies)."
+Find out about the [current government’s policies](#{url_maker.policies_url})."
 
   policy_paper = Publication.new(
     title: title,

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -67,78 +67,83 @@ end
 gds_user = User.find_by!(name: "GDS Inside Government Team")
 url_maker = Whitehall.url_maker
 
-Policy.publicly_visible.with_translations.each do |policy|
-  puts %{Creating policy paper from policy ##{policy.id}}
+CSV.open(Rails.root+"tmp/#{Time.zone.now.strftime('%F-%H-%M-%S')}-policy_paper_creation_output.csv", "wb") do |csv|
+  csv << ["policy_id", "policy_paper_id", "policy_state"]
 
-  title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
-  short_title = "2010 to 2015 coalition policy: #{policy.title}"
+  Policy.publicly_visible.with_translations.each do |policy|
+    puts %{Creating policy paper from policy ##{policy.id}}
 
-  supporting_pages = policy.supporting_pages.published.with_translations
+    title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
+    short_title = "2010 to 2015 coalition policy: #{policy.title}"
 
-  alternative_format_provider = policy.lead_organisations.first
+    supporting_pages = policy.supporting_pages.published.with_translations
 
-  html_attachment = HtmlAttachment.new(
-    title: title,
-    ordering: 0,
-    govspeak_content: GovspeakContent.new(
-      body: PolicyMigrationHelpers.build_html_attachment_body(policy, url_maker, alternative_format_provider),
-      manually_numbered_headings: false,
-    ),
-  )
+    alternative_format_provider = policy.lead_organisations.first
 
-  policy_paper_body = "This policy paper shows the policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
+    html_attachment = HtmlAttachment.new(
+      title: title,
+      ordering: 0,
+      govspeak_content: GovspeakContent.new(
+        body: PolicyMigrationHelpers.build_html_attachment_body(policy, url_maker, alternative_format_provider),
+        manually_numbered_headings: false,
+      ),
+    )
 
-Find out about the [current government’s policies](#{url_maker.policies_url})."
+    policy_paper_body = "This policy paper shows the policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
 
-  policy_paper = Publication.new(
-    title: title,
-    summary: policy.summary,
-    body: policy_paper_body,
-    publication_type_id: PublicationType::PolicyPaper.id,
-    first_published_at: DateTime.new(2015, 3, 27, 6, 0, 0), # 6am, 27 March 2015
-    political: true,
-    creator: gds_user,
-    alternative_format_provider: alternative_format_provider,
-    document: Document.new(
-      sluggable_string: short_title,
-      content_id: SecureRandom.uuid
-    ),
-  )
+  Find out about the [current government’s policies](#{url_maker.policies_url})."
 
-  PolicyMigrationHelpers.copy_associations!(policy, policy_paper)
+    policy_paper = Publication.new(
+      title: title,
+      summary: policy.summary,
+      body: policy_paper_body,
+      publication_type_id: PublicationType::PolicyPaper.id,
+      first_published_at: DateTime.new(2015, 3, 27, 6, 0, 0), # 6am, 27 March 2015
+      political: true,
+      creator: gds_user,
+      alternative_format_provider: alternative_format_provider,
+      document: Document.new(
+        sluggable_string: short_title,
+        content_id: SecureRandom.uuid
+      ),
+    )
 
-  if policy_paper.save
+    PolicyMigrationHelpers.copy_associations!(policy, policy_paper)
 
-    policy_paper.attachments << html_attachment
-    supporting_pages.map(&:attachments).flatten.uniq.each_with_index do |attachment, index|
-      puts %{-- Adding attachment "#{attachment.html? ? 'HTML' : attachment.filename}"}
+    if policy_paper.save
 
-      existing_attachment = attachment.deep_clone
+      policy_paper.attachments << html_attachment
+      supporting_pages.map(&:attachments).flatten.uniq.each_with_index do |attachment, index|
+        puts %{-- Adding attachment "#{attachment.html? ? 'HTML' : attachment.filename}"}
 
-      # Reset attachment ordering, accounting for the HTML attachment
-      # These have never been manually set for supporting pages,
-      # so we don't need to worry about preserving order.
-      existing_attachment.ordering = index + 1
+        existing_attachment = attachment.deep_clone
 
-      policy_paper.attachments << existing_attachment
-    end
+        # Reset attachment ordering, accounting for the HTML attachment
+        # These have never been manually set for supporting pages,
+        # so we don't need to worry about preserving order.
+        existing_attachment.ordering = index + 1
 
-    puts %{Created policy paper ##{policy_paper.id} "#{policy_paper.title}" from policy ##{policy.id}}
-  else
-    policy_paper.errors.full_messages.each do |error|
-      puts %{-- #{error}}
+        policy_paper.attachments << existing_attachment
+      end
 
-      puts %{---- #{policy_paper.body}} if error =~ /invalid formatting/
+      csv << [policy.id, policy_paper.id, policy.state]
+      puts %{Created policy paper ##{policy_paper.id} "#{policy_paper.title}" from policy ##{policy.id}}
+    else
+      policy_paper.errors.full_messages.each do |error|
+        puts %{-- #{error}}
 
-      if error =~ /Attachments/
-        policy_paper.attachments.each do |attachment|
-          puts %{---- #{attachment.errors.full_messages.join(',')}}
+        puts %{---- #{policy_paper.body}} if error =~ /invalid formatting/
+
+        if error =~ /Attachments/
+          policy_paper.attachments.each do |attachment|
+            puts %{---- #{attachment.errors.full_messages.join(',')}}
+          end
         end
       end
+
+      puts %{Failed to create policy paper from policy ##{policy.id} "#{policy_paper.title}"}
     end
 
-    puts %{Failed to create policy paper from policy ##{policy.id} "#{policy_paper.title}"}
+    puts
   end
-
-  puts
 end

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -73,7 +73,7 @@ CSV.open(Rails.root+"tmp/#{Time.zone.now.strftime('%F-%H-%M-%S')}-policy_paper_c
   Policy.publicly_visible.with_translations.each do |policy|
     puts %{Creating policy paper from policy ##{policy.id}}
 
-    title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
+    title = "2010 to 2015 government policy: #{policy.title}"
 
     supporting_pages = policy.supporting_pages.published.with_translations
 

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -1,0 +1,142 @@
+module PolicyMigrationHelpers
+  def self.build_html_attachment_body(policy, url_maker, alternative_format_provider)
+    callout = %|
+$CTA
+This is a copy of a document that stated a policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
+The previous URL of this page was [#{url_maker.public_document_url(policy)}](#{url_maker.public_document_path(policy)})
+Current policies can be found at the GOV.UK [policies list](/government/policies).
+$CTA
+
+|
+
+    combined_body = callout + policy.body
+
+    supporting_pages = policy.supporting_pages.published
+    supporting_pages.each_with_index do |supporting_page, index|
+      combined_body += extract_supporting_page(supporting_page, index, alternative_format_provider)
+    end
+
+    return combined_body
+  end
+
+  def self.copy_associations!(policy, policy_paper)
+    [
+      :lead_organisations,
+      :supporting_organisations,
+      :topics,
+      :topical_events,
+      :nation_inapplicabilities,
+      :role_appointments,
+      :fact_check_requests,
+      :world_locations,
+      :related_documents,
+      :specialist_sectors,
+    ].each do |association|
+      policy_paper.send("#{association}=".to_sym, policy.send(association))
+    end
+  end
+
+  def self.extract_supporting_page(supporting_page, index, alternative_format_provider)
+    appendix_title = "Appendix #{index+1}: #{supporting_page.title}"
+
+    puts "-- Adding supporting page ##{supporting_page.id}: as #{appendix_title}"
+
+    sp_body = %|
+
+###{appendix_title}
+
+$CTA
+This was a supporting detail page of the main policy document.
+$CTA
+
+#{supporting_page.body.gsub(/^(\s*[#]{2,})/, '\1#')}
+|
+
+    sp_body.gsub(/\[InlineAttachment:([0-9]+)\]/) do
+      if attachment = supporting_page.attachments[$1.to_i - 1]
+        "[#{attachment.title}](#{attachment.url})"
+      else
+        ""
+      end
+    end
+  end
+end
+
+gds_user = User.find_by!(name: "GDS Inside Government Team")
+url_maker = UrlMaker.new
+
+Policy.published.each do |policy|
+  puts %{Creating policy paper from policy ##{policy.id}}
+
+  title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
+  short_title = "2010 to 2015 coalition policy: #{policy.title}"
+
+  supporting_pages = policy.supporting_pages.published
+
+  alternative_format_provider = policy.lead_organisations.first
+
+  html_attachment = HtmlAttachment.new(
+    title: title,
+    ordering: 0,
+    govspeak_content: GovspeakContent.new(
+      body: PolicyMigrationHelpers.build_html_attachment_body(policy, url_maker, alternative_format_provider),
+      manually_numbered_headings: false,
+    ),
+  )
+
+  policy_paper_body = "This policy paper shows the policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
+
+Find out about the [current government’s policies](/government/policies)."
+
+  policy_paper = Publication.new(
+    title: title,
+    summary: policy.summary,
+    body: policy_paper_body,
+    publication_type_id: PublicationType::PolicyPaper.id,
+    first_published_at: DateTime.new(2015, 3, 27, 6, 0, 0), # 6am, 27 March 2015
+    political: true,
+    creator: gds_user,
+    alternative_format_provider: alternative_format_provider,
+    document: Document.new(
+      sluggable_string: short_title,
+      content_id: SecureRandom.uuid
+    ),
+  )
+
+  PolicyMigrationHelpers.copy_associations!(policy, policy_paper)
+
+  if policy_paper.save
+
+    policy_paper.attachments << html_attachment
+    supporting_pages.map(&:attachments).flatten.uniq.each_with_index do |attachment, index|
+      puts %{-- Adding attachment "#{attachment.html? ? 'HTML' : attachment.filename}"}
+
+      existing_attachment = attachment.deep_clone
+
+      # Reset attachment ordering, accounting for the HTML attachment
+      # These have never been manually set for supporting pages,
+      # so we don't need to worry about preserving order.
+      existing_attachment.ordering = index + 1
+
+      policy_paper.attachments << existing_attachment
+    end
+
+    puts %{Created policy paper ##{policy_paper.id} "#{policy_paper.title}" from policy ##{policy.id}}
+  else
+    policy_paper.errors.full_messages.each do |error|
+      puts %{-- #{error}}
+
+      puts %{---- #{policy_paper.body}} if error =~ /invalid formatting/
+
+      if error =~ /Attachments/
+        policy_paper.attachments.each do |attachment|
+          puts %{---- #{attachment.errors.full_messages.join(',')}}
+        end
+      end
+    end
+
+    puts %{Failed to create policy paper from policy ##{policy.id} "#{policy_paper.title}"}
+  end
+
+  puts
+end

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -74,7 +74,6 @@ CSV.open(Rails.root+"tmp/#{Time.zone.now.strftime('%F-%H-%M-%S')}-policy_paper_c
     puts %{Creating policy paper from policy ##{policy.id}}
 
     title = "2010 to 2015 Conservative and Liberal Democrat coalition policy: #{policy.title}"
-    short_title = "2010 to 2015 coalition policy: #{policy.title}"
 
     supporting_pages = policy.supporting_pages.published.with_translations
 
@@ -91,7 +90,7 @@ CSV.open(Rails.root+"tmp/#{Time.zone.now.strftime('%F-%H-%M-%S')}-policy_paper_c
 
     policy_paper_body = "This policy paper shows the policy of the 2010 to 2015 Conservative and Liberal Democrat coalition government.
 
-  Find out about the [current government’s policies](#{url_maker.policies_url})."
+Find out about the [current government’s policies](#{url_maker.policies_url})."
 
     policy_paper = Publication.new(
       title: title,
@@ -102,16 +101,11 @@ CSV.open(Rails.root+"tmp/#{Time.zone.now.strftime('%F-%H-%M-%S')}-policy_paper_c
       political: true,
       creator: gds_user,
       alternative_format_provider: alternative_format_provider,
-      document: Document.new(
-        sluggable_string: short_title,
-        content_id: SecureRandom.uuid
-      ),
     )
 
     PolicyMigrationHelpers.copy_associations!(policy, policy_paper)
 
     if policy_paper.save
-
       policy_paper.attachments << html_attachment
       supporting_pages.map(&:attachments).flatten.uniq.each_with_index do |attachment, index|
         puts %{-- Adding attachment "#{attachment.html? ? 'HTML' : attachment.filename}"}

--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -52,8 +52,10 @@ $CTA
 #{supporting_page.body.gsub(/^(\s*[#]{2,})/, '\1#')}
 |
 
-    sp_body.gsub(/\[InlineAttachment:([0-9]+)\]/) do
-      if attachment = supporting_page.attachments[$1.to_i - 1]
+    sp_body.gsub(/(?:^!@([0-9]+)|\[InlineAttachment:([0-9]+)\])/) do
+      attachment_index = $1 || $2
+
+      if attachment_index && attachment = supporting_page.attachments[$1.to_i - 1]
         "[#{attachment.title}](#{attachment.url})"
       else
         ""


### PR DESCRIPTION
- [x] Product signoff
- [x] Final copy signoff
- [x] Code signoff

This takes the old policies with their verbose content of supporting pages and attachments, and merges them into a single policy paper for each policy.

The original policies will be replaced with equivalents in the new policy format.

The main content of the new policy paper appears as an HTML attachment.

Supporting page content is appended to the HTML attachment as appendices, with their headers indented by one notch.

Attachments orderings are reset when they're merged together.  They have never been manually ordered.

Inline attachments in supporting pages are injected appropriately into the HTML attachment.

Notices are injected into the HTML attachment indicating the provenance of the content.

More information here: https://trello.com/c/TId1MPNH/120-convert-existing-policy-pages-into-html-attachments-to-new-publications

## Policy paper:
![screenshot 2015-04-09 13 14 48](https://cloud.githubusercontent.com/assets/109225/7066699/1cc02d82-debd-11e4-97d7-d695fd5c898c.png)
### [..cut attachments..]
![screenshot 2015-04-13 14 56 18](https://cloud.githubusercontent.com/assets/109225/7116927/49b90e98-e1ed-11e4-8d08-a1166dbebf6d.png)

## HTML attachment:
![screenshot 2015-04-09 13 29 09](https://cloud.githubusercontent.com/assets/109225/7066709/319304fa-debd-11e4-94d7-d57cd0bddf24.png)
### [..cut..]
![screenshot 2015-04-09 13 29 24](https://cloud.githubusercontent.com/assets/109225/7066713/3cdee8e2-debd-11e4-8bb9-b580a14fa9b6.png)
### [..cut..]

## Additional inline attachment replacement:
Before:
![screenshot 2015-04-16 11 10 49](https://cloud.githubusercontent.com/assets/109225/7178852/15a5029e-e42a-11e4-9576-2cbba293e9ce.png)

After:
![screenshot 2015-04-16 11 11 11](https://cloud.githubusercontent.com/assets/109225/7178862/225ab2ea-e42a-11e4-9728-731b8a1c7887.png)
