### PR TITLE
Add OrganisationType for "Court"

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,7 +8,7 @@ class OrganisationsController < PublicFacingController
   before_filter :set_cache_max_age, only: [:show]
 
   def index
-    @organisations = OrganisationsIndexPresenter.new(Organisation.listable.ordered_by_name_ignoring_prefix)
+    @organisations = OrganisationsIndexPresenter.new(Organisation.excluding_courts.listable.ordered_by_name_ignoring_prefix)
   end
 
   def show
@@ -102,7 +102,7 @@ private
   end
 
   def load_organisation
-    @organisation = Organisation.with_translations(I18n.locale).find(params[:id])
+    @organisation = Organisation.excluding_courts.with_translations(I18n.locale).find(params[:id])
   end
 
   def set_cache_max_age

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -56,4 +56,8 @@ module Organisation::OrganisationTypeConcern
     @active_child_organisations_excluding_sub_organisations_grouped_by_type ||=
       active_child_organisations_excluding_sub_organisations.group_by(&:organisation_type).sort_by { |type, department| type.listing_position }
   end
+
+  def can_index_in_search?
+    super && !organisation_type.court?
+  end
 end

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -27,6 +27,10 @@ module Organisation::OrganisationTypeConcern
     scope :allowed_promotional, -> {
       where(organisation_type_key: OrganisationType.allowed_promotional_keys)
     }
+
+    scope :excluding_courts, -> {
+      where.not(organisation_type_key: :court)
+    }
   end
 
   def organisation_type_key

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -60,4 +60,8 @@ module Organisation::OrganisationTypeConcern
   def can_index_in_search?
     super && !organisation_type.court?
   end
+
+  def can_publish_to_publishing_api?
+    super && !organisation_type.court?
+  end
 end

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -14,6 +14,7 @@ class OrganisationType
     sub_organisation:            { name: "Sub-organisation",                       analytics_prefix: "OT", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     other:                       { name: "Other",                                  analytics_prefix: "OT", agency_or_public_body: true,  non_departmental_public_body: false, allowed_promotional: false },
     civil_service:               { name: "Civil Service",                          analytics_prefix: "CS", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },
+    court:                       { name: "Court",                                  analytics_prefix: "CO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
   }
 
   LISTING_ORDER = [
@@ -31,6 +32,7 @@ class OrganisationType
     :sub_organisation,
     :other,
     :civil_service,
+    :court,
   ]
 
   @@instances = {}
@@ -99,6 +101,9 @@ class OrganisationType
   end
   def self.civil_service
     get :civil_service
+  end
+  def self.court
+    get :court
   end
   def self.agencies_and_public_bodies
     DATA.select { |k, v| v[:agency_or_public_body] }
@@ -178,5 +183,9 @@ class OrganisationType
 
   def civil_service?
     key == :civil_service
+  end
+
+  def court?
+    key == :court
   end
 end

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -73,10 +73,6 @@ module Searchable
       end
     end
 
-    def can_index_in_search?
-      self.class.searchable_instances.find_by(id: self.id).present? && Whitehall.searchable_classes.include?(self.class)
-    end
-
     def update_in_search_index
       if can_index_in_search?
         Whitehall::SearchIndex.add(self)
@@ -110,5 +106,9 @@ module Searchable
         end
       end
     end
+  end
+
+  def can_index_in_search?
+    self.class.searchable_instances.find_by(id: self.id).present? && Whitehall.searchable_classes.include?(self.class)
   end
 end

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -378,6 +378,13 @@ ar:
         few:
         many:
         other:
+      Court:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       Devolved administration:
         zero:
         one:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -360,6 +360,9 @@ az:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -278,6 +278,11 @@ be:
         few:
         many:
         other:
+      Court:
+        one:
+        few:
+        many:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -179,6 +179,9 @@ bg:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -178,6 +178,9 @@ bn:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -228,6 +228,10 @@ cs:
         one:
         few:
         other:
+      Court:
+        one:
+        few:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -378,6 +378,13 @@ cy:
         few:
         many:
         other:
+      Court:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       Devolved administration:
         zero:
         one: Gweinyddiaeth ddatganoledig

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -178,6 +178,9 @@ de:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -178,6 +178,9 @@ dr:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -178,6 +178,9 @@ el:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,6 +390,9 @@ en:
       Civil Service:
         one: Civil Service
         other: Civil Services
+      Court:
+        one: Court
+        other: Courts
     headings:
       plus_others: + others
       what_we_do: What we do

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -178,6 +178,9 @@ es-419:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -178,6 +178,9 @@ es:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -178,6 +178,9 @@ et:
       Civil Service:
         one: Riigiamet
         other: Riigiametid
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -363,6 +363,9 @@ fa:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -178,6 +178,9 @@ fr:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -278,6 +278,11 @@ he:
         two:
         many:
         other:
+      Court:
+        one:
+        two:
+        many:
+        other:
       Devolved administration:
         one:
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -178,6 +178,9 @@ hi:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -364,6 +364,9 @@ hu:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -178,6 +178,9 @@ hy:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -363,6 +363,9 @@ id:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -178,6 +178,9 @@ it:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -361,6 +361,9 @@ ja:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -360,6 +360,9 @@ ka:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -361,6 +361,9 @@ ko:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -228,6 +228,10 @@ lt:
         one:
         few:
         other:
+      Court:
+        one:
+        few:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -178,6 +178,9 @@ lv:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -360,6 +360,9 @@ ms:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -278,6 +278,11 @@ pl:
         few:
         many:
         other:
+      Court:
+        one:
+        few:
+        many:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -178,6 +178,9 @@ ps:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -178,6 +178,9 @@ pt:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -228,6 +228,10 @@ ro:
         one:
         few:
         other:
+      Court:
+        one:
+        few:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -278,6 +278,11 @@ ru:
         few:
         many:
         other:
+      Court:
+        one:
+        few:
+        many:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -178,6 +178,9 @@ si:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -228,6 +228,10 @@ sk:
         one:
         few:
         other:
+      Court:
+        one:
+        few:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -178,6 +178,9 @@ so:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -178,6 +178,9 @@ sq:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -278,6 +278,11 @@ sr:
         few:
         many:
         other:
+      Court:
+        one:
+        few:
+        many:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -178,6 +178,9 @@ sw:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -178,6 +178,9 @@ ta:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -361,6 +361,9 @@ th:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -178,6 +178,9 @@ tk:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -362,6 +362,9 @@ tr:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -278,6 +278,11 @@ uk:
         few:
         many:
         other:
+      Court:
+        one:
+        few:
+        many:
+        other:
       Devolved administration:
         one:
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -178,6 +178,9 @@ ur:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -178,6 +178,9 @@ uz:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -363,6 +363,9 @@ vi:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -360,6 +360,9 @@ zh-hk:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -360,6 +360,9 @@ zh-tw:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -360,6 +360,9 @@ zh:
       Civil Service:
         one:
         other:
+      Court:
+        one:
+        other:
       Devolved administration:
         one:
         other:

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -4,12 +4,16 @@ module PublishesToPublishingApi
   included do
     before_validation :generate_content_id, on: :create
     validates :content_id, presence: true
-    after_commit :publish_to_publishing_api, if: :persisted?
+    after_commit :publish_to_publishing_api, if: :can_publish_to_publishing_api?
   end
 
 
   def generate_content_id
     self.content_id ||= SecureRandom.uuid
+  end
+
+  def can_publish_to_publishing_api?
+    persisted?
   end
 
   def publish_to_publishing_api

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -57,4 +57,8 @@ FactoryGirl.define do
     organisation_type_key :devolved_administration
     govuk_status 'exempt'
   end
+
+  factory :court, parent: :organisation do
+    organisation_type_key :court
+  end
 end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -671,6 +671,13 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select '#freedom-of-information', /not covered by the Freedom of Information Act/
   end
 
+  test "should not show Courts" do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      court = create(:court)
+      get :show, id: court
+    end
+  end
+
   private
 
   def assert_disclaimer_present(organisation)

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -104,4 +104,14 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     sub_organisation = create(:sub_organisation, parent_organisations: [parent])
     assert_equal [sub_organisation], parent.sub_organisations
   end
+
+  test "should index Organisations" do
+    organisation = create(:organisation)
+    assert organisation.can_index_in_search?
+  end
+
+  test "should not index Courts" do
+    court = create(:court)
+    refute court.can_index_in_search?
+  end
 end

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -114,4 +114,14 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     court = create(:court)
     refute court.can_index_in_search?
   end
+
+  test "should publish Organisations to Publishing API" do
+    organisation = create(:organisation)
+    assert organisation.can_publish_to_publishing_api?
+  end
+
+  test "should not publish Courts to Publishing API" do
+    court = create(:court)
+    refute court.can_publish_to_publishing_api?
+  end
 end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -380,6 +380,12 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.save
   end
 
+  test 'should not add courts to index on creating' do
+    court = build(:court)
+    Whitehall::SearchIndex.expects(:add).never
+    court.save
+  end
+
   test 'should add organisation to search index on updating' do
     organisation = create(:organisation)
 
@@ -389,10 +395,23 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.save
   end
 
+  test 'should not add courts to index on updating' do
+    court = create(:court)
+    Whitehall::SearchIndex.expects(:add).never
+    court.name = "Junk Appeals Court"
+    court.save
+  end
+
   test 'should remove organisation from search index on destroying' do
     organisation = create(:organisation)
     Whitehall::SearchIndex.expects(:delete).with(organisation)
     organisation.destroy
+  end
+
+  test 'should try to remove courts from index on destroying' do
+    court = create(:court)
+    Whitehall::SearchIndex.expects(:delete).with(court)
+    court.destroy
   end
 
   test 'should return search index data for all organisations' do

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -799,6 +799,12 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [org_with_announcement], Organisation.with_statistics_announcements
   end
 
+  test "excluding_courts scopes to non-court organisation types" do
+    court = create(:court)
+    other_org = create(:organisation)
+    assert_equal [other_org], Organisation.excluding_courts
+  end
+
   test "#has_services_and_information_link? returns true if slug is in the whitelist" do
     org = create(:organisation)
 

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -80,8 +80,4 @@ class OrganisationTypeTest < ActiveSupport::TestCase
     assert_equal 1, OrganisationType.get(:ministerial_department).listing_position
     assert_equal 5, OrganisationType.get(:advisory_ndpb).listing_position
   end
-
-  test "non_governmental_types returns an array of non-governmental types" do
-    assert_equal [:court], OrganisationType.non_governmental_types
-  end
 end

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -72,6 +72,7 @@ class OrganisationTypeTest < ActiveSupport::TestCase
       :sub_organisation,
       :other,
       :civil_service,
+      :court,
     ], OrganisationType.in_listing_order.map(&:key)
   end
 

--- a/test/unit/models/organisation_type_test.rb
+++ b/test/unit/models/organisation_type_test.rb
@@ -80,4 +80,8 @@ class OrganisationTypeTest < ActiveSupport::TestCase
     assert_equal 1, OrganisationType.get(:ministerial_department).listing_position
     assert_equal 5, OrganisationType.get(:advisory_ndpb).listing_position
   end
+
+  test "non_governmental_types returns an array of non-governmental types" do
+    assert_equal [:court], OrganisationType.non_governmental_types
+  end
 end

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -22,15 +22,29 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     assert_equal organisation.content_id, "a random UUID"
   end
 
-  test "create publishes to Publishing API" do
+  test "create publishes to Publishing API if not disallowed" do
     organisation = build(:organisation)
     Whitehall::PublishingApi.expects(:publish_async).with(organisation)
     organisation.save
   end
 
-  test "update publishes to Publishing API" do
+  test "update publishes to Publishing API if not disallowed" do
     organisation = create(:organisation)
     Whitehall::PublishingApi.expects(:publish_async).with(organisation)
+    organisation.update_attribute(:name, 'Edited org')
+  end
+
+  test "create does not publish to Publishing API if disallowed" do
+    organisation = build(:organisation)
+    organisation.stubs(:can_publish_to_publishing_api?).returns(false)
+    Whitehall::PublishingApi.expects(:publish_async).never
+    organisation.save
+  end
+
+  test "update does not publish to Publishing API if disallowed" do
+    organisation = create(:organisation)
+    organisation.stubs(:can_publish_to_publishing_api?).returns(false)
+    Whitehall::PublishingApi.expects(:publish_async).never
     organisation.update_attribute(:name, 'Edited org')
   end
 end


### PR DESCRIPTION
As per Pivotal story [#92038070](https://www.pivotaltracker.com/n/projects/1261204/stories/92038070), adds a new organisation type for "Court", and also ensures organisations of this type don't appear on GOV.UK anywhere. Future work will add pages for this type, and also index them and add them to content store/registry in the correct place.

Possible contentious point: adds a `non_governmental` flag for Organisation types. It seems this would be useful for any number of [qua]ngos that might be added to the site in the future.