### PR TITLE
Draft environment populator

### DIFF
--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -9,6 +9,7 @@ module PublishingApiPresenters
     presenter_class_for(model).new(model, options)
   end
 
+private
   def self.presenter_class_for(model)
     if model.is_a?(::Edition)
       presenter_class_for_edition(model)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,6 @@
+namespace :publishing_api do
+  desc "export all whitehall content to draft environment of publishing api"
+  task :populate_draft_environment => :environment do
+    Whitehall::PublishingApi::DraftEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+  end
+end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -14,10 +14,10 @@ module Whitehall
       do_action(model_instance, update_type_override)
     end
 
-    def self.publish_draft_async(model_instance, update_type_override=nil)
+    def self.publish_draft_async(model_instance, update_type_override=nil, queue_override=nil)
       return unless should_publish?(model_instance)
       locales_for(model_instance).each do |locale|
-        PublishingApiDraftWorker.perform_async(model_instance.class.name, model_instance.id, update_type_override, locale)
+        PublishingApiDraftWorker.perform_async_in_queue(queue_override, model_instance.class.name, model_instance.id, update_type_override, locale)
       end
     end
 

--- a/lib/whitehall/publishing_api/draft_environment_populator.rb
+++ b/lib/whitehall/publishing_api/draft_environment_populator.rb
@@ -1,0 +1,37 @@
+module Whitehall
+  class PublishingApi
+    class DraftEnvironmentPopulator
+      attr_reader :draft_items
+
+      def initialize(draft_items: default_draft_items)
+        @draft_items = draft_items
+      end
+
+      def call
+        draft_items.each do |edition|
+          PublishingApi.publish_draft_async(edition, 'bulk_draft_update', 'bulk_republishing')
+        end
+      end
+
+      def self.default_draft_items
+        Enumerator.new do |yielder|
+          Edition.latest_edition.find_each do |edition|
+            yielder << edition
+          end
+
+          [
+            MinisterialRole,
+            Organisation,
+            Person,
+            WorldLocation,
+            WorldwideOrganisation
+          ].each do |klass|
+            klass.find_each do |item|
+              yielder << item
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/whitehall/publishing_api/draft_environment_populator.rb
+++ b/lib/whitehall/publishing_api/draft_environment_populator.rb
@@ -1,10 +1,11 @@
 module Whitehall
   class PublishingApi
     class DraftEnvironmentPopulator
-      attr_reader :draft_items
+      attr_reader :draft_items, :logger
 
-      def initialize(draft_items: default_draft_items)
-        @draft_items = draft_items
+      def initialize(draft_items: nil, logger: Logger.new(nil))
+        @logger = logger
+        @draft_items = draft_items || default_draft_items
       end
 
       def call
@@ -13,10 +14,32 @@ module Whitehall
         end
       end
 
-      def self.default_draft_items
+    private
+      class ProgressLogger
+        attr_reader :name, :count, :logger
+
+        def initialize(count, logger)
+          @count = count
+          @logger = logger
+          @i = 0
+        end
+
+        def inc
+          @i += 1
+          if @i % 1000 == 0
+            logger.info "done #{i}..."
+          end
+        end
+      end
+
+      def default_draft_items
         Enumerator.new do |yielder|
+          progress_logger = ProgressLogger.new(Edition.latest_edition.count, logger)
+          logger.info "Exporting #{progress_logger.count} Editions"
+
           Edition.latest_edition.find_each do |edition|
             yielder << edition
+            progress_logger.inc
           end
 
           [
@@ -26,8 +49,12 @@ module Whitehall
             WorldLocation,
             WorldwideOrganisation
           ].each do |klass|
+            progress_logger = ProgressLogger.new(klass.count, logger)
+            logger.info "Exporting #{progress_logger.count} #{klass.name}s"
+
             klass.find_each do |item|
               yielder << item
+              progress_logger.inc
             end
           end
         end

--- a/test/unit/whitehall/publishing_api/draft_environment_populator_test.rb
+++ b/test/unit/whitehall/publishing_api/draft_environment_populator_test.rb
@@ -1,0 +1,37 @@
+require 'whitehall/publishing_api'
+
+module Whitehall
+  class PublishingApi
+    class DraftEnvironmentPopulatorTest < ActiveSupport::TestCase
+
+      test "calls PublishingApi.publish_draft_async for all editions" do
+        all_editions = [stub("edition")]
+        PublishingApi.expects(:publish_draft_async).with(all_editions.first, 'bulk_draft_update', 'bulk_republishing')
+        DraftEnvironmentPopulator.new(draft_items: all_editions).call
+      end
+
+      test "draft_items defaults to an enumeration of all items which can be sent to publishing api" do
+        organisation = create(:organisation)
+
+        expected_values = [
+          create(:published_edition),
+          create(:draft_edition),
+          create(:ministerial_role, organisations: [organisation]),
+          organisation,
+          create(:person),
+          create(:world_location),
+          create(:worldwide_organisation)
+        ]
+
+        assert_equal expected_values, DraftEnvironmentPopulator.new.draft_items.to_a
+      end
+
+      test "default draft_items has only the latest edition of a document" do
+        published_edition = create(:published_edition)
+        latest_edition = create(:draft_edition, document: published_edition.document)
+
+        assert_equal [latest_edition], DraftEnvironmentPopulator.new.draft_items.to_a
+      end
+    end
+  end
+end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -255,4 +255,17 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "#publish_draft_async propagates update_type and queue overrides to worker" do
+    queue_name = "bang"
+    update_type = "whizzo"
+
+    draft_edition = create(:draft_case_study)
+
+    PublishingApiDraftWorker.expects(:perform_async_in_queue)
+      .with(queue_name, draft_edition.class.name, draft_edition.id,
+            update_type, draft_edition.primary_locale.to_sym)
+
+    Whitehall::PublishingApi.publish_draft_async(draft_edition, update_type, queue_name)
+  end
 end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -45,6 +45,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     unpublishing = create(:unpublishing, edition: edition)
 
     Whitehall::PublishingApi.publish_async(unpublishing)
+
+    assert_not_requested :put, %r{/content/}
   end
 
   test "#publish sends case studies to the content store" do
@@ -62,6 +64,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     policy = create(:published_policy)
 
     Whitehall::PublishingApi.publish_async(policy)
+
+    assert_not_requested :put, %r{/content/}
   end
 
   test "#republish publishes to the Publishing API as a 'republish' update_type" do


### PR DESCRIPTION
## Purpose/rationale

We need a method to populate the draft content store. We'll need to do this when we first set it up, but may need to do it periodically as well. We want to avoid harming the normal publishing operations when this is running

https://trello.com/c/WrKWYuKf/113-script-to-send-all-published-and-draft-editions-to-content-store

## Solution

A script to send all draft documents (editions, organisations etc) to the publishing api.

It will send placeholders for all formats except for `CaseStudy`.

It will avoid sending any policies at all because these are now handled by the policy publisher.

It uses a different sidekiq queue to avoid flooding the main publishing queue.

We use an update_type of `bulk_draft_update` to be explicit that these
updates are not normal major/minor updates.
