### PR TITLE
Make WorldLocationNewsArticle always political

### DIFF
--- a/db/data_migration/20150413101340_world_location_news_article_is_always_political.rb
+++ b/db/data_migration/20150413101340_world_location_news_article_is_always_political.rb
@@ -1,0 +1,12 @@
+index = 0
+
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+edition_scope = Edition.where(state: PUBLISHED_AND_PUBLISHABLE_STATES, type: WorldLocationNewsArticle)
+edition_count = edition_scope.count
+
+edition_scope.find_each do |edition|
+  edition.update_column(:political, true)
+  index += 1
+
+  puts "Processed #{index} of #{edition_count} editions (#{(index.to_f/edition_count.to_f)*100}%)" if index % 1000 == 0
+end

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -1,10 +1,13 @@
 class PoliticalContentIdentifier
-  POLITICAL_FORMATS = [
+  DEPENDENT_POLITICAL_FORMATS = [
     Consultation,
     Speech,
     NewsArticle,
-    WorldLocationNewsArticle,
   ].freeze
+
+  ALWAYS_POLITICAL_FORMATS = [
+    WorldLocationNewsArticle,
+  ]
 
   POLITICAL_PUBLICATION_TYPES = [
     PublicationType::CorporateReport,
@@ -22,10 +25,10 @@ class PoliticalContentIdentifier
   end
 
   def political?
-    if can_be_political?
+    if political_format_or_type?
       is_associated_with_a_minister? || has_political_org?
     else
-      false
+      always_political_format? || false
     end
   end
 
@@ -40,8 +43,8 @@ private
       edition.organisations.where(political: true).any?
   end
 
-  def can_be_political?
-    political_publication_type? || political_format?
+  def political_format_or_type?
+    political_publication_type? || dependent_political_format?
   end
 
   def political_publication_type?
@@ -50,7 +53,11 @@ private
       POLITICAL_PUBLICATION_TYPES.include?(edition.publication_type)
   end
 
-  def political_format?
-    POLITICAL_FORMATS.include?(edition.class)
+  def dependent_political_format?
+    DEPENDENT_POLITICAL_FORMATS.include?(edition.class)
+  end
+
+  def always_political_format?
+    ALWAYS_POLITICAL_FORMATS.include?(edition.class)
   end
 end

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -17,6 +17,12 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     refute political?(statistics_publication)
   end
 
+  test 'world location news articles are always political' do
+    world_location_news_article = create(:world_location_news_article)
+
+    assert political?(world_location_news_article)
+  end
+
   test 'political formats associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])


### PR DESCRIPTION
`WorldLocationNewsArticle`s are political but are never published by a Political Org. This commit updates the `PoliticalContentIdentifier` to do this and adds a data migration to update all existing `WorldLocationNewsArticle`s.