### PR TITLE
Improve print stylesheets for html publications

### DIFF
--- a/app/assets/stylesheets/frontend/print/_html-publication.scss
+++ b/app/assets/stylesheets/frontend/print/_html-publication.scss
@@ -1,7 +1,41 @@
 .html-publications-show {
+
+  .publication-header {
+    .headings {
+      p {
+        margin-bottom: 0;
+        padding-bottom: 0;
+      }
+      h1 {
+        margin: 0;
+        padding-top: 0;
+      }
+    }
+  }
+
   nav.in-page-navigation {
     display: block!important;
+
+    h2 {
+      margin-top: $gutter-one-third;
+    }
+    ol {
+      margin-top: 0;
+      li {
+        padding: 0;
+      }
+    }
   }
+
+  .govspeak {
+    h2 {
+      padding-top: $gutter-one-third;
+    }
+    h2 + h3 {
+      margin-top: $gutter-one-third;
+    }
+  }
+
   .unnumbered {
     list-style: none;
     li {
@@ -16,6 +50,7 @@
   ul {
     li {
       margin-left: $gutter-two-thirds;
+      padding: 0;
     } 
   }
 }


### PR DESCRIPTION
Reduce the amount of paper used by reducing vertical spacing and
improve design and clarity when printing html pubs.

Changes made have been approved by Rebecca Cottrell

https://www.pivotaltracker.com/story/show/89702492

Side by side before and after (before on the right, after on the left) -
![screen shot 2015-04-13 at 14 00 10](https://cloud.githubusercontent.com/assets/1692222/7115997/a7970b80-e1e5-11e4-8ae5-dbbcb35a7615.png)
