### PR TITLE
Correct default queue when calling perform_async_in_queue

### DIFF
--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -2,6 +2,6 @@ class WorkerBase
   include Sidekiq::Worker
 
   def self.perform_async_in_queue(queue, *args)
-    client_push('class' => self, 'args' => args, 'queue' => queue)
+    client_push('class' => self, 'args' => args, 'queue' => queue || get_sidekiq_options["queue"])
   end
 end

--- a/test/unit/workers/worker_base_test.rb
+++ b/test/unit/workers/worker_base_test.rb
@@ -1,8 +1,11 @@
+require 'test_helper'
+
 class WorkerBaseTest < ActiveSupport::TestCase
   def self.worker_has_run!
   end
 
   class MyWorker < WorkerBase
+    sidekiq_options queue: "my-test-queue"
     def perform
       WorkerBaseTest.worker_has_run!
     end
@@ -23,5 +26,14 @@ class WorkerBaseTest < ActiveSupport::TestCase
     MyWorker.perform_async_in_queue('test_queue', example_arg)
   end
 
+  test ".perform_async_in_queue uses default queue if queue is nil" do
+    example_arg = stub("example arg")
+    WorkerBase.expects(:client_push).with(
+      'class' => WorkerBaseTest::MyWorker,
+      'args' => [example_arg],
+      'queue' => 'my-test-queue'
+    )
+    MyWorker.perform_async_in_queue(nil, example_arg)
+  end
 end
 


### PR DESCRIPTION
We were passing an empty string rather than a default when the method
was called without a queue argument, and this was being passed on in the
job itself. Sidekiq only executes jobs from queues it knows about, so
the jobs were remaining unprocessed.