### PR TITLE
Run changed hunks only through rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development, :test do
   gem 'test-queue', '0.2.11'
   gem 'ruby-prof'
   gem 'pry-byebug'
+  gem 'rubocop', require: false
 end
 
 group :development do
@@ -86,7 +87,6 @@ group :development do
   gem 'thin', '1.6.3'
   gem 'newrelic_rpm'
   gem 'quiet_assets'
-  gem 'rubocop', require: false
 end
 
 group :test do

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -48,6 +48,16 @@ rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+
+# Lint changes introduced in this branch, but not for master
+if [[ ${GIT_BRANCH} != "origin/master" ]]; then
+  bundle exec rubocop \
+    --require ./lib/rubocop_diff \
+    --format html --out rubocop-${GIT_COMMIT}.html \
+    --format clang \
+    app test lib -- --cached
+fi
+
 RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load
 RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rake ci:setup:minitest test:in_parallel --trace
 RAILS_ENV=production time bundle exec rake assets:precompile --trace

--- a/lib/rubocop_diff.rb
+++ b/lib/rubocop_diff.rb
@@ -1,0 +1,60 @@
+class RuboCopDiff
+  def self.changed_lines
+    @changed_lines ||= begin
+      changes = changed_files.map do |file|
+        next unless File.exist?(file)
+        [file, `git difftool #{commit_options} -y -x 'diff --new-line-format="%dn "
+                --unchanged-line-format="" --changed-group-format="%>"' #{file}`.split.map(&:to_i)]
+      end.compact
+
+      Hash[changes]
+    end
+  end
+
+private
+  def self.changed_files
+    `git diff #{commit_options} --name-only`.
+      split.
+      select { |f| f =~ %r{.rb$} }.
+      map { |f| File.expand_path(f.chomp, "./") }
+  end
+
+  def self.commit_options
+    @commit_options ||= begin
+      options = {diff_from: "origin/master", diff_to: "HEAD", cached: false}
+      OptionParser.new do |opts|
+        opts.on("--diff-from COMMITISH", "ref to compare from (default: origin/master") do |f|
+          options[:diff_from] = f
+        end
+        opts.on("--diff-to COMMITISH", "ref to compare to (default: HEAD)") do |t|
+          options[:diff_to] = t
+        end
+        opts.on("--cached", "diff staged files") do |c|
+          options[:cached] = true
+        end
+      end.parse!
+
+      if options[:cached]
+        "--cached #{options[:diff_from]}"
+      else
+        "#{options[:diff_from]} #{options[:diff_to]}"
+      end
+    end
+  end
+end
+
+module DiffEnabledLines
+  def enabled_line?(line_number)
+    super(line_number) &&
+      (RuboCopDiff.changed_lines[@processed_source.path] || []).include?(line_number)
+  end
+end
+
+module DiffTargetFinder
+  def find(args)
+    super(args).select { |f| RuboCopDiff.changed_lines.keys.include? f }
+  end
+end
+
+RuboCop::Cop::Cop.prepend DiffEnabledLines
+RuboCop::TargetFinder.prepend DiffTargetFinder


### PR DESCRIPTION
Makes Jenkins run Rubocop against the hunks changed within a branch, and fails the build if a change introduces Rubocop offenses.

Uses some pretty gnarly monkey-patching of Rubocop itself to achieve this. Advice on cleaner ways to achieve this are welcome.

Example failing build: https://ci-new.alphagov.co.uk/job/govuk_whitehall_branches/6013/console
Generated from: https://github.com/alphagov/whitehall/commit/b69f18253d4e26b86f1419c571a6317e659127a3