### PR TITLE
When unpublishing, republish the draft edition to draft stack

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -8,6 +8,12 @@ class PublishingApiWorker < WorkerBase
 
     I18n.with_locale(locale) do
       send_item(presenter.base_path, presenter.as_json)
+
+      if model.is_a?(::Unpublishing)
+        # Unpublishings will be mirrored to the draft content-store, but we want
+        # it to have the now-current draft edition
+        publish_draft_edition_to_draft_stack(model)
+      end
     end
   end
 
@@ -19,5 +25,11 @@ class PublishingApiWorker < WorkerBase
 
   def send_item(base_path, content)
     Whitehall.publishing_api_client.put_content_item(base_path, content)
+  end
+
+  def publish_draft_edition_to_draft_stack(unpublishing)
+    if draft = unpublishing.edition
+      Whitehall::PublishingApi.publish_draft_async(draft)
+    end
   end
 end

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -42,6 +42,15 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_publishing_api_put_item(path, format: 'unpublishing')
   end
 
+  test 'When a case study is unpublished, a job is queued to republish the draft to the draft stack' do
+    path = Whitehall.url_maker.public_document_path(@published_edition)
+    stub_panopticon_registration(@published_edition)
+
+    Whitehall::PublishingApi.expects(:publish_draft_async).once
+
+    unpublish(@published_edition, unpublishing_params)
+  end
+
   test 'When an edition that is not a case study is unpublished, no "unpublishing" is sent to the Publishing API' do
     detailed_guide = create(:published_detailed_guide)
     path = Whitehall.url_maker.public_document_path(detailed_guide)

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -5,6 +5,10 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     # Disable any predefined webmock stubs, we want a clean slate
     # TODO: investigate removing stubbing of publishing api calls from standard test setup
     WebMock.reset!
+
+    # In the case of unpublishings, we trigger a job to republish the draft
+    # edition. That job runs inline because we're in test mode, so we need to stub it.
+    stub_default_publishing_api_put_draft
   end
 
   test "#publish publishes an Edition with the Publishing API" do


### PR DESCRIPTION
We want the draft stack to have the current draft documents. Unpublishing an
edition changes the state of that edition to "draft" and sends an "unpublishing"
content item to publishing-api. Because publishing-api mirrors changes to live
to draft, this means that draft stack has the unpublishing, but we want it to
have the draft edition. Therefore, we need to explicitly republish the draft to
the draft stack.