### PR TITLE
Add LiveEnvironmentPopulator

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -3,4 +3,9 @@ namespace :publishing_api do
   task :populate_draft_environment => :environment do
     Whitehall::PublishingApi::DraftEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
   end
+
+  desc "export all published whitehall content to live environment of publishing api"
+  task :populate_live_environment => :environment do
+    Whitehall::PublishingApi::LiveEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+  end
 end

--- a/lib/whitehall/publishing_api/live_environment_populator.rb
+++ b/lib/whitehall/publishing_api/live_environment_populator.rb
@@ -1,6 +1,6 @@
 module Whitehall
   class PublishingApi
-    class DraftEnvironmentPopulator < Populator
+    class LiveEnvironmentPopulator < Populator
       def initialize(logger: )
         super(
           items: self.class.default_items,
@@ -10,13 +10,13 @@ module Whitehall
       end
 
       def self.send_to_publishing_api(item)
-        update_type = 'bulk_draft_update'
+        update_type = 'bulk_update'
         queue_name = 'bulk_republishing'
-        PublishingApi.publish_draft_async(item, update_type, queue_name)
+        PublishingApi.publish_async(item, update_type, queue_name)
       end
 
       def self.edition_scope
-        Edition.latest_edition
+        Edition.latest_published_edition
       end
     end
   end

--- a/lib/whitehall/publishing_api/populator.rb
+++ b/lib/whitehall/publishing_api/populator.rb
@@ -1,0 +1,66 @@
+module Whitehall
+  class PublishingApi
+    class Populator
+      attr_reader :items, :logger, :sender
+
+      def initialize(items:, sender:, logger: Logger.new(nil))
+        @logger = logger
+        @progress_logger = ProgressLogger.new(logger)
+        @items = items
+        @sender = sender
+      end
+
+      def call
+        items.each do |item|
+          @progress_logger.log(item)
+          sender.call(item)
+        end
+
+        logger.info "Finished."
+      end
+
+      def self.default_items
+        Enumerator.new do |yielder|
+          edition_scope.find_each do |edition|
+            yielder << edition
+          end
+
+          [
+            MinisterialRole,
+            Organisation,
+            Person,
+            WorldLocation,
+            WorldwideOrganisation
+          ].each do |klass|
+            klass.find_each do |item|
+              yielder << item
+            end
+          end
+        end
+      end
+
+    private
+      class ProgressLogger
+        attr_reader :logger
+
+        def initialize(logger)
+          @logger = logger
+          @i = 0
+          @type = nil
+        end
+
+        def log(item)
+          if @type != item.class
+            logger.info "Exporting items of class '#{item.class.name}'..."
+            @type = item.class
+          end
+
+          @i += 1
+          if @i % 1000 == 0
+            logger.info "done #{@i}..."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/whitehall/publishing_api/populator.rb
+++ b/lib/whitehall/publishing_api/populator.rb
@@ -19,6 +19,10 @@ module Whitehall
         logger.info "Finished."
       end
 
+      def self.edition_scope
+        raise "abstract method not implemented"
+      end
+
       def self.default_items
         Enumerator.new do |yielder|
           edition_scope.find_each do |edition|

--- a/test/unit/whitehall/publishing_api/live_environment_populator_test.rb
+++ b/test/unit/whitehall/publishing_api/live_environment_populator_test.rb
@@ -1,0 +1,44 @@
+require 'whitehall/publishing_api'
+
+module Whitehall
+  class PublishingApi
+    class LiveEnvironmentPopulatorTest < ActiveSupport::TestCase
+      test "default instance uses the default items and #send_to_publishing_api as sender" do
+        logger = stub("logger", info: nil)
+        items = [stub("item")]
+        LiveEnvironmentPopulator.stubs(:default_items).returns(items)
+        LiveEnvironmentPopulator.expects(:send_to_publishing_api).with(items.first)
+
+        LiveEnvironmentPopulator.new(logger: logger).call
+      end
+
+      test ".send_to_publishing_api calls publish_async with the item" do
+        item = stub("item")
+        PublishingApi.expects(:publish_async).with(item, 'bulk_update', 'bulk_republishing')
+        LiveEnvironmentPopulator.send_to_publishing_api(item)
+      end
+
+      test "default_items defaults to an enumeration of all published items which can be sent to publishing api" do
+        organisation = create(:organisation)
+
+        expected_values = [
+          create(:published_edition),
+          create(:ministerial_role, organisations: [organisation]),
+          organisation,
+          create(:person),
+          create(:world_location),
+          create(:worldwide_organisation)
+        ]
+
+        assert_equal expected_values, LiveEnvironmentPopulator.default_items.to_a
+      end
+
+      test "default_items has only the published edition of a document" do
+        published_edition = create(:published_edition)
+        latest_edition = create(:draft_edition, document: published_edition.document)
+
+        assert_equal [published_edition], LiveEnvironmentPopulator.default_items.to_a
+      end
+    end
+  end
+end

--- a/test/unit/whitehall/publishing_api/populator_test.rb
+++ b/test/unit/whitehall/publishing_api/populator_test.rb
@@ -1,0 +1,26 @@
+require 'whitehall/publishing_api'
+
+module Whitehall
+  class PublishingApi
+    class PopulatorTest < ActiveSupport::TestCase
+
+      test "calls the sender for each item" do
+        items = [stub("edition")]
+        sender = stub("sender")
+        sender.expects(:call).with(items.first)
+        Populator.new(items: items, sender: sender).call
+      end
+
+      test "logs each 1000 items" do
+        items = (1..1001).to_a + ["a string"]
+        logger = stub("logger")
+        logger.expects(:info).with("Exporting items of class 'Fixnum'...")
+        logger.expects(:info).with("done 1000...")
+        logger.expects(:info).with("Exporting items of class 'String'...")
+        logger.expects(:info).with("Finished.")
+
+        Populator.new(items: items, sender: ->(_) {}, logger: logger).call
+      end
+    end
+  end
+end


### PR DESCRIPTION
pulled out a general purpose `Populator` class which takes the list of
items and a sender function as constructor arguments.

The `Draft` and `Live` populators use this.

Possibly this is over-complicated, but it seems to work at least. Feedback welcome.