### PR TITLE
Remove access_limited checkbox for case studies.

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -133,7 +133,8 @@ module Admin::EditionsHelper
       concat render(partial: "standard_fields",
                     locals: { form: form, edition: edition })
       yield(form)
-      concat render('access_limiting_fields', form: form, edition: edition)
+      concat render('access_limiting_fields',
+                    form: form, edition: edition) if edition.can_be_access_limited?
       concat render(partial: "scheduled_publication_fields",
                     locals: { form: form, edition: edition })
       concat standard_edition_publishing_controls(form, edition)

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -26,4 +26,8 @@ class CaseStudy < Edition
   def translatable?
     !non_english_edition?
   end
+
+  def can_be_access_limited?
+    false
+  end
 end

--- a/app/models/edition/limited_access.rb
+++ b/app/models/edition/limited_access.rb
@@ -62,4 +62,8 @@ module Edition::LimitedAccess
       self.access_limited = self.access_limited_by_default?
     end
   end
+
+  def can_be_access_limited?
+    true
+  end
 end

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -19,4 +19,12 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_association_with_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
   should_allow_association_with_worldwide_priorities :case_study
+
+  view_test "should not display access limited field" do
+    get :new
+
+    assert_select "form#new_edition" do
+      assert_select "input[name='edition[access_limited]']", false
+    end
+  end
 end

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -29,6 +29,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "form#new_edition" do
       assert_select "select[name*='edition[first_published_at']", count: 5
       assert_select "select[name='edition[publication_type_id]']"
+      assert_select "input[name='edition[access_limited]']"
     end
   end
 


### PR DESCRIPTION
The draft stack does not currently support access limiting. Since this feature is seldom used for case studies, the decision was made to remove it to allow the migration to draft.