### PR TITLE
Ensure correct role model class is instantiated

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -52,7 +52,11 @@ class Admin::RolesController < Admin::BaseController
       :name, :role_type, :whip_organisation_id, :role_payment_type_id,
       :attends_cabinet_type_id, :responsibilities,
       organisation_ids: [],
-      worldwide_organisation_ids: []
-    )
+      worldwide_organisation_ids: [],
+    ).merge(type: sti_type)
+  end
+
+  def sti_type
+    RoleTypePresenter.role_attributes_from(params[:role][:role_type])[:type]
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -85,7 +85,6 @@ class Role < ActiveRecord::Base
     @role_type = role_type
     unless role_type.blank?
       role_attributes = RoleTypePresenter.role_attributes_from(role_type)
-      self.type = role_attributes[:type]
       self.attributes = role_attributes.except(:type)
     end
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -82,7 +82,6 @@ class Role < ActiveRecord::Base
   end
 
   def role_type=(role_type)
-    @role_type = role_type
     unless role_type.blank?
       role_attributes = RoleTypePresenter.role_attributes_from(role_type)
       self.attributes = role_attributes.except(:type)

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -174,7 +174,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
     end
   end
 
-  test "create should create a new ministerial role" do
+  test "create should create a new ministerial role with a content_id" do
     org_one, org_two = create(:organisation), create(:organisation)
 
     post :create, role: attributes_for(:ministerial_role,
@@ -186,6 +186,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
     assert role = MinisterialRole.last
     assert_equal "role-name", role.name
     assert_equal [org_one, org_two], role.organisations
+    refute_nil role.content_id
   end
 
   test "create should create a new board level manager role" do


### PR DESCRIPTION
This fixes a bug that causes ministerial roles to be created without a `content_id`, which makes it impossible to edit them (they fail validation).

There is model-specific code on the `MinisterialRole` class to generate `content_ids`  and push them to the Publishing API. Because of the way that the STI type column was being inferred and set from within the instance (with `the role_type=` setter) rather than at the point it was instantiated[1], ministerial roles were being created as base `Role` instances, which results in the publishing API code being skipped.

[1] If you call `Role.new(type: 'MinisterialRole')`, you get an instance of `MinisterialRole` back. If you set type after the fact on a `Role` instance, it remains (and behaves like) an instance of `Role` until it has been saved and reloaded from the database.

Trello: https://trello.com/c/7Ix2G9qw/189-bug-you-can-t-make-changes-to-newly-created-roles