### PR TITLE
Only show open ministerial orgs on ministers index

### DIFF
--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -35,6 +35,7 @@ private
 
   def ministers_by_organisation
     Organisation.ministerial_departments.
+                 excluding_govuk_status_closed.
                  with_translations.
                  with_translations_for(:ministerial_roles).
                  includes(ministerial_roles: [:current_people]).

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -59,6 +59,23 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     assert_equal expected_results, assigns(:ministers_by_organisation)
   end
 
+  test "doesn't list closed organisations in the ministers by organisation list" do
+    organisation_1 = create(:ministerial_department)
+    person_1 = create(:person, forename: 'Tony', surname: 'Blair')
+    role_1 = create(:ministerial_role, name: 'Prime Minister', cabinet_member: true, organisations: [organisation_1], seniority: 0)
+    appointment_1 = create(:ministerial_role_appointment, role: role_1, person: person_1)
+
+    organisation_2 = create(:ministerial_department, :closed)
+    person_2 = create(:person, forename: 'Frank', surname: 'Underwood')
+    role_2 = create(:ministerial_role, name: 'President', cabinet_member: true, organisations: [organisation_2], seniority: 0)
+    appointment = create(:ministerial_role_appointment, role: role_2, person: person_2)
+
+    get :index
+
+    expected_results = [[organisation_1, RolesPresenter.new([role_1], @controller.view_context)]]
+    assert_equal expected_results, assigns(:ministers_by_organisation)
+  end
+
   test "shows ministers who also attend cabinet separately" do
     organisation = create(:ministerial_department)
     person_1 = create(:person, forename: 'Nick', surname: 'Clegg')


### PR DESCRIPTION
If an organisation is closed we no longer want it to be listed in the
list of organisations on the ministers index page.