### PR TITLE
Prepare for feature flag switchover

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -311,8 +311,4 @@ module Admin::EditionsHelper
   def show_similar_slugs_warning?(edition)
     !edition.document.published? && edition.document.similar_slug_exists?
   end
-
-  def future_policies_enabled?
-    ENV["ENABLE_FUTURE_POLICIES"]
-  end
 end

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -1,5 +1,9 @@
 module PolicyHelper
   def array_of_links_to_policies(policies)
-    policies.map { |policy| link_to policy.title, public_document_path(policy), class: 'policy-link' }
+    policies.map { |policy| link_to policy.title, future_policy_path(policy), class: 'policy-link' }
+  end
+
+  def future_policy_path(policy)
+    policy.is_a?(Future::Policy) ? policy.base_path : public_document_path(policy)
   end
 end

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -28,6 +28,8 @@ module PublicDocumentRoutesHelper
       build_url_for_corporate_information_page(edition, options)
     when SupportingPage
       build_url_for_supporting_page(edition, options)
+    when Future::Policy
+      edition.base_path
     else
       path_name = if edition.is_a?(Publication) && edition.statistics?
                     "statistic"

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -28,8 +28,6 @@ module PublicDocumentRoutesHelper
       build_url_for_corporate_information_page(edition, options)
     when SupportingPage
       build_url_for_supporting_page(edition, options)
-    when Future::Policy
-      edition.base_path
     else
       path_name = if edition.is_a?(Publication) && edition.statistics?
                     "statistic"

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -45,7 +45,7 @@ module Edition::RelatedPolicies
   end
 
   def published_related_policies
-    if ENV["ENABLE_FUTURE_POLICIES"]
+    if Whitehall.future_policies_enabled?
       policies
     else
       super
@@ -53,7 +53,7 @@ module Edition::RelatedPolicies
   end
 
   def related_policies
-    if ENV["ENABLE_FUTURE_POLICIES"]
+    if Whitehall.future_policies_enabled?
       policies
     else
       super

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -44,6 +44,14 @@ module Edition::RelatedPolicies
     Future::Policy.from_content_ids(policy_content_ids)
   end
 
+  def published_related_policies
+    if ENV["ENABLE_FUTURE_POLICIES"]
+      policies
+    else
+      super
+    end
+  end
+
   def search_index
     super.merge(policies: policies.map(&:slug))
   end

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -52,6 +52,14 @@ module Edition::RelatedPolicies
     end
   end
 
+  def related_policies
+    if ENV["ENABLE_FUTURE_POLICIES"]
+      policies
+    else
+      super
+    end
+  end
+
   def search_index
     super.merge(policies: policies.map(&:slug))
   end

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -23,14 +23,6 @@ module Future
       end.compact
     end
 
-    def non_english_edition?
-      false
-    end
-
-    def translatable?
-      false
-    end
-
   private
     def extract_slug
       base_path.split('/').last

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -23,6 +23,14 @@ module Future
       end.compact
     end
 
+    def non_english_edition?
+      false
+    end
+
+    def translatable?
+      false
+    end
+
   private
     def extract_slug
       base_path.split('/').last

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -23,6 +23,10 @@ module Future
       end.compact
     end
 
+    def topics
+      []
+    end
+
   private
     def extract_slug
       base_path.split('/').last

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,13 +1,3 @@
-<fieldset>
-  <%= form.label :related_policy_ids, 'Related policies' %>
-  <%= form.select :related_policy_ids,
-                  options_for_select(taggable_policies_container, edition.related_policy_ids),
-                  { include_blank: true },
-                  multiple: true,
-                  class: 'chzn-select',
-                  data: { placeholder: "Choose related policies..."} %>
-</fieldset>
-
 <% if future_policies_enabled? %>
   <fieldset>
     <%= form.label :policy_content_ids, "Policies" %>
@@ -17,8 +7,15 @@
                     multiple: true,
                     class: 'chzn-select',
                     data: { placeholder: "Choose policies..."} %>
-    <p class="help-block"><em>
-      Note: This new policy field is experimental. Please do not use it unless requested.
-    </em></p>
+  </fieldset>
+<% else %>
+  <fieldset>
+    <%= form.label :related_policy_ids, 'Related policies' %>
+    <%= form.select :related_policy_ids,
+                    options_for_select(taggable_policies_container, edition.related_policy_ids),
+                    { include_blank: true },
+                    multiple: true,
+                    class: 'chzn-select',
+                    data: { placeholder: "Choose related policies..."} %>
   </fieldset>
 <% end %>

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,4 +1,4 @@
-<% if future_policies_enabled? %>
+<% if Whitehall.future_policies_enabled? %>
   <fieldset>
     <%= form.label :policy_content_ids, "Policies" %>
     <%= form.select :policy_content_ids,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,9 +54,6 @@ Whitehall::Application.configure do
   # them here means we don't have to explicitly set them just ro run tests.
   ENV['GOVUK_APP_DOMAIN'] ||= 'test.alphagov.co.uk'
   ENV['GOVUK_ASSET_ROOT'] ||= 'http://static.test.alphagov.co.uk'
-
-  # Turn on temporary feature-flag for future-policies feature during tests
-  ENV['ENABLE_FUTURE_POLICIES'] = 'true'
 end
 
 require Rails.root.join("test/support/skip_slimmer")

--- a/config/initializers/future_policies_feature_flag.rb
+++ b/config/initializers/future_policies_feature_flag.rb
@@ -1,0 +1,1 @@
+Whitehall.future_policies_enabled = !!ENV["ENABLE_FUTURE_POLICIES"]

--- a/features/admin-policy-tagging.feature
+++ b/features/admin-policy-tagging.feature
@@ -7,6 +7,7 @@ Feature: Tagging content with policies
   are created and managed in policy-publisher and stored in the content store.
   These policies will eventually replace the Policy format here in whitehall.
 
+  @future-policies
   Scenario: a writer can tag a document to a policy
     Given I am a writer
     When I start editing a draft document

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -87,7 +87,6 @@ module DocumentHelper
     policy = create(:policy)
     begin_drafting_document type: 'publication', title: title, summary: "Some summary of the content", alternative_format_provider: create(:alternative_format_provider)
     fill_in_publication_fields(options)
-    select policy.title, from: "Related policies"
   end
 
   def begin_drafting_statistical_data_set(options)

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,7 +1,7 @@
 # Turn on temporary feature-flag for future-policies feature during selected tests
 Around("@future-policies") do |scenario, block|
-  current_future_policy_env = ENV['ENABLE_FUTURE_POLICIES']
-  ENV['ENABLE_FUTURE_POLICIES'] = "true"
+  future_policies_setting = Whitehall.future_policies_enabled
+  Whitehall.future_policies_enabled = true
   block.call
-  ENV['ENABLE_FUTURE_POLICIES'] = current_future_policy_env
+  Whitehall.future_policies_enabled = future_policies_setting
 end

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,0 +1,7 @@
+# Turn on temporary feature-flag for future-policies feature during selected tests
+Around("@future-policies") do |scenario, block|
+  current_future_policy_env = ENV['ENABLE_FUTURE_POLICIES']
+  ENV['ENABLE_FUTURE_POLICIES'] = "true"
+  block.call
+  ENV['ENABLE_FUTURE_POLICIES'] = current_future_policy_env
+end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -24,6 +24,11 @@ module Whitehall
   mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
   mattr_accessor :case_study_publishing_api_rendering_app
+  mattr_accessor :future_policies_enabled
+
+  def self.future_policies_enabled?
+    future_policies_enabled
+  end
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -171,6 +171,19 @@ module DocumentControllerTestHelpers
         get :show, id: edition.document
         refute_select "#related-policies"
       end
+
+      view_test "should render related future policies on #{document_type} pages" do
+        future_policies_setting = Whitehall.future_policies_enabled?
+        Whitehall.future_policies_enabled = true
+
+        begin
+          edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
+          get :show, id: edition.document
+          assert_select ".meta a", text: policy_1["title"]
+        ensure
+          Whitehall.future_policies_enabled = future_policies_setting
+        end
+      end
     end
 
     def should_show_related_policies_and_topics_for(document_type)

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -124,16 +124,16 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     edition.save
     edition.reload
 
-    future_policies_setting = ENV["ENABLE_FUTURE_POLICIES"]
+    future_policies_setting = Whitehall.future_policies_enabled
 
-    ENV["ENABLE_FUTURE_POLICIES"] = nil
+    Whitehall.future_policies_enabled = false
     assert_equal 1, edition.published_related_policies.count
     assert_equal old_world_policy, edition.published_related_policies.first
 
-    ENV["ENABLE_FUTURE_POLICIES"] = "true"
+    Whitehall.future_policies_enabled = true
     assert_equal 1, edition.published_related_policies.count
     assert edition.published_related_policies.first.is_a?(Future::Policy)
 
-    ENV["ENABLE_FUTURE_POLICIES"] = future_policies_setting
+    Whitehall.future_policies_enabled = future_policies_setting
   end
 end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -114,4 +114,26 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
 
     assert_equal [content_id], new_edition.policy_content_ids
   end
+
+  test "#published_related_policies returns future policies if set" do
+    old_world_policy = create(:published_policy)
+    edition = create(:published_news_article, related_documents: [old_world_policy.document])
+
+    stub_content_register_policies
+    edition.policy_content_ids = [policy_1["content_id"]]
+    edition.save
+    edition.reload
+
+    future_policies_setting = ENV["ENABLE_FUTURE_POLICIES"]
+
+    ENV["ENABLE_FUTURE_POLICIES"] = nil
+    assert_equal 1, edition.published_related_policies.count
+    assert_equal old_world_policy, edition.published_related_policies.first
+
+    ENV["ENABLE_FUTURE_POLICIES"] = "true"
+    assert_equal 1, edition.published_related_policies.count
+    assert edition.published_related_policies.first.is_a?(Future::Policy)
+
+    ENV["ENABLE_FUTURE_POLICIES"] = future_policies_setting
+  end
 end


### PR DESCRIPTION
This switches the display of future vs old world policies in both admin and document metadata based on the ENABLE_FUTURE_POLICIES environment variable.  It also ensures case studies send the correct one to the content store based on this flag ahead of our republish of them.

https://trello.com/c/z77aXgss/187-prepare-whitehall-for-feature-flag-based-switchover

Admin, flag off (default):
![screenshot 2015-04-17 13 19 52](https://cloud.githubusercontent.com/assets/109225/7205902/9f198054-e524-11e4-83de-9b00e2e21fe0.png)

Admin, flag on:
![screenshot 2015-04-17 16 01 04](https://cloud.githubusercontent.com/assets/109225/7205907/aa5f6226-e524-11e4-92e5-2426c3cdae7a.png)

Frontend, flag off (default):
![screenshot 2015-04-17 17 01 55](https://cloud.githubusercontent.com/assets/109225/7205912/b31f917e-e524-11e4-9955-f96281236405.png)

Frontend, flag on:
![screenshot 2015-04-17 17 02 04](https://cloud.githubusercontent.com/assets/109225/7205916/b948eaf0-e524-11e4-9833-b527d2d631ed.png)
