### PR TITLE
Allow setting host for previewing case studies

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -43,11 +43,11 @@ module PublicDocumentRoutesHelper
   end
 
   def preview_document_url(edition, options = {})
-    query = {
-      preview: edition.latest_edition.id,
-      cachebust: Time.zone.now.getutc.to_i
-    }
-    document_url(edition, options.merge(query))
+    case_study_preview_host = edition.is_a?(CaseStudy) && Whitehall.case_study_preview_host
+    options.merge!(host: case_study_preview_host || request.host)
+    options.merge!(preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i)
+
+    document_url(edition, options)
   end
 
   private

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -6,7 +6,7 @@
                 button_text: 'Preview on website',
                 links: translation_preview_links(@edition) %>
   <% else %>
-    <%= link_to "Preview on website", preview_document_path(@edition), class: 'btn btn-large btn-primary preview_version', target: '_blank' %>
+    <%= link_to "Preview on website", preview_document_url(@edition), class: 'btn btn-large btn-primary preview_version', target: '_blank' %>
   <% end %>
 
   <% if @edition.editable? %>

--- a/config/initializers/case_study_preview_host.rb
+++ b/config/initializers/case_study_preview_host.rb
@@ -1,0 +1,4 @@
+# This file is overwritten on deploy.
+# Set to `nil` to use request.host.
+#
+Whitehall.case_study_preview_host = nil

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -24,6 +24,7 @@ module Whitehall
   mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
   mattr_accessor :case_study_publishing_api_rendering_app
+  mattr_accessor :case_study_preview_host
   mattr_accessor :future_policies_enabled
 
   def self.future_policies_enabled?


### PR DESCRIPTION
https://trello.com/c/5M2VTPv6

when previewing case studies, content designers should
be sent to the government-frontend of the draft stack.

this is feature flagged so that we enable it in production
only when we're comfortable that government-frontend works
as expected.

[related alphagov-deployment change](https://github.gds/gds/alphagov-deployment/pull/884)