### PR TITLE
Remove policies from /get-involved

### DIFF
--- a/app/assets/stylesheets/frontend/views/_get-involved.scss
+++ b/app/assets/stylesheets/frontend/views/_get-involved.scss
@@ -13,7 +13,7 @@
         margin-bottom: $gutter-half;
       }
     }
-    &#elsewhere-on-the-web, &#related-polices {
+    &#elsewhere-on-the-web {
       margin-top: $gutter*1.5;
     }
   }
@@ -222,17 +222,10 @@
         }
       }
 
-      &.policies {
-        .head-section .content {
-          padding-top: $gutter-one-third;
-        }
-      }
-
       .see-all {
         font-weight: bold;
         margin: $gutter-one-third 0 $gutter;
       }
-    
     }
 
     .article-clear {

--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -423,24 +423,6 @@
     border-width: 0 0 1px;
   }
 
-  .get-involved {
-    p {
-      clear: both;
-      @include media(tablet) {
-        padding: 0 $gutter-half;
-      }
-    }
-    @include media(tablet) {
-      padding-bottom: $gutter;
-      h3 {
-        padding: 0 $gutter-half;
-      }
-    }
-    .one-third p {
-      padding: 0;
-    }
-  }
-
   @media (min-width: 640px) and (max-width: 900px) {
     .prime-minister,
     .history {

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: 'shared/heading',
               locals: { big: true,
                         heading: "Get involved" } %>
-    <p class="intro-paragraph">Find out how you can <a href="#engage-with-government">engage with government</a> directly, and <a href="#take-part">take&nbsp;part</a> locally, nationally or internationally. You can also <a href="#related-polices">read&nbsp;policies</a> about how government is increasing participation.</p>
+    <p class="intro-paragraph">Find out how you can <a href="#engage-with-government">engage with government</a> directly, and <a href="#take-part">take&nbsp;part</a> locally, nationally or internationally.</p>
   </div>
 </header>
 
@@ -150,81 +150,6 @@
             <li><a href="/donating-to-charity">Make a donation to charity</a></li>
             <li><a href="http://schoolsonline.britishcouncil.org/programmes-and-funding/linking-programmes-worldwide/connecting-classrooms" rel="external">Link up with a school overseas </a></li>
           </ul>
-        </div>
-      </div>
-    </section>
-  </div>
-</div>
-
-<div class="block">
-  <div class="inner-block floated-children">
-    <section class="policies">
-      <h2 id="related-polices">Related policies</h2>
-      <div class="head-section">
-        <div class="content">
-          <p>The government wants to make it easier for people to be involved in decision&ndash;making. To find out what this means for you, take a look at the policies featured here:</p>
-        </div>
-      </div>
-      <div class="column">
-        <div class="content">
-          <ol class="document-list">
-            <li class="document-row">
-              <h3><a href="/government/policies/making-it-easier-to-set-up-and-run-a-charity-social-enterprise-or-voluntary-organisation">Making it easier to set up and run a charity, social enterprise, or voluntary organisation</a></h3>
-              <ul class="attributes">
-                <li>Cabinet Office</li>
-                <li>Community and society</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/improving-the-transparency-and-accountability-of-government-and-its-services">Improving the transparency and accountability of government and its services</a></h3>
-              <ul class="attributes">
-                <li>Cabinet Office and Efficiency and Reform Group</li>
-                <li>Government efficiency, transparency and accountability</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/increasing-the-number-of-academies-and-free-schools-to-create-a-better-and-more-diverse-school-system">Increasing the number of academies and free schools to create a better and more diverse school system</a></h3>
-              <ul class="attributes">
-                <li>Department for Education</li>
-                <li>Schools</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/promoting-social-action-encouraging-and-enabling-people-to-play-a-more-active-part-in-society/supporting-pages/national-citizen-service">Promoting social action: encouraging and enabling people to play a more active part in society</a></h3>
-              <ul class="attributes">
-                <li>Cabinet Office</li>
-                <li>Community and society</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/transforming-government-services-to-make-them-more-efficient-and-effective-for-users/supporting-pages/increasing-the-quality-of-public-services-with-commercial-models-and-public-service-mutuals">Transforming government services to make them more efficient and effective for users</a></h3>
-              <ul class="attributes">
-                <li>Cabinet Office and Efficiency and Reform Group</li>
-                <li>Government efficiency, transparency and accountability</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/giving-people-more-power-over-what-happens-in-their-neighbourhood">Giving people more power over what happens in their neighbourhood</a></h3>
-              <ul class="attributes">
-                <li>DCLG</li>
-                <li>Community and society</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/giving-communities-more-power-in-planning-local-development">Giving communities more power in planning local development</a></h3>
-              <ul class="attributes">
-                <li>DCLG</li>
-                <li>Planning and building</li>
-              </ul>
-            </li>
-            <li class="document-row">
-              <h3><a href="/government/policies/promoting-social-action-encouraging-and-enabling-people-to-play-a-more-active-part-in-society">Promoting social action: encouraging and enabling people to play a more active part in society</a></h3>
-              <ul class="attributes">
-                <li>CO</li>
-                <li>Community and society</li>
-              </ul>
-            </li>
-          </ol>
         </div>
       </div>
     </section>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -220,7 +220,18 @@
       <hr class="keyline">
 
       <div class="thirds-width-section get-involved">
-        <h3>Get involved</h3>
+        <div class="one-third">
+          <div class="inner-block">
+            <h3>Get involved</h3>
+          </div>
+        </div>
+
+        <div class="two-thirds">
+          <div class="inner-block">
+            <p>Read about ways to <a href="/government/get-involved/">get involved</a>.</p>
+          </div>
+        </div>
+
         <div class="one-third">
           <div class="inner-block">
             <h4>Engage with government</h4>
@@ -234,14 +245,6 @@
             <p><a href="/government/get-involved/#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
-
-        <div class="one-third">
-          <div class="inner-block">
-            <h4>Related policies</h4>
-            <p>You can also <a href="/government/get-involved/#related-polices">read policies</a> about how government is increasing participation.</p>
-          </div>
-        </div>
-        <p>Read about ways to <a href="/government/get-involved/">get involved</a>.</p>
       </div>
 
       <hr class="keyline">


### PR DESCRIPTION
These were hard-coded, likely to break or become inaccurate
as changes are made to policy titles/slugs.

For users interested in policy, it's still surfaced in
the header nav.

https://trello.com/c/TlRMcKWX/192-remove-policies-from-get-involved-page

- Policies section removed
- Updated lead paragraph (vs [live](https://www.gov.uk/government/get-involved))
![screenshot 2015-04-21 11 29 28](https://cloud.githubusercontent.com/assets/63201/7250384/c89eab82-e819-11e4-92e0-9fed781fc543.png)

- [x] Technical review
- [x] Product review