### PR TITLE
Supply public_updated_at for coming soon

### DIFF
--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -29,7 +29,9 @@ class PublishingApiPresenters::ComingSoon
       locale: locale,
       update_type: 'major',
       details: { publish_time: edition.scheduled_publication.as_json },
-      routes: [ { path: base_path, type: "exact" } ]
+      routes: [ { path: base_path, type: "exact" } ],
+      # We don't store when the coming_soon was created, so use the last time the record was updated
+      public_updated_at: edition.updated_at,
     }
   end
 

--- a/db/data_migration/20150424094040_republish_coming_soon.rb
+++ b/db/data_migration/20150424094040_republish_coming_soon.rb
@@ -1,0 +1,7 @@
+Edition.scheduled.each do |edition|
+  unless edition.document.published?
+    edition.translated_locales.each do |locale|
+      PublishingApiComingSoonWorker.perform_async(edition.id, locale)
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -19,7 +19,8 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
       locale: locale,
       update_type: 'major',
       details: { publish_time: publish_timestamp },
-      routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ]
+      routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ],
+      public_updated_at: edition.updated_at,
     }
 
     presenter = PublishingApiPresenters::ComingSoon.new(edition, locale)

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -19,7 +19,8 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       locale: locale,
       update_type: 'major',
       details: { publish_time: publish_time },
-      routes: [ { path: base_path, type: 'exact' } ]
+      routes: [ { path: base_path, type: 'exact' } ],
+      public_updated_at: edition.updated_at,
     }
 
     expected_request = stub_publishing_api_put_item(base_path, expected_payload)


### PR DESCRIPTION
If we want to make public_updated_at mandatory for everything, we need this
change.