### PR TITLE
Migrate old policy taggings to new

### DIFF
--- a/db/data_migration/20150422112600_merge_old_policies.rb
+++ b/db/data_migration/20150422112600_merge_old_policies.rb
@@ -1,0 +1,12 @@
+SLUG_TO_CONTENT_ID_MAPPING = {
+  "helping-government-departments-improve-their-efficiency-and-performance-to-save-the-taxpayer-money" => "5d2b59a2-7631-11e4-a3cb-005056011aef",
+  "making-it-easier-to-trade" => "5c7657ab-7631-11e4-a3cb-005056011aef",
+  "improving-the-uks-ability-to-absorb-respond-to-and-recover-from-emergencies" => "5c768de5-7631-11e4-a3cb-005056011aef",
+}
+
+SLUG_TO_CONTENT_ID_MAPPING.each do |slug, content_id|
+  document = Document.at_slug(Policy, slug)
+  other_document = Document.find_by(content_id: content_id)
+  puts "\tmerging '#{document.published_edition.title}' into '#{other_document.published_edition.title}'  (setting content_id to '#{content_id}')"
+  document.update_column(:content_id, content_id)
+end

--- a/lib/data_hygiene/future_policy_tagging_migrator.rb
+++ b/lib/data_hygiene/future_policy_tagging_migrator.rb
@@ -1,3 +1,9 @@
+# Used during the election period of 2015 to migrate the policy taggings on
+# editions such that they map to the new policies being managed by
+# policy-publisher.
+#
+# Note: Can be removed after the migration to new policies has been complete.
+#
 module DataHygiene
   class FuturePolicyTaggingMigrator
     def initialize(scope, logger=NullLogger.instance)

--- a/lib/data_hygiene/future_policy_tagging_migrator.rb
+++ b/lib/data_hygiene/future_policy_tagging_migrator.rb
@@ -1,0 +1,26 @@
+module DataHygiene
+  class FuturePolicyTaggingMigrator
+    def initialize(scope, logger=NullLogger.instance)
+      @scope = scope
+      @logger = logger
+    end
+
+    def migrate!
+      logger.info "Migrating #{scope.count} editions "
+
+      scope.find_each do |edition|
+        tag_to_new_policies(edition)
+        logger << '.'
+      end
+
+      logger.info "Migration complete"
+    end
+
+  private
+    attr_accessor :logger, :scope
+
+    def tag_to_new_policies(edition)
+      edition.policy_content_ids = edition.related_policies.map(&:content_id)
+    end
+  end
+end

--- a/lib/data_hygiene/future_policy_tagging_migrator.rb
+++ b/lib/data_hygiene/future_policy_tagging_migrator.rb
@@ -26,7 +26,11 @@ module DataHygiene
     attr_accessor :logger, :scope
 
     def tag_to_new_policies(edition)
-      edition.policy_content_ids = edition.related_policies.map(&:content_id)
+      # Cannot use the #related_policies method directly because it either
+      # returns new policies or old depending on the state of the feature-flag
+      # see the Edition::RelatedPolicies module.
+      content_ids = edition.related_policy_ids.map {|id| Edition.find(id).content_id }
+      edition.policy_content_ids = content_ids
     end
   end
 end

--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -5,4 +5,26 @@ namespace :election do
 
     DataHygiene::PublishingApiRepublisher.new(CaseStudy.published).perform
   end
+
+  desc "Creates the associations between all editions and new/future policies, based on their existing policy relations"
+  task :migrate_old_policy_taggings_to_new => :environment do
+    require 'data_hygiene/future_policy_tagging_migrator'
+
+    edition_scope = Edition.
+                      where(type: policy_taggable_edition_classes).
+                      where(state: editable_edition_states).
+                      includes(related_policies: :related_documents)
+
+    DataHygiene::FuturePolicyTaggingMigrator.new(edition_scope, Logger.new(STDOUT)).migrate!
+  end
+
+private
+
+  def editable_edition_states
+    Edition.state_machine.states.map(&:name) - [:superseded, :deleted, :archived]
+  end
+
+  def policy_taggable_edition_classes
+    Whitehall.edition_classes.select { |klass| klass.ancestors.include?(Edition::RelatedPolicies) }
+  end
 end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
-require 'gds_api/test_helpers/content_register'
 
 class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::ContentRegister
   include ContentRegisterHelpers
 
   test "#destroy should also remove the relationship to existing policies" do


### PR DESCRIPTION
Data migration and rake task for mapping editions to new (policy-publish) policies based on their existing whitehall policy relations.

The data migration cleans up some of the data by making sure merged policies share the same content_id.

The rake task creates associations for new (policy-publisher) policies on all non-archived/deleted/superseded editions. It relies on the fact that all policies in whitehall share their content_id with the equivalent policy in policy-publisher. This rake task will be run as part of the transition process to replace the existing policies section of GOV.UK with the new one.

Trello: https://trello.com/c/By11lgVl/24-script-to-migrate-old-whitehall-policy-taggings-to-new-world-policies