### PR TITLE
Use SitewideSetting rather than using ENV vars

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -45,7 +45,7 @@ module Edition::RelatedPolicies
   end
 
   def published_related_policies
-    if Whitehall.future_policies_enabled?
+    if SitewideSetting.on?('future_policies')
       policies
     else
       super
@@ -53,7 +53,7 @@ module Edition::RelatedPolicies
   end
 
   def related_policies
-    if Whitehall.future_policies_enabled?
+    if SitewideSetting.on?('future_policies')
       policies
     else
       super

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -1,5 +1,4 @@
 class SitewideSetting < ActiveRecord::Base
-  validates :govspeak, presence: true, if: :on
   validates :key, presence: true
   validates_uniqueness_of :key
   validates_with SafeHtmlValidator
@@ -12,4 +11,20 @@ class SitewideSetting < ActiveRecord::Base
     key.humanize
   end
 
+  def self.set(key, on)
+    flag = find_by_key_or_create(key)
+    flag.update(on: on)
+  end
+
+  def self.on?(name)
+    if flag = find_by(key: name)
+      flag.on
+    else
+      false
+    end
+  end
+
+  def self.find_by_key_or_create(key)
+    find_by(key: key) || create(key: key)
+  end
 end

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,4 +1,4 @@
-<% if Whitehall.future_policies_enabled? %>
+<% if SitewideSetting.on?('future_policies') %>
   <fieldset>
     <%= form.label :policy_content_ids, "Policies" %>
     <%= form.select :policy_content_ids,

--- a/config/initializers/future_policies_feature_flag.rb
+++ b/config/initializers/future_policies_feature_flag.rb
@@ -1,1 +1,0 @@
-Whitehall.future_policies_enabled = !!ENV["ENABLE_FUTURE_POLICIES"]

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,7 +1,7 @@
 # Turn on temporary feature-flag for future-policies feature during selected tests
 Around("@future-policies") do |scenario, block|
-  future_policies_setting = Whitehall.future_policies_enabled
-  Whitehall.future_policies_enabled = true
+  future_policies_setting = SitewideSetting.on?('future_policies')
+  SitewideSetting.set('future_policies', false)
   block.call
-  Whitehall.future_policies_enabled = future_policies_setting
+  SitewideSetting.set('future_policies', future_policies_setting)
 end

--- a/lib/tasks/sitewide_settings.rake
+++ b/lib/tasks/sitewide_settings.rake
@@ -1,0 +1,6 @@
+namespace :sitewide_settings do
+  desc "sets a sitewide setting"
+  task :set, [:key, :on] => :environment do |t, args|
+    SitewideSetting.set(args[:key], args[:on])
+  end
+end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -27,11 +27,6 @@ module Whitehall
   mattr_accessor :unified_search_client
   mattr_accessor :case_study_publishing_api_rendering_app
   mattr_accessor :case_study_preview_host
-  mattr_accessor :future_policies_enabled
-
-  def self.future_policies_enabled?
-    future_policies_enabled
-  end
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -173,15 +173,15 @@ module DocumentControllerTestHelpers
       end
 
       view_test "should render related future policies on #{document_type} pages" do
-        future_policies_setting = Whitehall.future_policies_enabled?
-        Whitehall.future_policies_enabled = true
+        future_policies_setting = SitewideSetting.on?('future_policies')
+        SitewideSetting.set('future_policies', true)
 
         begin
           edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
           get :show, id: edition.document
           assert_select ".meta a", text: policy_1["title"]
         ensure
-          Whitehall.future_policies_enabled = future_policies_setting
+          SitewideSetting.set('future_policies', future_policies_setting)
         end
       end
     end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -124,16 +124,16 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     edition.save
     edition.reload
 
-    future_policies_setting = Whitehall.future_policies_enabled
+    future_policies_setting = SitewideSetting.on?('future_policies')
 
-    Whitehall.future_policies_enabled = false
+    SitewideSetting.set('future_policies', false)
     assert_equal 1, edition.published_related_policies.count
     assert_equal old_world_policy, edition.published_related_policies.first
 
-    Whitehall.future_policies_enabled = true
+    SitewideSetting.set('future_policies', true)
     assert_equal 1, edition.published_related_policies.count
     assert edition.published_related_policies.first.is_a?(Future::Policy)
 
-    Whitehall.future_policies_enabled = future_policies_setting
+    SitewideSetting.set('future_policies', future_policies_setting)
   end
 end

--- a/test/unit/sitewide_setting_test.rb
+++ b/test/unit/sitewide_setting_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class SitewideSettingTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "enabled? returns false by default" do
+    refute SitewideSetting.on?('undefined-key')
+  end
+
+  test "enabled returns true when set" do
+    SitewideSetting.create(key: 'new-key', enabled: true)
+    assert SitewideSetting.on?('new-key')
+  end
+
+  test "set sets the value of a flag" do
+    SitewideSetting.set('set-key', true)
+    assert SitewideSetting.on?('set-key')
+    SitewideSetting.set('set-key', false)
+    refute SitewideSetting.on?('set-key')
+  end
 end


### PR DESCRIPTION
We want to be able to change policy flags without having the need to
update the puppet or deployment repos. The current approach of using ENV
variables would require this.

Use the sitewide setting module which can take a name and add boolean
value and a rake task to update or create those settings.

New sitewide settings can be created with:

    bundle exec rake sitewide_settings:set[new-key,false]

And if you want to update one you can call:

    bundle exec rake sitewide_settings:set[new-key,true]