### PR TITLE
Remove case study feature flag

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -12,7 +12,7 @@ class CaseStudy < Edition
   validates :first_published_at, presence: true, if: -> e { e.trying_to_convert_to_draft == true }
 
   def rendering_app
-    Whitehall.case_study_publishing_api_rendering_app
+    'government-frontend'
   end
 
   def display_type_key

--- a/config/initializers/publishing_api_rendering_app.rb
+++ b/config/initializers/publishing_api_rendering_app.rb
@@ -1,1 +1,0 @@
-Whitehall.case_study_publishing_api_rendering_app = 'whitehall-frontend'

--- a/db/data_migration/20150423095549_resend_all_case_studies_to_publishing_api.rb
+++ b/db/data_migration/20150423095549_resend_all_case_studies_to_publishing_api.rb
@@ -1,0 +1,1 @@
+DataHygiene::PublishingApiRepublisher.new(CaseStudy.published).perform

--- a/lib/data_hygiene/publishing_api_republisher.rb
+++ b/lib/data_hygiene/publishing_api_republisher.rb
@@ -25,7 +25,7 @@ module DataHygiene
 
       scope.find_each { |instance| republish(instance) }
 
-      logger.info("Queued #{republished} instances for repulishing")
+      logger.info("Queued #{republished} instances for republishing")
     end
 
   private

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -23,7 +23,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       public_updated_at: case_study.public_timestamp,
       update_type: 'major',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       routes: [
         { path: public_path, type: 'exact' }
       ],
@@ -64,18 +64,6 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
       presented_hash[:details].delete(:body)
 
     assert_equal expected_hash[:details], presented_hash[:details]
-  end
-
-
-  test "uses value of case_study_publishing_api_rendering_app to set rendering_app" do
-    Whitehall.stubs(:case_study_publishing_api_rendering_app).returns('government-frontend')
-    case_study = create(:published_case_study,
-                    title: 'Case study title',
-                    summary: 'The summary',
-                    body: 'Some content')
-    presented_hash = present(case_study)
-
-    assert_equal 'government-frontend', presented_hash[:rendering_app]
   end
 
 

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -13,7 +13,7 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
 
     expected_hash = {
       publishing_app: 'whitehall',
-      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
+      rendering_app: 'government-frontend',
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -14,7 +14,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
+      rendering_app: 'government-frontend',
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [
@@ -107,7 +107,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       locale: 'en',
       need_ids: [],
       publishing_app: 'whitehall',
-      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
+      rendering_app: 'government-frontend',
       public_updated_at: edition.public_timestamp,
       update_type: 'major',
       routes: [

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -13,7 +13,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
 
     expected_payload = {
       publishing_app: 'whitehall',
-      rendering_app: Whitehall.case_study_publishing_api_rendering_app,
+      rendering_app: 'government-frontend',
       format: 'coming_soon',
       title: 'Coming soon',
       locale: locale,


### PR DESCRIPTION
Set case studies to render via government-frontend in all environments, and republish them to make this live.