### PR TITLE
Pull policies on org pages from Rummager.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '18.2.0'
+gem 'gds-api-adapters', '18.5.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'addressable'
 gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'bootstrap-kaminari-views'
-gem 'gds-api-adapters', '18.5.0'
+gem 'gds-api-adapters', '18.6.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
@@ -125,13 +127,13 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (18.2.0)
+    gds-api-adapters (18.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.7.3)
+      rest-client (~> 1.8.0)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -157,6 +159,8 @@ GEM
     hashie (3.2.0)
     hitimes (1.2.2)
     htmlentities (4.3.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     invalid_utf8_rejector (0.0.1)
       rack (~> 1.0)
@@ -198,7 +202,7 @@ GEM
     minitest (5.5.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -290,7 +294,8 @@ GEM
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.1.0)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rubocop (0.28.0)
@@ -371,6 +376,9 @@ GEM
     uglifier (2.6.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.6.2)
       kgio (~> 2.6)
       rack
@@ -411,7 +419,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 18.2.0)
+  gds-api-adapters (= 18.5.0)
   gds-sso (~> 10.0)
   globalize!
   govspeak (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (18.5.0)
+    gds-api-adapters (18.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -419,7 +419,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 18.5.0)
+  gds-api-adapters (= 18.6.0)
   gds-sso (~> 10.0)
   globalize!
   govspeak (~> 3.2.0)

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -32,7 +32,7 @@ class OrganisationsController < PublicFacingController
             @promotional_features = PromotionalFeaturesPresenter.new(@organisation.promotional_features, view_context)
             render 'show-promotional'
           else
-            @policies = latest_presenters(@organisation.published_policies, translated: true)
+            @policies = policies
             @topics = @organisation.topics
             @mainstream_categories = @organisation.mainstream_categories
             @ministers = ministers
@@ -56,6 +56,15 @@ class OrganisationsController < PublicFacingController
   end
 
 private
+
+  def policies
+    rummager_results = Whitehall.unified_search_client.unified_search(
+      filter_organisations: [@organisation.slug],
+      filter_format: "policy"
+    ).results
+
+    Future::Policy.from_rummager(rummager_results[0...3])
+  end
 
   def ministers
     @ministerial_roles ||= filled_roles_presenter_for(@organisation, :ministerial)

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -32,7 +32,7 @@ class OrganisationsController < PublicFacingController
             @promotional_features = PromotionalFeaturesPresenter.new(@organisation.promotional_features, view_context)
             render 'show-promotional'
           else
-            @policies = policies
+            @policies = policy_results
             @topics = @organisation.topics
             @mainstream_categories = @organisation.mainstream_categories
             @ministers = ministers
@@ -57,13 +57,11 @@ class OrganisationsController < PublicFacingController
 
 private
 
-  def policies
-    rummager_results = Whitehall.unified_search_client.unified_search(
+  def policy_results
+    Whitehall.unified_search_client.unified_search(
       filter_organisations: [@organisation.slug],
       filter_format: "policy"
     ).results
-
-    Future::Policy.from_rummager(rummager_results[0...3])
   end
 
   def ministers

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -60,7 +60,8 @@ private
   def policy_results
     Whitehall.unified_search_client.unified_search(
       filter_organisations: [@organisation.slug],
-      filter_format: "policy"
+      filter_format: "policy",
+      count: "3",
     ).results
   end
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -62,6 +62,7 @@ private
       filter_organisations: [@organisation.slug],
       filter_format: "policy",
       count: "3",
+      order: "-public_timestamp"
     ).results
   end
 

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -2,12 +2,17 @@
 # and stored in the content-store.
 module Future
   class Policy
-    attr_reader :base_path, :content_id, :slug, :title
+    include ActiveModel::Model
+
+    attr_reader :base_path, :content_id, :slug, :title, :summary
 
     def initialize(attributes)
+      attributes = attributes.with_indifferent_access
+
       @base_path = attributes["base_path"]
       @content_id = attributes["content_id"]
       @title = attributes["title"]
+      @summary = attributes["summary"]
       @slug = extract_slug
     end
 
@@ -21,6 +26,18 @@ module Future
           new(match)
         end
       end.compact
+    end
+
+    def self.from_rummager(rummager_results)
+      rummager_results.map do |rummager_policy|
+        rummager_policy = rummager_policy.marshal_dump
+
+        new(
+          base_path: rummager_policy[:link],
+          title: rummager_policy[:title],
+          summary: rummager_policy[:description]
+        )
+      end
     end
 
     def topics

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -2,17 +2,12 @@
 # and stored in the content-store.
 module Future
   class Policy
-    include ActiveModel::Model
-
-    attr_reader :base_path, :content_id, :slug, :title, :summary
+    attr_reader :base_path, :content_id, :slug, :title
 
     def initialize(attributes)
-      attributes = attributes.with_indifferent_access
-
       @base_path = attributes["base_path"]
       @content_id = attributes["content_id"]
       @title = attributes["title"]
-      @summary = attributes["summary"]
       @slug = extract_slug
     end
 
@@ -26,18 +21,6 @@ module Future
           new(match)
         end
       end.compact
-    end
-
-    def self.from_rummager(rummager_results)
-      rummager_results.map do |rummager_policy|
-        rummager_policy = rummager_policy.marshal_dump
-
-        new(
-          base_path: rummager_policy[:link],
-          title: rummager_policy[:title],
-          summary: rummager_policy[:description]
-        )
-      end
     end
 
     def topics

--- a/app/views/policies/_list_description.html.erb
+++ b/app/views/policies/_list_description.html.erb
@@ -1,8 +1,8 @@
 <ol class="policies document-list">
   <% policies.each do |policy| %>
-    <%= content_tag_for(:li, policy, class: "document-row") do %>
-      <h2><%= link_to policy.title, policy.base_path %></h2>
-      <p class="summary"><%= policy.summary %></p>
+    <%= content_tag(:li, class: "document-row") do %>
+      <h2><%= link_to policy.title, policy.link %></h2>
+      <p class="summary"><%= policy.description %></p>
     <% end %>
   <% end %>
 </ol>

--- a/app/views/policies/_list_description.html.erb
+++ b/app/views/policies/_list_description.html.erb
@@ -1,7 +1,7 @@
 <ol class="policies document-list">
   <% policies.each do |policy| %>
     <%= content_tag_for(:li, policy, class: "document-row") do %>
-      <h2><%= link_to policy.title, public_document_path(policy) %></h2>
+      <h2><%= link_to policy.title, policy.base_path %></h2>
       <p class="summary"><%= policy.summary %></p>
     <% end %>
   <% end %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -70,20 +70,6 @@
 
   <div class="documents-grid <%= topic_grid_size_class(@policies, @publications, @consultations, @announcements, @detailed_guides, @related_classifications) %>">
     <div class="inner-block">
-      <% if @policies.any? %>
-        <section id="policies" class="policies document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Policies</h1>
-          <div class="content">
-            <%= render partial: "policies/list_description", locals: { policies: @policies.limit(5) } %>
-            <% if @policies.count > 5 %>
-              <p class="see-all">
-                <%= link_to "See all #{@policies.count} policies", policies_filter_path(@classification) %>
-              </p>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
-
       <%= render(partial: 'document_list', locals: { documents: @publications, type: :publications }) if @publications.any? %>
       <%= render(partial: 'document_list', locals: { documents: @consultations, type: :consultations }) if @consultations.any? %>
       <%= render(partial: 'document_list', locals: { documents: @announcements, type: :announcements }) if @announcements.any? %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -59,28 +59,6 @@
     </div>
   <% end %>
 
-  <div class="block block-4 heading-block">
-    <div class="inner-block">
-      <% if @policies.any? %>
-        <section id="policies" class="policies">
-          <div class="head-section">
-            <h1 class="label">Policies
-              <span class="count"><%= @policies.count %></span>
-            </h1>
-          </div>
-          <div class="content">
-            <%= render partial: "policies/list_description", locals: { policies: @policies.limit(5) } %>
-            <% if @policies.count > 5 %>
-              <p class="see-all">
-                <%= link_to "See all #{@policies.count} policies", policies_filter_path(@classification) %>
-              </p>
-            <% end %>
-          </div>
-        </section>
-      <% end %>
-    </div>
-  </div>
-
   <div class="documents-grid <%= topic_grid_size_class(@announcements, @consultations, @publications, @statistics) %>">
     <div class="inner-block">
       <%= render(partial: 'document_list', locals: { documents: @announcements, type: :announcements }) if @announcements.any? %>

--- a/app/views/world_locations/show.html.erb
+++ b/app/views/world_locations/show.html.erb
@@ -72,23 +72,6 @@
     </section>
   <% end %>
 
-  <% if @policies.any? %>
-    <div class="block-5 heading-block">
-      <div class="inner-block">
-        <section id="policies">
-          <div class="head-section">
-            <h1 class="label"><%= t('world_location.headings.related_policies') %></h1>
-          </div>
-          <div class="content">
-            <%= render partial: "policies/list_description", locals: {policies: @policies} %>
-            <p class="see-all">
-              <%= link_to t_see_all_our(:policy), policies_filter_path(@world_location) %>
-            </p>
-          </div>
-        </section>
-      </div>
-    </div>
-  <% end %>
   <% if (@non_statistics_publications + @announcements + @statistics_publications).any? %>
     <div class="block documents-grid">
       <div class="inner-block">

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -54,4 +54,5 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Before do
   create(:world_location, name: "United Kingdom", iso2: "GB")
+  rummager_has_no_policies_for_any_organisation
 end

--- a/features/topics.feature
+++ b/features/topics.feature
@@ -24,21 +24,6 @@ Scenario: Deleting a topic
   Given a topic called "No more beards" with description "No more hairy-faced men"
   Then I should be able to delete the topic "No more beards"
 
-Scenario: Ordering policies within a topic
-  Given a topic called "Facial Hair" with description "Against All Follicles"
-  And a published policy "Outlaw Moustaches" exists in the "Facial Hair" topic
-  And a published policy "No more beards" exists in the "Facial Hair" topic
-  And a published policy "Free monobrow treatment" exists in the "Facial Hair" topic
-  When I set the order of the policies in the "Facial Hair" topic to:
-    |Topic|
-    |No more beards|
-    |Outlaw Moustaches|
-    |Free monobrow treatment|
-  Then I should see the order of the policies in the "Facial Hair" topic is:
-    |No more beards|
-    |Outlaw Moustaches|
-    |Free monobrow treatment|
-
 Scenario: Choosing and ordering lead organisations within a topic
   Given a topic called "Facial Hair" with description "Against All Follicles"
   And the topic "Facial Hair" has "Ministry of Grooming" as a lead organisation
@@ -58,22 +43,24 @@ Scenario: Choosing and ordering lead organisations within a topic
     |Ministry of War|
 
 Scenario: Viewing the list of topics
-  Given the topic "Higher Education" contains some policies
-  And the topic "Science and Innovation" contains some policies
+  Given a topic called "Higher Education" exists
+  And a topic called "Science and Innovation" exists
   When I visit the list of topics
   Then I should see the topics "Higher Education" and "Science and Innovation"
 
 Scenario: Visiting a topic page
-  Given the topic "Higher Education" contains some policies
+  Given a topic called "Higher Education" exists
+  And a topic called "Science and Innovation" exists
   And the topic "Higher Education" is related to the topic "Scientific Research"
   When I visit the "Higher Education" topic
-  Then I should see published policies belonging to the "Higher Education" topic
-  And I should see a link to the related topic "Scientific Research"
+  Then I should see a link to the related topic "Scientific Research"
 
 Scenario: Featuring content on a topic page
-  Given the topic "Higher Education" contains some policies
-  When I feature one of the policies on the topic
-  Then I should see the policy featured on the public topic page
+  Given a published publication "Cold fusion" with a PDF attachment
+  And a topic called "Science and Innovation" exists
+  And the publication "Cold fusion" is associated with the topic "Science and Innovation"
+  When I feature the publication "Cold fusion" on the topic "Science and Innovation"
+  Then I should see the publication "Cold fusion" featured on the public topic page for "Science and Innovation"
 
 Scenario: Creating offsite content on a topic page
   Given a topic called "Excellent Topic" exists

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -44,7 +44,7 @@ Feature: World location news for people local to countries
     Then I should be able to associate "Spanish News" with the worldwide organisation "Spanish Department"
     When I force publish the world location news article "Spanish News"
     Then the worldwide organisation "Spanish Department" is listed as a producing org on the world location news article "Spanish News"
-    
+
   Scenario: Associate a world location news article with a topical event
     Given the topical event "French Topical Event" exists
     When I draft a valid world location news article "French News"
@@ -76,12 +76,6 @@ Feature: World location news for people local to countries
     When I view the world location "British Antarctic Territory"
     Then I should see the news article "Larsen ice sheet disintegrates"
 
-  Scenario: View policies relating to a world location
-    Given a world location "British Antarctic Territory" exists
-    And a published policy "Icebergs of the World, Unite!" exists relating to the world location "British Antarctic Territory"
-    When I view the world location "British Antarctic Territory"
-    Then I should see the policy "Icebergs of the World, Unite!"
-
   Scenario: The publication is about a world location
     Given a world location "British Antarctic Territory" exists
     And a published publication "Penguins have rights too" exists that is about "British Antarctic Territory"
@@ -109,4 +103,3 @@ Feature: World location news for people local to countries
 
     When I view the world location "United Nations"
     Then I should see that it is an international delegation
-

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -52,7 +52,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:corporate_information_page, organisation: organisation)
     organisation.add_contact_to_home_page!(contact)
 
-    rummager_has_four_old_policies_for_every_organisation
+    rummager_has_old_policies_for_every_organisation
 
     get :show, id: organisation
 
@@ -272,21 +272,14 @@ class OrganisationsControllerTest < ActionController::TestCase
   ## OLD POLICIES
   view_test "should display the organisation's policies with content" do
     organisation = create(:organisation)
-    rummager_has_four_old_policies_for_every_organisation
+    rummager_has_old_policies_for_every_organisation
 
     get :show, id: organisation
 
-    sample_policy = Future::Policy.new(
-      title: "Employment",
-      summary: "How the government is getting Britain working and helping people break the cycle of benefit dependency.",
-      base_path: "/government/policies/helping-people-to-find-and-stay-in-work",
-    )
-
     assert_select "#policies" do
-      assert_select_object sample_policy do
-        assert_select 'h2', text: sample_policy.title
-        assert_select '.summary', text: sample_policy.summary
-      end
+      assert_select "a[href='/government/policies/helping-people-to-find-and-stay-in-work']",
+                    text: "Employment"
+      assert_select ".summary", text: "How the government is getting Britain working and helping people break the cycle of benefit dependency."
 
       assert_select "a[href='#{policies_filter_path(organisation)}']"
     end
@@ -294,7 +287,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   test "should display organisation's latest three policies" do
     organisation = create(:organisation)
-    rummager_has_four_old_policies_for_every_organisation
+    rummager_has_old_policies_for_every_organisation(count: 3)
 
     get :show, id: organisation
 
@@ -313,21 +306,13 @@ class OrganisationsControllerTest < ActionController::TestCase
   ## NEW POLICIES
   view_test "should display the organisation's future policies with content" do
     organisation = create(:organisation)
-    rummager_has_four_new_policies_for_every_organisation
-
-    sample_policy = Future::Policy.new(
-      title: "Welfare reform",
-      summary: "The governments policy on welfare reform",
-      base_path: "/government/policies/welfare-reform",
-    )
+    rummager_has_new_policies_for_every_organisation
 
     get :show, id: organisation
 
     assert_select "#policies" do
-      assert_select_object sample_policy do
-        assert_select 'h2', text: sample_policy.title
-        assert_select '.summary', text: sample_policy.summary
-      end
+      assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
+      assert_select ".summary", text: "The governments policy on welfare reform"
 
       assert_select "a[href='#{policies_filter_path(organisation)}']"
     end
@@ -335,7 +320,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   test "should display organisation's latest three future policies" do
     organisation = create(:organisation)
-    rummager_has_four_new_policies_for_every_organisation
+    rummager_has_new_policies_for_every_organisation(count: 3)
 
     get :show, id: organisation
 

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -24,20 +24,6 @@ class TopicsControllerTest < ActionController::TestCase
     assert_select "a[href=?]", organisation_path(organisation_2)
   end
 
-  view_test "GET :show lists the published policies and their summaries" do
-    published_policy = create(:published_policy, title: "policy-title", summary: "policy-summary")
-    topic = create(:topic, editions: [published_policy])
-
-    get :show, id: topic
-
-    assert_select "#policies" do
-      assert_select_object(published_policy) do
-        assert_select "h2", text: "policy-title"
-        assert_select ".summary", text: /policy-summary/
-      end
-    end
-  end
-
   view_test "GET :show lists published publications and links to more" do
     topic = create(:topic)
     published = []

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -6,7 +6,6 @@ class WorldLocationsControllerTest < ActionController::TestCase
   include FeedHelper
 
   should_be_a_public_facing_controller
-  should_show_published_documents_associated_with :world_location, :policies
   should_show_published_documents_associated_with :world_location, :worldwide_priorities
 
   def assert_featured_editions(editions)
@@ -275,7 +274,6 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select ".type", "Localisation"
     assert_select "#worldwide-priorities", /Priorités/
-    assert_select "#policies .see-all a", /Voir toutes nos priorités politiques/
     assert_select "#publications .see-all a", /Voir toutes nos publications/
   end
 
@@ -321,17 +319,6 @@ class WorldLocationsControllerTest < ActionController::TestCase
     get :show, id: world_location, locale: 'fr'
 
     assert_equal [translated_statistics], assigns(:statistics_publications).object
-  end
-
-  test "should only display translated policies when requested for a locale" do
-    world_location = create(:world_location, translated_into: [:fr])
-
-    translated_policy = create(:published_policy, world_locations: [world_location], translated_into: [:fr])
-    untranslated_policy = create(:published_policy, world_locations: [world_location])
-
-    get :show, id: world_location, locale: 'fr'
-
-    assert_equal [translated_policy], assigns(:policies).object
   end
 
   test "should only display translated recently updated editions when requested for a locale" do

--- a/test/support/content_register_helpers.rb
+++ b/test/support/content_register_helpers.rb
@@ -24,4 +24,22 @@ module ContentRegisterHelpers
         "base_path" => "/government/policies/policy-2",
       }
   end
+
+  def policy_3
+    @policy_3 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 3",
+        "base_path" => "/government/policies/policy-3",
+      }
+  end
+
+  def policy_4
+    @policy_4 ||= {
+        "content_id" => SecureRandom.uuid,
+        "format" => "policy",
+        "title" => "Policy 4",
+        "base_path" => "/government/policies/policy-4",
+      }
+  end
 end


### PR DESCRIPTION
This loads both old and new policies into the page.

When the old policies are unpublished they will be
removed from the index, but in any case it only shows
the top 3 which will almost certainly always be
the new ones.

https://trello.com/c/RuReu0tZ/50-policies-on-org-homepages

### Before
![screenshot 2015-04-23 13 52 05](https://cloud.githubusercontent.com/assets/109225/7297917/e630fde8-e9c3-11e4-84e2-0a261248e075.png)

### After
![screenshot 2015-04-23 13 52 11](https://cloud.githubusercontent.com/assets/109225/7297927/f907a278-e9c3-11e4-968c-fbfa0687f4c5.png)
