### PR TITLE
Use FeatureFlag model rather than using ENV vars

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -45,7 +45,7 @@ module Edition::RelatedPolicies
   end
 
   def published_related_policies
-    if Whitehall.future_policies_enabled?
+    if FeatureFlag.enabled?('future_policies')
       policies
     else
       super
@@ -53,7 +53,7 @@ module Edition::RelatedPolicies
   end
 
   def related_policies
-    if Whitehall.future_policies_enabled?
+    if FeatureFlag.enabled?('future_policies')
       policies
     else
       super

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,14 @@
+class FeatureFlag < ActiveRecord::Base
+  def self.set(key, value)
+    flag = find_by!(key: key)
+    flag.update(enabled: value)
+  end
+
+  def self.enabled?(name)
+    if flag = find_by(key: name)
+      flag.enabled
+    else
+      false
+    end
+  end
+end

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,4 +1,4 @@
-<% if Whitehall.future_policies_enabled? %>
+<% if FeatureFlag.enabled?('future_policies') %>
   <fieldset>
     <%= form.label :policy_content_ids, "Policies" %>
     <%= form.select :policy_content_ids,

--- a/config/initializers/future_policies_feature_flag.rb
+++ b/config/initializers/future_policies_feature_flag.rb
@@ -1,1 +1,0 @@
-Whitehall.future_policies_enabled = !!ENV["ENABLE_FUTURE_POLICIES"]

--- a/db/migrate/20150422083934_create_feature_flags.rb
+++ b/db/migrate/20150422083934_create_feature_flags.rb
@@ -1,0 +1,10 @@
+class CreateFeatureFlags < ActiveRecord::Migration
+  def change
+    create_table :feature_flags do |t|
+      t.string :key, unique: true
+      t.boolean :enabled, default: false
+    end
+
+    FeatureFlag.create(key: 'future_policies')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323155555) do
+ActiveRecord::Schema.define(version: 20150422083934) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -502,6 +502,11 @@ ActiveRecord::Schema.define(version: 20150323155555) do
     t.text    "personal_details"
   end
 
+  create_table "feature_flags", force: true do |t|
+    t.string  "key"
+    t.boolean "enabled"
+  end
+
   create_table "feature_lists", force: true do |t|
     t.integer  "featurable_id"
     t.string   "featurable_type"
@@ -592,8 +597,8 @@ ActiveRecord::Schema.define(version: 20150323155555) do
     t.string   "name"
     t.date     "start_date"
     t.date     "end_date"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "governments", ["end_date"], name: "index_governments_on_end_date", using: :btree

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,7 +1,8 @@
 # Turn on temporary feature-flag for future-policies feature during selected tests
 Around("@future-policies") do |scenario, block|
-  future_policies_setting = Whitehall.future_policies_enabled
-  Whitehall.future_policies_enabled = true
+  future_policies_setting = FeatureFlag.enabled?('future_policies')
+  FeatureFlag.find_or_create_by(key: 'future_policies')
+  FeatureFlag.set('future_policies', true)
   block.call
-  Whitehall.future_policies_enabled = future_policies_setting
+  FeatureFlag.set('future_policies', future_policies_setting)
 end

--- a/lib/tasks/feature_flag.rake
+++ b/lib/tasks/feature_flag.rake
@@ -1,0 +1,6 @@
+namespace :feature_flag do
+  desc "sets a feature flag"
+  task :set, [:key, :value] => :environment do |t, args|
+    FeatureFlag.set(args[:key], args[:value])
+  end
+end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -27,11 +27,6 @@ module Whitehall
   mattr_accessor :unified_search_client
   mattr_accessor :case_study_publishing_api_rendering_app
   mattr_accessor :case_study_preview_host
-  mattr_accessor :future_policies_enabled
-
-  def self.future_policies_enabled?
-    future_policies_enabled
-  end
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -173,15 +173,16 @@ module DocumentControllerTestHelpers
       end
 
       view_test "should render related future policies on #{document_type} pages" do
-        future_policies_setting = Whitehall.future_policies_enabled?
-        Whitehall.future_policies_enabled = true
+        future_policies_setting = FeatureFlag.enabled?('future_policies')
+        FeatureFlag.find_or_create_by(key: 'future_policies')
+        FeatureFlag.set('future_policies', true)
 
         begin
           edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
           get :show, id: edition.document
           assert_select ".meta a", text: policy_1["title"]
         ensure
-          Whitehall.future_policies_enabled = future_policies_setting
+          FeatureFlag.set('future_policies', future_policies_setting)
         end
       end
     end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -124,16 +124,17 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     edition.save
     edition.reload
 
-    future_policies_setting = Whitehall.future_policies_enabled
+    future_policies_setting = FeatureFlag.enabled?('future_policies')
+    FeatureFlag.find_or_create_by(key: 'future_policies')
 
-    Whitehall.future_policies_enabled = false
+    FeatureFlag.set('future_policies', false)
     assert_equal 1, edition.published_related_policies.count
     assert_equal old_world_policy, edition.published_related_policies.first
 
-    Whitehall.future_policies_enabled = true
+    FeatureFlag.set('future_policies', true)
     assert_equal 1, edition.published_related_policies.count
     assert edition.published_related_policies.first.is_a?(Future::Policy)
 
-    Whitehall.future_policies_enabled = future_policies_setting
+    FeatureFlag.set('future_policies', future_policies_setting)
   end
 end

--- a/test/unit/feature_flag_test.rb
+++ b/test/unit/feature_flag_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class FeatureFlagTest < ActiveSupport::TestCase
+  test "enabled? returns false by default" do
+    refute FeatureFlag.enabled?('undefined-key')
+  end
+
+  test "enabled returns true when set" do
+    FeatureFlag.create(key: 'new-key', enabled: true)
+    assert FeatureFlag.enabled?('new-key')
+  end
+
+  test "set sets the value of a flag" do
+    FeatureFlag.create(key: 'set-key')
+    FeatureFlag.set('set-key', true)
+    assert FeatureFlag.enabled?('set-key')
+    FeatureFlag.set('set-key', false)
+    refute FeatureFlag.enabled?('set-key')
+  end
+end


### PR DESCRIPTION
We want to be able to change feature flags without having the need to
update the puppet or deployment repos. The current approach of using ENV
variables would require this.

Created a feature flag module which can take a name and a boolean value
and a rake task to update those feature flags. Feature flags will need to be
created via a data migration.

If you want to update a feature flag you can call:

    bundle exec rake feature_flag:set[new-key,true]

This is the minimum needed to get us the functionality we want to enable
the deployment of future policies.