### PR TITLE
Rake task to republish case studies to Pub API

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -1,0 +1,8 @@
+namespace :election do
+  desc "Republishes all case studies to the Publishing API"
+  task :republish_case_studies => :environment do
+    require 'data_hygiene/publishing_api_republisher'
+
+    DataHygiene::PublishingApiRepublisher.new(CaseStudy.published).perform
+  end
+end


### PR DESCRIPTION
This commit adds a rake task in an election namespace to republish all published Case Studies to the Publishing API. [Ticket](https://trello.com/c/X1mmQlZw/206-create-rake-task-to-republish-case-studies-to-content-store).