### PR TITLE
Courts and HMCTS Tribunals as Organisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'dalli'
 gem 'rails_translation_manager', '0.0.1'
 gem 'rails-observers'
 gem 'sprockets', '3.0.0.beta.8'
+gem 'rinku', require: 'rails_rinku'
 
 if ENV['GLOBALIZE_DEV']
   gem 'globalize', path: '../globalize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rinku (1.7.3)
     rubocop (0.28.0)
       astrolabe (~> 1.3)
       parser (>= 2.2.0.pre.7, < 3.0)
@@ -454,6 +455,7 @@ DEPENDENCIES
   rails_translation_manager (= 0.0.1)
   raindrops (= 0.11.0)
   rake (= 10.1.0)
+  rinku
   rubocop
   ruby-prof
   rummageable (= 1.2.0)

--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -812,6 +812,7 @@
   #traffic_commissioners h1,
   #chief_professional_officers h1,
   #special_representatives h1,
+  #judges h1,
   #org-contacts h2,
   #what-we-do h1 {
     border-bottom-width: 5px;

--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -643,7 +643,7 @@
       @include core-19;
       font-weight: bold;
     }
-    
+
     p.comments {
       clear: both;
     }
@@ -814,14 +814,21 @@
   #special_representatives h1,
   #judges h1,
   #org-contacts h2,
-  #what-we-do h1 {
+  #what-we-do h1, #who-we-are h1 {
     border-bottom-width: 5px;
     border-bottom-style: solid;
+  }
+  #who-we-are .overview h1 {
+    border-bottom: 0px;
   }
   @include organisation-brand-colour("h1", border-color);
   @include organisation-brand-colour("h2", border-color);
   @include organisation-brand-colour(".social-media-link .connect", background-color, $websafe: true);
   @include organisation-brand-colour("a", color, $websafe: true);
+
+  .govuk-beta-label {
+    margin: 0px 30px;
+  }
 }
 .organisations-external {
   @include media(desktop) {
@@ -977,7 +984,7 @@
     }
 
     #featured-topics-and-policies,
-    #what-we-do {
+    #what-we-do, #who-we-are {
       @include media(tablet) {
         width: $two-thirds;
         float: left;
@@ -1319,5 +1326,3 @@
     }
   }
 }
-
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include Slimmer::Headers
   include Slimmer::Template
+  include Slimmer::SharedTemplates
 
   protect_from_forgery
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -50,7 +50,7 @@ class OrganisationsController < PublicFacingController
             @traffic_commissioners = traffic_commissioners
             @chief_professional_officers = chief_professional_officers
             @special_representatives = special_representatives
-            @judges = judges
+            @judges = params[:courts_only] ? [] : judges
             @sub_organisations = @organisation.sub_organisations
             @foi_contacts = @organisation.foi_contacts
           end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,7 +8,15 @@ class OrganisationsController < PublicFacingController
   before_filter :set_cache_max_age, only: [:show]
 
   def index
-    @organisations = OrganisationsIndexPresenter.new(Organisation.excluding_courts.listable.ordered_by_name_ignoring_prefix)
+    if params[:courts_only]
+      @courts = Organisation.courts.listable.ordered_by_name_ignoring_prefix
+      @hmcts_tribunals = Organisation.hmcts_tribunals.listable.ordered_by_name_ignoring_prefix
+      render :courts_index
+    else
+      @organisations = OrganisationsIndexPresenter.new(
+        Organisation.excluding_courts_and_tribunals.listable.ordered_by_name_ignoring_prefix)
+      render :index
+    end
   end
 
   def show
@@ -111,7 +119,12 @@ private
   end
 
   def load_organisation
-    @organisation = Organisation.excluding_courts.with_translations(I18n.locale).find(params[:id])
+    @organisation = Organisation.with_translations(I18n.locale).find(params[:id])
+    if params[:courts_only]
+      raise ActiveRecord::RecordNotFound if !@organisation.court_or_hmcts_tribunal?
+    else
+      raise ActiveRecord::RecordNotFound if @organisation.court_or_hmcts_tribunal?
+    end
   end
 
   def set_cache_max_age

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -50,6 +50,7 @@ class OrganisationsController < PublicFacingController
             @traffic_commissioners = traffic_commissioners
             @chief_professional_officers = chief_professional_officers
             @special_representatives = special_representatives
+            @judges = judges
             @sub_organisations = @organisation.sub_organisations
             @foi_contacts = @organisation.foi_contacts
           end
@@ -102,6 +103,11 @@ private
   def special_representatives
     @special_representative_roles ||= roles_presenter_for(@organisation, :special_representative)
     @special_representative_roles.with_unique_people
+  end
+
+  def judges
+    @judge_roles ||= roles_presenter_for(@organisation, :judge)
+    @judge_roles.with_unique_people
   end
 
   def filled_roles_presenter_for(organisation, association)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -221,7 +221,11 @@ module ApplicationHelper
     when "ministerial_roles"
       ministerial_roles_path
     when "organisations", "groups", "services_and_information", "email_signup_information"
-      organisations_path
+      if parameters[:courts_only]
+        courts_path
+      else
+        organisations_path
+      end
     when "corporate_information_pages"
       if parameters.has_key?(:worldwide_organisation_id)
         world_locations_path

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -188,7 +188,8 @@ module OrganisationHelper
       @important_board_members.any? ||
       @military_personnel.any? ||
       @chief_professional_officers.any? ||
-      @traffic_commissioners.any?
+      @traffic_commissioners.any? ||
+      @judges.any?
   end
 
   def organisations_grouped_by_type(organisations)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -258,4 +258,8 @@ module OrganisationHelper
     organisation.live? && (!organisation.court_or_hmcts_tribunal? ||
       organisation.corporate_information_pages.published.reject { |cip| cip.slug == "about" }.any?)
   end
+
+  def organisation_body_heading_key(organisation)
+    organisation.court_or_hmcts_tribunal? ? 'who_we_are' : 'what_we_do'
+  end
 end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -244,4 +244,12 @@ module OrganisationHelper
     contents = content_tag(:span, org_array.length, class: 'count js-filter-count')
     content_tag(:p, contents.html_safe)
   end
+
+  def organisation_or_court_path(organisation_or_court)
+    if organisation_or_court.court_or_hmcts_tribunal?
+      court_path(organisation_or_court)
+    else
+      organisation_path(organisation_or_court)
+    end
+  end
 end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -253,4 +253,9 @@ module OrganisationHelper
       organisation_path(organisation_or_court)
     end
   end
+
+  def show_corporate_information_pages?(organisation)
+    organisation.live? && (!organisation.court_or_hmcts_tribunal? ||
+      organisation.corporate_information_pages.published.reject { |cip| cip.slug == "about" }.any?)
+  end
 end

--- a/app/models/judge_role.rb
+++ b/app/models/judge_role.rb
@@ -1,0 +1,2 @@
+class JudgeRole < Role
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -67,6 +67,10 @@ class Organisation < ActiveRecord::Base
             class_name: 'RoleAppointment',
             through: :ministerial_whip_roles,
             source: :role_appointments
+  has_many :judge_roles,
+           class_name: 'JudgeRole',
+           through: :organisation_roles,
+           source: :role
 
   has_many :people, through: :roles
 

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -75,11 +75,11 @@ module Organisation::OrganisationTypeConcern
   end
 
   def can_index_in_search?
-    super && !organisation_type.court?
+    super && !court_or_hmcts_tribunal?
   end
 
   def can_publish_to_publishing_api?
-    super && !organisation_type.court?
+    super && !court_or_hmcts_tribunal?
   end
 
   def hmcts_tribunal?

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -28,9 +28,26 @@ module Organisation::OrganisationTypeConcern
       where(organisation_type_key: OrganisationType.allowed_promotional_keys)
     }
 
-    scope :excluding_courts, -> {
-      where.not(organisation_type_key: :court)
+    scope :hmcts_tribunals, -> {
+      hmcts_id = Organisation.where(slug: "hm-courts-and-tribunals-service").ids.first
+      joins(:parent_organisational_relationships).
+        where(organisation_type_key: :tribunal_ndpb).
+        where("organisational_relationships.parent_organisation_id" => hmcts_id)
     }
+
+    scope :excluding_hmcts_tribunals, -> {
+      hmcts_id = Organisation.where(slug: "hm-courts-and-tribunals-service").ids.first
+      joins("LEFT JOIN organisational_relationships parent_organisational_relationships
+        ON parent_organisational_relationships.child_organisation_id = organisations.id").
+      where("NOT (parent_organisational_relationships.parent_organisation_id = ? AND
+              organisations.organisation_type_key = ?) OR
+              parent_organisational_relationships.child_organisation_id IS NULL",
+              hmcts_id, :tribunal_ndpb)
+    }
+
+    scope :excluding_courts, -> { where.not(organisation_type_key: :court) }
+
+    scope :excluding_courts_and_tribunals, -> { excluding_courts.excluding_hmcts_tribunals }
   end
 
   def organisation_type_key
@@ -63,5 +80,14 @@ module Organisation::OrganisationTypeConcern
 
   def can_publish_to_publishing_api?
     super && !organisation_type.court?
+  end
+
+  def hmcts_tribunal?
+    organisation_type_key == :tribunal_ndpb &&
+      parent_organisations.pluck(:slug).include?("hm-courts-and-tribunals-service")
+  end
+
+  def court_or_hmcts_tribunal?
+    organisation_type.court? || hmcts_tribunal?
   end
 end

--- a/app/presenters/role_type_presenter.rb
+++ b/app/presenters/role_type_presenter.rb
@@ -38,6 +38,9 @@ class RoleTypePresenter
       "governor" => RoleType.new(GovernorRole.name, false, false, false),
       "deputy_head_of_mission" => RoleType.new(DeputyHeadOfMissionRole.name, false, false, false),
       "worldwide_office_staff" => RoleType.new(WorldwideOfficeStaffRole.name, false, false, false)
+    },
+    "MOJ only" => {
+      "judge" => RoleType.new(JudgeRole.name, false, false, false)
     }
   }.freeze
 

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -41,7 +41,7 @@
       <% end %>
 
       <% if contact.comments.present? %>
-        <p class="comments"><%= format_with_html_line_breaks(h(contact.comments)) %></p>
+        <p class="comments"><%= auto_link(format_with_html_line_breaks(h(contact.comments))) %></p>
       <% end %>
 
       <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -25,17 +25,19 @@
       </ul>
     </nav>
   </div>
-  <div class="corporate-information-block">
-    <h2><%= t('organisation.corporate_information.jobs_and_contacts') %></h2>
-    <nav class="group sub_navigation" role="navigation">
-      <ul>
-        <% organisation.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |corporate_information_page| %>
-          <li><%= link_to corporate_information_page.title, organisation_corporate_information_page_path(organisation, corporate_information_page.slug) %></li>
-        <% end %>
-        <li><%= link_to('Jobs', organisation.jobs_url, ({rel: 'external'} if is_external?(organisation.jobs_url))) %></li>
-      </ul>
-    </nav>
-  </div>
+  <% unless @organisation.court_or_hmcts_tribunal? %>
+    <div class="corporate-information-block">
+      <h2><%= t('organisation.corporate_information.jobs_and_contacts') %></h2>
+      <nav class="group sub_navigation" role="navigation">
+        <ul>
+          <% organisation.corporate_information_pages.published.by_menu_heading(:jobs_and_contracts).each do |corporate_information_page| %>
+            <li><%= link_to corporate_information_page.title, organisation_corporate_information_page_path(organisation, corporate_information_page.slug) %></li>
+          <% end %>
+          <li><%= link_to('Jobs', organisation.jobs_url, ({rel: 'external'} if is_external?(organisation.jobs_url))) %></li>
+        </ul>
+      </nav>
+    </div>
+  <% end %>
   <p class="information">
     <% if organisation.corporate_information_pages.published.for_slug("publication-scheme").present? %>
       <%= t('worldwide_organisation.corporate_information.publication_scheme_html',

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -18,6 +18,15 @@
           }.to_sentence.html_safe
         %>
       </p>
+    <% elsif organisation.court_or_hmcts_tribunal? %>
+      <p class="parent-organisations">
+        Administered by
+        <%=
+          organisation.parent_organisations.map { |parent_org|
+            link_to parent_org.name, organisation_path(parent_org)
+          }.to_sentence.html_safe
+        %>
+      </p>
     <% end %>
   </div>
 

--- a/app/views/organisations/_index_item_plain.html.erb
+++ b/app/views/organisations/_index_item_plain.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag_for :li, organisation, class: 'js-filter-item department index-item-plain',
               "data-filter-terms" => filter_terms(organisation) do %>
-  <%= link_to organisation.name, organisation_path(organisation), id: organisation.slug, class: 'department-link' %>
+  <%= link_to organisation.name, organisation_or_court_path(organisation),
+    id: organisation.slug, class: 'department-link' %>
   <%= govuk_status_meta_data_for(organisation) %>
   <% if include_works_with %>
     <%= render partial: 'works_with', locals: { organisation: organisation } %>

--- a/app/views/organisations/_index_section.html.erb
+++ b/app/views/organisations/_index_section.html.erb
@@ -3,13 +3,14 @@
   block_id ||= false
   header_text ||= nil
   include_works_with ||= false
+  hide_organisation_count_paragraph ||= false
 %>
 
 <div class="heading-block js-filter-block <%= "js-hide-department-children " if include_works_with %><%= block_class %>" <%= raw("id=\"#{block_id}\"") if block_id %>>
   <% if header_text %>
     <header class="type-heading">
       <h1><%= raw(header_text) %></h1>
-      <%= organisation_count_paragraph(organisations) %>
+      <%= organisation_count_paragraph(organisations) if !hide_organisation_count_paragraph %>
     </header>
   <% end %>
 

--- a/app/views/organisations/courts_index.html.erb
+++ b/app/views/organisations/courts_index.html.erb
@@ -1,0 +1,32 @@
+<% page_title "Courts and Tribunals" %>
+<% page_class "index-list-page" %>
+
+<div class="organisations-index">
+  <div class="block-1">
+    <div class="inner-block">
+      <%= render partial: 'govuk_component/beta_label' , locals: {
+        message: 'This part of GOV.UK is still being built – you can access information <a href="http://www.justice.gov.uk/">on the Justice website</a> in the meantime'} %>
+      <header class="page-header">
+        <h1 class="title">Courts and Tribunals</h1>
+      </header>
+    </div>
+  </div>
+
+  <div class="block-2">
+    <div class="inner-block">
+      <%= render 'organisations/index_section', organisations:      @courts,
+                                  header_text:        'Courts',
+                                  block_id:           'courts',
+                                  list_item_partial:  'organisations/index_item_plain',
+                                  show_govuk_status:  false,
+                                  hide_organisation_count_paragraph: true %>
+      <%= render 'organisations/index_section', organisations:      @hmcts_tribunals,
+                                  header_text:        'Tribunals',
+                                  block_id:           'tribunals',
+                                  list_item_partial:  'organisations/index_item_plain',
+                                  show_govuk_status:  false,
+                                  hide_organisation_count_paragraph: true %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -24,7 +24,7 @@
       <section id="<%= @organisation.court_or_hmcts_tribunal? ? 'who-we-are' : 'what-we-do'
         %>" class="what-we-do">
         <div class="content">
-          <h1 class="label"><%= t("organisation.headings.#{@organisation.court_or_hmcts_tribunal? ? 'who_we_are' : 'what_we_do'}") %></h1>
+          <h1 class="label"><%= t("organisation.headings.#{organisation_body_heading_key(@organisation)}") %></h1>
           <div class="overview">
             <% if @organisation.court_or_hmcts_tribunal? && @organisation.about_us %>
               <%= govspeak_to_html @organisation.about_us.body %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -302,7 +302,7 @@
         <% end %>
       </div>
 
-      <% if @organisation.live? %>
+      <% if show_corporate_information_pages? @organisation %>
         <%= render partial: 'corporate_information',
                    locals: { organisation: @organisation,
                              show_corporate_reports: true } %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -4,6 +4,10 @@
 <%= api_link_tag api_organisation_url(@organisation) %>
 
 <%= organisation_wrapper(@organisation) do %>
+<% if @organisation.court_or_hmcts_tribunal? %>
+  <%= render partial: 'govuk_component/beta_label' , locals: {
+    message: 'This part of GOV.UK is still being built – you can access information <a href="http://www.justice.gov.uk/">on the Justice website</a> in the meantime'} %>
+<% end %>
 
   <div class="block-1 headings-block<%= " service-priority" if @organisation.service_priority_homepage? %>">
     <div class="inner-block">
@@ -17,17 +21,23 @@
                 locals: { feature_list: @feature_list,
                           recently_updated: @recently_updated,
                           organisation: @organisation } %>
-      <section id="what-we-do" class="what-we-do">
+      <section id="<%= @organisation.court_or_hmcts_tribunal? ? 'who-we-are' : 'what-we-do'
+        %>" class="what-we-do">
         <div class="content">
-          <h1 class="label"><%= t('organisation.headings.what_we_do') %></h1>
+          <h1 class="label"><%= t("organisation.headings.#{@organisation.court_or_hmcts_tribunal? ? 'who_we_are' : 'what_we_do'}") %></h1>
           <div class="overview">
-            <p class="description"><%= @organisation.summary %></p>
-            <% if @organisation.parent_organisations.any? || @organisation.active_child_organisations_excluding_sub_organisations.any? %>
+            <% if @organisation.court_or_hmcts_tribunal? && @organisation.about_us %>
+              <%= govspeak_to_html @organisation.about_us.body %>
+            <% else %>
+              <p class="description"><%= @organisation.summary %></p>
+            <% end %>
+            <% if !@organisation.court_or_hmcts_tribunal? &&
+              (@organisation.parent_organisations.any? || @organisation.active_child_organisations_excluding_sub_organisations.any?) %>
               <p class="parent_organisations">
                 <%= organisation_display_name_including_parental_and_child_relationships(@organisation) %>
               </p>
             <% end %>
-            <p><%= link_to t('organisation.about.read_more'), polymorphic_path([@organisation, CorporateInformationPage]), id: 'read_more_link' %></p>
+            <p><%= link_to t('organisation.about.read_more'), polymorphic_path([@organisation, CorporateInformationPage]), id: 'read_more_link' unless @organisation.court_or_hmcts_tribunal? %></p>
             <% if @organisation.slug === 'department-for-international-development' %>
               <div class="uk-aid">
                 <h2><a href="https://www.gov.uk/government/publications/uk-aid-standards-for-using-the-logo">UK aid from the British people</a></h2>
@@ -202,6 +212,24 @@
               </ul>
             </section>
           <% end %>
+
+          <% if @judges.any? %>
+            <section id="judges">
+              <h1 class="label"><%= t('organisation.headings.judges') %></h1>
+              <ul>
+                <% @judges.each_with_index do |role, i| %>
+                  <%= render partial: "people/person",
+                             locals: {
+                               person: role.current_person,
+                               roles: @judge_roles.roles_for(role.current_person),
+                               hlevel: "h3",
+                               hide_image: false,
+                               extra_class: (i % 4 == 0) ? 'clear-person' : ''
+                             } %>
+                <% end %>
+              </ul>
+            </section>
+          <% end %>
         </section>
       </div>
     </div>
@@ -231,30 +259,32 @@
           </div>
         <% end %>
 
-        <section id="freedom-of-information">
-          <% if @organisation.foi_exempt? %>
-            <h1 class='label'><%= t('organisation.headings.freedom_of_information_act') %></h1>
+        <% unless @organisation.court_or_hmcts_tribunal? %>
+          <section id="freedom-of-information">
+            <% if @organisation.foi_exempt? %>
+              <h1 class='label'><%= t('organisation.headings.freedom_of_information_act') %></h1>
 
-            <p class="see-legislation"><%= t('organisation.foi_exemption_html', foi_url: 'http://www.legislation.gov.uk/ukpga/2000/36/schedule/1') %></p>
-          <% else %>
-            <h1 class="label"><%= t('organisation.headings.making_foi_requests') %></h1>
-            <ol class="steps">
-              <li><%= t('organisation.making_foi_requests.step1_html', how_to_path: 'https://www.gov.uk/make-a-freedom-of-information-request/the-freedom-of-information-act') %></li>
-              <li><%= t('organisation.making_foi_requests.step2_html', our_releases_path: publications_filter_path(@organisation, publication_type: 'foi-releases')) %></li>
+              <p class="see-legislation"><%= t('organisation.foi_exemption_html', foi_url: 'http://www.legislation.gov.uk/ukpga/2000/36/schedule/1') %></p>
+            <% else %>
+              <h1 class="label"><%= t('organisation.headings.making_foi_requests') %></h1>
+              <ol class="steps">
+                <li><%= t('organisation.making_foi_requests.step1_html', how_to_path: 'https://www.gov.uk/make-a-freedom-of-information-request/the-freedom-of-information-act') %></li>
+                <li><%= t('organisation.making_foi_requests.step2_html', our_releases_path: publications_filter_path(@organisation, publication_type: 'foi-releases')) %></li>
+                <% if @foi_contacts.any? %>
+                  <li><%= t('organisation.making_foi_requests.step3_html') %></li>
+                <% end %>
+              </ol>
+
               <% if @foi_contacts.any? %>
-                <li><%= t('organisation.making_foi_requests.step3_html') %></li>
-              <% end %>
-            </ol>
-
-            <% if @foi_contacts.any? %>
-              <div class="org-contacts">
-                <div class="addresses js-hide-extra-contacts">
-                  <%= render partial: 'contacts/contact', collection: @foi_contacts %>
+                <div class="org-contacts">
+                  <div class="addresses js-hide-extra-contacts">
+                    <%= render partial: 'contacts/contact', collection: @foi_contacts %>
+                  </div>
                 </div>
-              </div>
+              <% end %>
             <% end %>
-          <% end %>
-        </section>
+          </section>
+        <% end %>
 
         <% if @sub_organisations.any? %>
           <section id="high-profile-units">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -482,6 +482,7 @@ ar:
       making_foi_requests:
       our_announcements: "إعلاناتنا"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "إدارتنا"
       our_ministers: "وزراؤنا"
@@ -495,6 +496,7 @@ ar:
       special_representatives: "الممثلون الخاصون"
       traffic_commissioners: "مفوضو المرور"
       what_we_do: "عملنا"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -333,6 +333,7 @@ az:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -346,6 +347,7 @@ az:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -358,6 +358,7 @@ be:
       making_foi_requests:
       our_announcements: "Нашы абвесткі"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Наша кіраўніцтва"
       our_ministers: "Нашы міністры"
@@ -371,6 +372,7 @@ be:
       special_representatives: "Спецыяльныя прадстаўнікі"
       traffic_commissioners: "Транспартны суд"
       what_we_do: "Што мы робім"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -235,6 +235,7 @@ bg:
       making_foi_requests:
       our_announcements: "Съобщенията ни"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Нашето ръководство"
       our_ministers: "Нашите министи"
@@ -248,6 +249,7 @@ bg:
       special_representatives: "Специални представители"
       traffic_commissioners: "Комисари по трафика"
       what_we_do: "Нашата дейност"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -234,6 +234,7 @@ bn:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -247,6 +248,7 @@ bn:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -296,6 +296,7 @@ cs:
       making_foi_requests:
       our_announcements: Naše prohlášení
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Naše vedení
       our_ministers: Naši ministři
@@ -309,6 +310,7 @@ cs:
       special_representatives: Zvláštní reprezentanti
       traffic_commissioners: Dopravní komisaři
       what_we_do: Co děláme
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -482,6 +482,7 @@ cy:
       making_foi_requests: Gwneud cais DRhG
       our_announcements: Ein cyhoeddiadau
       our_consultations: Ein ymgynghoriadau
+      our_judges:
       our_mainstream_categories:
       our_management: Ein rheolaeth
       our_ministers: Ein gweinidogion
@@ -495,6 +496,7 @@ cy:
       special_representatives: Cynrychiolwyr arbennig
       traffic_commissioners: Comisiynwyr traffig
       what_we_do: Yr hyn rydym ni'n ei wneud
+      who_we_are:
     making_foi_requests:
       step1_html: Darllenwch am y Ddeddf Rhyddid Gwybodaeth (DRhG) a <a href="%{how_to_path}">sut
         i wneud cais</a>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -234,6 +234,7 @@ de:
       making_foi_requests:
       our_announcements: Unsere Meldungen
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Unser Management
       our_ministers: Unsere Minister
@@ -247,6 +248,7 @@ de:
       special_representatives: Sonderbeauftragte
       traffic_commissioners: Verkehrsbeauftragte
       what_we_do: Was wir tun
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -234,6 +234,7 @@ dr:
       making_foi_requests:
       our_announcements: "اعلانات ما"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "اداره ما"
       our_ministers: "وزرای ما"
@@ -247,6 +248,7 @@ dr:
       special_representatives: "نماینده های خاص"
       traffic_commissioners: "کمشنران ترافیک"
       what_we_do: "ما روی چه کار میکنیم"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -235,6 +235,7 @@ el:
       making_foi_requests:
       our_announcements: "Οι ανακοινώσεις μας"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Η ηγεσία μας"
       our_ministers: "Οι υπουργοί μας"
@@ -248,6 +249,7 @@ el:
       special_representatives: "Ειδικοί αντιπρόσωποι"
       traffic_commissioners: "Ομάδα ρύθμισης μεταφορών "
       what_we_do: "Οι δράσεις μας"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -396,6 +396,7 @@ en:
     headings:
       plus_others: + others
       what_we_do: What we do
+      who_we_are: Who we are
       our_topics: We work on these topics
       our_mainstream_categories: We produce detailed guidance in these categories
       our_policies: Our policies
@@ -407,6 +408,7 @@ en:
       our_ministers: Our ministers
       our_senior_military_officials: Our senior military officials
       our_management: Our management
+      our_judges: Our judges
       traffic_commissioners: Traffic commissioners
       chief_professional_officers: Our chief professional officers
       special_representatives: Special representatives

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -234,6 +234,7 @@ es-419:
       making_foi_requests:
       our_announcements: Nuestras novedades
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Nuestra administración
       our_ministers: Nuestros ministros
@@ -247,6 +248,7 @@ es-419:
       special_representatives: Representantes especiales
       traffic_commissioners: Comisionados de tráfico
       what_we_do: Qué hacemos
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -234,6 +234,7 @@ es:
       making_foi_requests:
       our_announcements: Anuncios
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Equipo directivo
       our_ministers: Nuestros ministros
@@ -247,6 +248,7 @@ es:
       special_representatives: Representantes especiales
       traffic_commissioners: Inspector de tráfico
       what_we_do: Qué hacemos
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -235,6 +235,7 @@ et:
       making_foi_requests: Esita FOI päring
       our_announcements: Meie teadaanded
       our_consultations: Meie konsultatsioonid
+      our_judges:
       our_mainstream_categories: 'Me väljastame detailseid juhendeid alljärgnevates
         kategooriates:'
       our_management: Meie juhtkond
@@ -249,6 +250,7 @@ et:
       special_representatives: Eriesindajad
       traffic_commissioners: Liiklusvolinikud
       what_we_do: Millega me tegeleme
+      who_we_are:
     making_foi_requests:
       step1_html: Lugege lähemalt Teabevabaduse seadusest (FOI) ja <a href="%{how_to_path}">kuidas
         esitada päringut</a>

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -336,6 +336,7 @@ fa:
       making_foi_requests:
       our_announcements: "اطلاعیه های ما"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "مدیریت ما"
       our_ministers: "معاونین وزیر ما"
@@ -349,6 +350,7 @@ fa:
       special_representatives: "نمایندگان ویژه"
       traffic_commissioners: "ماموران ترافیک"
       what_we_do: "فعالیت ما"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -234,6 +234,7 @@ fr:
       making_foi_requests:
       our_announcements: Nos actualités
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Notre direction
       our_ministers: Nos ministres
@@ -247,6 +248,7 @@ fr:
       special_representatives: Représentants spéciaux
       traffic_commissioners: Commissaires du trafic
       what_we_do: Nos activités
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -358,6 +358,7 @@ he:
       making_foi_requests:
       our_announcements: "ההודעות שלנו"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "ההנהלה שלנו"
       our_ministers: "השרים שלנו"
@@ -371,6 +372,7 @@ he:
       special_representatives: "נציגים מיוחדים"
       traffic_commissioners: "ממונים על תעבורה"
       what_we_do: "מה אנחנו עושים"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -234,6 +234,7 @@ hi:
       making_foi_requests:
       our_announcements: "हमारी घोषणाएं"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "हमारा प्रबंधन"
       our_ministers: "हमारे मंत्री"
@@ -247,6 +248,7 @@ hi:
       special_representatives: "विशेष प्रतिनिधि"
       traffic_commissioners: "यातायात आयुक्त"
       what_we_do: "हम क्या करते हैं"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -337,6 +337,7 @@ hu:
       making_foi_requests:
       our_announcements: Híreink
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Vezetőségünk
       our_ministers: Minisztereink
@@ -350,6 +351,7 @@ hu:
       special_representatives: Különleges képviselők
       traffic_commissioners: Forgalmi biztosok
       what_we_do: Feladatunk
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -234,6 +234,7 @@ hy:
       making_foi_requests:
       our_announcements: "Մեր հայտարարությունները"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Մեր ղեկավարումը"
       our_ministers: "Մեր նաքարարներ"
@@ -247,6 +248,7 @@ hy:
       special_representatives: "Հատուկ ներկայացուցիչներ"
       traffic_commissioners: "Երթևեկության հանձնաժողով"
       what_we_do: "Ինչ ենք մենք անում"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -336,6 +336,7 @@ id:
       making_foi_requests:
       our_announcements: Pengumuman-pengumuman kami
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Manajemen kami
       our_ministers: Menteri-menteri kami
@@ -349,6 +350,7 @@ id:
       special_representatives: Perwakilan khusus
       traffic_commissioners: Komisioner lalu lintas
       what_we_do: Kerja kami
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -234,6 +234,7 @@ it:
       making_foi_requests:
       our_announcements: I nostri annunci
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Il nostro corpo direttivo
       our_ministers: I nostri ministri
@@ -247,6 +248,7 @@ it:
       special_representatives: Rappresentanti speciali
       traffic_commissioners: Commissari per le attività commerciali
       what_we_do: Cosa facciamo
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -334,6 +334,7 @@ ja:
       making_foi_requests:
       our_announcements: "ニュース"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "幹部職員"
       our_ministers: "大臣"
@@ -347,6 +348,7 @@ ja:
       special_representatives: "特別代表"
       traffic_commissioners: "交通担当コミッショナー"
       what_we_do: "業務案内"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -333,6 +333,7 @@ ka:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -346,6 +347,7 @@ ka:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -334,6 +334,7 @@ ko:
       making_foi_requests:
       our_announcements: "뉴스"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "조직"
       our_ministers: "장관급"
@@ -347,6 +348,7 @@ ko:
       special_representatives: "특별 대사"
       traffic_commissioners: "트래픽 커미셔너"
       what_we_do: "업무 내용"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -296,6 +296,7 @@ lt:
       making_foi_requests:
       our_announcements: Mūsų skelbimai
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Mūsų vadovybė
       our_ministers: Mūsų ministrai
@@ -309,6 +310,7 @@ lt:
       special_representatives: Specialieji atstovai
       traffic_commissioners: Eismo komisarai
       what_we_do: Ką mes darome
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -234,6 +234,7 @@ lv:
       making_foi_requests:
       our_announcements: Mūsu paziņojumi
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Mūsu vadība
       our_ministers: Mūsu ministri
@@ -247,6 +248,7 @@ lv:
       special_representatives: "Īpašie pārstāvji"
       traffic_commissioners: Satiksmes komisāri
       what_we_do: Par mums
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -333,6 +333,7 @@ ms:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -346,6 +347,7 @@ ms:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -358,6 +358,7 @@ pl:
       making_foi_requests:
       our_announcements: Nasze ogłoszenia
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Nasze kierownictwo
       our_ministers: Nasi ministrowie
@@ -371,6 +372,7 @@ pl:
       special_representatives: Specjalni wysłannicy
       traffic_commissioners: Komisarze z wydziałów ruchu drogowego
       what_we_do: Czym się zajmujemy
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -236,6 +236,7 @@ ps:
       making_foi_requests:
       our_announcements: "زمونږه اعلانات"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "زمونږه اداره"
       our_ministers: "زموږه وزیران"
@@ -249,6 +250,7 @@ ps:
       special_representatives: "خصوصی نمایندګان"
       traffic_commissioners: "د ترافیکو کمشنران"
       what_we_do: "موږڅه کوو"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -234,6 +234,7 @@ pt:
       making_foi_requests:
       our_announcements: Nossos anúncios
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Nossa administração
       our_ministers: Nossos ministros
@@ -247,6 +248,7 @@ pt:
       special_representatives: Representantes especiais
       traffic_commissioners: Comissonários de Tráfego
       what_we_do: O que fazemos
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -297,6 +297,7 @@ ro:
       making_foi_requests:
       our_announcements: "Știri "
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: 'Echipa ambasadei '
       our_ministers: 'Miniștrii '
@@ -310,6 +311,7 @@ ro:
       special_representatives: 'Reprezentanți speciali '
       traffic_commissioners: 'Monitorizarea traficului '
       what_we_do: Activitatea noastră
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -358,6 +358,7 @@ ru:
       making_foi_requests:
       our_announcements: "Наши объявления"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Наше руководство"
       our_ministers: "Наши министры"
@@ -371,6 +372,7 @@ ru:
       special_representatives: "Специальные преставители"
       traffic_commissioners: "Сотрудники, Ответственные за транспортные перевозки"
       what_we_do: "Чем мы занимаемся"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -235,6 +235,7 @@ si:
       making_foi_requests:
       our_announcements: "අපේ නිවේදන"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "අපේ කළමනාකරණය"
       our_ministers: "අපේ ඇමතිවරුන්"
@@ -248,6 +249,7 @@ si:
       special_representatives: "විශේෂ නියෝජිතයන්"
       traffic_commissioners: "රථ වාහන කොමසාරිස්වරු"
       what_we_do: "අපි කරන්නේ මොනවද"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -296,6 +296,7 @@ sk:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -309,6 +310,7 @@ sk:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -234,6 +234,7 @@ so:
       making_foi_requests:
       our_announcements: Ogeysiisyadeenna
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Maareeyeyaasheenna
       our_ministers: Wasiirradeenna
@@ -247,6 +248,7 @@ so:
       special_representatives: Wakiil gaar ah
       traffic_commissioners: Madaxa Taraafikada
       what_we_do: Waxa aan qabanno
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -234,6 +234,7 @@ sq:
       making_foi_requests:
       our_announcements: Njoftimet tona
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Manaxhimi yne
       our_ministers: Ministrat tane
@@ -247,6 +248,7 @@ sq:
       special_representatives: Perfaqesues speciale
       traffic_commissioners: Komisionere te trafikut
       what_we_do: Cfare bejme ne
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -358,6 +358,7 @@ sr:
       making_foi_requests:
       our_announcements: Naše objave
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Naše rukovodstvo
       our_ministers: Naši ministri
@@ -371,6 +372,7 @@ sr:
       special_representatives: specijalni predstavnici
       traffic_commissioners: poverenik za saobraćaj
       what_we_do: Radimo na
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -234,6 +234,7 @@ sw:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -247,6 +248,7 @@ sw:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -234,6 +234,7 @@ ta:
       making_foi_requests:
       our_announcements: "எங்களது அறிவிப்புகள்"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "எங்களது முகாமைத்துவம்"
       our_ministers: "எங்களது அமைச்சர்கள்"
@@ -247,6 +248,7 @@ ta:
       special_representatives: "விசேட பிரதிநிதிகள்"
       traffic_commissioners: "போக்குவரத்து ஆணையாளர்கள்"
       what_we_do: "நாங்கள் செய்வது என்ன"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -334,6 +334,7 @@ th:
       making_foi_requests:
       our_announcements: "ข่าวสารของเรา"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "การบริหารจัดการของเรา"
       our_ministers: "รัฐมนตรีของเรา"
@@ -347,6 +348,7 @@ th:
       special_representatives: "ผู้แทนพิเศษ"
       traffic_commissioners: "ผู้บัญชาการจราจร"
       what_we_do: "สิ่งที่เราทำ"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -234,6 +234,7 @@ tk:
       making_foi_requests:
       our_announcements:
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management:
       our_ministers:
@@ -247,6 +248,7 @@ tk:
       special_representatives:
       traffic_commissioners:
       what_we_do:
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -335,6 +335,7 @@ tr:
       making_foi_requests:
       our_announcements: 'Duyurular '
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Yönetim
       our_ministers: Bakanlarımız
@@ -348,6 +349,7 @@ tr:
       special_representatives: "Özel temsilciler"
       traffic_commissioners: Trafik Şube Müdürü
       what_we_do: 'Hakkımızda '
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -358,6 +358,7 @@ uk:
       making_foi_requests:
       our_announcements: "Наші оголошення"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "Наше керівництво"
       our_ministers: "Наші міністри"
@@ -371,6 +372,7 @@ uk:
       special_representatives: "Спеціальні представники"
       traffic_commissioners: "Уповноважені з питань транспорту"
       what_we_do: "Що ми робимо"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -234,6 +234,7 @@ ur:
       making_foi_requests:
       our_announcements: "ہمارے اعلانات"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "ہماری انتظامیہ"
       our_ministers: "ہمارے وزرا"
@@ -247,6 +248,7 @@ ur:
       special_representatives: "خصوصی نمائندے"
       traffic_commissioners: "ٹریفک کمشنرز"
       what_we_do: "ہمارے فرائض"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -234,6 +234,7 @@ uz:
       making_foi_requests:
       our_announcements: Bizning e'lonlar
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Bizning rahbariyat
       our_ministers: Bizning vazirlar
@@ -247,6 +248,7 @@ uz:
       special_representatives: Maxsus vakil
       traffic_commissioners: Traffik va transport savollari bo'yicha komissar 
       what_we_do: Bizning faoliyatimiz
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -336,6 +336,7 @@ vi:
       making_foi_requests:
       our_announcements: Các thông báo của chúng tôi
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: Ban quản lý
       our_ministers: Các Thứ trưởng
@@ -349,6 +350,7 @@ vi:
       special_representatives: "Đại diện đặc biệt"
       traffic_commissioners: Các ủy viên giao thông
       what_we_do: "Điều chúng tôi làm"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -333,6 +333,7 @@ zh-hk:
       making_foi_requests:
       our_announcements: "我們的公告"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "我們的管理層"
       our_ministers: "我們的大臣"
@@ -346,6 +347,7 @@ zh-hk:
       special_representatives: "特別代表"
       traffic_commissioners: "交通事務專員"
       what_we_do: "我們的工作"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -333,6 +333,7 @@ zh-tw:
       making_foi_requests:
       our_announcements: "我們的公告"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "我們的管理層"
       our_ministers: "我們的首相/大臣"
@@ -346,6 +347,7 @@ zh-tw:
       special_representatives: "特別代表"
       traffic_commissioners: "交通事務專員"
       what_we_do: "我們的工作"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -333,6 +333,7 @@ zh:
       making_foi_requests:
       our_announcements: "我们的公告"
       our_consultations:
+      our_judges:
       our_mainstream_categories:
       our_management: "我们的管理层"
       our_ministers: "我们的首相/大臣/秘书"
@@ -346,6 +347,7 @@ zh:
       special_representatives: "特别代表"
       traffic_commissioners: "交通事务专员"
       what_we_do: "我们的工作"
+      who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,6 +402,9 @@ Whitehall::Application.routes.draw do
     get '/placeholder' => 'placeholder#show', as: :placeholder
   end
 
+  resources :organisations, only: [:index, :show], path: 'courts-tribunals', localised: true,
+    as: :courts, courts_only: true
+
   get 'healthcheck' => 'healthcheck#check'
   get 'healthcheck/overdue' => 'healthcheck#overdue'
 

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -19,6 +19,7 @@ namespace :router do
   desc "Register the government prefix with the router"
   task :register_routes => :router_environment do
     @router_api.add_route("/government", "prefix", @application_id)
+    @router_api.add_route("/courts-tribunals", "prefix", @application_id)
   end
 
   desc "Register all detailed guidance categories with the router"

--- a/test/factories/judge_roles.rb
+++ b/test/factories/judge_roles.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :judge_role do
+    sequence(:name) { |n| "Chief Justice ##{n}" }
+    after :build do |role, evaluator|
+      role.organisations = [FactoryGirl.build(:court)] unless evaluator.organisations.any?
+    end
+  end
+end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -62,6 +62,8 @@ FactoryGirl.define do
     organisation_type_key :court
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
+    parent_organisations { [Organisation.find_by(slug: "hm-courts-and-tribunals-service") ||
+      build(:organisation, slug: "hm-courts-and-tribunals-service", name: "HMCTS")] }
   end
 
   factory :hmcts_tribunal, parent: :organisation do
@@ -69,6 +71,6 @@ FactoryGirl.define do
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
     parent_organisations { [Organisation.find_by(slug: "hm-courts-and-tribunals-service") ||
-      build(:organisation, slug: "hm-courts-and-tribunals-service")] }
+      build(:organisation, slug: "hm-courts-and-tribunals-service", name: "HMCTS")] }
   end
 end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -60,5 +60,15 @@ FactoryGirl.define do
 
   factory :court, parent: :organisation do
     organisation_type_key :court
+    organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
+    logo_formatted_name { name }
+  end
+
+  factory :hmcts_tribunal, parent: :organisation do
+    organisation_type_key :tribunal_ndpb
+    organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
+    logo_formatted_name { name }
+    parent_organisations { [Organisation.find_by(slug: "hm-courts-and-tribunals-service") ||
+      build(:organisation, slug: "hm-courts-and-tribunals-service")] }
   end
 end

--- a/test/factories/role_appointments.rb
+++ b/test/factories/role_appointments.rb
@@ -32,4 +32,8 @@ FactoryGirl.define do
   factory :historic_role_appointment, parent: :role_appointment do
     association :role, factory: :historic_role
   end
+
+  factory :judge_role_appointment, parent: :role_appointment do
+    association :role, factory: :judge_role
+  end
 end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -898,6 +898,24 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "organisations shows the default Jobs link" do
+    organisation = create(:organisation)
+    get :show, id: organisation
+    assert_select "a", text: "Jobs"
+  end
+
+  view_test "courts don't show a Jobs link" do
+    court = create(:court)
+    get :show, id: court, courts_only: true
+    refute_select "a", text: "Jobs"
+  end
+
+  view_test "HMCTS tribunals don't show a Jobs link" do
+    hmcts_tribunal = create(:hmcts_tribunal)
+    get :show, id: hmcts_tribunal, courts_only: true
+    refute_select "a", text: "Jobs"
+  end
+
   private
 
   def assert_disclaimer_present(organisation)

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -886,6 +886,18 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "auto-links comments in contacts" do
+    organisation = create(:organisation)
+    contact = create(:contact, comments: "This is a link: http://www.example.com")
+    organisation.add_contact_to_home_page!(contact)
+
+    get :show, id: organisation
+
+    assert_select ".comments", text: "This is a link: http://www.example.com" do
+      assert_select "a[href=http://www.example.com]", text: "http://www.example.com"
+    end
+  end
+
   private
 
   def assert_disclaimer_present(organisation)

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -233,6 +233,40 @@ class OrganisationHelperTest < ActionView::TestCase
     assert_nil govuk_status_meta_data_for(build(:organisation, govuk_status: 'live'))
     assert_nil govuk_status_meta_data_for(build(:organisation, govuk_status: 'closed'))
   end
+
+  test "#show_corporate_information_pages? for organisations that are not live should be false" do
+    organisation = create(:organisation, :closed)
+
+    refute show_corporate_information_pages?(organisation)
+  end
+
+  test "#show_corporate_information_pages? for live organisations should be true" do
+    organisation = create(:organisation)
+
+    assert show_corporate_information_pages?(organisation)
+  end
+
+  test "#show_corporate_information_pages? for live courts with published corporate information pages should be true" do
+    organisation = create(:court)
+    create(:published_corporate_information_page, organisation: organisation)
+
+    assert show_corporate_information_pages?(organisation)
+  end
+
+  test "#show_corporate_information_pages? for live courts with only a published about_us page should be false" do
+    organisation = create(:court)
+    create(:about_corporate_information_page, organisation: organisation)
+
+    refute show_corporate_information_pages?(organisation)
+  end
+
+  test "#show_corporate_information_pages? for live courts with published about_us and other corporate information pages should be true" do
+    organisation = create(:court)
+    create(:published_corporate_information_page, organisation: organisation)
+    create(:about_corporate_information_page, organisation: organisation)
+
+    assert show_corporate_information_pages?(organisation)
+  end
 end
 
 class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::TestCase

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -818,12 +818,6 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [org_with_announcement], Organisation.with_statistics_announcements
   end
 
-  test "excluding_courts scopes to non-court organisation types" do
-    court = create(:court)
-    other_org = create(:organisation)
-    assert_equal [other_org], Organisation.excluding_courts
-  end
-
   test "#has_services_and_information_link? returns true if slug is in the whitelist" do
     org = create(:organisation)
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -389,8 +389,16 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test 'should not add courts to index on creating' do
     court = build(:court)
-    Whitehall::SearchIndex.expects(:add).never
+    Whitehall::SearchIndex.expects(:add).once
+    Whitehall::SearchIndex.expects(:add).with(court).never
     court.save
+  end
+
+  test 'should not add HMCTS tribunals to index on creating' do
+    hmcts_tribunal = build(:hmcts_tribunal)
+    Whitehall::SearchIndex.expects(:add).once
+    Whitehall::SearchIndex.expects(:add).with(hmcts_tribunal).never
+    hmcts_tribunal.save
   end
 
   test 'should add organisation to search index on updating' do

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -278,6 +278,13 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [chief_professional_officer], organisation.chief_professional_officer_roles
   end
 
+  test '#judge_roles includes only judges' do
+    judge = create(:judge_role)
+    chief_professional_officer = create(:chief_professional_officer_role)
+    organisation = create(:organisation, roles:  [chief_professional_officer, judge])
+    assert_equal [judge], organisation.judge_roles
+  end
+
   test 'should be creatable with featured link data' do
     params = {
       featured_links_attributes: [

--- a/test/unit/presenters/role_type_presenter_test.rb
+++ b/test/unit/presenters/role_type_presenter_test.rb
@@ -28,6 +28,9 @@ class RoleTypePresenterTest < PresenterTestCase
         ["Deputy head of mission", "deputy_head_of_mission"],
         ["Worldwide office staff", "worldwide_office_staff"]
       ]],
+      ["MOJ only", [
+        ["Judge", "judge"],
+      ]],
       ["Ministerial", [
         ["Cabinet minister", "cabinet_minister"],
         ["Minister", "minister"]


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/92039418

This PR expands the current Organisations resource to display Courts and (HMCTS) Tribunals (aka Judicial Bodies) on GOV.UK, but outside of `/government/organisations`.

Changes in this branch:

- About Us CIP body is rendered as Govspeak for these new resources under a changed heading of "Who we are"
- Added new Role for Judges
- Distinguish between Tribunals that should exist under `/courts-tribunals` and `/government/organisations`. Both types should be of the Organisation Type of `tribunal_ndpb`. However, if the organisation is a child of `hm-courts-and-tribunals-service` they will be shown under `/courts-tribunals`.
- Add auto-linking to the Comments field of Organisation contacts. This is to allow for nicely formatted links to e.g. Court Finder. This uses the `rinku` gem, as the `auto_link` helper has been removed from Rails.
- Disable Jobs and FOI sections for courts and tribunals.
- Added Beta label to the courts and tribunals pages.

Screenshots:

![screencapture-whitehall-frontend-dev-gov-uk-courts-tribunals-1429871424208](https://cloud.githubusercontent.com/assets/18276/7321619/2f3dd92a-ea9b-11e4-8186-45f4904a1d68.png)
![screencapture-whitehall-frontend-dev-gov-uk-courts-tribunals-bankruptcy-court-1429871404389](https://cloud.githubusercontent.com/assets/18276/7321622/3653af1e-ea9b-11e4-91e2-086466dcbf29.png)
![screencapture-whitehall-frontend-dev-gov-uk-courts-tribunals-bankruptcy-court-1429871124867](https://cloud.githubusercontent.com/assets/18276/7321628/3d51b1d0-ea9b-11e4-89f9-33bc05c54714.png)
