### PR TITLE
Fix publishing API populator scripts

### DIFF
--- a/lib/whitehall/publishing_api/populator.rb
+++ b/lib/whitehall/publishing_api/populator.rb
@@ -54,9 +54,11 @@ module Whitehall
         end
 
         def log(item)
-          if @type != item.class
-            logger.info "Exporting items of class '#{item.class.name}'..."
-            @type = item.class
+          new_class = item.class
+          new_class = new_class.base_class if new_class.method_exists?(:base_class)
+          if @type != new_class
+            @type = new_class
+            logger.info "Exporting items of class '#{@type}'..."
           end
 
           @i += 1

--- a/test/unit/whitehall/publishing_api/populator_test.rb
+++ b/test/unit/whitehall/publishing_api/populator_test.rb
@@ -21,6 +21,17 @@ module Whitehall
 
         Populator.new(items: items, sender: ->(_) {}, logger: logger).call
       end
+
+      test "logs a new header when base class changes" do
+        items = [build(:case_study), build(:publication), build(:news_article)]
+        items << build(:organisation)
+        logger = stub("logger")
+        logger.expects(:info).with("Exporting items of class 'Edition'...")
+        logger.expects(:info).with("Exporting items of class 'Organisation'...")
+        logger.expects(:info).with("Finished.")
+
+        Populator.new(items: items, sender: ->(_) {}, logger: logger).call
+      end
     end
   end
 end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -306,6 +306,19 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested request
   end
 
+  test "#publish_async propagates update_type and queue overrides to worker" do
+    queue_name = "bang"
+    update_type = "whizzo"
+
+    edition = create(:published_case_study)
+
+    PublishingApiWorker.expects(:perform_async_in_queue)
+      .with(queue_name, edition.class.name, edition.id,
+            update_type, edition.primary_locale.to_sym)
+
+    Whitehall::PublishingApi.publish_async(edition, update_type, queue_name)
+  end
+
   test "#publish_draft_async propagates update_type and queue overrides to worker" do
     queue_name = "bang"
     update_type = "whizzo"


### PR DESCRIPTION
The LiveEnvironmentPopulator was based on the DraftEnvironmentPopulator which passed a `queue_override` parameter to the PublishingApi, but this argument is not supported by the `publish_async` method. This change adds that support, and fixes an issue with the logger outputting too many lines when given a mix of edition types.