### PR TITLE
Supply public_updated_at for draft editions

### DIFF
--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -15,6 +15,11 @@ module PublishingApiPresenters
       Whitehall.url_maker.public_document_path(edition)
     end
 
+    def public_updated_at
+      # If there is no public_timestamp, the edition should be a draft
+      edition.public_timestamp || edition.updated_at
+    end
+
     def as_json
       {
         content_id: edition.content_id,
@@ -23,7 +28,7 @@ module PublishingApiPresenters
         format: "placeholder",
         locale: I18n.locale.to_s,
         need_ids: edition.need_ids,
-        public_updated_at: edition.public_timestamp,
+        public_updated_at: public_updated_at,
         update_type: update_type,
         publishing_app: "whitehall",
         # We're not using edition.rendering_app because we're defaulting to a

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -45,6 +45,44 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     assert_valid_against_schema(presented_hash, 'placeholder')
   end
 
+  test 'can present a draft Edition for the publishing API' do
+    edition = create(:publication,
+                title: 'The title',
+                summary: 'The summary',
+                primary_specialist_sector_tag: 'oil-and-gas/taxation',
+                secondary_specialist_sector_tags: ['oil-and-gas/licensing'])
+
+    public_path = Whitehall.url_maker.public_document_path(edition)
+
+    expected_hash = {
+      content_id: edition.document.content_id,
+      title: 'The title',
+      description: 'The summary',
+      format: 'placeholder',
+      locale: 'en',
+      need_ids: [],
+      public_updated_at: edition.updated_at,
+      update_type: 'major',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      routes: [
+        { path: public_path, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        change_note: nil,
+        tags: {
+          browse_pages: [],
+          topics: ['oil-and-gas/taxation', 'oil-and-gas/licensing']
+        }
+      },
+    }
+
+    presented_hash = present(edition)
+    assert_equal expected_hash, presented_hash
+    assert_valid_against_schema(presented_hash, 'placeholder')
+  end
+
   test 'includes the most recent change note even when the edition is only a minor change' do
     user  = create(:gds_editor)
     first = create(:published_edition)


### PR DESCRIPTION
Currently, Whitehall can't publish draft editions because they don't have a `public_timestamp`.