### PR TITLE
New policy email alerts

### DIFF
--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -2,13 +2,12 @@
 # and stored in the content-store.
 module Future
   class Policy
-    attr_reader :base_path, :content_id, :slug, :title
+    attr_reader :base_path, :content_id, :title
 
     def initialize(attributes)
       @base_path = attributes["base_path"]
       @content_id = attributes["content_id"]
       @title = attributes["title"]
-      @slug = extract_slug
     end
 
     def self.all
@@ -27,9 +26,8 @@ module Future
       []
     end
 
-  private
-    def extract_slug
-      base_path.split('/').last
+    def slug
+      @slug ||= base_path.split('/').last
     end
   end
 end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -42,27 +42,25 @@ module PublishingApiPresenters
 
   private
 
-    # An incomplete and temporary details hash that only currently includes
-    # specialist topics. This is to enable the email alerts service to generate
-    # email alerts based on taggings to topics.
-    #
-    # Note that we are referencing tags using the temporary `tags` hash here in
-    # `details` instead of the top-level `links` hash because topics are not yet
-    # being registered in the content store. Once they are available in the
-    # content store, the `links` hash should be used instead.
-    #
-    # Note also that the `browse_pages` key is here as a marker for a future
-    # feature where email alerts will be generated based on taggings to browse
-    # pages. Again, this should be moved to the `links` hash at the earliest
-    # possible time.
     def details
       {
         change_note: edition.most_recent_change_note,
+        # These tags are used downstream for sending email alerts.
+        # For more details please see https://gov-uk.atlassian.net/wiki/display/TECH/Email+alerts+2.0
         tags: {
           browse_pages: [],
+          policies: policies,
           topics: specialist_sectors,
         }
       }
+    end
+
+    def policies
+      if FeatureFlag.enabled?('future_policies')
+        edition.policies.map(&:slug)
+      else
+        []
+      end
     end
 
     def default_update_type

--- a/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
+++ b/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
@@ -27,6 +27,8 @@ module Whitehall
       end
 
       def relevant_to_local_government?
+        return false if FeatureFlag.enabled?('future_policies')
+
         edition.relevant_to_local_government?
       end
 
@@ -134,6 +136,8 @@ module Whitehall
       end
 
       def policy_urls
+        return [] if FeatureFlag.enabled?('future_policies')
+
         if edition.can_be_related_to_policies?
           generate_urls(url_maker.method(:activity_policy_url), edition.published_related_policies.map(&:document))
         else

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -39,7 +39,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
         ],
         tags: {
           browse_pages: [],
-          topics: []
+          topics: [],
+          policies: []
         }
       },
       links: {


### PR DESCRIPTION
This does two things based on new policies being enabled:

1. Sends policies as tags to the publishing API, and thence to the new emailing system.
2. Prevents the old email system sending subscription URLs related to policies or local government relevance.

This is the Whitehall half of https://trello.com/c/06dLz09T/207-make-email-work-for-new-style-policies