### PR TITLE
Tweak future policies flag

### DIFF
--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -4,7 +4,7 @@ class CaseStudiesController < DocumentsController
   end
 
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     @document = CaseStudyPresenter.new(@document, view_context)
   end
 

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -5,7 +5,7 @@ class ConsultationsController < DocumentsController
   end
 
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     set_meta_description(@document.summary)
     expire_on_open_state_change(@document)
   end

--- a/app/controllers/detailed_guides_controller.rb
+++ b/app/controllers/detailed_guides_controller.rb
@@ -7,7 +7,7 @@ class DetailedGuidesController < DocumentsController
   def show
     @categories = @document.mainstream_categories
     @topics = @document.topics
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
   end
 
 private

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -49,6 +49,16 @@ private
     end
   end
 
+  # Returns either classic whitehall policies or the new future-policies, based
+  # on the feature-flag/
+  def document_related_policies
+    if FeatureFlag.enabled?('future_policies')
+      @document.policies
+    else
+      @document.published_related_policies
+    end
+  end
+
   def find_unpublishing
     Unpublishing.from_slug(params[:id], document_class)
   end

--- a/app/controllers/fatality_notices_controller.rb
+++ b/app/controllers/fatality_notices_controller.rb
@@ -1,6 +1,6 @@
 class FatalityNoticesController < DocumentsController
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     @document = FatalityNoticePresenter.new(@document, @view_context)
     set_slimmer_format_header("news")
   end

--- a/app/controllers/news_articles_controller.rb
+++ b/app/controllers/news_articles_controller.rb
@@ -2,7 +2,7 @@ class NewsArticlesController < DocumentsController
   before_filter :set_analytics_format, only: [:show]
 
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     @document = NewsArticlePresenter.new(@document, view_context)
     set_meta_description(@document.summary)
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -24,7 +24,7 @@ class PublicationsController < DocumentsController
   end
 
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     set_meta_description(@document.summary)
   end
 

--- a/app/controllers/speeches_controller.rb
+++ b/app/controllers/speeches_controller.rb
@@ -1,6 +1,6 @@
 class SpeechesController < DocumentsController
   def show
-    @related_policies = @document.published_related_policies
+    @related_policies = document_related_policies
     @topics = @related_policies.map { |d| d.topics }.flatten.uniq
     set_meta_description(@document.summary)
   end

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -44,22 +44,6 @@ module Edition::RelatedPolicies
     Future::Policy.from_content_ids(policy_content_ids)
   end
 
-  def published_related_policies
-    if FeatureFlag.enabled?('future_policies')
-      policies
-    else
-      super
-    end
-  end
-
-  def related_policies
-    if FeatureFlag.enabled?('future_policies')
-      policies
-    else
-      super
-    end
-  end
-
   def search_index
     super.merge(policies: policies.map(&:slug))
   end

--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -99,7 +99,13 @@ class DocumentListExportPresenter
   end
 
   def policies
-    edition.related_policies.map(&:title) if edition.respond_to? :related_policies
+    if edition.respond_to? :related_policies
+      if FeatureFlag.enabled?('future_policies')
+        edition.policies.map(&:title)
+      else
+        edition.related_policies.map(&:title)
+      end
+    end
   end
 
   def specialist_sectors

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -12,7 +12,7 @@ private
   def links
     {
       lead_organisations: edition.lead_organisations.map(&:content_id),
-      related_policies: edition.related_policies.map(&:content_id),
+      related_policies: policy_content_ids,
       supporting_organisations: edition.supporting_organisations.map(&:content_id),
       document_collections: edition.published_document_collections.map(&:content_id),
       world_locations: edition.world_locations.map(&:content_id),
@@ -66,5 +66,13 @@ private
 
   def presented_case_study
     CaseStudyPresenter.new(edition)
+  end
+
+  def policy_content_ids
+    if FeatureFlag.enabled?('future_policies')
+      edition.policy_content_ids
+    else
+      edition.related_policies.map(&:content_id)
+    end
   end
 end

--- a/features/support/future_policies.rb
+++ b/features/support/future_policies.rb
@@ -1,8 +1,6 @@
 # Turn on temporary feature-flag for future-policies feature during selected tests
 Around("@future-policies") do |scenario, block|
-  future_policies_setting = FeatureFlag.enabled?('future_policies')
   FeatureFlag.find_or_create_by(key: 'future_policies')
   FeatureFlag.set('future_policies', true)
   block.call
-  FeatureFlag.set('future_policies', future_policies_setting)
 end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -173,17 +173,12 @@ module DocumentControllerTestHelpers
       end
 
       view_test "should render related future policies on #{document_type} pages" do
-        future_policies_setting = FeatureFlag.enabled?('future_policies')
         FeatureFlag.find_or_create_by(key: 'future_policies')
         FeatureFlag.set('future_policies', true)
 
-        begin
-          edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
-          get :show, id: edition.document
-          assert_select ".meta a", text: policy_1["title"]
-        ensure
-          FeatureFlag.set('future_policies', future_policies_setting)
-        end
+        edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
+        get :show, id: edition.document
+        assert_select ".meta a", text: policy_1["title"]
       end
     end
 

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -112,27 +112,4 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
 
     assert_equal [content_id], new_edition.policy_content_ids
   end
-
-  test "#published_related_policies returns future policies if set" do
-    old_world_policy = create(:published_policy)
-    edition = create(:published_news_article, related_documents: [old_world_policy.document])
-
-    stub_content_register_policies
-    edition.policy_content_ids = [policy_1["content_id"]]
-    edition.save
-    edition.reload
-
-    future_policies_setting = FeatureFlag.enabled?('future_policies')
-    FeatureFlag.find_or_create_by(key: 'future_policies')
-
-    FeatureFlag.set('future_policies', false)
-    assert_equal 1, edition.published_related_policies.count
-    assert_equal old_world_policy, edition.published_related_policies.first
-
-    FeatureFlag.set('future_policies', true)
-    assert_equal 1, edition.published_related_policies.count
-    assert edition.published_related_policies.first.is_a?(Future::Policy)
-
-    FeatureFlag.set('future_policies', future_policies_setting)
-  end
 end

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -68,16 +68,11 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
 
   test '#policies returns policy titles with future-policies flag on' do
     stub_content_register_policies
-    future_policies_setting = FeatureFlag.enabled?('future_policies')
     FeatureFlag.find_or_create_by(key: 'future_policies')
     FeatureFlag.set('future_policies', true)
 
-    begin
-      news = create(:news_article, policy_content_ids: [policy_1["content_id"]])
-      pr = DocumentListExportPresenter.new(news)
-      assert_equal [policy_1["title"]], pr.policies
-    ensure
-      FeatureFlag.set('future_policies', future_policies_setting)
-    end
+    news = create(:news_article, policy_content_ids: [policy_1["content_id"]])
+    pr = DocumentListExportPresenter.new(news)
+    assert_equal [policy_1["title"]], pr.policies
   end
 end

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
-class DocumentListExportPresenterTest < PresenterTestCase
+class DocumentListExportPresenterTest < ActiveSupport::TestCase
+  include ContentRegisterHelpers
 
   test '#sub_content_type returns the correct subtype for news articles' do
     article = build(:news_article, news_article_type: NewsArticleType::PressRelease)
@@ -58,4 +59,25 @@ class DocumentListExportPresenterTest < PresenterTestCase
     assert_equal('Org 1', pr.lead_organisations)
   end
 
+  test '#policies returns a list of the related policies' do
+    policy = create(:policy)
+    news   = create(:news_article, related_documents: [policy.document])
+    pr = DocumentListExportPresenter.new(news)
+    assert_equal [policy.title], pr.policies
+  end
+
+  test '#policies returns policy titles with future-policies flag on' do
+    stub_content_register_policies
+    future_policies_setting = FeatureFlag.enabled?('future_policies')
+    FeatureFlag.find_or_create_by(key: 'future_policies')
+    FeatureFlag.set('future_policies', true)
+
+    begin
+      news = create(:news_article, policy_content_ids: [policy_1["content_id"]])
+      pr = DocumentListExportPresenter.new(news)
+      assert_equal [policy_1["title"]], pr.policies
+    ensure
+      FeatureFlag.set('future_policies', future_policies_setting)
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -192,7 +192,6 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     assert_equal [policy_1["content_id"]], presented_hash[:links][:related_policies]
   end
 
-
   test "links hash includes worldwide priorities" do
     priority = create(:worldwide_priority)
     case_study = create(:published_case_study)

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -182,19 +182,14 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
   test 'links hash includes future-policies when flag is on' do
     stub_content_register_policies
-    future_policies_setting = FeatureFlag.enabled?('future_policies')
     FeatureFlag.find_or_create_by(key: 'future_policies')
     FeatureFlag.set('future_policies', true)
 
-    begin
-      case_study = create(:published_case_study, policy_content_ids: [policy_1["content_id"]])
-      presented_hash = present(case_study)
+    case_study = create(:published_case_study, policy_content_ids: [policy_1["content_id"]])
+    presented_hash = present(case_study)
 
-      assert_valid_against_schema(presented_hash, 'case_study')
-      assert_equal [policy_1["content_id"]], presented_hash[:links][:related_policies]
-    ensure
-      FeatureFlag.set('future_policies', future_policies_setting)
-    end
+    assert_valid_against_schema(presented_hash, 'case_study')
+    assert_equal [policy_1["content_id"]], presented_hash[:links][:related_policies]
   end
 
 


### PR DESCRIPTION
This adjusts the way that the feature-flagging for future-policies affects the running application to make it more robust by avoiding overriding existing relation methods, and instead, performing the checks as and where they are required.

Previously, the feature-flag switching was happening in the `Edition` model by overriding the existing `related_policies` and `published_related_policies` associations such that they either return existing whitehalll `Policy` instances or the new `Future::Policy` instances based on the state of the flag. This introduced a couple of bugs[1], [2] and makes it harder to remove the flag later without breaking the test suite, as large chunks of the codebase (app code and tests) still assumes that old policies exist and the relations can be created. This change removes the override and instead, moves the feature-flag checks only to the places where they matter, i.e. the frontend controller code that loads policies to show to users, and also a couple of presenters that list policies related to documents.

These changes should make it trivial to remove the feature flag once new policies are deployed - it should simply be a case of updating the frontend[3] and backend[4] macros for testing policies. The existing app and test code related to the old Policy model can be left in place until such a time as we are ready to properly clean things up post-election.

[1] https://errbit.preview.alphagov.co.uk/apps/53020c2d0da11590e70000a0/problems/553647df6578630f7d260000
[2] https://errbit.preview.alphagov.co.uk/apps/53020c2d0da11590e70000a0/problems/55350e0465786346c7da0000
[3] https://github.com/alphagov/whitehall/blob/master/test/support/document_controller_test_helpers.rb#L147
[4] https://github.com/alphagov/whitehall/blob/master/test/support/admin_edition_controller_test_helpers.rb#L531