### PR TITLE
Add new World Locations for St Martin and Saint-Barthélemy

### DIFF
--- a/db/data_migration/20150428101428_add_st_martin_world_location.rb
+++ b/db/data_migration/20150428101428_add_st_martin_world_location.rb
@@ -1,0 +1,5 @@
+WorldLocation.create!(
+  :name => "St Martin",
+  :title => "UK and St Martin",
+  :world_location_type => WorldLocationType::WorldLocation
+)

--- a/db/data_migration/20150428125749_add_saint_barthelemy_world_location.rb
+++ b/db/data_migration/20150428125749_add_saint_barthelemy_world_location.rb
@@ -1,0 +1,5 @@
+WorldLocation.create!(
+  :name => "Saint-Barthélemy",
+  :title => "UK and Saint-Barthélemy",
+  :world_location_type => WorldLocationType::WorldLocation
+)


### PR DESCRIPTION
- St Martin is the French side of the Caribbean island of St Maarten
  (which with that spelling is Dutch). Saint-Barthélemy is another
  French-Caribbean island, and these two both need pages on GOV.UK.

Tested these in dev and they both exist at `/government/admin/world_locations/uk-and-st-martin` and `/government/admin/world_locations/uk-and-saint-barthelemy` respectively.