### PR TITLE
Add statistics atom feed + email

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -16,7 +16,10 @@ class AnnouncementsController < DocumentsController
       format.atom do
         documents = Announcement.published_with_eager_loading(@filter.documents.map(&:id))
         @announcements = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, AnnouncementPresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          AnnouncementPresenter,
+          view_context
+        )
       end
     end
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -18,7 +18,10 @@ class PublicationsController < DocumentsController
       format.atom do
         documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
         @publications = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          PublicationesquePresenter,
+          view_context
+        )
       end
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,5 +1,5 @@
 class StatisticsController < DocumentsController
-  enable_request_formats index: [:json]
+  enable_request_formats index: [:json, :atom]
   before_filter :inject_statistics_publication_filter_option_param, only: :index
   before_filter :expire_cache_when_next_publication_published
 
@@ -13,6 +13,11 @@ class StatisticsController < DocumentsController
       end
       format.json do
         render json: StatisticsFilterJsonPresenter.new(@filter, view_context, PublicationesquePresenter)
+      end
+      format.atom do
+        documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
+        @statistics = Whitehall::Decorators::CollectionDecorator.new(
+          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
       end
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -17,7 +17,10 @@ class StatisticsController < DocumentsController
       format.atom do
         documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
         @statistics = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          PublicationesquePresenter,
+          view_context
+        )
       end
     end
   end

--- a/app/views/statistics/index.atom.builder
+++ b/app/views/statistics/index.atom.builder
@@ -1,0 +1,8 @@
+atom_feed language: 'en-GB', root_url: root_url do |feed|
+  feed.title 'Statistics on GOV.UK'
+  feed.author do |author|
+    author.name 'HM Government'
+  end
+
+  documents_as_feed_entries(@statistics, feed)
+end

--- a/lib/whitehall/feed_url_builder.rb
+++ b/lib/whitehall/feed_url_builder.rb
@@ -12,6 +12,8 @@ module Whitehall
         Whitehall.url_maker.publications_url(url_params)
       when 'announcements'
         Whitehall.url_maker.announcements_url(url_params)
+      when 'statistics'
+        Whitehall.url_maker.statistics_url(url_params)
       end
     end
 

--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -32,7 +32,7 @@ module Whitehall
       end
 
       def filtered_documents_feed?
-        %w(publications announcements).include?(feed_type)
+        %w(publications announcements statistics).include?(feed_type)
       end
 
     protected
@@ -92,6 +92,8 @@ module Whitehall
           @feed_type = 'publications'
         elsif uri.path == url_maker.announcements_path
           @feed_type = 'announcements'
+        elsif uri.path == url_maker.statistics_path
+          @feed_type = 'publications'
         else
           path_root_fragment = uri.path.split('/')[2];
           @feed_object_slug = uri.path.match(/([^\/]*)\.atom$/)[1]

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -177,6 +177,20 @@ class StatisticsControllerTest < ActionController::TestCase
     assert_equal %Q{Part of a collection: #{link}}, result['publication_collections']
   end
 
+  view_test "index generates an atom feed with entries for statistics matching the current filter" do
+    org = create(:organisation, name: "org-name")
+    org2 = create(:organisation, name: "other-org")
+    statistics_publication = create(:published_statistics, title: "statistics-title",
+                                                           organisations: [org, org2],
+                                                           first_published_at: Date.parse("2012-03-14"))
+
+    get :index, format: :atom, departments: [org.to_param]
+
+    assert_select_atom_feed do
+      assert_select_atom_entries([statistics_publication])
+    end
+  end
+
   view_test "#show displays a badge when the publication is national statistics" do
     publication = create(:published_publication, publication_type_id: PublicationType::NationalStatistics.id)
     get :show, id: publication.document

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -182,9 +182,15 @@ class StatisticsControllerTest < ActionController::TestCase
     org2 = create(:organisation, name: "other-org")
     statistics_publication = create(:published_statistics, title: "statistics-title",
                                                            organisations: [org, org2],
-                                                           first_published_at: Date.parse("2012-03-14"))
+                                                           first_published_at: Date.parse("2015-03-14"))
 
     get :index, format: :atom, departments: [org.to_param]
+
+    # So, this works (ie 'publication' in the slug)
+    assert_match 'https://www.test.alphagov.co.uk/government/publications/statistics-title', response.body
+
+    # But this doesn't work (ie 'statistics')
+    assert_match 'https://www.test.alphagov.co.uk/government/statistics/statistics-title', response.body
 
     assert_select_atom_feed do
       assert_select_atom_entries([statistics_publication])

--- a/test/unit/whitehall/feed_url_builder_test.rb
+++ b/test/unit/whitehall/feed_url_builder_test.rb
@@ -10,6 +10,10 @@ module Whitehall
       assert_equal feed_url("announcements.atom"), FeedUrlBuilder.new(document_type: 'announcements').url
     end
 
+    test "with :document_type as statistics it generates the announcements feed url" do
+      assert_equal feed_url("statistics.atom"), FeedUrlBuilder.new(document_type: 'statistics').url
+    end
+
     test "with :document_type as publications and other params it generate a publications atom feed url with the given params as query string" do
       filter_params = {
         document_type: 'publications',

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -52,6 +52,21 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     assert_equal "announcements related to The Cabinet Office, Arts and culture and Afghanistan", validator.description
   end
 
+  test 'validates and describes a statistics filter feed url with filter options' do
+    create(:topic, slug: 'arts-and-culture', name: 'Arts and culture')
+    create(:ministerial_department, :with_published_edition, name: 'The Cabinet Office')
+
+    feed_url = feed_url_for(
+      document_type: "statistics",
+      topics: ["arts-and-culture"],
+      departments: ["the-cabinet-office"]
+    )
+    validator = FeedUrlValidator.new(feed_url)
+
+    assert validator.valid?
+    assert_equal "statistics related to The Cabinet Office and Arts and culture", validator.description
+  end
+
   test 'uses the announcement_filter_option when given' do
     feed_url = feed_url_for(document_type: "announcements", announcement_filter_option: "fatality-notices")
     validator = FeedUrlValidator.new(feed_url)


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/n/projects/1261204/stories/87099378

I've taken @camilleldn's WIP branch
https://github.com/alphagov/whitehall/compare/statistics-feed?expand=1
and put it in here, along with support in the statistics controller.

So if you go to gov.uk/government/statistics.atom you'll get an atom feed.
I'm not sure I've gotten this right, it definitely works but I'm very unfamiliar
with whitehall and atom.

And if you go to  eg `government/email-signup/new?email_signup%5Bfeed%5D=http%3A%2F%2Fwww.dev.gov.uk%2Fgovernment%2Fstatistics.atom%3Fpublication_filter_option%3Dstatistics%26topics%255B%255D%3Dborders-and-immigration` you can sign up to email notifications
