### PR TITLE
Allow tagging new policies to topics in topic edit.

### DIFF
--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -3,6 +3,7 @@ class Admin::ClassificationsController < Admin::BaseController
 
   before_filter :build_object, only: [:new]
   before_filter :load_object, only: [:show, :edit]
+  before_filter :remove_blank_parameters, only: [:create, :update]
 
   def index
     @classifications = model_class.includes(:related_classifications).order(:name)
@@ -64,6 +65,7 @@ class Admin::ClassificationsController < Admin::BaseController
     params.require(model_name).permit(
       :name, :description, :logo, :logo_alt_text, :logo_cache, :remove_logo,
       :start_date, :end_date,
+      policy_content_ids: [],
       related_classification_ids: [],
       classification_memberships_attributes: [:id, :ordering],
       social_media_accounts_attributes: [
@@ -72,5 +74,10 @@ class Admin::ClassificationsController < Admin::BaseController
       featured_links_attributes: [:title, :url, :_destroy, :id],
       organisation_classifications_attributes: [:id, :lead, :lead_ordering]
     )
+  end
+
+  def remove_blank_parameters
+    return if params[model_name][:policy_content_ids].blank?
+    params[model_name][:policy_content_ids].reject!(&:blank?)
   end
 end

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -7,7 +7,6 @@ class TopicalEventsController < ClassificationsController
 
   def show
     @classification = TopicalEvent.friendly.find(params[:id])
-    @policies = @classification.published_policies.includes(:translations, :document)
     @publications = fetch_associated(:published_publications, PublicationesquePresenter)
     @consultations = fetch_associated(:published_consultations, PublicationesquePresenter)
     @announcements = fetch_associated(:published_announcements, AnnouncementPresenter)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -6,7 +6,6 @@ class TopicsController < ClassificationsController
 
     respond_to do |format|
       format.html do
-        @policies = @classification.published_policies.includes(:translations, :document)
         @consultations = latest_presenters(@classification.published_consultations)
         @publications = latest_presenters(@classification.published_non_statistics_publications)
         @statistics = latest_presenters(@classification.published_statistics_publications)

--- a/app/helpers/admin/topics_helper.rb
+++ b/app/helpers/admin/topics_helper.rb
@@ -1,10 +1,2 @@
 module Admin::TopicsHelper
-  def policies_preventing_destruction(topic)
-    topic.policies.map do |d|
-      link_to(d.title, admin_edition_path(d)) + " " +
-      content_tag(:span,
-                   %{(#{d.state} #{d.format_name})},
-                   class: "document_state")
-    end
-  end
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -17,7 +17,6 @@ module TopicsHelper
 
   def classification_contents_breakdown(classification)
     capture do
-      concat content_tag(:span, pluralize(classification.published_policies.count, "published policy"))
       concat content_tag(:span, pluralize(classification.published_detailed_guides.count, "published detailed guide"))
     end
   end

--- a/app/models/classification_policy.rb
+++ b/app/models/classification_policy.rb
@@ -1,0 +1,2 @@
+class ClassificationPolicy < ActiveRecord::Base
+end

--- a/app/views/admin/classifications/_form.html.erb
+++ b/app/views/admin/classifications/_form.html.erb
@@ -12,25 +12,13 @@
   </fieldset>
 
   <fieldset>
+    <%= render "admin/shared/policy_fields", form: classification_form %>
+
     <%= classification_form.label :related_classification_ids, "Related topics" %>
     <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose related topics..."} %>
   </fieldset>
 
   <%= render partial: 'custom_form_fields', locals: {classification_form: classification_form} %>
-
-  <fieldset id="policy_order" class="named sortable">
-    <legend>Policy ordering</legend>
-    <%= classification_form.fields_for :classification_memberships, classification.classification_memberships.order("ordering asc").for_type(Policy).published do |classification_membership_form| %>
-      <% policy = classification_membership_form.object.policy %>
-      <div id="<%= dom_id(policy) %>" class="well">
-        <%= classification_membership_form.text_field :ordering, label_text: link_to(policy.title, admin_edition_path(policy)), class: "ordering" %>
-        <p>
-          <%= [pluralize(Publication.published.related_to(policy).count, "publication"),
-               pluralize(NewsArticle.published.related_to(policy).count, "news article")].to_sentence %>
-        </p>
-      </div>
-    <% end %>
-  </fieldset>
 
   <div class="row-fluid">
     <fieldset id="organisations" class="named span4">

--- a/app/views/admin/classifications/edit.html.erb
+++ b/app/views/admin/classifications/edit.html.erb
@@ -20,8 +20,8 @@
       <div class="policies_preventing_destruction">
         <p>This topic can't be deleted as it has associated policies:</p>
         <ul>
-          <% policies_preventing_destruction(@classification).each do |policy| %>
-            <li><%= policy %></li>
+          <% @classification.policies.each do |policy| %>
+            <li><%= link_to(policy.title, future_policy_path(policy)) %></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/admin/editions/_related_policy_fields.html.erb
+++ b/app/views/admin/editions/_related_policy_fields.html.erb
@@ -1,13 +1,5 @@
 <% if FeatureFlag.enabled?('future_policies') %>
-  <fieldset>
-    <%= form.label :policy_content_ids, "Policies" %>
-    <%= form.select :policy_content_ids,
-                    taggable_policy_content_ids_container,
-                    { include_blank: true },
-                    multiple: true,
-                    class: 'chzn-select',
-                    data: { placeholder: "Choose policies..."} %>
-  </fieldset>
+  <%= render "admin/shared/policy_fields", form: form %>
 <% else %>
   <fieldset>
     <%= form.label :related_policy_ids, 'Related policies' %>

--- a/app/views/admin/shared/_policy_fields.html.erb
+++ b/app/views/admin/shared/_policy_fields.html.erb
@@ -1,0 +1,9 @@
+<fieldset>
+  <%= form.label :policy_content_ids, "Policies" %>
+  <%= form.select :policy_content_ids,
+                  taggable_policy_content_ids_container,
+                  { include_blank: true },
+                  multiple: true,
+                  class: 'chzn-select',
+                  data: { placeholder: "Choose policies..."} %>
+</fieldset>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -68,7 +68,7 @@
     </div>
   </div>
 
-  <div class="documents-grid <%= topic_grid_size_class(@policies, @publications, @consultations, @announcements, @detailed_guides, @related_classifications) %>">
+  <div class="documents-grid <%= topic_grid_size_class(@publications, @consultations, @announcements) %>">
     <div class="inner-block">
       <%= render(partial: 'document_list', locals: { documents: @publications, type: :publications }) if @publications.any? %>
       <%= render(partial: 'document_list', locals: { documents: @consultations, type: :consultations }) if @consultations.any? %>

--- a/db/migrate/20150430084915_create_classification_policies.rb
+++ b/db/migrate/20150430084915_create_classification_policies.rb
@@ -1,0 +1,12 @@
+class CreateClassificationPolicies < ActiveRecord::Migration
+  def change
+    create_table :classification_policies do |t|
+      t.references :classification
+      t.string :policy_content_id
+      t.timestamps
+    end
+
+    add_index :classification_policies, :classification_id
+    add_index :classification_policies, :policy_content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422083934) do
+ActiveRecord::Schema.define(version: 20150430084915) do
 
   create_table "about_pages", force: true do |t|
     t.integer  "topical_event_id"
@@ -113,6 +113,16 @@ ActiveRecord::Schema.define(version: 20150422083934) do
 
   add_index "classification_memberships", ["classification_id"], name: "index_classification_memberships_on_classification_id", using: :btree
   add_index "classification_memberships", ["edition_id"], name: "index_classification_memberships_on_edition_id", using: :btree
+
+  create_table "classification_policies", force: true do |t|
+    t.integer  "classification_id"
+    t.string   "policy_content_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "classification_policies", ["classification_id"], name: "index_classification_policies_on_classification_id", using: :btree
+  add_index "classification_policies", ["policy_content_id"], name: "index_classification_policies_on_policy_content_id", using: :btree
 
   create_table "classification_relations", force: true do |t|
     t.integer  "classification_id",         null: false

--- a/features/admin-policy-tagging.feature
+++ b/features/admin-policy-tagging.feature
@@ -11,4 +11,10 @@ Feature: Tagging content with policies
   Scenario: a writer can tag a document to a policy
     Given I am a writer
     When I start editing a draft document
-    Then I can tag it to some policies
+    Then I can tag the edition to some policies
+
+  @future-policies
+  Scenario: a writer can tag a topic to a policy
+    Given I am a writer
+    When I start creating a topic
+    Then I can tag the topic to some policies

--- a/features/step_definitions/admin_policy_tagging_steps.rb
+++ b/features/step_definitions/admin_policy_tagging_steps.rb
@@ -1,4 +1,9 @@
-Then(/^I can tag it to some policies$/) do
+Then(/^I can tag the edition to some policies$/) do
   tag_to_policies(policies: [policy_1])
   check_edition_is_tagged_to_policies(edition: Publication.last, policies: [policy_1])
+end
+
+Then(/^I can tag the topic to some policies$/) do
+  tag_to_policies(policies: [policy_1])
+  check_topic_is_tagged_to_policies(topic: Topic.last, policies: [policy_1])
 end

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -252,3 +252,7 @@ Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" topic page$/) d
   visit admin_topic_path(topic)
   page.has_link?(title, href: edit_admin_topic_offsite_link_path(topic.id, offsite_link.id))
 end
+
+When(/^I start creating a topic$/) do
+  start_creating_topic
+end

--- a/features/support/admin_policy_tagging_helper.rb
+++ b/features/support/admin_policy_tagging_helper.rb
@@ -6,10 +6,16 @@ module AdminPolicyTaggingHelper
     end
   end
 
-  def check_edition_is_tagged_to_policies(edition:, policies:)
+  def check_edition_is_tagged_to_policies(edition:, policies: [])
     assert_path admin_publication_path(edition)
     policy_content_ids = policies.map {|policy| policy["content_id"] }
     assert_equal policy_content_ids, edition.policy_content_ids
+  end
+
+  def check_topic_is_tagged_to_policies(topic:, policies: [])
+    assert_path admin_topic_path(topic)
+    policy_content_ids = policies.map {|policy| policy["content_id"] }
+    assert_equal policy_content_ids, topic.policy_content_ids
   end
 end
 

--- a/features/support/topics_helper.rb
+++ b/features/support/topics_helper.rb
@@ -1,5 +1,10 @@
 module TopicsHelper
   def create_topic(options = {})
+    start_creating_topic(options)
+    save_document
+  end
+
+  def start_creating_topic(options = {})
     visit admin_root_path
     click_link "Topics"
     click_link "Create topic"
@@ -8,7 +13,6 @@ module TopicsHelper
     (options[:related_classifications] || []).each do |related_name|
       select related_name, from: "Related topics"
     end
-    click_button "Save"
   end
 end
 

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -73,19 +73,6 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     assert_select "input[name='topic[name]'][value='#{topic.name}']"
   end
 
-  view_test "GET :edit only lists published editions for ordering" do
-    topic = create(:topic)
-    policy = create(:published_policy, topics: [topic])
-    draft_policy = create(:draft_policy, topics: [topic])
-    published_association = topic.classification_memberships.where(edition_id: policy.id).first
-    draft_association = topic.classification_memberships.where(edition_id: draft_policy.id).first
-
-    get :edit, id: topic.id
-
-    assert_select "#policy_order input[type=hidden][value=#{published_association.id}]"
-    refute_select "#policy_order input[type=hidden][value=#{draft_association.id}]"
-  end
-
   ### Describing :update ###
 
   test "PUT :update saves changes to the topic and redirects" do
@@ -132,7 +119,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   end
 
   test "DELETE :destroy does not delete topics with associated content" do
-    topic = create(:topic, editions: [build(:published_policy)])
+    topic = create(:topic, policy_content_ids: [policy_1["content_id"]])
 
     delete :destroy, id: topic
     assert_equal "Cannot destroy Topic with associated content", flash[:alert]

--- a/test/unit/helpers/topics_helper_test.rb
+++ b/test/unit/helpers/topics_helper_test.rb
@@ -3,18 +3,6 @@ require 'test_helper'
 class TopicsHelperTest < ActionView::TestCase
   include TextAssertions
 
-  test 'classification_contents_breakdown generates a sentence that starts with the number of published policies belonging to the classification' do
-    t = create(:topic)
-
-    assert_match(/0 published policies/, classification_contents_breakdown(t))
-
-    create(:published_policy, topics: [t])
-    assert_match(/1 published policy/, classification_contents_breakdown(t))
-
-    create(:published_policy, topics: [t])
-    assert_match(/2 published policies/, classification_contents_breakdown(t))
-  end
-
   test 'classification_contents_breakdown generates a sentence that ends with the number of published detailed guides belonging to the classification' do
     t = create(:topic)
 


### PR DESCRIPTION
- [ ] Code review
- [ ] Product review

This supports a number of features required such
as email and relevance to local government.

https://trello.com/c/Hg6umd6V/193-add-ability-to-tag-to-new-policies-from-whitehall-topics