### PR TITLE
Reinstate Courts and Tribunals publishing with correct URLs

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -246,14 +246,6 @@ module OrganisationHelper
     content_tag(:p, contents.html_safe)
   end
 
-  def organisation_or_court_path(organisation_or_court)
-    if organisation_or_court.court_or_hmcts_tribunal?
-      court_path(organisation_or_court)
-    else
-      organisation_path(organisation_or_court)
-    end
-  end
-
   def show_corporate_information_pages?(organisation)
     organisation.live? && (!organisation.court_or_hmcts_tribunal? ||
       organisation.corporate_information_pages.published.reject { |cip| cip.slug == "about" }.any?)

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -50,6 +50,32 @@ module PublicDocumentRoutesHelper
     document_url(edition, options)
   end
 
+  def organisation_url(slug_or_organisation, options = {})
+    organisation_or_court = case slug_or_organisation
+                            when String
+                              Organisation.find_by(slug: slug_or_organisation)
+                            when Organisation
+                              organisation_or_court = slug_or_organisation
+                            else
+                              raise ArgumentError.new("Must provide a slug or Organisation")
+                            end
+
+    if organisation_or_court.nil?
+      logger.warn "Generating a URL for a missing organisation: #{slug_or_organisation}"
+      return super(slug_or_organisation, options)
+    end
+
+    if organisation_or_court.court_or_hmcts_tribunal?
+      court_url(organisation_or_court, options)
+    else
+      super(organisation_or_court, options)
+    end
+  end
+
+  def organisation_path(organisation_or_court_or_slug, options = {})
+    organisation_url(organisation_or_court_or_slug, options.merge(only_path: true))
+  end
+
   private
 
   def build_url_for_corporate_information_page(edition, options)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -366,10 +366,7 @@ class Organisation < ActiveRecord::Base
   end
 
   def search_link
-    # This should be organisation_path(self), but we can't use that because friendly_id's #to_param returns
-    # the old value of the slug (e.g. nil for a new record) if the record is dirty, and apparently the record
-    # is still marked as dirty during after_save callbacks.
-    Whitehall.url_maker.organisation_path(slug)
+    Whitehall.url_maker.organisation_path(self)
   end
 
   def published_speeches

--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -74,14 +74,6 @@ module Organisation::OrganisationTypeConcern
       active_child_organisations_excluding_sub_organisations.group_by(&:organisation_type).sort_by { |type, department| type.listing_position }
   end
 
-  def can_index_in_search?
-    super && !court_or_hmcts_tribunal?
-  end
-
-  def can_publish_to_publishing_api?
-    super && !court_or_hmcts_tribunal?
-  end
-
   def hmcts_tribunal?
     organisation_type_key == :tribunal_ndpb &&
       parent_organisations.pluck(:slug).include?("hm-courts-and-tribunals-service")

--- a/app/views/organisations/_index_item_plain.html.erb
+++ b/app/views/organisations/_index_item_plain.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag_for :li, organisation, class: 'js-filter-item department index-item-plain',
               "data-filter-terms" => filter_terms(organisation) do %>
-  <%= link_to organisation.name, organisation_or_court_path(organisation),
+  <%= link_to organisation.name, organisation_path(organisation),
     id: organisation.slug, class: 'department-link' %>
   <%= govuk_status_meta_data_for(organisation) %>
   <% if include_works_with %>

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -118,4 +118,38 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
       assert public_document_url(non_english_edition, locale: 'de').include? ".fr"
     end
   end
+
+  test "organisations have the correct path generated" do
+    org = create(:organisation)
+
+    assert_equal "/government/organisations/#{org.slug}", organisation_path(org)
+    assert_equal "http://test.host/government/organisations/#{org.slug}", organisation_url(org)
+  end
+
+  test "courts have the correct path generated" do
+    court = create(:court)
+
+    assert_equal "/courts-tribunals/#{court.slug}", organisation_path(court)
+    assert_equal "http://test.host/courts-tribunals/#{court.slug}", organisation_url(court)
+  end
+
+  test "HMCTS tribunals have the correct path generated" do
+    tribunal = create(:hmcts_tribunal)
+
+    assert_equal "/courts-tribunals/#{tribunal.slug}", organisation_path(tribunal)
+    assert_equal "http://test.host/courts-tribunals/#{tribunal.slug}", organisation_url(tribunal)
+  end
+
+  test "organisation_path still works with slugs" do
+    court = create(:court)
+    org = create(:organisation)
+
+    assert_equal "/courts-tribunals/#{court.slug}", organisation_path(court.slug)
+    assert_equal "/government/organisations/#{org.slug}", organisation_path(org.slug)
+  end
+
+  test "organisation_path naively uses the slug in the path if the organisation is missing" do
+    assert_equal "/government/organisations/foobar", organisation_path("foobar")
+    assert_equal "http://test.host/government/organisations/foobar", organisation_url("foobar")
+  end
 end

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -158,9 +158,9 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     assert organisation.can_index_in_search?
   end
 
-  test "should not index Courts" do
+  test "should index Courts" do
     court = create(:court)
-    refute court.can_index_in_search?
+    assert court.can_index_in_search?
   end
 
   test "should publish Organisations to Publishing API" do
@@ -168,9 +168,9 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     assert organisation.can_publish_to_publishing_api?
   end
 
-  test "should not publish Courts to Publishing API" do
+  test "should publish Courts to Publishing API" do
     court = create(:court)
-    refute court.can_publish_to_publishing_api?
+    assert court.can_publish_to_publishing_api?
   end
 
   test "#hmcts_tribunal? should be true if it's an HMCTS tribunal only" do

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -387,17 +387,19 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.save
   end
 
-  test 'should not add courts to index on creating' do
-    court = build(:court)
-    Whitehall::SearchIndex.expects(:add).once
-    Whitehall::SearchIndex.expects(:add).with(court).never
+  test 'should add courts to index on creating' do
+    hmcts = create(:organisation, slug: "hm-courts-and-tribunals-service", name: "HMCTS")
+
+    court = build(:court, parent_organisations: [hmcts])
+    Whitehall::SearchIndex.expects(:add).once.with(court)
     court.save
   end
 
-  test 'should not add HMCTS tribunals to index on creating' do
-    hmcts_tribunal = build(:hmcts_tribunal)
-    Whitehall::SearchIndex.expects(:add).once
-    Whitehall::SearchIndex.expects(:add).with(hmcts_tribunal).never
+  test 'should add HMCTS tribunals to index on creating' do
+    hmcts = create(:organisation, slug: "hm-courts-and-tribunals-service", name: "HMCTS")
+
+    hmcts_tribunal = build(:hmcts_tribunal, parent_organisations: [hmcts])
+    Whitehall::SearchIndex.expects(:add).once.with(hmcts_tribunal)
     hmcts_tribunal.save
   end
 
@@ -410,9 +412,9 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.save
   end
 
-  test 'should not add courts to index on updating' do
+  test 'should add courts to index on updating' do
     court = create(:court)
-    Whitehall::SearchIndex.expects(:add).never
+    Whitehall::SearchIndex.expects(:add).with(court)
     court.name = "Junk Appeals Court"
     court.save
   end
@@ -423,7 +425,7 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.destroy
   end
 
-  test 'should try to remove courts from index on destroying' do
+  test 'should remove courts from index on destroying' do
     court = create(:court)
     Whitehall::SearchIndex.expects(:delete).with(court)
     court.destroy


### PR DESCRIPTION
This reinstates Courts and HMCTS Tribunals (aka judicial bodies) into the Publishing and Indexing process with the correct URLs. These were set up in #2114.

