### PR TITLE
Add background for missing person image placeholder

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -39,10 +39,11 @@
         padding: 0;
       }
       &:after {
+        background: $grey-4;
         content: '';
         display: block;
-        padding-top: 64.81%; // This percentage allows the .blank-person-inner to have an aspect ratio like an image
-        padding-bottom: $gutter-half;
+        padding-top: 66.667%; // This percentage allows the .blank-person-inner to have an aspect ratio like an image
+        margin-bottom: 8px;
       }
     }
   }


### PR DESCRIPTION
The default image was recently removed, as it wasn't representative,
and replaced with a white background instead.

This caused some confusion in lists of people where there were many
images missing, and looks like the grid is broken (large whitespace
between rows).

Lots of missing images is likely to happen during the election, so
change the background to be a light grey, making clear the space is
a placeholder for an image, rather than the page breaking

It also tweaks the dimensions/layout of the placeholder, as the
padding/content distinction is important, now there is a solid
background colour.

The `padding-top` % now matches the aspect ratio of the images
exactly. The padding is switched to a margin (so it doesn't add
to the visible area of the placeholder) and reduced to line up
against the grid of people with images - as there will be a mix
of without and without images.

(The 8px is a little bit of a fudge to match the margin on the
image version, which looks like its coming from whitespace)

**Before**
![ministers gov uk](https://cloud.githubusercontent.com/assets/63201/7418256/77abe3b4-ef64-11e4-901e-c8437505d5b2.png)

**After**
![ministers gov uk - new](https://cloud.githubusercontent.com/assets/63201/7418255/77973c84-ef64-11e4-882a-4bc1c2ea51fd.png)
