### PR TITLE
Bump govuk-content-schema-test-helpers to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :test do
   gem 'database_cleaner', '1.4.0'
   gem 'equivalent-xml', '0.5.1', require: false
   gem 'test_track', '~> 0.1.0', github: 'alphagov/test_track'
-  gem 'govuk-content-schema-test-helpers', '1.0.1'
+  gem 'govuk-content-schema-test-helpers', '1.3.0'
 end
 
 group :test_coverage do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk-content-schema-test-helpers (1.0.1)
+    govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
     govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   gds-sso (~> 10.0)
   globalize!
   govspeak (~> 3.2.0)
-  govuk-content-schema-test-helpers (= 1.0.1)
+  govuk-content-schema-test-helpers (= 1.3.0)
   govuk_frontend_toolkit (= 3.1.0)
   invalid_utf8_rejector (~> 0.0.1)
   isbn_validation


### PR DESCRIPTION
This version is forward-compatible with the new folder structure of
govuk-content-schemas. Upgrading will allow us to gracefully migrate to
the [new folder structure](https://github.com/alphagov/govuk-content-schemas/pull/60).

https://trello.com/c/4cvyiiDd/135-fix-folder-structure-of-govuk-content-schemas