### PR TITLE
Retry rummager export more slowly and verbosely on failure

### DIFF
--- a/script/rummager_export.rb
+++ b/script/rummager_export.rb
@@ -65,6 +65,7 @@ def output_es_line(obj, output)
     if max_retry_count <= 0
       raise
     else
+      logger.warn("Export of #{obj.class.name}##{obj.id} failed, #{max_retry_count} retries left")
       retry
     end
   end

--- a/script/rummager_export.rb
+++ b/script/rummager_export.rb
@@ -66,6 +66,7 @@ def output_es_line(obj, output)
       raise
     else
       logger.warn("Export of #{obj.class.name}##{obj.id} failed, #{max_retry_count} retries left")
+      sleep 5
       retry
     end
   end


### PR DESCRIPTION
As per @rboulton's comments here: https://github.com/alphagov/whitehall/pull/2130/files#r29677737