### PR TITLE
Default publishing locales to :en.

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -53,7 +53,11 @@ module Whitehall
     # PolicyGroup. Once we are pushing those to the Publishing API, this method
     # will need updating to return just the English locale for those models.
     def self.locales_for(model_instance)
-      model_instance.translated_locales
+      if (locales = model_instance.translated_locales).empty?
+        [:en]
+      else
+        locales
+      end
     end
 
     def self.push_live(model_instance, update_type_override=nil, queue_override=nil)

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -47,4 +47,15 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.expects(:publish_async).never
     organisation.update_attribute(:name, 'Edited org')
   end
+
+  test "update publishes to Publishing API using :en locale when no translated fields are set" do
+    person = create(:person, attributes_for(:person).except(:biography))
+
+    content_item = PublishingApiPresenters.presenter_for(person).as_json
+    expected_publish_request = stub_publishing_api_put_item(person.search_link, content_item)
+
+    person.update_attribute(:forename, 'Edited person')
+
+    assert_requested expected_publish_request
+  end
 end


### PR DESCRIPTION
If an object has not been created with fields that
are translated, globalize does not create the
translation associations.

With no translations it considers the object to
have no locales, which prevents our publishing API
callbacks from working properly.

This defaults the locales for this case to :en.

It does not cover the case mentioned in the comments
regarding objects which are not translated at all.