### PR TITLE
Batch update political status and publication type

### DIFF
--- a/db/data_migration/20150505155406_batch_update_policital_status.csv
+++ b/db/data_migration/20150505155406_batch_update_policital_status.csv
@@ -1,0 +1,363 @@
+type,slug,political,publication-type
+publication,central-office-of-information-annual-reports-and-accounts,true,Corporate reports
+publication,uk-public-bodies-that-operate-in-scotland,true,Corporate reports
+publication,cabinet-office-annual-report-and-accounts-2011-2012,true,Corporate reports
+publication,cabinet-office-data-sets-annual-report-and-accounts-2012-to-2013,true,Corporate reports
+publication,hs2-ltd-triennial-review-2011,true,Corporate reports
+publication,nick-hurd-letter-on-improving-social-investment-regulation,true,Correspondence
+publication,business-compact-signatories-and-factsheet,true,Forms
+publication,civil-contingencies-act-2004-performance-assessment-frameworks,false,Guidance
+publication,civil-contingencies-act-category-2-responders-overview-of-sectors-and-emergency-planning-arrangements,false,Guidance
+publication,civil-contingencies-act-enhancement-programme-briefing-pack,false,Guidance
+publication,national-emergency-plan-for-the-telecommunications-sector,false,Guidance
+publication,project-bank-accounts,false,Guidance
+publication,revised-chapters-of-emergency-preparedness-government-responses,false,Guidance
+publication,special-advisers-code-of-conduct,false,Guidance
+publication,protocol-for-appointment-process-of-lord-lieutenants,false,Guidance
+publication,protocol-for-avoidance-and-resolution-of-disputes-devolved-administrations,false,Guidance
+publication,emergency-responder-interoperability-lexicon,false,Guidance
+publication,public-emergency-alerts-reviews-and-guidance,false,Guidance
+publication,construction-cost-benchmark-data,false,Guidance
+publication,procurement-policy-note-0513-modernising-eu-procurement-rules,false,Guidance
+publication,procurement-policy-note-0613-promoting-tax-compliance,false,Guidance
+publication,procurement-policy-note-0713-eu-statistics-on-public-procurement-annual-return-for-calendar-year-2012,false,Guidance
+publication,procurement-policy-note-0813-eu-statistics-on-utilities-sector-procurement-annual-return-for-calendar-year-2012,false,Guidance
+publication,procurement-policy-note-0913-implementing-the-new-classifications-policy,false,Guidance
+publication,procurement-policy-note-0314-promoting-tax-compliance,false,Guidance
+publication,procurement-policy-note-0214-extending-mystery-shopper,false,Guidance
+publication,national-exemption-order-scheme,false,Guidance
+publication,procurement-policy-note-0914-cyber-essentials-scheme-certification,false,Guidance
+publication,procurement-policy-note-1014-the-plan-for-public-procurement-of-food-and-catering,false,Guidance
+publication,using-a-total-impact-approach-to-achieve-social-outcomes,false,Guidance
+publication,procurement-policy-note-1114-references-and-public-procurement,false,Guidance
+publication,the-cabinet-committees-system-and-list-of-cabinet-committees,false,Guidance
+publication,procurement-policy-note-0115-implementing-energy-efficiency-directive-article-6-further-information,false,Guidance
+publication,government-ministers-and-responsibilities,false,Guidance
+publication,procurement-policy-note-0215-public-contracts-regulations-2015,false,Guidance
+publication,procurement-policy-note-0714-implementing-energy-efficiency-directive-article-6,false,Guidance
+publication,procurement-policy-note-0614-short-form-terms-and-conditions,false,Guidance
+publication,procurement-policy-note-0514-staff-transfers-and-pensions,false,Guidance
+publication,procurement-policy-note-0414-model-services-contract,false,Guidance
+publication,procurement-policy-note-0114-sharing-information-within-government,false,Guidance
+publication,government-commercial-management-cabinet-office-role,false,Guidance
+publication,promoting-tax-compliance-and-procurement-procurement-policy-information-note,false,Guidance
+publication,procurement-policy-note-02-13-supplier-financial-risk-issues,false,Guidance
+publication,procurement-policy-note-03-13-measures-to-promote-tax-compliance,false,Guidance
+publication,procurement-policy-note-1013-new-threshold-levels-for-2014,false,Guidance
+publication,procurement-policy-note-0315-reforms-to-make-public-procurement-more-accessible-to-smes,false,Guidance
+publication,procurement-policy-note-0415-taking-account-of-suppliers-past-performance,false,Guidance
+publication,procurement-policy-note-0615-sustainable-skills-development-through-major-projects,false,Guidance
+publication,procurement-policy-note-0715-open-standards-for-technology,false,Guidance
+publication,procurement-policy-note-0515-prompt-payment-and-performance-reporting,false,Guidance
+publication,procurement-policy-note-0815-tax-arrangements-of-appointees,false,Guidance
+publication,early-intervention-smart-investment-massive-savings,false,Independent reports
+publication,the-handling-of-detainees-in-afghanistan-guantanamo-bay-and-iraq,false,Independent reports
+publication,iraqi-weapons-of-mass-destruction-intelligence-and-assessments,false,Independent reports
+publication,inquiry-into-intelligence-prior-to-the-bali-terrorist-bombings,false,Independent reports
+publication,us-prism-gchqs-alleged-interception-of-communications,false,Independent reports
+publication,rendition-report-by-the-intelligence-and-security-committee,false,Independent reports
+publication,report-into-the-london-terrorist-attacks-on-7-july-2005,false,Independent reports
+publication,london-terrorist-attacks-on-77-review-of-the-intelligence,false,Independent reports
+publication,communications-data-access-by-the-intelligence-and-security-agencies,false,Independent reports
+publication,women-in-whitehall-culture-leadership-talent,false,Independent reports
+publication,cross-government-review-of-major-contracts-terms-of-reference,true,Policy papers
+publication,better-together-preparing-for-local-spending-cuts-to-the-voluntary-community-and-social-enterprise-sector,true,Policy papers
+publication,civil-service-task-group-on-disability-resources,true,Policy papers
+publication,community-commissioning-case-studies,true,Policy papers
+publication,construction-conference,true,Policy papers
+publication,the-crown-and-suppliers-a-new-way-of-working-conference,yes ,Policy papers
+publication,the-crown-and-suppliers-a-new-way-of-working-documents,yes ,Policy papers
+publication,electoral-registration-annual-canvass-2012,true,Policy papers
+publication,ict-strategy-governance-structure,true,Policy papers
+publication,innovation-in-giving-fund-round-1-grant-recipients,true,Policy papers
+publication,international-alignment-and-co-ordination-ict,true,Policy papers
+publication,media-emergency-forum-annual-reports,true,Policy papers
+publication,shared-services,true,Policy papers
+publication,progress-implementing-the-government-construction-strategy,true,Policy papers
+publication,big-society-faqs-and-useful-links,true,Policy papers
+publication,us-uk-cyber-communique,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-february-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-january-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-december-2012,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-november-2012,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-september-2012,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-october-2012,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-march-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-april-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-may-2013,true,Policy papers
+publication,g8-factsheet-social-investment-and-social-enterprise,true,Policy papers
+publication,g8-factsheet-trade,true,Policy papers
+publication,g8-factsheet-tax,true,Policy papers
+publication,g8-factsheet-transparency,true,Policy papers
+publication,g8-transparency-challenges,true,Policy papers
+publication,construction-costs-departmental-reductions-2011-2012,true,Policy papers
+publication,construction-cost-benchmarking-departmental-progress-2012,true,Policy papers
+publication,improving-the-electoral-register-through-data-matching,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-july-2013,true,Policy papers
+publication,big-society-capital-faqs,true,Policy papers
+publication,electoral-registration-factors-in-england-and-wales,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-september-2013,true,Policy papers
+publication,honours-system-checks-on-candidates,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-october-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-november-2013,true,Policy papers
+publication,individual-electoral-registration-data-matching-methodology,true,Policy papers
+publication,construction-costs-departmental-reductions-2012-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-june-2013,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-december-2013,true,Policy papers
+publication,delivering-differently-workshop-materials,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-january-2014,true,Policy papers
+publication,the-social-investment-readiness-charter,true,Policy papers
+publication,delivering-differently-qa,true,Policy papers
+publication,moving-more-living-more-olympic-and-paralympic-games-legacy,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-february-2014,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-march-2014,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-april-2014,true,Policy papers
+publication,delivering-differently-programme-services-contract-notice,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-may-2014,true,Policy papers
+publication,queens-speech-2014-what-it-means-for-you,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-june-2014,true,Policy papers
+publication,construction-costs-departmental-reductions-2013-2014,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-july-2014,true,Policy papers
+publication,the-olympic-and-paralympic-legacy-inspired-by-2012-second-annual-report,true,Policy papers
+publication,delivering-differently-for-young-people-frequently-asked-questions,true,Policy papers
+publication,maximising-electoral-registration-evaluation-of-local-activities,true,Policy papers
+publication,social-investment-an-introduction-to-the-governments-approach,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-september-2014,true,Policy papers
+publication,evaluation-confirming-electors-through-data-matching,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-october-2014,true,Policy papers
+publication,using-data-matching-to-confirm-electors-in-great-britain,true,Policy papers
+publication,using-data-matching-to-confirm-electors-interim-evaluation,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-november-2014,true,Policy papers
+publication,d5-london-summit-themes,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-december-2014,true,Policy papers
+publication,care-leaver-strategy,true,Policy papers
+publication,democratic-engagement-programme,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-january-2015,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-february-2015,true,Policy papers
+publication,business-statements-office-of-the-leader-of-the-house-of-commons-march-2015,true,Policy papers
+publication,prime-ministers-challenge-on-dementia-2020,true,Policy papers
+publication,talent-action-plan-removing-the-barriers-to-success,true,Policy papers
+publication,communities-and-victims-panel-terms-of-reference--2,true,Policy papers
+publication,opening-doors-breaking-barriers-a-strategy-for-social-mobility-update-on-progress-since-april-2011,true,Policy papers
+publication,canada-united-kingdom-joint-declaration,true,Policy papers
+publication,g8-factsheet-trade,true,Policy papers
+publication,g8-factsheet-tax,true,Policy papers
+publication,g8-factsheet-transparency,true,Policy papers
+publication,chemical-weapon-use-by-syrian-regime-uk-government-legal-position,true,Policy papers
+publication,military-action-in-iraq-against-isil-government-legal-position,true,Policy papers
+publication,youth-count-democracy-challenge,true,Promotional material
+publication,digital-voter-engagement-and-registration-toolkit,true,Promotional material
+publication,voting-and-registering-to-vote-an-easy-read-guide,true,Promotional material
+publication,youth-democracy-peer-education-training-and-resources,true,Promotional material
+publication,rock-enrol-engaging-young-people-in-democracy,true,Promotional material
+publication,your-vote-matters,true,Promotional material
+publication,not-for-profit-advice-services-in-england,false,Research and analysis
+publication,queens-award-for-voluntary-service-recipients-2013,false,Transparency data
+publication,queens-award-for-voluntary-service-recipients-2014,false,Transparency data
+publication,hmrc-customer-service-lines-report-2014,false,Transparency data
+publication,cabinet-office-food-sustainability,false,Transparency data
+case_study,adam-taylor-winner-of-2013-opening-doors-award,true,
+case_study,business-compact-partners,true,
+case_study,channel-4-winner-of-2013-opening-doors-award,true,
+case_study,ee-winner-of-2013-opening-doors-award,true,
+case_study,mark-oreilly-winner-of-2013-opening-doors-award,true,
+case_study,naomi-tamar-winner-of-2013-opening-doors-award,true,
+case_study,slaughter-and-may-winner-of-2013-opening-doors-award,true,
+document_collection,business-plan-quarterly-data-summary,true,
+document_collection,city-deals,true,
+document_collection,city-deals,true,
+document_collection,civil-service-reform,true,
+document_collection,civil-society-update-series,true,
+document_collection,coaltion-programme-for-government,true,
+document_collection,construction-cost-benchmark-data,true,
+document_collection,cyber-security-strategy-progress-so-far--2,true,
+document_collection,delivering-differently-programme-for-local-authorities,true,
+document_collection,democratic-engagement-resources,true,
+document_collection,departmental-digital-strategies,true,
+document_collection,g8-communique-and-documents,true,
+document_collection,g8-factsheets,true,
+document_collection,government-digital-strategy-reports-and-research,true,
+document_collection,individual-electoral-registration,true,
+document_collection,innovative-uses-of-government-open-data,true,
+document_collection,local-growth-deals,true,
+document_collection,national-wellbeing,true,
+document_collection,open-public-services,true,
+document_collection,opening-doors,true,
+document_collection,positive-for-youth,true,
+document_collection,reserve-forces-toolkit,true,
+document_collection,social-impact-bonds,true,
+document_collection,social-investment,true,
+document_collection,social-investment-tax-relief,true,
+document_collection,state-of-the-estate,true,
+document_collection,typhoon-haiyan-news-archive,true,
+publication,allegations-against-rt-hon-dr-liam-fox-mp-report-by-the-cabinet-secretary,true,
+publication,andy-coulson-sir-gus-odonnells-letter-to-ivan-lewis-mp,true,
+publication,big-lottery-fund-triennial-review-2014,true,
+publication,committee-on-standards-in-public-life-triennial-review,true,
+publication,construction-newsletter-february-2014,true,
+publication,construction-newsletter-may-2013,true,
+publication,construction-newsletter-september-2013,true,
+publication,dadabhai-naoroji-awards-nomination-form,true,
+publication,family-friendly-award-competition,true,
+publication,francis-maudes-letter-to-uk-ogp-civil-society-network,true,
+publication,green-ict-maturity-model,true,
+publication,international-classified-information,false,
+publication,joint-letter-to-all-directors-of-childrens-services,true,
+publication,letter-from-nick-hurd-about-new-public-service-delivery-models,true,
+publication,major-projects-authority-priorities,false,
+publication,martha-lane-fox-resignation-letter,true,
+publication,mental-health-heroes-nomination-form,true,
+publication,nick-hurd-letter-on-national-citizen-service-entrustment,true,
+publication,opening-public-services-leaflet,true,
+publication,procurement-trial-case-study-cookham-wood-prison,true,
+publication,security-vetting-appeals-panel-triennial-review-2013-to-2014,true,
+publication,social-security-advisory-committee-triennial-review-2012,true,
+publication,state-of-the-nation-2014-report,false,
+publication,transparency-of-lobbying-bill-response-to-38-degrees,true,
+publication,young-people-in-work-encouraging-work-experience-placements,true,
+publication,immigration-rules-archive-appendix-t-13-december-2012-to-31-december-2012,true,
+publication,immigration-rules-archive-6-september-2013-to-30-september-2012,true,
+publication,immigration-rules-archive-28-october-to-29-november-2013,true,
+publication,immigration-rules-archive-1-october-to-12-december-2012,true,
+publication,immigration-rules-archive-16-august-to-6-september-2012,true,
+publication,immigration-rules-archive-28-feb-2013-to-31-march-2013,true,
+publication,immigration-rules-archive-9-july-to-19-july-2012,true,
+publication,immigration-rules-archive-31-january-2013-to-27-february-2013,true,
+publication,immigration-rules-archive-30-november-to-29-december-2013,true,
+publication,immigration-rules-archive-1-april-to-5-april-2013,true,
+publication,immigration-rules-archive-part-6a-13-december-2012-to-30-january-2013,true,
+publication,immigration-rules-archive-1-july-to-31-july-2013,true,
+publication,immigration-rules-archive-appendix-a-31-december-2012-to-30-january-2013,true,
+publication,immigration-rules-archive-1-october-to-27-october-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc346-22-february-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1053-20-april-2006,true,
+publication,statement-of-changes-to-the-immigration-rules-hc420-17-march-2008,true,
+publication,statement-of-changes-to-the-immigration-rules-hc277-9-february-2009,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1719-20-december-2011,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1622-7-november-2011,true,
+publication,statement-of-changes-to-the-immigration-rules-cm-8690-july-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc321-february-2008-corrections,true,
+publication,statement-of-changes-to-the-immigration-rules-cm5829-may-2003,true,
+publication,statement-of-changes-to-the-immigration-rules-cm5949-august-2003,true,
+publication,statement-of-changes-to-immigration-rules-hc1224-november-2003,true,
+publication,statement-of-changes-to-the-immigration-rules-hc95-december-2003,true,
+publication,statement-of-changes-to-the-immigration-rules-cm6297-august-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-cm6339-september-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1112-18-october-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc164-december-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc176-january-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc370-february-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc464-march-2004,true,
+publication,statement-of-changes-to-the-immigration-rules-hc104-15-june-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc299-july-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc302-february-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-22-february-2005,true,
+publication,statement-of-change-to-the-immigration-rules-hc486-march-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc582-24-october-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc645-9-november-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc697-21-november-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc769-19-december-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-cm6918-september-2006,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1016-30-march-2006,true,
+publication,statement-of-changes-to-the-immigration-rules-hc130-11-december-2006,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1337-july-2006,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1702-november-2006,true,
+publication,immigration-rules-archive-1-august-to-30-september-2013,true,
+publication,immigration-rules-archive-6-april-2013-to-30-april-2013,true,
+publication,part-9-of-the-immigration-rules-archive-13-december-2012-to-30-jan-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc686-9-october-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc194-january-2005,true,
+publication,statement-of-changes-to-the-immigration-rules-hc194-june-2012,true,
+publication,immigration-rules-archive-1-may-2013-to-30-june-2013,true,
+publication,immigration-rules-archive-30-december-2013-to-13-january-2014,true,
+publication,immigration-rules-archive-14-january-to-25-february-2014,true,
+publication,immigration-rules-archive-25-february-to-6-april-2014,true,
+publication,immigration-rules-archive-7-april-to-5-may-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc198-10-june-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1201-1-april-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1138-13-march-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1130-10-march-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc938-18-december-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc901-10-december-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc887-9-december-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc803-november-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc-628-6-september-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc-244-10-june-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-cm8599-april-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1039-14-march-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1038-11-march-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc967-7-february-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-hc943-30-january-2013,true,
+publication,statement-of-changes-to-the-immigration-rules-cm8423-july-2012,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1888-15-march-2012,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1733-19-january-2012,true,
+publication,immigration-rules-part-4,true,
+publication,immigration-rules-part-6,true,
+publication,immigration-rules-part-11a,true,
+publication,immigration-rules-part-11b,true,
+publication,immigration-rules-part-14,true,
+publication,immigration-rules-appendix-2,true,
+publication,immigration-rules-appendix-6,true,
+publication,immigration-rules-appendix-d,true,
+publication,immigration-rules-appendix-h,true,
+publication,statement-of-changes-to-the-immigration-rules-hc532-10-july-2014,true,
+publication,immigration-rules-archive-5-may-to-30-june-2014,true,
+publication,statement-of-changes-to-the-immigration-rules-hc693-16-october-2014,true,
+publication,immigration-rules-part-13,true,
+publication,immigration-rules-appendix-l,true,
+publication,immigration-rules-appendix-p,true,
+publication,immigration-rules-archive-6-november-to-30-november-2014,true,
+publication,immigration-rules-appendix-g,true,
+publication,immigration-rules-part-10,true,
+publication,statement-of-changes-to-the-immigration-rules-no-395-may-1994,true,
+publication,statement-of-changes-to-the-immigration-rules-no-704-july-2000,true,
+publication,statement-of-changes-in-immigration-rules-hc-321-february-2008,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1511-correction-october-2011,true,
+publication,statement-of-changes-to-the-immigration-rules-hc-1888-march-2012,true,
+publication,statement-of-changes-to-the-immigration-rules-hc-514-july-2012,true,
+publication,changes-to-immigration-rules-statement-of-policy,true,
+publication,statement-of-changes-to-the-immigration-rules-hc-847-december-2012,true,
+publication,immigration-rules-archive-1-july-to-27-july-2014,true,
+publication,immigration-rules-archive-28-july-to-31-july-2014,true,
+publication,immigration-rules-archive-1-august-to-20-october-2014,true,
+publication,immigration-rules-archive-1-july-to-10-july-2014,true,
+publication,immigration-rules-archive-20-october-to-5-november-2014,true,
+publication,indicative-visa-charges-for-2015-to-2016,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1025-26-february-2015,true,
+publication,immigration-rules-archive-30-november-2014-to-27-february-2015,true,
+publication,immigration-rules-archive-27-february-to-02-march-2015,true,
+publication,statement-of-changes-to-the-immigration-rules-hc1116-16-march-2015,true,
+publication,visa-regulations-revised-table,true,
+publication,immigration-rules-appendix-armed-forces,true,
+publication,immigration-rules-appendix-b,true,
+publication,immigration-rules-appendix-c,true,
+publication,immigration-rules-part-15-condition-to-hold-an-atas-clearance-certificate,true,
+publication,immigration-rules-appendix-e,true,
+publication,immigration-rules-appendix-fm,true,
+publication,immigration-rules-appendix-fm-se,true,
+publication,immigration-rules-appendix-i,true,
+publication,immigration-rules-appendix-j,true,
+publication,immigration-rules-appendix-k,true,
+publication,immigration-rules-appendix-koll,true,
+publication,immigration-rules-appendix-m,true,
+publication,immigration-rules-appendix-n,true,
+publication,immigration-rules-appendix-o,true,
+publication,immigration-rules-appendix-t,true,
+publication,immigration-rules-part-11,true,
+publication,immigration-rules-part-12,true,
+publication,immigration-rules-appendix-ar-administrative-review,true,
+publication,immigration-rules-appendix-7,true,
+publication,immigration-rules-appendix-a,true,
+publication,immigration-rules-part-9,true,
+publication,immigration-rules-appendix-v-visitor-rules,true,
+publication,immigration-rules-introduction,true,
+publication,immigration-rules-part-1,true,
+publication,immigration-rules-part-3,true,
+publication,immigration-rules-part-5,true,
+publication,immigration-rules-part-6a,true,
+publication,immigration-rules-part-7,true,
+publication,immigration-rules-part-8,true,
+publication,immigration-rules-appendix-f,true,
+publication,immigration-rules-part-2,true,
+publication,immigration-rules-index,true,

--- a/db/data_migration/20150505155406_batch_update_policital_status.rb
+++ b/db/data_migration/20150505155406_batch_update_policital_status.rb
@@ -1,0 +1,38 @@
+require "csv"
+
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+
+csv_file = File.join(File.dirname(__FILE__), "20150505155406_batch_update_policital_status.csv")
+csv = CSV.parse(File.open(csv_file), headers: true)
+
+csv.each do |row|
+  puts "#{row["type"]},#{row["slug"]}"
+  document = Document.find_by(document_type: row["type"].camelize, slug: row["slug"])
+  unless document
+    puts "!! no document found"
+    next
+  end
+  editions = document.editions.where(state: PUBLISHED_AND_PUBLISHABLE_STATES)
+  unless editions
+    puts "!! no editions found"
+    next
+  end
+
+  puts "\tsetting political status to: #{row["political"]}"
+  editions.each { |edition|
+    edition.update_column(:political, row["political"] == "true")
+  }
+
+  if row["publication-type"]
+    new_type = PublicationType.find_by_slug(row["publication-type"].parameterize)
+    unless new_type
+      puts "!! publication type not found: #{row["publication-type"]}"
+      next
+    end
+
+    puts "\tsetting publication type to: #{new_type.singular_name}"
+    editions.each { |edition|
+      edition.update_column(:publication_type_id, new_type.id)
+    }
+  end
+end


### PR DESCRIPTION
A couple of organisations have requested we batch update some documents
political status. This sets the political status for those editions and
also updates some publication types to new publication types.