### PR TITLE
Rake task to reslug a Person

### DIFF
--- a/lib/data_hygiene/person_reslugger.rb
+++ b/lib/data_hygiene/person_reslugger.rb
@@ -1,0 +1,64 @@
+module DataHygiene
+  # Reslugs a person to new_slug.
+  #
+  # When run, the following happens:
+  #
+  #   - updates the Person record's slug
+  #   - reindexes the person for search
+  #   - republishes the person to Publishing API
+  #   - publishes a redirect content item to Publishing API
+  #   - reindexes all dependent documents in search
+  #
+  class PersonReslugger
+    def initialize(person, new_slug)
+      @person = person
+      @new_slug = new_slug
+      @old_slug = person.slug
+    end
+
+    def run!
+      remove_from_search_index
+      update_slug
+      register_redirect
+      republish_dependencies
+    end
+
+  private
+    attr_reader :person, :new_slug, :old_slug
+
+    def remove_from_search_index
+      Whitehall::SearchIndex.delete(person)
+    end
+
+    def update_slug
+      # Note: This will trigger calls to both rummager and the Publishing API,
+      # meaning that entries in both places will exist with the correct slug
+      person.update_attributes!(slug: new_slug)
+    end
+
+    def old_base_path
+      Whitehall.url_maker.person_path(old_slug)
+    end
+
+    def new_base_path
+      Whitehall.url_maker.person_path(new_slug)
+    end
+
+    def redirects
+      @redirects ||= [
+        { path: old_base_path, destination: new_base_path, type: "exact" },
+        { path: (old_base_path + ".atom"), destination: (new_base_path + ".atom"), type: "exact" },
+      ]
+    end
+
+    def register_redirect
+      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
+      Whitehall::PublishingApi.publish_redirect(redirect_item)
+    end
+
+    def republish_dependencies
+      person.published_speeches.each(&:update_in_search_index)
+      person.published_news_articles.each(&:update_in_search_index)
+    end
+  end
+end

--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -1,0 +1,22 @@
+require 'gds_api/router'
+require 'gds_api/publishing_api'
+
+namespace :reslug do
+  desc "Change a person slug (DANGER!).\n
+
+  This rake task changes a person's slug in whitehall.
+
+  It performs the following steps:
+  - changes the person's slug
+  - reindexes the person for search
+  - republishes the person to Publishing API
+  - publishes a redirect content item to Publishing API
+  - reindexes all dependent documents in search"
+  task :person, [:old_slug, :new_slug] => :environment do |_task, args|
+    old_slug = args[:old_slug]
+    new_slug = args[:new_slug]
+    person = Person.find_by!(slug: old_slug)
+
+    DataHygiene::PersonReslugger.new(person, new_slug).run!
+  end
+end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -47,6 +47,10 @@ module Whitehall
       end
     end
 
+    def self.publish_redirect(redirect)
+      Whitehall.publishing_api_client.put_content_item(redirect.base_path, redirect.as_json)
+    end
+
   private
 
     # Note: this method does not account for non-translatable models, e.g.

--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -1,0 +1,24 @@
+module Whitehall
+  class PublishingApi
+    class Redirect
+      attr_reader :base_path
+
+      def initialize(base_path, redirects)
+        @redirects = redirects
+        @base_path  = base_path
+      end
+
+      def as_json
+        {
+          format: "redirect",
+          publishing_app: "whitehall",
+          update_type: "major",
+          redirects: redirects,
+        }
+      end
+
+    private
+      attr_reader :redirects
+    end
+  end
+end

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'gds_api/test_helpers/rummager'
+
+class PersonSlugChangerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Rummager
+  self.use_transactional_fixtures = false
+
+  setup do
+    DatabaseCleaner.clean_with :truncation
+    @person = create(:person, forename: 'old', surname: 'slug', biography: 'Biog')
+    @reslugger = DataHygiene::PersonReslugger.new(@person, 'updated-slug')
+  end
+
+  teardown do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  test "re-slugs the person" do
+    @reslugger.run!
+    assert_equal 'updated-slug', @person.slug
+  end
+
+  test "publishes to Publishing API with the new slug and redirects the old" do
+    content_item = PublishingApiPresenters.presenter_for(@person).as_json
+    old_base_path = @person.search_link
+    new_base_path = "/government/people/updated-slug"
+    content_item[:routes][0][:path] = new_base_path
+    redirects = [
+      { path: old_base_path, type: "exact", destination: new_base_path },
+      { path: (old_base_path + ".atom"), type: "exact", destination: (new_base_path + ".atom") }
+    ]
+    redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
+
+    expected_publish_request = stub_publishing_api_put_item(new_base_path, content_item)
+    expected_redirect = stub_publishing_api_put_item(old_base_path, redirect_item)
+
+    @reslugger.run!
+
+    assert_requested expected_redirect
+    assert_requested expected_publish_request
+  end
+
+  test "deletes the old slug from the search index" do
+    Whitehall::SearchIndex.expects(:delete).with { |person| person.slug == 'old-slug' }
+    @reslugger.run!
+
+  end
+
+  test "adds the new slug from the search index" do
+    Whitehall::SearchIndex.expects(:add).with { |person| person.slug == 'updated-slug' }
+    @reslugger.run!
+  end
+
+  test "re-indexes all the published dependent documents" do
+    published_news = create(:published_news_article)
+    draft_news = create(:draft_news_article)
+    role_appointment = create(:role_appointment,
+                        person: @person,
+                        editions: [published_news, draft_news])
+
+    published_speech = create(:published_speech, role_appointment: role_appointment)
+    draft_speech = create(:draft_speech, role_appointment: role_appointment)
+
+    Whitehall::SearchIndex.stubs(:add)
+    Whitehall::SearchIndex.expects(:add).with(published_news)
+    Whitehall::SearchIndex.expects(:add).with(published_speech)
+    Whitehall::SearchIndex.expects(:add).with(draft_news).never
+    Whitehall::SearchIndex.expects(:add).with(draft_speech).never
+    @reslugger.run!
+  end
+end

--- a/test/unit/whitehall/publishing_api/redirect_test.rb
+++ b/test/unit/whitehall/publishing_api/redirect_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class Whitehall::PublishingApi::RedirectTest < ActiveSupport::TestCase
+  setup do
+    @base_path = "/government/thong"
+    @redirects = [
+      { path: @base_path, type: "exact", destination: "/government/thing" }
+    ]
+    @redirect = Whitehall::PublishingApi::Redirect.new(@base_path, @redirects)
+    @output_hash = @redirect.as_json
+  end
+
+  test "generates a valid redirect content item" do
+    assert_valid_against_schema(@output_hash, 'redirect')
+  end
+
+  test "#base_path returns the base_path" do
+    assert_equal @base_path, @redirect.base_path
+  end
+
+  test "sets the publishing_app to 'whitehall'" do
+    assert_equal "whitehall", @output_hash[:publishing_app]
+  end
+
+  test "sets the redirects as provided" do
+    assert_equal @redirects, @output_hash[:redirects]
+  end
+end

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -331,4 +331,16 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     Whitehall::PublishingApi.publish_draft_async(draft_edition, update_type, queue_name)
   end
+
+  test "#publish_redirect publishes a redirect to the Publishing API" do
+    base_path = "/government/people/milly-vanilly"
+    redirects = [
+      { path: base_path, type: "exact", destination: "/government/poeple/milli-vanilli"}
+    ]
+    redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects)
+    expected_request = stub_publishing_api_put_item(redirect.base_path, redirect.as_json)
+    Whitehall::PublishingApi.publish_redirect(redirect)
+
+    assert_requested expected_request
+  end
 end


### PR DESCRIPTION
This rake task can be used to reslug a Person instance:

	$ bundle exec rake reslug:person["old-slug","new-slug"]

It will do the following:

* Update the slug of the instance in the database
* Re-index the person with the new slug
* Republish the person to the Publishing API with the new slug
* Publish a "redirect" content_item to redirect the old slug to the new
* Re-index all dependent documents (published news articles and speeches)

Trello: https://trello.com/c/HG019ljy/215-5-create-rake-task-to-reslug-people