### PR TITLE
Publish policy papers generated from current policies

### DIFF
--- a/lib/tasks/election/policy_paper_publisher.rb
+++ b/lib/tasks/election/policy_paper_publisher.rb
@@ -14,6 +14,7 @@ module Election
             policy_paper.minor_change = true
             policy_paper.major_change_published_at = policy_paper.first_published_at
             policy_paper.force_publish!
+            policy_paper.update_column(:public_timestamp, 1.day.ago)
           end
         else
           Rails.logger.warn("WARNING: Couldn't find policy paper ##{policy_paper_id}")

--- a/lib/tasks/election/policy_paper_publisher.rb
+++ b/lib/tasks/election/policy_paper_publisher.rb
@@ -16,6 +16,9 @@ module Election
 
             Edition::AuditTrail.acting_as(gds_user) do
               EditionForcePublisher.new(policy_paper).perform!
+              ServiceListeners::PanopticonRegistrar.new(policy_paper).register!
+              ServiceListeners::SearchIndexer.new(policy_paper).index!
+              Whitehall::PublishingApi.publish_async(policy_paper)
             end
 
             policy_paper.update_column(:public_timestamp, 1.day.ago)

--- a/lib/tasks/election/policy_paper_publisher.rb
+++ b/lib/tasks/election/policy_paper_publisher.rb
@@ -10,16 +10,25 @@ module Election
           if policy_paper.published?
             Rails.logger.warn("WARNING: Policy paper ##{policy_paper_id} already published")
           else
-            Rails.logger.info("Force publishing policy paper ##{policy_paper_id} as a minor change")
-            policy_paper.minor_change = true
-            policy_paper.major_change_published_at = policy_paper.first_published_at
-            policy_paper.force_publish!
+            Rails.logger.info("Force publishing policy paper ##{policy_paper_id} as a major change without email alerts")
+            policy_paper.minor_change = false
+
+            Edition::AuditTrail.acting_as(gds_user) do
+              EditionForcePublisher.new(policy_paper).perform!
+            end
+
             policy_paper.update_column(:public_timestamp, 1.day.ago)
           end
         else
           Rails.logger.warn("WARNING: Couldn't find policy paper ##{policy_paper_id}")
         end
       end
+    end
+
+  private
+
+    def gds_user
+      @gds_user ||= User.find_by(email: "govuk-whitehall@digital.cabinet-office.gov.uk")
     end
   end
 end

--- a/lib/tasks/election/policy_paper_publisher.rb
+++ b/lib/tasks/election/policy_paper_publisher.rb
@@ -12,6 +12,7 @@ module Election
           else
             Rails.logger.info("Force publishing policy paper ##{policy_paper_id} as a major change without email alerts")
             policy_paper.minor_change = false
+            policy_paper.change_note = historical_change_note
 
             Edition::AuditTrail.acting_as(gds_user) do
               EditionForcePublisher.new(policy_paper).perform!
@@ -26,6 +27,10 @@ module Election
     end
 
   private
+
+    def historical_change_note
+      "Policy document from the 2010 to 2015 government preserved in a different format for reference"
+    end
 
     def gds_user
       @gds_user ||= User.find_by(email: "govuk-whitehall@digital.cabinet-office.gov.uk")

--- a/test/unit/tasks/election/policy_paper_publisher_test.rb
+++ b/test/unit/tasks/election/policy_paper_publisher_test.rb
@@ -9,38 +9,66 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
 
     @gds_user = FactoryGirl.create(:user, email: "govuk-whitehall@digital.cabinet-office.gov.uk")
 
-    Election::PolicyPaperPublisher.new([@policy_paper.id]).run!
-
-    @policy_paper.reload
+    Whitehall::GovUkDelivery::Worker.stubs(:notify!)
+    Whitehall::SearchIndex.stubs(:add)
+    ServiceListeners::PanopticonRegistrar.any_instance.stubs(:register!)
   end
 
   test "it publishes the policy paper" do
+    publish_policy_paper
     assert @policy_paper.published?
   end
 
   test "it doesn't send emails" do
     Whitehall::GovUkDelivery::Worker.expects(:notify!).never
+    publish_policy_paper
+  end
+
+  test "it indexes the policy paper" do
+    Whitehall::SearchIndex.expects(:add).with(@policy_paper)
+    publish_policy_paper
+  end
+
+  test "it registers the policy paper with panopticon" do
+    registrar = stub(:registrar)
+    ServiceListeners::PanopticonRegistrar.stubs(:new).with(@policy_paper).returns(registrar)
+    registrar.expects(:register!).once
+    publish_policy_paper
+  end
+
+  test "it registers the policy paper with the publishing API" do
+    Whitehall::PublishingApi.expects(:publish_async).with(@policy_paper)
+    publish_policy_paper
   end
 
   test "it retains the first_published_at from the draft" do
+    publish_policy_paper
     assert_equal 1.year.ago, @policy_paper.first_published_at
   end
 
   test "doesn't explode if given a published publication" do
-    policy_paper = create(:published_policy_paper)
-    Election::PolicyPaperPublisher.new([policy_paper.id]).run!
+    @policy_paper = create(:published_policy_paper)
+    publish_policy_paper
   end
 
   test "it sets the public_timestamp to 24 hours ago" do
+    publish_policy_paper
     assert_equal Time.zone.now - 1.day, @policy_paper.public_timestamp
   end
 
   test "it creates a change note marking the historical nature of the policy paper" do
+    publish_policy_paper
     assert_equal "Policy document from the 2010 to 2015 government preserved in a different format for reference",
                  @policy_paper.change_note
   end
 
   test "it publishes as the GDS user" do
+    publish_policy_paper
     assert_equal @gds_user, @policy_paper.versions.where(state: "published").last.user
+  end
+
+  def publish_policy_paper
+    Election::PolicyPaperPublisher.new([@policy_paper.id]).run!
+    @policy_paper.reload
   end
 end

--- a/test/unit/tasks/election/policy_paper_publisher_test.rb
+++ b/test/unit/tasks/election/policy_paper_publisher_test.rb
@@ -6,7 +6,11 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
     @policy_paper = create(:draft_policy_paper,
       first_published_at: 1.year.ago
     )
+
+    @gds_user = FactoryGirl.create(:user, email: "govuk-whitehall@digital.cabinet-office.gov.uk")
+
     Election::PolicyPaperPublisher.new([@policy_paper.id]).run!
+
     @policy_paper.reload
   end
 
@@ -14,16 +18,12 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
     assert @policy_paper.published?
   end
 
-  test "it publishes as a minor change" do
-    assert @policy_paper.minor_change?
+  test "it doesn't send emails" do
+    Whitehall::GovUkDelivery::Worker.expects(:notify!).never
   end
 
   test "it retains the first_published_at from the draft" do
     assert_equal 1.year.ago, @policy_paper.first_published_at
-  end
-
-  test "it sets the major change timestamp to match the first published timestamp" do
-    assert_equal @policy_paper.first_published_at, @policy_paper.major_change_published_at
   end
 
   test "doesn't explode if given a published publication" do
@@ -33,5 +33,9 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
 
   test "it sets the public_timestamp to 24 hours ago" do
     assert_equal Time.zone.now - 1.day, @policy_paper.public_timestamp
+  end
+
+  test "it publishes as the GDS user" do
+    assert_equal @gds_user, @policy_paper.versions.where(state: "published").last.user
   end
 end

--- a/test/unit/tasks/election/policy_paper_publisher_test.rb
+++ b/test/unit/tasks/election/policy_paper_publisher_test.rb
@@ -35,6 +35,11 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
     assert_equal Time.zone.now - 1.day, @policy_paper.public_timestamp
   end
 
+  test "it creates a change note marking the historical nature of the policy paper" do
+    assert_equal "Policy document from the 2010 to 2015 government preserved in a different format for reference",
+                 @policy_paper.change_note
+  end
+
   test "it publishes as the GDS user" do
     assert_equal @gds_user, @policy_paper.versions.where(state: "published").last.user
   end

--- a/test/unit/tasks/election/policy_paper_publisher_test.rb
+++ b/test/unit/tasks/election/policy_paper_publisher_test.rb
@@ -30,4 +30,8 @@ class PolicyPaperPublisherTest < ActiveSupport::TestCase
     policy_paper = create(:published_policy_paper)
     Election::PolicyPaperPublisher.new([policy_paper.id]).run!
   end
+
+  test "it sets the public_timestamp to 24 hours ago" do
+    assert_equal Time.zone.now - 1.day, @policy_paper.public_timestamp
+  end
 end


### PR DESCRIPTION
Published policy papers that were generated to replace the current policies and act as a historical record.

This sets the public timestamp to 24 hours ago.
in order to bring the policy paper to the top of
the policy finder after the creation of the new
government.

This uses the service-based publishers to make more of the normal processes work whilst
still not doing things like sending emails.

This explicitly triggers:
- Panopticon registration
- Rummager indexing
- Publishing API publishing

Also adds a historical change note to the policy papers.