### PR TITLE
Government.current handles overlapping government

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -16,7 +16,7 @@ class Government < ActiveRecord::Base
   def self.on_date(date)
     return if date.to_date > Date.today
 
-    where('start_date <= ?', date).order(start_date: :desc).first
+    where('start_date <= ?', date).order(start_date: :asc).last
   end
 
   def current?

--- a/test/factories/governments.rb
+++ b/test/factories/governments.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
   end
 
   factory :current_government, parent: :government do
-    start_date { 2.years.ago + 1.day }
+    start_date { 2.years.ago }
   end
 
   factory :previous_government, parent: :government do

--- a/test/unit/government_test.rb
+++ b/test/unit/government_test.rb
@@ -126,7 +126,7 @@ class GovernmentOnDateTest < ActiveSupport::TestCase
   test "knows the active government at a date" do
     assert_equal @current_government, Government.on_date(Date.today)
     assert_equal @previous_government, Government.on_date(4.years.ago)
-    assert_equal @previous_government, Government.on_date(@previous_government.end_date)
+    assert_equal @previous_government, Government.on_date(@previous_government.end_date - 1.day)
     assert_equal @current_government, Government.on_date(@current_government.start_date)
   end
 


### PR DESCRIPTION
This fixes a bug where `Government.on_date` would return the previous government if given the date where an old government closes and the new government is formed. This would result in documents published on the day to be incorrectly marked as historic.

This changes the factories for current and previous government to better reflect the way they will be created in reality, i.e. with the current government starting on the same day as the previous government closed.

https://trello.com/c/djgxV9LV/250-history-mode-bug