### PR TITLE
Don't overwrite government end date when closing.

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -40,7 +40,7 @@ class Admin::GovernmentsController < Admin::BaseController
   def close
     government = Government.find(params[:id])
 
-    government.update_attribute(:end_date, Date.today)
+    government.update_attribute(:end_date, Date.today) unless government.end_date
 
     current_active_ministerial_appointments.each do |appointment|
       appointment.update_attribute(:ended_at, Time.zone.now)

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -28,4 +28,19 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     get :new
     assert_select "input[name='government[start_date]'][value='#{Date.today}']"
   end
+
+  test "#close sets the end date to today" do
+    login_as :gds_admin
+    post :close, id: @government.id
+    @government.reload
+    assert_equal Date.today, @government.end_date
+  end
+
+  test "#close doesn't overwrite an end date if there is one" do
+    login_as :gds_admin
+    @government.update(end_date: 10.days.ago.to_date)
+    post :close, id: @government.id
+    @government.reload
+    assert_equal 10.days.ago.to_date, @government.end_date
+  end
 end


### PR DESCRIPTION
This allows GDS admins to set an end date ahead of
time but still use the "close the government"
functionality to close the associated ministerial
roles.

This would happen in a situation where the government
was being closed in whitehall admin on the day
after the actual closing (or later).  Unlikely, but
possible.

https://trello.com/c/8l4Z1Eae/251-don-t-overwrite-end-date-when-closing-government