### PR TITLE
Don't crash rummager export on missing editions.

### DIFF
--- a/script/rummager_export.rb
+++ b/script/rummager_export.rb
@@ -86,7 +86,7 @@ export_classes(classes_to_index, id_groups) do |klass, output, id_group|
   end
 
   if id_group
-    association.find(id_group).each do |obj|
+    association.where(id: id_group).each do |obj|
       output_es_line(obj, output)
     end
   else


### PR DESCRIPTION
Since the script in parallel mode preloads all the
edition IDs, if one of the editions is deleted
while the export is happening we don't want to
crash when loading it from the database.

https://trello.com/c/lSwJuaML/252-don-t-crash-rummager-export-if-editions-are-missing