### PR TITLE
Only migrate tags on new editions

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -13,6 +13,7 @@ namespace :election do
     edition_scope = Edition.
                       where(type: policy_taggable_edition_classes).
                       where(state: editable_edition_states).
+                      where("updated_at > '2015-05-05'").
                       includes(related_policies: :related_documents)
 
     DataHygiene::FuturePolicyTaggingMigrator.new(edition_scope, Logger.new(STDOUT)).migrate!


### PR DESCRIPTION
We have run the tagging on older editions on production so we should
only need to update the taggings on newer editions.