### PR TITLE
Ensure role appointment data integrity

### DIFF
--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -43,7 +43,7 @@ class Admin::GovernmentsController < Admin::BaseController
     government.update_attribute(:end_date, Date.today) unless government.end_date
 
     current_active_ministerial_appointments.each do |appointment|
-      appointment.update_attribute(:ended_at, Time.zone.now)
+      appointment.update_attribute(:ended_at, government.end_date)
     end
 
     redirect_to edit_admin_government_path(government), notice: "Government closed"

--- a/features/governments.feature
+++ b/features/governments.feature
@@ -28,3 +28,13 @@ Scenario: changing government after an election
   When I close the current government
   And I create a government called "Robo-alien Overlords"
   Then the current government should be "Robo-alien Overlords"
+
+Scenario: appointing a minister to the new government
+  Given I am a GDS admin
+  And a person called "Fred Fancy"
+  And "Johnny Macaroon" is the "Minister of Crazy" for the "Department of Woah"
+  And there is a current government
+  When I close the current government
+  And I create a government called "Robo-alien Overlords"
+  And I appoint "Fred Fancy" as the "Minister of Crazy"
+  Then I should be able to create a news article associated with "Fred Fancy" as the "Minister of Crazy"

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -68,6 +68,25 @@ When /^I add a new "([^"]*)" translation to the role "([^"]*)" with:$/ do |local
   click_on "Save"
 end
 
+When(/^I appoint "(.*?)" as the "(.*?)"$/) do |person_name, role_name|
+  visit admin_roles_path
+  role = Role.find_by(name: role_name)
+  click_on role.name
+  click_on "New appointment"
+  select person_name, from: "Person"
+  click_on "Save"
+end
+
+Then(/^I should be able to create a news article associated with "(.*?)" as the "(.*?)"$/) do |person_name, role_name|
+  begin_drafting_news_article title: "New #{role_name}!"
+  select "#{person_name}, #{role_name}", from: "Ministers"
+
+  click_button "Save"
+
+  assert news = NewsArticle.find_by(title: "New #{role_name}!")
+  assert_equal person_name, news.role_appointments.first.person.name
+end
+
 Then /^I should be able to appoint "([^"]*)" to the new role$/ do |person_name|
   role = Role.last
   click_on role.name

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -43,4 +43,17 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     @government.reload
     assert_equal 10.days.ago.to_date, @government.end_date
   end
+
+  test "#close ends all the current ministerial role appointments on the same day as the government closes" do
+    login_as :gds_admin
+    @government.update(end_date: 1.day.ago.to_date)
+    ministerial = create(:ministerial_role_appointment)
+    ambassadorial = create(:ambassador_role_appointment)
+
+    post :close, id: @government.id
+
+    assert_equal @government.end_date, ministerial.reload.ended_at
+    assert_nil ambassadorial.ended_at
+    assert ambassadorial.current?
+  end
 end


### PR DESCRIPTION
Fixes a bug which causes the subsequent appointments to ministerial roles closed when the government is closed to be invalid.

The RoleAppointment model does various checks to ensure appointments do not overlap. This code assumes that all the role appointments have dates and not times set for both the `started_at` and `ended_at` fields. This is fine when they are being administered through the admin interface as the form fields only allow dates to be selected. The bug is caused by the code that closes the government and ends all existing ministerial roles with a time and not a date.

The precise problem is a little nuanced and is rooted in the fact that the `role_appointments` `started_at` and `ended_at` columns are `datetime` and not `date` columns[1]. If an existing role appointment is closed with a timestamp (e.g. 12th May 00:09:00), any role appointment that is created the same day using the admin interface will have a `started_at` that is less than the `ended_at` of the previous appointment because ActiveRecord is casting the date supplied to a timestamp set to the beginning of the day (e.g. 12th May 00:00:00).

Trello: https://trello.com/c/mOUchwOS/256-role-appointments-bug

[1] Ultimately, these columns should be converted to be dates and not datetimes. This will happen in a future pull request as there may be other unintended consequences to doing this.