### PR TITLE
Reslug roles

### DIFF
--- a/lib/data_hygiene/role_reslugger.rb
+++ b/lib/data_hygiene/role_reslugger.rb
@@ -1,0 +1,58 @@
+module DataHygiene
+  # Reslugs a role to new_slug.
+  #
+  # When run, the following happens:
+  #
+  #   - updates the Role record's slug
+  #   - reindexes the role for search
+  #   - republishes the role to Publishing API
+  #   - publishes a redirect content item to Publishing API
+  #   - reindexes all dependent documents in search
+  #
+  class RoleReslugger
+    def initialize(role, new_slug)
+      @role = role
+      @new_slug = new_slug
+      @old_slug = @role.slug
+    end
+
+    def run!
+      remove_from_search_index
+      update_slug
+      register_redirect
+    end
+
+  private
+    attr_reader :role, :new_slug, :old_slug
+
+    def remove_from_search_index
+      Whitehall::SearchIndex.delete(role)
+    end
+
+    def update_slug
+      # Note: This will trigger calls to both rummager and the Publishing API,
+      # meaning that entries in both places will exist with the correct slug
+      role.update_attributes!(slug: new_slug)
+    end
+
+    def old_base_path
+      Whitehall.url_maker.ministerial_role_path(old_slug)
+    end
+
+    def new_base_path
+      Whitehall.url_maker.ministerial_role_path(new_slug)
+    end
+
+    def redirects
+      @redirects ||= [
+        { path: old_base_path, destination: new_base_path, type: "exact" },
+        { path: (old_base_path + ".atom"), destination: (new_base_path + ".atom"), type: "exact" },
+      ]
+    end
+
+    def register_redirect
+      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
+      Whitehall::PublishingApi.publish_redirect(redirect_item)
+    end
+  end
+end

--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -19,4 +19,21 @@ namespace :reslug do
 
     DataHygiene::PersonReslugger.new(person, new_slug).run!
   end
+
+  desc "Change a role slug (DANGER!).\n
+
+  This rake task changes a roles's slug in whitehall.
+
+  It performs the following steps:
+  - changes the role's slug
+  - reindexes the role for search
+  - republishes the role to Publishing API
+  - publishes a redirect content item to Publishing API"
+  task :role, [:old_slug, :new_slug] => :environment do |_task, args|
+    old_slug = args[:old_slug]
+    new_slug = args[:new_slug]
+    role = Role.find_by!(slug: old_slug)
+
+    DataHygiene::RoleReslugger.new(role, new_slug).run!
+  end
 end

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class MinisterialRoleResluggerTest < ActiveSupport::TestCase
+  self.use_transactional_fixtures = false
+
+  setup do
+    DatabaseCleaner.clean_with :truncation
+    @ministerial_role = create(:ministerial_role, name: "Misspelt role")
+    @reslugger = DataHygiene::RoleReslugger.new(@ministerial_role, 'corrected-slug')
+  end
+
+  teardown do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  test "re-slugs the role" do
+    @reslugger.run!
+    assert_equal 'corrected-slug', @ministerial_role.slug
+  end
+
+  test "publishes to Publishing API with the new slug and redirects the old" do
+    content_item = PublishingApiPresenters.presenter_for(@ministerial_role).as_json
+    old_base_path = @ministerial_role.search_link
+    new_base_path = "/government/ministers/corrected-slug"
+    content_item[:routes][0][:path] = new_base_path
+    redirects = [
+      { path: old_base_path, type: "exact", destination: new_base_path },
+      { path: (old_base_path + ".atom"), type: "exact", destination: (new_base_path + ".atom") }
+    ]
+    redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
+
+    expected_publish_request = stub_publishing_api_put_item(new_base_path, content_item)
+    expected_redirect = stub_publishing_api_put_item(old_base_path, redirect_item)
+
+    @reslugger.run!
+
+    assert_requested expected_redirect
+    assert_requested expected_publish_request
+  end
+
+  test "deletes the old slug from the search index" do
+    Whitehall::SearchIndex.expects(:delete).with { |minister| minister.slug == 'misspelt-role' }
+    @reslugger.run!
+  end
+
+  test "adds the new slug from the search index" do
+    Whitehall::SearchIndex.expects(:add).with { |minister| minister.slug == 'corrected-slug' }
+    @reslugger.run!
+  end
+end


### PR DESCRIPTION
Adds a rake task to reslug a role:

```shell
$ rake reslug:role['old-slug','new-slug']
```

When run, it will:

* Update the slug of the role in the database
* Remove the old search index entry for the role
* Index the role for search with the new slug
* Register a redirect from the old slug to the new.

Roles do have dependent documents, but these are not exposed in the search directly, instead documents that are associated with a role appointment are associated using the person's slug and not the roles.

Trello: https://trello.com/c/PuzDJ50p/216-5-create-rake-task-to-reslug-roles