### PR TITLE
Add feed and email subscriptions for statistics page

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -16,7 +16,10 @@ class AnnouncementsController < DocumentsController
       format.atom do
         documents = Announcement.published_with_eager_loading(@filter.documents.map(&:id))
         @announcements = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, AnnouncementPresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          AnnouncementPresenter,
+          view_context,
+        )
       end
     end
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -18,7 +18,10 @@ class PublicationsController < DocumentsController
       format.atom do
         documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
         @publications = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          PublicationesquePresenter,
+          view_context,
+        )
       end
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,5 +1,5 @@
 class StatisticsController < DocumentsController
-  enable_request_formats index: [:json]
+  enable_request_formats index: [:json, :atom]
   before_filter :inject_statistics_publication_filter_option_param, only: :index
   before_filter :expire_cache_when_next_publication_published
 
@@ -13,6 +13,11 @@ class StatisticsController < DocumentsController
       end
       format.json do
         render json: StatisticsFilterJsonPresenter.new(@filter, view_context, PublicationesquePresenter)
+      end
+      format.atom do
+        documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
+        @statistics = Whitehall::Decorators::CollectionDecorator.new(
+          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
       end
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -17,7 +17,10 @@ class StatisticsController < DocumentsController
       format.atom do
         documents = Publicationesque.published_with_eager_loading(@filter.documents.map(&:id))
         @statistics = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse, PublicationesquePresenter, view_context)
+          documents.sort_by(&:public_timestamp).reverse,
+          PublicationesquePresenter,
+          view_context,
+        )
       end
     end
   end

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -29,7 +29,7 @@ module PublicDocumentRoutesHelper
     when SupportingPage
       build_url_for_supporting_page(edition, options)
     else
-      path_name = if edition.is_a?(Publication) && edition.statistics?
+      path_name = if edition.statistics?
                     "statistic"
                   else
                     edition.to_model.class.name.underscore

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -441,6 +441,10 @@ class Edition < ActiveRecord::Base
     false
   end
 
+  def statistics?
+    false
+  end
+
   # @!endgroup
 
   def create_draft(user)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -445,6 +445,10 @@ class Edition < ActiveRecord::Base
     false
   end
 
+  def included_in_statistics_feed?
+    search_format_types.include?("publicationesque-statistics")
+  end
+
   # @!endgroup
 
   def create_draft(user)

--- a/app/views/statistics/index.atom.builder
+++ b/app/views/statistics/index.atom.builder
@@ -1,0 +1,8 @@
+atom_feed language: 'en-GB', root_url: root_url do |feed|
+  feed.title 'Statistics on GOV.UK'
+  feed.author do |author|
+    author.name 'HM Government'
+  end
+
+  documents_as_feed_entries(@statistics, feed)
+end

--- a/lib/whitehall/feed_url_builder.rb
+++ b/lib/whitehall/feed_url_builder.rb
@@ -12,6 +12,8 @@ module Whitehall
         Whitehall.url_maker.publications_url(url_params)
       when 'announcements'
         Whitehall.url_maker.announcements_url(url_params)
+      when 'statistics'
+        Whitehall.url_maker.statistics_url(url_params)
       end
     end
 

--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -32,7 +32,7 @@ module Whitehall
       end
 
       def filtered_documents_feed?
-        %w(publications announcements).include?(feed_type)
+        %w(publications announcements statistics).include?(feed_type)
       end
 
     protected
@@ -92,6 +92,8 @@ module Whitehall
           @feed_type = 'publications'
         elsif uri.path == url_maker.announcements_path
           @feed_type = 'announcements'
+        elsif uri.path == url_maker.statistics_path
+          @feed_type = 'statistics'
         else
           path_root_fragment = uri.path.split('/')[2];
           @feed_object_slug = uri.path.match(/([^\/]*)\.atom$/)[1]
@@ -121,7 +123,7 @@ module Whitehall
           fragment_for_filter_option('publication_filter_option').downcase
         elsif feed_params['announcement_filter_option'].present?
           fragment_for_filter_option('announcement_filter_option').downcase
-        elsif ['publications', 'announcements'].include? feed_type
+        elsif ['publications', 'announcements', 'statistics'].include? feed_type
           feed_type
         else
           label_for_resource

--- a/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
+++ b/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
@@ -48,7 +48,11 @@ module Whitehall
         when Announcement
           url_helpers_for_announcements
         when Publicationesque
-          url_helpers_for_publications
+          if edition.included_in_statistics_feed?
+            url_helpers_for_statistics
+          else
+            url_helpers_for_publications
+          end
         else
           []
         end
@@ -60,6 +64,10 @@ module Whitehall
 
       def url_helpers_for_announcements
         [url_maker.method(:announcements_url)]
+      end
+
+      def url_helpers_for_statistics
+        url_helpers_for_publications + [url_maker.method(:statistics_url)]
       end
 
       def url_helpers_for_publications

--- a/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
+++ b/lib/whitehall/gov_uk_delivery/subscription_url_generator.rb
@@ -37,17 +37,37 @@ module Whitehall
         end
       end
 
-      def edition_url(args = {})
-        url_params = args.merge(format: :atom)
+      def url_helpers
+        url_helpers_for_edition_type + url_helpers_for_global_feed
+      end
 
+      def url_helpers_for_edition_type
         case edition
         when Policy
-          url_maker.policies_url(url_params)
+          url_helpers_for_policies
         when Announcement
-          url_maker.announcements_url(url_params)
+          url_helpers_for_announcements
         when Publicationesque
-          url_maker.publications_url(url_params)
+          url_helpers_for_publications
+        else
+          []
         end
+      end
+
+      def url_helpers_for_policies
+        [url_maker.method(:policies_url)]
+      end
+
+      def url_helpers_for_announcements
+        [url_maker.method(:announcements_url)]
+      end
+
+      def url_helpers_for_publications
+        [url_maker.method(:publications_url)]
+      end
+
+      def url_helpers_for_global_feed
+        [url_maker.method(:atom_feed_url)]
       end
 
       def filter_option
@@ -125,10 +145,8 @@ module Whitehall
           combinatorial_args << { relevant_to_local_government: 1 } if relevant_to_local_government?
 
           all_combinations_of_args(combinatorial_args).map do |combined_args|
-            [
-              edition_url(combined_args),
-              url_maker.atom_feed_url(combined_args.merge(format: :atom))
-            ]
+            url_args = combined_args.merge(format: :atom)
+            url_helpers.map { |helper| helper.call(url_args) }
           end
         end
       end

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -177,6 +177,20 @@ class StatisticsControllerTest < ActionController::TestCase
     assert_equal %Q{Part of a collection: #{link}}, result['publication_collections']
   end
 
+  view_test "index generates an atom feed with entries for statistics matching the current filter" do
+    org = create(:organisation, name: "org-name")
+    org2 = create(:organisation, name: "other-org")
+    statistics_publication = create(:published_statistics, title: "statistics-title",
+                                                           organisations: [org, org2],
+                                                           first_published_at: Date.parse("2012-03-14"))
+
+    get :index, format: :atom, departments: [org.to_param]
+
+    assert_select_atom_feed do
+      assert_select_atom_entries([statistics_publication])
+    end
+  end
+
   view_test "#show displays a badge when the publication is national statistics" do
     publication = create(:published_publication, publication_type_id: PublicationType::NationalStatistics.id)
     get :show, id: publication.document

--- a/test/unit/whitehall/feed_url_builder_test.rb
+++ b/test/unit/whitehall/feed_url_builder_test.rb
@@ -10,6 +10,10 @@ module Whitehall
       assert_equal feed_url("announcements.atom"), FeedUrlBuilder.new(document_type: 'announcements').url
     end
 
+    test "with :document_type as statistics it generates the statistics feed url" do
+      assert_equal feed_url("statistics.atom"), FeedUrlBuilder.new(document_type: 'statistics').url
+    end
+
     test "with :document_type as publications and other params it generate a publications atom feed url with the given params as query string" do
       filter_params = {
         document_type: 'publications',

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -52,6 +52,21 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     assert_equal "announcements related to The Cabinet Office, Arts and culture and Afghanistan", validator.description
   end
 
+  test 'validates and describes a statistics filter feed url with filter options' do
+    create(:topic, slug: 'arts-and-culture', name: 'Arts and culture')
+    create(:ministerial_department, :with_published_edition, name: 'The Cabinet Office')
+
+    feed_url = feed_url_for(
+      document_type: "statistics",
+      topics: ["arts-and-culture"],
+      departments: ["the-cabinet-office"]
+    )
+    validator = FeedUrlValidator.new(feed_url)
+
+    assert validator.valid?
+    assert_equal "statistics related to The Cabinet Office and Arts and culture", validator.description
+  end
+
   test 'uses the announcement_filter_option when given' do
     feed_url = feed_url_for(document_type: "announcements", announcement_filter_option: "fatality-notices")
     validator = FeedUrlValidator.new(feed_url)

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -325,4 +325,37 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     refute urls_for(@edition).any? { |feed_url| feed_url =~ /policies/ }
     refute urls_for(@edition).any? { |feed_url| feed_url =~ /relevant_to_local_government/ }
   end
+
+  test "#subscription_urls for a statistics publication returns atom feed urls for both publications and statistics" do
+    @edition = create(:publication, publication_type: PublicationType::Statistics)
+
+    assert_subscription_urls_for_edition_include(
+      "publications.atom",
+      "publications.atom?publication_filter_option=statistics",
+      "statistics.atom",
+      "statistics.atom?publication_filter_option=statistics",
+    )
+  end
+
+  test "#subscription_urls for a national statistics publication returns atom feed urls for both publications and statistics" do
+    @edition = create(:publication, publication_type: PublicationType::NationalStatistics)
+
+    assert_subscription_urls_for_edition_include(
+      "publications.atom",
+      "publications.atom?publication_filter_option=statistics",
+      "statistics.atom",
+      "statistics.atom?publication_filter_option=statistics",
+    )
+  end
+
+  test "#subscription_urls for a statistical data set returns atom feed urls for both publications and statistics" do
+    @edition = create(:statistical_data_set)
+
+    assert_subscription_urls_for_edition_include(
+      "publications.atom",
+      "publications.atom?publication_filter_option=statistics",
+      "statistics.atom",
+      "statistics.atom?publication_filter_option=statistics",
+    )
+  end
 end


### PR DESCRIPTION
This only adds feed and email for published statistics (ie https://www.gov.uk/government/statistics) and not for announcements (ie https://www.gov.uk/government/statistics/announcements)

Follow up to #2120.
Ticket: https://www.pivotaltracker.com/n/projects/1261204/stories/87099378