### PR TITLE
Deduplicate organisations returned by excluding_hmcts_tribunals scope

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -37,7 +37,7 @@ module Organisation::OrganisationTypeConcern
 
     scope :excluding_hmcts_tribunals, -> {
       hmcts_id = Organisation.where(slug: "hm-courts-and-tribunals-service").ids.first
-      joins("LEFT JOIN organisational_relationships parent_organisational_relationships
+      distinct.joins("LEFT JOIN organisational_relationships parent_organisational_relationships
         ON parent_organisational_relationships.child_organisation_id = organisations.id").
       where("NOT (parent_organisational_relationships.parent_organisation_id = ? AND
               organisations.organisation_type_key = ?) OR

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -82,6 +82,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
       @other_org = create(:organisation)
       @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb,
         name: "Copyright Tribunal")
+      @multiple_parent_child_org = create(:organisation, parent_organisations: [@other_org, @copyright_tribunal])
       @court = create(:court)
       @hmcts_tribunal = create(:hmcts_tribunal)
     end
@@ -116,6 +117,11 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
       assert_includes result, @copyright_tribunal
       refute_includes result, @court
       assert_includes result, @hmcts_tribunal
+    end
+
+    test "excluding_hmcts_tribunals deduplicates organisations" do
+      result = Organisation.excluding_hmcts_tribunals.listable.map(&:id)
+      assert_equal result, result.uniq
     end
   end
 


### PR DESCRIPTION
The LEFT JOIN added by this scope will return orgs with multiple parents multiple times. Adding a DISTINCT to the query fixes this