### PR TITLE
Ministers history mode

### DIFF
--- a/db/data_migration/20150511162040_reclassify_correspondence.rb
+++ b/db/data_migration/20150511162040_reclassify_correspondence.rb
@@ -1,0 +1,24 @@
+PUBLISHED_AND_PUBLISHABLE_STATES = %w(published draft archived submitted rejected scheduled)
+
+correspondence_scope = Publication.
+  where(state: PUBLISHED_AND_PUBLISHABLE_STATES).
+  where(publication_type_id: PublicationType::Correspondence.id)
+
+count = correspondence_scope.count
+index = 0
+reclassified_count = 0
+
+puts "Checking the political status of #{count} correspondence"
+
+correspondence_scope.find_each do |edition|
+  if PoliticalContentIdentifier.political?(edition) && !edition.political?
+    edition.update_column(:political, true)
+    reclassified_count += 1
+  end
+
+  index += 1
+
+  puts "Processed #{index} of #{count} correspondence (#{sprintf "%.2f", (index.to_f/count.to_f)*100}%)" if index % 1000 == 0
+end
+
+puts "Re-classification complete. #{reclassified_count} correspondence out of #{count} re-classified as political"

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -58,7 +58,14 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     refute political?(edition)
   end
 
-  test 'political formats associated with ministerial role appointments are political' do
+  test 'publications of a non-political sub-type associated with ministers are political' do
+    political_organisation = create(:organisation, :political)
+    edition = create(:publication, publication_type_id: PublicationType::Correspondence.id, role_appointments: [create(:ministerial_role_appointment)])
+
+    assert political?(edition)
+  end
+
+  test 'political formats associated with ministers are political' do
     edition = create(:news_article, role_appointments: [create(:ministerial_role_appointment)])
 
     assert political?(edition)


### PR DESCRIPTION
Updates the `PoliticalContentIdentifier` to always mark documents associated with ministers as political, unless they are a statistics publication or a fatality notice. There is also a data migration to re-classify all `Publication`s of type `Correspondence`, as these are the publications that should definitely be marked as political if associated with a minister.

Trello: https://trello.com/c/ukmwHRD8/258-content-associated-with-a-minister-should-always-take-history-mode

 - [x] Code review
 - [ ] Product review