### PR TITLE
Remove local government email alerts and filtering.

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -17,6 +17,6 @@ class EmailSignupsController < PublicFacingController
 private
 
   def email_signup_params
-    params.require(:email_signup).permit(:feed, :local_government)
+    params.require(:email_signup).permit(:feed)
   end
 end

--- a/app/views/email_signups/_form.html.erb
+++ b/app/views/email_signups/_form.html.erb
@@ -2,9 +2,7 @@
   <%= form.hidden_field :feed %>
 
   <p>You're signing up to all alerts for <strong><%= email_signup.description %></strong></p>
-  <p>
-    <%= form.check_box :local_government, label_text: 'Only include results relevant to local government' %>
-  </p>
+
   <div class="submit">
     <%= button_tag 'Create subscription' %>
     <p>You can enter your email address on the next page to complete the subscription</p>

--- a/features/email-signup-for-documents.feature
+++ b/features/email-signup-for-documents.feature
@@ -35,12 +35,3 @@ Feature: Email signup for documents
 
     When I publish a new news article of the type "News story" called "Example News Story"
     Then a govuk_delivery notification should have been sent to the mailing list I signed up for
-
-  Scenario: Signing up for a feed which is relevant to local governments
-    Given a published policy "Re-introduce feudalism to Cornwall" relevant to local government
-    When I filter the announcements list by "News stories"
-    When I sign up for emails, checking the relevant to local government box
-    Then I should be signed up for the local government news stories mailing list
-
-    When I publish a news article "Serfdom is prooving to be an unpopular lifestyle choice, says the mayor of Penzance" associated with the policy "Re-introduce feudalism to Cornwall"
-    Then a govuk_delivery notification should have been sent to the mailing list I signed up for

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -12,15 +12,6 @@ When(/^I sign up for emails$/) do
   click_on 'Create subscription'
 end
 
-When(/^I sign up for emails, checking the relevant to local government box$/) do
-  within '.feeds' do
-    click_on 'email'
-  end
-
-  check 'Only include results relevant to local government'
-  click_on 'Create subscription'
-end
-
 Then(/^I should be signed up for the all publications mailing list$/) do
   assert_signed_up_to_mailing_list("/government/publications.atom", "publications")
 end
@@ -35,10 +26,6 @@ end
 
 Then(/^I should be signed up for the news stories mailing list$/) do
   assert_signed_up_to_mailing_list("/government/announcements.atom?announcement_filter_option=news-stories", "news stories")
-end
-
-Then(/^I should be signed up for the local government news stories mailing list$/) do
-  assert_signed_up_to_mailing_list("/government/announcements.atom?announcement_filter_option=news-stories&relevant_to_local_government=1", "news stories which are relevant to local government")
 end
 
 Then(/^I should be signed up for the "(.*?)" organisation mailing list$/) do |org_name|

--- a/lib/tasks/describe_filters.rake
+++ b/lib/tasks/describe_filters.rake
@@ -40,7 +40,6 @@ task :describe_filters, [:topic_list_csv] => :environment do |t, args|
       topics: h.filter_results_selections(filter.selected_topics, 'topics').map {|h| h[:name]},
       world_locations: h.filter_results_selections(filter.selected_locations, 'world_locations').map {|h| h[:name]},
       keywords: h.filter_results_keywords(filter.keywords),
-      relevant_to_local_government: filter.relevant_to_local_government ? "relevant to local government" : "",
       include_world_location_news: filter.include_world_location_news ? "including location-specific news" : ""
     }
   end

--- a/lib/whitehall/document_filter/cleaned_params.rb
+++ b/lib/whitehall/document_filter/cleaned_params.rb
@@ -9,7 +9,6 @@ module Whitehall::DocumentFilter
                                          to_date
                                          keywords
                                          locale
-                                         relevant_to_local_government
                                          include_world_location_news
                                          official_document_status
                                          publication_type

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -15,7 +15,6 @@ module Whitehall::DocumentFilter
       @keywords        = params[:keywords]
       @locale          = params[:locale]
 
-      @relevant_to_local_government = params[:relevant_to_local_government]
       @include_world_location_news  = params[:include_world_location_news]
 
       @topics          = Array(@params[:topics])
@@ -81,10 +80,6 @@ module Whitehall::DocumentFilter
       else
         []
       end
-    end
-
-    def relevant_to_local_government
-      @relevant_to_local_government.to_s == '1'
     end
 
     def include_world_location_news

--- a/lib/whitehall/document_filter/mysql.rb
+++ b/lib/whitehall/document_filter/mysql.rb
@@ -27,7 +27,6 @@ module Whitehall::DocumentFilter
       filter_by_date!
       filter_by_publication_filter_option!
       filter_by_announcement_filter_option!
-      filter_by_relevant_to_local_government_option!
       filter_by_include_world_location_news_option!
       filter_by_location!
       apply_sort_direction!
@@ -95,12 +94,6 @@ module Whitehall::DocumentFilter
             @documents.arel_table[:news_article_type_id].in(
               selected_announcement_filter_option.news_article_types.map(&:id)))
         end
-      end
-    end
-
-    def filter_by_relevant_to_local_government_option!
-      if relevant_to_local_government
-        @documents = @documents.relevant_to_local_government(relevant_to_local_government)
       end
     end
 

--- a/lib/whitehall/document_filter/options.rb
+++ b/lib/whitehall/document_filter/options.rb
@@ -30,7 +30,6 @@ module Whitehall
         announcement_type: 'announcement_filter_option',
         official_documents: 'official_document_status',
         locations: 'world_locations',
-        local_government: 'relevant_to_local_government'
       }.freeze
 
       def valid_option_name?(option_name)

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -28,7 +28,6 @@ module Whitehall::DocumentFilter
     def standard_filter_args
       default_filter_args
         .merge(filter_by_keywords)
-        .merge(filter_by_relevance_to_local_government)
         .merge(filter_by_people)
         .merge(filter_by_topics)
         .merge(filter_by_organisations)
@@ -40,14 +39,6 @@ module Whitehall::DocumentFilter
     def filter_by_keywords
       if @keywords.present?
         {keywords: @keywords.to_s}
-      else
-        {}
-      end
-    end
-
-    def filter_by_relevance_to_local_government
-      if relevant_to_local_government
-        {relevant_to_local_government: "1"}
       else
         {}
       end

--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -15,7 +15,7 @@ module Whitehall
 
       def description
         if valid?
-          [leading_fragment, parameter_fragments, command_and_act_fragment, relevant_to_local_government_fragment].compact.join " "
+          [leading_fragment, parameter_fragments, command_and_act_fragment].compact.join " "
         end
       end
 
@@ -67,7 +67,7 @@ module Whitehall
         if filtered_documents_feed?
           filter_param_keys_valid? && filter_param_resources_exist?
         else
-          feed_params.except('relevant_to_local_government').none?
+          feed_params.none?
         end
       end
 
@@ -129,7 +129,7 @@ module Whitehall
       end
 
       def resource_filter_params
-        feed_params.except(*%w(publication_filter_option announcement_filter_option official_document_status relevant_to_local_government))
+        feed_params.except(*%w(publication_filter_option announcement_filter_option official_document_status))
       end
 
       def parameter_fragments
@@ -152,17 +152,6 @@ module Whitehall
           when "act_papers_only"
             "which are act papers"
           end
-        end
-      end
-
-      def relevant_to_local_government_fragment
-        relevant_to_local_government = feed_params['relevant_to_local_government'] && feed_params['relevant_to_local_government'] != "0"
-        if relevant_to_local_government && feed_params['official_document_status'].present?
-          "and are relevant to local government"
-        elsif relevant_to_local_government
-          "which are relevant to local government"
-        else
-          nil
         end
       end
 

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -64,7 +64,6 @@ module Whitehall
           },
           date: %w{public_timestamp},
           boolean: %w{
-            relevant_to_local_government
             has_official_document
             has_command_paper
             has_act_paper

--- a/test/unit/email_signup_test.rb
+++ b/test/unit/email_signup_test.rb
@@ -1,17 +1,6 @@
 require 'test_helper'
 
 class EmailSignupTest < ActiveSupport::TestCase
-  test "merges the local_government parameter with the feed URL" do
-    assert_equal feed_url("publications.atom"),
-                 email_signup("publications.atom").feed
-    assert_equal feed_url("publications.atom"),
-                  email_signup("publications.atom", false).feed
-    assert_equal feed_url("feed?relevant_to_local_government=1"),
-                 email_signup("feed", true).feed
-    assert_equal feed_url("publications.atom?departments[]=all&relevant_to_local_government=1"),
-                 email_signup("publications.atom?departments[]=all", true).feed
-  end
-
   test "#save ensures that a relevant topic exists in GovDelivery using the feed and the signup description" do
     email_signup = EmailSignup.new(feed: feed_url)
 
@@ -49,7 +38,7 @@ class EmailSignupTest < ActiveSupport::TestCase
     "#{Whitehall.public_protocol}://#{Whitehall.public_host}/government/#{feed_path}"
   end
 
-  def email_signup(feed_path, is_local_government = false)
-    EmailSignup.new(feed: feed_url(feed_path), local_government: (is_local_government ? '1' : '0'))
+  def email_signup(feed_path)
+    EmailSignup.new(feed: feed_url(feed_path))
   end
 end

--- a/test/unit/whitehall/document_filter/mysql_test.rb
+++ b/test/unit/whitehall/document_filter/mysql_test.rb
@@ -271,36 +271,6 @@ module Whitehall::DocumentFilter
       assert filter.documents.include?(world_news)
     end
 
-    test 'will include all editions, including local government unless told otherwise' do
-      policy_1 = create(:published_policy, :with_document, relevant_to_local_government: true)
-      policy_2 = create(:published_policy, :with_document, relevant_to_local_government: false)
-      publication_1 = create(:published_publication, related_policy_ids: [policy_1.id])
-      publication_2 = create(:published_publication, related_policy_ids: [policy_2.id])
-      unfiltered = Edition.published
-
-      filter = create_filter(unfiltered, {})
-
-      assert filter.documents.include?(policy_1)
-      assert filter.documents.include?(policy_2)
-      assert filter.documents.include?(publication_1)
-      assert filter.documents.include?(publication_2)
-    end
-
-    test 'will reject all non-local government editions if asked to' do
-      policy_1 = create(:published_policy, :with_document, relevant_to_local_government: true)
-      policy_2 = create(:published_policy, :with_document, relevant_to_local_government: false)
-      publication_1 = create(:published_publication, related_policy_ids: [policy_1.id])
-      publication_2 = create(:published_publication, related_policy_ids: [policy_2.id])
-      unfiltered = Edition.published
-
-      filter = create_filter(unfiltered, relevant_to_local_government: '1')
-
-      assert filter.documents.include?(policy_1)
-      refute filter.documents.include?(policy_2)
-      assert filter.documents.include?(publication_1)
-      refute filter.documents.include?(publication_2)
-    end
-
   private
 
     def create_filter(document_set, args)
@@ -329,7 +299,6 @@ module Whitehall::DocumentFilter
       document_scope.stubs(:published_in_topic).returns(document_scope)
       document_scope.stubs(:in_organisation).returns(document_scope)
       document_scope.stubs(:where).with(has_entry(:publication_type_id, anything)).returns(document_scope)
-      document_scope.stubs(:where).with(has_entry(:relevant_to_local_government, anything)).returns(document_scope)
       document_scope.stubs(:per).returns(document_scope)
       document_scope.stubs(:page).returns(document_scope)
       document_scope

--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -60,7 +60,6 @@ module Whitehall
           announcement_type
           official_documents
           locations
-          local_government
         }
 
         valid_option_names.each do |option_name|
@@ -78,7 +77,6 @@ module Whitehall
           announcement_filter_option
           official_document_status
           world_locations
-          relevant_to_local_government
         }
 
         valid_filter_keys.each do |filter_key|

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -189,22 +189,6 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     assert_nil FeedUrlValidator.new('http://bad/feed').description
   end
 
-  test 'appends "which are relevant to local government" when relevant_to_local_government is truthy' do
-    feed_url  = feed_url_for(document_type: "publications", relevant_to_local_government: '1')
-    validator = FeedUrlValidator.new(feed_url)
-
-    assert validator.valid?
-    assert_equal "publications which are relevant to local government", validator.description
-  end
-
-  test 'appends "which are command papers and are relevant to local government" when relevant_to_local_government is truthy and official_document_status is present' do
-    feed_url = feed_url_for(document_type: "publications", official_document_status: "command_papers_only", relevant_to_local_government: '1')
-    validator = FeedUrlValidator.new(feed_url)
-
-    assert validator.valid?
-    assert_equal "publications which are command papers and are relevant to local government", validator.description
-  end
-
 private
 
   def feed_url_for(params)

--- a/test/unit/whitehall/not_quite_as_fake_search_test.rb
+++ b/test/unit/whitehall/not_quite_as_fake_search_test.rb
@@ -76,21 +76,21 @@ module Whitehall
 
       test "advanced search can select documents using a boolean filter" do
         documents = build_documents(*%w{Foo Bar})
-        documents[0]['relevant_to_local_government'] = true
+        documents[0]['has_official_document'] = true
         @index.add_batch(documents)
-        assert_search_returns_documents %w{Foo}, relevant_to_local_government: "true"
-        assert_search_returns_documents %w{Foo}, relevant_to_local_government: "1"
-        assert_search_returns_documents %w{Bar}, relevant_to_local_government: "false"
-        assert_search_returns_documents %w{Bar}, relevant_to_local_government: "0"
+        assert_search_returns_documents %w{Foo}, has_official_document: "true"
+        assert_search_returns_documents %w{Foo}, has_official_document: "1"
+        assert_search_returns_documents %w{Bar}, has_official_document: "false"
+        assert_search_returns_documents %w{Bar}, has_official_document: "0"
       end
 
       test "advanced search raises if boolean filter is not a boolean-ish value" do
-        assert_invalid_search(relevant_to_local_government: "hello")
-        assert_invalid_search(relevant_to_local_government: "")
-        assert_invalid_search(relevant_to_local_government: "yes")
-        assert_invalid_search(relevant_to_local_government: "no")
-        assert_invalid_search(relevant_to_local_government: "false evidence")
-        assert_invalid_search(relevant_to_local_government: "true facts")
+        assert_invalid_search(has_official_document: "hello")
+        assert_invalid_search(has_official_document: "")
+        assert_invalid_search(has_official_document: "yes")
+        assert_invalid_search(has_official_document: "no")
+        assert_invalid_search(has_official_document: "false evidence")
+        assert_invalid_search(has_official_document: "true facts")
       end
 
       test "advanced search raises if date filter is not a pure date" do
@@ -176,7 +176,7 @@ module Whitehall
             "description" => "#{title}-description",
             "indexable_content" => "#{title}-indexable_content",
             topics: ["#{title}-topic1", "#{title}-topic2"],
-            "relevant_to_local_government" => false,
+            "has_official_document" => false,
             "public_timestamp" => Time.zone.parse("2011-01-01 00:00:00")
           }
         end


### PR DESCRIPTION
These are to be handled by e.g. the local government
topic and subtopics: https://www.gov.uk/local-government

https://trello.com/c/GpW8gI5b/199-0-5-remove-local-government-checkbox