### PR TITLE
Add EU logo to EAFRD Editions

### DIFF
--- a/app/assets/stylesheets/frontend/views/_detailed_guides.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides.scss
@@ -255,7 +255,17 @@
   }
 
   .heading-extra {
-    padding-top: 45px;
+    margin-top: 0;
+
+    #logo-image{
+      max-width: 70%;
+      @include media(tablet) {
+        max-width: 100%;
+      }
+    }
+    @include media(tablet) {
+      padding-top: 45px;
+    }
   }
 
 

--- a/app/assets/stylesheets/frontend/views/_document-collection.scss
+++ b/app/assets/stylesheets/frontend/views/_document-collection.scss
@@ -5,6 +5,20 @@
     padding-top: $gutter;
   }
 
+  .heading-extra {
+    margin-top: 0;
+
+    #logo-image{
+      max-width: 70%;
+      @include media(tablet) {
+        max-width: 100%;
+      }
+    }
+    @include media(tablet) {
+      padding-top: 45px;
+    }
+  }
+
   .description {
     margin-top: 0;
   }

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -19,6 +19,9 @@
 <div class="heading-extra">
   <div class="inner-heading">
     <%= render partial: 'shared/available_languages', locals: {object: document} %>
+    <% if @document.respond_to?(:logo_url) && @document.logo_url %>
+      <%= image_tag @document.logo_url, id: "logo-image" %>
+    <% end %>
     <%= national_statistics_logo(document) %>
   </div>
 </div>

--- a/db/data_migration/20150514105208_add_eu_logo_url_to_eafrd_editions.rb
+++ b/db/data_migration/20150514105208_add_eu_logo_url_to_eafrd_editions.rb
@@ -1,0 +1,24 @@
+slugs = [
+  "countryside-stewardship-facilitation-funding",
+  "countryside-stewardship-water-capital-grants-2015-capital-items",
+  "countryside-stewardship-water-capital-grants-catchment-sensitive-farming",
+  "countryside-stewardship-woodland-capital-grants-2015",
+  "countryside-productivity-scheme",
+  "rural-development-programme-for-england-leader-funding"
+]
+logo_url = "https://assets.digital.cabinet-office.gov.uk/media/55547b94ed915d15d8000057/european-agricultural-fund-for-rural-development.gif"
+
+puts "Adding logos to EAFRD editions"
+slugs.each do |slug|
+  document = Document.find_by(slug: slug)
+  latest_published_edition = document.editions.latest_published_edition.first
+  draft_edition = document.editions.latest_edition.draft.first
+
+  puts "Updating logo in #{slug} published version"
+  latest_published_edition.update_column(:logo_url, logo_url)
+
+  if draft_edition
+    puts "Updating logo in #{slug} draft version"
+    draft_edition.update_column(:logo_url, logo_url)
+  end
+end

--- a/db/migrate/20150512132243_add_logo_url_to_editions.rb
+++ b/db/migrate/20150512132243_add_logo_url_to_editions.rb
@@ -1,0 +1,5 @@
+class AddLogoUrlToEditions < ActiveRecord::Migration
+  def change
+    add_column :editions, :logo_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -465,6 +465,7 @@ ActiveRecord::Schema.define(version: 20150514093737) do
     t.string   "need_ids",                                    limit: 255
     t.string   "primary_locale",                              limit: 255,   default: "en",    null: false
     t.boolean  "political",                                   limit: 1,     default: false
+    t.string   "logo_url"
   end
 
   add_index "editions", ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree

--- a/test/unit/edition/creating_draft_test.rb
+++ b/test/unit/edition/creating_draft_test.rb
@@ -154,4 +154,12 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
       assert_equal 'spanish-body', draft_priority.body
     end
   end
+
+  test "should copy logo url when creating draft " do
+    published_edition = create(:published_edition, logo_url: 'logos/flag.jpeg')
+    draft_edition = published_edition.create_draft(create(:policy_writer))
+
+    assert_equal 'logos/flag.jpeg', draft_edition.logo_url
+  end
+
 end


### PR DESCRIPTION
[PT Ticket](https://www.pivotaltracker.com/story/show/93888708)

Some Editions must comply with EU legislations and they therefore need to display the relative EU logo.

Quote from the legislation:
*"[...]the Union emblem and the reference to the Union shall be visible, when landing on the website, inside the viewing area of a digital device, without requiring a user to scroll down the page[...]"*

## Guidance desktop version:
![screen shot 2015-05-14 at 12 00 28](https://cloud.githubusercontent.com/assets/5038475/7630786/ca9328bc-fa31-11e4-89e3-80ac725e233c.png)
## Guidance mobile version:
![screen shot 2015-05-14 at 12 00 53](https://cloud.githubusercontent.com/assets/5038475/7630787/caa77a60-fa31-11e4-8326-f46768583e6d.png)
## Collection desktop version:
![screen shot 2015-05-14 at 12 06 14](https://cloud.githubusercontent.com/assets/5038475/7630789/caadca64-fa31-11e4-874f-0583656f85e9.png)
## Collection mobile version:
![screen shot 2015-05-14 at 12 06 36](https://cloud.githubusercontent.com/assets/5038475/7630788/caad870c-fa31-11e4-953d-7cce8ee9ade5.png)