### PR TITLE
Index all people in search, including ministers

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,8 +40,7 @@ class Person < ActiveRecord::Base
   searchable title: :name,
              link: :search_link,
              content: :biography_without_markup,
-             slug: :slug,
-             only: :without_a_current_ministerial_role #Already covered by MinisterialRole
+             slug: :slug
 
   extend FriendlyId
   friendly_id :slug_name
@@ -60,12 +59,6 @@ class Person < ActiveRecord::Base
 
   def biography_without_markup
     Govspeak::Document.new(biography).to_text
-  end
-
-  def self.without_a_current_ministerial_role
-    includes(:current_roles)
-      .where("(#{RoleAppointment.arel_table[:id].eq(nil).to_sql}) OR (#{Role.arel_table[:type].not_eq("MinisterialRole").to_sql})")
-      .references(:role_appointments)
   end
 
   def ministerial_roles_at(date)

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -222,33 +222,6 @@ class PersonTest < ActiveSupport::TestCase
     assert person.translated_locales.include?(:es)
   end
 
-  test '#without_current_ministerial_roles finds people with no roles' do
-    person = create(:person)
-
-    assert_includes Person.without_a_current_ministerial_role, person
-  end
-
-  test '#without_a_current_ministerial_role finds people with a ministerial role that has ended' do
-    person = create(:person)
-    create(:ministerial_role_appointment, person: person, started_at: 2.years.ago, ended_at: 1.day.ago)
-
-    assert_includes Person.without_a_current_ministerial_role, person
-  end
-
-  test '#without_current_ministerial_roles finds people with current role that is not ministerial' do
-    person = create(:person)
-    create(:board_member_role_appointment, person: person)
-
-    assert_includes Person.without_a_current_ministerial_role, person
-  end
-
-  test '#without_current_ministerial_roles does not include people with a current ministerial role' do
-    person = create(:person)
-    mini_role = create(:ministerial_role_appointment, person: person)
-
-    refute_includes Person.without_a_current_ministerial_role, person
-  end
-
   test '#can_have_historical_accounts? returns true when person has roles that support them' do
     person = create(:person)
     refute person.can_have_historical_accounts?


### PR DESCRIPTION
Previously: Ministerial roles are indexed in search, as well as
people, so to avoid someone with a ministerial role appearing
twice in search we didn't index people with ministerial roles.

We're not happy to include the duplicates, as they are slightly
different, and the 'people' result may be more useful for users
than the role.

The finding things team are happy with this change, and once
all people are being index they're going to look at weighting
to promote people results above roles.

We want all people to be in search so that other results, which
reference a perosn through a 'people' field (eg, an edition linked
to a minister), can have the 'people' field automatically expanded
to include more fields than just the slug, as we currently do for
some fields, like organisations