### PR TITLE
Remove old edition / role association code and data.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -193,7 +193,6 @@ class Admin::EditionsController < Admin::BaseController
       :corporate_information_page_type_id,
       :political,
       secondary_specialist_sector_tags: [],
-      ministerial_role_ids: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],
       organisation_ids: [],

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -353,10 +353,6 @@ class Edition < ActiveRecord::Base
     false
   end
 
-  def can_be_associated_with_ministers?
-    false
-  end
-
   def can_be_associated_with_role_appointments?
     false
   end

--- a/app/models/edition_ministerial_role.rb
+++ b/app/models/edition_ministerial_role.rb
@@ -1,4 +1,0 @@
-class EditionMinisterialRole < ActiveRecord::Base
-  belongs_to :edition
-  belongs_to :ministerial_role
-end

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -55,19 +55,6 @@
       </div>
     <% end %>
 
-    <% if @edition.can_be_associated_with_ministers? && (ministerial_roles = @edition.organisations.flat_map(&:ministerial_roles)).any? %>
-      <div class="row-fluid">
-        <h3>Ministers</h3>
-        <% ministerial_roles.each do |role| %>
-          <label class="checkbox">
-            <%= check_box_tag 'edition[ministerial_role_ids][]', role.id, @edition.ministerial_roles.include?(role) %>
-            <%= RolePresenter.new(role, self).current_person.name %>
-            <span class="muted"><%= RolePresenter.new(role, self).name %></span>
-          </label>
-        <% end %>
-      </div>
-    <% end %>
-
     <% if @edition.can_be_related_to_policies? %>
       <div class="row-fluid">
         <h3>Related policies</h3>

--- a/db/migrate/20150514093737_delete_edition_ministerial_role.rb
+++ b/db/migrate/20150514093737_delete_edition_ministerial_role.rb
@@ -1,0 +1,5 @@
+class DeleteEditionMinisterialRole < ActiveRecord::Migration
+  def change
+    drop_table :edition_ministerial_roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150430084915) do
+ActiveRecord::Schema.define(version: 20150514093737) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -325,16 +325,6 @@ ActiveRecord::Schema.define(version: 20150430084915) do
 
   add_index "edition_mainstream_categories", ["edition_id"], name: "index_edition_mainstream_categories_on_edition_id", using: :btree
   add_index "edition_mainstream_categories", ["mainstream_category_id"], name: "index_edition_mainstream_categories_on_mainstream_category_id", using: :btree
-
-  create_table "edition_ministerial_roles", force: :cascade do |t|
-    t.integer  "edition_id",          limit: 4
-    t.integer  "ministerial_role_id", limit: 4
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "edition_ministerial_roles", ["edition_id"], name: "index_edition_ministerial_roles_on_edition_id", using: :btree
-  add_index "edition_ministerial_roles", ["ministerial_role_id"], name: "index_edition_ministerial_roles_on_ministerial_role_id", using: :btree
 
   create_table "edition_organisations", force: :cascade do |t|
     t.integer  "edition_id",      limit: 4


### PR DESCRIPTION
Editions are no longer associated directly to roles
but to role appointments, as of https://github.com/alphagov/whitehall/pull/2055

This change removes the remaining code references
and the database table.

https://trello.com/c/Y5XdfZtw/155-clean-up-edition-and-role-association-code