### PR TITLE
Update policy urls to use 'org rather than 'dept'

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+
+  def policies_finder_path(query_params)
+    "/government/policies?#{query_params.to_query}"
+  end
+
   def page_title(*title_parts)
     if title_parts.any?
       title_parts.push("Admin") if params[:controller] =~ /^admin\//

--- a/app/helpers/filter_routes_helper.rb
+++ b/app/helpers/filter_routes_helper.rb
@@ -15,10 +15,6 @@ module FilterRoutesHelper
     statistical_data_sets_path(path_arguments(objects))
   end
 
-  def policies_filter_path(*objects)
-    policies_path(path_arguments(objects))
-  end
-
   def filter_atom_feed_url
     Whitehall::FeedUrlBuilder.new({document_type: params[:controller].to_s}.merge(params)).url
   end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -81,7 +81,7 @@
           <div class="content">
             <%= render partial: "policies/list_description", locals: {policies: @policies} %>
             <p class="see-all">
-              <%= link_to t_see_all_our(:policy), policies_filter_path(@organisation) %>
+              <%= link_to t_see_all_our(:policy), policies_finder_path(organisations: [@organisation]) %>
             </p>
           </div>
         </section>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "gds_api/test_helpers/rummager"
 
 class OrganisationsControllerTest < ActionController::TestCase
+  include ApplicationHelper
   include FeedHelper
   include FilterRoutesHelper
   include OrganisationControllerTestHelpers
@@ -354,7 +355,7 @@ class OrganisationsControllerTest < ActionController::TestCase
                     text: "Employment"
       assert_select ".summary", text: "How the government is getting Britain working and helping people break the cycle of benefit dependency."
 
-      assert_select "a[href='#{policies_filter_path(organisation)}']"
+      assert_select "a[href='#{policies_finder_path(organisations: [organisation])}']"
     end
   end
 
@@ -387,7 +388,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
       assert_select ".summary", text: "The governments policy on welfare reform"
 
-      assert_select "a[href='#{policies_filter_path(organisation)}']"
+      assert_select "a[href='#{policies_finder_path(organisations: [organisation])}']"
     end
   end
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -26,6 +26,17 @@ class ApplicationHelperTest < ActionView::TestCase
     controller.request
   end
 
+  test "#policies_finder_path escapes provided query params" do
+    assert_equal "/government/policies?organisations%5B%5D=slug",
+      policies_finder_path(organisations: ['slug'])
+
+    assert_equal "/government/policies?organisations%5B%5D=slug1&organisations%5B%5D=slug2",
+      policies_finder_path(organisations: ['slug1', 'slug2'])
+
+    assert_equal "/government/policies?keywords=word&organisations%5B%5D=slug1",
+      policies_finder_path(keywords: 'word', organisations: ['slug1'])
+  end
+
   test '#link_to_attachment returns nil when attachment is nil' do
     assert_nil link_to_attachment(nil)
   end

--- a/test/unit/helpers/filter_routes_helper_test.rb
+++ b/test/unit/helpers/filter_routes_helper_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class FilterRoutesHelperTest < ActionView::TestCase
-  [:announcements, :publications, :policies].each do |filter|
+  [:announcements, :publications].each do |filter|
     test "uses the organisation to generate the route to #{filter} filter" do
       organisation = create(:organisation)
       assert_equal send("#{filter}_path", departments: [organisation.slug]), send("#{filter}_filter_path", organisation)


### PR DESCRIPTION
With the new style policies the query string to filter by organisation
is now 'organisation' rather than 'departments' which the filter pages
use.

Update links to policies pages to use a new hard-coded path for policy
pages which uses the correct query string. This stops using the path
helper as these pages are no longer being served by whitehall and being
served by finder-frontend instead and the routes will eventually be
removed in cleanup.