### PR TITLE
Fix sequential slugging bug

### DIFF
--- a/lib/friendly_id/sequential_slug_generator.rb
+++ b/lib/friendly_id/sequential_slug_generator.rb
@@ -16,18 +16,12 @@ module FriendlyId
   private
 
     def next_sequence_number
-      if last_sequence_number == 0
-        2
-      else
-        last_sequence_number + 1
-      end
+      last_sequence_number ? last_sequence_number + 1 : 2
     end
 
     def last_sequence_number
-      if slug_conflicts.size > 1
-        slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
-      else
-        0
+      if match = /#{slug}#{sequence_separator}(\d+)/.match(slug_conflicts.last)
+        match[1].to_i
       end
     end
 

--- a/lib/friendly_id/sequential_slug_generator.rb
+++ b/lib/friendly_id/sequential_slug_generator.rb
@@ -24,7 +24,11 @@ module FriendlyId
     end
 
     def last_sequence_number
-      slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
+      if slug_conflicts.size > 1
+        slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
+      else
+        0
+      end
     end
 
     def slug_conflicts

--- a/test/unit/whitehall/slugging_test.rb
+++ b/test/unit/whitehall/slugging_test.rb
@@ -10,7 +10,13 @@ class SluggingTest < ActiveSupport::TestCase
   test "should resolve a conflict" do
     document = create(:document, sluggable_string: "Slug conflict")
     document2 = create(:document, sluggable_string: "Slug conflict")
-    assert_match /--2/, document2.slug
+    assert_equal 'slug-conflict--2', document2.slug
+  end
+
+  test 'should handle document titles with numbers' do
+    document = create(:document, sluggable_string: "2010-2015 conflict")
+    document2 = create(:document, sluggable_string: "2010-2015 conflict")
+    assert_equal '2010-2015-conflict--2', document2.slug
   end
 
   test "should strip punctuation properly" do


### PR DESCRIPTION
Fixes a bug where a slug conflicting with a slug that starts with a number would get incorrectly sequenced based on the number at the start of the slug, rather than as a fresh sequence. e.g. a conflict with `"2010-2015-slug"` would result in the next sequential slug being `"2010-2015-slug--2011"` instead of the expected `"2010-2015-slug--2"`