### PR TITLE
Exclude Courts and Tribunals when finding child organisations

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -116,7 +116,7 @@ module OrganisationHelper
 
   def organisation_display_name_including_parental_and_child_relationships(organisation)
     organisation_name = organisation_display_name_and_parental_relationship(organisation)
-    child_organisations = organisation.active_child_organisations_excluding_sub_organisations
+    child_organisations = organisation.supporting_bodies
 
     if child_organisations.any?
       organisation_name.chomp!('.')

--- a/app/views/organisations/_works_with.html.erb
+++ b/app/views/organisations/_works_with.html.erb
@@ -1,10 +1,10 @@
 <%
   link_to_homepage ||= false
 %>
-<% if organisation.active_child_organisations_excluding_sub_organisations.any? %>
+<% if organisation.supporting_bodies.any? %>
   <p class="works-with">
-    Works with <%= organisation.active_child_organisations_excluding_sub_organisations.count %>
-    <% if organisation.active_child_organisations_excluding_sub_organisations.count == 1 %>
+    Works with <%= organisation.supporting_bodies.count %>
+    <% if organisation.supporting_bodies.count == 1 %>
       public body
     <% else %>
       agencies and public bodies
@@ -14,7 +14,7 @@
     <% if link_to_homepage %>
       <p><%= link_to "#{organisation.name} homepage", organisation_path(organisation) %></p>
     <% end %>
-    <% organisation.active_child_organisations_excluding_sub_organisations_grouped_by_type.each do |type,departments| %>
+    <% organisation.supporting_bodies_grouped_by_type.each do |type, departments| %>
       <% unless type.executive_office? %>
         <h3><%= type.name %></h3>
       <% end %>

--- a/app/views/organisations/not_live.html.erb
+++ b/app/views/organisations/not_live.html.erb
@@ -23,7 +23,7 @@
       <div class="description">
         <%= govspeak_to_html @organisation.summary %>
         <% unless @organisation.closed? %>
-          <% if @organisation.parent_organisations.any? || @organisation.active_child_organisations_excluding_sub_organisations.any? %>
+          <% if @organisation.parent_organisations.any? || @organisation.supporting_bodies.any? %>
             <p class="parent_organisations">
               <%= organisation_display_name_including_parental_and_child_relationships(@organisation) %>
             </p>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -32,7 +32,7 @@
               <p class="description"><%= @organisation.summary %></p>
             <% end %>
             <% if !@organisation.court_or_hmcts_tribunal? &&
-              (@organisation.parent_organisations.any? || @organisation.active_child_organisations_excluding_sub_organisations.any?) %>
+              (@organisation.parent_organisations.any? || @organisation.supporting_bodies.any?) %>
               <p class="parent_organisations">
                 <%= organisation_display_name_including_parental_and_child_relationships(@organisation) %>
               </p>

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -391,7 +391,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
 
   test 'organisations of type other with no relationships are described correctly' do
     organisation = create(:organisation, organisation_type_key: "other", acronym: "OON", name: "Other Organisation Name")
-    organisation.stubs(:active_child_organisations_excluding_sub_organisations).returns([])
+    organisation.stubs(:supporting_bodies).returns([])
 
     description = organisation_display_name_including_parental_and_child_relationships(organisation)
     assert description.include? 'Other Organisation Name'

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -125,18 +125,19 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     end
   end
 
-  test "active_child_organisations_excluding_sub_organisations should live up to it's name and in alphabetical order" do
+  test "supporting_bodies should exclude closed orgs, sub orgs, and courts and tribunals and be in alphabetical order" do
     parent_org_1 = create(:organisation)
     parent_org_2 = create(:organisation)
     child_org_1 = create(:organisation, parent_organisations: [parent_org_1], name: "b second")
     child_org_2 = create(:sub_organisation, parent_organisations: [parent_org_1])
     child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
     child_org_4 = create(:closed_organisation, parent_organisations: [parent_org_1])
+    child_org_5 = create(:court, parent_organisations: [parent_org_1])
 
-    assert_equal [child_org_3, child_org_1], parent_org_1.active_child_organisations_excluding_sub_organisations
+    assert_equal [child_org_3, child_org_1], parent_org_1.supporting_bodies
   end
 
-  test "active_child_organisations_excluding_sub_organisations_grouped_by_type should return a 2D array with each 1st level member being a OrganisationType and a collection of organisations" do
+  test "supporting_bodies_grouped_by_type should return a 2D array with each 1st level member being a OrganisationType and a collection of organisations" do
     parent_org = create(:organisation)
     child_org_1 = create(:organisation, parent_organisations: [parent_org], organisation_type_key: :executive_agency)
     child_org_2 = create(:sub_organisation, parent_organisations: [parent_org], organisation_type_key: :advisory_ndpb)
@@ -144,7 +145,7 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     assert_equal [
       [OrganisationType.executive_agency, [child_org_1]],
       [OrganisationType.advisory_ndpb,    [child_org_2]]
-    ], parent_org.active_child_organisations_excluding_sub_organisations_grouped_by_type
+    ], parent_org.supporting_bodies_grouped_by_type
   end
 
   test 'can list its sub-organisations' do


### PR DESCRIPTION
Fixes this:
![screen shot 2015-05-15 at 09 41 19](https://cloud.githubusercontent.com/assets/18276/7649616/95387ab8-fae6-11e4-9cef-73577de992c3.png)
so it reverts to previous behaviour, this:
![screen shot 2015-05-15 at 09 42 01](https://cloud.githubusercontent.com/assets/18276/7649627/ac22eca4-fae6-11e4-9231-2ee0a6215945.png)
Still works fine for orgs with non Court/Tribunal child orgs:
![screen shot 2015-05-15 at 09 42 47](https://cloud.githubusercontent.com/assets/18276/7649639/c6aa23a8-fae6-11e4-9061-c9221389345e.png)
