### PR TITLE
Roles created at end of organisation roles list

### DIFF
--- a/app/models/organisation_role.rb
+++ b/app/models/organisation_role.rb
@@ -3,4 +3,17 @@ class OrganisationRole < ActiveRecord::Base
   belongs_to :role, inverse_of: :organisation_roles
 
   validates :organisation, :role, presence: true
+
+  before_create :set_ordering, if: -> { ordering.blank? }
+
+private
+
+  def set_ordering
+    self.ordering = next_ordering
+  end
+
+  def next_ordering
+    max = organisation.organisation_roles.maximum(:ordering)
+    max ? max + 1 : 0
+  end
 end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -36,6 +36,21 @@ class RoleTest < ActiveSupport::TestCase
     assert_equal "Treasury secretary", role.to_s
   end
 
+  test "the ordering on organisation roles defaults to the end of the list" do
+    organisation_1 = create(:organisation)
+    organisation_2 = create(:organisation)
+    role_1 = create(:role, organisations: [organisation_1, organisation_2])
+    role_2 = create(:role, organisations: [organisation_2])
+    role_3 = create(:role, organisations: [organisation_1])
+    role_4 = create(:role, organisations: [organisation_1])
+
+    assert_equal [role_1, role_3, role_4], organisation_1.roles
+    assert_equal [role_1, role_2], organisation_2.roles
+
+    assert_equal [0, 1, 2], organisation_1.organisation_roles.pluck(:ordering)
+    assert_equal [0, 1], organisation_2.organisation_roles.pluck(:ordering)
+  end
+
   test "should be able to get the current person" do
     bob = create(:person, forename: "Bob")
     role = create(:role)


### PR DESCRIPTION
Newly created roles should be given an appropriate ordering to ensure they
appear at the end of the list of an organisation's roles.

Trello: https://trello.com/c/9DFOlsXI/268-newly-created-roles-are-at-the-top-of-the-list