### PR TITLE
Update Rack to 1.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '10.1.0'
 gem 'rails', '4.2.1'
+gem 'rack', '~> 1.6.1'  # Bug in Rack 1.6.0 prevents large forms being uploaded in Multipart mode
 gem 'statsd-ruby', '~> 1.2.1', require: 'statsd'
 gem 'mysql2'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       pry (~> 0.10)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cache (1.2)
@@ -472,6 +472,7 @@ DEPENDENCIES
   poltergeist (~> 1.5.1)
   pry-byebug
   quiet_assets
+  rack (~> 1.6.1)
   rack-test (~> 0.6.3)
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.1)


### PR DESCRIPTION
This fixes a bug where all form fields in a request are counted against the multipart file limit:
https://github.com/rack/rack/pull/814

This is an issue in production - some publications and organisations have a large number of dynamically added nested forms. When the form is submitted, a 500 is returned because the number of fields exceeds the limit. It only affects forms posted with multipart, e.g. ones that contain file fields.

Zendesk: https://govuk.zendesk.com/agent/tickets/1037587
Story: https://www.pivotaltracker.com/story/show/94668330