### PR TITLE
Use SassC to compile Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ else
 end
 
 gem 'sass', '3.4.9'
-gem 'sass-rails'
+gem 'sass-rails' # required by bootstrap-sass, but not listed as a dependency of it
 gem 'sassc-rails', github: 'bolandrm/sassc-rails', branch: 'master'
 gem 'uglifier'
 

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ end
 
 gem 'sass', '3.4.9'
 gem 'sass-rails'
+gem 'sassc-rails', github: 'bolandrm/sassc-rails', branch: 'master'
 gem 'uglifier'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.4.9)
-    sass-rails (5.0.1)
+    sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,18 @@ GIT
     test_track (0.1.0)
       rails (>= 3.1.0)
 
+GIT
+  remote: git://github.com/bolandrm/sassc-rails.git
+  revision: cac614328c2830646dc9d1ee218caf6204b8e0c8
+  branch: master
+  specs:
+    sassc-rails (0.0.9)
+      rails (>= 4.0.0)
+      sass
+      sassc (~> 1.2.0)
+      sprockets (> 2.11)
+      tilt
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -344,6 +356,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sassc (1.2.0)
+      bundler
+      ffi (~> 1.9.6)
     shared_mustache (0.2.0)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
@@ -488,6 +503,7 @@ DEPENDENCIES
   rummageable (= 1.2.0)
   sass (= 3.4.9)
   sass-rails
+  sassc-rails!
   shared_mustache (~> 0.2.0)
   sidekiq (~> 3.3.0)
   sidekiq-logging-json (= 0.0.14)

--- a/app/assets/stylesheets/admin/govuk_admin_template/_mixins.scss
+++ b/app/assets/stylesheets/admin/govuk_admin_template/_mixins.scss
@@ -4,35 +4,35 @@
 }
 
 @mixin add-top-margin($important: "") {
-  margin-top: $default-vertical-margin #{$important};
+  margin-top: $default-vertical-margin unquote($important);
 }
 
 @mixin remove-top-margin($important: "") {
-  margin-top: 0 #{$important};
+  margin-top: 0 unquote($important);
 }
 
 @mixin add-bottom-margin($important: "") {
-  margin-bottom: $default-vertical-margin #{$important};
+  margin-bottom: $default-vertical-margin unquote($important);
 }
 
 @mixin remove-bottom-margin($important: "") {
-  margin-bottom: 0 #{$important};
+  margin-bottom: 0 unquote($important);
 }
 
 @mixin add-right-margin($important: "") {
-  margin-right: $default-horizontal-margin #{$important};
+  margin-right: $default-horizontal-margin unquote($important);
 }
 
 @mixin add-left-margin($important: "") {
-  margin-left: $default-horizontal-margin #{$important};
+  margin-left: $default-horizontal-margin unquote($important);
 }
 
 @mixin add-right-gutter($important: "") {
-  margin-right: $default-horizontal-margin * 2 #{$important};
+  margin-right: $default-horizontal-margin * 2 unquote($important);
 }
 
 @mixin add-left-gutter($important: "") {
-  margin-left: $default-horizontal-margin * 2 #{$important};
+  margin-left: $default-horizontal-margin * 2 unquote($important);
 }
 
 @mixin add-label-margin {
@@ -45,9 +45,9 @@
 }
 
 @mixin add-top-padding($important: "") {
-  padding-top: $default-vertical-padding #{$important};
+  padding-top: $default-vertical-padding unquote($important);
 }
 
 @mixin add-bottom-padding($important: "") {
-  padding-bottom: $default-vertical-padding #{$important};
+  padding-bottom: $default-vertical-padding unquote($important);
 }

--- a/config/initializers/sassc_rails.rb
+++ b/config/initializers/sassc_rails.rb
@@ -1,3 +1,4 @@
+# As recommended in https://github.com/bolandrm/sassc-rails/issues/6#issuecomment-100949872
 require "sprockets/engines"
 
 module Extensions

--- a/config/initializers/sassc_rails.rb
+++ b/config/initializers/sassc_rails.rb
@@ -1,0 +1,21 @@
+require "sprockets/engines"
+
+module Extensions
+  module Sprockets
+    module Engines
+      def register_engine(ext, klass)
+        return if [
+          Sass::Rails::SassTemplate,
+          Sass::Rails::ScssTemplate
+        ].include?(klass)
+
+        super
+      end
+    end
+  end
+end
+
+Sprockets::Base.send(:prepend, Extensions::Sprockets::Engines)
+
+Rails.application.assets.register_engine '.sass', SassC::Rails::SassTemplate
+Rails.application.assets.register_engine '.scss', SassC::Rails::ScssTemplate


### PR DESCRIPTION
~~Relies on a fork at the moment, hoping to have the change merged upstream:~~ `sassc-rails` Gem not been released yet, relies on a bugfix in master only: https://github.com/bolandrm/sassc-rails/pull/17

I've compared the output of both engines in `:expanded` mode. It's not the easiest diff in the world to review, but it does seem to be mostly whitespace, wrapping of long selectors and leading zeroes, e.g. `.5em` versus `0.5em`:  https://gist.github.com/boffbowsh/28da0cdd02022b26eada. `<` is ruby Sass, `>` is SassC.

Speedup on my laptop is 47s versus 3m11s.