### PR TITLE
De-index all publicly visible supporting pages

### DIFF
--- a/db/data_migration/20150518092033_de_index_supoprting_pages.rb
+++ b/db/data_migration/20150518092033_de_index_supoprting_pages.rb
@@ -1,0 +1,5 @@
+puts 'Removing publicly visible supporting pages from search'
+SupportingPage.publicly_visible.with_translations(I18n.locale).find_each do |supporting_page|
+  puts "'#{supporting_page.title}' (#{supporting_page.id})"
+  supporting_page.remove_from_search_index
+end


### PR DESCRIPTION
This content has been replaced by new policies and should no longer appear in
search.

Trello: https://trello.com/c/jhNb9FPl/262-supporting-pages-should-be-removed-from-site-search