### PR TITLE
Send groups to content store

### DIFF
--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -1,6 +1,7 @@
 class PolicyGroup < ActiveRecord::Base
   include Searchable
   include ::Attachable
+  include PublishesToPublishingApi
 
   validates :email, email_format: true, allow_blank: true
   validates :name, presence: true

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -16,6 +16,8 @@ private
       presenter_class_for_edition(model)
     when ::Unpublishing
       PublishingApiPresenters::Unpublishing
+    when PolicyGroup
+      PublishingApiPresenters::WorkingGroup
     else
       PublishingApiPresenters::Placeholder
     end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -11,9 +11,10 @@ module PublishingApiPresenters
 
 private
   def self.presenter_class_for(model)
-    if model.is_a?(::Edition)
+    case model
+    when ::Edition
       presenter_class_for_edition(model)
-    elsif model.is_a?(::Unpublishing)
+    when ::Unpublishing
       PublishingApiPresenters::Unpublishing
     else
       PublishingApiPresenters::Placeholder
@@ -21,7 +22,8 @@ private
   end
 
   def self.presenter_class_for_edition(edition)
-    if edition.is_a?(::CaseStudy)
+    case edition
+    when ::CaseStudy
       PublishingApiPresenters::CaseStudy
     else
       PublishingApiPresenters::Edition

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -1,0 +1,7 @@
+class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Placeholder
+  private
+
+  def format
+    "placeholder_working_group"
+  end
+end

--- a/db/data_migration/20150518124939_send_policy_groups_to_content_store_as_working_groups.rb
+++ b/db/data_migration/20150518124939_send_policy_groups_to_content_store_as_working_groups.rb
@@ -1,0 +1,3 @@
+PolicyGroup.all.each do |policy_group|
+  policy_group.publish_to_publishing_api
+end

--- a/db/migrate/20150518121912_add_content_id_to_working_groups.rb
+++ b/db/migrate/20150518121912_add_content_id_to_working_groups.rb
@@ -1,0 +1,13 @@
+class AddContentIdToWorkingGroups < ActiveRecord::Migration
+  def up
+    add_column :policy_groups, :content_id, :string, null: false
+
+    PolicyGroup.all.each do |group|
+      group.update_column(:content_id, SecureRandom.uuid)
+    end
+  end
+
+  def down
+    remove_column :policy_groups, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150514093737) do
+ActiveRecord::Schema.define(version: 20150518121912) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -947,6 +947,7 @@ ActiveRecord::Schema.define(version: 20150514093737) do
     t.text     "description", limit: 65535
     t.text     "summary",     limit: 65535
     t.string   "slug",        limit: 255
+    t.string   "content_id",  limit: 255,   null: false
   end
 
   add_index "policy_groups", ["slug"], name: "index_policy_groups_on_slug", using: :btree

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -28,4 +28,10 @@ class PolicyGroupTest < ActiveSupport::TestCase
   end
 
   should_not_accept_footnotes_in(:description)
+
+  test "publishes to the publishing API" do
+    policy_group = create(:policy_group)
+    Whitehall::PublishingApi.expects(:publish_async).with(policy_group).once
+    policy_group.publish_to_publishing_api
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
+  test 'presents a valid placeholder "working_group" content item' do
+    group = create(:policy_group,
+      name: "Government Digital Service"
+    )
+
+    expected_hash = {
+      content_id: group.content_id,
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      format: "placeholder_working_group",
+      title: "Government Digital Service",
+      locale: "en",
+      update_type: "major",
+      routes: [
+        {
+          path: '/government/groups/government-digital-service',
+          type: 'exact'
+        }
+      ],
+      public_updated_at: group.updated_at,
+    }
+
+    presenter = PublishingApiPresenters::WorkingGroup.new(group)
+
+    assert_equal expected_hash, presenter.as_json
+    assert_valid_against_schema(presenter.as_json, 'placeholder')
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -39,4 +39,11 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     assert_equal PublishingApiPresenters::Placeholder, presenter.class
     assert_equal world_location, presenter.item
   end
+
+  test ".presenter_for returns a WorkingGroup presenter for a policy group" do
+    policy_group = PolicyGroup.new
+    presenter = PublishingApiPresenters.presenter_for(policy_group)
+
+    assert_equal PublishingApiPresenters::WorkingGroup, presenter.class
+  end
 end


### PR DESCRIPTION
"Working group" is the new cross-gov.uk name for a
Whitehall PolicyGroup aka PolicyAdvisoryGroup.

The Whitehall Group model is separate (though
similar) and will eventually be merged, though both
are still in relatively active use.

These working groups need to be in the content
store so that policies (now published from the
Policy Publisher) can continue to be tagged to them.

This code adds content IDs to the policy groups
via a normal migration, and sends them to the
content store via a data migration as custom placeholders.

https://trello.com/c/pV7ExOoE/203-5-associate-policy-to-a-group