### PR TITLE
Remove descriptions from lists of policies

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_document_list.scss
+++ b/app/assets/stylesheets/frontend/helpers/_document_list.scss
@@ -3,12 +3,13 @@
 
   .document-row {
     display: block;
-    overflow: hidden;
     list-style: none;
     border-bottom: 1px solid $border-colour;
     padding: $gutter-one-sixth 0 $gutter-one-third;
 
-    h2, h3 {
+    h2, h3,
+    .title {
+      display: block;
       @include core-19;
       font-weight: bold;
       margin-top: $gutter-one-sixth;

--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -99,7 +99,7 @@
         <section class="policy" id="policies">
           <h1><%= t('policies.heading') %></h1>
 
-          <%= render 'policies/list_description', policies: @ministerial_role.published_policies %>
+          <%= render 'policies/document_list', policies: @ministerial_role.published_policies %>
         </section>
       <% end %>
 

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -79,7 +79,7 @@
             <h1 class="label"><%= t('organisation.headings.our_policies') %></h1>
           </div>
           <div class="content">
-            <%= render partial: "policies/list_description", locals: {policies: @policies} %>
+            <%= render partial: "policies/document_list", locals: {policies: @policies} %>
             <p class="see-all">
               <%= link_to t_see_all_our(:policy), policies_finder_path(organisations: [@organisation]) %>
             </p>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -97,7 +97,7 @@
         <section id="policy">
           <h1><%= t('policies.heading') %></h1>
 
-          <%= render 'policies/list_description', policies: @person.published_policies %>
+          <%= render 'policies/document_list', policies: @person.published_policies %>
         </section>
       <% end %>
 

--- a/app/views/policies/_document_list.html.erb
+++ b/app/views/policies/_document_list.html.erb
@@ -1,8 +1,7 @@
 <ol class="policies document-list">
   <% policies.each do |policy| %>
     <%= content_tag(:li, class: "document-row") do %>
-      <h2><%= link_to policy.title, policy.link %></h2>
-      <p class="summary"><%= policy.description %></p>
+      <%= link_to policy.title, policy.link, class: 'title' %>
     <% end %>
   <% end %>
 </ol>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -353,7 +353,6 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "#policies" do
       assert_select "a[href='/government/policies/helping-people-to-find-and-stay-in-work']",
                     text: "Employment"
-      assert_select ".summary", text: "How the government is getting Britain working and helping people break the cycle of benefit dependency."
 
       assert_select "a[href='#{policies_finder_path(organisations: [organisation])}']"
     end
@@ -386,7 +385,6 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     assert_select "#policies" do
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
-      assert_select ".summary", text: "The governments policy on welfare reform"
 
       assert_select "a[href='#{policies_finder_path(organisations: [organisation])}']"
     end

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -97,7 +97,6 @@ class PeopleControllerTest < ActionController::TestCase
 
     assert_select "#policy" do
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
-      assert_select ".summary", text: "The governments policy on welfare reform"
     end
   end
 end


### PR DESCRIPTION
New style policies don't have short descriptions like the old ones used
to have. This means the pages don't look great with the descriptions
visible. Also we have now switched to showing more policies in these
lists so a shorter list is preferable.

Remove a `overflow:hidden` as it was previously used to contain floats.
The only element with the element which has any floated elements also
has our float clear fix so it was redundant and caused the top of some
of the text to be chopped off.

before:
![before](https://cloud.githubusercontent.com/assets/35035/7683413/e37c824a-fd76-11e4-8f1d-998fcfb1f97f.png)

after:
![after](https://cloud.githubusercontent.com/assets/35035/7683419/e8f56458-fd76-11e4-86ed-9a2c8dc12be1.png)

