### PR TITLE
Bump shared_mustache gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'gds-api-adapters', '18.7.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'
-gem 'shared_mustache', '~> 0.2.0'
+gem 'shared_mustache', '~> 0.2.1'
 gem 'rails-i18n'
 gem 'link_header'
 gem 'logstasher', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,7 @@ GEM
     sassc (1.2.0)
       bundler
       ffi (~> 1.9.6)
-    shared_mustache (0.2.0)
+    shared_mustache (0.2.1)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
     sidekiq (3.3.0)
@@ -505,7 +505,7 @@ DEPENDENCIES
   sass (= 3.4.9)
   sass-rails
   sassc-rails!
-  shared_mustache (~> 0.2.0)
+  shared_mustache (~> 0.2.1)
   sidekiq (~> 3.3.0)
   sidekiq-logging-json (= 0.0.14)
   simplecov


### PR DESCRIPTION
Bump gem to 0.2.1 to pickup fix and prevent pages with the heading "Exports" from breaking the mustache library.

Fixes https://www.pivotaltracker.com/story/show/87097366

See https://github.com/alphagov/shared_mustache/pull/8 for details