### PR TITLE
Make Courts/Tribunals messaging consistent with other organisations

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -258,8 +258,4 @@ module OrganisationHelper
     organisation.live? && (!organisation.court_or_hmcts_tribunal? ||
       organisation.corporate_information_pages.published.reject { |cip| cip.slug == "about" }.any?)
   end
-
-  def organisation_body_heading_key(organisation)
-    organisation.court_or_hmcts_tribunal? ? 'who_we_are' : 'what_we_do'
-  end
 end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -21,10 +21,9 @@
                 locals: { feature_list: @feature_list,
                           recently_updated: @recently_updated,
                           organisation: @organisation } %>
-      <section id="<%= @organisation.court_or_hmcts_tribunal? ? 'who-we-are' : 'what-we-do'
-        %>" class="what-we-do">
+      <section id="what-we-do" class="what-we-do">
         <div class="content">
-          <h1 class="label"><%= t("organisation.headings.#{organisation_body_heading_key(@organisation)}") %></h1>
+          <h1 class="label"><%= t("organisation.headings.what_we_do") %></h1>
           <div class="overview">
             <% if @organisation.court_or_hmcts_tribunal? && @organisation.about_us %>
               <%= govspeak_to_html @organisation.about_us.body %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -871,13 +871,13 @@ class OrganisationsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "courts show the 'About Us' body as govspeak under 'Who we are', with no link to the page" do
+  view_test "courts show the 'About Us' body as govspeak under 'What we do', with no link to the page" do
     court = create(:court)
     create(:about_corporate_information_page, organisation: court, body: "This is *who* we are")
     get :show, id: court, courts_only: true
 
-    assert_select "#who-we-are" do
-      assert_select "h1", text: "Who we are"
+    assert_select "#what-we-do" do
+      assert_select "h1", text: "What we do"
       assert_select ".overview", text: /This is who we are/
       refute_select ".overview a", text: /Read more about what we do/
       refute_select ".parent_organisations"
@@ -889,8 +889,8 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:about_corporate_information_page, organisation: hmcts_tribunal, body: "This is *who* we are")
     get :show, id: hmcts_tribunal, courts_only: true
 
-    assert_select "#who-we-are" do
-      assert_select "h1", text: "Who we are"
+    assert_select "#what-we-do" do
+      assert_select "h1", text: "What we do"
       assert_select ".overview", text: /This is who we are/
       refute_select ".overview a", text: /Read more about what we do/
       refute_select ".parent_organisations"


### PR DESCRIPTION
Currently courts/tribunals have their "What we do" heading replaced with "Who we are". This reverts that, making it consistent with normal organisations.