### PR TITLE
Remove topics from metadata

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -202,7 +202,7 @@ Please tell us:
     link_to native_language_name_for(locale), locale: locale
   end
 
-  def part_of_metadata(document, policies = [], topics = [], sector_tag_finder = nil, primary_mainstream_category = nil)
+  def part_of_metadata(document, policies = [], sector_tag_finder = nil, primary_mainstream_category = nil)
     part_of = []
 
     if document.respond_to?(:part_of_published_collection?) && document.part_of_published_collection?
@@ -229,10 +229,6 @@ Please tell us:
       part_of << link_to(primary_mainstream_category.title,
                          mainstream_category_path(primary_mainstream_category),
                          class: 'primary-mainstream-category-link')
-    end
-
-    if topics.any?
-      part_of += array_of_links_to_topics(topics)
     end
 
     if document.respond_to?(:world_locations) && document.world_locations.any?

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -13,7 +13,6 @@
                     document: @document,
                     footer_meta: true,
                     policies: @related_policies,
-                    topics: @document.topics,
                     primary_mainstream_category: @document.primary_mainstream_category
                   } %>
     </div>

--- a/app/views/documents/_document_footer_meta.html.erb
+++ b/app/views/documents/_document_footer_meta.html.erb
@@ -1,6 +1,5 @@
 <%
   policies ||= []
-  topics ||= []
   history = document.change_history
 %>
 <div class="document-footer-meta js-footer">
@@ -40,7 +39,7 @@
         <% end %>
       <% end %>
 
-      <% if (part_of = part_of_metadata(document, policies, topics)).any? %>
+      <% if (part_of = part_of_metadata(document, policies)).any? %>
         <dt><%= t('document.headings.part_of') %>:</dt>
         <% part_of.each do |link| %>
           <dd class="part-of"><%= link %></dd>

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -5,7 +5,6 @@
 <%
   header_title ||= ""
   policies ||= nil
-  topics ||= []
   primary_mainstream_category ||= nil
   specialist_tag_finder = SpecialistTagFinder.new(@document)
 %>
@@ -28,7 +27,6 @@
 <%= render 'documents/metadata', document: document,
                                  footer_meta: (defined?(footer_meta) ? footer_meta : false),
                                  policies: policies,
-                                 topics: topics,
                                  primary_mainstream_category: primary_mainstream_category,
                                  specialist_tag_finder: specialist_tag_finder %>
 

--- a/app/views/documents/_metadata.html.erb
+++ b/app/views/documents/_metadata.html.erb
@@ -1,6 +1,5 @@
 <%
   policies ||= []
-  topics ||= []
   primary_mainstream_category ||= nil
 %>
 <aside class="meta metadata-list">
@@ -17,7 +16,7 @@
       <%= render  partial: 'documents/change_notes',
                   locals: { document: document, footer_meta: footer_meta } %>
 
-      <% if (part_of = part_of_metadata(document, policies, topics, specialist_tag_finder, primary_mainstream_category)).any? %>
+      <% if (part_of = part_of_metadata(document, policies, specialist_tag_finder, primary_mainstream_category)).any? %>
         <dt><%= t('document.headings.part_of') %>:</dt>
         <dd class="js-hide-extra-metadata"><%= part_of.to_sentence.html_safe %></dd>
       <% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,6 +1,5 @@
 <%
   header_title ||= ""
-  topics ||= []
   show_share_links ||= false
 %>
 <% page_title @document.title, "Documents" if page_title.blank? %>
@@ -14,7 +13,6 @@
                     document: @document,
                     footer_meta: true,
                     policies: @related_policies,
-                    topics: topics
                   } %>
     </div>
   </header>
@@ -44,7 +42,7 @@
   <% end %>
   <div class="block-5">
     <div class="inner-block">
-      <%= render partial: 'documents/document_footer_meta', locals: { document: @document, policies: @related_policies, topics: topics } %>
+      <%= render partial: 'documents/document_footer_meta', locals: { document: @document, policies: @related_policies } %>
     </div>
   </div>
 <% end %>

--- a/app/views/news_articles/show.html.erb
+++ b/app/views/news_articles/show.html.erb
@@ -9,7 +9,6 @@
                     document: @document,
                     footer_meta: true,
                     policies: @related_policies,
-                    topics: @document.topics
                   } %>
     </div>
   </header>

--- a/app/views/speeches/show.html.erb
+++ b/app/views/speeches/show.html.erb
@@ -2,6 +2,5 @@
 <%= render  template: 'documents/show',
             locals: {
               header_title: t_display_type(@document),
-              topics: @document.topics,
               show_share_links: true
             } %>

--- a/features/policies.feature
+++ b/features/policies.feature
@@ -8,11 +8,6 @@ A member of the public Should be able to view policies
 Background:
   Given I am a writer
 
-Scenario: Viewing a policy that appears in multiple topics
-  Given a published policy "Policy" that appears in the "Education" and "Work and pensions" topics
-  When I visit the policy "Policy"
-  Then I should see links to the "Education" and "Work and pensions" topics
-
 Scenario: Viewing a policy that has multiple responsible ministers
   Given a published policy "Policy" that's the responsibility of:
     | Ministerial Role  | Person          |

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -160,13 +160,6 @@ Then /^I should see the topics "([^"]*)" and "([^"]*)"$/ do |first_topic_name, s
   assert page.has_css?(record_css_selector(second_topic), text: second_topic_name)
 end
 
-Then /^I should see links to the "([^"]*)" and "([^"]*)" topics$/ do |topic_1_name, topic_2_name|
-  topic_1 = Topic.find_by!(name: topic_1_name)
-  topic_2 = Topic.find_by!(name: topic_2_name)
-  assert page.has_css?("a[href='#{topic_path(topic_1)}']", text: topic_1_name)
-  assert page.has_css?("a[href='#{topic_path(topic_2)}']", text: topic_2_name)
-end
-
 Then /^I should see a link to the related topic "([^"]*)"$/ do |related_name|
   related_topic = Topic.find_by(name: related_name)
   assert page.has_css?(".related-topics a[href='#{topic_path(related_topic)}']", text: related_name)

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -100,25 +100,6 @@ class PoliciesControllerTest < ActionController::TestCase
     assert_equal published_edition, assigns(:document)
   end
 
-  view_test "should link to topics related to the policy" do
-    first_topic = create(:topic)
-    second_topic = create(:topic)
-    edition = create(:published_policy, topics: [first_topic, second_topic])
-
-    get :show, id: edition.document
-
-    assert_select "a", text: first_topic.name
-    assert_select "a", text: second_topic.name
-  end
-
-  view_test "should not show topics where none exist" do
-    edition = create(:published_policy, topics: [])
-
-    get :show, id: edition.document
-
-    assert_select ".topics", count: 0
-  end
-
   view_test "should link to organisations related to the policy" do
     first_org = create(:ministerial_department)
     second_org = create(:sub_organisation)
@@ -200,16 +181,6 @@ That's all
       assert_select "a[href='#{policy_supporting_pages_path(policy.document)}']"
       assert_select "a[href='#{activity_policy_path(policy.document)}']"
     end
-  end
-
-  view_test "activity displays the policy's topics" do
-    topic = create(:topic)
-    policy = create(:published_policy, topics: [topic])
-    publication = create(:published_publication, related_editions: [policy])
-
-    get :activity, id: policy.document
-
-    assert_select '.meta a', text: topic.name
   end
 
   view_test "activity adds the current class to the activity link in the policy navigation" do

--- a/test/functional/supporting_pages_controller_test.rb
+++ b/test/functional/supporting_pages_controller_test.rb
@@ -126,18 +126,6 @@ class SupportingPagesControllerTest < ActionController::TestCase
     assert_equal supporting_page, assigns(:document)
   end
 
-  view_test "should link to topics" do
-    first_topic = create(:topic)
-    second_topic = create(:topic)
-    policy = create(:published_policy, topics: [first_topic, second_topic])
-    supporting_page = create(:published_supporting_page, related_policies: [policy])
-
-    get :show, policy_id: policy.document, id: supporting_page.document
-
-    assert_select "a", text: first_topic.name
-    assert_select "a", text: second_topic.name
-  end
-
   view_test "should link to organisations from within the metadata navigation" do
     first_org = create(:organisation)
     second_org = create(:organisation)

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -190,22 +190,11 @@ class DocumentHelperTest < ActionView::TestCase
     mainstream_category = create(:mainstream_category)
     guide = create(:news_article)
 
-    metadata_links = part_of_metadata(guide, [], [], nil, mainstream_category).join(' ')
+    metadata_links = part_of_metadata(guide, [], nil, mainstream_category).join(' ')
     assert_select_within_html metadata_links,
                               "a[href=?]",
                               mainstream_category_path(mainstream_category),
                               text: mainstream_category.title
-  end
-
-  test "part_of_metadata generates topic metadata" do
-    topic = create(:topic)
-    edition = create(:news_article, topics: [topic])
-
-    metadata_links = part_of_metadata(edition, [], [topic]).join(' ')
-    assert_select_within_html metadata_links,
-                              "a[href=?]",
-                              topic_path(topic),
-                              text: topic.name
   end
 
   test "part_of_metadata generates world_locations metadata" do


### PR DESCRIPTION
Since the renaming of policies to make them more generic we have been
seeing people get confused between policies and topics. This removes
topics from the metadata on documents so that people won't get confused.
This also follows the pattern which is to eventually get rid of topics.