### PR TITLE
Only show Worldwide Orgs once in the dropdown

### DIFF
--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -144,7 +144,7 @@ module Admin::TaggableContentHelper
   # organisation and its ID.
   def taggable_worldwide_organisations_container
     Rails.cache.fetch(taggable_worldwide_organisations_cache_digest, expires_in: 1.day) do
-      WorldwideOrganisation.with_translations.map {|wo| [wo.name, wo.id] }
+      WorldwideOrganisation.with_translations(:en).map {|wo| [wo.name, wo.id] }
     end
   end
 

--- a/test/unit/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/helpers/admin/taggable_content_helper_test.rb
@@ -222,6 +222,16 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     ], taggable_worldwide_organisations_container
   end
 
+  test '#taggable_worldwide_organisations_container only returns worldwide organisations once even if they have more than one translation' do
+    world_org_1 = create(:worldwide_organisation, name: 'World Org 1', translated_into: [:fr, :es])
+    world_org_2 = create(:worldwide_organisation, name: 'World Org 2')
+
+    assert_equal [
+      ["World Org 1", world_org_1.id],
+      ["World Org 2", world_org_2.id],
+    ], taggable_worldwide_organisations_container
+  end
+
   test '#taggable_ministerial_role_appointments_cache_digest changes when a role appointment is updated' do
     role_appointment = Timecop.travel 1.year.ago do
       create(:ministerial_role_appointment, started_at: 1.day.ago)


### PR DESCRIPTION
Worldwide orgs that have more than one translation were showing up for
every translation they had. This ensures we only get the current locale
for each org rather than every translation they have available.

https://www.pivotaltracker.com/story/show/94961926