### PR TITLE
Display related policies on policy group pages.

### DIFF
--- a/app/controllers/policy_groups_controller.rb
+++ b/app/controllers/policy_groups_controller.rb
@@ -5,7 +5,7 @@ class PolicyGroupsController < PublicFacingController
 
   def show
     @policy_group = PolicyGroup.friendly.find(params[:id])
-    @policies = @policy_group.policies.published.in_reverse_chronological_order
+    @policies = @policy_group.published_policies
 
     set_meta_description(@policy_group.summary)
   end

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -9,8 +9,13 @@ class PolicyGroup < ActiveRecord::Base
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :description
 
-  has_many :edition_policy_groups
-  has_many :policies, through: :edition_policy_groups, source: :edition
+  def published_policies
+    Whitehall.unified_search_client.unified_search(
+      filter_policy_groups: [slug],
+      filter_format: "policy",
+      order: "-public_timestamp"
+    ).results
+  end
 
   def has_summary?
     true

--- a/app/views/policy_groups/show.html.erb
+++ b/app/views/policy_groups/show.html.erb
@@ -51,13 +51,7 @@
       <% end %>
       <% if @policies.any? %>
         <h2 class="label" id="policies">Policies</h2>
-        <ul class="policies">
-          <% @policies.each do |policy| %>
-            <%= content_tag_for :li, policy do %>
-              <% link_to policy.title, public_document_path(policy) %>
-            <% end %>
-          <% end %>
-        </ul>
+        <%= render 'policies/document_list', policies: @policies %>
       <% end %>
       <% if @policy_group.email.present? %>
         <h2 class="label" id="contact-details">Contact details</h2>

--- a/test/functional/policy_groups_controller_test.rb
+++ b/test/functional/policy_groups_controller_test.rb
@@ -1,11 +1,29 @@
 require 'test_helper'
+require "gds_api/test_helpers/rummager"
 
 class PolicyGroupsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::Rummager
+
+  setup do
+    rummager_has_no_policies_for_any_type
+  end
+
   test "show sets meta description" do
     policy_group = create(:policy_group, summary: 'my meta description')
 
     get :show, id: policy_group
 
     assert_equal 'my meta description', assigns(:meta_description)
+  end
+
+  view_test "should display the group's policies" do
+    policy_group = create(:policy_group)
+    rummager_has_new_policies_for_every_type
+
+    get :show, id: policy_group
+
+    assert_select ".policies" do
+      assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
+    end
   end
 end

--- a/test/support/policy_tagging_helpers.rb
+++ b/test/support/policy_tagging_helpers.rb
@@ -1,0 +1,24 @@
+require "gds_api/test_helpers/rummager"
+
+module PolicyTaggingHelpers
+  include GdsApi::TestHelpers::Rummager
+
+  def assert_published_policies_returns_all_tagged_policies(object)
+    rummager_has_new_policies_for_every_type
+
+    all_policy_titles = [
+      "Welfare reform",
+      "State Pension simplification",
+      "State Pension age",
+      "Poverty and social justice",
+      "Older people",
+      "Household energy",
+      "Health and safety reform",
+      "European funds",
+      "Employment",
+      "Child maintenance reform",
+    ]
+
+    assert_equal all_policy_titles, object.published_policies.map(&:title)
+  end
+end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
-require "gds_api/test_helpers/rummager"
 
 class PersonTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::Rummager
+  include PolicyTaggingHelpers
 
   should_protect_against_xss_and_content_attacks_on :biography
 
@@ -247,23 +246,8 @@ class PersonTest < ActiveSupport::TestCase
     end
   end
 
-  test "#published_policies should return the all policies" do
+  test "#published_policies should return all tagged policies" do
     person = create(:person)
-    rummager_has_new_policies_for_every_type
-
-    all_policy_titles = [
-      "Welfare reform",
-      "State Pension simplification",
-      "State Pension age",
-      "Poverty and social justice",
-      "Older people",
-      "Household energy",
-      "Health and safety reform",
-      "European funds",
-      "Employment",
-      "Child maintenance reform",
-    ]
-
-    assert_equal all_policy_titles, person.published_policies.map(&:title)
+    assert_published_policies_returns_all_tagged_policies(person)
   end
 end

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require "gds_api/test_helpers/rummager"
 
 class PolicyGroupTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Rummager
+
   test "should be invalid without a name" do
     policy_group = build(:policy_group, name: '')
     refute policy_group.valid?
@@ -33,5 +36,25 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group = create(:policy_group)
     Whitehall::PublishingApi.expects(:publish_async).with(policy_group).once
     policy_group.publish_to_publishing_api
+  end
+
+  test "#published_policies should return the all policies" do
+    policy_group = create(:policy_group)
+    rummager_has_new_policies_for_every_type
+
+    all_policy_titles = [
+      "Welfare reform",
+      "State Pension simplification",
+      "State Pension age",
+      "Poverty and social justice",
+      "Older people",
+      "Household energy",
+      "Health and safety reform",
+      "European funds",
+      "Employment",
+      "Child maintenance reform",
+    ]
+
+    assert_equal all_policy_titles, policy_group.published_policies.map(&:title)
   end
 end

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -1,8 +1,7 @@
 require "test_helper"
-require "gds_api/test_helpers/rummager"
 
 class PolicyGroupTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::Rummager
+  include PolicyTaggingHelpers
 
   test "should be invalid without a name" do
     policy_group = build(:policy_group, name: '')
@@ -38,23 +37,8 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group.publish_to_publishing_api
   end
 
-  test "#published_policies should return the all policies" do
+  test "#published_policies should return all tagged policies" do
     policy_group = create(:policy_group)
-    rummager_has_new_policies_for_every_type
-
-    all_policy_titles = [
-      "Welfare reform",
-      "State Pension simplification",
-      "State Pension age",
-      "Poverty and social justice",
-      "Older people",
-      "Household energy",
-      "Health and safety reform",
-      "European funds",
-      "Employment",
-      "Child maintenance reform",
-    ]
-
-    assert_equal all_policy_titles, policy_group.published_policies.map(&:title)
+    assert_published_policies_returns_all_tagged_policies(policy_group)
   end
 end

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -59,19 +59,6 @@ class PolicyTest < ActiveSupport::TestCase
     assert draft_policy.related_editions.include?(second_draft)
   end
 
-  test "should build a draft copy with policy groups" do
-    published_policy = create(:published_policy)
-    policy_group = create(:policy_group, policies: [published_policy])
-
-    assert published_policy.policy_groups.include?(policy_group)
-
-    draft_policy = published_policy.create_draft(create(:policy_writer))
-    draft_policy.change_note = 'change-note'
-    assert draft_policy.valid?
-
-    assert draft_policy.policy_groups.include?(policy_group)
-  end
-
   test "can belong to multiple topics" do
     topic_1 = create(:topic)
     topic_2 = create(:topic)


### PR DESCRIPTION
These existed on the page before, and need restoring.

https://github.com/alphagov/rummager/pull/434 **MUST** be deployed before this.

Pre-requisites to things actually showing up (but not to this going out):
- [x] Merge and deploy https://github.com/alphagov/policy-publisher/pull/76 and do the things listed there

https://trello.com/c/pV7ExOoE/203-5-associate-policy-to-a-group

![screenshot 2015-05-20 14 52 09](https://cloud.githubusercontent.com/assets/109225/7729091/cfb9494c-ff0a-11e4-8c3b-a751a50c40a3.png)
