### PR TITLE
Fix a bug in supporting page conversion code.

### DIFF
--- a/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
+++ b/db/data_migration/20150407095340_convert_policies_to_html_publications.rb
@@ -55,7 +55,7 @@ $CTA
     sp_body.gsub(/(?:^!@([0-9]+)|\[InlineAttachment:([0-9]+)\])/) do
       attachment_index = $1 || $2
 
-      if attachment_index && attachment = supporting_page.attachments[$1.to_i - 1]
+      if attachment_index && attachment = supporting_page.attachments[attachment_index.to_i - 1]
         "[#{attachment.title}](#{attachment.url})"
       else
         ""


### PR DESCRIPTION
https://trello.com/c/4BkwlEpM/289-spike-missing-attachments-from-html-publications

This bug lead to any supporting page which used
`InlineAttachment` in its code to have the final
attachment inserted instead of the intended one
when generating the policy papers.

This migration is unlikely to be run again but the
code may be reused, possibly to regenerate the
policy papers, hence the fix.

The 42 supporting pages affected were:
```
271711
272265
273639
295176
300636
304881
318193
335116
338542
345583
360752
374073
376562
396483
396846
405190
405387
436196
438390
446469
447757
457906
459673
459753
459823
461549
462074
462717
463689
466218
469982
474181
478983
479711
480879
481023
482618
483143
483331
486735
486884
490567
```