### PR TITLE
DocumentHistory handles adopted supporting pages

### DIFF
--- a/app/models/document_history.rb
+++ b/app/models/document_history.rb
@@ -83,7 +83,7 @@ class DocumentHistory
 
   def unique_supporting_pages_changes
     supporting_pages_changes.reject do |sub_change|
-      document_changes.any? { |main_change| main_change.public_timestamp.to_i == sub_change.public_timestamp.to_i }
+      document_changes.any? { |main_change| sub_change.public_timestamp.to_i <= main_change.public_timestamp.to_i }
     end
   end
 end


### PR DESCRIPTION
This fixes an issue that results in a strange document history on policies that
adopt previously-published supporting pages from other policies.

Policies can linked to supporting pages that have already been published with
another policy. In such a case, it is possible that the supporting page will
have been published before the policy itself. This can results in a strange
change history where the entry for the supporting page appears before that of
the policy's "First published." change note. This updates the code such that any
change notes on supporting pages published before the policy itself are ignored,
resulting in a more accurate change history.

Before: 

![screen shot 2015-05-21 at 15 21 41](https://cloud.githubusercontent.com/assets/3687/7750675/723b4a04-ffcd-11e4-9883-959ca30dc3dc.png)

After:

![screen shot 2015-05-21 at 15 22 38](https://cloud.githubusercontent.com/assets/3687/7750677/761a1d44-ffcd-11e4-8917-8cb47f469f78.png)


Note: this change is needed for some work that will back-fill the policy history onto the publications that replaced them in whitehall: https://trello.com/c/Gxkzqtpf/197-backfill-change-history-on-html-policy-publications