### PR TITLE
Use 14px external links in HTML publication table

### DIFF
--- a/app/assets/stylesheets/frontend/print/_html-publication.scss
+++ b/app/assets/stylesheets/frontend/print/_html-publication.scss
@@ -51,6 +51,6 @@
     li {
       margin-left: $gutter-two-thirds;
       padding: 0;
-    } 
+    }
   }
 }

--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -280,6 +280,10 @@
           ol+p {
             margin-top: $gutter-one-third;
           }
+
+          a[rel="external"] {
+            @include external-link-14;
+          }
         }
       }
       .contact {

--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -106,7 +106,7 @@
           &.numbered {
             margin-left: $gutter-two-thirds;
             @include media(desktop) {
-              margin-left: $gutter;              
+              margin-left: $gutter;
             }
             a {
               .heading-number {


### PR DESCRIPTION
Default external link icon was for a larger font and caused the icon to sit below the baseline.
Fixes https://www.pivotaltracker.com/story/show/88192714

### Before
![screen shot 2015-05-21 at 15 47 19](https://cloud.githubusercontent.com/assets/319055/7751282/03880daa-ffd1-11e4-8a61-069a616ec4c3.png)

### After
![screen shot 2015-05-21 at 15 47 03](https://cloud.githubusercontent.com/assets/319055/7751277/0191a894-ffd1-11e4-8c6f-82343cb5b2a2.png)