### PR TITLE
Prevent statistics tabs from causing horizontal scroll

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_activity-nav.scss
+++ b/app/assets/stylesheets/frontend/helpers/_activity-nav.scss
@@ -4,6 +4,7 @@
   width: $full-width;
   margin: 0 ($gutter * -1 + 2px);
   padding: 0 ($gutter - 2px);
+  @include box-sizing(border-box);
 
   li {
     list-style: none;


### PR DESCRIPTION
Using 100% width with padding will cause an element to grow larger than its container. At smaller browser widths this causes horizontal scrolling.

* Use border-box so the padding is taken into account when calculating the full width.

Fixes https://www.pivotaltracker.com/story/show/94287040

### Problem
![screen shot 2015-05-21 at 16 23 31](https://cloud.githubusercontent.com/assets/319055/7752161/cfad060c-ffd5-11e4-88b4-c4934549a773.png)

### Before
![screen shot 2015-05-21 at 16 24 14](https://cloud.githubusercontent.com/assets/319055/7752166/d7ba7e24-ffd5-11e4-9253-f172b67dec16.png)

### After
![screen shot 2015-05-21 at 16 24 25](https://cloud.githubusercontent.com/assets/319055/7752169/dc99b1ee-ffd5-11e4-86e4-2f9927b55eb1.png)