### PR TITLE
Fix sideways scrolling on service priority organisation pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -257,7 +257,6 @@
     }
 
     &.service-priority {
-      @extend %grid-row;
       .logo {
         @include grid-column( 1/3 );
 

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
   <div class="block-1 headings-block<%= " service-priority" if @organisation.service_priority_homepage? %>">
-    <div class="inner-block">
+    <div class="inner-block<%= " floated-children" if @organisation.service_priority_homepage? %>">
       <%= render 'header', organisation: @organisation, show_featured_links: true, languages_available: true %>
     </div>
   </div>


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/92350934
Zendesk: https://govuk.zendesk.com/tickets/974685

The `.service-priority` class was including grid-row styles to contain floats, but this came with a negative margin. This negative margin caused sideways scrolling on thin page widths. Instead use the existing `floated-children` class on the inner block to contain the floats (and alter padding at different screen sizes) and stop extending with `grid-row`.

Outcome is a page that looks exactly the same but doesn’t sideways scroll.

Example of live bug: https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency

![image1](https://cloud.githubusercontent.com/assets/319055/7769656/b90bae00-007d-11e5-98b8-52a839f06e27.PNG)