### PR TITLE
Refine history backfill

### DIFF
--- a/lib/data_hygiene/policy_publication_history_writer.rb
+++ b/lib/data_hygiene/policy_publication_history_writer.rb
@@ -38,7 +38,7 @@ module DataHygiene
     end
 
     def add_an_editorial_remark
-      latest_edition.editorial_remarks.create(body: "Rewrote document history to match original publication", author: gds_user)
+      latest_edition.editorial_remarks.create(body: "Rewrote document history to match original policy", author: gds_user)
     end
 
     def re_archive_if_required

--- a/lib/data_hygiene/policy_publication_history_writer.rb
+++ b/lib/data_hygiene/policy_publication_history_writer.rb
@@ -11,6 +11,7 @@ module DataHygiene
         logger.info "Backfilling history for: (#{publication.id}) #{publication.title}"
         store_publication_history_and_reset_first_edition
         store_and_reset_archiving
+        reset_first_published_at_to_match_policy
         re_edition_for_major_policy_changes
         replay_publication_history
         re_archive_if_required
@@ -45,6 +46,10 @@ module DataHygiene
         latest_edition.unpublishing = @unpublishing
         latest_edition.update_column(:state, :archived)
       end
+    end
+
+    def reset_first_published_at_to_match_policy
+      latest_edition.update_column(:first_published_at, policy.first_published_at)
     end
 
     def replay_publication_history

--- a/script/rewrite_policy_publication_history.rb
+++ b/script/rewrite_policy_publication_history.rb
@@ -30,7 +30,7 @@ logger.info '# Checking for publications with suspect first_published_at dates..
 with_publications_and_policies do |publication, policy|
   latest_edition = publication.document.latest_edition
   if latest_edition.first_published_at.to_date > policy.first_published_at.to_date
-    logger.warn "Publication #{publication.id} to be repaired: Frst published is #{latest_edition.first_published_at}; policy has #{policy.first_published_at}"
+    logger.warn "Publication #{publication.id} to be repaired: First published is #{latest_edition.first_published_at}; policy has #{policy.first_published_at}"
   end
 end
 

--- a/script/rewrite_policy_publication_history.rb
+++ b/script/rewrite_policy_publication_history.rb
@@ -4,27 +4,39 @@
 # NOTE: This script is NOT idempotent and so should only be run once!
 require 'csv'
 
-mapping_csv_path = Rails.root+"lib/tasks/election/2015-04-20-13-42-38-policy_paper_creation_output.csv"
 logger = Logger.new(STDOUT)
 
-# Make sure no publications have an open edition as we can't handle those
-CSV.parse(File.open(mapping_csv_path).read, headers: true).each do |row|
-  publication = Publication.find_by_id(row["policy_paper_id"])
-  next unless publication
+def with_publications_and_policies(&block)
+  mapping_csv_path = Rails.root.join("lib/tasks/election/2015-04-20-13-42-38-policy_paper_creation_output.csv")
 
-  document = publication.document
-  if document.published_edition != document.latest_edition
-    @cannot_proceed = true
-    logger.warn "Warning: Publication #{document.published_edition.id} has a #{document.latest_edition.state} edition"
-  end
-end
-raise 'Cannot proceed with open editions on publications' if @cannot_proceed
-
-ActiveRecord::Base.transaction do
   CSV.parse(File.open(mapping_csv_path).read, headers: true).each do |row|
     publication = Publication.find(row["policy_paper_id"])
     policy = Policy.find(row['policy_id'])
+    yield publication, policy
+  end
+end
 
+logger.info 'Checking for publications with open editions on them...'
+with_publications_and_policies do |publication, _|
+  document = publication.document
+  if document.published_edition != document.latest_edition
+    @cannot_proceed = true
+    logger.warn "Publication #{document.published_edition.id} has a #{document.latest_edition.state} edition"
+  end
+end
+abort('Cannot proceed with open editions on publications') if @cannot_proceed
+
+logger.info 'Checking for publications with suspect first_published_at dates...'
+with_publications_and_policies do |publication, policy|
+  latest_edition = publication.document.latest_edition
+  if latest_edition.first_published_at.to_date > policy.first_published_at.to_date
+    logger.warn "Publication #{publication.id} to be repaired: Frst published is #{latest_edition.first_published_at}; policy has #{policy.first_published_at}"
+  end
+end
+
+logger.info 'Back-filling publication histories...'
+ActiveRecord::Base.transaction do
+  with_publications_and_policies do |publication, policy|
     DataHygiene::PolicyPublicationHistoryWriter.new(publication, policy, logger).rewrite_history!
   end
 end


### PR DESCRIPTION
Some adjustments to the script that will be back-filling policy publication histories:

* Resets the first published timestamp to match that of the original policy
* Queues publications for re-indexing in search
* Reworks the script to give more detailed logging output

Trello: https://trello.com/c/Gxkzqtpf/197-backfill-change-history-on-html-policy-publications