### PR TITLE
Frontend uses "withdrawn" instead of "archived" terminology

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -46,7 +46,7 @@
 #whitehall-wrapper {
   @import "helpers/_activity-nav.scss";
   @import "helpers/_announcements.scss";
-  @import "helpers/_archive-notice.scss";
+  @import "helpers/_withdrawal-notice.scss";
   @import "helpers/_attachment.scss";
   @import "helpers/_available_languages.scss";
   @import "helpers/_browse.scss";

--- a/app/assets/stylesheets/frontend/helpers/_withdrawal-notice.scss
+++ b/app/assets/stylesheets/frontend/helpers/_withdrawal-notice.scss
@@ -1,4 +1,4 @@
-.archive-notice {
+.withdrawal-notice {
   .govspeak {
     p {
       @include ig-core-19;

--- a/app/assets/stylesheets/frontend/layouts/detailed-guidance.scss
+++ b/app/assets/stylesheets/frontend/layouts/detailed-guidance.scss
@@ -6,7 +6,7 @@ body.detailed-guidance {
     padding-bottom: 0;
     margin-bottom: 0;
 
-    .archive-notice {
+    .withdrawal-notice {
       margin: 0 $gutter $gutter*2 $gutter;
     }
 

--- a/app/assets/stylesheets/frontend/views/_document-collection.scss
+++ b/app/assets/stylesheets/frontend/views/_document-collection.scss
@@ -38,7 +38,7 @@
     padding: $gutter/2 0 $gutter/2 0;
   }
 
-  .archive-notice {
+  .withdrawal-notice {
     padding: $gutter-half;
     h2 {
       @include core-36;

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -10,7 +10,7 @@ module DocumentHelper
   include TranslationHelper
 
   def edition_page_title(edition)
-    edition.archived? ? "[Archived] #{edition.title}" : edition.title
+    edition.archived? ? "[Withdrawn] #{edition.title}" : edition.title
   end
 
   def document_block_counter

--- a/app/views/documents/_archive_notice.html.erb
+++ b/app/views/documents/_archive_notice.html.erb
@@ -1,4 +1,0 @@
-<div class="status-block archive-notice">
-  <h2>This <%= type.downcase %> was archived on <%= document.updated_at.to_date.to_s(:long_ordinal) %></h2>
-  <%= govspeak_to_html document.unpublishing.explanation unless document.unpublishing.explanation.blank? %>
-</div>

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -13,7 +13,7 @@
                     heading: document.title,
                     extra: true } %>
 
-<%= render('documents/archive_notice', document: document, type: document.format_name) if document.archived? %>
+<%= render('documents/withdrawn_notice', document: document, type: document.format_name) if document.archived? %>
 
 <div class="heading-extra">
   <div class="inner-heading">

--- a/app/views/documents/_withdrawn_notice.html.erb
+++ b/app/views/documents/_withdrawn_notice.html.erb
@@ -1,0 +1,4 @@
+<div class="status-block withdrawal-notice">
+  <h2>This <%= type.downcase %> was withdrawn on <%= document.updated_at.to_date.to_s(:long_ordinal) %></h2>
+  <%= govspeak_to_html document.unpublishing.explanation unless document.unpublishing.explanation.blank? %>
+</div>

--- a/app/views/supporting_pages/show.html.erb
+++ b/app/views/supporting_pages/show.html.erb
@@ -31,7 +31,7 @@
     <h2>Supporting detail:</h2>
       <h1 class="supporting-page-title"><%= @document.title %></h1>
 
-      <%= render 'documents/archive_notice', document: @document, type: '' if @document.archived? %>
+      <%= render 'documents/withdrawn_notice', document: @document, type: '' if @document.archived? %>
 
       <%= render "document_content" %>
     </div>

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -47,7 +47,7 @@ Then(/^the policy should be marked as archived on the public site$/) do
   policy = Policy.last
   visit public_document_path(policy)
   assert page.has_content?(policy.title)
-  assert page.has_content?('This policy was archived')
+  assert page.has_content?('This policy was withdrawn')
   assert page.has_content?(policy.unpublishing.explanation)
 end
 


### PR DESCRIPTION
Updates whitehall frontend to use the "withdrawn" terminology instead of "archived" to be consistent with the retention policy guidance: https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy

BEFORE:

![screen shot 2015-05-27 at 16 15 20](https://cloud.githubusercontent.com/assets/3687/7839700/b9acb572-048b-11e5-84dc-3a099cf7e554.png)

AFTER:

![screen shot 2015-05-27 at 16 16 04](https://cloud.githubusercontent.com/assets/3687/7839703/bcd09606-048b-11e5-9650-6926058709aa.png)


Part one of: https://trello.com/c/nhvXmcY9/127-changing-archiving-to-withdrawing-in-whitehall-and-on-frontend