### PR TITLE
Infer programme to policy relationship

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -50,7 +50,7 @@ private
   end
 
   def document_related_policies
-    @document.policies
+    @document.policy_areas + @document.policies
   end
 
   def find_unpublishing

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -5,8 +5,16 @@ module Admin::TaggableContentHelper
   # Returns an Array that represents the curret set of taggable (new-world)
   # policies. Each element of the array consists of two values: the name and
   # the content id of the policy
+  #
+  # If the Policy is part of a Policy Area, its name will be displayed as:
+  # Policy Area 1; Policy Area 2 -> Policy
   def taggable_policy_content_ids_container
-    Future::Policy.all.map { |policy| [policy.title, policy.content_id]}
+    Future::Policy.all.map { |policy|
+      [
+        taggable_policy_title(policy),
+        policy.content_id,
+      ]
+    }
   end
 
   # Returns an Array that represents the current set of taggable topics.
@@ -279,5 +287,12 @@ private
     end
 
     [person, role, organisations].join(', ')
+  end
+
+  def taggable_policy_title(policy)
+    [
+      policy.policy_area_titles.join('; ').presence,
+      policy.title,
+    ].compact.join(' -> ')
   end
 end

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -44,8 +44,17 @@ module Edition::RelatedPolicies
     Future::Policy.from_content_ids(policy_content_ids)
   end
 
+  def policy_areas
+    policies.flat_map(&:policy_areas).uniq
+  end
+
   def search_index
-    super.merge(policies: policies.map(&:slug))
+    super.merge(
+      policies: [
+        policy_areas.map(&:slug),
+        policies.map(&:slug),
+      ].flatten.uniq
+    )
   end
 
   def can_be_related_to_policies?

--- a/app/models/future/policy.rb
+++ b/app/models/future/policy.rb
@@ -8,6 +8,7 @@ module Future
       @base_path = attributes["base_path"]
       @content_id = attributes["content_id"]
       @title = attributes["title"]
+      @links = attributes["links"]
     end
 
     def self.find(content_id)
@@ -32,7 +33,17 @@ module Future
       @slug ||= base_path.split('/').last
     end
 
+    def policy_areas
+      @policy_areas ||= Future::Policy.from_content_ids(policy_area_content_ids)
+    end
+
+    def policy_area_titles
+      policy_areas.map(&:title)
+    end
+
   private
+
+    attr_reader :links
 
     def self.entries
       content_register.entries("policy")
@@ -44,6 +55,10 @@ module Future
 
     def self.content_register
       @content_register ||= Whitehall.content_register
+    end
+
+    def policy_area_content_ids
+      links.fetch("policy_areas", []).map { |link| link["content_id"] }
     end
   end
 end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -57,7 +57,10 @@ module PublishingApiPresenters
 
     def policies
       if edition.can_be_related_to_policies?
-        edition.policies.map(&:slug)
+        [
+          edition.policy_areas.map(&:slug),
+          edition.policies.map(&:slug),
+        ].flatten.uniq
       else
         []
       end

--- a/test/support/content_register_helpers.rb
+++ b/test/support/content_register_helpers.rb
@@ -7,6 +7,19 @@ module ContentRegisterHelpers
     stub_content_register_entries("policy", [policy_1, policy_2, policy_relevant_to_local_government])
   end
 
+  def stub_content_register_policies_with_policy_areas
+    stub_content_register_entries("policy",
+      [
+        policy_1,
+        policy_2,
+        policy_3,
+        policy_area_1,
+        policy_area_2,
+        policy_area_3,
+      ]
+    )
+  end
+
   def content_register_has_policies(policy_titles)
     policies = policy_titles.map { |title|
       {
@@ -14,6 +27,7 @@ module ContentRegisterHelpers
         "format" => "policy",
         "title" => title,
         "base_path" => "/government/policies/#{title.parameterize}",
+        "links" => {}
       }
     }
 
@@ -27,6 +41,13 @@ module ContentRegisterHelpers
         "format" => "policy",
         "title" => "Policy 1",
         "base_path" => "/government/policies/policy-1",
+        "links" => {
+          "policy_areas" => [
+            {
+              "content_id" => policy_area_1["content_id"],
+            }
+          ]
+        }
       }
   end
 
@@ -36,6 +57,16 @@ module ContentRegisterHelpers
         "format" => "policy",
         "title" => "Policy 2",
         "base_path" => "/government/policies/policy-2",
+        "links" => {
+          "policy_areas" => [
+            {
+              "content_id" => policy_area_1["content_id"],
+            },
+            {
+              "content_id" => policy_area_2["content_id"],
+            }
+          ]
+        }
       }
   end
 
@@ -45,6 +76,13 @@ module ContentRegisterHelpers
         "format" => "policy",
         "title" => "Policy 3",
         "base_path" => "/government/policies/policy-3",
+        "links" => {
+          "policy_areas" => [
+            {
+              "content_id" => policy_area_3["content_id"],
+            }
+          ]
+        }
       }
   end
 
@@ -54,6 +92,13 @@ module ContentRegisterHelpers
         "format" => "policy",
         "title" => "Policy 4",
         "base_path" => "/government/policies/policy-4",
+        "links" => {
+          "policy_areas" => [
+            {
+              "content_id" => policy_area_4["content_id"],
+            }
+          ]
+        }
       }
   end
 
@@ -63,6 +108,47 @@ module ContentRegisterHelpers
       "format" => "policy",
       "title" => "2012 olympic and paralympic legacy",
       "base_path" => "/government/policies/2012-olympic-and-paralympic-legacy",
+      "links" => {},
     }
+  end
+
+  def policy_area_1
+    @policy_area_1 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "policy",
+      "title" => "Parent Policy 1",
+      "base_path" => "/government/policies/policy-area-1",
+      "links" => {},
+    }
+  end
+
+  def policy_area_2
+    @policy_area_2 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "policy",
+      "title" => "Parent Policy 2",
+      "base_path" => "/government/policies/policy-area-2",
+      "links" => {},
+    }
+  end
+
+  def policy_area_3
+    @policy_area_3 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "policy",
+      "title" => "Parent Policy 3",
+      "base_path" => "/government/policies/policy-area-3",
+      "links" => {},
+    }
+  end
+
+  def policy_area_4
+    @policy_area_4 ||= {
+      "content_id" => SecureRandom.uuid,
+      "format" => "policy",
+      "title" => "Parent Policy 4",
+      "base_path" => "/government/policies/parent-policy-4",
+      "links" => {},
+      }
   end
 end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -89,6 +89,26 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     assert_equal ['policy-1'], edition.search_index[:policies]
   end
 
+  test 'includes linked policies with policy areas in search index data' do
+    stub_content_register_policies_with_policy_areas
+
+    edition = create(:news_article)
+    assert_equal [], edition.search_index[:policies]
+
+    edition.policy_content_ids = [policy_1['content_id']]
+    assert_equal ['policy-area-1', 'policy-1'], edition.search_index[:policies]
+  end
+
+  test 'includes linked policies with multiple parents in search index data' do
+    stub_content_register_policies_with_policy_areas
+
+    edition = create(:news_article)
+    assert_equal [], edition.search_index[:policies]
+
+    edition.policy_content_ids = [policy_2['content_id']]
+    assert_equal ['policy-area-1', 'policy-area-2', 'policy-2'], edition.search_index[:policies]
+  end
+
   test 'ignores non-existant content_ids' do
     stub_content_register_policies
 

--- a/test/unit/models/future/policy_test.rb
+++ b/test/unit/models/future/policy_test.rb
@@ -22,5 +22,15 @@ module Future
       assert_equal policy_1["content_id"], future_policy.content_id
       assert_equal policy_1["title"], future_policy.title
     end
+
+    test "#policy_areas returns the policy areas associated with the policy" do
+      stub_content_register_policies_with_policy_areas
+
+      future_policy_1 = Future::Policy.find(policy_1["content_id"])
+      future_policy_2 = Future::Policy.find(policy_2["content_id"])
+
+      assert_equal policy_area_1["title"], future_policy_1.policy_areas.first.title
+      assert_equal [policy_area_1["title"], policy_area_2["title"]] , future_policy_2.policy_areas.map(&:title)
+    end
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -138,4 +138,22 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     assert_equal ["policy-1"], present(edition)[:details][:tags][:policies]
   end
+
+  test "includes new policy associations with their policy areas" do
+    stub_content_register_policies_with_policy_areas
+    edition = create(:publication, :published,
+      policy_content_ids: [policy_1["content_id"]]
+    )
+
+    assert_equal ["policy-area-1", "policy-1"], present(edition)[:details][:tags][:policies]
+  end
+
+  test "includes new policy associations with their multiple policy areas" do
+    stub_content_register_policies_with_policy_areas
+    edition = create(:publication, :published,
+      policy_content_ids: [policy_2["content_id"]]
+    )
+
+    assert_equal ["policy-area-1", "policy-area-2", "policy-2"], present(edition)[:details][:tags][:policies]
+  end
 end


### PR DESCRIPTION
When publishing an Edition only tagged to a Programme/Child Policy, we want to also tag it to the Parent Policy/Policy Ara when publishing to GOV.UK. This PR does this for both Rummager and the Publishing API by looking up the parent Policies through the links of the entry in the Content Register. As such, this work relies on https://github.com/alphagov/content-register/pull/21 being merged first. [Ticket](https://trello.com/c/dD6bkH5j/180-infer-programme-to-policy-relationship-when-tagging-editions).