### PR TITLE
Add ordering to ministerial departments

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -6,11 +6,13 @@ class Admin::CabinetMinistersController < Admin::BaseController
     @cabinet_minister_roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
     @also_attends_cabinet_roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
     @whip_roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
+    @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
   end
 
   def update
     update_ordering(:roles, :seniority)
     update_ordering(:whips, :whip_ordering)
+    update_organisation_ordering
 
     redirect_to admin_cabinet_ministers_path
   end
@@ -25,6 +27,15 @@ private
     params[key].keys.each do |id|
       Role.where(id: id).update_all(
         column => params[key]["#{id}"]["ordering"],
+      )
+    end
+  end
+
+  def update_organisation_ordering
+    return unless params.include?(:organisation)
+    params[:organisation].each_pair do |id, org_params|
+      Organisation.find(id).update_attributes(
+        ministerial_ordering: org_params["ordering"]
       )
     end
   end

--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -39,7 +39,7 @@ private
                  with_translations.
                  with_translations_for(:ministerial_roles).
                  includes(ministerial_roles: [:current_people]).
-                 order('organisation_roles.ordering').map do |organisation|
+                 order('organisations.ministerial_ordering, organisation_roles.ordering').map do |organisation|
       roles_presenter = RolesPresenter.new(organisation.ministerial_roles, view_context)
       roles_presenter.remove_unfilled_roles!
       [organisation, roles_presenter]

--- a/app/helpers/admin/cabinet_ministers_helper.rb
+++ b/app/helpers/admin/cabinet_ministers_helper.rb
@@ -11,4 +11,17 @@ module Admin::CabinetMinistersHelper
       )
     end.join.html_safe
   end
+
+  def organisation_ordering_fields(organisations)
+    organisations.map do |org|
+      label = org.name
+      content_tag(:div,
+        [
+          label_tag("organisation[#{org.id}][ordering]", org.name),
+          text_field_tag("organisation[#{org.id}][ordering]", org.ministerial_ordering, class: "ordering")
+        ].join.html_safe,
+        class: "well"
+      )
+    end.join.html_safe
+  end
 end

--- a/app/views/admin/cabinet_ministers/show.html.erb
+++ b/app/views/admin/cabinet_ministers/show.html.erb
@@ -3,7 +3,7 @@
 <%= form_for admin_cabinet_ministers_path, method: :put do |form| %>
   <div id="role_ordering" class="row-fluid">
   <% if @cabinet_minister_roles.any? %>
-    <div class="span4">
+    <div class="span3">
       <fieldset id="minister_ordering" class="sortable">
         <legend>Cabinet ministers ordering</legend>
         <%= ministers_role_ordering_fields(form, @cabinet_minister_roles, 'roles', &:seniority) %>
@@ -12,7 +12,7 @@
   <% end %>
 
   <% if @also_attends_cabinet_roles.any? %>
-    <div class="span4">
+    <div class="span3">
       <fieldset id="special_representative_ordering" class="sortable">
         <legend>Also attends cabinet ordering</legend>
         <%= ministers_role_ordering_fields(form, @also_attends_cabinet_roles, 'roles', &:seniority) %>
@@ -21,10 +21,20 @@
   <% end %>
 
   <% if @whip_roles.any? %>
-    <div class="span4">
+    <div class="span3">
       <fieldset id="special_representative_ordering" class="sortable">
         <legend>Whips ordering</legend>
         <%= ministers_role_ordering_fields(form, @whip_roles, 'whips', &:whip_ordering) %>
+      </fieldset>
+    </div>
+  <% end %>
+
+
+  <% if @organisations.any? %>
+    <div class="span3">
+      <fieldset id="organisations_ordering" class="sortable">
+        <legend>Organisations ordering</legend>
+        <%= organisation_ordering_fields(@organisations) %>
       </fieldset>
     </div>
   <% end %>

--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -82,7 +82,7 @@
                   person: PersonPresenter.new(role.current_person, self),
                   roles: ministers.roles_for(role.current_person),
                   hlevel: "h4",
-                  prefix: 'by-organisation',
+                  prefix: "by-organisation-#{organisation.slug}",
                   hide_image: true,
                   extra_class: (i % 3 == 0) ? 'clear-person' : ''
                 } %>

--- a/db/migrate/20150527084520_add_ministerial_ordering_to_organisations.rb
+++ b/db/migrate/20150527084520_add_ministerial_ordering_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddMinisterialOrderingToOrganisations < ActiveRecord::Migration
+  def change
+    add_column :organisations, :ministerial_ordering, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518121912) do
+ActiveRecord::Schema.define(version: 20150527084520) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -906,6 +906,7 @@ ActiveRecord::Schema.define(version: 20150518121912) do
     t.string   "content_id",                              limit: 255
     t.string   "homepage_type",                           limit: 255, default: "news"
     t.boolean  "political",                               limit: 1,   default: false
+    t.integer  "ministerial_ordering",                    limit: 4
   end
 
   add_index "organisations", ["content_id"], name: "index_organisations_on_content_id", unique: true, using: :btree

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -47,4 +47,26 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_equal MinisterialRole.whip.order(:seniority).to_a, [role_2, role_1]
     assert_equal MinisterialRole.whip.order(:whip_ordering).to_a, [role_1, role_2]
   end
+
+  test 'should list ministerial organisations in ministerial order' do
+    org_1 = create(:ministerial_department, ministerial_ordering: 0)
+    org_2 = create(:ministerial_department, ministerial_ordering: 2)
+    org_3 = create(:ministerial_department, ministerial_ordering: 1)
+
+    get :show
+
+    assert_equal assigns(:organisations).to_a, [org_1, org_3, org_2]
+  end
+
+  test 'should reorder ministerial organisations' do
+    org_2 = create(:organisation)
+    org_1 = create(:organisation)
+
+    put :update, organisation: {
+      "#{org_1.id}" => {ordering: 0},
+      "#{org_2.id}" => {ordering: 1},
+    }
+
+    assert_equal Organisation.order(:ministerial_ordering), [org_1, org_2]
+  end
 end

--- a/test/unit/helpers/admin/cabinet_ministers_helper_test.rb
+++ b/test/unit/helpers/admin/cabinet_ministers_helper_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class Admin::CabinetMinistersHelperTest < ActionView::TestCase
+  test "#organisation_ordering_fields returns input for org" do
+    org_1 = build(:organisation, id: 1, ministerial_ordering: 1, name: "first org")
+    org_2 = build(:organisation, id: 2, ministerial_ordering: 2, name: "second org")
+
+    html = organisation_ordering_fields([org_1, org_2])
+
+    assert_select_within_html(html, "div label[for='organisation_#{org_1.id}_ordering']", text: "first org")
+    assert_select_within_html(html, "div label[for='organisation_#{org_2.id}_ordering']", text: "second org")
+
+    assert_select_within_html(html, "div input[name='organisation[#{org_1.id}][ordering]']", value: "1")
+    assert_select_within_html(html, "div input[name='organisation[#{org_2.id}][ordering]']", value: "2")
+  end
+end


### PR DESCRIPTION
There is a need to manually curate the order which departments are
listed on the ministers page. This adds a ministerial ordering to
organisations which can be updated on the cabinet ministers page.

Also updated the prefix on the ministers by org objects on the ministers
page as some ministers were appearing twice and causing the same html ID
to be used twice. As this is invalid markup nokogiri was failing.