### PR TITLE
Change the Courts and Tribunals index page beta label

### DIFF
--- a/app/views/organisations/courts_index.html.erb
+++ b/app/views/organisations/courts_index.html.erb
@@ -5,7 +5,7 @@
   <div class="block-1">
     <div class="inner-block">
       <%= render partial: 'govuk_component/beta_label' , locals: {
-        message: 'This part of GOV.UK is still being built – you can access information <a href="http://www.justice.gov.uk/">on the Justice website</a> in the meantime'} %>
+        message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals')}'>HM Courts and Tribunals service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
       <header class="page-header">
         <h1 class="title">Courts and Tribunals</h1>
       </header>


### PR DESCRIPTION
- The previous wording was determined not to be generic enough for all
  forty-six courts and tribunals.

![screen shot 2015-05-28 at 12 10 20](https://cloud.githubusercontent.com/assets/355033/7858780/f8f178d8-0532-11e5-9738-f356cf2293c1.png)
