### PR TITLE
Add rel link to parent document to attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -18,6 +18,11 @@ class AttachmentsController < PublicUploadsController
     render layout: 'html_attachments'
   end
 
+  def show
+    super
+    link_rel_headers
+  end
+
 private
 
   def attachment_visible?
@@ -32,6 +37,12 @@ private
       redirect_to replacement.url, status: 301
     else
       super
+    end
+  end
+
+  def link_rel_headers
+    if edition = attachment_visibility.visible_edition
+      response.headers['Link'] = "<#{public_document_url(edition)}>; rel=\"up\""
     end
   end
 

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -45,6 +45,16 @@ class AttachmentsControllerTest < ActionController::TestCase
     assert_match attachment_data.filename, response.headers['Content-Disposition']
   end
 
+  test 'document attachments that are visible are sent with a Link: header' do
+    visible_edition = create(:published_publication, :with_file_attachment)
+    attachment_data = visible_edition.attachments.first.attachment_data
+
+    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+    get_show attachment_data
+
+    assert_match response.headers['Link'], "<#{public_document_url(visible_edition)}>; rel=\"up\""
+  end
+
   test 'attachments on policy groups are always visible' do
     attachment = create(:file_attachment, attachable: create(:policy_group))
     attachment_data = attachment.attachment_data


### PR DESCRIPTION
So that the cover sheet for an attachment is easily discoverable by
crawlers and other clients, we should surface the attachment edition's
public URL via HTTP headers.

It looks like this:

    Link: <http://www.gov.uk/government/publications/example>; rel="up"

This specific header construct gotten from:

http://tools.ietf.org/html/rfc5988#section-5

We're using `up` because it:

> Refers to a parent document in a hierarchy of documents.

http://tools.ietf.org/html/rfc5988#section-6.2.2

The user need for this came out of a meeting with the British Library's archiving team, but would also be useful for debugging attachments as it's currently non-trivial to reverse the parent document from a given attachment.