### PR TITLE
Link to the publication's whitehall-admin URL from the CSV export

### DIFF
--- a/app/helpers/admin/edition_routes_helper.rb
+++ b/app/helpers/admin/edition_routes_helper.rb
@@ -25,8 +25,9 @@ module Admin::EditionRoutesHelper
     polymorphic_path([:admin, edition], *args)
   end
 
-  def admin_edition_url(edition, *args)
-    polymorphic_url([:admin, edition], *args)
+  def admin_edition_url(edition, options = {})
+    default_options = {host: Whitehall.admin_host}
+    polymorphic_url([:admin, edition], default_options.merge(options))
   end
 
   def edit_admin_edition_path(edition, *args)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -77,7 +77,7 @@ namespace :export do
             edition.id,
             edition.title,
             edition.state,
-            routes_helper.admin_edition_url(edition, host: Whitehall.admin_host),
+            routes_helper.admin_edition_url(edition),
             *edition.authors.uniq.map(&:name)
           ]
         end
@@ -118,7 +118,7 @@ namespace :export do
           csv << [
             org.display_name,
             routes_helper.public_document_url(edition),
-            routes_helper.admin_edition_url(edition, host: Whitehall.admin_host),
+            routes_helper.admin_edition_url(edition),
             edition.title,
             edition.display_type,
             edition.public_timestamp,

--- a/lib/whitehall/exporters/redirector_document_mappings.rb
+++ b/lib/whitehall/exporters/redirector_document_mappings.rb
@@ -21,7 +21,7 @@ class Whitehall::Exporters::RedirectorDocumentMappings
       public_url,
       http_status(edition),
       slug,
-      url_maker.admin_edition_url(edition, host: Whitehall.admin_host),
+      url_maker.admin_edition_url(edition),
       edition.state]
   rescue => e
     Rails.logger.error("Whitehall::Exporters::RedirectorDocumentMappings: when exporting #{edition} - #{e} - #{e.backtrace.join("\n")}")

--- a/test/functional/notifications_test.rb
+++ b/test/functional/notifications_test.rb
@@ -80,7 +80,7 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
   end
 
   test "email body should contain a link to the comment on the edition page" do
-    url = admin_edition_url(@request.edition, anchor: dom_id(@request))
+    url = admin_edition_url(@request.edition, anchor: dom_id(@request), host: 'example.com')
     assert_match Regexp.new(url), @mail.body.to_s
   end
 

--- a/test/unit/helpers/admin/edition_routes_helper_test.rb
+++ b/test/unit/helpers/admin/edition_routes_helper_test.rb
@@ -7,9 +7,16 @@ class Admin::EditionRoutesHelperTest < ActionView::TestCase
     assert_equal "/government/admin/policies/#{p.id}", admin_edition_path(p)
   end
 
-  test 'admin_edition_url take an edition instance and uses polymorphic routes to generate the correct url' do
+  test 'admin_edition_url takes an edition instance and uses polymorphic routes to generate the correct whitehall-admin url by default' do
+    admin_host = 'whitehall-admin.production.alphagov.co.uk'
+    Whitehall.stubs(:admin_host).returns(admin_host)
     s = FactoryGirl.create(:speech)
-    assert_equal "http://www.gov.uk/government/admin/speeches/#{s.id}", admin_edition_url(s, host: 'www.gov.uk')
+    assert_equal "http://#{admin_host}/government/admin/speeches/#{s.id}", admin_edition_url(s)
+  end
+
+  test 'admin_edition_url takes an edition instance and uses polymorphic routes to generate the correct url for the specified hostname' do
+    s = FactoryGirl.create(:speech)
+    assert_equal "http://www.gov.uk/government/admin/speeches/#{s.id}", admin_edition_url(s, host: "www.gov.uk")
   end
 
   test 'edit_admin_edition_path take an edition instance and uses polymorphic routes to generate the correct path' do


### PR DESCRIPTION
- The default not being `whitehall-admin.ENV.alphagov.co.uk` was
  confusing to people using the CSV export feature as they then had to
  copy and paste the path onto the end of a whitehall-admin URL. This
  makes `whitehall-admin.ENV.alphagov.co.uk` the default (using the
  existing `Whitehall.admin_host` method) and gives the ability to
  specify a hostname (e.g. `www.gov.uk`) in the parameters for
  `admin_edition_url`.

Thanks to @evilstreak for helping with this!