### PR TITLE
Update auto-topic picker to use new style policies

### DIFF
--- a/app/assets/javascripts/admin/edition_publishing.js
+++ b/app/assets/javascripts/admin/edition_publishing.js
@@ -167,11 +167,11 @@ jQuery(function($) {
 (function($) {
   var SetTopicsFromPolicy = {
     init: function() {
-      this.$policies = $('select#edition_related_policy_ids');
+      this.$policies = $('select#edition_policy_content_ids');
       this.$topics = $('select#edition_topic_ids');
       if (this.$policies.length > 0 && this.$topics.length > 0) {
         this.updateTopicsWhenPolicySelected();
-        label = $('label[for=edition_related_policy_ids]');
+        label = $('label[for=edition_policy_content_ids]');
         label.text(label.text() + ' (choosing policies will suggest some topics)');
       }
     },
@@ -200,7 +200,7 @@ jQuery(function($) {
 
     selectTopics: function(data, textStatus, jqXHR) {
       $.each(data['topics'], function(i, topic) {
-        SetTopicsFromPolicy.$topics.find('option[value=' + topic.id + ']').prop('selected', true);
+        SetTopicsFromPolicy.$topics.find('option[value=' + topic + ']').prop('selected', true);
         SetTopicsFromPolicy.$topics.trigger('chosen:updated.chosen');
       });
     },

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -3,7 +3,7 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :clean_edition_parameters, only: [:create, :update]
   before_filter :build_array_out_of_need_ids_string, only: [:create, :update]
   before_filter :clear_scheduled_publication_if_not_activated, only: [:create, :update]
-  before_filter :find_edition, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy, :topics]
+  before_filter :find_edition, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
   before_filter :prevent_modification_of_unmodifiable_edition, only: [:edit, :update]
   before_filter :delete_absent_edition_organisations, only: [:create, :update]
   before_filter :build_edition, only: [:new, :create]
@@ -18,9 +18,9 @@ class Admin::EditionsController < Admin::BaseController
 
   def enforce_permissions!
     case action_name
-    when 'index'
+    when 'index', 'topics'
       enforce_permission!(:see, edition_class || Edition)
-    when 'show', 'topics'
+    when 'show'
       enforce_permission!(:see, @edition)
     when 'new'
       enforce_permission!(:create, edition_class || Edition)

--- a/app/controllers/admin/policies_controller.rb
+++ b/app/controllers/admin/policies_controller.rb
@@ -2,9 +2,11 @@ class Admin::PoliciesController < Admin::EditionsController
   before_filter :forbid_access_to_non_admins!, except: [:index, :show, :topics]
 
   def topics
+    topics = ClassificationPolicy.where(policy_content_id: params[:policy_id])
+    topics = topics.map(&:classification_id)
+
     respond_to do |format|
-      presenters = @edition.topics.map { |topic| TopicPresenter.new(topic) }
-      format.json { render json: { topics: presenters } }
+      format.json { render json: { topics: topics } }
     end
   end
 

--- a/app/models/classification_policy.rb
+++ b/app/models/classification_policy.rb
@@ -1,2 +1,3 @@
 class ClassificationPolicy < ActiveRecord::Base
+  belongs_to :classification
 end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -1,5 +1,0 @@
-class TopicPresenter < Struct.new(:topic)
-  def as_json(options = {})
-    topic.attributes.slice('id', 'name')
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,7 @@ Whitehall::Application.routes.draw do
         resources :publications, except: [:index]
 
         resources :policies, except: [:index] do
-          member { get :topics }
+          get :topics
         end
         resources :supporting_pages, path: "supporting-pages", except: [:index]
         resources :worldwide_priorities, path: "priority", except: [:index]

--- a/test/factories/classification_policy.rb
+++ b/test/factories/classification_policy.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :classification_policy do
+    association :classification, factory: :topic
+  end
+end

--- a/test/functional/admin/policies_controller_test.rb
+++ b/test/functional/admin/policies_controller_test.rb
@@ -60,10 +60,13 @@ class Admin::PoliciesControllerTest < ActionController::TestCase
 
   view_test "topics returns list of the policy's topics when JSON requested" do
     topics = [create(:topic), create(:topic)]
-    policy = create(:policy, topics: topics)
-    get :topics, id: policy, format: :json
-    assert_equal topics.first.name, json_response['topics'].first['name']
-    assert_equal topics.second.name, json_response['topics'].second['name']
+    policy_content_id = 'asfd-asdf-asdf-asdf'
+    create(:classification_policy, policy_content_id: policy_content_id, classification: topics.first)
+    create(:classification_policy, policy_content_id: policy_content_id, classification: topics.second)
+
+    get :topics, policy_id: policy_content_id, format: :json
+    assert_equal topics.first.id, json_response['topics'].first
+    assert_equal topics.second.id, json_response['topics'].second
   end
 
   view_test "allows policy editing for GDS admins" do


### PR DESCRIPTION
Since the move to using content store policies the auto picking of
topics stopped working. This brings back the old functionality so that
when you pick a policy with a topic associated to it that topic will be
auto selected in the admin.

Removed the TopicPresenter and instead just used the topic id's as the
presenter as nothing else is needed by the JavaScript and the extra
layer added confusion as to what was rendered. Added a factory for
classification_policy so that the controller could be unit tested.