### PR TITLE
Data migration to rename some specialist sectors

### DIFF
--- a/db/data_migration/20150603151733_rename_population_screening_specialist_sector.rb
+++ b/db/data_migration/20150603151733_rename_population_screening_specialist_sector.rb
@@ -1,0 +1,5 @@
+
+SpecialistSector.where(['edition_id IS NOT NULL AND tag LIKE ?', 'nhs-population-screening-programmes%']).each do |sector|
+  sector.tag = sector.tag.sub(/\Anhs-/, '')
+  sector.save!
+end


### PR DESCRIPTION
These draft sectors have been renamed in collections-publisher, and will
be updated in panopticon (see https://github.com/alphagov/panopticon/pull/253)

The query here only looks at items where edition_id is NOT NULL because
there are many (1000+) entries in the database with a NULL edition_id,
and these fail validation.  These can't be useful because they don't
relate to anything, but fixing that is a job for a separate PR.