### PR TITLE
Migrate archived editions to be withdrawn

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -74,7 +74,7 @@ module Admin::EditionsHelper
   end
 
   def admin_edition_state_text(edition)
-    edition.archived? ? 'Withdrawn' : edition.state.humanize
+    edition.withdrawn_or_archived? ? 'Withdrawn' : edition.state.humanize
   end
 
   def admin_world_location_filter_options(current_user)

--- a/db/data_migration/20150604131458_make_archived_withdrawn.rb
+++ b/db/data_migration/20150604131458_make_archived_withdrawn.rb
@@ -1,0 +1,1 @@
+Edition.archived.update_all(state: 'withdrawn')


### PR DESCRIPTION
Update the state of all archived editions to now be withdrawn. The code
has been updated everywhere to already handle archived or withdrawn
and we want to delete archived eventually.

The pull request to change to withdrawing was: https://github.com/alphagov/whitehall/pull/2200