### PR TITLE
Add a continue button to role form

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -13,7 +13,7 @@ class Admin::RolesController < Admin::BaseController
   def create
     @role = Role.new(role_params)
     if @role.save
-      redirect_to admin_roles_path, notice: %{"#{@role.name}" created.}
+      redirect_to index_or_edit_path, notice: %{"#{@role.name}" created.}
     else
       render action: "new"
     end
@@ -25,7 +25,7 @@ class Admin::RolesController < Admin::BaseController
 
   def update
     if @role.update_attributes(role_params)
-      redirect_to admin_roles_path, notice: %{"#{@role.name}" updated.}
+      redirect_to index_or_edit_path, notice: %{"#{@role.name}" updated.}
     else
       render action: "edit"
     end
@@ -42,6 +42,14 @@ class Admin::RolesController < Admin::BaseController
   end
 
   private
+
+  def index_or_edit_path
+    if params[:save_and_continue].present?
+      edit_admin_role_path(@role)
+    else
+      admin_roles_path
+    end
+  end
 
   def load_role
     @role = Role.find(params[:id])

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -34,5 +34,5 @@
       Do not create ministerial roles without consulting GDS.
     <% end %>
   </p>
-  <%= form.save_or_cancel cancel: admin_roles_path %>
+  <%= form.save_or_continue_or_cancel cancel: admin_roles_path %>
 <% end %>


### PR DESCRIPTION
You currently create role appointments from the role edit page. Having a
continue button on the form means if you are creating a new role you
will be able to straight away create an appointment for that role rather
than having to re-find that role in the list of roles.