### PR TITLE
Order previous appointments newest first

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -101,7 +101,7 @@ class Person < ActiveRecord::Base
   end
 
   def previous_role_appointments
-    role_appointments - current_role_appointments
+    (role_appointments - current_role_appointments).sort_by(&:started_at).reverse
   end
 
   def sort_key

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -80,6 +80,13 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal [], person.previous_role_appointments
   end
 
+  test '#previous_role_appointments is in reverse chronological order' do
+    person = create(:person)
+    older_appointment = create(:ministerial_role_appointment, person: person, started_at: 2.year.ago, ended_at: 1.year.ago)
+    newer_appointment = create(:ministerial_role_appointment, person: person, started_at: 1.year.ago, ended_at: 1.day.ago)
+    assert_equal [newer_appointment, older_appointment], person.previous_role_appointments
+  end
+
   test '#organisations includes organisations linked through current ministerial roles' do
     person = create(:person)
     role_appointment = create(:ministerial_role_appointment, person: person, started_at: 1.year.ago, ended_at: nil)


### PR DESCRIPTION
To match the ordering of other things on the site, list newest
appointments first.