### PR TITLE
Stop non-gds editors from editing historic content

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -15,6 +15,14 @@ class Admin::EditionsController < Admin::BaseController
   before_filter :redirect_to_controller_for_type, only: [:show]
   before_filter :deduplicate_specialist_sectors, only: [:create, :update]
   before_filter :trigger_previously_published_validations, only: [:create], if: :document_can_be_previously_published
+  before_filter :forbid_editing_of_historic_content!, only: [:create, :edit, :update, :submit, :destory, :revise]
+
+  def forbid_editing_of_historic_content!
+    unless can?(:modify, @edition)
+      redirect_to [:admin, @edition],
+        alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please <a href="https://support.production.alphagov.co.uk/content_change_request/new">contact GDS</a> if you need to change it.}
+    end
+  end
 
   def enforce_permissions!
     case action_name

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -674,7 +674,7 @@ class Edition < ActiveRecord::Base
   end
 
   def government
-    Government.on_date(date_for_government) unless date_for_government.nil?
+    @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
   end
 
   def search_government_name

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -39,6 +39,8 @@ module Whitehall::Authority::Rules
         return false
       elsif action == :unpublish && actor.managing_editor?
         return true
+      elsif action == :modify && @subject.historic?
+        return actor.gds_editor? || actor.gds_admin?
       else
         if actor.gds_admin?
           gds_admin_can?(action)

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -28,4 +28,32 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     get :new
     assert_select '.political-status', count: 0
   end
+
+  view_test "doesn't let non-gds users edit historic documents" do
+    old_government = create(:previous_government, name: 'old')
+    new_government = create(:current_government, name: 'new')
+
+    login_as :managing_editor
+
+    published_edition = create(:published_news_article, first_published_at: 3.years.ago)
+    new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
+
+    get :edit, id: new_draft
+
+    assert_response :redirect
+  end
+
+  view_test "lets gds users edit historic documents" do
+    old_government = create(:previous_government, name: 'old')
+    new_government = create(:current_government, name: 'new')
+
+    login_as :gds_editor
+
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
+
+    get :edit, id: new_draft
+
+    assert_response :success
+  end
 end

--- a/test/unit/whitehall/authority/authority_test_helper.rb
+++ b/test/unit/whitehall/authority/authority_test_helper.rb
@@ -44,6 +44,11 @@ module AuthorityTestHelper
       fse.stubs(:scheduled_by).returns(user)
       fse
     end
+    define_method("historic_#{edition_type}") do
+      he = FactoryGirl.build(:"published_#{edition_type}", force_published: true)
+      he.stubs(:historic?).returns(true)
+      he
+    end
   end
 
   define_edition_factory_methods :edition

--- a/test/unit/whitehall/authority/department_editor_test.rb
+++ b/test/unit/whitehall/authority/department_editor_test.rb
@@ -166,4 +166,8 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   test 'cannot mark editions as political' do
     refute enforcer_for(department_editor, normal_edition).can?(:mark_political)
   end
+
+  test 'cannot modify historic editions' do
+    refute enforcer_for(department_editor, historic_edition).can?(:modify)
+  end
 end

--- a/test/unit/whitehall/authority/department_writer_test.rb
+++ b/test/unit/whitehall/authority/department_writer_test.rb
@@ -142,4 +142,8 @@ class DepartmentWriterTest < ActiveSupport::TestCase
   test 'cannot mark editions as political' do
     refute enforcer_for(department_writer, normal_edition).can?(:mark_political)
   end
+
+  test 'cannot modify historic editions' do
+    refute enforcer_for(department_writer, historic_edition).can?(:modify)
+  end
 end

--- a/test/unit/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/whitehall/authority/gds_admin_test.rb
@@ -41,4 +41,8 @@ class GDSAdminTest < ActiveSupport::TestCase
   test "Non GDS-admin cannot modify policies" do
     refute enforcer_for(non_gds_admin, Policy).can?(:modify)
   end
+
+  test 'can modify historic editions' do
+    assert enforcer_for(gds_admin, historic_edition).can?(:modify)
+  end
 end

--- a/test/unit/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/whitehall/authority/gds_editor_test.rb
@@ -176,4 +176,9 @@ class GDSEditorTest < ActiveSupport::TestCase
   test 'can mark editions as political' do
     assert enforcer_for(gds_editor, normal_edition).can?(:mark_political)
   end
+
+  test 'can modify historic editions' do
+    assert enforcer_for(gds_editor, historic_edition).can?(:modify)
+  end
+
 end

--- a/test/unit/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/whitehall/authority/managing_editor_test.rb
@@ -175,4 +175,9 @@ class ManagingEditorTest < ActiveSupport::TestCase
   test 'can mark editions as political' do
     assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
+
+    test 'cannot modify historic editions' do
+    refute enforcer_for(managing_editor, historic_edition).can?(:modify)
+  end
+
 end

--- a/test/unit/whitehall/authority/world_editor_test.rb
+++ b/test/unit/whitehall/authority/world_editor_test.rb
@@ -204,4 +204,9 @@ class WorldEditorTest < ActiveSupport::TestCase
     user = world_editor(['hat land', 'tie land'])
     refute enforcer_for(user, normal_edition).can?(:mark_political)
   end
+
+  test 'cannot modify historic editions' do
+    user = world_editor(['hat land', 'tie land'])
+    refute enforcer_for(user, historic_edition).can?(:modify)
+  end
 end

--- a/test/unit/whitehall/authority/world_writer_test.rb
+++ b/test/unit/whitehall/authority/world_writer_test.rb
@@ -200,4 +200,9 @@ class WorldWriterTest < ActiveSupport::TestCase
     user = world_writer(['hat land', 'tie land'])
     refute enforcer_for(user, normal_edition).can?(:mark_political)
   end
+
+  test 'cannot modify historic editions' do
+    user = world_writer(['hat land', 'tie land'])
+    refute enforcer_for(user, historic_edition).can?(:modify)
+  end
 end


### PR DESCRIPTION
Once the Government on politically marked content has ended the content
shouldn't be modified. This stops non-gds editors from changing that
content.

--

The words in the alert are subject to change on feedback from product people but would appreciate code review.