### PR TITLE
Update content items to be withdrawn

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -29,7 +29,7 @@ private
       change_history: edition.change_history.as_json,
     }).tap do |json|
       json[:image] = image_details if image_available?
-      json[:archive_notice] = archive_notice if edition.withdrawn_or_archived?
+      json[:withdrawn_notice] = withdrawn_notice if edition.withdrawn_or_archived?
     end
   end
 
@@ -41,10 +41,10 @@ private
     }
   end
 
-  def archive_notice
+  def withdrawn_notice
     {
       explanation: unpublishing_explanation,
-      archived_at: edition.updated_at
+      withdrawn_at: edition.updated_at
     }
   end
 

--- a/db/data_migration/20150605102704_republish_withdrawn_case_studies_to_content_store.rb
+++ b/db/data_migration/20150605102704_republish_withdrawn_case_studies_to_content_store.rb
@@ -1,0 +1,3 @@
+require 'data_hygiene/publishing_api_republisher'
+
+DataHygiene::PublishingApiRepublisher.new(CaseStudy.withdrawn_or_archived).perform

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api"
 class WithdrawingTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
-  test "When an edition is withdrawn, it gets republished to the Publishing API with an archive notice" do
+  test "When an edition is withdrawn, it gets republished to the Publishing API with an withdrawn notice" do
     edition   = create(:published_case_study)
     presenter = PublishingApiPresenters.presenter_for(edition)
     edition.build_unpublishing(explanation: 'Old information',
@@ -28,6 +28,6 @@ private
   def archived_payload?(json)
     payload = JSON.parse(json)
     payload['update_type'] == 'republish' &&
-      payload['details']['archive_notice'].is_a?(Hash)
+      payload['details']['withdrawn_notice'].is_a?(Hash)
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -219,8 +219,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     }
 
     assert_valid_against_schema(present(case_study), 'case_study')
-    assert_equal archive_notice[:archived_at], present(case_study)[:details][:archive_notice][:archived_at]
+    assert_equal archive_notice[:archived_at], present(case_study)[:details][:withdrawn_notice][:withdrawn_at]
     assert_equivalent_html archive_notice[:explanation],
-      present(case_study)[:details][:archive_notice][:explanation]
+      present(case_study)[:details][:withdrawn_notice][:explanation]
   end
 end


### PR DESCRIPTION
The naming of archiving has changed to withdrawing. Send withdrawn
notices to content store rather than archive notices.

---

This is the matching pull request for this: https://github.com/alphagov/govuk-content-schemas/pull/79 and  https://github.com/alphagov/government-frontend/pull/45 and shouldn't be merged till after government-frontend has been deployed with that change. 