### PR TITLE
Use a released version of sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ end
 
 gem 'sass', '3.4.9'
 gem 'sass-rails' # required by bootstrap-sass, but not listed as a dependency of it
-gem 'sassc-rails', github: 'bolandrm/sassc-rails', ref: 'cac614328c2830646dc9d1ee218caf6204b8e0c8'
+gem 'sassc-rails', '0.1.0'
 gem 'uglifier'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,6 @@ GIT
     test_track (0.1.0)
       rails (>= 3.1.0)
 
-GIT
-  remote: git://github.com/bolandrm/sassc-rails.git
-  revision: cac614328c2830646dc9d1ee218caf6204b8e0c8
-  ref: cac614328c2830646dc9d1ee218caf6204b8e0c8
-  specs:
-    sassc-rails (0.0.9)
-      rails (>= 4.0.0)
-      sass
-      sassc (~> 1.2.0)
-      sprockets (> 2.11)
-      tilt
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -359,6 +347,12 @@ GEM
     sassc (1.2.0)
       bundler
       ffi (~> 1.9.6)
+    sassc-rails (0.1.0)
+      rails (>= 4.0.0)
+      sass
+      sassc (~> 1.2.0)
+      sprockets (> 2.11)
+      tilt
     shared_mustache (0.2.1)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
@@ -504,7 +498,7 @@ DEPENDENCIES
   rummageable (= 1.2.0)
   sass (= 3.4.9)
   sass-rails
-  sassc-rails!
+  sassc-rails (= 0.1.0)
   shared_mustache (~> 0.2.1)
   sidekiq (~> 3.3.0)
   sidekiq-logging-json (= 0.0.14)


### PR DESCRIPTION
The change we were fetching via git has been released:
https://github.com/bolandrm/sassc-rails/pull/17

/cc @boffbowsh 