### PR TITLE
Send detailed format to Rummager

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -286,6 +286,7 @@ class Edition < ActiveRecord::Base
     organisations: nil,
     people: nil,
     display_type: :display_type,
+    detailed_format: -> d { d.display_type.parameterize },
     public_timestamp: :public_timestamp,
     relevant_to_local_government: :relevant_to_local_government?,
     world_locations: nil,


### PR DESCRIPTION
In order to get proper objects back from Rummager for `display_type` we
need to create a new field which will use the Rummager allowed values
feature to return the correct label. This will allow us to filter for
`detailed_format` within Rummager powered pages such as Finders.

All editions will need to be republished when this is live.

Ticket:
https://trello.com/c/TAuAS4wp/174-8-add-more-filter-options-to-policy-pages

Relies on https://github.com/alphagov/rummager/pull/449 being merged first.