### PR TITLE
Remove references to archived

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -69,12 +69,12 @@ module Admin::EditionsHelper
       ["Scheduled", 'scheduled'],
       ["Published", 'published'],
       ["Force published (not reviewed)", 'force_published'],
-      ['Withdrawn', 'withdrawn_or_archived']
+      ['Withdrawn', 'withdrawn']
     ]
   end
 
   def admin_edition_state_text(edition)
-    edition.withdrawn_or_archived? ? 'Withdrawn' : edition.state.humanize
+    edition.withdrawn? ? 'Withdrawn' : edition.state.humanize
   end
 
   def admin_world_location_filter_options(current_user)

--- a/app/helpers/admin/supporting_pages_helper.rb
+++ b/app/helpers/admin/supporting_pages_helper.rb
@@ -1,7 +1,7 @@
 module Admin::SupportingPagesHelper
   def related_policy_links(supporting_page)
     supporting_page.related_policies.map do |policy|
-      href = if supporting_page.published? || supporting_page.withdrawn_or_archived?
+      href = if supporting_page.published? || supporting_page.withdrawn?
         public_document_url(supporting_page, policy_id: policy.document)
       else
         preview_document_path(supporting_page, policy_id: policy.document)

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -10,7 +10,7 @@ module DocumentHelper
   include TranslationHelper
 
   def edition_page_title(edition)
-    edition.withdrawn_or_archived? ? "[Withdrawn] #{edition.title}" : edition.title
+    edition.withdrawn? ? "[Withdrawn] #{edition.title}" : edition.title
   end
 
   def document_block_counter

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -46,8 +46,8 @@ class Edition < ActiveRecord::Base
   UNMODIFIABLE_STATES = %w(scheduled published superseded deleted).freeze
   FROZEN_STATES = %w(superseded deleted).freeze
   PRE_PUBLICATION_STATES = %w(imported draft submitted rejected scheduled).freeze
-  POST_PUBLICATION_STATES = %w(published superseded archived withdrawn).freeze
-  PUBLICLY_VISIBLE_STATES = %w(published archived withdrawn).freeze
+  POST_PUBLICATION_STATES = %w(published superseded withdrawn).freeze
+  PUBLICLY_VISIBLE_STATES = %w(published withdrawn).freeze
 
   scope :with_title_or_summary_containing, -> *keywords {
     pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
@@ -106,7 +106,7 @@ class Edition < ActiveRecord::Base
     end
 
     def being_unpublished?(previous_state, current_state)
-      previous_state == 'published' && %w(draft archived withdrawn).include?(current_state)
+      previous_state == 'published' && %w(draft withdrawn).include?(current_state)
     end
   end
 

--- a/app/models/edition/supporting_pages.rb
+++ b/app/models/edition/supporting_pages.rb
@@ -17,7 +17,7 @@ module Edition::SupportingPages
   end
 
   def withdrawn_supporting_pages
-    supporting_pages.withdrawn_or_archived
+    supporting_pages.withdrawn
   end
 
   def allows_supporting_pages?

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -11,11 +11,7 @@ module Edition::Workflow
     end
 
     def valid_state?(state)
-      %w(active imported draft submitted rejected published scheduled force_published archived withdrawn_or_archived not_published).include?(state)
-    end
-
-    def withdrawn_or_archived
-      where(state: %w(archived withdrawn))
+      %w(active imported draft submitted rejected published scheduled force_published withdrawn not_published).include?(state)
     end
   end
 
@@ -33,7 +29,6 @@ module Edition::Workflow
       state :published
       state :superseded
       state :deleted
-      state :archived
       state :withdrawn
 
       event :try_draft do
@@ -94,10 +89,6 @@ module Edition::Workflow
     end
 
     validate :edition_has_no_unpublished_editions, on: :create
-  end
-
-  def withdrawn_or_archived?
-    archived? || withdrawn?
   end
 
   def pre_publication?

--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -81,7 +81,7 @@ class RegisterableEdition
 private
 
   def no_longer_published?
-    %w(archived deleted withdrawn).include?(edition.state) || edition.unpublishing != nil
+    %w(deleted withdrawn).include?(edition.state) || edition.unpublishing != nil
   end
 
   def published?

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -29,7 +29,7 @@ private
       change_history: edition.change_history.as_json,
     }).tap do |json|
       json[:image] = image_details if image_available?
-      json[:withdrawn_notice] = withdrawn_notice if edition.withdrawn_or_archived?
+      json[:withdrawn_notice] = withdrawn_notice if edition.withdrawn?
     end
   end
 

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -13,7 +13,7 @@
                     heading: document.title,
                     extra: true } %>
 
-<%= render('documents/withdrawn_notice', document: document, type: document.format_name) if document.withdrawn_or_archived? %>
+<%= render('documents/withdrawn_notice', document: document, type: document.format_name) if document.withdrawn? %>
 
 <div class="heading-extra">
   <div class="inner-heading">

--- a/app/views/supporting_pages/show.html.erb
+++ b/app/views/supporting_pages/show.html.erb
@@ -31,7 +31,7 @@
     <h2>Supporting detail:</h2>
       <h1 class="supporting-page-title"><%= @document.title %></h1>
 
-      <%= render 'documents/withdrawn_notice', document: @document, type: '' if @document.withdrawn_or_archived? %>
+      <%= render 'documents/withdrawn_notice', document: @document, type: '' if @document.withdrawn? %>
 
       <%= render "document_content" %>
     </div>

--- a/lib/collection_data_reporter.rb
+++ b/lib/collection_data_reporter.rb
@@ -47,7 +47,7 @@ private
       select(
           'editions.*',
           'COUNT(editions_editions.political = 1 OR NULL) AS num_political',
-          'COUNT(editions_editions.state = "archived" OR editions_editions.state = "withdrawn" OR NULL) AS num_withdrawn').
+          'COUNT(editions_editions.state = "withdrawn" OR NULL) AS num_withdrawn').
       in_default_locale.
       includes(:document).
       joins(:editions).

--- a/lib/data_hygiene/edition_unwithdrawer.rb
+++ b/lib/data_hygiene/edition_unwithdrawer.rb
@@ -6,7 +6,7 @@ module DataHygiene
 
     def initialize(edition_id, logger = Rails.logger)
       @edition = Edition.find(edition_id)
-      raise "Cannot unwithdraw an edition with state '#{@edition.state}'" unless @edition.withdrawn_or_archived?
+      raise "Cannot unwithdraw an edition with state '#{@edition.state}'" unless @edition.withdrawn?
       @user = User.find(GDS_INSIDE_GOV_USER_ID)
       @logger = logger
     end

--- a/lib/whitehall/exporters/mappings.rb
+++ b/lib/whitehall/exporters/mappings.rb
@@ -1,5 +1,5 @@
 class Whitehall::Exporters::Mappings
-  STATES_TO_INCLUDE = Edition::PRE_PUBLICATION_STATES + %w(published archived withdrawn)
+  STATES_TO_INCLUDE = Edition::PRE_PUBLICATION_STATES + %w(published withdrawn)
 
   def export(target)
     target << ['Old URL', 'New URL', 'Admin URL', 'State']

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -27,14 +27,6 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [draft_edition], Admin::EditionFilter.new(Edition, @current_user, state: 'draft').editions
   end
 
-  test 'handles both legacy "archived" and "withdrawn" states when filtering' do
-    legacy_archived = create(:news_article, state: 'archived')
-    withdrawn       = create(:news_article, :withdrawn)
-    draft           = create(:draft_news_article)
-
-    assert_equal [legacy_archived, withdrawn], Admin::EditionFilter.new(Edition, @current_user, state: 'withdrawn_or_archived').editions
-  end
-
   test "should filter by edition author" do
     author = create(:user)
     edition = create(:policy, authors: [author])

--- a/test/unit/data_hygiene/edition_unwithdrawer_test.rb
+++ b/test/unit/data_hygiene/edition_unwithdrawer_test.rb
@@ -21,7 +21,7 @@ module DataHygiene
       assert_equal @user, EditionUnwithdrawer.new(@edition.id).user
     end
 
-    test "initialize raises an error unless the edition is archived or withdrawn" do
+    test "initialize raises an error unless the edition is withdrawn" do
       @edition.update_attribute(:state, "published")
       assert_raises RuntimeError do
         EditionUnwithdrawer.new(@edition.id)
@@ -45,7 +45,7 @@ module DataHygiene
       assert_equal "superseded", @edition.state
     end
 
-    test "unwithdraw publishes a draft of the archived edition" do
+    test "unwithdraw publishes a draft of the withdrawn edition" do
       unwithdrawen_edition = EditionUnwithdrawer.new(@edition.id).unwithdraw!
       assert unwithdrawen_edition.published?
       assert unwithdrawen_edition.minor_change
@@ -54,8 +54,8 @@ module DataHygiene
       assert_equal "Unwithdrawn", unwithdrawen_edition.editorial_remarks.first.body
     end
 
-    test "unwithdraw handles legacy archived editions" do
-      edition = FactoryGirl.create(:published_edition, state: 'archived')
+    test "unwithdraw handles legacy withdrawn editions" do
+      edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
       unwithdrawen_edition = EditionUnwithdrawer.new(edition.id).unwithdraw!
       assert unwithdrawen_edition.published?
       assert unwithdrawen_edition.minor_change

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -121,16 +121,16 @@ class DocumentTest < ActiveSupport::TestCase
     assert_equal publication, document.scheduled_edition
   end
 
-  test "#ever_published_editions returns all editions that have ever been published, archived or withdrawn" do
+  test "#ever_published_editions returns all editions that have ever been published or withdrawn" do
     document = create(:document)
     superseded = create(:superseded_edition, document: document)
-    legacy_archived = create(:edition, state: 'archived', document: document)
+    withdrawn = create(:edition, state: 'withdrawn', document: document)
     current = create(:published_edition, document: document)
 
-    assert_equal [superseded, legacy_archived, current], document.ever_published_editions
+    assert_equal [superseded, withdrawn, current], document.ever_published_editions
 
     current.withdraw!
-    assert_equal [superseded, legacy_archived, current], document.reload.ever_published_editions
+    assert_equal [superseded, withdrawn, current], document.reload.ever_published_editions
   end
 
   test "#humanized_document_type should return document type in a user friendly format" do

--- a/test/unit/edition/workflow_test.rb
+++ b/test/unit/edition/workflow_test.rb
@@ -11,7 +11,7 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     end
 
     assert_equal [:imported, :draft, :submitted, :rejected, :scheduled], pre
-    assert_equal [:published, :superseded , :deleted, :archived, :withdrawn], post
+    assert_equal [:published, :superseded , :deleted, :withdrawn], post
   end
 
   test "rejecting a submitted edition transitions it into the rejected state" do

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -123,28 +123,23 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   test "#republish raises error for editions that are not publicly visible" do
     draft     = create(:draft_edition)
     published = create(:published_edition)
-    archived  = create(:published_edition, state: 'archived')
     withdrawn = create(:published_edition, state: 'withdrawn')
 
     draft_payload     = PublishingApiPresenters.presenter_for(draft, update_type: "republish").as_json
     published_payload = PublishingApiPresenters.presenter_for(published, update_type: "republish").as_json
-    archived_payload  = PublishingApiPresenters.presenter_for(archived, update_type: "republish").as_json
     withdrawn_payload = PublishingApiPresenters.presenter_for(withdrawn, update_type: "republish").as_json
 
     draft_request     = stub_publishing_api_put_item(draft.search_link, draft_payload)
     published_request = stub_publishing_api_put_item(published.search_link, published_payload)
-    archived_request  = stub_publishing_api_put_item(archived.search_link, archived_payload)
     withdrawn_request = stub_publishing_api_put_item(withdrawn.search_link, withdrawn_payload)
 
     Whitehall::PublishingApi.republish_async(published)
-    Whitehall::PublishingApi.republish_async(archived)
     Whitehall::PublishingApi.republish_async(withdrawn)
     assert_raise Whitehall::UnpublishableInstanceError do
       Whitehall::PublishingApi.republish_async(draft)
     end
 
     assert_requested published_request
-    assert_requested archived_request
     assert_requested withdrawn_request
     assert_not_requested draft_request
   end


### PR DESCRIPTION
Now that we are no longer moving editions into an archived state and we
have updated all archived editions to be in a withdrawn state we should
remove references to archived.

---

This shouldn't be merged until after the data migration in https://github.com/alphagov/whitehall/pull/2210 has been run.