### PR TITLE
Silence Rails 4.2 deprecation warnings in the benchmark environment

### DIFF
--- a/config/environments/benchmark.rb
+++ b/config/environments/benchmark.rb
@@ -9,7 +9,9 @@ Whitehall::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = true
+  config.serve_static_files = true
+
+  config.eager_load = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true


### PR DESCRIPTION
- `config.serve_static_assets` => `config.serve_static_files` and
  `config.eager_load = nil` => `config.eager_load = false`.
- Noticed this when running `bundle exec rake` in dev. I was initially
  puzzled because the usual environment config had all the right
  settings, but then I noticed that this benchmark environment config
  was the source.