### PR TITLE
Don't check authenticity_token for unsaved changes

### DIFF
--- a/app/assets/javascripts/admin/form_change_protection.js
+++ b/app/assets/javascripts/admin/form_change_protection.js
@@ -15,7 +15,8 @@
     },
 
     serialisedFormValues: function () {
-      var formdata = this.$form.serialize();
+      var formdata = this.$form.find("*").
+        not('input[name=authenticity_token]').serialize();
 
       this.$form.find('input[type=file]').each(function () {
         formdata = formdata + $(this).val();


### PR DESCRIPTION
When a user attempts to navigate away from the admin/editions/edit page, the
GOVUK.formChangeProtection (JavaScript) module compares the edit form's initial
state to its current state.

We've recently received reports about a significant number of false positives,
where the user hasn't made any changes on the form but has still been warned
"You have unsaved changes..." when navigating away from the page.

I managed to reproduce the bug on production, preview and in my development
environment without trying. During my poking around, the only difference
between the two form states was the value of the `authenticity_token` hidden
input field.