### PR TITLE
Editions can be important

### DIFF
--- a/app/assets/javascripts/admin/edition_publishing.js
+++ b/app/assets/javascripts/admin/edition_publishing.js
@@ -217,3 +217,21 @@ jQuery(function($) {
 
   SetTopicsFromPolicy.init();
 }(jQuery));
+
+(function($) {
+  var $policyInput = $('#edition_policy_content_ids'),
+      $importantCheckbox = $('#edition_important');
+
+  function toggleCheckboxIfPoliciesSelected() {
+    if ($policyInput.val()) {
+      $importantCheckbox.prop('disabled', false);
+    } else {
+      $importantCheckbox.prop('disabled', true);
+    }
+  }
+
+  if ($policyInput.length > 0 && $importantCheckbox.length > 0) {
+    toggleCheckboxIfPoliciesSelected();
+    $policyInput.on('change', toggleCheckboxIfPoliciesSelected);
+  }
+}(jQuery));

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -200,6 +200,7 @@ class Admin::EditionsController < Admin::BaseController
       :primary_specialist_sector_tag,
       :corporate_information_page_type_id,
       :political,
+      :important,
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -267,7 +267,8 @@ class Edition < ActiveRecord::Base
     latest_change_note: :most_recent_change_note,
     is_political: :political?,
     is_historic: :historic?,
-    government_name: :search_government_name
+    government_name: :search_government_name,
+    important: :important?,
   )
 
   def search_title
@@ -648,6 +649,10 @@ class Edition < ActiveRecord::Base
     return false unless government
 
     political? && !government.current?
+  end
+
+  def important?
+    important
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -268,7 +268,7 @@ class Edition < ActiveRecord::Base
     is_political: :political?,
     is_historic: :historic?,
     government_name: :search_government_name,
-    important: :important?,
+    important_to_policy: :important?,
   )
 
   def search_title

--- a/app/views/admin/shared/_policy_fields.html.erb
+++ b/app/views/admin/shared/_policy_fields.html.erb
@@ -8,7 +8,7 @@
                   data: { placeholder: "Choose policies..."} %>
   <% if form.object.respond_to?(:important) %>
     <div id="important">
-      <%= form.check_box :important, label_text: "Is this an important document?" %>
+      <%= form.check_box :important, label_text: "Is this an important document? (<a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#marking-a-document-as-important-to-a-policy'>What this does</a>)".html_safe %>
     </div>
   <% end %>
   <br/>

--- a/app/views/admin/shared/_policy_fields.html.erb
+++ b/app/views/admin/shared/_policy_fields.html.erb
@@ -6,4 +6,10 @@
                   multiple: true,
                   class: 'chzn-select',
                   data: { placeholder: "Choose policies..."} %>
+  <% if form.object.respond_to?(:important) %>
+    <div id="important">
+      <%= form.check_box :important, label_text: "Is this an important document?" %>
+    </div>
+  <% end %>
+  <br/>
 </fieldset>

--- a/db/migrate/20150611152014_add_important_to_edition.rb
+++ b/db/migrate/20150611152014_add_important_to_edition.rb
@@ -1,0 +1,5 @@
+class AddImportantToEdition < ActiveRecord::Migration
+  def change
+    add_column :editions, :important, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,18 +81,6 @@ ActiveRecord::Schema.define(version: 20150623074259) do
   add_index "attachments", ["attachment_data_id"], name: "index_attachments_on_attachment_data_id", using: :btree
   add_index "attachments", ["ordering"], name: "index_attachments_on_ordering", using: :btree
 
-  create_table "checksum", id: false, force: :cascade do |t|
-    t.string   "db",         limit: 64,  null: false
-    t.string   "tbl",        limit: 64,  null: false
-    t.integer  "chunk",      limit: 4,   null: false
-    t.string   "boundaries", limit: 100, null: false
-    t.string   "this_crc",   limit: 40,  null: false
-    t.integer  "this_cnt",   limit: 4,   null: false
-    t.string   "master_crc", limit: 40
-    t.integer  "master_cnt", limit: 4
-    t.datetime "ts",                     null: false
-  end
-
   create_table "classification_featuring_image_data", force: :cascade do |t|
     t.string   "carrierwave_image", limit: 255
     t.datetime "created_at"
@@ -451,7 +439,8 @@ ActiveRecord::Schema.define(version: 20150623074259) do
     t.string   "need_ids",                                    limit: 255
     t.string   "primary_locale",                              limit: 255,   default: "en",    null: false
     t.boolean  "political",                                   limit: 1,     default: false
-    t.string   "logo_url"
+    t.string   "logo_url",                                    limit: 255
+    t.boolean  "important",                                   limit: 1,     default: false
   end
 
   add_index "editions", ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree

--- a/features/news-articles.feature
+++ b/features/news-articles.feature
@@ -47,6 +47,14 @@ Scenario: Creating a news article related to multiple policies
   When I draft a new news article "Healthy Eating" relating it to the policies "Policy 1" and "Policy 3"
   Then I should see in the preview that "Healthy Eating" should related to "Policy 1" and "Policy 3" policies
 
+Scenario: Creating a news article that is important in Policy
+  Given I am a writer
+  And two published policies "Totally Tangy Tofu" and "Awakened Tastebuds" exist
+  When I draft a new important news article "Healthy Eating" relating it to the policies "Totally Tangy Tofu" and "Awakened Tastebuds"
+  Then I should see in the preview that "Healthy Eating" should related to "Totally Tangy Tofu" and "Awakened Tastebuds" policies
+  Then "Healthy Eating" is marked as important
+
+
 Scenario: Viewing a published news article with related policies
   Given a published news article "News 1" with related published policies "Policy 1" and "Policy 2"
   When I visit the news article "News 1"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -131,3 +131,17 @@ When(/^I filter the announcements list by "(.*?)"$/) do |announcement_type|
   select announcement_type, from: "Announcement type"
   click_on "Refresh results"
 end
+
+When(/^I draft a new important news article "(.*?)" relating it to the policies "(.*?)" and "(.*?)"$/) do |news_article_title, policy_title_1, policy_title_2|
+  policies = content_register_has_policies([policy_title_1, policy_title_2])
+
+  create(:published_news_article, title: news_article_title, policy_content_ids: policies.map {|p| p['content_id']}, important: true)
+end
+
+Then(/^"(.*?)" is marked as important$/) do |news_article_title|
+  assert NewsArticle.where(title: news_article_title).first.important == true
+end
+
+And(/^two published policies "(.*?)" and "(.*?)" exist$/) do |policy_title_1, policy_title_2|
+  policies = content_register_has_policies([policy_title_1, policy_title_2])
+end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     change_note "change-note"
     summary 'edition-summary'
     previously_published false
+    important false
 
     after :build do |edition, evaluator|
       edition.skip_virus_status_check = true

--- a/test/factories/world_location_news_articles.rb
+++ b/test/factories/world_location_news_articles.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     title "world-location-news-title"
     summary "world-location-news-summary"
     body  "world-location-news-body"
+    important false
 
     after :build do |news, evaluator|
       news.world_locations = [FactoryGirl.build(:world_location)] unless evaluator.world_locations.any?


### PR DESCRIPTION
This PR adds an `important` attribute to `Edition`. This is a boolean that can be set by Editors when tagging any content to Policies if that content is an `Edition`. The `important` flag isn't used for anything yet and is being added as an experiment to see how Editors use it.

If it is used correctly we may use this as a way to increase relevance when a user is searching. There's obvious danger that Editors will mark all their content as important making this information worthless in which case we will remove this feature. [Ticket](https://trello.com/c/Q9qwl6kn/293-identify-an-edition-as-important).