### PR TITLE
Data migration to replace policy admin URLs in content.

### DIFF
--- a/db/data_migration/20150615092751_replace_policy_admin_links.rb
+++ b/db/data_migration/20150615092751_replace_policy_admin_links.rb
@@ -1,0 +1,3 @@
+require "policy_admin_url_replacer"
+
+PolicyAdminURLReplacer.replace_in!(Edition.where(state: Edition::PUBLICLY_VISIBLE_STATES + Edition::PRE_PUBLICATION_STATES))

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150527084520) do
+ActiveRecord::Schema.define(version: 20150615080039) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4

--- a/lib/policy_admin_url_replacer.rb
+++ b/lib/policy_admin_url_replacer.rb
@@ -1,0 +1,84 @@
+# This can be deleted once db/data_migration/20150615092751_replace_policy_admin_links.rb is done with.
+class PolicyAdminURLReplacer
+  def self.replace_in!(edition_scope)
+    self.new.replace_in!(edition_scope)
+  end
+
+  def replace_in!(edition_scope)
+    edition_scope.find_each do |edition|
+      edition.body = replace_short_form(edition.body, edition.id)
+      edition.body = replace_long_form(edition.body, edition.id)
+      edition.save
+    end
+  end
+
+private
+
+  def replace_short_form(text, edition_id)
+    short_form_regex = %r{\[([^\]]+)\]\([^(]+/admin/(?:editions|policies|supporting-pages)/([^)/ ]+?)( [^)]+)?\)}
+    text.gsub(short_form_regex) {|admin_url|
+      link_text = $1
+      id_or_slug = $2
+      possible_title_text = $3
+
+      get_replacement(
+        id_or_slug: id_or_slug,
+        possible_title_text: possible_title_text,
+        link_text: link_text,
+        original: admin_url,
+        edition_id: edition_id,
+      )
+    }
+  end
+
+  def replace_long_form(text, edition_id)
+    long_form_regex = %r{\[([^\]]+)\]\([^(]+/admin/(?:editions|policies)/(?:[^)/ ]+?)/supporting-pages/([^)/ ]+)( [^)]+)?\)}
+    text.gsub(long_form_regex) {|admin_url|
+      link_text = $1
+      sp_id = $2
+      possible_title_text = $3
+      # Map from old non-editioned supporting pages to new ones.
+      if sp_id =~ /^\d+$/ && new_id = EditionedSupportingPageMapping.where(old_supporting_page_id: sp_id).last.try(:new_supporting_page_id)
+        id_or_slug = new_id.to_s
+      else
+        id_or_slug = sp_id
+      end
+
+      get_replacement(
+        id_or_slug: id_or_slug,
+        possible_title_text: possible_title_text,
+        link_text: link_text,
+        original: admin_url,
+        edition_id: edition_id,
+      )
+    }
+  end
+
+  def get_replacement(id_or_slug:, possible_title_text:, link_text:, original:, edition_id:)
+    if replacement_url = id_to_url_mapping[id_or_slug]
+      replacement = "[#{link_text}](#{replacement_url}#{possible_title_text})"
+    else
+      replacement = link_text
+    end
+
+    puts "Edition #{edition_id}: #{original} -> #{replacement}"
+    return replacement
+  end
+
+  def id_to_url_mapping
+    return @id_to_url_mapping if @id_to_url_mapping
+
+    puts "Building ID/slug to URL mapping"
+
+    policies_and_supporting_pages = Edition.unscoped.where(type: ["Policy", "SupportingPage"])
+
+    @id_to_url_mapping = policies_and_supporting_pages.inject({}) {|hash, edition|
+      url = Whitehall.url_maker.public_document_url(edition, {}, include_deleted_documents: true)
+
+      hash.merge(
+        edition.id.to_s => url,
+        edition.slug => url,
+      )
+    }
+  end
+end

--- a/lib/policy_admin_url_replacer.rb
+++ b/lib/policy_admin_url_replacer.rb
@@ -5,7 +5,7 @@ class PolicyAdminURLReplacer
   end
 
   def replace_in!(edition_scope)
-    edition_scope.find_each do |edition|
+    edition_scope.find_each(batch_size: 50) do |edition|
       edition.body = replace_short_form(edition.body, edition.id)
       edition.body = replace_long_form(edition.body, edition.id)
       edition.body = replace_long_form_direct_links(edition.body, edition.id)

--- a/lib/policy_admin_url_replacer.rb
+++ b/lib/policy_admin_url_replacer.rb
@@ -8,6 +8,8 @@ class PolicyAdminURLReplacer
     edition_scope.find_each do |edition|
       edition.body = replace_short_form(edition.body, edition.id)
       edition.body = replace_long_form(edition.body, edition.id)
+      edition.body = replace_long_form_direct_links(edition.body, edition.id)
+      edition.body = replace_short_form_direct_links(edition.body, edition.id)
       edition.save
     end
   end
@@ -15,13 +17,13 @@ class PolicyAdminURLReplacer
 private
 
   def replace_short_form(text, edition_id)
-    short_form_regex = %r{\[([^\]]+)\]\([^(]+/admin/(?:editions|policies|supporting-pages)/([^)/ ]+?)( [^)]+)?\)}
+    short_form_regex = %r{\[([^\[\]]+)\]\([^()]+/admin/(?:editions|policies|supporting-pages)/([^()/ ]+?)( [^()]+)?\)}
     text.gsub(short_form_regex) {|admin_url|
       link_text = $1
       id_or_slug = $2
       possible_title_text = $3
 
-      get_replacement(
+      get_markdown_replacement(
         id_or_slug: id_or_slug,
         possible_title_text: possible_title_text,
         link_text: link_text,
@@ -32,7 +34,7 @@ private
   end
 
   def replace_long_form(text, edition_id)
-    long_form_regex = %r{\[([^\]]+)\]\([^(]+/admin/(?:editions|policies)/(?:[^)/ ]+?)/supporting-pages/([^)/ ]+)( [^)]+)?\)}
+    long_form_regex = %r{\[([^\[\]]+?)\]\([^()]+/admin/(?:editions|policies)/(?:[^()/ ]+?)/supporting-pages/([^()/ ]+)( [^()]+)?\)}
     text.gsub(long_form_regex) {|admin_url|
       link_text = $1
       sp_id = $2
@@ -44,7 +46,7 @@ private
         id_or_slug = sp_id
       end
 
-      get_replacement(
+      get_markdown_replacement(
         id_or_slug: id_or_slug,
         possible_title_text: possible_title_text,
         link_text: link_text,
@@ -54,9 +56,64 @@ private
     }
   end
 
-  def get_replacement(id_or_slug:, possible_title_text:, link_text:, original:, edition_id:)
+  def replace_long_form_direct_links(text, edition_id)
+    link_regex = %r{(<a .*?href=.)https?://whitehall-admin.\w+.alphagov.co.uk/government/admin/(?:editions|policies)/(?:[^"'/ ]+?)/supporting-pages/([^"'/ ]+)(["'].*?>)(.*?)</a>}
+    text.gsub(link_regex) {|admin_url|
+      tag_start = $1
+      sp_id = $2
+      tag_end = $3
+      link_text = $4
+      # Map from old non-editioned supporting pages to new ones.
+      if sp_id =~ /^\d+$/ && new_id = EditionedSupportingPageMapping.where(old_supporting_page_id: sp_id).last.try(:new_supporting_page_id)
+        id_or_slug = new_id.to_s
+      else
+        id_or_slug = sp_id
+      end
+
+      get_html_replacement(
+        id_or_slug: id_or_slug,
+        link_text: link_text,
+        original: admin_url,
+        edition_id: edition_id,
+        tag_start: tag_start,
+        tag_end: tag_end,
+      )
+    }
+  end
+
+  def replace_short_form_direct_links(text, edition_id)
+    link_regex = %r{(<a .*?href=.)https?://whitehall-admin.\w+.alphagov.co.uk/government/admin/(?:editions|policies|supporting-pages)/([^"'/ ]+)(["'].*?>)(.*?)</a>}
+    text.gsub(link_regex) {|admin_url|
+      tag_start = $1
+      id_or_slug = $2
+      tag_end = $3
+      link_text = $4
+
+      get_html_replacement(
+        id_or_slug: id_or_slug,
+        link_text: link_text,
+        original: admin_url,
+        edition_id: edition_id,
+        tag_start: tag_start,
+        tag_end: tag_end,
+      )
+    }
+  end
+
+  def get_markdown_replacement(id_or_slug:, possible_title_text:, link_text:, original:, edition_id:)
     if replacement_url = id_to_url_mapping[id_or_slug]
       replacement = "[#{link_text}](#{replacement_url}#{possible_title_text})"
+    else
+      replacement = link_text
+    end
+
+    puts "Edition #{edition_id}: #{original} -> #{replacement}"
+    return replacement
+  end
+
+  def get_html_replacement(id_or_slug:, link_text:, original:, edition_id:, tag_start:, tag_end:)
+    if replacement_url = id_to_url_mapping[id_or_slug]
+      replacement = "#{tag_start}#{replacement_url}#{tag_end}#{link_text}</a>"
     else
       replacement = link_text
     end

--- a/test/unit/policy_admin_url_replacer_test.rb
+++ b/test/unit/policy_admin_url_replacer_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+require 'policy_admin_url_replacer'
+
+class PolicyAdminURLReplacerTest < ActiveSupport::TestCase
+  def setup
+    old_policies = [create(:published_policy), create(:published_policy), create(:published_policy)]
+    old_policies[0..1].each {|p| p.unpublish; p.delete! }
+
+    old_sps = [create(:published_supporting_page), create(:published_supporting_page), create(:published_supporting_page)]
+    old_sps[0..1].each {|sp| sp.unpublish; sp.delete! }
+
+    @policy = create(:published_policy, title: "Test policy")
+    @supporting_page = create(:published_supporting_page, title: "Test supporting page", related_policies: [@policy])
+  end
+
+  test "replaces policies and supporting pages by ID and slug" do
+    edition = create(:publication, body: %{
+      # Generic "editions" links
+      [policy link](/government/admin/editions/#{@policy.id})
+      [policy link](/government/admin/editions/#{@policy.slug})
+      [sp link](/government/admin/editions/#{@supporting_page.id})
+      [sp link](/government/admin/editions/#{@supporting_page.slug})
+
+      # Explicit links to subclassed resources
+      [policy link](/government/admin/policies/#{@policy.id})
+      [policy link](/government/admin/policies/#{@policy.slug})
+      [sp link](/government/admin/supporting-pages/#{@supporting_page.id})
+      [sp link](/government/admin/supporting-pages/#{@supporting_page.slug})
+
+      # Generic "editions" full URLs
+      [policy link](https://www.gov.uk/government/admin/editions/#{@policy.id})
+      [policy link](https://whitehall-admin.production.alphagov.co.uk/government/admin/editions/#{@policy.id})
+
+      # Supporting page sub-links
+      [sp link](/government/admin/policies/#{@policy.id}/supporting-pages/#{@supporting_page.id})
+      [sp link](/government/admin/policies/#{@policy.id}/supporting-pages/#{@supporting_page.slug})
+      [sp link](/government/admin/editions/#{@policy.id}/supporting-pages/#{@supporting_page.id})
+    })
+
+    PolicyAdminURLReplacer.replace_in!(Edition.all)
+
+    assert_all_admin_links_replaced(edition)
+    assert_correct_replacement_url(edition)
+  end
+
+  test "replaces links when policies have been deleted" do
+    edition = create(:publication, body: %{
+      [policy link](/government/admin/editions/#{@policy.id})
+      [sp link](/government/admin/editions/#{@policy.id}/supporting-pages/#{@supporting_page.id})
+    })
+
+    @policy.unpublish
+    @policy.delete!
+
+    PolicyAdminURLReplacer.replace_in!(Edition.all)
+
+    assert_all_admin_links_replaced(edition)
+    assert_correct_replacement_url(edition)
+  end
+
+  test "replaces links when supporting pages have been deleted" do
+    edition = create(:publication, body: %{
+      [sp link](/government/admin/editions/#{@policy.id}/supporting-pages/#{@supporting_page.id})
+    })
+
+    @supporting_page.unpublish
+    @supporting_page.delete!
+
+    PolicyAdminURLReplacer.replace_in!(Edition.all)
+
+    assert_all_admin_links_replaced(edition)
+    assert_correct_replacement_url(edition)
+  end
+
+  test "retains title text" do
+    edition = create(:publication, body: %{
+      [policy link](/government/admin/policies/#{@policy.id} "Policy title text")
+      [sp link](/government/admin/policies/#{@policy.id}/supporting-pages/#{@supporting_page.id} "Supporting page title text")
+    })
+
+    PolicyAdminURLReplacer.replace_in!(Edition.all)
+
+    assert_all_admin_links_replaced(edition)
+    assert edition.body.include?(%{ "Policy title text"})
+    assert edition.body.include?(%{ "Supporting page title text"})
+  end
+
+  test "deals with the policy having been hard-deleted" do
+    edition = create(:publication, body: %{
+      [policy link](/government/admin/editions/#{@policy.id})
+      [sp link](/government/admin/editions/#{@policy.id}/supporting-pages/#{@supporting_page.id})
+    })
+
+    Policy.connection.delete("DELETE FROM editions WHERE id = #{@policy.id}")
+
+    PolicyAdminURLReplacer.replace_in!(Edition.all)
+
+    assert_all_admin_links_erased(edition)
+  end
+
+  def assert_all_admin_links_replaced(edition)
+    remaining_admin_links = edition.reload.body.split("\n").map(&:strip).select {|line|
+      line =~ /admin/
+    }
+
+    assert_equal [], remaining_admin_links
+  end
+
+  def assert_all_admin_links_erased(edition)
+    remaining_admin_links = edition.reload.body.split("\n").map(&:strip).reject(&:blank?).each do |md_link|
+      assert md_link =~ %r{^[^\[\]()]+$}
+    end
+  end
+
+  def assert_correct_replacement_url(edition)
+    assert edition.body.include?("policies/#{@policy.slug}/supporting-pages/#{@supporting_page.slug}")
+  end
+end


### PR DESCRIPTION
These will stop working once the code and/or data is removed, and so need replacing with their full public URL.

Output when run locally: https://gist.github.com/elliotcm/3c63f101d6d49241a912

https://trello.com/c/8nYU9WTp/324-replace-admin-links-for-policies-and-supporting-pages-with-static-public-links