### PR TITLE
Use process forks when replacing URLs in editions.

### DIFF
--- a/db/data_migration/20150615092751_replace_policy_admin_links.rb
+++ b/db/data_migration/20150615092751_replace_policy_admin_links.rb
@@ -1,3 +1,31 @@
 require "policy_admin_url_replacer"
 
-PolicyAdminURLReplacer.replace_in!(Edition.where(state: Edition::PUBLICLY_VISIBLE_STATES + Edition::PRE_PUBLICATION_STATES))
+puts "Building ID/slug to URL mapping"
+
+policies_and_supporting_pages = Edition.unscoped.where(type: ["Policy", "SupportingPage"])
+
+id_to_url_mapping = policies_and_supporting_pages.inject({}) {|hash, edition|
+  url = Whitehall.url_maker.public_document_url(edition, {}, include_deleted_documents: true)
+
+  id = edition.id.to_s
+  slug = edition.slug
+
+  edition = nil
+
+  hash.merge(
+    id => url,
+    slug => url,
+  )
+}
+
+edition_ids = Edition.where(state: Edition::PUBLICLY_VISIBLE_STATES + Edition::PRE_PUBLICATION_STATES).pluck(:id)
+
+edition_ids.each_slice(50).with_index do |ids, index|
+  puts "Starting batch #{index}"
+
+  pid = fork do
+    PolicyAdminURLReplacer.new(id_to_url_mapping).replace_in!(Edition.where(id: ids))
+  end
+
+  Process.wait(pid)
+end


### PR DESCRIPTION
The large size of editions can lead to very large
chunks of memory being taken up for a given batch.

Ruby never frees memory once it has been claimed
so long as there's more available to assign new
objects, but it does free memory when closing forks.