### PR TITLE
Fix typo in Russian locale for find_out_more

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -565,7 +565,7 @@ ru:
       social_media_use_html: "Ознакомиться с нашей политикой по %{link}."
       welsh_language_scheme_html: "Выяснить о наших обязательствах по публикации можно
         по %{link}."
-    find_out_more: "Общая иформация и контакты"
+    find_out_more: "Общая информация и контакты"
     headings:
       about_us: "О нас"
       contact_us: "Связь с нами"


### PR DESCRIPTION
This request came from somebody at the FCO. I don't speak Russian, but Google Translate would suggest that this is a good change to make. Ideally this should be reviewed by somebody who understands the change.

- Zendesk: https://govuk.zendesk.com/tickets/1071218
- Pivotal: https://www.pivotaltracker.com/story/show/97509118