### PR TITLE
Increase the batch size of admin URL data migration.

### DIFF
--- a/db/data_migration/20150615092751_replace_policy_admin_links.rb
+++ b/db/data_migration/20150615092751_replace_policy_admin_links.rb
@@ -20,7 +20,7 @@ id_to_url_mapping = policies_and_supporting_pages.inject({}) {|hash, edition|
 
 edition_ids = Edition.where(state: Edition::PUBLICLY_VISIBLE_STATES + Edition::PRE_PUBLICATION_STATES).pluck(:id)
 
-edition_ids.each_slice(50).with_index do |ids, index|
+edition_ids.each_slice(1000).with_index do |ids, index|
   puts "Starting batch #{index}"
 
   pid = fork do


### PR DESCRIPTION
Increasing from 50 to 1000 increases the transient
memory usage from 350MB to 550MB but decreases the
time per 1000 editions from 50s to 30s.