### PR TITLE
[DO NOT MERGE] Rename `Topic` to `Policy Area`

### DIFF
--- a/app/views/admin/classifications/_form.html.erb
+++ b/app/views/admin/classifications/_form.html.erb
@@ -14,8 +14,8 @@
   <fieldset>
     <%= render 'admin/shared/policy_fields', form: classification_form %>
 
-    <%= classification_form.label :related_classification_ids, "Related topics" %>
-    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose related topics..."} %>
+    <%= classification_form.label :related_classification_ids, "Related policy areas" %>
+    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose related policy areas..."} %>
   </fieldset>
 
   <%= render partial: 'custom_form_fields', locals: {classification_form: classification_form} %>

--- a/app/views/admin/classifications/edit.html.erb
+++ b/app/views/admin/classifications/edit.html.erb
@@ -18,7 +18,7 @@
             data: { confirm: "Are you sure you want to delete: #{@classification} ?", class: 'btn btn-danger' } %>
     <% else %>
       <div class="policies_preventing_destruction">
-        <p>This topic can't be deleted as it has associated policies:</p>
+        <p>This policy area can't be deleted as it has associated policies:</p>
         <ul>
           <% @classification.policies.each do |policy| %>
             <li><%= link_to(policy.title, future_policy_path(policy)) %></li>

--- a/app/views/admin/classifications/new.html.erb
+++ b/app/views/admin/classifications/new.html.erb
@@ -1,4 +1,4 @@
-<% page_title "New topic" %>
+<% page_title "New policy area" %>
 <div class="span8">
 <h1>New <%= human_friendly_model_name.downcase %></h1>
 <p class="warning">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.</p>

--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -24,11 +24,11 @@
 
   <% if edition.can_be_associated_with_topics? %>
     <section>
-      <h1>Topics</h1>
+      <h1>Policy Areas</h1>
       <% if edition.topics.any? %>
         <%= render partial: "classifications/list", locals: {topics: edition.topics} %>
       <% else %>
-        <p>This document isn't assigned to any topics.</p>
+        <p>This document isn't assigned to any policy areas.</p>
       <% end %>
     </section>
   <% end %>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -51,7 +51,7 @@ Don’t use a single # – this is H1 and is for the title only</pre>
 [an admin path](/government/admin/policies/12345)
 [a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
 
-  <p>All content created under an organisation tab – collection pages, topics, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
+  <p>All content created under an organisation tab – collection pages, policy areas, organisations, people, roles etc – should be linked to using the full, public URLs:</p>
   <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
 
   <p>For external websites, use the full URL including http://:</p>

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -57,7 +57,7 @@
 
     <% if @edition.can_be_associated_with_topics? %>
       <div class="row-fluid">
-        <h3>Topics</h3>
+        <h3>Policy Areas</h3>
         <%= render partial: 'topic_fields', locals: { form: form, edition: @edition } %>
       </div>
     <% end %>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -73,11 +73,11 @@
       <%= organisation_form.select :parent_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.parent_organisation_ids), {}, multiple: true, class: 'chzn-select', data: { placeholder: "Choose parent organisations..." } %>
     </p>
 
-    <h3>Topics</h3>
+    <h3>Policy Areas</h3>
     <% organisation_form.object.organisation_classifications.each do |ot| %>
       <p>
         <%= label_tag "organisation_topic_ids_#{ot.ordering}" do %>
-          Topic <%= ot.ordering + 1 %>
+          Policy Area <%= ot.ordering + 1 %>
           <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select', data: { placeholder: "Choose topics..."}, id: "organisation_topic_ids_#{ot.ordering}" %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][ordering]", ot.ordering %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][id]", ot.id %>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -35,7 +35,7 @@
               None
             <% end %>
           </td></tr>
-          <tr><th>Topics and topical events</th><td>
+          <tr><th>Policy Areas and topical events</th><td>
             <% if @organisation.classifications.any? %>
               <%= @organisation.classifications.map {|t| link_to(t.name, [:edit, :admin, t]) }.to_sentence.html_safe %>
             <% else %>

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -29,7 +29,7 @@
                   { }, multiple: true, class: 'chzn-select' %>
   </div>
   <div class="form-group stats-chosen-wrapper">
-    <%= form.label  :topic_ids, 'Topics', required: true %>
+    <%= form.label  :topic_ids, 'Policy Areas', required: true %>
     <%= form.select :topic_ids,
                   options_for_select(taggable_topics_container, statistics_announcement.topic_ids),
                   { prompt: 'Select a topic' },

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -66,7 +66,7 @@
             <th>Announcement title</th>
             <th>Publication</th>
             <th>Organisations</th>
-            <th>Topics</th>
+            <th>Policy Areas</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -45,7 +45,7 @@
     <dd><%= @statistics_announcement.display_type %></dd>
     <dt>Organisations:</dt>
     <dd><%= @statistics_announcement.organisations.map(&:name).to_sentence %></dd>
-    <dt>Topics:</dt>
+    <dt>Policy Areas:</dt>
     <dd><%= @statistics_announcement.topics.map(&:name).to_sentence %></dd>
   </dl>
 

--- a/app/views/classifications/index.html.erb
+++ b/app/views/classifications/index.html.erb
@@ -1,11 +1,11 @@
-<% page_title "Topics" %>
+<% page_title "Policy Areas" %>
 <% page_class "classifications-index index-list-page" %>
 
 
 <div class="block-1">
   <div class="inner-block">
     <header class="page-header js-filter-list">
-        <h1 class="title">Topics</h1>
+        <h1 class="title">Polocy Areas</h1>
         <form class="js-filter-form"><label for="what-is-the-government-doing-about" class="label">What&nbsp;is the government<br />doing about <div><input name="what-is-the-government-doing-about" id="what-is-the-government-doing-about" placeholder="Example: housing"> ?</div></label></form>
     </header>
   </div>
@@ -20,7 +20,7 @@
         </div>
       </div>
     <% else %>
-      <p>We don't have any topics with published documents at present.</p>
+      <p>We don't have any policy area with published documents at present.</p>
     <% end %>
     <% if @topical_events.any? %>
       <div class="heading-block js-filter-block">
@@ -33,7 +33,7 @@
       </div>
     <% end %>
     <div class="js-filter-no-results">
-      <p>No topics match that filter.</p>
+      <p>No policy areas match that filter.</p>
     </div>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -7,7 +7,7 @@
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
-                locals: { type: 'Topic',
+                locals: { type: 'Policy Area',
                           heading: "#{h(@classification.name)}#{' <span class="archived">(Archived)</span>' if @classification.archived?}".html_safe,
                           big: true, extra: true } %>
       <% if @classification.logo_url.present? %>
@@ -90,7 +90,7 @@
       <% end %>
       <% if @related_classifications.any? %>
         <section id="related-topics" class="document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Related topics</h1>
+          <h1 class="label">Related policy areas</h1>
           <div class="content">
             <ol class="document-list">
               <% @related_classifications.each do |topic| %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title @classification.name, "Topics" %>
+<% page_title @classification.name, "Policy Area" %>
 <% page_class "topics-show" %>
 <% atom_discovery_link_tag atom_feed_url_for(@classification), "Latest activity on #{@classification.name}" %>
 
@@ -7,7 +7,7 @@
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
-                locals: { type: "Topic",
+                locals: { type: "Policy Area",
                           heading: @classification.name,
                           big: true, extra: true } %>
 
@@ -24,7 +24,7 @@
                           locals: { organisations: @classification.organisations } %>
             </dd>
             <% if @related_classifications.any? %>
-              <dt>Related topics:</dt>
+              <dt>Related policy areas:</dt>
               <dd class="js-hide-other-links related-topics">
                 <%= @related_classifications.map { |rc| link_to(rc.name, rc) }.to_sentence.html_safe %>
               </dd>

--- a/features/filtering_featured_documents_on_a_topic.feature
+++ b/features/filtering_featured_documents_on_a_topic.feature
@@ -1,8 +1,8 @@
-Feature: Filtering Featured Documents On A Topic
+Feature: Filtering Featured Documents On A Policy Area
 
   Background:
-    Given there is a topic with published documents
-    When I view featured documents for that topic
+    Given there is a policy area with published documents
+    When I view featured documents for that policy area
 
   Scenario: User filters by title
     When I filter by title

--- a/features/importing-new-editions.feature
+++ b/features/importing-new-editions.feature
@@ -123,7 +123,7 @@ Feature: Importing new editions
     Then the import succeeds, creating 1 imported publication for "Foreign Commonwealth Office" with "imported-awaiting-type" publication type
 
   Scenario: Importing publications sets imported state, ImportedAwaitingType type and default organisation, to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "Publication" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,publication_type,document_collection_1,publication_date,order_url,price,isbn,urn,command_paper_number,ignore_1,attachment_1_url,attachment_1_title,country_1,topic_1
@@ -135,7 +135,7 @@ Feature: Importing new editions
     Then I can make the imported publication into a draft edition
 
   Scenario: Importing publications with blank publication dates allows them to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "Publication" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,publication_type,document_collection_1,publication_date,order_url,price,isbn,urn,command_paper_number,ignore_1,attachment_1_url,attachment_1_title,country_1,topic_1
@@ -156,7 +156,7 @@ Feature: Importing new editions
     And the imported publication has an html attachment with the title "HTML attachment title" and body "Body part one plus body part two"
 
   Scenario: Importing news article sets imported state, ImportedAwaitingType type and default organisation, to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "News article" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,minister_1,first_published,country_1,news_article_type,topic_1
@@ -168,7 +168,7 @@ Feature: Importing new editions
     Then I can make the imported news article into a draft edition
 
   Scenario: Importing news article with blank first published allows them to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "News article" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,minister_1,first_published,country_1,news_article_type,topic_1
@@ -180,7 +180,7 @@ Feature: Importing new editions
     Then I can make the imported news article into a draft edition
 
   Scenario: Importing speeches sets ImportedAwaitingType speech type and blank "delivered by", to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "Speech" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,type,delivered_by,delivered_on,event_and_location,country_1,topic_1
@@ -196,7 +196,7 @@ Feature: Importing new editions
 
   Scenario: Importing speeches with blank delivered on means it must be filled in later, along with the deliverer
     Given a person called "Joe Bloggs"
-    And a topic with the slug "my-topic" exists
+    And a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "Speech" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,type,delivered_by,delivered_on,event_and_location,country_1,topic_1
@@ -210,7 +210,7 @@ Feature: Importing new editions
     Then I can make the imported speech into a draft edition
 
   Scenario: Importing consultations with blank dates allows them to be filled in later
-    Given a topic with the slug "my-topic" exists
+    Given a policy area with the slug "my-topic" exists
     When I import the following data as CSV as "Consultation" for "Department for Transport":
       """
       old_url,title,summary,body,organisation,opening_date,closing_date,response_date,response_summary,topic_1
@@ -231,8 +231,8 @@ Feature: Importing new editions
       """
     Then I can delete the imported edition if I choose to
 
-  Scenario: Importing detailed guides with topic, detailed guidance category, related detailed guide and related mainstream content
-    Given a topic with the slug "my-topic" exists
+  Scenario: Importing detailed guides with policy area, detailed guidance category, related detailed guide and related mainstream content
+    Given a policy area with the slug "my-topic" exists
     And a published document collection "My document collection" exists
     And a mainstream category with the slug "my-detailed-guidance-category" exists
     And a published detailed guide "My related detailed guide" for the organisation "Foreign Commonwealth Office"

--- a/features/latest-documents.feature
+++ b/features/latest-documents.feature
@@ -2,7 +2,7 @@ Feature: List of most recently published documents
   So that I can …
   As a user
   I want to be able to see the most recently published content by an
-  organisation or about a topic, topical event or world location
+  organisation or about a policy area, topical event or world location
 
   Scenario: Latest documents on topical event page
     Given a topical event with published documents

--- a/features/step_definitions/admin_policy_tagging_steps.rb
+++ b/features/step_definitions/admin_policy_tagging_steps.rb
@@ -3,7 +3,7 @@ Then(/^I can tag the edition to some policies$/) do
   check_edition_is_tagged_to_policies(edition: Publication.last, policies: [policy_1])
 end
 
-Then(/^I can tag the topic to some policies$/) do
+Then(/^I can tag the policy area to some policies$/) do
   tag_to_policies(policies: [policy_1])
   check_topic_is_tagged_to_policies(topic: Topic.last, policies: [policy_1])
 end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -13,17 +13,17 @@ Given /^a published document "([^"]*)" exists$/ do |title|
   create(:published_publication, title: title)
 end
 
-Given /^a draft (publication|news article|consultation) "([^"]*)" exists in the "([^"]*)" topic$/ do |document_type, title, topic_name|
+Given /^a draft (publication|news article|consultation) "([^"]*)" exists in the "([^"]*)" policy area$/ do |document_type, title, topic_name|
   topic = Topic.find_by!(name: topic_name)
   create("draft_#{document_class(document_type).name.underscore}".to_sym, title: title, topics: [topic])
 end
 
-Given /^a submitted (publication|news article|consultation|detailed guide) "([^"]*)" exists in the "([^"]*)" topic$/ do |document_type, title, topic_name|
+Given /^a submitted (publication|news article|consultation|detailed guide) "([^"]*)" exists in the "([^"]*)" policy area$/ do |document_type, title, topic_name|
   topic = Topic.find_by!(name: topic_name)
   create("submitted_#{document_class(document_type).name.underscore}".to_sym, title: title, topics: [topic])
 end
 
-Given /^a published (publication|news article|consultation) "([^"]*)" exists in the "([^"]*)" topic$/ do |document_type, title, topic_name|
+Given /^a published (publication|news article|consultation) "([^"]*)" exists in the "([^"]*)" policy area$/ do |document_type, title, topic_name|
   topic = Topic.find_by!(name: topic_name)
   create("published_#{document_class(document_type).name.underscore}".to_sym, title: title, topics: [topic])
 end
@@ -205,7 +205,7 @@ Then /^(#{THE_DOCUMENT}) should be visible to the public$/ do |edition|
   assert page.has_css?(record_css_selector(edition), text: edition.title)
 end
 
-Then /^I should see in the preview that "([^"]*)" should be in the "([^"]*)" and "([^"]*)" topics$/ do |title, first_topic, second_topic|
+Then /^I should see in the preview that "([^"]*)" should be in the "([^"]*)" and "([^"]*)" policy area$/ do |title, first_topic, second_topic|
   visit_document_preview title
   assert has_css?(".meta a", text: first_topic, exact: false)
   assert has_css?(".meta a", text: second_topic, exact: false)

--- a/features/step_definitions/filtering_featured_documents_on_a_topic_steps.rb
+++ b/features/step_definitions/filtering_featured_documents_on_a_topic_steps.rb
@@ -1,4 +1,4 @@
-Given(/^there is a topic with published documents$/) do
+Given(/^there is a policy area with published documents$/) do
   @topic = create(:topic, name: "A Topic")
   department = create(:ministerial_department, name: "A Department")
 
@@ -9,7 +9,7 @@ Given(/^there is a topic with published documents$/) do
   @news = create(:published_news_article, title: "News #2", topics: [@topic])
 end
 
-When(/^I view featured documents for that topic$/) do
+When(/^I view featured documents for that policy area$/) do
   visit admin_topic_classification_featurings_url(@topic)
   page.click_on "Reset all fields"
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -7,8 +7,8 @@ When(/^I (?:also )?filter by (only )?a publication type$/) do |only|
   select_filter "Publication type", "Guidance", !!only
 end
 
-When(/^I (?:also )?filter by (only )?a topic$/) do |only|
-  select_filter "Topic", "A Topic", !!only
+When(/^I (?:also )?filter by (only )?a policy area$/) do |only|
+  select_filter "Policy Area", "A Policy Area", !!only
 end
 
 When(/^I (?:also )?filter by (only )?a department$/) do |only|
@@ -31,13 +31,13 @@ end
 ### Publications
 
 Given(/^there are some published publications$/) do
-  topic = create :topic, name: "A Topic"
+  topic = create :topic, name: "A Policy Area"
   department = create(:ministerial_department, name: "A Department")
   world_location = create(:world_location, name: "A World Location")
 
   create :published_publication, title: "Publication with keyword"
   create :published_guidance, title: "Guidance publication"
-  create :published_publication, title: "Publication with the topic", topics: [topic]
+  create :published_publication, title: "Publication with the policy area", topics: [topic]
   create :published_publication, title: "Publication with the department and keyword", organisations: [department]
   create :published_publication, :with_command_paper, title: "Publication which is a command paper"
   create :published_publication, :with_act_paper, title: "Publication which is an act paper"
@@ -51,7 +51,7 @@ When(/^I visit the publications index page$/) do
   visit publications_path
 end
 
-Then(/^I should be able to filter publications by keyword, publication type, topic, department, official document status, world location, and publication date$/) do
+Then(/^I should be able to filter publications by keyword, publication type, policy area, department, official document status, world location, and publication date$/) do
   fill_in_filter "Contains", "keyword"
 
   assert_listed_document_count 2
@@ -68,10 +68,10 @@ Then(/^I should be able to filter publications by keyword, publication type, top
   assert_listed_document_count 1
   assert page.has_content? "Guidance publication"
 
-  select_filter "Topic", "A Topic", and_clear_others: true
+  select_filter "Policy Area", "A Policy Area", and_clear_others: true
   assert_listed_document_count 1
-  assert page.has_content? "Publication with the topic"
-  assert page.text.match /1 publication about A Topic ./
+  assert page.has_content? "Publication with the policy area"
+  assert page.text.match /1 publication about A Policy Area ./
 
   select_filter "Department", "A Department", and_clear_others: true
   assert_listed_document_count 1
@@ -130,16 +130,16 @@ end
 ### Announcements
 
 Given(/^there are some published announcements$/) do
-  topic = create :topic, name: "A Topic"
+  topic = create :topic, name: "A Policy Area"
   department = create(:ministerial_department, name: "A Department")
   world_location = create(:world_location, name: "A World Location")
 
-  create :published_news_story, title: "News Article with keyword, topic, department, world location published within date range",
+  create :published_news_story, title: "News Article with keyword, polic area, department, world location published within date range",
          first_published_at: "2013-02-01",
          topics: [topic],
          organisations: [department],
          world_locations: [world_location]
-  create :published_fatality_notice, title: "Fatality Notice with keyword, topic, department, world location published within date range",
+  create :published_fatality_notice, title: "Fatality Notice with keyword, policy area, department, world location published within date range",
          first_published_at: "2013-02-01",
          topics: [topic],
          organisations: [department],
@@ -149,7 +149,7 @@ Given(/^there are some published announcements$/) do
          topics: [topic],
          organisations: [department],
          world_locations: [world_location]
-  create :published_news_story, title: "News Article with keyword without topic",
+  create :published_news_story, title: "News Article with keyword without policy area",
          first_published_at: "2013-02-01",
          organisations: [department],
          world_locations: [world_location]
@@ -172,12 +172,12 @@ When(/^I visit the announcements index page$/) do
   visit announcements_path
 end
 
-Then(/^I should be able to filter announcements by keyword, announcement type, topic, department, world location and publication date$/) do
+Then(/^I should be able to filter announcements by keyword, announcement type, policy area, department, world location and publication date$/) do
   clear_filters
   within '#document-filter' do
     page.fill_in "Contains", with: "keyword"
     page.select "News stories", from: "Announcement type"
-    page.select "A Topic", from: "Topic"
+    page.select "A Policy Area", from: "Policy Area"
     page.select "A Department", from: "Department"
     page.select "A World Location", from: "World locations"
     page.fill_in "Published after", with: "01/01/2013"
@@ -186,8 +186,8 @@ Then(/^I should be able to filter announcements by keyword, announcement type, t
   page.click_on "Refresh results"
 
   assert_listed_document_count 1
-  assert page.has_content? "News Article with keyword, topic, department, world location published within date range"
-  assert page.text.match /1 announcement about A Topic . by A Department . from A World Location . containing keyword . published after 01\/01\/2013 published before 01\/03\/2013/
+  assert page.has_content? "News Article with keyword, policy area, department, world location published within date range"
+  assert page.text.match /1 announcement about A Policy Area . by A Department . from A World Location . containing keyword . published after 01\/01\/2013 published before 01\/03\/2013/
 end
 
 Given(/^there are some published announcments including a few in French$/) do

--- a/features/step_definitions/import_steps.rb
+++ b/features/step_definitions/import_steps.rb
@@ -1,4 +1,4 @@
-Given /^a (topic|mainstream category) with the slug "([^"]*)" exists$/ do |type, slug|
+Given /^a (policy area|mainstream category) with the slug "([^"]*)" exists$/ do |type, slug|
   o = create(type.parameterize.underscore)
   o.update_attributes!(slug: slug)
 end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -47,11 +47,11 @@ When /^I publish a news article "([^"]*)" associated with "([^"]*)"$/ do |title,
   publish(force: true)
 end
 
-When /^I publish a news article "([^"]*)" associated with the (topic|topical event) "([^"]*)"$/ do |title, type, topic_name|
+When /^I publish a news article "([^"]*)" associated with the (policy area|topical event) "([^"]*)"$/ do |title, type, topic_name|
   begin_drafting_news_article title: title, skip_topic_selection: (type == 'topic')
 
   if type == 'topic'
-    select topic_name, from: "Topics"
+    select topic_name, from: "Policy Areas"
   else
     select topic_name, from: "Topical events"
   end

--- a/features/step_definitions/statistics_announcement_steps.rb
+++ b/features/step_definitions/statistics_announcement_steps.rb
@@ -34,13 +34,13 @@ Given(/^there is a cancelled statistics announcement, originally due to be publi
                                      precision: StatisticsAnnouncementDate::PRECISION[:exact])
 end
 
-Given(/^there are some statistics announcements for various departments and topics$/) do
+Given(/^there are some statistics announcements for various departments and policy areas$/) do
   @department = create :ministerial_department
   @topic = create :topic
 
   create :statistics_announcement, title: "Announcement for both department and topic", organisation_ids: [@department.id], topics: [@topic]
   create :statistics_announcement, title: "Announcement for department", organisation_ids: [@department.id]
-  create :statistics_announcement, title: "Announcement for topic", topics: [@topic]
+  create :statistics_announcement, title: "Announcement for policy area", topics: [@topic]
 
 end
 
@@ -75,7 +75,7 @@ end
 When(/^I filter the statistics announcements by department and topic$/) do
   within '.filter-form' do
     select @department.name, from: "Department"
-    select @topic.name, from: "Topic"
+    select @topic.name, from: "Policy Area"
     click_on "Refresh results"
   end
 end
@@ -109,13 +109,13 @@ Then(/^I should only see statistics announcements for those filters$/) do
   assert_equal 1, page.all(".document-list .document-row").length
 end
 
-Then(/^I should only see statistics announcements for the selected departments and topics$/) do
-  assert page.has_content? "Announcement for both department and topic"
+Then(/^I should only see statistics announcements for the selected departments and policy areas$/) do
+  assert page.has_content? "Announcement for both department and policy area"
   assert page.has_no_content? "Announcement for department"
-  assert page.has_no_content? "Announcement for topic"
+  assert page.has_no_content? "Announcement for policy area"
 end
 
-Then(/^I should be on a page showing the title, release date, organisation, topic, summary and date change information of the release announcement$/) do
+Then(/^I should be on a page showing the title, release date, organisation, policy area, summary and date change information of the release announcement$/) do
   assert_equal statistics_announcement_path(@announcement), current_path
 
   assert page.has_content? @announcement.title

--- a/features/step_definitions/statistics_steps.rb
+++ b/features/step_definitions/statistics_steps.rb
@@ -61,7 +61,7 @@ When(/^I should only see statistics matching the given keyword, from date and to
   assert_equal 1, page.all(".document-list .document-row").length
 end
 
-Given(/^there are some statisics for various departments and topics$/) do
+Given(/^there are some statisics for various departments and policy areas$/) do
   beard_topic = create(:topic, name: 'Beards')
   wombat_topic = create(:topic, name: 'Wombats')
 
@@ -82,15 +82,15 @@ Given(/^there are some statisics for various departments and topics$/) do
 
 end
 
-When(/^I filter the statistics by department and topic$/) do
+When(/^I filter the statistics by department and policy area$/) do
   within '.filter-form' do
-    select "Beards", from: "Topic"
+    select "Beards", from: "Policy Area"
     select "Wombats of Wimbledon", from: "Department"
     click_on "Refresh results"
   end
 end
 
-Then(/^I should only see statistics for the selected departments and topics$/) do
+Then(/^I should only see statistics for the selected departments and policy areas$/) do
   within('.filter-results') do
     assert page.has_content? "Average beard lengths of wombat organisations"
     assert page.has_no_content? "2015 Average beard lengths figures"

--- a/features/step_definitions/topic_assigment_steps.rb
+++ b/features/step_definitions/topic_assigment_steps.rb
@@ -1,25 +1,25 @@
-Given(/^a publicationesque that can be assigned to policies and topics$/) do
+Given(/^a publicationesque that can be assigned to policies and policy areas$/) do
   @edition = create(:draft_publication)
   @topic = create(:topic)
 end
 
-When(/^I assign the publicationesque to a topic$/) do
+When(/^I assign the publicationesque to a policy area$/) do
   visit edit_admin_publication_path(@edition)
   select @topic.name, from: 'edition_topic_ids'
   click_button 'Save'
 end
 
-Then(/^the edition will be assigned to the topic$/) do
+Then(/^the edition will be assigned to the policy area$/) do
   assert @edition.topics.include?(@topic)
 end
 
-Given(/^an announcement that can be assigned to policies and topics$/) do
+Given(/^an announcement that can be assigned to policies and policy areas$/) do
   @edition = create(:draft_news_article)
   @topic = create(:topic)
   stub_content_register_policies
 end
 
-When(/^I assign the announcement to a policy with topics$/) do
+When(/^I assign the announcement to a policy with policy areas$/) do
   visit edit_admin_news_article_path(@edition)
   select "Policy 1", from: 'edition_policy_content_ids'
 end

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -1,42 +1,42 @@
-Given /^a topic called "([^"]*)" exists$/ do |name|
+Given /^a policy area called "([^"]*)" exists$/ do |name|
   @topic = create(:topic, name: name)
 end
 
-Given /^a topic called "([^"]*)" with description "([^"]*)"$/ do |name, description|
+Given /^a policy area called "([^"]*)" with description "([^"]*)"$/ do |name, description|
   create(:topic, name: name, description: description)
 end
 
-Given(/^the publication "(.*?)" is associated with the topic "(.*?)"$/) do |publication_name, topic_name|
+Given(/^the publication "(.*?)" is associated with the policy area "(.*?)"$/) do |publication_name, topic_name|
   publication = Publication.find_by!(title: publication_name)
   topic = Topic.find_by!(name: topic_name)
 
   publication.topics << topic
 end
 
-Given /^the topic "([^"]*)" is associated with organisation "([^"]*)"$/ do |topic_name, organisation_name|
+Given /^the policy area "([^"]*)" is associated with organisation "([^"]*)"$/ do |topic_name, organisation_name|
   topic = Topic.find_by(name: topic_name) || create(:topic, name: topic_name)
   organisation = Organisation.find_by(name: organisation_name) || create(:ministerial_department, name: organisation_name)
   organisation.topics << topic
 end
 
-Given /^the topic "([^"]*)" has "([^"]*)" as a lead organisation$/ do |topic_name, organisation_name|
+Given /^the policy area "([^"]*)" has "([^"]*)" as a lead organisation$/ do |topic_name, organisation_name|
   topic = Topic.find_by(name: topic_name) || create(:topic, name: topic_name)
   organisation = Organisation.find_by(name: organisation_name) || create(:ministerial_department, name: organisation_name)
   OrganisationClassification.create(topic: topic, organisation: organisation, lead: true)
 end
 
-Given /^two topics "([^"]*)" and "([^"]*)" exist$/ do |first_topic, second_topic|
+Given /^two policy areas "([^"]*)" and "([^"]*)" exist$/ do |first_topic, second_topic|
   create(:topic, name: first_topic)
   create(:topic, name: second_topic)
 end
 
-Given /^the topic "([^"]*)" is related to the topic "([^"]*)"$/ do |name, related_name|
+Given /^the policy area "([^"]*)" is related to the policy area "([^"]*)"$/ do |name, related_name|
   related_topic = create(:topic, name: related_name)
   topic = Topic.find_by(name: name)
   topic.update_attributes!(related_classifications: [related_topic])
 end
 
-Given(/^a (topic|topical event) called "(.*?)" exists with featured documents$/) do |type, name|
+Given(/^a (policy area|topical event) called "(.*?)" exists with featured documents$/) do |type, name|
   classification = if type == 'topic'
     create(:topic, name: name)
   else
@@ -46,34 +46,34 @@ Given(/^a (topic|topical event) called "(.*?)" exists with featured documents$/)
   create(:classification_featuring, classification: classification)
 end
 
-Given(/^I have an offsite link "(.*?)" for the topic "(.*?)"$/) do |title, topic_name|
+Given(/^I have an offsite link "(.*?)" for the policy area "(.*?)"$/) do |title, topic_name|
   topic = Topic.find_by(name: topic_name)
   @offsite_link = create :offsite_link, title: title, parent: topic
 end
 
-When /^I create a new topic "([^"]*)" with description "([^"]*)"$/ do |name, description|
+When /^I create a new policy area "([^"]*)" with description "([^"]*)"$/ do |name, description|
   create_topic(name: name, description: description)
 end
 
-When /^I create a new topic "([^"]*)" related to topic "([^"]*)"$/ do |name, related_name|
+When /^I create a new policy area "([^"]*)" related to policy area "([^"]*)"$/ do |name, related_name|
   create_topic(name: related_name)
   create_topic(name: name, related_classifications: [related_name])
 end
 
-When /^I edit the topic "([^"]*)" to have description "([^"]*)"$/ do |name, description|
+When /^I edit the policy area "([^"]*)" to have description "([^"]*)"$/ do |name, description|
   visit admin_root_path
-  click_link "Topics"
+  click_link "Policy Areas"
   click_link name
   click_on "Edit"
   fill_in "Description", with: description
   click_button "Save"
 end
 
-When /^I visit the list of topics$/ do
+When /^I visit the list of policy areas$/ do
   visit topics_path
 end
 
-When /^I visit the "([^"]*)" (topic|topical event)$/ do |name, type|
+When /^I visit the "([^"]*)" (policy area|topical event)$/ do |name, type|
   classification = if type == 'topic'
     Topic.find_by!(name: name)
   else
@@ -83,7 +83,7 @@ When /^I visit the "([^"]*)" (topic|topical event)$/ do |name, type|
   visit polymorphic_path(classification)
 end
 
-When /^I set the order of the policies in the "([^"]*)" topic to:$/ do |name, table|
+When /^I set the order of the policies in the "([^"]*)" policy area to:$/ do |name, table|
   topic = Topic.find_by!(name: name)
   visit edit_admin_topic_path(topic)
   table.rows.each_with_index do |(policy_name), index|
@@ -92,7 +92,7 @@ When /^I set the order of the policies in the "([^"]*)" topic to:$/ do |name, ta
   click_button "Save"
 end
 
-When /^I set the order of the lead organisations in the "([^"]*)" topic to:$/ do |topic_name, table|
+When /^I set the order of the lead organisations in the "([^"]*)" policy area to:$/ do |topic_name, table|
   topic = Topic.find_by!(name: topic_name)
   visit edit_admin_topic_path(topic)
 
@@ -109,27 +109,27 @@ When /^I set the order of the lead organisations in the "([^"]*)" topic to:$/ do
   click_button "Save"
 end
 
-Then /^I should see in the admin the "([^"]*)" topic description is "([^"]*)"$/ do |name, description|
+Then /^I should see in the admin the "([^"]*)" policy area description is "([^"]*)"$/ do |name, description|
   visit admin_topics_path
   assert page.has_css?(".name", text: name)
   assert page.has_css?(".description", text: description)
 end
 
-Then /^I should see in the admin the "([^"]*)" topic is related to topic "([^"]*)"$/ do |name, related_name|
+Then /^I should see in the admin the "([^"]*)" policy area is related to policy area "([^"]*)"$/ do |name, related_name|
   visit admin_topics_path
   topic = Topic.find_by(name: name)
   related_topic = Topic.find_by(name: related_name)
   assert page.has_css?("#{record_css_selector(topic)} .related #{record_css_selector(related_topic)}")
 end
 
-Then /^I should be able to delete the topic "([^"]*)"$/ do |name|
+Then /^I should be able to delete the policy area "([^"]*)"$/ do |name|
   visit admin_topics_path
   click_link name
   click_on 'Edit'
   click_button 'Delete'
 end
 
-Then /^I should see the order of the policies in the "([^"]*)" topic is:$/ do |name, expected_table|
+Then /^I should see the order of the policies in the "([^"]*)" policy area is:$/ do |name, expected_table|
   topic = Topic.find_by!(name: name)
   visit topic_path(topic)
   rows = find("#policies").all('h2')
@@ -137,7 +137,7 @@ Then /^I should see the order of the policies in the "([^"]*)" topic is:$/ do |n
   expected_table.diff!(table)
 end
 
-Then /^I should see the order of the lead organisations in the "([^"]*)" topic is:$/ do |topic_name, expected_table|
+Then /^I should see the order of the lead organisations in the "([^"]*)" policy area is:$/ do |topic_name, expected_table|
   topic = Topic.find_by!(name: topic_name)
   visit edit_admin_topic_path(topic)
   rows = find("#lead_organisation_order").all(:xpath, './/label[./a]')
@@ -145,7 +145,7 @@ Then /^I should see the order of the lead organisations in the "([^"]*)" topic i
   expected_table.diff!(table)
 end
 
-Then /^I should see the following organisations for the "([^"]*)" topic:$/ do |topic_name, expected_table|
+Then /^I should see the following organisations for the "([^"]*)" policy area:$/ do |topic_name, expected_table|
   topic = Topic.find_by!(name: topic_name)
   visit edit_admin_topic_path(topic)
   rows = find("#organisations").all(:xpath, './/label[./a]')
@@ -153,19 +153,19 @@ Then /^I should see the following organisations for the "([^"]*)" topic:$/ do |t
   expected_table.diff!(table)
 end
 
-Then /^I should see the topics "([^"]*)" and "([^"]*)"$/ do |first_topic_name, second_topic_name|
+Then /^I should see the policy areas "([^"]*)" and "([^"]*)"$/ do |first_topic_name, second_topic_name|
   first_topic = Topic.find_by!(name: first_topic_name)
   second_topic = Topic.find_by!(name: second_topic_name)
   assert page.has_css?(record_css_selector(first_topic), text: first_topic_name)
   assert page.has_css?(record_css_selector(second_topic), text: second_topic_name)
 end
 
-Then /^I should see a link to the related topic "([^"]*)"$/ do |related_name|
+Then /^I should see a link to the related policy area "([^"]*)"$/ do |related_name|
   related_topic = Topic.find_by(name: related_name)
   assert page.has_css?(".related-topics a[href='#{topic_path(related_topic)}']", text: related_name)
 end
 
-When(/^I feature the publication "([^"]*)" on the topic "([^"]*)"$/) do |publication_name, topic_name|
+When(/^I feature the publication "([^"]*)" on the policy area "([^"]*)"$/) do |publication_name, topic_name|
   publication = Publication.find_by!(title: publication_name)
   topic = Topic.find_by!(name: topic_name)
 
@@ -180,7 +180,7 @@ When(/^I feature the publication "([^"]*)" on the topic "([^"]*)"$/) do |publica
   click_button "Save"
 end
 
-When(/^I add the offsite link "(.*?)" of type "(.*?)" to the topic "(.*?)"$/) do |title, type, topic_name|
+When(/^I add the offsite link "(.*?)" of type "(.*?)" to the policy area "(.*?)"$/) do |title, type, topic_name|
   topic = Topic.find_by!(name: topic_name)
   visit admin_topic_classification_featurings_path(topic)
   click_link "Create an offsite link"
@@ -191,7 +191,7 @@ When(/^I add the offsite link "(.*?)" of type "(.*?)" to the topic "(.*?)"$/) do
   click_button "Save"
 end
 
-When(/^I feature the offsite link "(.*?)" for topic "(.*?)" with image "(.*?)"$/) do |offsite_link_title, topic_name, image_filename|
+When(/^I feature the offsite link "(.*?)" for policy area "(.*?)" with image "(.*?)"$/) do |offsite_link_title, topic_name, image_filename|
   topic = Topic.find_by!(name: topic_name)
   visit admin_topic_classification_featurings_path(topic)
   @offsite_link = OffsiteLink.find_by(title: offsite_link_title)
@@ -203,7 +203,7 @@ When(/^I feature the offsite link "(.*?)" for topic "(.*?)" with image "(.*?)"$/
   click_button "Save"
 end
 
-Then(/^I should see the publication "([^"]*)" featured on the public topic page for "([^"]*)"$/) do |publication_name, topic_name|
+Then(/^I should see the publication "([^"]*)" featured on the public policy area page for "([^"]*)"$/) do |publication_name, topic_name|
   publication = Publication.find_by!(title: publication_name)
   topic = Topic.find_by!(name: topic_name)
 
@@ -214,14 +214,14 @@ Then(/^I should see the publication "([^"]*)" featured on the public topic page 
   end
 end
 
-Then(/^I should see the offsite link featured on the public topic page$/) do
+Then(/^I should see the offsite link featured on the public policy area page$/) do
   visit topic_path(@topic)
   within('section.featured-news') do
     assert page.has_content?(@offsite_link.title)
   end
 end
 
-When /^I add some featured links to the topic "([^"]*)" via the admin$/ do |topic_name|
+When /^I add some featured links to the policy area "([^"]*)" via the admin$/ do |topic_name|
   topic = Topic.find_by!(name: topic_name)
   visit admin_topic_path(topic)
   click_link "Edit"
@@ -232,20 +232,20 @@ When /^I add some featured links to the topic "([^"]*)" via the admin$/ do |topi
   click_button "Save"
 end
 
-Then /^the featured links for the topic "([^"]*)" should be visible on the public site$/ do |topic_name|
+Then /^the featured links for the policy area "([^"]*)" should be visible on the public site$/ do |topic_name|
   visit_topic topic_name
   within ".featured-links" do
     assert page.has_css?("a[href='https://www.gov.uk/mainstream/tool-alpha']", "Tool Alpha")
   end
 end
 
-Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" topic page$/) do |title, topic_name|
+Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" policy area page$/) do |title, topic_name|
   topic = Topic.find_by!(name: topic_name)
   offsite_link = OffsiteLink.find_by!(title: title)
   visit admin_topic_path(topic)
   page.has_link?(title, href: edit_admin_topic_offsite_link_path(topic.id, offsite_link.id))
 end
 
-When(/^I start creating a topic$/) do
+When(/^I start creating a policy area$/) do
   start_creating_topic
 end

--- a/features/support/filtering_documents_helper.rb
+++ b/features/support/filtering_documents_helper.rb
@@ -27,7 +27,7 @@ module FilteringDocumentsHelper
     within '#document-filter' do
       page.fill_in "Contains", with: ""
       page.select "All publication types", from: "Publication type" if page.has_selector?('label', text: "Publication type", wait: false)
-      page.select "All topics", from: "Topic"
+      page.select "All policy areas", from: "Policy Area"
       page.select "All departments", from: "Department"
       page.select "All documents", from: "Official document status" if page.has_selector?('label', text: "Official document status", wait: false)
       page.select "All locations", from: "World locations"

--- a/features/support/topics_helper.rb
+++ b/features/support/topics_helper.rb
@@ -7,11 +7,11 @@ module TopicsHelper
   def start_creating_topic(options = {})
     visit admin_root_path
     click_link "Policy Areas"
-    click_link "Create topic"
+    click_link "Create policy area"
     fill_in "Name", with: options[:name] || "topic-name"
     fill_in "Description", with: options[:description] || "topic-description"
     (options[:related_classifications] || []).each do |related_name|
-      select related_name, from: "Related topics"
+      select related_name, from: "Related policy areas"
     end
   end
 end

--- a/features/support/topics_helper.rb
+++ b/features/support/topics_helper.rb
@@ -6,7 +6,7 @@ module TopicsHelper
 
   def start_creating_topic(options = {})
     visit admin_root_path
-    click_link "Topics"
+    click_link "Policy Areas"
     click_link "Create topic"
     fill_in "Name", with: options[:name] || "topic-name"
     fill_in "Description", with: options[:description] || "topic-description"

--- a/features/topic-assigment.feature
+++ b/features/topic-assigment.feature
@@ -1,10 +1,10 @@
-Feature: Assigning editions to topics, via policies
+Feature: Assigning editions to policy areas, via policies
 
   Background:
     Given I am a GDS editor
 
   @javascript
-  Scenario: Editions can be assigned directly to topics
-    Given a publicationesque that can be assigned to policies and topics
-    When I assign the publicationesque to a topic
-    Then the edition will be assigned to the topic
+  Scenario: Editions can be assigned directly to policy areas
+    Given a publicationesque that can be assigned to policies and policy areas
+    When I assign the publicationesque to a policy area
+    Then the edition will be assigned to the policy area

--- a/features/topics.feature
+++ b/features/topics.feature
@@ -1,79 +1,79 @@
-Feature: Topics
+Feature: Policy Areas
 
   As an editor
-  I want to be able to edit the description text of a topic
+  I want to be able to edit the description text of a policy area
   So that it best represents the policies that it gathers
 
 Background:
   Given I am an editor
 
-Scenario: Adding a new topic
-  When I create a new topic "Flying monkeys" with description "Fly my pretties!"
-  Then I should see in the admin the "Flying monkeys" topic description is "Fly my pretties!"
+Scenario: Adding a new policy area
+  When I create a new policy area "Flying monkeys" with description "Fly my pretties!"
+  Then I should see in the admin the "Flying monkeys" policy area description is "Fly my pretties!"
 
-Scenario: Adding a new topic related to another topic
-  When I create a new topic "Flying monkeys" related to topic "No more beards"
-  Then I should see in the admin the "Flying monkeys" topic is related to topic "No more beards"
+Scenario: Adding a new policy area related to another policy area
+  When I create a new policy area "Flying monkeys" related to policy area "No more beards"
+  Then I should see in the admin the "Flying monkeys" policy area is related to policy area "No more beards"
 
 Scenario: Editing the description
-  Given a topic called "No more beards" with description "No more hairy-faced men"
-  When I edit the topic "No more beards" to have description "No more hairy-faced people"
-  Then I should see in the admin the "No more beards" topic description is "No more hairy-faced people"
+  Given a policy area called "No more beards" with description "No more hairy-faced men"
+  When I edit the policy area "No more beards" to have description "No more hairy-faced people"
+  Then I should see in the admin the "No more beards" policy area description is "No more hairy-faced people"
 
-Scenario: Deleting a topic
-  Given a topic called "No more beards" with description "No more hairy-faced men"
-  Then I should be able to delete the topic "No more beards"
+Scenario: Deleting a policy area
+  Given a policy area called "No more beards" with description "No more hairy-faced men"
+  Then I should be able to delete the policy area "No more beards"
 
-Scenario: Choosing and ordering lead organisations within a topic
-  Given a topic called "Facial Hair" with description "Against All Follicles"
-  And the topic "Facial Hair" has "Ministry of Grooming" as a lead organisation
-  And the topic "Facial Hair" has "Ministry of War" as a lead organisation
-  And the topic "Facial Hair" is associated with organisation "Department of Scissors and Wax"
-  And the topic "Facial Hair" is associated with organisation "Ministry of Sideburns"
-  When I set the order of the lead organisations in the "Facial Hair" topic to:
+Scenario: Choosing and ordering lead organisations within a policy area
+  Given a policy area called "Facial Hair" with description "Against All Follicles"
+  And the policy area "Facial Hair" has "Ministry of Grooming" as a lead organisation
+  And the policy area "Facial Hair" has "Ministry of War" as a lead organisation
+  And the policy area "Facial Hair" is associated with organisation "Department of Scissors and Wax"
+  And the policy area "Facial Hair" is associated with organisation "Ministry of Sideburns"
+  When I set the order of the lead organisations in the "Facial Hair" policy area to:
     |Organisation|
     |Ministry of Sideburns|
     |Department of Scissors and Wax|
     |Ministry of Grooming|
-  Then I should see the order of the lead organisations in the "Facial Hair" topic is:
+  Then I should see the order of the lead organisations in the "Facial Hair" policy area is:
     |Ministry of Sideburns|
     |Department of Scissors and Wax|
     |Ministry of Grooming|
-  And I should see the following organisations for the "Facial Hair" topic:
+  And I should see the following organisations for the "Facial Hair" policy area:
     |Ministry of War|
 
-Scenario: Viewing the list of topics
-  Given a topic called "Higher Education" exists
-  And a topic called "Science and Innovation" exists
-  When I visit the list of topics
-  Then I should see the topics "Higher Education" and "Science and Innovation"
+Scenario: Viewing the list of policy areas
+  Given a policy area called "Higher Education" exists
+  And a policy area called "Science and Innovation" exists
+  When I visit the list of policy areas
+  Then I should see the policy areas "Higher Education" and "Science and Innovation"
 
-Scenario: Visiting a topic page
-  Given a topic called "Higher Education" exists
-  And a topic called "Science and Innovation" exists
-  And the topic "Higher Education" is related to the topic "Scientific Research"
-  When I visit the "Higher Education" topic
-  Then I should see a link to the related topic "Scientific Research"
+Scenario: Visiting a policy area page
+  Given a policy area called "Higher Education" exists
+  And a policy area called "Science and Innovation" exists
+  And the policy area "Higher Education" is related to the policy area "Scientific Research"
+  When I visit the "Higher Education" policy area
+  Then I should see a link to the related policy area "Scientific Research"
 
-Scenario: Featuring content on a topic page
+Scenario: Featuring content on a policy area page
   Given a published publication "Cold fusion" with a PDF attachment
-  And a topic called "Science and Innovation" exists
-  And the publication "Cold fusion" is associated with the topic "Science and Innovation"
-  When I feature the publication "Cold fusion" on the topic "Science and Innovation"
-  Then I should see the publication "Cold fusion" featured on the public topic page for "Science and Innovation"
+  And a policy area called "Science and Innovation" exists
+  And the publication "Cold fusion" is associated with the policy area "Science and Innovation"
+  When I feature the publication "Cold fusion" on the policy area "Science and Innovation"
+  Then I should see the publication "Cold fusion" featured on the public policy area page for "Science and Innovation"
 
-Scenario: Creating offsite content on a topic page
-  Given a topic called "Excellent Topic" exists
-  When I add the offsite link "Offsite Thing" of type "Alert" to the topic "Excellent Topic"
-  Then I should see the edit offsite link "Offsite Thing" on the "Excellent Topic" topic page
+Scenario: Creating offsite content on a policy area page
+  Given a policy area called "Excellent policy area" exists
+  When I add the offsite link "Offsite Thing" of type "Alert" to the policy area "Excellent policy area"
+  Then I should see the edit offsite link "Offsite Thing" on the "Excellent policy area" policy area page
 
-Scenario: Featuring offsite content on a topic page
-  Given a topic called "Excellent Topic" exists
-  And I have an offsite link "Offsite Thing" for the topic "Excellent Topic"
-  When I feature the offsite link "Offsite Thing" for topic "Excellent Topic" with image "minister-of-funk.960x640.jpg"
-  Then I should see the offsite link featured on the public topic page
+Scenario: Featuring offsite content on a policy area page
+  Given a policy area called "Excellent policy area" exists
+  And I have an offsite link "Offsite Thing" for the policy area "Excellent policy area"
+  When I feature the offsite link "Offsite Thing" for policy area "Excellent policy area" with image "minister-of-funk.960x640.jpg"
+  Then I should see the offsite link featured on the public policy area page
 
 Scenario: Adding featured links
-  Given a topic called "Housing prices" exists
-  When I add some featured links to the topic "Housing prices" via the admin
-  Then the featured links for the topic "Housing prices" should be visible on the public site
+  Given a policy area called "Housing prices" exists
+  When I add some featured links to the policy area "Housing prices" via the admin
+  Then the featured links for the policy area "Housing prices" should be visible on the public site

--- a/lib/data_hygiene/tag_changes_processor.rb
+++ b/lib/data_hygiene/tag_changes_processor.rb
@@ -44,7 +44,7 @@ private
     tagging.destroy
 
     add_editorial_remark(edition,
-      "Bulk retagging from topic '#{@source_topic_id}' to '#{@destination_topic_id}' resulted in duplicate tag - removed it"
+      "Bulk retagging from policy area '#{@source_topic_id}' to '#{@destination_topic_id}' resulted in duplicate tag - removed it"
     )
   end
 
@@ -55,7 +55,7 @@ private
     tagging.save!
 
     add_editorial_remark(edition,
-      "Bulk retagging from topic '#{@source_topic_id}' to '#{@destination_topic_id}' changed tag"
+      "Bulk retagging from policy area '#{@source_topic_id}' to '#{@destination_topic_id}' changed tag"
     )
   end
 

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -44,7 +44,7 @@ task :specialist_sector_cleanup => :environment do
   end
 end
 
-desc "Export csv for topic retagging"
+desc "Export csv for policy area retagging"
 task topic_retagging_csv_export: :environment do
   require "data_hygiene/tag_changes_exporter"
 
@@ -80,7 +80,7 @@ task topic_retagging_csv_export: :environment do
   TagChangesExporter.new(csv_location, source_topic_id, destination_topic_id).export
 end
 
-desc "Process csv for topic retagging"
+desc "Process csv for policy area retagging"
 task process_topic_retagging_csv: :environment do
   require "data_hygiene/tag_changes_processor"
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -86,7 +86,7 @@ namespace :export do
         "People",
         "Document collections",
         "Policies",
-        "Topics",
+        "Policy areas",
         "Topical events"
       ]
 

--- a/test/functional/admin/policies_controller_test.rb
+++ b/test/functional/admin/policies_controller_test.rb
@@ -5,7 +5,7 @@ class Admin::PoliciesControllerTest < ActionController::TestCase
     login_as :writer
   end
 
-  view_test "topics returns list of the policy's topics when JSON requested" do
+  view_test "policy areas returns list of the policy's topics when JSON requested" do
     topics = [create(:topic), create(:topic)]
     policy_content_id = 'asfd-asdf-asdf-asdf'
     create(:classification_policy, policy_content_id: policy_content_id, classification: topics.first)

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   ### Describing :show ###
 
-  view_test "GET :show lists the topic's details" do
+  view_test "GET :show lists the policy area's details" do
     topic = create(:topic)
     get :show, id: topic
 
@@ -39,7 +39,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   ### Describing :create ###
 
-  test "POST :create creates a new topic" do
+  test "POST :create creates a new policy area" do
     first_topic = create(:topic)
     second_topic = create(:topic)
     attributes = attributes_for(:topic)
@@ -75,7 +75,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   ### Describing :update ###
 
-  test "PUT :update saves changes to the topic and redirects" do
+  test "PUT :update saves changes to the policy area and redirects" do
     topic = create(:topic)
 
     put :update, id: topic, topic: {
@@ -110,7 +110,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   ### Describing :destroy ###
 
-  test "DELETE :destroy deletes a deletable topic" do
+  test "DELETE :destroy deletes a deletable policy area" do
     topic = create(:topic)
     delete :destroy, id: topic.id
 
@@ -118,11 +118,11 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     assert topic.reload.deleted?
   end
 
-  test "DELETE :destroy does not delete topics with associated content" do
+  test "DELETE :destroy does not delete policy areas with associated content" do
     topic = create(:topic, policy_content_ids: [policy_1["content_id"]])
 
     delete :destroy, id: topic
-    assert_equal "Cannot destroy Topic with associated content", flash[:alert]
+    assert_equal "Cannot destroy Policy Area with associated content", flash[:alert]
     refute topic.reload.deleted?
   end
 end

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -222,7 +222,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "index requested as JSON includes email signup path with organisation and topic parameters" do
+  view_test "index requested as JSON includes email signup path with organisation and policy area parameters" do
     topic = create(:topic)
     organisation = create(:organisation)
 

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -5,7 +5,7 @@ class TopicsControllerTest < ActionController::TestCase
 
   should_be_a_public_facing_controller
 
-  view_test "GET :shows lists the topic details, setting the expiry headers based on the scheduled editions" do
+  view_test "GET :shows lists the policy area details, setting the expiry headers based on the scheduled editions" do
     organisation_1 = create(:organisation)
     organisation_2 = create(:organisation)
     publication = create(:draft_publication, :scheduled)

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -791,7 +791,7 @@ module AdminEditionControllerTestHelpers
         }
 
         assert_select ".document.conflict" do
-          assert_select "h1", "Topics"
+          assert_select "h1", "Policy Areas"
           assert_select record_css_selector(topic)
         end
       end

--- a/test/unit/classification_relation_test.rb
+++ b/test/unit/classification_relation_test.rb
@@ -1,17 +1,17 @@
 require 'test_helper'
 
 class ClassificationRelationTest < ActiveSupport::TestCase
-  test "should be invalid without a topic id" do
+  test "should be invalid without a policy area id" do
     classification_relation = build(:classification_relation, classification_id: nil)
     refute classification_relation.valid?
   end
 
-  test "should be invalid without a related topic id" do
+  test "should be invalid without a related policy area id" do
     classification_relation = build(:classification_relation, related_classification_id: nil)
     refute classification_relation.valid?
   end
 
-  test "should be invalid if more than one relation exists from one topic to another" do
+  test "should be invalid if more than one relation exists from one policy area to another" do
     existing_relation = create(:classification_relation)
     relation = build(:classification_relation,
       topic: existing_relation.topic,
@@ -20,21 +20,21 @@ class ClassificationRelationTest < ActiveSupport::TestCase
     refute relation.valid?
   end
 
-  test "should be valid if one topic is related to two others" do
+  test "should be valid if one policy area is related to two others" do
     topic = create(:topic)
     existing_relation = create(:classification_relation, topic: topic)
     relation = build(:classification_relation, topic: topic)
     assert relation.valid?
   end
 
-  test "should be valid if one topic is related from two others" do
+  test "should be valid if one policy area is related from two others" do
     topic = create(:topic)
     existing_relation = create(:classification_relation, related_topic: topic)
     relation = build(:classification_relation, related_topic: topic)
     assert relation.valid?
   end
 
-  test "should be invalid if a topic is related to itself" do
+  test "should be invalid if a policy area is related to itself" do
     topic = create(:topic)
     relation = build(:classification_relation, topic: topic, related_topic: topic)
     refute relation.valid?

--- a/test/unit/edition/topics_test.rb
+++ b/test/unit/edition/topics_test.rb
@@ -16,21 +16,21 @@ class Edition::TopicsTest < ActiveSupport::TestCase
     refute ClassificationMembership.exists?(relation.id)
   end
 
-  test "new edition of document that is a member of a topic should remain a member of that topic" do
+  test "new edition of document that is a member of a policy area should remain a member of that policy area" do
     edition = create(:published_publication, topics: [@topic])
     new_edition = edition.create_draft(create(:writer))
 
     assert_equal [@topic], new_edition.topics
   end
 
-  test "edition should be invalid without a topic" do
+  test "edition should be invalid without a policy area" do
     edition = EditionWithTopics.new(attributes_for_edition)
 
     refute edition.valid?, "Edition should not be valid"
     assert_match /at least one required/, edition.errors[:topics].first
   end
 
-  test "imported editions are valid without any topics" do
+  test "imported editions are valid without any policy areas" do
     edition = EditionWithTopics.new(attributes_for_edition.merge(state: 'imported'))
 
     assert edition.valid?

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -138,7 +138,7 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil Edition.scheduled_for_publication_as('unknown')
   end
 
-  test "should return a list of editions in a topic" do
+  test "should return a list of editions in a policy area" do
     topic_1 = create(:topic)
     topic_2 = create(:topic)
     draft_publication = create(:draft_publication, topics: [topic_1])

--- a/test/unit/email_signup_test.rb
+++ b/test/unit/email_signup_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class EmailSignupTest < ActiveSupport::TestCase
-  test "#save ensures that a relevant topic exists in GovDelivery using the feed and the signup description" do
+  test "#save ensures that a relevant policy area exists in GovDelivery using the feed and the signup description" do
     email_signup = EmailSignup.new(feed: feed_url)
 
     Whitehall.govuk_delivery_client.expects(:topic).with(feed_url, email_signup.description)

--- a/test/unit/import_test.rb
+++ b/test/unit/import_test.rb
@@ -152,7 +152,7 @@ class ImportTest < ActiveSupport::TestCase
     end
   end
 
-  test '#perform assigns topics to the document' do
+  test '#perform assigns policy areas to the document' do
     topic = create(:topic)
     data = publication_csv_sample('topic_1' => topic.slug)
 

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -8,7 +8,7 @@ class LatestDocumentsFilterTest < ActiveSupport::TestCase
     end
   end
 
-  test '.for_subject should return an instance of ClassificationFilter for a topic' do
+  test '.for_subject should return an instance of ClassificationFilter for a policy area' do
     topic = create(:topic)
     filter = LatestDocumentsFilter.for_subject(topic)
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -517,7 +517,7 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal 0, EditionOrganisation.count
   end
 
-  test 'destroy removes topic relationships' do
+  test 'destroy removes policy area relationships' do
     organisation = create(:organisation)
     topic = create(:topic)
     topic.organisations << organisation
@@ -628,7 +628,7 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal "FOO123", organisation.reload.analytics_identifier
   end
 
-  test "topics are explicitly ordered" do
+  test "policy areas are explicitly ordered" do
     topics = [create(:topic), create(:topic)]
     organisation = create(:organisation)
     organisation.organisation_classifications.create(classification_id: topics[0].id, ordering: 2)

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -23,7 +23,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal 'beard-statistics-2015', announcement.slug
   end
 
-  test 'must have at least one topic' do
+  test 'must have at least one policy area' do
     announcement = build(:statistics_announcement, topics: [])
     refute announcement.valid?
   end
@@ -209,7 +209,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     end
   end
 
-  test '#destroy destroys topic associations' do
+  test '#destroy destroys policy area associations' do
     statistics_announcement = create(:statistics_announcement)
     assert_difference %w(StatisticsAnnouncement.count StatisticsAnnouncementTopic.count), -1 do
       statistics_announcement.destroy

--- a/test/unit/topic_test.rb
+++ b/test/unit/topic_test.rb
@@ -7,7 +7,7 @@ class TopicTest < ActiveSupport::TestCase
     stub_content_register_policies
   end
 
-  test "should set a slug from the topic name" do
+  test "should set a slug from the policy area name" do
     topic = create(:topic, name: 'Love all the people')
     assert_equal 'love-all-the-people', topic.slug
   end
@@ -34,7 +34,7 @@ class TopicTest < ActiveSupport::TestCase
     refute topic.deleted?
   end
 
-  test "return topics bi-directionally related to specific topic" do
+  test "return topics bi-directionally related to specific policy area" do
     topic_1 = create(:topic)
     topic_2 = create(:topic)
     topic = build(:topic, related_classifications: [topic_1, topic_2])

--- a/test/unit/uploader/finders/slugged_model_finder_test.rb
+++ b/test/unit/uploader/finders/slugged_model_finder_test.rb
@@ -11,7 +11,7 @@ class Whitehall::Uploader::Finders::SluggedModelFinderTest < ActiveSupport::Test
     @finder = Whitehall::Uploader::Finders::SluggedModelFinder.new(@model_class, @log, @line_number)
   end
 
-  test "returns the topics by slug" do
+  test "returns the policy areas by slug" do
     assert_equal [@model_instance_1], @finder.find(["slug-1"])
   end
 
@@ -23,16 +23,16 @@ class Whitehall::Uploader::Finders::SluggedModelFinderTest < ActiveSupport::Test
     assert_equal [], @finder.find(['', ''])
   end
 
-  test "returns an empty array if a topic can't be found for the given slug" do
+  test "returns an empty array if a policy area can't be found for the given slug" do
     assert_equal [], @finder.find(['made-up-policy-slug'])
   end
 
-  test "logs an error if a topic can't be found for the given slug" do
+  test "logs an error if a policy area can't be found for the given slug" do
     @log.expects(:error).with(%q{Unable to find Model Class with slug 'made-up-slug'}, @line_number)
     @finder.find(['made-up-slug'])
   end
 
-  test "returns an empty array if the topic for the given slug that cannot be found" do
+  test "returns an empty array if the policy area for the given slug that cannot be found" do
     assert_equal [], @finder.find(['made-up-policy-slug'])
   end
 

--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -38,7 +38,7 @@ module Whitehall
         assert_equal "All locations", filter_options.label_for("world_locations", "all")
       end
 
-      test '#label_for downcases topics' do
+      test '#label_for downcases policy areas' do
         topic = create(:topic, name: "Example Topic", slug: "example-topic")
         topical_event = create(:topical_event, :active, name: "Example Topical Event", slug: "example-topical-event")
 
@@ -138,7 +138,7 @@ module Whitehall
         assert_equal [], options.ungrouped
       end
 
-      test "can get the list of options for topics" do
+      test "can get the list of options for policy areas" do
         topic = create(:topic)
         topical_event = create(:topical_event, :active)
 

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -84,7 +84,7 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     assert_equal organisation.name, validator.description
   end
 
-  test 'validates and describes a topic feed url' do
+  test 'validates and describes a policy area feed url' do
     topic     = create(:topic)
     feed_url  = atom_feed_maker.topic_url(topic)
     validator = FeedUrlValidator.new(feed_url)

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -193,7 +193,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     )
   end
 
-  test '#subscription_urls for an announcement returns an atom feed url that does not include departments or topics (with and without the publication_filter_option param)' do
+  test '#subscription_urls for an announcement returns an atom feed url that does not include departments or policy areas (with and without the publication_filter_option param)' do
     topic = create(:topic)
     organisation = create(:ministerial_department)
     @edition = create(:news_article, organisations: [organisation], news_article_type: NewsArticleType::PressRelease)
@@ -246,7 +246,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     )
   end
 
-  test '#subscription_urls for an edition related to topics includes the atom feed for both the generic feed and the specific topic feed' do
+  test '#subscription_urls for an edition related to policy areas includes the atom feed for both the generic feed and the specific policy area feed' do
     topic = create(:topic)
     @edition = create(:news_article, topics: [topic])
 


### PR DESCRIPTION
We are renaming the bits which say "topic" in the whitehall-admin to say "policy area".

This work needs to go in advance of renaming "specialist sector" to "topic" in whitehall-admin.

Needs coordination with comms and content team for deployment; also needs coordination with this zendesk ticket: https://govuk.zendesk.com/agent/tickets/1021549