### PR TITLE
Remove `edition_policy_groups` model.

### DIFF
--- a/app/models/edition_policy_group.rb
+++ b/app/models/edition_policy_group.rb
@@ -1,6 +1,0 @@
-class EditionPolicyGroup < ActiveRecord::Base
-  belongs_to :edition
-  belongs_to :policy_group
-
-  belongs_to :policy, class_name: 'Policy', foreign_key: :edition_id
-end

--- a/db/migrate/20150615080039_delete_policies_and_supporting_pages.rb
+++ b/db/migrate/20150615080039_delete_policies_and_supporting_pages.rb
@@ -16,7 +16,6 @@ class DeletePoliciesAndSupportingPages < ActiveRecord::Migration
       EditionDependency,
       EditionMainstreamCategory,
       EditionOrganisation,
-      EditionPolicyGroup,
       EditionRelation,
       EditionRoleAppointment,
       EditionStatisticalDataSet,


### PR DESCRIPTION
This is now handled in the policy publisher.