### PR TITLE
Let organisations feature policies on their homepages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -929,7 +929,9 @@
       }
     }
 
-    #what-we-do, #who-we-are {
+    #featured-policies,
+    #what-we-do,
+    #who-we-are {
       @include media(tablet) {
         width: $two-thirds;
         float: left;
@@ -943,6 +945,9 @@
           border-bottom: 1px solid $border-colour;
           padding: $gutter-one-sixth 0;
         }
+      }
+      .see-all {
+        margin-top: $gutter-one-third;
       }
     }
 

--- a/app/controllers/admin/featured_policies_controller.rb
+++ b/app/controllers/admin/featured_policies_controller.rb
@@ -1,0 +1,32 @@
+class Admin::FeaturedPoliciesController < Admin::BaseController
+  before_filter :load_organisation
+
+  def index
+    @featured_policies = @organisation.featured_policies.order(:ordering)
+    @policies = Policy.all.sort_by(&:title)
+  end
+
+  def create
+    featured_policy = @organisation.featured_policies.build(policy_content_id: params[:policy_content_id])
+    featured_policy.save!
+    redirect_to admin_organisation_featured_policies_path(@organisation), notice: 'Policy featured'
+  end
+
+  def destroy
+    featured_policy = @organisation.featured_policies.find(params[:id])
+    featured_policy.destroy!
+    redirect_to admin_organisation_featured_policies_path(@organisation), notice: "'#{featured_policy.title}' unfeatured"
+  end
+
+  def reorder
+    params[:ordering].each_pair do |featured_policy_id, order|
+      FeaturedPolicy.find(featured_policy_id).update_attributes(ordering: order)
+    end
+    redirect_to admin_organisation_featured_policies_path(@organisation), notice: 'Order updated'
+  end
+
+private
+  def load_organisation
+    @organisation = Organisation.friendly.find(params[:organisation_id])
+  end
+end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -40,7 +40,7 @@ class OrganisationsController < PublicFacingController
             @promotional_features = PromotionalFeaturesPresenter.new(@organisation.promotional_features, view_context)
             render 'show-promotional'
           else
-            @policies = policy_results
+            @policies = @organisation.featured_policies.order('ordering').limit(5)
             @topics = @organisation.topics
             @mainstream_categories = @organisation.mainstream_categories
             @ministers = ministers
@@ -65,15 +65,6 @@ class OrganisationsController < PublicFacingController
   end
 
 private
-
-  def policy_results
-    Whitehall.unified_search_client.unified_search(
-      filter_organisations: [@organisation.slug],
-      filter_format: "policy",
-      count: "3",
-      order: "-public_timestamp"
-    ).results
-  end
 
   def ministers
     @ministerial_roles ||= filled_roles_presenter_for(@organisation, :ministerial)

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -32,6 +32,7 @@ class OrganisationsController < PublicFacingController
         if @organisation.live?
           @recently_updated = recently_updated_source.with_translations(I18n.locale).limit(3)
           @feature_list = OrganisationFeatureListPresenter.new(@organisation, view_context)
+          @policies = @organisation.featured_policies.order('ordering').limit(5)
           set_meta_description(@organisation.summary)
 
           expire_on_next_scheduled_publication(@organisation.scheduled_editions)
@@ -40,7 +41,6 @@ class OrganisationsController < PublicFacingController
             @promotional_features = PromotionalFeaturesPresenter.new(@organisation.promotional_features, view_context)
             render 'show-promotional'
           else
-            @policies = @organisation.featured_policies.order('ordering').limit(5)
             @topics = @organisation.topics
             @mainstream_categories = @organisation.mainstream_categories
             @ministers = ministers

--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -34,7 +34,8 @@ module Admin::OrganisationHelper
       "Governance groups" => admin_organisation_groups_path(organisation),
       "People" => people_admin_organisation_path(organisation),
       "Translations" => admin_organisation_translations_path(organisation),
-      "Financial Reports" => admin_organisation_financial_reports_path(organisation)
+      "Financial Reports" => admin_organisation_financial_reports_path(organisation),
+      "Featured policies" => admin_organisation_featured_policies_path(organisation),
     }
     tabs
   end

--- a/app/models/featured_policy.rb
+++ b/app/models/featured_policy.rb
@@ -1,0 +1,28 @@
+class FeaturedPolicy < ActiveRecord::Base
+  extend ActiveSupport::Concern
+
+  belongs_to :organisation, inverse_of: :featured_policies
+
+  before_create :set_ordering, if: -> { ordering.blank? }
+
+  def set_ordering
+    self.ordering = next_ordering
+  end
+
+  def next_ordering
+    max = organisation.featured_policies.maximum(:ordering)
+    max ? max + 1 : 0
+  end
+
+  def title
+    policy.title
+  end
+
+  def link
+    policy.base_path
+  end
+
+  def policy
+    @policy ||= Policy.find(policy_content_id)
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -108,6 +108,8 @@ class Organisation < ActiveRecord::Base
 
   has_many :offsite_links, as: :parent
 
+  has_many :featured_policies
+
   # I'm trying to use a domain centric design rather than a persistence
   # centric design, so I do not want to expose a has_many :home_page_lists
   # and all that this implies. I really only want to expose a list of
@@ -139,6 +141,7 @@ class Organisation < ActiveRecord::Base
   accepts_nested_attributes_for :organisation_classifications, reject_if: -> attributes { attributes['classification_id'].blank? }, allow_destroy: true
   accepts_nested_attributes_for :organisation_mainstream_categories, reject_if: -> attributes { attributes['mainstream_category_id'].blank? }, allow_destroy: true
   accepts_nested_attributes_for :offsite_links
+  accepts_nested_attributes_for :featured_policies
 
   validates :slug, presence: true, uniqueness: true
   validates_with SafeHtmlValidator

--- a/app/views/admin/featured_policies/_feature_list.html.erb
+++ b/app/views/admin/featured_policies/_feature_list.html.erb
@@ -1,0 +1,36 @@
+<h2>Currently featured policies</h2>
+<p class="warning">
+  Warning: changes to features appear instantly on the live site.
+</p>
+
+<% if featured_policies.any? %>
+  <% if featured_policies.many? %>
+    <p>
+      To change the order of your featured policies, drag them up or down and then click "Save ordering". Only the top 5 policies will be shown on the site.
+    </p>
+  <% end %>
+  <%= form_for organisation, url: reorder_admin_organisation_featured_policies_path, method: :post do |form| %>
+    <fieldset class="sortable">
+      <% featured_policies.each do |featured_policy| %>
+        <div class="well feature-list">
+          <%= label_tag "ordering-#{featured_policy.id}" do %>
+            <div class="icon"><i class="icon-align-justify"></i></div>
+            <%= featured_policy.title %>
+            <div class="button">
+              <%= link_to(admin_organisation_featured_policy_path(organisation, featured_policy),
+                    data: { confirm: "Unfeature '#{featured_policy.title}'?" },
+                    method: :delete,
+                    class: "btn btn-danger") do %>
+                Unfeature <span class="visuallyhidden"><%= featured_policy.title %></span>
+              <% end %>
+            </div>
+          <% end %>
+          <%= text_field_tag "ordering[#{featured_policy.id}]", featured_policy.ordering, id: "ordering-#{featured_policy.id}", class: "ordering" %>
+        </div>
+      <% end %>
+    </fieldset>
+    <%= form.submit "Save ordering", class: "btn btn-primary btn-large" %>
+  <% end %>
+<% else %>
+  <p>Nothing featured yet</p>
+<% end %>

--- a/app/views/admin/featured_policies/_policy_list.html.erb
+++ b/app/views/admin/featured_policies/_policy_list.html.erb
@@ -1,0 +1,23 @@
+<h2>Policies available to feature</h2>
+<table class="table table-striped">
+  <thead>
+    <tr class="table-header">
+      <th>Title</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% policies.each do |policy| %>
+      <tr>
+        <td><%= policy.title %></td>
+        <td>
+          <%= button_to(admin_organisation_featured_policies_path(policy_content_id: policy.content_id),
+                method: :post,
+                class: 'btn') do %>
+            Feature <span class="visuallyhidden"><%= policy.title %></span>
+          <% end %>
+        </td>
+      <% end %>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/admin/featured_policies/index.html.erb
+++ b/app/views/admin/featured_policies/index.html.erb
@@ -1,0 +1,18 @@
+<% page_title @organisation.name %>
+<div class="row-fluid organisation-header">
+  <div class="span8">
+    <h1><%= @organisation.name %></h1>
+    <%= link_to "View on website", organisation_path(@organisation) %>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span12 organisation-details">
+    <section>
+      <%= tab_navigation_for(@organisation) do %>
+        <%= render 'feature_list', featured_policies: @featured_policies, organisation: @organisation %>
+        <%= render 'policy_list', policies: @policies %>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/organisations/show-promotional.html.erb
+++ b/app/views/organisations/show-promotional.html.erb
@@ -29,13 +29,25 @@
 
   <div class="block feature-block">
     <div class="inner-block floated-children">
-      <section id="what-we-do" class="promo">
-        <div class="content">
-          <h2>What we do</h2>
-          <p class="description"><%= @organisation.summary %></p>
-          <p><%= link_to t('organisation.about.read_more'), organisation_corporate_information_pages_path(@organisation), id: 'read_more_link' %></p>
-        </div>
-      </section>
+      <% if @policies.any? %>
+        <section id="featured-policies" class="promo">
+          <div class="content">
+            <h2>Featured policies</h2>
+            <%= render partial: "policies/document_list", locals: {policies: @policies} %>
+            <p class="see-all">
+              <%= link_to t_see_all_our(:policy), policies_finder_path(organisations: [@organisation]) %>
+            </p>
+          </div>
+        </section>
+      <% else %>
+        <section id="what-we-do" class="promo">
+          <div class="content">
+            <h2>What we do</h2>
+            <p class="description"><%= @organisation.summary %></p>
+            <p><%= link_to t('organisation.about.read_more'), organisation_corporate_information_pages_path(@organisation), id: 'read_more_link' %></p>
+          </div>
+        </section>
+      <% end %>
 
       <% if @organisation.social_media_accounts.any? %>
         <div class="social-media promo">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,9 @@ Whitehall::Application.routes.draw do
           end
           resources :financial_reports, except: [:show]
           resources :offsite_links
+          resources :featured_policies do
+            post :reorder, on: :collection
+          end
         end
         resources :corporate_information_pages, only: [] do
           resources :attachments, except: [:show] do

--- a/db/data_migration/20150624075140_populate_featured_policies.rb
+++ b/db/data_migration/20150624075140_populate_featured_policies.rb
@@ -1,0 +1,47 @@
+
+def policies_to_organisations(policies)
+  organisation_content_ids = policies.inject([]) do |memo, policy|
+    orgs = policy["links"]["organisations"]
+    if orgs
+      orgs.each do |org|
+        memo << org["content_id"]
+      end
+    end
+
+    memo
+  end
+  organisation_content_ids = organisation_content_ids.uniq
+
+  Organisation.where(content_id: organisation_content_ids)
+end
+
+def top_3_policy_results(organisation)
+  Whitehall.unified_search_client.unified_search(
+    filter_organisations: [organisation.slug],
+    filter_format: "policy",
+    count: "3",
+    order: "-public_timestamp"
+  ).results
+end
+
+def policy_content_id(policies, policy_link)
+  policy = policies.find do |policy|
+    policy["base_path"] == policy_link
+  end
+  policy["content_id"]
+end
+
+
+policies = Whitehall.content_register.entries("policy")
+
+policies_to_organisations(policies).each do |organisation|
+  org_policies = top_3_policy_results(organisation)
+
+  org_policies.each.with_index do |policy, index|
+    FeaturedPolicy.create(
+      organisation: organisation,
+      policy_content_id: policy_content_id(policies, policy.link),
+      ordering: index
+    )
+  end
+end

--- a/db/migrate/20150623085836_create_featured_policies.rb
+++ b/db/migrate/20150623085836_create_featured_policies.rb
@@ -1,0 +1,9 @@
+class CreateFeaturedPolicies < ActiveRecord::Migration
+  def change
+    create_table :featured_policies do |t|
+      t.string :policy_content_id
+      t.integer :ordering, null: false
+      t.references :organisation
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150623074259) do
+ActiveRecord::Schema.define(version: 20150623085836) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -523,6 +523,12 @@ ActiveRecord::Schema.define(version: 20150623074259) do
     t.string   "linkable_type", limit: 255
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+  end
+
+  create_table "featured_policies", force: :cascade do |t|
+    t.string  "policy_content_id", limit: 255
+    t.integer "ordering",          limit: 4,   null: false
+    t.integer "organisation_id",   limit: 4
   end
 
   create_table "features", force: :cascade do |t|

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -213,3 +213,27 @@ Scenario: Citizen views a closed organisation
   When I view the organisation
   Then I can see that the organisation is closed and has been superseded by the other
   And I can see the documents associated with that organisation
+
+Scenario: Featuring policies on an organisation
+  Given I am an editor in the organisation "Department of Fun"
+  And and the policies "Dance around" and "Sing aloud" exist
+  When I feature the policies "Dance around" and "Sing aloud" for "Department of Fun"
+  Then I should see the featured policies in the "Department of Fun" organisation are:
+    |Dance around|
+    |Sing aloud|
+  When I stop featuring the polices "Dance around" for "Department of Fun"
+  Then I should see the featured policies in the "Department of Fun" organisation are:
+    |Sing aloud|
+  When I stop featuring the polices "Sing aloud" for "Department of Fun"
+  Then there should be no featured policies on the home page of "Department of Fun"
+
+Scenario: Setting the order of policies featured on an organisation
+  Given I am an editor in the organisation "Department of Fun"
+  And and the policies "Dance around" and "Sing aloud" exist
+  When I feature the policies "Dance around" and "Sing aloud" for "Department of Fun"
+  And I order the featured policies in the "Department of Fun" organisation as:
+    |Sing aloud|
+    |Dance around|
+  Then I should see the featured policies in the "Department of Fun" organisation are:
+    |Sing aloud|
+    |Dance around|

--- a/features/step_definitions/organisation_policy_steps.rb
+++ b/features/step_definitions/organisation_policy_steps.rb
@@ -1,0 +1,28 @@
+Given /^and the policies "(.*?)" and "(.*?)" exist$/ do |policy_name_1, policy_name_2|
+  content_register_has_policies([policy_name_1, policy_name_2])
+end
+
+When /^I feature the policies "(.*?)" and "(.*?)" for "(.*?)"$/ do |policy_name_1, policy_name_2, organisation_name|
+  visit_organisation_featured_policies_admin organisation_name
+  feature_policies_on_organisation [policy_name_1, policy_name_2]
+end
+
+When(/^I stop featuring the polices "(.*?)" for "(.*?)"$/) do |policy_name, organisation_name|
+  visit_organisation_featured_policies_admin organisation_name
+  unfeature_organisation_policy(policy_name)
+end
+
+Then(/^there should be no featured policies on the home page of "(.*?)"$/) do |organisation_name|
+  visit_organisation organisation_name
+  check_no_featured_policies
+end
+
+When(/^I order the featured policies in the "(.*?)" organisation as:$/) do |organisation_name, table|
+  visit_organisation_featured_policies_admin organisation_name
+  order_features_from(table)
+end
+
+Then(/^I should see the featured policies in the "(.*?)" organisation are:$/) do |organisation_name, table|
+  visit_organisation organisation_name
+  check_policies_are_featured_in_order(table)
+end

--- a/features/support/organisation_helper.rb
+++ b/features/support/organisation_helper.rb
@@ -11,6 +11,26 @@ module OrganisationHelper
     fill_in "Logo formatted name", with: translation["logo formatted name"]
     click_on "Save"
   end
+
+  def feature_policies_on_organisation(policies)
+    policies.each do |policy|
+      click_button "Feature #{policy}"
+    end
+  end
+
+  def unfeature_organisation_policy(policy)
+    click_link "Unfeature #{policy}"
+  end
+
+  def check_no_featured_policies
+    refute page.has_css?("#policies")
+  end
+
+  def check_policies_are_featured_in_order(table)
+    rows = find('ol.policies').all('li a')
+    found_policies = rows.map { |row| [row.text.strip] }
+    table.diff!(found_policies)
+  end
 end
 
 World(OrganisationHelper)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -34,6 +34,12 @@ module NavigationHelpers
     visit organisation_email_signup_information_path(organisation)
   end
 
+  def visit_organisation_featured_policies_admin(name)
+    organisation = Organisation.find_by!(name: name)
+    visit admin_organisation_path(organisation)
+    click_link "Featured policies"
+  end
+
   def visit_worldwide_organisation_page(name)
     worldwide_organisation = WorldwideOrganisation.find_by!(name: name)
     visit worldwide_organisation_path(worldwide_organisation)

--- a/test/factories/featured_policies.rb
+++ b/test/factories/featured_policies.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :featured_policy do
+    organisation
+  end
+end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -239,6 +239,16 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_template 'show-promotional'
   end
 
+  view_test "promotional template shows featured policies if there are any" do
+    organisation = create(:executive_office, govuk_status: 'live')
+    policies = content_register_has_policies(['test-policy'])
+    create(:featured_policy, organisation: organisation, policy_content_id: policies.first["content_id"])
+
+    get :show, id: organisation
+
+    assert_select "#featured-policies"
+  end
+
   test "showing a joining organisation renders the not live template" do
     organisation = create(:organisation, govuk_status: 'joining')
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -113,7 +113,8 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:corporate_information_page, organisation: organisation)
     organisation.add_contact_to_home_page!(contact)
 
-    rummager_has_policies_for_every_type
+    policy = content_register_has_policies(['test-title']).first
+    create(:featured_policy, organisation: organisation, policy_content_id: policy["content_id"])
 
     get :show, id: organisation
 
@@ -362,28 +363,32 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should display the organisation's policies with content" do
     organisation = create(:organisation)
-    rummager_has_policies_for_every_type
+    policy = content_register_has_policies(['Welfare reform']).first
+    create(:featured_policy, organisation: organisation, policy_content_id: policy["content_id"])
 
     get :show, id: organisation
 
     assert_select "#policies" do
-      assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
+      assert_select "a[href='#{policy["base_path"]}']", text: "Welfare reform"
 
       assert_select "a[href='#{policies_finder_path(organisations: [organisation])}']"
     end
   end
 
   test "should display organisation's latest three policies" do
-    organisation = create(:organisation)
-    rummager_has_policies_for_every_type(count: 3)
-
-    get :show, id: organisation
-
     first_three_policy_titles = [
       "Welfare reform",
       "State Pension simplification",
       "State Pension age",
     ]
+
+    organisation = create(:organisation)
+    policies = content_register_has_policies(first_three_policy_titles)
+    create(:featured_policy, organisation: organisation, policy_content_id: policies[0]["content_id"])
+    create(:featured_policy, organisation: organisation, policy_content_id: policies[1]["content_id"])
+    create(:featured_policy, organisation: organisation, policy_content_id: policies[2]["content_id"])
+
+    get :show, id: organisation
 
     assert_equal first_three_policy_titles, assigns[:policies].map(&:title)
   end

--- a/test/unit/featured_policy_test.rb
+++ b/test/unit/featured_policy_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class FeaturedPolicyTest < ActiveSupport::TestCase
+  test "the order defaults to the end of the orgs policies" do
+    org_1 = create(:organisation)
+    org_2 = create(:organisation)
+
+    featured_policy_1 = create(:featured_policy, organisation: org_1)
+    featured_policy_2 = create(:featured_policy, organisation: org_2)
+    featured_policy_3 = create(:featured_policy, organisation: org_2)
+
+    assert_equal [0], org_1.featured_policies.map(&:ordering)
+    assert_equal [0, 1], org_2.featured_policies.map(&:ordering)
+  end
+end


### PR DESCRIPTION
As an organisation I want to feature the most important and high profile polices we are working on, on our homepage. This will let users of our high profile policies be able to find the content they want quicker.

---

This adds a new tab in the organisation admin to let and organisation pick their featured policies:

![screen shot 2015-06-24 at 13 38 54](https://cloud.githubusercontent.com/assets/35035/8330070/a6a4c338-1a76-11e5-8cea-004e586564c2.png)

Which are then displayed on their homepages in the order specified.

<table>
<tr>
<th>Number 10's page</th>
<th>Standard departments page</th>
</tr>
<tr>
<td><img src="https://cloud.githubusercontent.com/assets/35035/8330076/b0776604-1a76-11e5-80f9-33da8d1e41fa.png"></td><td><img src="https://cloud.githubusercontent.com/assets/35035/8330077/b2088bf6-1a76-11e5-968d-6d1df16bccef.png"></td>
</tr>
</table>

There is a data migration which will ensure that any organisation which currently has policies showing on their homepages will continue to have the same policies listed. They can then be manually edited in the admin if they want a different collection of policies.