### PR TITLE
Use the correct slug for the British Office Taipei

### DIFF
--- a/db/data_migration/20150624134532_british_office_taipei_slug_change.rb
+++ b/db/data_migration/20150624134532_british_office_taipei_slug_change.rb
@@ -1,0 +1,5 @@
+require 'data_hygiene/organisation_reslugger'
+
+organisation = WorldwideOrganisation.find_by(slug: "british-trade-cultural-office-taiwan")
+
+DataHygiene::OrganisationReslugger.new(organisation, "british-office-taipei").run!

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -1,0 +1,85 @@
+module DataHygiene
+  # Reslugs an organisation to new_slug.
+  #
+  # When run, the following happens:
+  #
+  #   - updates the Organisation's slug
+  #   - reindexes the org for search
+  #   - republishes the org to Publishing API
+  #   - publishes a redirect content item to Publishing API
+  #   - reindexes all dependent documents in search
+  #
+  #
+  class OrganisationReslugger
+    def initialize(organisation, new_slug)
+      @organisation = organisation
+      @new_slug = new_slug
+      @old_slug = @organisation.slug
+    end
+
+    def run!
+      remove_from_search_index
+      update_slug
+      update_users if organisation.is_a? Organisation
+      update_editions if organisation.is_a? Organisation
+      register_redirect
+    end
+
+  private
+    attr_reader :organisation, :new_slug, :old_slug
+
+    def remove_from_search_index
+      Whitehall::SearchIndex.delete(organisation)
+    end
+
+    def update_slug
+      # Note: This will trigger calls to both rummager and the Publishing API,
+      # meaning that entries in both places will exist with the correct slug
+      organisation.update_attributes!(slug: new_slug)
+    end
+
+    def update_users
+      User.where(organisation_slug: old_slug).update_all(organisation_slug: new_slug)
+    end
+
+    def update_editions
+      organisation.editions.published.each do |edition|
+        edition.update_in_search_index
+      end
+    end
+
+    def old_base_path
+      case organisation
+      when Organisation
+        Whitehall.url_maker.organisation_path(old_slug)
+      when WorldwideOrganisation
+        Whitehall.url_maker.worldwide_organisation_path(old_slug)
+      end
+    end
+
+    def new_base_path
+      case organisation
+      when Organisation
+        Whitehall.url_maker.organisation_path(new_slug)
+      when WorldwideOrganisation
+        Whitehall.url_maker.worldwide_organisation_path(new_slug)
+      end
+    end
+
+    def redirects
+      redirects = [{ path: old_base_path, destination: new_base_path, type: "exact" }]
+
+      if organisation.is_a? Organisation
+        redirects << { path: (old_base_path + ".atom"),
+                       destination: (new_base_path + ".atom"),
+                       type: "exact" }
+      end
+      redirects
+    end
+
+    def register_redirect
+      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
+      Whitehall::PublishingApi.publish_redirect(redirect_item)
+    end
+  end
+end

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+require "gds_api/test_helpers/publishing_api"
+
+module OrganisationResluggerTest
+  module SharedTests
+    include GdsApi::TestHelpers::PublishingApi
+    extend ActiveSupport::Testing::Declarative
+
+    def self.included(klass)
+      klass.use_transactional_fixtures = false
+    end
+
+    def setup
+      DatabaseCleaner.clean_with :truncation
+      @organisation = create_organisation
+      @reslugger = DataHygiene::OrganisationReslugger.new(@organisation, 'corrected-slug')
+    end
+
+    def teardown
+      WebMock.reset!
+      DatabaseCleaner.clean_with :truncation
+    end
+
+    test "re-slugs the organisation" do
+      @reslugger.run!
+      assert_equal 'corrected-slug', @organisation.slug
+    end
+
+    test "publishes to Publishing API with the new slug and redirects the old" do
+      content_item = PublishingApiPresenters.presenter_for(@organisation).as_json
+      old_base_path = @organisation.search_link
+      new_base_path = "#{base_path}/corrected-slug"
+      content_item[:routes][0][:path] = new_base_path
+
+      redirects = [
+        { path: old_base_path, type: "exact", destination: new_base_path },
+      ]
+
+      if @organisation.is_a? Organisation
+        redirects << { path: (old_base_path + ".atom"),
+                       type: "exact",
+                       destination: (new_base_path + ".atom") }
+      end
+
+      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
+
+      expected_publish_request = stub_publishing_api_put_item(new_base_path, content_item)
+      expected_redirect = stub_publishing_api_put_item(old_base_path, redirect_item)
+
+      @reslugger.run!
+
+      assert_requested expected_redirect
+      assert_requested expected_publish_request
+    end
+
+    test "deletes the old slug from the search index" do
+      Whitehall::SearchIndex.expects(:delete).with { |org| org.slug == 'old-slug' }
+      @reslugger.run!
+    end
+
+    test "adds the new slug from the search index" do
+      Whitehall::SearchIndex.expects(:add).with { |org| org.slug == 'corrected-slug' }
+      @reslugger.run!
+    end
+  end
+
+  class OrganisationTest < ActiveSupport::TestCase
+    include SharedTests
+
+    def create_organisation
+      create(:organisation, name: "Old slug")
+    end
+
+    def base_path
+      "/government/organisations"
+    end
+
+    test "updates users belonging to the organisation" do
+      user = create(:user, organisation_slug: @organisation.slug)
+
+      @reslugger.run!
+
+      user.reload
+      assert_equal user.organisation_slug, "corrected-slug"
+    end
+
+    test "re-registers editions belonging to the organisation" do
+      edition = create(:published_corporate_information_page, :published, organisation: @organisation)
+
+      Whitehall::SearchIndex.stubs(:add)
+      Whitehall::SearchIndex.expects(:add).with edition
+      @reslugger.run!
+    end
+  end
+
+  class WorldwideOrganisationTest < ActiveSupport::TestCase
+    include SharedTests
+
+    def create_organisation
+      create(:worldwide_organisation, name: "Old slug")
+    end
+
+    def base_path
+      "/government/world/organisations"
+    end
+  end
+end


### PR DESCRIPTION
Story:
https://www.pivotaltracker.com/n/projects/1261204/stories/96081066

This adds a new Data Hygiene class for renaming slugs of both
organisations and worldwide organisations, based on the Ops Manual
guide and the work done in
https://github.com/alphagov/whitehall/pull/1596.

After investigation, I’ve determined that the work required to reslug
Worldwide Organisations only touches Whitehall. From the Ops Manual
page for reslugging normal Organisations, steps 4 thru 9 and step 12 do
not apply, we only need to rename things in Whitehall, publish to
Publishing API / Search and add redirects.