### PR TITLE
Remove worldwide priority data.

### DIFF
--- a/db/data_migration/20150625110100_delete_worldwide_priorities.rb
+++ b/db/data_migration/20150625110100_delete_worldwide_priorities.rb
@@ -1,0 +1,58 @@
+document_ids = Document.where(document_type: "WorldwidePriority").pluck(:id)
+
+edition_ids = Edition.where(document_id: document_ids).pluck(:id)
+
+puts "Deleting data (but not tables) for #{edition_ids.count} WorldwidePriority editions and #{document_ids.count} documents"
+
+[
+  ClassificationFeaturing,
+  ConsultationParticipation,
+  EditionAuthor,
+  EditionDependency,
+  EditionMainstreamCategory,
+  EditionOrganisation,
+  EditionRelation,
+  EditionRoleAppointment,
+  EditionStatisticalDataSet,
+  EditionWorldLocation,
+  EditionWorldwideOrganisation,
+  EditorialRemark,
+  FactCheckRequest,
+  Image,
+  NationInapplicability,
+  RecentEditionOpening,
+  Response,
+  SpecialistSector,
+  Unpublishing,
+].each do |edition_join_model|
+  join_models = edition_join_model.where(edition_id: edition_ids)
+  puts "Deleting all #{join_models.count} #{edition_join_model} edition join models"
+  join_models.delete_all
+end
+
+[
+  DocumentCollectionGroupMembership,
+  DocumentSource,
+  EditionRelation,
+  EditionStatisticalDataSet,
+  Feature,
+].each do |document_join_model|
+  join_models = document_join_model.where(document_id: document_ids)
+  puts "Deleting all #{join_models.count} #{document_join_model} document join models"
+  join_models.delete_all
+end
+
+puts "Deleting all edition dependencies"
+EditionDependency.where(
+  dependable_id: edition_ids,
+  dependable_type: "Edition",
+).delete_all
+
+puts "Hard-deleting all WorldwidePriority editions, documents, and translations"
+Edition.connection.execute(%{
+  DELETE d, e, et
+  FROM documents d
+  JOIN editions e ON e.`document_id` = d.id
+  JOIN `edition_translations` et ON et.`edition_id` = e.id
+  WHERE d.`document_type` = 'WorldwidePriority';
+})


### PR DESCRIPTION
These are being migrated to policy papers and the
format is being retired.

Requires conversion to have been run in production before merging: https://github.com/alphagov/whitehall/pull/2223

https://trello.com/c/UbEYd9y5/328-remove-worldwide-priorities-data-from-whitehall