### PR TITLE
Rename Topic to PolicyArea in views

### DIFF
--- a/app/controllers/admin/about_pages_controller.rb
+++ b/app/controllers/admin/about_pages_controller.rb
@@ -34,6 +34,11 @@ class Admin::AboutPagesController < Admin::BaseController
   end
 
   def human_friendly_model_name
+    # `PolicyArea` used to be called `Topic` in the frontend part of Whitehall.
+    # This hack can be removed when `Topic` will become `PolicyArea` in the
+    # backend too.
+    return 'Policy area' if model_name == 'topic'
+
     model_name.humanize
   end
 

--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -44,6 +44,11 @@ class Admin::ClassificationsController < Admin::BaseController
   end
 
   def human_friendly_model_name
+    # `PolicyArea` used to be called `Topic` in the frontend part of Whitehall.
+    # This hack can be removed when `Topic` will become `PolicyArea` in the
+    # backend too.
+    return 'Policy area' if model_name == 'topic'
+
     model_name.humanize
   end
 

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -10,7 +10,7 @@ module Admin::UrlHelper
   end
 
   def admin_topics_header_menu_link
-    admin_header_menu_link "Topics", admin_topics_path
+    admin_header_menu_link "Policy Areas", admin_topics_path
   end
 
   def admin_featured_header_link

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -6,7 +6,7 @@ module FilterHelper
   end
 
   def topic_options_for_statistics_announcement_filter(selected_slug = nil)
-    options_for_select(Topic.with_statistics_announcements.alphabetical.map { |topic| [topic.name, topic.slug] }.unshift(['All topics', nil]), Array(selected_slug))
+    options_for_select(Topic.with_statistics_announcements.alphabetical.map { |topic| [topic.name, topic.slug] }.unshift(['All policy areas', nil]), Array(selected_slug))
   end
 
   def describe_filter(filter, base_url, opts = {})

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -59,7 +59,7 @@ class Classification < ActiveRecord::Base
   def self.grouped_by_type
     Rails.cache.fetch("filter_options/topics", expires_in: 30.minutes) do
       {
-        'Topics' => Topic.alphabetical.map { |o| [o.name, o.slug] },
+        'Policy areas' => Topic.alphabetical.map { |o| [o.name, o.slug] },
         'Topical events' => TopicalEvent.active.order_by_start_date.map { |o| [o.name, o.slug] }
       }
     end

--- a/app/views/admin/classifications/_form.html.erb
+++ b/app/views/admin/classifications/_form.html.erb
@@ -14,8 +14,8 @@
   <fieldset>
     <%= render 'admin/shared/policy_fields', form: classification_form %>
 
-    <%= classification_form.label :related_classification_ids, "Related topics" %>
-    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related topics…"} %>
+    <%= classification_form.label :related_classification_ids, "Related policy areas" %>
+    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related policy areas..."} %>
   </fieldset>
 
   <%= render partial: 'custom_form_fields', locals: {classification_form: classification_form} %>

--- a/app/views/admin/classifications/edit.html.erb
+++ b/app/views/admin/classifications/edit.html.erb
@@ -17,7 +17,7 @@
             data: { confirm: "Are you sure you want to delete: #{@classification} ?" } %>
     <% else %>
       <div class="policies_preventing_destruction">
-        <p>This topic can’t be deleted as it has associated policies:</p>
+        <p>This policy area can't be deleted as it has associated policies:</p>
         <ul>
           <% @classification.policies.each do |policy| %>
             <li><%= link_to(policy.title, policy_path(policy)) %></li>

--- a/app/views/admin/classifications/index.html.erb
+++ b/app/views/admin/classifications/index.html.erb
@@ -1,8 +1,8 @@
-<% page_title model_name.humanize.pluralize %>
+<% page_title human_friendly_model_name.pluralize %>
 
-<h1><%= model_name.humanize.pluralize %></h1>
-<p class="warning remove-top-margin">Do not create <%= model_class.name.underscore.humanize.downcase %>s without consulting GDS.</p>
-<%= link_to "Create #{model_name.humanize.downcase}", [:new, :admin, model_name], class: "btn btn-default new_resource", title: "Create a #{model_name.humanize.downcase}" %>
+<h1><%= human_friendly_model_name.pluralize %></h1>
+<p class="warning remove-top-margin">Do not create <%= human_friendly_model_name.downcase %>s without consulting GDS.</p>
+<%= link_to "Create #{human_friendly_model_name.downcase}", [:new, :admin, model_name], class: "btn btn-default new_resource", title: "Create a #{human_friendly_model_name.downcase}" %>
 
 <table class="<%= model_name %> table table-striped table-bordered add-top-margin">
   <%= render 'table_header' %>

--- a/app/views/admin/classifications/new.html.erb
+++ b/app/views/admin/classifications/new.html.erb
@@ -1,4 +1,4 @@
-<% page_title "New topic" %>
+<% page_title "New policy area" %>
 <div class="row">
   <div class="col-md-8">
     <h1>New <%= human_friendly_model_name.downcase %></h1>

--- a/app/views/admin/classifications/show.html.erb
+++ b/app/views/admin/classifications/show.html.erb
@@ -30,7 +30,7 @@
           <ul>
             <% @classification.related_classifications.each do |pa| %>
               <%= content_tag_for(:li, pa) do %>
-                <%= link_to pa.name, [:admin, pa], title: "Edit #{model_name.humanize.downcase} #{pa.name}" %>
+                <%= link_to pa.name, [:admin, pa], title: "Edit #{human_friendly_model_name.downcase} #{pa.name}" %>
               <% end %>
             <% end %>
           </ul>

--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -24,11 +24,11 @@
 
   <% if edition.can_be_associated_with_topics? %>
     <section>
-      <h1>Topics</h1>
+      <h1>Policy Areas</h1>
       <% if edition.topics.any? %>
         <%= render partial: "classifications/list", locals: {topics: edition.topics} %>
       <% else %>
-        <p>This document isn’t assigned to any topics.</p>
+        <p>This document isn't assigned to any policy areas.</p>
       <% end %>
     </section>
   <% end %>

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -54,7 +54,7 @@
     <% end %>
 
     <% if @edition.can_be_associated_with_topics? %>
-      <h3>Topics</h3>
+      <h3>Policy Areas</h3>
       <%= render partial: 'topic_fields', locals: { form: form, edition: @edition } %>
     <% end %>
 

--- a/app/views/admin/editions/_topic_fields.html.erb
+++ b/app/views/admin/editions/_topic_fields.html.erb
@@ -1,6 +1,6 @@
 <% cache_if edition.topic_ids.empty?, taggable_topics_cache_digest do %>
   <fieldset class="edition-topic-fields">
-    <%= form.label :topic_ids, 'Topics', required: true %>
-    <%= form.select :topic_ids, options_for_select(taggable_topics_container, edition.topic_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose topics…"} %>
+    <%= form.label :topic_ids, 'Policy Areas', required: true %>
+    <%= form.select :topic_ids, options_for_select(taggable_topics_container, edition.topic_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose policy areas..."} %>
   </fieldset>
 <% end %>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -77,12 +77,12 @@
       <%= organisation_form.select :parent_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.parent_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose parent organisations…" } %>
     </p>
 
-    <h3>Topics</h3>
+    <h3>Policy Areas</h3>
     <% organisation_form.object.organisation_classifications.each do |ot| %>
       <p>
         <%= label_tag "organisation_topic_ids_#{ot.ordering}" do %>
-          Topic <%= ot.ordering + 1 %>
-          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose topics…"}, id: "organisation_topic_ids_#{ot.ordering}" %>
+          Policy Area <%= ot.ordering + 1 %>
+          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose policy areas..."}, id: "organisation_topic_ids_#{ot.ordering}" %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][ordering]", ot.ordering %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][id]", ot.id %>
         <% end %>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -30,7 +30,7 @@
           None
         <% end %>
       </td></tr>
-      <tr><th>Topics and topical events</th><td>
+      <tr><th>Policy areas and topical events</th><td>
         <% if @organisation.classifications.any? %>
           <%= @organisation.classifications.map {|t| link_to(t.name, [:edit, :admin, t]) }.to_sentence.html_safe %>
         <% else %>

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -27,7 +27,7 @@
                   { }, multiple: true, class: 'chzn-select form-control' %>
   </div>
   <div class="form-group stats-chosen-wrapper">
-    <%= form.label  :topic_ids, 'Topics', required: true %>
+    <%= form.label  :topic_ids, 'Policy Areas', required: true %>
     <%= form.select :topic_ids,
                   options_for_select(taggable_topics_container, statistics_announcement.topic_ids),
                   { prompt: 'Select a topic' },

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -67,7 +67,7 @@
             <th>Announcement title</th>
             <th>Publication</th>
             <th>Organisations</th>
-            <th>Topics</th>
+            <th>Policy Areas</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -46,7 +46,7 @@
       <dd><%= @statistics_announcement.display_type %></dd>
       <dt>Organisations:</dt>
       <dd><%= @statistics_announcement.organisations.map(&:name).to_sentence %></dd>
-      <dt>Topics:</dt>
+      <dt>Policy Areas:</dt>
       <dd><%= @statistics_announcement.topics.map(&:name).to_sentence %></dd>
     </dl>
 

--- a/app/views/admin/topical_events/_topical_event.html.erb
+++ b/app/views/admin/topical_events/_topical_event.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag_for(:tr, topical_event) do %>
   <td class="name">
-    <%= link_to topical_event.name, [:admin, topical_event], title: "Edit #{model_name.humanize.downcase} #{topical_event.name}" %>
+    <%= link_to topical_event.name, [:admin, topical_event], title: "Edit #{human_friendly_model_name.downcase} #{topical_event.name}" %>
   </td>
   <td class="description"><%= truncate(topical_event.description, length: 130, separator: ' ') %></td>
   <td class="details"><%= classification_contents_breakdown(topical_event) %></td>
@@ -13,7 +13,7 @@
     <ul>
       <% topical_event.related_classifications.each do |pa| %>
         <%= content_tag_for(:li, pa) do %>
-          <%= link_to pa.name, edit_admin_topic_path(pa), title: "Edit #{model_name.humanize.downcase} #{pa.name}" %>
+          <%= link_to pa.name, edit_admin_topic_path(pa), title: "Edit #{human_friendly_model_name.downcase} #{pa.name}" %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/admin/topics/_topic.html.erb
+++ b/app/views/admin/topics/_topic.html.erb
@@ -1,13 +1,13 @@
 <%= content_tag_for(:tr, topic) do %>
   <td class="name">
-    <%= link_to topic.name, [:admin, topic], title: "Edit #{model_name.humanize.downcase} #{topic.name}" %>
+    <%= link_to topic.name, [:admin, topic], title: "Edit #{human_friendly_model_name.downcase} #{topic.name}" %>
   </td>
   <td class="description"><%= truncate(topic.description, length: 130, separator: ' ') %></td>
   <td class="related">
     <ul>
       <% topic.related_classifications.each do |pa| %>
         <%= content_tag_for(:li, pa) do %>
-          <%= link_to pa.name, [:admin, pa], title: "Edit #{model_name.humanize.downcase} #{pa.name}" %>
+          <%= link_to pa.name, [:admin, pa], title: "Edit #{human_friendly_model_name.downcase} #{pa.name}" %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/classifications/index.html.erb
+++ b/app/views/classifications/index.html.erb
@@ -1,11 +1,11 @@
-<% page_title "Topics" %>
+<% page_title "Policy Areas" %>
 <% page_class "classifications-index index-list-page" %>
 
 
 <div class="block-1">
   <div class="inner-block">
     <header class="page-header js-filter-list">
-        <h1 class="title">Topics</h1>
+        <h1 class="title">Policy Areas</h1>
         <form class="js-filter-form"><label for="what-is-the-government-doing-about" class="label">What&nbsp;is the government<br />doing about <div><input name="what-is-the-government-doing-about" id="what-is-the-government-doing-about" placeholder="Example: housing"> ?</div></label></form>
     </header>
   </div>
@@ -20,7 +20,7 @@
         </div>
       </div>
     <% else %>
-      <p>We don't have any topics with published documents at present.</p>
+      <p>We don't have any policy areas with published documents at present.</p>
     <% end %>
     <% if @topical_events.any? %>
       <div class="heading-block js-filter-block">
@@ -33,7 +33,7 @@
       </div>
     <% end %>
     <div class="js-filter-no-results">
-      <p>No topics match that filter.</p>
+      <p>No policy areas match that filter.</p>
     </div>
   </div>
 </div>

--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -30,7 +30,7 @@
 
         <% if filters.include? :topic %>
           <div class="filter">
-            <%= label_tag "topics", "Topic" %>
+            <%= label_tag "topics", "Policy Area" %>
             <%= select_tag "topics[]", topic_filter_options(@filter.selected_topics), class: "single-row-select", id: "topics" %>
           </div>
         <% end %>

--- a/app/views/statistics_announcements/index.html.erb
+++ b/app/views/statistics_announcements/index.html.erb
@@ -28,7 +28,7 @@
             <%= text_field_tag :keywords, @filter.keywords, placeholder: "keywords" %>
           </div>
           <div class="filter">
-            <%= label_tag "topics", "Topic" %>
+            <%= label_tag "topics", "Policy Area" %>
             <%= select_tag "topics[]", topic_options_for_statistics_announcement_filter(@filter.topic_slugs), id: "topics", class: "single-row-select" %>
           </div>
           <div class="filter">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -90,7 +90,7 @@
       <% end %>
       <% if @related_classifications.any? %>
         <section id="related-topics" class="document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Related topics</h1>
+          <h1 class="label">Related policy areas</h1>
           <div class="content">
             <ol class="document-list">
               <% @related_classifications.each do |topic| %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -7,7 +7,7 @@
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
-                locals: { type: "Topic",
+                locals: { type: "Policy Area",
                           heading: @classification.name,
                           big: true, extra: true } %>
 
@@ -24,7 +24,7 @@
                           locals: { organisations: @classification.organisations } %>
             </dd>
             <% if @related_classifications.any? %>
-              <dt>Related topics:</dt>
+              <dt>Related policy areas:</dt>
               <dd class="js-hide-other-links related-topics">
                 <%= @related_classifications.map { |rc| link_to(rc.name, rc) }.to_sentence.html_safe %>
               </dd>

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -68,7 +68,7 @@ Then(/^I should be able to filter publications by keyword, publication type, top
   assert_listed_document_count 1
   assert page.has_content? "Guidance publication"
 
-  select_filter "Topic", "A Topic", and_clear_others: true
+  select_filter "Policy Area", "A Topic", and_clear_others: true
   assert_listed_document_count 1
   assert page.has_content? "Publication with the topic"
   assert page.text.match /1 publication about A Topic ./
@@ -177,7 +177,7 @@ Then(/^I should be able to filter announcements by keyword, announcement type, t
   within '#document-filter' do
     page.fill_in "Contains", with: "keyword"
     page.select "News stories", from: "Announcement type"
-    page.select "A Topic", from: "Topic"
+    page.select "A Topic", from: "Policy Area"
     page.select "A Department", from: "Department"
     page.select "A World Location", from: "World locations"
     page.fill_in "Published after", with: "01/01/2013"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -51,7 +51,7 @@ When /^I publish a news article "([^"]*)" associated with the (topic|topical eve
   begin_drafting_news_article title: title, skip_topic_selection: (type == 'topic')
 
   if type == 'topic'
-    select topic_name, from: "Topics"
+    select topic_name, from: "Policy Areas"
   else
     select topic_name, from: "Topical events"
   end

--- a/features/step_definitions/statistics_announcement_steps.rb
+++ b/features/step_definitions/statistics_announcement_steps.rb
@@ -75,7 +75,7 @@ end
 When(/^I filter the statistics announcements by department and topic$/) do
   within '.filter-form' do
     select @department.name, from: "Department"
-    select @topic.name, from: "Topic"
+    select @topic.name, from: "Policy Area"
     click_on "Refresh results"
   end
 end

--- a/features/step_definitions/statistics_steps.rb
+++ b/features/step_definitions/statistics_steps.rb
@@ -84,7 +84,7 @@ end
 
 When(/^I filter the statistics by department and topic$/) do
   within '.filter-form' do
-    select "Beards", from: "Topic"
+    select "Beards", from: "Policy Area"
     select "Wombats of Wimbledon", from: "Department"
     click_on "Refresh results"
   end

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -62,7 +62,7 @@ end
 
 When /^I edit the topic "([^"]*)" to have description "([^"]*)"$/ do |name, description|
   visit admin_root_path
-  click_link "Topics"
+  click_link "Policy Areas"
   click_link name
   click_on "Edit"
   fill_in "Description", with: description

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -140,7 +140,7 @@ module DocumentHelper
   def select_topic_if_required
     if has_css?(".edition-topic-fields", wait: false)
       within(".edition-topic-fields") do
-        select Topic.first.name, from: "Topics"
+        select Topic.first.name, from: "Policy Areas"
       end
     end
   end

--- a/features/support/filtering_documents_helper.rb
+++ b/features/support/filtering_documents_helper.rb
@@ -27,7 +27,7 @@ module FilteringDocumentsHelper
     within '#document-filter' do
       page.fill_in "Contains", with: ""
       page.select "All publication types", from: "Publication type" if page.has_selector?('label', text: "Publication type", wait: false)
-      page.select "All topics", from: "Topic"
+      page.select "All policy areas", from: "Policy Area"
       page.select "All departments", from: "Department"
       page.select "All documents", from: "Official document status" if page.has_selector?('label', text: "Official document status", wait: false)
       page.select "All locations", from: "World locations"

--- a/features/support/topics_helper.rb
+++ b/features/support/topics_helper.rb
@@ -6,12 +6,12 @@ module TopicsHelper
 
   def start_creating_topic(options = {})
     visit admin_root_path
-    click_link "Topics"
-    click_link "Create topic"
+    click_link "Policy Areas"
+    click_link "Create policy area"
     fill_in "Name", with: options[:name] || "topic-name"
     fill_in "Description", with: options[:description] || "topic-description"
     (options[:related_classifications] || []).each do |related_name|
-      select related_name, from: "Related topics"
+      select related_name, from: "Related policy areas"
     end
   end
 end

--- a/lib/whitehall/document_filter/options.rb
+++ b/lib/whitehall/document_filter/options.rb
@@ -73,7 +73,7 @@ module Whitehall
       end
 
       def options_for_topics
-        @options_for_topics ||= StructuredOptions.new(all_label: "All topics", grouped: Classification.grouped_by_type)
+        @options_for_topics ||= StructuredOptions.new(all_label: "All policy areas", grouped: Classification.grouped_by_type)
       end
 
       def options_for_document_type

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -122,7 +122,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     topic = create(:topic, policy_content_ids: [policy_1["content_id"]])
 
     delete :destroy, id: topic
-    assert_equal "Cannot destroy Topic with associated content", flash[:alert]
+    assert_equal "Cannot destroy Policy area with associated content", flash[:alert]
     refute topic.reload.deleted?
   end
 end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -237,7 +237,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index
 
     assert_select "select[name='topics[]']" do
-      assert_select "option[selected='selected']", text: "All topics"
+      assert_select "option[selected='selected']", text: "All policy areas"
     end
   end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -791,7 +791,7 @@ module AdminEditionControllerTestHelpers
         }
 
         assert_select ".document.conflict" do
-          assert_select "h1", "Topics"
+          assert_select "h1", "Policy Areas"
           assert_select record_css_selector(topic)
         end
       end

--- a/test/unit/helpers/filter_helper_test.rb
+++ b/test/unit/helpers/filter_helper_test.rb
@@ -24,7 +24,7 @@ class FilterHelperTest < ActionView::TestCase
     rendered = Nokogiri::HTML::DocumentFragment.parse(topic_options_for_statistics_announcement_filter(topic_3.slug))
     options = rendered.css("option")
 
-    assert_equal ["All topics", topic_3.name, topic_2.name], options.map(&:text)
+    assert_equal ["All policy areas", topic_3.name, topic_2.name], options.map(&:text)
     assert_equal ["", topic_3.slug, topic_2.slug], options.map {|option| option[:value]}
     assert options[1][:selected]
   end

--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -44,7 +44,7 @@ module Whitehall
 
         assert_equal "Example Topic", filter_options.label_for("topics", "example-topic")
         assert_equal "Example Topical Event", filter_options.label_for("topics", "example-topical-event")
-        assert_equal "All topics", filter_options.label_for("topics", "all")
+        assert_equal "All policy areas", filter_options.label_for("topics", "all")
       end
 
       test '#label_for downcases official docs' do
@@ -145,10 +145,10 @@ module Whitehall
         options = filter_options.for(:topics)
 
         expected_grouped_options = {
-          "Topics" => [[topic.name, topic.slug]],
+          "Policy areas" => [[topic.name, topic.slug]],
           "Topical events" => [[topical_event.name, topical_event.slug]]
         }
-        assert_equal ["All topics", "all"], options.all
+        assert_equal ["All policy areas", "all"], options.all
         assert_equal expected_grouped_options, options.grouped
         assert_equal [], options.ungrouped
       end


### PR DESCRIPTION
This needed to be done in advance of renaming "specialist sector" to "topic" in whitehall-admin.

The work goes through renaming the (many) bits which say "topic" in Whitehall views.

Needs coordination with comms and content team for deployment; also needs coordination with this Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1021549

Trello ticket: https://trello.com/c/KMOhcErO/203-rename-topic-to-policy-area-in-whitehall-admin

# Before:
![screen shot 2015-07-01 at 08 14 36](https://cloud.githubusercontent.com/assets/5038475/8451083/363595c0-1fd8-11e5-8d3a-48758ef72f25.png)

# After:
![screen shot 2015-07-01 at 10 00 32](https://cloud.githubusercontent.com/assets/5038475/8451086/39fba302-1fd8-11e5-87c9-32feae632b35.png)

# Before:

![screen shot 2015-07-06 at 15 44 24](https://cloud.githubusercontent.com/assets/5038475/8524941/febc4d1a-23f5-11e5-85d2-e45d0151bd56.png)

# After:

![screen shot 2015-07-06 at 15 44 04](https://cloud.githubusercontent.com/assets/5038475/8524939/fbf315a0-23f5-11e5-8e4a-c51b4b96d2fe.png)
