### PR TITLE
Fix zombie processes from PDF thumbnail generation

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'open3'
 require 'carrierwave/processing/mime_types'
 
 class AttachmentUploader < WhitehallUploader
@@ -42,11 +43,11 @@ class AttachmentUploader < WhitehallUploader
   end
 
   def get_first_page_as_png(width, height)
-    output = Timeout.timeout(THUMBNAIL_GENERATION_TIMEOUT) do
-      `#{pdf_thumbnail_command(width, height)}`
+    output, status = Timeout.timeout(THUMBNAIL_GENERATION_TIMEOUT) do
+      Open3.capture2e(pdf_thumbnail_command(width, height))
     end
-    unless $?.success?
-      Rails.logger.warn "Error thumbnailing PDF. Exit status: #{$?.exitstatus}; Output: #{output}"
+    unless status.success?
+      Rails.logger.warn "Error thumbnailing PDF. Exit status: #{status.exitstatus}; Output: #{output}"
       use_fallback_pdf_thumbnail
     end
   rescue Timeout::Error => e


### PR DESCRIPTION
Combining backticks with Timeout means that ruby won't wait on the child
process once the timeout has been triggered.  This leads to zombie
processes being left behind that won't get cleaned up until the unicorn
worker restarts.

Switching to use Open3 fixes this because Open3 does the right thing
when a timeout is triggered.

It doesn't seem feasible to write a test to expose this as that would
require triggering a real timeout, and then querying the processlist.
The bahaviour has been verified manually.