### PR TITLE
Re enable access limiting on case studies

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -136,8 +136,7 @@ module Admin::EditionsHelper
       concat form.errors
       concat render("standard_fields", form: form, edition: edition)
       yield(form)
-      concat render('access_limiting_fields',
-                    form: form, edition: edition) if edition.can_be_access_limited?
+      concat render('access_limiting_fields', form: form, edition: edition)
       concat render("scheduled_publication_fields", form: form, edition: edition)
       concat standard_edition_publishing_controls(form, edition)
     end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -134,13 +134,11 @@ module Admin::EditionsHelper
       concat render('locale_fields', form: form, edition: edition)
       concat edition_information(@information) if @information
       concat form.errors
-      concat render(partial: "standard_fields",
-                    locals: { form: form, edition: edition })
+      concat render("standard_fields", form: form, edition: edition)
       yield(form)
       concat render('access_limiting_fields',
                     form: form, edition: edition) if edition.can_be_access_limited?
-      concat render(partial: "scheduled_publication_fields",
-                    locals: { form: form, edition: edition })
+      concat render("scheduled_publication_fields", form: form, edition: edition)
       concat standard_edition_publishing_controls(form, edition)
     end
   end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -26,8 +26,4 @@ class CaseStudy < Edition
   def translatable?
     !non_english_edition?
   end
-
-  def can_be_access_limited?
-    false
-  end
 end

--- a/app/models/edition/limited_access.rb
+++ b/app/models/edition/limited_access.rb
@@ -62,8 +62,4 @@ module Edition::LimitedAccess
       self.access_limited = self.access_limited_by_default?
     end
   end
-
-  def can_be_access_limited?
-    true
-  end
 end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -84,7 +84,7 @@ module PublishingApiPresenters
 
     def access_limited
       {
-        users: users.map(&:uid)
+        users: users.map(&:uid).compact
       }
     end
 

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -21,6 +21,16 @@ module PublishingApiPresenters
     end
 
     def as_json
+      if edition.access_limited? && !edition.publicly_visible?
+        standard_fields.merge(access_limited: access_limited)
+      else
+        standard_fields
+      end
+    end
+
+  private
+
+    def standard_fields
       {
         content_id: edition.content_id,
         title: edition.title,
@@ -39,8 +49,6 @@ module PublishingApiPresenters
         details: details
       }
     end
-
-  private
 
     def details
       {
@@ -72,6 +80,16 @@ module PublishingApiPresenters
 
     def specialist_sectors
       [edition.primary_specialist_sector_tag].compact + edition.secondary_specialist_sector_tags
+    end
+
+    def access_limited
+      {
+        users: users.map(&:uid)
+      }
+    end
+
+    def users
+      @users ||= User.where(organisation: edition.organisations)
     end
   end
 end

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -18,12 +18,4 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_setting_first_published_at_during_speed_tagging :case_study
   should_allow_association_with_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
-
-  view_test "should not display access limited field" do
-    get :new
-
-    assert_select "form#new_edition" do
-      assert_select "input[name='edition[access_limited]']", false
-    end
-  end
 end

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -156,4 +156,43 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     assert_equal ["policy-area-1", "policy-area-2", "policy-2"], present(edition)[:details][:tags][:policies]
   end
+
+  test "includes all users in access limiting fields for lead and supporting orgs" do
+    lead_org_1 = create(:organisation)
+    lead_org_2 = create(:organisation)
+    supporting_org = create(:organisation)
+
+    edition = create(:publication,
+      lead_organisations: [lead_org_1, lead_org_2],
+      supporting_organisations: [supporting_org],
+      access_limited: true,
+    )
+
+    org_users = [
+      create(:user, organisation: lead_org_1),
+      create(:user, organisation: lead_org_2),
+      create(:user, organisation: supporting_org),
+    ]
+
+    assert_equal org_users.map(&:uid).sort, present(edition)[:access_limited][:users].sort
+  end
+
+  test "does not include access limiting fields if not access limited" do
+    edition = create(:publication, access_limited: false)
+    assert_nil present(edition)[:access_limited]
+  end
+
+  test "does not include access limiting fields if publicly visible" do
+    edition = create(:publication, :published, access_limited: true)
+    assert_nil present(edition)[:access_limited]
+
+    edition = create(:publication, :withdrawn, access_limited: true)
+    assert_nil present(edition)[:access_limited]
+
+    edition = create(:publication, :draft, access_limited: true)
+    refute_nil present(edition)[:access_limited]
+
+    edition = create(:publication, :submitted, access_limited: true)
+    refute_nil present(edition)[:access_limited]
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -177,6 +177,21 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     assert_equal org_users.map(&:uid).sort, present(edition)[:access_limited][:users].sort
   end
 
+  test "removes users with no uid" do
+    lead_org = create(:organisation)
+
+    edition = create(:publication,
+      lead_organisations: [lead_org],
+      access_limited: true,
+    )
+
+    org_users = [
+      create(:user, organisation: lead_org, uid: nil),
+    ]
+
+    assert_equal [], present(edition)[:access_limited][:users]
+  end
+
   test "does not include access limiting fields if not access limited" do
     edition = create(:publication, access_limited: false)
     assert_nil present(edition)[:access_limited]


### PR DESCRIPTION
This adds a key to the publishing API JSON hash if
the edition has been marked as access limited.

It replicates the internal whitehall rules for
access limiting in that it:
- Includes the authors regardless of their organisation
- Includes all users for all organisations, lead
  and supporting.

It breaks from the internal rules by not taking
into account world location, as that is apparently
not relevant here.

The access limiting key schema is defined here:
https://github.com/alphagov/govuk-content-schemas/blob/master/formats/metadata.json#L64-L77

https://trello.com/c/xOUmu6I8/200-re-enable-access-limiting-for-case-studies-in-whitehall