### PR TITLE
Cache policies from content register

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -45,7 +45,9 @@ private
   attr_reader :links
 
   def self.entries
-    content_register.entries("policy")
+    Rails.cache.fetch('policy.entries', expires_in: 5.minutes) do
+      content_register.entries("policy").to_a
+    end
   end
 
   def self.find_entry(content_id)


### PR DESCRIPTION
There are currently lots of calls to get the policies from
content-register to power some of the frontend pages. This is because we
don't store the policy names in whitehall so have to get the full list
to get the names to display metadata on pages.

Content-register is designed to be used only by publishing tools so
doesn't want a cache put in front of it. Eventually when the whitehall
frontend pages are moved into the content-store properly there won't be
any need to call content-register as the link expansion will be done in
content-store.

This adds a 5 minute cache onto the responses from content-register so
that whitehall isn't hitting it to frequently (up to many 10's of times
a second at the moment).

This is a follow up in response to the conversations after https://github.com/alphagov/content-register/pull/23