### PR TITLE
Remove task to register detailed guides with router.

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -33,28 +33,6 @@ namespace :router do
     @router_api.commit_routes
   end
 
-  desc "Register all detailed guides with the router"
-  task :register_guidance => [:environment, :router_environment, :register_backend, :register_detailed_guidance_categories, :register_unpublished_guidance] do
-    DetailedGuide.published.includes(:document).each do |guide|
-      path = "/#{guide.slug}"
-      @logger.info "Registering detailed guide #{path}..."
-      @router_api.add_route(path, "exact", @application_id)
-    end
-    @logger.info "Guides registered, reloading routes..."
-    @router_api.commit_routes
-  end
-
-  desc "Register all unpublished detailed guides with the router"
-  task :register_unpublished_guidance => [:environment, :router_environment, :register_backend] do
-    Unpublishing.where(document_type: DetailedGuide.name).each do |unpublishing|
-      path = "/#{unpublishing.slug}"
-      @logger.info "Registering detailed guide unpublishing #{path}..."
-      @router_api.add_route(path, "exact", @application_id)
-    end
-    @logger.info "Guides unpublishings registered, reloading routes..."
-    @router_api.commit_routes
-  end
-
   desc "Register whitehall backend and routes with the router"
   task :register => [ :register_backend, :register_routes ]
 end


### PR DESCRIPTION
Routes for detailed guides are registered via panopticon (since #1428).
Registering them directly with the router bypasses the url-arbiter, and
could therefore potentially overwrite the route for another piece of
content.

These tasks aren't normally used, but their presence poses a risk that
they could be run manually.