### PR TITLE
Bump GDS API adapters to 20.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '2.3.2'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '19.0.0'
+gem 'gds-api-adapters', '20.1.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (19.0.0)
+    gds-api-adapters (20.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -458,7 +458,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 19.0.0)
+  gds-api-adapters (= 20.1.0)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.3.0)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information