### PR TITLE
Correctly position "Latest" block on service priority org pages

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
@@ -71,7 +71,7 @@
   }
 
   @include media(tablet) {
-    &.with-featured-services-and-guidance {
+    &.with-featured-links {
       &.items-1,
       &.items-4 {
         .recently-updated {

--- a/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisation-news.scss
@@ -5,58 +5,72 @@
       .content {
         padding: $gutter-half 0 $gutter-one-third 0;
         @extend %contain-floats;
+
         .image-holder {
           width: $full-width;
-          @include media(tablet){
+          @include media(tablet) {
             width: $two-thirds;
             float: left;
           }
+
           .img {
             padding: 0 $gutter-half;
           }
         }
+
         .text {
           width: $full-width;
-          .meta, h2, .summary {
+
+          h2,
+          .meta,
+          .summary {
             padding: 0 $gutter-half;
           }
-          @include media(tablet){
+
+          @include media(tablet) {
             width: $one-third;
             float: left;
 
             .meta, h2, .summary {
               padding-left: $gutter-half;
             }
+
             .meta {
               padding-top: 0;
             }
           }
+
           h2 {
             @include ig-core-24;
           }
+
           .summary {
             @include ig-core-19;
           }
         }
       }
     }
+
     &.item-3 {
       clear: both;
     }
   }
+
   &.items-1,
   &.items-4 {
     .recently-updated {
-      @include media(tablet){
+      @include media(tablet) {
         clear: both;
         width: $two-thirds;
       }
     }
   }
+
   &.items-2 {
     @extend %contain-floats;
   }
-  @include media(tablet){
+
+  @include media(tablet) {
     &.with-featured-services-and-guidance {
       &.items-1,
       &.items-4 {
@@ -65,6 +79,7 @@
           width: $one-third;
         }
       }
+
       &.items-3,
       &.items-6 {
         .recently-updated {


### PR DESCRIPTION
On service priority organisations the "Latest" block appeared in the wrong place.

* Use correct featured links wrapper class – `.featured-services-and-guidance` wrapper was renamed in fd7476e

https://trello.com/c/QbRztL2M/16-align-latest-news-panel-on-organisation-homepages-small

## Before
<img width="852" alt="screen shot 2015-07-03 at 11 50 38" src="https://cloud.githubusercontent.com/assets/319055/8498022/1681a77a-217a-11e5-892d-99f20dc6f3ae.png">

## After
<img width="843" alt="screen shot 2015-07-03 at 11 50 57" src="https://cloud.githubusercontent.com/assets/319055/8498023/1b6811a2-217a-11e5-8fc2-4691c8ea8f25.png">