### PR TITLE
Stop unpublish when other pre-pub editions exist

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -482,10 +482,6 @@ class Edition < ActiveRecord::Base
     end
   end
 
-  def other_draft_editions
-    other_editions.draft
-  end
-
   def latest_edition
     document.editions.latest_edition.first
   end

--- a/app/services/edition_unpublisher.rb
+++ b/app/services/edition_unpublisher.rb
@@ -8,8 +8,8 @@ class EditionUnpublisher < EditionService
   def failure_reason
     @failure_reason ||= if !can_transition?
       "An edition that is #{edition.current_state} cannot be #{past_participle}"
-    elsif edition.other_draft_editions.any?
-      "There is already a draft edition of this document. You must discard it before you can #{verb} this edition."
+    elsif other_edition = edition.other_editions.in_pre_publication_state.first
+      "There is already a #{other_edition.state} edition of this document. You must discard it before you can #{verb} this edition."
     elsif edition.unpublishing.blank?
       "The reason for unpublishing must be present"
     elsif !edition.unpublishing.valid?

--- a/test/unit/services/edition_unpublisher_test.rb
+++ b/test/unit/services/edition_unpublisher_test.rb
@@ -62,6 +62,16 @@ class EditionUnpublisherTest < ActiveSupport::TestCase
       unpublisher.failure_reason
   end
 
+  test 'cannot unpublish a published edition if a newer submitted version exists' do
+    edition = create(:published_edition)
+    submitted_edition = create(:submitted_edition, document: edition.document)
+    unpublisher = EditionUnpublisher.new(edition, unpublishing: unpublishing_params)
+
+    refute unpublisher.can_perform?
+    assert_equal 'There is already a submitted edition of this document. You must discard it before you can unpublish this edition.',
+      unpublisher.failure_reason
+  end
+
   test 'cannot unpublish without an unpublishing details' do
     edition = create(:published_edition)
     unpublisher = EditionUnpublisher.new(edition)


### PR DESCRIPTION
If a document has a pre-publication edition you shouldn't be able to
unpublish the document. If you are able to you can get into the state
where there are two pre-publication documents and the system can get
very confused.

The exact replication which we have seen in the wild is:

- Take a published document
- Create a new draft of that document and submit it to 2nd eyes
- Unpublish the published document
- You now have two editions which are both pre-publication

If you publish these in the wrong order the code which depends upon the
edition with the greatest `id` will break. This change stops you from
ever getting into this state.

Update the check which looked for draft editions and make it more
generic to handle any pre-publication editions.


https://trello.com/c/NueJpaQh/15-whitehall-editions-should-not-supersede-themselves-medium