### PR TITLE
Smart quotes ’n’ ellipses…

### DIFF
--- a/app/views/admin/about_pages/show.html.erb
+++ b/app/views/admin/about_pages/show.html.erb
@@ -26,7 +26,7 @@
     </div>
   <% else %>
     <p>
-      <%= @topical_event.name %> doesn't yet have a page showing more information about it.
+      <%= @topical_event.name %> doesn’t yet have a page showing more information about it.
     </p>
     <div class="form-actions">
       <%= link_to 'Create', new_admin_topical_event_about_pages_path, class: 'btn btn-lg btn-primary' %>

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -2,7 +2,7 @@
 
 <% if attachable.can_order_attachments? && attachable.attachments.many? %>
   <p class="alert alert-info">
-    To change the order of your attachments, drag them up or down and then click "Save attachment order" at
+    To change the order of your attachments, drag them up or down and then click ‘Save attachment order’ at
     the bottom of the page.
   </p>
 <% end %>

--- a/app/views/admin/classification_featurings/_classification_featuring.html.erb
+++ b/app/views/admin/classification_featurings/_classification_featuring.html.erb
@@ -11,7 +11,7 @@
         <div class="button col-md-2 text-right">
           <%= link_to('Unfeature',
                 polymorphic_path([:admin, classification_featuring.classification, classification_featuring]),
-                data: { confirm: "Unfeature '#{classification_featuring.title}'?" },
+                data: { confirm: "Unfeature ‘#{classification_featuring.title}’?" },
                 method: :delete,
                 class: "btn btn-danger") %>
         </div>
@@ -25,7 +25,7 @@
         <div class="button col-md-2 text-right">
           <%= link_to('Unfeature',
                 polymorphic_path([:admin, classification_featuring.classification, classification_featuring]),
-                data: { confirm: "Unfeature '#{classification_featuring.title}'?" },
+                data: { confirm: "Unfeature ‘#{classification_featuring.title}’?" },
                 method: :delete,
                 class: "btn btn-danger") %>
         </div>

--- a/app/views/admin/classifications/_form.html.erb
+++ b/app/views/admin/classifications/_form.html.erb
@@ -15,7 +15,7 @@
     <%= render 'admin/shared/policy_fields', form: classification_form %>
 
     <%= classification_form.label :related_classification_ids, "Related topics" %>
-    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related topics..."} %>
+    <%= classification_form.select :related_classification_ids, options_from_collection_for_select(Topic.all - [classification_form.object], 'id', 'name', classification_form.object.related_classification_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related topics…"} %>
   </fieldset>
 
   <%= render partial: 'custom_form_fields', locals: {classification_form: classification_form} %>

--- a/app/views/admin/classifications/edit.html.erb
+++ b/app/views/admin/classifications/edit.html.erb
@@ -17,7 +17,7 @@
             data: { confirm: "Are you sure you want to delete: #{@classification} ?" } %>
     <% else %>
       <div class="policies_preventing_destruction">
-        <p>This topic can't be deleted as it has associated policies:</p>
+        <p>This topic can’t be deleted as it has associated policies:</p>
         <ul>
           <% @classification.policies.each do |policy| %>
             <li><%= link_to(policy.title, policy_path(policy)) %></li>

--- a/app/views/admin/contact_translations/edit.html.erb
+++ b/app/views/admin/contact_translations/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Edit translation for #{@contact.title}" %>
 
-<h1>Edit '<%= translation_locale.native_language_name %> (<%= translation_locale.english_language_name %>)' translation for: <%= @contact.title %></h1>
+<h1>Edit ‘<%= translation_locale.native_language_name %> (<%= translation_locale.english_language_name %>)’ translation for: <%= @contact.title %></h1>
 
 <%= render partial: 'form', locals: { translated_contact: @translated_contact,
                                       form_path: admin_organisation_contact_translation_path(@contactable, @translated_contact, translation_locale),

--- a/app/views/admin/contacts/_contact_type_details_form.html.erb
+++ b/app/views/admin/contacts/_contact_type_details_form.html.erb
@@ -4,5 +4,5 @@
                           options_from_collection_for_select(ContactType.all, :id, :name, contact_form.object.contact_type_id),
                           { include_blank: true },
                           class: 'chzn-select form-control',
-                          data: { placeholder: "Choose the contact type..." } %>
+                          data: { placeholder: "Choose the contact type…" } %>
 </div>

--- a/app/views/admin/contacts/_form_fields.html.erb
+++ b/app/views/admin/contacts/_form_fields.html.erb
@@ -12,7 +12,7 @@
                             options_from_collection_for_select(WorldLocation.geographical, :id, :name, contact_form.object.country_id),
                             { include_blank: true },
                             class: 'chzn-select form-control',
-                            data: { placeholder: "Choose the country..." } %>
+                            data: { placeholder: "Choose the country…" } %>
   </div>
 </fieldset>
 

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -6,7 +6,7 @@
   <% unless form.object.persisted? %>
     <div class="form-group">
       <%= form.label :corporate_information_page_type_id, 'Type' %>
-      <%= form.select :corporate_information_page_type_id, corporate_information_page_types(@organisation), {disabled: @organisation.corporate_information_pages.map(&:corporate_information_page_type_id), allow_blank: true}, {class: 'chzn-select form-control', data: { placeholder: "Type of page..." }} %>
+      <%= form.select :corporate_information_page_type_id, corporate_information_page_types(@organisation), {disabled: @organisation.corporate_information_pages.map(&:corporate_information_page_type_id), allow_blank: true}, {class: 'chzn-select form-control', data: { placeholder: "Type of page…" }} %>
     </div>
   <% end %>
 

--- a/app/views/admin/corporate_information_pages_translations/edit.html.erb
+++ b/app/views/admin/corporate_information_pages_translations/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Edit translation for: #{@english_corporate_information_page.title}" %>
 
-<h1>Edit '<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)' translation for: <%= @english_corporate_information_page.title %></h1>
+<h1>Edit ‘<%= @translation_locale.native_language_name %> (<%= @translation_locale.english_language_name %>)’ translation for: <%= @english_corporate_information_page.title %></h1>
 
 <%= form_for @translated_corporate_information_page, url: [:admin, @organisational_entity, @translated_corporate_information_page, translation_locale], method: :put do |form| %>
   <%= form.errors %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -11,10 +11,10 @@
       <%= render partial: 'topic_fields', locals: { form: form, edition: edition } %>
 
       <%= form.label :primary_mainstream_category_id, 'Primary detailed guidance category' %>
-      <%= form.select :primary_mainstream_category_id, mainstream_category_options(edition, edition.primary_mainstream_category_id), {}, class: 'chzn-select form-control', data: { placeholder: "Choose a primary detailed guidance category..."} %>
+      <%= form.select :primary_mainstream_category_id, mainstream_category_options(edition, edition.primary_mainstream_category_id), {}, class: 'chzn-select form-control', data: { placeholder: "Choose a primary detailed guidance category…"} %>
 
       <%= form.label :other_mainstream_category_ids, 'Other detailed guidance categories' %>
-      <%= form.select :other_mainstream_category_ids, mainstream_category_options(edition, edition.other_mainstream_category_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose other detailed guidance categories..."} %>
+      <%= form.select :other_mainstream_category_ids, mainstream_category_options(edition, edition.other_mainstream_category_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose other detailed guidance categories…"} %>
 
       <%= form.text_field :need_ids, label_text: 'Maslow Need IDs (enter a comma-separated list)', placeholder: "Enter a comma-separated list of Maslow Need IDs", value: edition.need_ids.join(", ") %>
 
@@ -24,7 +24,7 @@
 
       <% cache_if edition.related_detailed_guide_ids.empty?, taggable_detailed_guides_cache_digest do %>
         <%= form.label :related_detailed_guide_ids, 'Related guides' %>
-        <%= form.select :related_detailed_guide_ids, options_for_select(taggable_detailed_guides_container, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related detailed guides..."} %>
+        <%= form.select :related_detailed_guide_ids, options_for_select(taggable_detailed_guides_container, edition.related_detailed_guide_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose related detailed guides…"} %>
       <% end %>
     </fieldset>
 

--- a/app/views/admin/document_collection_groups/delete.html.erb
+++ b/app/views/admin/document_collection_groups/delete.html.erb
@@ -9,7 +9,7 @@
       <div class="alert alert-danger">
         <% if @collection.groups.size == 1 %>
           <p>
-            Every document collection needs at least one group, so you can't
+            Every document collection needs at least one group, so you can’t
             delete the last one.
           </p>
           <p>
@@ -17,7 +17,7 @@
             collection page, click the edit link, and rename it instead.
           </p>
         <% else %>
-          You can't delete a group that has documents in it &ndash;
+          You can’t delete a group that has documents in it &ndash;
           remove the documents first, or move them into another group.
         <% end %>
       </div>
@@ -28,7 +28,7 @@
     <% else %>
       <%= form_for [@collection, @group], url: admin_document_collection_group_path(@collection, @group), method: 'delete' do |form| %>
         <p>
-          Are you sure you want to delete the group '<%= @group.heading %>'?
+          Are you sure you want to delete the group ‘<%= @group.heading %>’?
         </p>
         <%= form.form_actions(buttons: { delete: 'Delete' }, cancel: admin_document_collection_groups_path(@collection)) %>
       <% end %>

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -19,7 +19,7 @@
         <%= button_tag 'Find', type: 'button', id: 'find-documents', class: 'btn btn-default btn-sm add-right-margin' %>
         <%= image_tag 'loading-666666.gif', class: 'js-loader' %>
         <p class="tip">
-          Only the first 10 results are returned - be as specific as you can
+          Only the first 10 results are returned – be as specific as you can
         </p>
       </div>
       to the

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="format-advice">
-  <p><strong>Use this format for:</strong> Continuously curated, permanent lists of closely related documents for a specific audience - not just by subject.</p>
+  <p><strong>Use this format for:</strong> Continuously curated, permanent lists of closely related documents for a specific audience – not just by subject.</p>
 </div>
 
 <%= edition_editing_tabs(edition) do %>

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -4,13 +4,13 @@
   <div class="radio">
     <%= form.label :minor_change_true do %>
       <%= form.radio_button(:minor_change, true) %>
-      <strong>Update the document silently</strong> - for minor changes like fixes to typos, links, GOV.UK style or metadata
+      <strong>Update the document silently</strong> – for minor changes like fixes to typos, links, GOV.UK style or metadata
     <% end %>
   </div>
   <div class="radio">
     <%= form.label :minor_change_false do %>
       <%= form.radio_button(:minor_change, false) %>
-      <strong>Alert the public to what's changed</strong> - for important changes to the content or attached files
+      <strong>Alert the public to what’s changed</strong> – for important changes to the content or attached files
     <% end %>
   </div>
   <div class="js-change-notes-section">

--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -17,7 +17,7 @@
       <% if edition.organisations.any? %>
         <%= render partial: "admin/organisations/organisations_name_list", locals: {organisations: edition.sorted_organisations} %>
       <% else %>
-        <p>This document isn't assigned to any organisations.</p>
+        <p>This document isn’t assigned to any organisations.</p>
       <% end %>
     </section>
   <% end %>
@@ -28,7 +28,7 @@
       <% if edition.topics.any? %>
         <%= render partial: "classifications/list", locals: {topics: edition.topics} %>
       <% else %>
-        <p>This document isn't assigned to any topics.</p>
+        <p>This document isn’t assigned to any topics.</p>
       <% end %>
     </section>
   <% end %>
@@ -39,7 +39,7 @@
       <% if edition.world_locations.any? %>
         <%= render partial: "world_locations/list", locals: {world_locations: edition.world_locations} %>
       <% else %>
-        <p>This document isn't assigned to any world locations.</p>
+        <p>This document isn’t assigned to any world locations.</p>
       <% end %>
     </section>
   <% end %>

--- a/app/views/admin/editions/_document_collection_fields.html.erb
+++ b/app/views/admin/editions/_document_collection_fields.html.erb
@@ -4,5 +4,5 @@
                   options_for_select(taggable_document_collection_groups_container, edition.document_collection_group_ids),
                   { allow_blank: true },
                   { multiple: true, class: 'chzn-select form-control',
-                  data: { placeholder: "Choose collection this document is a part of..." } } %>
+                  data: { placeholder: "Choose collection this document is a part of…" } } %>
 <% end %>

--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -21,7 +21,7 @@
     </div>
   <% else %>
     <div class="alert alert-info access-limited-latest-edition">
-      <p>This isn’t the most recent edition of this document - you are
+      <p>This isn’t the most recent edition of this document – you are
           unable to view the most recent edition because it can only be
           accessed by members of the producing organisation.</p>
     </div>

--- a/app/views/admin/editions/_history_state.html.erb
+++ b/app/views/admin/editions/_history_state.html.erb
@@ -21,7 +21,7 @@
     </div>
   <% else %>
     <div class="alert alert-info access-limited-latest-edition">
-      <p>This isn't the most recent edition of this document - you are
+      <p>This isn’t the most recent edition of this document - you are
           unable to view the most recent edition because it can only be
           accessed by members of the producing organisation.</p>
     </div>

--- a/app/views/admin/editions/_html_version_fields.html.erb
+++ b/app/views/admin/editions/_html_version_fields.html.erb
@@ -6,8 +6,8 @@
       You can create and edit HTML attachments in the
       <%= link_to 'same tab as the other attachments', admin_edition_attachments_path(@edition) %>.
     <% else %>
-      If you'd like to add an HTML attachment to this document, please save
-      it first. You'll then find a new tab at the top of the page that you
+      If you’d like to add an HTML attachment to this document, please save
+      it first. You’ll then find a new tab at the top of the page that you
       can use to create, edit and delete attachments.
     <% end %>
   </p>

--- a/app/views/admin/editions/_inline_attachments_info.html.erb
+++ b/app/views/admin/editions/_inline_attachments_info.html.erb
@@ -24,7 +24,7 @@
                         ),
                         { include_blank: true, multiple: false },
                         class: 'chzn-select form-control',
-                        data: { placeholder: "Choose which organisation will provide alternative formats..." }) %>
+                        data: { placeholder: "Choose which organisation will provide alternative formats…" }) %>
         <p class="help-block">
           If the email address you need isn’t here, it should be added to the relevant Department or Agency
         </p>

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -1,3 +1,2 @@
 <%= form.label :operational_field_id, 'Field of operation', required: true %>
-<%= form.select :operational_field_id, operational_field_select_options(edition), {include_blank: true, allow_blank: true}, {class: 'chzn-select form-control', data: { placeholder: "Choose the field of operation..." }} %>
-
+<%= form.select :operational_field_id, operational_field_select_options(edition), {include_blank: true, allow_blank: true}, {class: 'chzn-select form-control', data: { placeholder: "Choose the field of operation…" }} %>

--- a/app/views/admin/editions/_policy_group_fields.html.erb
+++ b/app/views/admin/editions/_policy_group_fields.html.erb
@@ -3,4 +3,4 @@
   ["#{group.name} (#{group.email})", group.id]}, { include_blank: true },
   multiple: true,
   class: 'chzn-select form-control',
-  data: { placeholder: "Choose groups..."} %>
+  data: { placeholder: "Choose groups…"} %>

--- a/app/views/admin/editions/_recent_openings.html.erb
+++ b/app/views/admin/editions/_recent_openings.html.erb
@@ -8,7 +8,7 @@
           </div>
           <%= linked_author(opening.editor) %> started editing this
           <%= edition.format_name %>
-          <%= time_ago_in_words opening.created_at %> ago and hasn't yet saved their work.
+          <%= time_ago_in_words opening.created_at %> ago and hasn’t yet saved their work.
         </li>
       <% end %>
     </ul>

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -5,5 +5,5 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose statistical data sets..."} %>
+                  data: { placeholder: "Choose statistical data sets…"} %>
 <% end %>

--- a/app/views/admin/editions/_topic_fields.html.erb
+++ b/app/views/admin/editions/_topic_fields.html.erb
@@ -1,6 +1,6 @@
 <% cache_if edition.topic_ids.empty?, taggable_topics_cache_digest do %>
   <fieldset class="edition-topic-fields">
     <%= form.label :topic_ids, 'Topics', required: true %>
-    <%= form.select :topic_ids, options_for_select(taggable_topics_container, edition.topic_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose topics..."} %>
+    <%= form.select :topic_ids, options_for_select(taggable_topics_container, edition.topic_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose topics…"} %>
   </fieldset>
 <% end %>

--- a/app/views/admin/editions/_words_to_avoid_guidance.html.erb
+++ b/app/views/admin/editions/_words_to_avoid_guidance.html.erb
@@ -7,23 +7,23 @@
 <h3><a data-toggle="collapse" href="#js-words-to-avoid-list">Words to avoid</a></h3>
 <div class="collapse" id="js-words-to-avoid-list">
   <ul>
-    <li><span class="js-word-to-avoid">agenda</span> (unless it's for a meeting)</li>
+    <li><span class="js-word-to-avoid">agenda</span> (unless it’s for a meeting)</li>
     <li><span class="js-word-to-avoid">advancing</span></li>
-    <li><span class="js-word-to-avoid">collaborate</span> (use 'working with')</li>
+    <li><span class="js-word-to-avoid">collaborate</span> (use ‘working with’)</li>
     <li><span class="js-word-to-avoid">combating</span></li>
-    <li><span class="js-word-to-avoid">commit</span>/<span class="js-word-to-avoid">pledge</span> (we need to be more specific – we're either doing something or we're not)</li>
+    <li><span class="js-word-to-avoid">commit</span>/<span class="js-word-to-avoid">pledge</span> (we need to be more specific – we’re either doing something or we’re not)</li>
     <li><span class="js-word-to-avoid">countering</span></li>
-    <li><span class="js-word-to-avoid">deliver</span> (pizzas, post and services are delivered – not abstract concepts like 'improvements' or 'priorities')</li>
-    <li><span class="js-word-to-avoid">deploy</span> (unless it's military or software)</li>
+    <li><span class="js-word-to-avoid">deliver</span> (pizzas, post and services are delivered – not abstract concepts like ‘improvements’ or ‘priorities’)</li>
+    <li><span class="js-word-to-avoid">deploy</span> (unless it’s military or software)</li>
     <li><span class="js-word-to-avoid">dialogue</span> (we speak to people)</li>
     <li><span class="js-word-to-avoid">disincentivise</span> (and <span class="js-word-to-avoid">incentivise</span>)</li>
     <li><span class="js-word-to-avoid">empower</span></li>
     <li><span class="js-word-to-avoid">facilitate</span> (instead, say something specific about how you are helping)</li>
     <li><span class="js-word-to-avoid">focusing</span></li>
-    <li><span class="js-word-to-avoid">foster</span> (unless it's children)</li>
+    <li><span class="js-word-to-avoid">foster</span> (unless it’s children)</li>
     <li><span class="js-word-to-avoid">impact</span> (as a verb)</li>
     <li><span class="js-word-to-avoid">initiate</span></li>
-    <li><span class="js-word-to-avoid">key</span> (unless it unlocks something. A subject/thing isn't 'key' – it's probably 'important')</li>
+    <li><span class="js-word-to-avoid">key</span> (unless it unlocks something. A subject/thing isn’t ‘key’ – it’s probably ‘important’)</li>
     <li><span class="js-word-to-avoid">land</span> (as a verb. Only use if you are talking about aircraft)</li>
     <li><span class="js-word-to-avoid">leverage</span> (unless in the financial sense)</li>
     <li><span class="js-word-to-avoid">liaise</span></li>
@@ -31,10 +31,10 @@
     <li><span class="js-word-to-avoid">progress</span> (as a verb – what are you actually doing?)</li>
     <li><span class="js-word-to-avoid">promote</span> (unless you are talking about an ad campaign or some other marketing promotion)</li>
     <li><span class="js-word-to-avoid">robust</span></li>
-    <li><span class="js-word-to-avoid">slimming</span> down (processes don't diet – we are probably removing x amount of paperwork, etc)</li>
+    <li><span class="js-word-to-avoid">slimming</span> down (processes don’t diet – we are probably removing x amount of paperwork, etc)</li>
     <li><span class="js-word-to-avoid">streamline</span></li>
-    <li><span class="js-word-to-avoid">strengthening</span> (unless it's strengthening bridges or other structures)</li>
-    <li><span class="js-word-to-avoid">tackling</span> (unless it's rugby, football or some other sport)</li>
+    <li><span class="js-word-to-avoid">strengthening</span> (unless it’s strengthening bridges or other structures)</li>
+    <li><span class="js-word-to-avoid">tackling</span> (unless it’s rugby, football or some other sport)</li>
     <li><span class="js-word-to-avoid">transforming</span> (what are you actually doing to change it?)</li>
     <li><span class="js-word-to-avoid">utilise</span></li>
   </ul>
@@ -43,9 +43,9 @@
 
   <ul>
     <li><span class="js-word-to-avoid">drive</span> (you can only drive vehicles; not schemes or people)</li>
-    <li><span class="js-word-to-avoid">drive out</span> (unless it's cattle)</li>
+    <li><span class="js-word-to-avoid">drive out</span> (unless it’s cattle)</li>
     <li><span class="js-word-to-avoid">going forward</span> (unlikely we are giving travel directions)</li>
-    <li><span class="js-word-to-avoid">in order to</span> (superfluous – don't use it)</li>
+    <li><span class="js-word-to-avoid">in order to</span> (superfluous – don’t use it)</li>
     <li><span class="js-word-to-avoid">one-stop shop</span> (we are government, not a retail outlet)</li>
     <li><span class="js-word-to-avoid">ring fencing</span></li>
   </ul>

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -8,5 +8,5 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "World locations..."} %>
+                  data: { placeholder: "World locations…"} %>
 <% end %>

--- a/app/views/admin/editions/_worldwide_priority_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_priority_fields.html.erb
@@ -5,5 +5,5 @@
                   {},
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose worldwide priorities..."} %>
+                  data: { placeholder: "Choose worldwide priorities…"} %>
 <% end %>

--- a/app/views/admin/fact_check_requests/edition_unavailable.html.erb
+++ b/app/views/admin/fact_check_requests/edition_unavailable.html.erb
@@ -1,4 +1,4 @@
 <% page_title "Document unavailable for fact checking" %>
 <div class="fact_check_request alert">
-  <p class="apology">We're sorry, but this document is no longer available for fact checking.</p>
+  <p class="apology">We’re sorry, but this document is no longer available for fact checking.</p>
 </div>

--- a/app/views/admin/find_in_admin_bookmarklet/ie.html.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/ie.html.erb
@@ -13,7 +13,7 @@
 
   <h2 id="ie">Instructions for Internet explorer</h2>
 
-  <p>1. First, make sure that your 'Favourites bar' is enabled</p>
+  <p>1. First, make sure that your ‘Favourites bar’ is enabled</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/1.png' %></p>
 
   <p>you should see the favourites bar:</p>
@@ -25,15 +25,15 @@
     <a class='btn btn-lg btn-primary' href="javascript:<%= render("bookmarklet").gsub(/[\r\n]/,'') %>">Find in admin</a>
   </p>
 
-  <p> and select 'Add to Favourites…'</p>
+  <p> and select ‘Add to Favourites…’</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/3.png' %></p>
 
-  <p>3. If you get a security alert, select 'Yes'</p>
+  <p>3. If you get a security alert, select ‘Yes’</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/4.png' %></p>
 
-  <p>4. Now choose where you want to create the bookmarklet. You should select 'Favourites bar'</p>
+  <p>4. Now choose where you want to create the bookmarklet. You should select ‘Favourites bar’</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/5.png' %></p>
-  <p>Then press 'Add'</p>
+  <p>Then press ‘Add’</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/6.png' %></p>
 
   <p>5. DONE! Your bookmarklet should now appear in the Favourites bar</p>

--- a/app/views/admin/find_in_admin_bookmarklet/ie.html.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/ie.html.erb
@@ -25,7 +25,7 @@
     <a class='btn btn-lg btn-primary' href="javascript:<%= render("bookmarklet").gsub(/[\r\n]/,'') %>">Find in admin</a>
   </p>
 
-  <p> and select 'Add to Favourites...'</p>
+  <p> and select 'Add to Favourites…'</p>
   <p><%= image_tag 'find_in_admin_bookmarklet_instructions/3.png' %></p>
 
   <p>3. If you get a security alert, select 'Yes'</p>

--- a/app/views/admin/find_in_admin_bookmarklet/other.html.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/other.html.erb
@@ -18,5 +18,5 @@
     <a class='btn btn-lg btn-primary' href="javascript:<%= render("bookmarklet").gsub(/[\r\n]/,'') %>">Find in admin</a>
   </p>
 
-  <p>Then, when you're on a frontend page on www.gov.uk you can click 'Find in admin' from your bookmarks toolbar to go to the corresponding admin page.</p>
+  <p>Then, when you’re on a frontend page on www.gov.uk you can click ‘Find in admin’ from your bookmarks toolbar to go to the corresponding admin page.</p>
 </div>

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -17,6 +17,6 @@
   <% end %>
 
   <span class="or_cancel">
-    <%= link_to "No! Don't do that! Noooo!", edit_admin_government_path(@government) %>
+    <%= link_to "No! Don’t do that! Noooo!", edit_admin_government_path(@government) %>
   </span>
 </div>

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -10,7 +10,7 @@
                         { include_blank: true },
                         multiple: true,
                         class: 'chzn-select form-control',
-                        data: { placeholder: "Role(s) this account is for..."} %>
+                        data: { placeholder: "Role(s) this account is for…"} %>
         </div>
         <%= form.text_area :summary , rows: 2 %>
         <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>

--- a/app/views/admin/imports/new.html.erb
+++ b/app/views/admin/imports/new.html.erb
@@ -16,7 +16,7 @@
         <% end %>
         <%= content_tag :div, class: "form-group" do %>
           <%= import_form.label :organisation_id, 'Default organisation' %>
-          <%= import_form.select :organisation_id, options_from_collection_for_select(Organisation.all, 'id', 'name', @import.organisation_id), { include_blank: true }, class: 'chzn-select form-control', data: { placeholder: "Choose organisation to use as default when not specified..." } %>
+          <%= import_form.select :organisation_id, options_from_collection_for_select(Organisation.all, 'id', 'name', @import.organisation_id), { include_blank: true }, class: 'chzn-select form-control', data: { placeholder: "Choose organisation to use as default when not specified…" } %>
         <% end %>
         <%= content_tag :div, class: "form-group" do %>
           <%= import_form.label :file, 'CSV File' %>

--- a/app/views/admin/imports/new_document_list.html.erb
+++ b/app/views/admin/imports/new_document_list.html.erb
@@ -7,7 +7,7 @@
       <% if document.latest_edition %>
         [<%= document.latest_edition.state.humanize %>] <%= link_to document.latest_edition.title, admin_edition_path(document.latest_edition) %>
       <% else %>
-        DELETED - &ldquo;<%= Edition.unscoped.where(:document_id => document.id).first.title %>&rdquo;
+        DELETED – ‘<%= Edition.unscoped.where(:document_id => document.id).first.title %>’
       <% end %>
       imported from
       <%= document.document_sources.map { |ds| link_to(ds.url, ds.url) }.to_sentence.html_safe %>

--- a/app/views/admin/offsite_links/edit.html.erb
+++ b/app/views/admin/offsite_links/edit.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Edit an offsite link" %>
 
 <h2>
-  Edit the offsite link within '<%= @parent.name %>'
+  Edit the offsite link within ‘<%= @parent.name %>’
 </h2>
 
 <%= render partial: "form", locals: {parent: @parent, offsite_link: @offsite_link} %>

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -12,7 +12,7 @@
     <p><%= organisation_form.text_area :logo_formatted_name, rows: "4", style: "width: auto" %></p>
     <p>
       <%= organisation_form.label :organisation_logo_type_id, 'Logo crest' %>
-      <%= organisation_form.select :organisation_logo_type_id, options_from_collection_for_select(OrganisationLogoType.all, "id", "title", organisation.organisation_logo_type_id), {}, class: 'chzn-select form-control', data: { placeholder: "Choose logo crest..."} %>
+      <%= organisation_form.select :organisation_logo_type_id, options_from_collection_for_select(OrganisationLogoType.all, "id", "title", organisation.organisation_logo_type_id), {}, class: 'chzn-select form-control', data: { placeholder: "Choose logo crest…"} %>
     </p>
     <p class="organisation-custom-logo <%= logo_visibility_css(organisation) %>">
       <%= organisation_form.label :logo, 'Custom logo' %>
@@ -22,7 +22,7 @@
     </p>
     <p>
       <%= organisation_form.label :organisation_brand_colour_id, 'Brand colour' %>
-      <%= organisation_form.select :organisation_brand_colour_id, options_from_collection_for_select(OrganisationBrandColour.all, "id", "title", organisation.organisation_brand_colour_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose brand colour..."} %>
+      <%= organisation_form.select :organisation_brand_colour_id, options_from_collection_for_select(OrganisationBrandColour.all, "id", "title", organisation.organisation_brand_colour_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose brand colour…"} %>
     </p>
     <%= organisation_form.fields_for :default_news_image do |image_fields| %>
       <%= render partial: "admin/shared/default_news_image_fields", locals: {image_fields: image_fields} %>
@@ -32,7 +32,7 @@
     </p>
     <p>
       <%= organisation_form.label :organisation_type_key, "Organisation type" %>
-      <%= organisation_form.select :organisation_type_key, options_from_collection_for_select(OrganisationType.in_listing_order, "key", "name", organisation.organisation_type_key), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the organisation type..." } %>
+      <%= organisation_form.select :organisation_type_key, options_from_collection_for_select(OrganisationType.in_listing_order, "key", "name", organisation.organisation_type_key), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the organisation type…" } %>
     </p>
     <p>
       <%= organisation_form.text_field :alternative_format_contact_email, label_text: "Email address for ordering attached files in an alternative format" %>
@@ -47,7 +47,7 @@
     </p>
     <p class="js-closed-organisation-field js-superseded-organisation-field">
       <%= organisation_form.label :superseding_organisation_ids, "Superseded by" %>
-      <%= organisation_form.select :superseding_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.superseding_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose which organisation(s) this organisation has been superseded by..." } %>
+      <%= organisation_form.select :superseding_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.superseding_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose which organisation(s) this organisation has been superseded by…" } %>
     </p>
     <div class="js-closed-organisation-field">
       <div class="form-group">
@@ -74,7 +74,7 @@
     <%= hidden_field_tag "organisation[parent_organisation_ids][]", "", id: "organisation_parent_organisation_ids_default" %>
     <p>
       <%= organisation_form.label :parent_organisation_ids, 'Sponsoring organisations' %>
-      <%= organisation_form.select :parent_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.parent_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose parent organisations..." } %>
+      <%= organisation_form.select :parent_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.parent_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose parent organisations…" } %>
     </p>
 
     <h3>Topics</h3>
@@ -82,7 +82,7 @@
       <p>
         <%= label_tag "organisation_topic_ids_#{ot.ordering}" do %>
           Topic <%= ot.ordering + 1 %>
-          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose topics..."}, id: "organisation_topic_ids_#{ot.ordering}" %>
+          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose topics…"}, id: "organisation_topic_ids_#{ot.ordering}" %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][ordering]", ot.ordering %>
           <%= hidden_field_tag "organisation[organisation_classifications_attributes][][id]", ot.id %>
         <% end %>
@@ -94,7 +94,7 @@
       <p>
         <%= label_tag "organisation_mainstream_categories_ids_#{omc.ordering}" do %>
           Detailed guidance category <%= omc.ordering + 1 %>
-          <%= select_tag "organisation[organisation_mainstream_categories_attributes][][mainstream_category_id]", options_from_collection_for_select(MainstreamCategory.all, 'id', 'title', omc.mainstream_category_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose detailed guidance category..."}, id: "organisation_mainstream_category_ids_#{omc.ordering}" %>
+          <%= select_tag "organisation[organisation_mainstream_categories_attributes][][mainstream_category_id]", options_from_collection_for_select(MainstreamCategory.all, 'id', 'title', omc.mainstream_category_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose detailed guidance category…"}, id: "organisation_mainstream_category_ids_#{omc.ordering}" %>
           <%= hidden_field_tag "organisation[organisation_mainstream_categories_attributes][][ordering]", omc.ordering %>
           <%= hidden_field_tag "organisation[organisation_mainstream_categories_attributes][][id]", omc.id %>
         <% end %>

--- a/app/views/admin/policy_groups/_form.html.erb
+++ b/app/views/admin/policy_groups/_form.html.erb
@@ -13,8 +13,8 @@
     <%= render 'admin/attachments/markdown_codes', attachable: policy_group %>
   <% else %>
     <p>
-      If you'd like to add an attachment to this group,
-      please save it first. You'll then find a new tab at the top of the page
+      If you’d like to add an attachment to this group,
+      please save it first. You’ll then find a new tab at the top of the page
       that you can use to upload, edit and delete attachments.
     </p>
   <% end %>

--- a/app/views/admin/promotional_features/edit.html.erb
+++ b/app/views/admin/promotional_features/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title "Edit #{@promotional_feature.title} promotional feature" %>
-<h1>Edit '<%= @promotional_feature.title %>' feature</h1>
+<h1>Edit ‘<%= @promotional_feature.title %>’ feature</h1>
 
 <%= form_for [:admin, @promotional_feature.organisation, @promotional_feature], html: { class: "form-horizontal promotional_feature_item" } do |form| %>
   <%= form.errors %>

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -5,7 +5,7 @@
                 options_for_select(disambiguated_people_names, form.object.person_id),
                 {include_blank: true},
                 class: 'chzn-select form-control',
-                data: { placeholder: "Choose person..." },
+                data: { placeholder: "Choose person…" },
                 disabled: !form.object.new_record? %>
 
 <% if form.object.new_record? %>

--- a/app/views/admin/shared/_policy_fields.html.erb
+++ b/app/views/admin/shared/_policy_fields.html.erb
@@ -5,5 +5,5 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose policies..."} %>
+                  data: { placeholder: "Choose policies…"} %>
 </fieldset>

--- a/app/views/admin/speeches/_delivered_by_fields.html.erb
+++ b/app/views/admin/speeches/_delivered_by_fields.html.erb
@@ -5,7 +5,7 @@
                   options_for_select(taggable_role_appointments_container, edition.role_appointment_id),
                   { include_blank: true },
                   class: 'chzn-select form-control',
-                    data: { placeholder: "Choose a person..." } %>
+                    data: { placeholder: "Choose a person…" } %>
 <% end %>
 </div>
 

--- a/app/views/admin/statistics_announcements/_document_linker.html.erb
+++ b/app/views/admin/statistics_announcements/_document_linker.html.erb
@@ -1,5 +1,5 @@
 <% initialise_script 'GOVUK.documentFinder', type: 'publication', subtypes: [statistics_announcement.publication_type_id], state: 'not_published',
-    no_results_message: "Couldn't find a matching draft publication of type '#{statistics_announcement.publication_type.singular_name}'" %>
+    no_results_message: "Couldn’t find a matching draft publication of type ‘#{statistics_announcement.publication_type.singular_name}’" %>
 <% initialise_script 'GOVUK.statisticsAnnouncementLinker' %>
 
 <%= form_for [:admin, statistics_announcement], html: { style: 'display:none' } do |form| %>

--- a/app/views/admin/statistics_announcements/_document_linker.html.erb
+++ b/app/views/admin/statistics_announcements/_document_linker.html.erb
@@ -17,7 +17,7 @@
     <%= button_tag "Search", type: 'button', id: 'find-documents', class: 'btn btn-default' %>
     <%= image_tag 'loading-666666.gif', class: 'js-loader' %>
     <p class="tip">
-      Only the first 10 results are returned - be as specific as you can
+      Only the first 10 results are returned – be as specific as you can
     </p>
   </div>
 <% end %>

--- a/app/views/admin/topical_events/_custom_form_fields.html.erb
+++ b/app/views/admin/topical_events/_custom_form_fields.html.erb
@@ -28,7 +28,7 @@
   <%= classification_form.fields_for :social_media_accounts do |account_form| %>
     <div class="form-group">
       <%= account_form.label :social_media_service_id, 'Service' %>
-      <%= account_form.select :social_media_service_id, options_from_collection_for_select(SocialMediaService.all, :id, :name, account_form.object.social_media_service_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media service..." } %>
+      <%= account_form.select :social_media_service_id, options_from_collection_for_select(SocialMediaService.all, :id, :name, account_form.object.social_media_service_id), {include_blank: true}, class: 'chzn-select form-control', data: { placeholder: "Choose the social media service…" } %>
     </div>
     <%= account_form.text_field :url %>
   <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -11,7 +11,7 @@
                       { include_blank: true },
                       multiple: true,
                       class: 'chzn-select form-control',
-                      data: { placeholder: "World locations..."} %>
+                      data: { placeholder: "World locations…"} %>
 
 
     <% end %>

--- a/app/views/admin/worldwide_office_translations/edit.html.erb
+++ b/app/views/admin/worldwide_office_translations/edit.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Edit translation for #{@contact.title}" %>
 
-<h1>Edit '<%= translation_locale.native_language_name %> (<%= translation_locale.english_language_name %>)' translation for: <%= @contact.title %></h1>
+<h1>Edit ‘<%= translation_locale.native_language_name %> (<%= translation_locale.english_language_name %>)’ translation for: <%= @contact.title %></h1>
 
 <%= render partial: 'admin/contact_translations/form',
            locals: { translated_contact: @translated_contact,

--- a/app/views/admin/worldwide_offices/_form.html.erb
+++ b/app/views/admin/worldwide_offices/_form.html.erb
@@ -13,7 +13,7 @@
             ),
             {},
             class: ['chzn-select', 'form-control'],
-            data: { placeholder: "Choose office type..." } %>
+            data: { placeholder: "Choose office type…" } %>
       </div>
       <%= render partial: 'admin/contacts/embed_details_for_form', locals: { contact: office_form.object.contact } %>
       <%= render partial: 'admin/contacts/contact_type_details_form', locals: { contact_form: contact_form } %>

--- a/app/views/admin/worldwide_offices/_worldwide_office.html.erb
+++ b/app/views/admin/worldwide_offices/_worldwide_office.html.erb
@@ -41,7 +41,7 @@
         [:admin, worldwide_organisation, worldwide_office],
         method: "delete",
         class: "btn btn-danger",
-        data: { confirm: "Delete office '#{worldwide_office.title}'?" } %>
+        data: { confirm: "Delete office ‘#{worldwide_office.title}’?" } %>
   <%= link_to icon("Edit"), [:edit, :admin, worldwide_organisation, worldwide_office], class: "btn btn-default" %>
   <% unless worldwide_organisation.is_main_office?(worldwide_office) %>
     <%= button_to 'Set as main office', set_main_office_admin_worldwide_organisation_path(worldwide_organisation, worldwide_organisation: {main_office_id: worldwide_office.id}), method: :put, class: 'btn btn-info' %>

--- a/test/functional/admin/about_pages_controller_test.rb
+++ b/test/functional/admin/about_pages_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::AboutPagesControllerTest < ActionController::TestCase
     get :show, topical_event_id: @topical_event.to_param
     assert_response :success
     assert_select 'h1', @topical_event.name
-    assert_select 'p', /doesn't yet have a page/
+    assert_select 'p', /doesn’t yet have a page/
   end
 
   view_test "GET new allows user to enter copy for new about page" do

--- a/test/functional/admin/contact_translations_controller_test.rb
+++ b/test/functional/admin/contact_translations_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
 
     get :edit, organisation_id: organisation, contact_id: contact, id: "fr"
 
-    assert_select "h1", text: "Edit 'Français (French)' translation for: english-title"
+    assert_select "h1", text: "Edit ‘Français (French)’ translation for: english-title"
   end
 
   view_test "edit displays translation boxes for contact numbers" do

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -87,13 +87,13 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     @group.documents = [create(:publication).document]
     @collection.groups << build(:document_collection_group)
     get :delete, document_collection_id: @collection, id: @group
-    assert_select 'div.alert', /can't delete a group.*documents/
+    assert_select 'div.alert', /can’t delete a group.*documents/
     assert_select 'input[type="submit"]', count: 0
   end
 
   view_test "GET #delete explains you can't delete the last group" do
     get :delete, document_collection_id: @collection, id: @group
-    assert_select 'div.alert', /can't\s+delete the last/
+    assert_select 'div.alert', /can’t\s+delete the last/
     assert_select 'input[type="submit"]', count: 0
   end
 

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     get :show, id: fact_check_request
 
-    assert_select ".fact_check_request .apology", text: "We're sorry, but this document is no longer available for fact checking."
+    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
     refute_select ".title", text: "deleted-publication-title"
     refute_select ".body", text: "deleted-publication-body"
   end
@@ -49,7 +49,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     get :edit, id: fact_check_request
 
-    assert_select ".fact_check_request .apology", text: "We're sorry, but this document is no longer available for fact checking."
+    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
     refute_select ".document .title", text: "deleted-publication-title"
     refute_select ".document .body", text: "deleted-publication-body"
   end
@@ -137,7 +137,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
 
     put :update, id: fact_check_request, fact_check_request: attributes
 
-    assert_select ".fact_check_request .apology", text: "We're sorry, but this document is no longer available for fact checking."
+    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end
 end
 
@@ -244,7 +244,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     edition = create(:deleted_publication)
     post :create, edition_id: edition.id, fact_check_request: @attributes
 
-    assert_select ".fact_check_request .apology", text: "We're sorry, but this document is no longer available for fact checking."
+    assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end
 
   private


### PR DESCRIPTION
Minor typography improvements to Whitehall.

* Use ellipses (… not ...)
* Use smart quotes http://smartquotesforsmartpeople.com/
* Use en dashes not hyphens