### PR TITLE
Fix case study preview URLs

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -271,11 +271,11 @@ module Admin::EditionsHelper
     links = []
 
     if edition.available_in_english?
-      links << [preview_document_path(edition), 'Language: English']
+      links << [preview_document_url(edition), 'Language: English']
     end
 
     links + edition.non_english_translated_locales.map do |locale|
-      [preview_document_path(edition, locale: locale),
+      [preview_document_url(edition, locale: locale),
        "Language: #{locale.native_and_english_language_name}"]
     end
   end

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -45,9 +45,11 @@ module PublicDocumentRoutesHelper
   end
 
   def preview_document_url(edition, options = {})
-    case_study_preview_host = edition.is_a?(CaseStudy) && Whitehall.case_study_preview_host
-    options.merge!(host: case_study_preview_host || request.host)
-    options.merge!(preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i)
+    if edition.is_a?(CaseStudy) && Whitehall.case_study_preview_host.present?
+      options[:host] = Whitehall.case_study_preview_host
+    else
+      options.merge!(preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i)
+    end
 
     document_url(edition, options)
   end

--- a/app/views/admin/editions/_alerts.html.erb
+++ b/app/views/admin/editions/_alerts.html.erb
@@ -3,7 +3,7 @@
     <p><strong>Warning</strong> This edition was force published and has not yet been reviewed by a second pair of eyes.</p>
 
     <% if can?(:approve, edition) %>
-      <p><%= link_to "View this on the website", preview_document_path(@edition), target: '_blank' %> and check everything thoroughly.</p>
+      <p><%= link_to "View this on the website", preview_document_url(@edition), target: '_blank' %> and check everything thoroughly.</p>
       <p><%= approve_retrospectively_edition_button(edition) %></p>
     <% else %>
       <p> Please have an editor other than the original publisher review the document to clear this warning.</p>

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -88,7 +88,7 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     end
   end
 
-  test 'Locale is ignored if edition is a non-tranlatable type' do
+  test 'Locale is ignored if edition is a non-translatable type' do
     non_translatable_edition = create(:consultation)
     refute public_document_url(non_translatable_edition, locale: 'fr').include?('fr')
   end
@@ -98,6 +98,19 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     with_locale :de do
       assert public_document_url(non_english_edition, locale: 'de').include? ".fr"
     end
+  end
+
+  test "Creates a preview URL with cachebust and edition parameters" do
+    edition = create(:draft_publication)
+    preview_url = preview_document_url(edition)
+    assert_equal "http://test.host/government/publications/#{edition.slug}?cachebust=#{Time.zone.now.getutc.to_i}&preview=#{edition.id}", preview_url
+  end
+
+  test "Creates a preview URL without parameters for case studies" do
+    Whitehall.stubs(case_study_preview_host: 'content.preview')
+    edition = create(:draft_case_study)
+    preview_url = preview_document_url(edition)
+    assert_equal "http://content.preview/government/case-studies/#{edition.slug}", preview_url
   end
 
   test "organisations have the correct path generated" do


### PR DESCRIPTION
When case studies are previewed through Content Preview, there is no
need for the edition or cachebust parameters in the URL. This is because
content preview always displays the latest edition, and has a short
cache timeout.

In addition, some admin links were still using the relative path, rather than the full URL potentially pointing to content preview.