### PR TITLE
Data hygiene task to bulk tag documents to topics

### DIFF
--- a/lib/data_hygiene/specialist_sector_tagger.rb
+++ b/lib/data_hygiene/specialist_sector_tagger.rb
@@ -1,0 +1,77 @@
+class SpecialistSectorTagger
+  def self.process_from_csv(csv_location, logger: Logger.new(nil))
+    CSV.foreach(csv_location, headers: true) do |row|
+      new(
+        row.fetch("document_type"),
+        row.fetch("slug"),
+        row.fetch("tag"),
+        logger: logger,
+      ).process
+    end
+  end
+
+  def initialize(document_type,
+                 document_slug,
+                 specialist_sector_slug,
+                 logger: Logger.new(nil)
+                )
+    @document_type = document_type
+    @document_slug = document_slug
+    @specialist_sector_slug = specialist_sector_slug
+    @logger = logger
+  end
+
+  def process
+    if document.nil?
+      log "warning: failed to find #{@document_type} document with slug" +
+        " #{@document_slug} - skipping"
+      return
+    end
+
+    document.editions.each do |edition|
+      if edition.specialist_sectors.any? {|s| s.tag == @specialist_sector_slug }
+        log "skipping '#{document.slug}' #{document.document_type} edition" +
+          " #{edition.id}(#{edition.state})" +
+          "- already tagged to #{@specialist_sector_slug}"
+      else
+        log "tagging '#{document.slug}' #{document.document_type} edition" +
+          " #{edition.id}(#{edition.state})" +
+          " to #{@specialist_sector_slug}"
+        SpecialistSector.create!(edition: edition, tag: @specialist_sector_slug)
+      end
+    end
+    if document.published_edition.present?
+      register_edition(document.published_edition)
+    end
+  end
+
+private
+
+  def document
+    @document ||= Document.at_slug(@document_type, @document_slug)
+  end
+
+  def register_edition(edition)
+    log "registering '#{edition.slug}' #{document.document_type}"
+    edition.reload
+    register_with_panopticon(edition)
+    register_with_publishing_api(edition)
+    register_with_search(edition)
+  end
+
+  def register_with_panopticon(edition)
+    ServiceListeners::PanopticonRegistrar.new(edition).register!
+  end
+
+  def register_with_publishing_api(edition)
+    Whitehall::PublishingApi.republish_async(edition)
+  end
+
+  def register_with_search(edition)
+    ServiceListeners::SearchIndexer.new(edition).index!
+  end
+
+  def log(message)
+    @logger.info message
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -94,6 +94,20 @@ task process_topic_retagging_csv: :environment do
   TagChangesProcessor.new(csv_location, logger: Logger.new(STDOUT)).process
 end
 
+desc "Process CSV for topic tagging"
+task process_topic_tagging_csv: :environment do
+  require "data_hygiene/specialist_sector_tagger"
+
+  csv_location = ENV['CSV_LOCATION']
+
+  unless csv_location
+    $stderr.puts "No CSV path specified: please pass CSV_LOCATION"
+    exit 1
+  end
+
+  SpecialistSectorTagger.process_from_csv(csv_location, logger: Logger.new(STDOUT))
+end
+
 desc "Unwithdraw an edition (creates and publishes a draft with audit trail)"
 task :unwithdraw_edition, [:edition_id] => :environment do |t,args|
   DataHygiene::EditionUnwithdrawer.new(args[:edition_id], Logger.new(STDOUT)).unwithdraw!

--- a/test/unit/data_hygiene/specialist_sector_tagger_test.rb
+++ b/test/unit/data_hygiene/specialist_sector_tagger_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+require "data_hygiene/specialist_sector_tagger"
+
+class SpecialistSectorTaggerTest < ActiveSupport::TestCase
+  setup do
+    @published_edition = create(:published_edition)
+    @document = @published_edition.document
+    @draft_edition = create(:draft_edition, document: @document)
+    @gds_user = create(:gds_team_user)
+    @tag_slug = "transport/transporting-goods"
+    stub_registration
+  end
+
+  test "adds specialist_sector taggings to all editions of the document" do
+    SpecialistSectorTagger.new(@document.document_type, @document.slug,
+                               @tag_slug).process
+
+    assert_equal 1, @published_edition.specialist_sectors.size
+    assert_equal 1, @draft_edition.specialist_sectors.size
+    assert_equal @tag_slug, @published_edition.specialist_sectors.first.tag
+    assert_equal @tag_slug, @draft_edition.specialist_sectors.first.tag
+  end
+
+  test "does not add duplicate taggings" do
+    SpecialistSector.create!(edition_id: @draft_edition.id, tag: @tag_slug)
+
+    SpecialistSectorTagger.new(@document.document_type, @document.slug,
+                               @tag_slug).process
+
+    assert_equal 1, @draft_edition.specialist_sectors.size
+  end
+
+  test "logs a warning and returns if a document cannot be found" do
+    log_output = StringIO.new("")
+    assert_nothing_raised do
+      SpecialistSectorTagger.new(@document.document_type, "foo", @tag_slug,
+                                 logger: Logger.new(log_output)).process
+    end
+
+    assert_match /warning/, log_output.string
+  end
+
+  test "re-registers the published edition" do
+    Whitehall::PublishingApi.expects(:republish_async).with(@published_edition)
+    ServiceListeners::SearchIndexer.expects(:new).with(@published_edition)
+      .returns(mock(index!: true))
+    ServiceListeners::PanopticonRegistrar.expects(:new).with(@published_edition)
+      .returns(mock(register!: true))
+
+    SpecialistSectorTagger.new(@document.document_type, @document.slug,
+                               @tag_slug).process
+  end
+
+  test "registers nothing if there are no published editions" do
+    @published_edition.destroy
+    Whitehall::PublishingApi.expects(:republish_async).never
+    ServiceListeners::SearchIndexer.expects(:new).never
+    ServiceListeners::PanopticonRegistrar.expects(:new).never
+
+    SpecialistSectorTagger.new(@document.document_type, @document.slug,
+                               @tag_slug).process
+  end
+
+  def stub_registration
+    Whitehall::PublishingApi.stubs(:republish_async)
+    ServiceListeners::SearchIndexer.any_instance.stubs(:index!)
+    ServiceListeners::PanopticonRegistrar.any_instance.stubs(:register!)
+  end
+end


### PR DESCRIPTION
Add a data hygiene task to bulk add topics (aka specialist_sectors) to
documents.  This will be used as part of the migration away from detailed
guide categories.