### PR TITLE
Stop using deprecated contentapi path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '2.3.4'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '20.1.0'
+gem 'gds-api-adapters', '21.0.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (20.1.0)
+    gds-api-adapters (21.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -460,7 +460,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 20.1.0)
+  gds-api-adapters (= 21.0.0)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.3.0)

--- a/README.md
+++ b/README.md
@@ -220,13 +220,7 @@ call `save!` on it.
 ## Specifying a different endpoint for the GDS Content API
 
 Whitehall uses the GDS Content API to serve categorisation for
-Detailed Guidance.
-
-You need to set the following environment variables :-
-
-    CONTENT_API_ENDPOINT_URL # e.g. https://contentapi.preview.alphagov.co.uk
-    CONTENT_API_USERNAME
-    CONTENT_API_PASSWORD
+Detailed Guidance. In tests, this is stubbed out, see `config/initializers/content_api.rb`.
 
 ## Generating the documentation
 

--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -1,7 +1,7 @@
 require 'gds_api/content_api'
 
 class GdsApi::ContentApi::Fake
-  def tag(tag)
+  def tag(tag, tag_type)
     {}
   end
 

--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -14,11 +14,8 @@ class GdsApi::ContentApi::Fake
   end
 end
 
-if endpoint_url = ENV["CONTENT_API_ENDPOINT_URL"]
-  credentials = { user: ENV["CONTENT_API_USERNAME"], password: ENV["CONTENT_API_PASSWORD"] }
-  Whitehall.content_api = GdsApi::ContentApi.new(endpoint_url, basic_auth: credentials)
-elsif Rails.env.production?
-  Whitehall.content_api = GdsApi::ContentApi.new(Plek.find("contentapi"))
-else
+if Rails.env.test?
   Whitehall.content_api = GdsApi::ContentApi::Fake.new
+else
+  Whitehall.content_api = GdsApi::ContentApi.new(Plek.find("contentapi"))
 end

--- a/lib/breadcrumb_trail.rb
+++ b/lib/breadcrumb_trail.rb
@@ -15,6 +15,12 @@ class BreadcrumbTrail
   def url_maker
     Whitehall.url_maker
   end
+
+private
+
+  def mainstream_section_tag_for(string_tag_id)
+    Whitehall.content_api.tag(string_tag_id, "section") || {}
+  end
 end
 
 class DetailedGuideBreadcrumbTrail < BreadcrumbTrail
@@ -38,7 +44,7 @@ class DetailedGuideBreadcrumbTrail < BreadcrumbTrail
 
 private
   def tag_hash(mainstream_category)
-    tag = Whitehall.content_api.tag(mainstream_category.parent_tag) || {}
+    tag = mainstream_section_tag_for(mainstream_category.parent_tag)
     {
       title: mainstream_category.title,
       id: mainstream_category.path,
@@ -68,7 +74,9 @@ class MainstreamCategoryBreadcrumbTrail < BreadcrumbTrail
       format: 'section',
       web_url: url_maker.mainstream_category_path(@mainstream_category),
       id: @mainstream_category.path,
-      tags: [Whitehall.content_api.tag(@mainstream_category.parent_tag).to_hash]
+      tags: [
+        mainstream_section_tag_for(@mainstream_category.parent_tag).to_hash
+      ]
     }
   end
 end

--- a/test/unit/breadcrumb_trail_test.rb
+++ b/test/unit/breadcrumb_trail_test.rb
@@ -5,7 +5,9 @@ class BreadcrumbTrailTest < ActiveSupport::TestCase
     mainstream_category = create(:mainstream_category, parent_tag: "business/tax")
     detailed_guide = create(:detailed_guide, title: "detailed-guide-title", primary_mainstream_category: mainstream_category)
     content_api = stub("content-api")
-    content_api.expects(:tag).with(mainstream_category.parent_tag).returns(business_tax_tag)
+    content_api.expects(:tag)
+      .with(mainstream_category.parent_tag, "section")
+      .returns(business_tax_tag)
 
     with_content_api(content_api) do
       breadcrumb_trail = BreadcrumbTrail.for(detailed_guide)
@@ -49,7 +51,9 @@ class BreadcrumbTrailTest < ActiveSupport::TestCase
   test "should build hash suitable for slimmer from mainstream_category" do
     mainstream_category = create(:mainstream_category, parent_tag: "business/tax")
     content_api = stub("content-api")
-    content_api.expects(:tag).with(mainstream_category.parent_tag).returns(business_tax_tag)
+    content_api.expects(:tag)
+      .with(mainstream_category.parent_tag, "section")
+      .returns(business_tax_tag)
 
     with_content_api(content_api) do
       breadcrumb_trail = BreadcrumbTrail.for(mainstream_category)


### PR DESCRIPTION
If we can migrate our clients off the deprecated path, then we can remove it.