### PR TITLE
[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -45,8 +45,9 @@ module PublicDocumentRoutesHelper
   end
 
   def preview_document_url(edition, options = {})
-    if edition.is_a?(CaseStudy) && Whitehall.case_study_preview_host.present?
-      options[:host] = Whitehall.case_study_preview_host
+    case edition
+    when CaseStudy
+      options[:host] = Plek.current.find("draft-origin")
     else
       options.merge!(preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i)
     end


### PR DESCRIPTION
__This PR is intended as a reminder that we should tidy this up, and should not be merged as-is__

Now that draft functionality exists in Production, we should no longer
need to set `Whitehall.case_study_preview_host` to determine the
location of the draft origin where users can preview content.

Change the `if` block to use `case` statements as they are better suited
to matching multiple options, e.g.:

    case edition
    when CaseStudy, DocTypeA, DocTypeB

The changes as-is fail the tests; this PR is mostly intended as a reminder that this is something we can tidy up.

We shouldn't hardcode `draft-origin`; perhaps we could set this with an environment variable as part of the move towards 12 factor applications.