### PR TITLE
Fix email notification environment indicator

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -59,7 +59,9 @@ class Notifications < ActionMailer::Base
 
   def no_reply_email_address
     name = "DO NOT REPLY"
-    name << " [#{Plek.new.parent_domain}]" unless Plek.new.parent_domain =~ /production/
+    if GovukAdminTemplate.environment_label !~ /production/i
+      name.prepend("[GOV.UK #{GovukAdminTemplate.environment_label}] ")
+    end
     "#{name} <inside-government@digital.cabinet-office.gov.uk>"
   end
 end

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -59,7 +59,7 @@ class Notifications < ActionMailer::Base
 
   def no_reply_email_address
     name = "DO NOT REPLY"
-    name << " (#{Plek.new.parent_domain})" unless Plek.new.parent_domain =~ /production/
+    name << " [#{Plek.new.parent_domain}]" unless Plek.new.parent_domain =~ /production/
     "#{name} <inside-government@digital.cabinet-office.gov.uk>"
   end
 end


### PR DESCRIPTION
Currently, the email environment label doesn't get shown to users (fixed in the first commit).

This fixes that and improves and future-proofs the label generally.