### PR TITLE
Fix specialist_sector_cleanup task.

### DIFF
--- a/lib/data_hygiene/specialist_sector_cleanup.rb
+++ b/lib/data_hygiene/specialist_sector_cleanup.rb
@@ -8,7 +8,7 @@ class SpecialistSectorCleanup
   end
 
   def any_published_taggings?
-    taggings.map(&:edition).any? do |edition|
+    taggings.map(&:edition).compact.any? do |edition|
       edition.document.ever_published_editions.any?
     end
   end
@@ -16,12 +16,15 @@ class SpecialistSectorCleanup
   def remove_taggings(add_note: true)
     taggings.each do |tagging|
       edition = tagging.edition
-
-      puts "Removing tagging to edition ##{edition.id}"
+      if edition
+        puts "Removing tagging to edition ##{edition.id}"
+      else
+        puts "Removing orphaned tagging to edition_id ##{tagging.edition_id}"
+      end
 
       tagging.destroy
 
-      if add_note
+      if add_note && edition
         puts "Adding an editorial note from the GDS user"
 
         gds_user = User.find_by(email: "govuk-whitehall@digital.cabinet-office.gov.uk")

--- a/test/unit/data_hygiene/specialist_sector_cleanup_test.rb
+++ b/test/unit/data_hygiene/specialist_sector_cleanup_test.rb
@@ -29,6 +29,17 @@ class SpecialistSectorCleanupTest < ActiveSupport::TestCase
     assert cleanup.any_published_taggings?
   end
 
+  test "#any_published_taggings? handles orphaned taggings" do
+    cleanup = SpecialistSectorCleanup.new('oil-and-gas/offshore')
+
+    tagging = create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    tagging.update_column(:edition_id, 12345)
+    refute cleanup.any_published_taggings?
+
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+    assert cleanup.any_published_taggings?
+  end
+
   test "#remove_taggings(add_note: false) removes the taggings without adding notes" do
     create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
     create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
@@ -37,6 +48,17 @@ class SpecialistSectorCleanupTest < ActiveSupport::TestCase
 
     assert_equal 0, SpecialistSector.count
     assert_equal 0, EditorialRemark.count
+  end
+
+  test "#remove_taggings handles orphaned taggings" do
+    tagging = create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @draft_edition)
+    tagging.update_column(:edition_id, 12345)
+    create(:specialist_sector, tag: 'oil-and-gas/offshore', edition: @published_edition)
+
+    SpecialistSectorCleanup.new('oil-and-gas/offshore').remove_taggings
+
+    assert_equal 0, SpecialistSector.count
+    #assert_equal 0, EditorialRemark.count
   end
 
   test "#remove_taggings(add_note: true) removes the taggings and adds notes" do


### PR DESCRIPTION
This was blowing up if it encountered an orphaned tagging.  This updates
it to be more robust and handle this case.