### PR TITLE
Fix broken fix for email notifications env indicators

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -62,6 +62,9 @@ class Notifications < ActionMailer::Base
     if GovukAdminTemplate.environment_label !~ /production/i
       name.prepend("[GOV.UK #{GovukAdminTemplate.environment_label}] ")
     end
-    "#{name} <inside-government@digital.cabinet-office.gov.uk>"
+
+    address = Mail::Address.new("inside-government@digital.cabinet-office.gov.uk")
+    address.display_name = name
+    address.format
   end
 end

--- a/test/unit/services/listeners/author_notifier_test.rb
+++ b/test/unit/services/listeners/author_notifier_test.rb
@@ -34,4 +34,16 @@ class ServiceListeners::AuthorNotifierTest < ActiveSupport::TestCase
     assert_equal creator.email, first_notification.to[0]
     assert_match /\'#{edition.title}\' has been published/, first_notification.subject
   end
+
+  test 'sets a suitable "from" including a quoted display name' do
+    edition = create(:edition)
+
+    ServiceListeners::AuthorNotifier.new(edition).notify!
+
+    assert_equal 1, ActionMailer::Base.deliveries.size
+
+    first_notification = ActionMailer::Base.deliveries.first
+    # GovukAdminTemplate.environment_label isn't set in tests, hence the space inside the brackets
+    assert_equal '"[GOV.UK ] DO NOT REPLY" <inside-government@digital.cabinet-office.gov.uk>', first_notification[:from].to_s
+  end
 end


### PR DESCRIPTION
The fix here: c74383ac0f5f4de916b33c969a9fb6e4cc6c7905 meant that emails in
non-production environments stopped being sent.

This seems to be because square brackets require the display_name part to be quoted. The parentheses
that we used previously were treated as a comment and so not displayed to users
whereas the square brackets seem to prevent the email from being sent.

Emails in production were unaffected because they do not include the square
brackets.

I've used the mail gem because it will quote the 'display_name' as required but
it also reduces the knowledge our code has to have about formatting the 'from'
field correctly.