### PR TITLE
Fix no results response for detailed categories api.

### DIFF
--- a/app/controllers/api/detailed_guides_controller.rb
+++ b/app/controllers/api/detailed_guides_controller.rb
@@ -22,11 +22,7 @@ class Api::DetailedGuidesController < PublicFacingController
 
   def tags
     @results = MainstreamCategory.with_published_content.where(parent_tag: params[:parent_id])
-    if @results.any?
-      respond_with Api::MainstreamCategoryTagPresenter.new(@results)
-    else
-      respond_with_not_found
-    end
+    respond_with Api::MainstreamCategoryTagPresenter.new(@results)
   end
 
   private

--- a/test/functional/api/detailed_guides_controller_test.rb
+++ b/test/functional/api/detailed_guides_controller_test.rb
@@ -75,10 +75,10 @@ class Api::DetailedGuidesControllerTest < ActionController::TestCase
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
-  view_test "tags responds with 404 if there aren't any valid children" do
+  view_test "tags responds with empty array if there aren't any valid children" do
     MainstreamCategory.stubs(:with_published_content).returns(stub('scope', where: []))
     get :tags, { parent_id: 'test1/test2', format: 'json' }
-    assert_response :not_found
-    assert_equal 'not found', json_response['_response_info']['status']
+    assert_equal 'ok', json_response['_response_info']['status']
+    assert_equal [], json_response['results']
   end
 end


### PR DESCRIPTION
This was returning a 404 when no categories were found.  Given this is a
plural endpoint, it is more correct for this to return empty array in
this situation.