### PR TITLE
Rake task for adding logos to documents

### DIFF
--- a/lib/tasks/add_logo.rake
+++ b/lib/tasks/add_logo.rake
@@ -1,0 +1,18 @@
+desc "Adds a logo to the last edition of a given slug"
+task :add_logo, [ :slug, :document_type, :logo_url ] => :environment do |t, args|
+  slug = args[:slug]
+  document_type = args[:document_type]
+  logo_url = args[:logo_url]
+
+  document = Document.find_by(slug: slug, document_type: document_type)
+  latest_published_edition = document.editions.latest_published_edition.first
+  draft_edition = document.editions.latest_edition.draft.first
+
+  puts "Updating logo in #{slug} published version"
+  latest_published_edition.update_column(:logo_url, logo_url)
+
+  if draft_edition
+    puts "Updating logo in #{slug} draft version"
+    draft_edition.update_column(:logo_url, logo_url)
+  end
+end


### PR DESCRIPTION
As GOV.UK,
we need to add the EU logo to entrance pages of content which reference EU funding,
so we help departments remain compliant.

This rake task allows adding a logo to the last edition of a particular document (which is found by slug), eg:


    bundle exec rake add_logo[cabinet-office-takeover,https://assets.digital.cabinet-office.gov.uk/media/5540ab8aed915d15d8000030/esi_funds_eu_logo.gif]

The logo will be rendered for any document, but the CSS scaling only works correctly
for detailed guides and document collections. The main usecase is to add the EU funding
logo. The code was taken from [the data migration of a previous pull request](https://github.com/alphagov/whitehall/pull/2164).

/cc @fofr