### PR TITLE
Data migration for adding an EU logo to a detailed guide

### DIFF
--- a/db/data_migration/20150714163600_add_eu_logo_to_detailed_guide.rb
+++ b/db/data_migration/20150714163600_add_eu_logo_to_detailed_guide.rb
@@ -1,0 +1,14 @@
+logo_url = " https://assets.digital.cabinet-office.gov.uk/media/5540ab8aed915d15d8000030/european-structural-investment-funds.png"
+document = Document.find_by(slug: 'england-2014-to-2020-european-structural-and-investment-funds', document_type: 'DetailedGuide')
+latest_published_edition = document.editions.latest_published_edition.first
+draft_edition = document.editions.latest_edition.draft.first
+
+if latest_published_edition
+  puts "Updating logo in #{slug} published version"
+  latest_published_edition.update_column(:logo_url, logo_url)
+end
+
+if draft_edition
+  puts "Updating logo in #{slug} draft version"
+  draft_edition.update_column(:logo_url, logo_url)
+end


### PR DESCRIPTION
As GOV.UK,
we need to add the EU logo to entrance pages of content which reference EU funding,
so we help departments remain compliant.

This data migration adds an EU logo to the last edition of a particular document.
There is no editing interface for this field so it has to be done as a migration.
The code was copied from [the data migration of a previous pull request](https://github.com/alphagov/whitehall/pull/2164).