### PR TITLE
Bugfix: display tribunal ndpb as a ministerial dpt

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -29,20 +29,23 @@ module Organisation::OrganisationTypeConcern
     }
 
     scope :hmcts_tribunals, -> {
-      hmcts_id = Organisation.where(slug: "hm-courts-and-tribunals-service").ids.first
+      hmcts_id = Organisation.unscoped.where(slug: "hm-courts-and-tribunals-service").ids.first
       joins(:parent_organisational_relationships).
         where(organisation_type_key: :tribunal_ndpb).
         where("organisational_relationships.parent_organisation_id" => hmcts_id)
     }
 
     scope :excluding_hmcts_tribunals, -> {
-      hmcts_id = Organisation.where(slug: "hm-courts-and-tribunals-service").ids.first
-      distinct.joins("LEFT JOIN organisational_relationships parent_organisational_relationships
-        ON parent_organisational_relationships.child_organisation_id = organisations.id").
-      where("NOT (parent_organisational_relationships.parent_organisation_id = ? AND
-              organisations.organisation_type_key = ?) OR
-              parent_organisational_relationships.child_organisation_id IS NULL",
-              hmcts_id, :tribunal_ndpb)
+      hmcts_id = Organisation.unscoped.where(slug: "hm-courts-and-tribunals-service").ids.first
+
+      if hmcts_id
+        distinct.joins("LEFT JOIN organisational_relationships parent_organisational_relationships
+          ON parent_organisational_relationships.child_organisation_id = organisations.id").
+          where("NOT (parent_organisational_relationships.parent_organisation_id = ? AND
+                organisations.organisation_type_key = ?) OR
+                parent_organisational_relationships.child_organisation_id IS NULL",
+                hmcts_id, :tribunal_ndpb)
+      end
     }
 
     scope :excluding_courts, -> { where.not(organisation_type_key: :court) }

--- a/test/unit/models/organisation/organisation_type_concern_test.rb
+++ b/test/unit/models/organisation/organisation_type_concern_test.rb
@@ -81,18 +81,20 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     def setup
       @other_org = create(:organisation)
       @copyright_tribunal = create(:organisation, organisation_type_key: :tribunal_ndpb,
-        name: "Copyright Tribunal")
+        name: "Copyright Tribunal", parent_organisations: [@other_org])
       @multiple_parent_child_org = create(:organisation, parent_organisations: [@other_org, @copyright_tribunal])
       @court = create(:court)
       @hmcts_tribunal = create(:hmcts_tribunal)
+      @closed_hmcts_tribunal = create(:hmcts_tribunal, :closed)
     end
 
     test "hmcts_tribunals selects Tribunals that are administrered by HMCTS" do
-      result = Organisation.hmcts_tribunals.listable
+      result = Organisation.closed.hmcts_tribunals
       refute_includes result, @other_org
       refute_includes result, @copyright_tribunal
       refute_includes result, @court
-      assert_includes result, @hmcts_tribunal
+      assert_includes result, @closed_hmcts_tribunal
+      refute_includes result, @hmcts_tribunal
     end
 
     test "excluding_hmcts_tribunals excludes Tribunals that are administrered by HMCTS" do
@@ -133,8 +135,9 @@ class OrganisationTypeConcernTest < ActiveSupport::TestCase
     child_org_3 = create(:organisation, parent_organisations: [parent_org_1], name: "a first")
     child_org_4 = create(:closed_organisation, parent_organisations: [parent_org_1])
     child_org_5 = create(:court, parent_organisations: [parent_org_1])
+    child_org_6 = create(:organisation, parent_organisations: [parent_org_1], name: "c third", organisation_type_key: :tribunal_ndpb)
 
-    assert_equal [child_org_3, child_org_1], parent_org_1.supporting_bodies
+    assert_equal [child_org_3, child_org_1, child_org_6], parent_org_1.supporting_bodies
   end
 
   test "supporting_bodies_grouped_by_type should return a 2D array with each 1st level member being a OrganisationType and a collection of organisations" do


### PR DESCRIPTION
Tribunal NDPBs should be listed under the "Ministerial departments'
section on the main government/organisations page but they are not.

This bug was due to the `supported_bodies` method chaining scopes - the
'excluding_hmcts_tribunals' scope implicitly retained the
"excluding_govuk_status_closed" scope that was called just before.

Adding "unscoped" to the 'excluding_hmcts_tribunals' query
solves it. For similar reasons, adding "unscoped" to the
'hmcts_tribunals' scope. Adding tests for both.

before:
![screen shot 2015-07-14 at 17 15 31](https://cloud.githubusercontent.com/assets/8225167/8678388/3054dade-2a4c-11e5-8447-c3406e4557ef.png)
after:
![screen shot 2015-07-14 at 17 16 27](https://cloud.githubusercontent.com/assets/8225167/8678390/36144bee-2a4c-11e5-8e88-35baa9e93be4.png)

cc @boffbowsh 

[Trello story](https://trello.com/c/dIRj1v5H/28-tribunal-ndpbs-should-appear-in-the-ministerial-depts-section-of-the-organisations-page-small)