### PR TITLE
Hide empty link from accessibility software

### DIFF
--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -2,17 +2,20 @@
   extra_description ||= ""
   published_on ||= ""
   help_block_id = "attachment-#{attachment.id}-accessibility-help"
-  attachment_link_options = attachment.accessible? ? {} : { "aria-describedby" => help_block_id }
-  attachment_link_options['rel'] = 'external' if attachment.external?
+  thumbnail_link_options = { "aria-hidden" => true, class: 'thumbnail' }
+
+  title_link_options = {}
+  title_link_options['rel'] = 'external' if attachment.external?
+  title_link_options["aria-describedby"] = help_block_id unless attachment.accessible?
 %>
 <%= content_tag_for(:section, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded") do %>
   <div class="attachment-thumb">
     <% unless defined?(hide_thumbnail) && hide_thumbnail %>
-      <%= link_to_unless previewable?(attachment), attachment_thumbnail(attachment), attachment.url(preview: params[:preview]), attachment_link_options.merge({ class: 'thumbnail' }).except('rel') %>
+      <%= link_to_unless previewable?(attachment), attachment_thumbnail(attachment), attachment.url(preview: params[:preview]), thumbnail_link_options %>
     <% end %>
   </div>
   <div class="attachment-details">
-    <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), attachment_link_options %></h2>
+    <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), title_link_options %></h2>
     <% unless extra_description.empty? %>
       <p class="extra-description"><%= extra_description %></p>
     <% end %>

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -79,10 +79,10 @@ module DocumentControllerTestHelpers
 
         assert_select_object(attachment_1) do
           refute_select '.accessibility-warning'
-          refute_select "a.thumbnail[aria-describedby='attachment-#{attachment_1.id}-accessibility-help']"
+          refute_select ".title a[aria-describedby='attachment-#{attachment_1.id}-accessibility-help']"
         end
         assert_select_object(attachment_2) do
-          assert_select "a.thumbnail[aria-describedby='attachment-#{attachment_2.id}-accessibility-help']"
+          assert_select "title. a[aria-describedby='attachment-#{attachment_2.id}-accessibility-help']"
           assert_select '.accessibility-warning'
         end
       end


### PR DESCRIPTION
The `attachment_thumbnail` will always produce an image with an empty
`alt` attribute. This causes the link which wraps the thumbnail to
always contain no content. Accessibility software doesn't like empty
links. As the link wrapping the header points to the same place as the
link wrapping the thumbnail we can just hide the thumbnail using
`aria-hidden`. This also stops the possibility of having a duplicate
link (which is also non-ideal).