### PR TITLE
Remove tagging to detailed guide categories

### DIFF
--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -10,12 +10,6 @@
       <%= render 'admin/shared/policy_fields', form: form %>
       <%= render partial: 'topic_fields', locals: { form: form, edition: edition } %>
 
-      <%= form.label :primary_mainstream_category_id, 'Primary detailed guidance category' %>
-      <%= form.select :primary_mainstream_category_id, mainstream_category_options(edition, edition.primary_mainstream_category_id), {}, class: 'chzn-select form-control', data: { placeholder: "Choose a primary detailed guidance category…"} %>
-
-      <%= form.label :other_mainstream_category_ids, 'Other detailed guidance categories' %>
-      <%= form.select :other_mainstream_category_ids, mainstream_category_options(edition, edition.other_mainstream_category_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose other detailed guidance categories…"} %>
-
       <%= form.text_field :need_ids, label_text: 'Maslow Need IDs (enter a comma-separated list)', placeholder: "Enter a comma-separated list of Maslow Need IDs", value: edition.need_ids.join(", ") %>
 
       <%= render partial: 'specialist_sector_fields', locals: { form: form, edition: edition } %>

--- a/features/detailed-guides.feature
+++ b/features/detailed-guides.feature
@@ -20,13 +20,6 @@ Scenario: Publishing a submitted detailed guide
   Then I should see the detailed guide "Finer points of moustache trimming" in the list of published documents
   And the detailed guide "Finer points of moustache trimming" should be visible to the public
 
-Scenario: Publishing a submitted detailed guide to a mainstream category
-  Given I am an editor in the organisation "Department of Examples"
-  Given a mainstream category "Finer points of yak shaving" exists
-  And a submitted detailed guide "Yak shaving tools" exists in the "Finer points of yak shaving" mainstream category
-  When I publish the detailed guide "Yak shaving tools"
-  Then the detailed guide "Yak shaving tools" should be visible to the public in the mainstream category "Finer points of yak shaving"
-
 Scenario: Viewing detailed guide publishing history
   Given I am an editor in the organisation "Department of Examples"
   Given a published detailed guide "Ban Beards" exists

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -10,14 +10,12 @@ Given /^a published detailed guide "([^"]*)" for the organisation "([^"]*)"$/ do
 end
 
 When /^I draft a new detailed guide "([^"]*)"$/ do |title|
-  category = create(:mainstream_category)
-  begin_drafting_document type: 'detailed_guide', title: title, primary_mainstream_category: category, previously_published: false
+  begin_drafting_document type: 'detailed_guide', title: title, previously_published: false
   click_button "Save"
 end
 
 Given /^I start drafting a new detailed guide$/ do
-  category = create(:mainstream_category)
-  begin_drafting_document type: 'detailed_guide', title: "Detailed Guide", primary_mainstream_category: category, previously_published: false
+  begin_drafting_document type: 'detailed_guide', title: "Detailed Guide", previously_published: false
 end
 
 When /^I visit the detailed guide "([^"]*)"$/ do |name|

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -24,32 +24,6 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_overriding_of_first_published_at_for :detailed_guide
   should_allow_access_limiting_of :detailed_guide
 
-  view_test "new allows selection of mainstream categories" do
-    funk = create(:mainstream_category,
-      title: "Funk",
-      slug: "funk",
-      parent_title: "Musical style",
-      parent_tag: "music/70s")
-
-    get :new
-
-    assert_select "form#new_edition[action='#{admin_detailed_guides_path}']" do
-      assert_select "select[name='edition[primary_mainstream_category_id]']" do
-        assert_select "optgroup[label='#{funk.parent_title}']" do
-          assert_select "option[value='#{funk.id}']", funk.title
-        end
-      end
-    end
-
-    assert_select "form#new_edition[action='#{admin_detailed_guides_path}']" do
-      assert_select "select[name='edition[other_mainstream_category_ids][]']" do
-        assert_select "optgroup[label='#{funk.parent_title}']" do
-          assert_select "option[value='#{funk.id}']", funk.title
-        end
-      end
-    end
-  end
-
   test "associate user needs with a guide" do
     attributes = controller_attributes_for(:detailed_guide, need_ids: "123456, 789012")
 
@@ -91,33 +65,10 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
     end
   end
 
-  test "create records chosen primary mainstream category" do
-    funk = create(:mainstream_category)
-
-    attributes = controller_attributes_for(:detailed_guide, primary_mainstream_category_id: funk.id)
-
-    post :create, edition: attributes
-
-    assert_equal funk, DetailedGuide.first.primary_mainstream_category
-  end
-
-  test "create records chosen other mainstream categories" do
-    funk = create(:mainstream_category, title: "Funk")
-    soul = create(:mainstream_category, title: "Soul")
-
-    attributes = controller_attributes_for(:detailed_guide, primary_mainstream_category_id: funk.id,
-                                           other_mainstream_category_ids: [soul.id])
-
-    post :create, edition: attributes
-
-    assert_equal [soul], DetailedGuide.first.other_mainstream_categories
-  end
-
   private
 
   def controller_attributes_for(edition_type, attributes = {})
     super.except(:primary_mainstream_category, :alternative_format_provider).reverse_merge(
-      primary_mainstream_category_id: create(:mainstream_category).id,
       alternative_format_provider_id: create(:alternative_format_provider).id
     )
   end


### PR DESCRIPTION
Detailed guide categories have been deprecated.

This commit removes the select boxes to add detailed guide categories and removes some associated tests. It does not remove all the code related to this feature - that will be done in subsequent PRs.

We change the absolute minimum here to prevent users from tagging content to detailed guide categories.

## Before

![screen shot 2015-07-15 at 10 32 38](https://cloud.githubusercontent.com/assets/233676/8696468/73249e7e-2ae4-11e5-94f6-04747e5132a1.png)

## After

![screen shot 2015-07-15 at 10 34 41](https://cloud.githubusercontent.com/assets/233676/8696469/73273fe4-2ae4-11e5-8020-b8d5cbed0e81.png)

Trello: https://trello.com/c/kNTpVAOQ

cc @rboulton 