### PR TITLE
Stop using detailed guide categories for ERDF logos

### DIFF
--- a/app/assets/stylesheets/frontend/views/_detailed_guides.scss
+++ b/app/assets/stylesheets/frontend/views/_detailed_guides.scss
@@ -62,15 +62,6 @@
     background: yellow;
   }
 
-  .category-european-regional-development-funding .heading-extra .inner-heading {
-    height: 60px;
-    background: image-url("erdf-logo.png") no-repeat $gutter-half 0;
-    @include media(tablet){
-      height: 140px;
-      background-position: 80% 100%;
-    }
-  }
-
   .summary {
     padding-bottom: $gutter-half;
 

--- a/app/views/detailed_guides/show.html.erb
+++ b/app/views/detailed_guides/show.html.erb
@@ -3,8 +3,7 @@
 
 <%= api_link_tag api_detailed_guide_url(@document.document) %>
 
-<% category_slug_classes =  @document.mainstream_categories.map { |cat| "category-#{cat.slug}" } %>
-<%= content_tag_for :article, @document, nil, class: "#{@document.type.downcase} #{category_slug_classes.join(' ')}" do %>
+<%= content_tag_for :article, @document, nil, class: @document.type.downcase do %>
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render  partial: 'header',

--- a/db/data_migration/20150716094419_add_eu_logo_to_regional_development_funding.rb
+++ b/db/data_migration/20150716094419_add_eu_logo_to_regional_development_funding.rb
@@ -1,0 +1,25 @@
+slugs = [
+  'erdf-programmes-and-resources',
+  'erdf-programmes-progress-and-achievements',
+  'applying-for-erdf-funding',
+  'erdf-national-guidance',
+  'previous-erdf-programmes-retaining-documents',
+  'european-territorial-cooperation-programmes',
+  'reuniting-europe-programme-turkey'
+]
+logo_url = "https://assets.digital.cabinet-office.gov.uk/government/assets/erdf-logo.png"
+
+puts "Adding logos to ERDF editions"
+slugs.each do |slug|
+  document = Document.find_by(slug: slug)
+  latest_published_edition = document.editions.latest_published_edition.first
+  draft_edition = document.editions.latest_edition.draft.first
+
+  puts "Updating logo in #{slug} published version"
+  latest_published_edition.update_column(:logo_url, logo_url)
+
+  if draft_edition
+    puts "Updating logo in #{slug} draft version"
+    draft_edition.update_column(:logo_url, logo_url)
+  end
+end

--- a/test/functional/detailed_guides_controller_test.rb
+++ b/test/functional/detailed_guides_controller_test.rb
@@ -99,14 +99,6 @@ That's all
     assert_equal "detailed_guidance", response.headers["X-Slimmer-Format"]
   end
 
-  view_test "guides have their mainstream categories added as classes" do
-    category = create(:mainstream_category)
-    guide = create(:published_detailed_guide, primary_mainstream_category: category)
-    get :show, id: guide.document
-
-    assert_select ".category-#{category.slug}"
-  end
-
   view_test "guides show more like this when there are categories" do
     category = create(:mainstream_category)
     guide = create(:published_detailed_guide, primary_mainstream_category: category)


### PR DESCRIPTION
Currently, the ERDF logos on [pages like this one](https://www.gov.uk/erdf-programmes-and-resources) are displayed on pages with the CSS class `.category-european-regional-development-funding`.

`.category-` classes are added for each detailed guide category the organisation has. 

Detailed guide categories will be removed soon, so we can't rely on this anymore. This commit removes the css-based display and adds a data migration to show the logo by setting an attribute on the edition - as this is the new way to do it ([see this previous data migration](https://github.com/alphagov/whitehall/blob/master/db/data_migration/20150514105208_add_eu_logo_url_to_eafrd_editions.rb), [this page for an example how it looks](https://www.gov.uk/rural-development-programme-for-england-leader-funding)).

The logo position changes slightly.

## Before

![screen shot 2015-07-16 at 10 55 32](https://cloud.githubusercontent.com/assets/233676/8723363/ec790216-2bc4-11e5-9c1c-06179a8fc3f0.png)

## After

![screen shot 2015-07-16 at 10 56 02](https://cloud.githubusercontent.com/assets/233676/8723355/e5610cd0-2bc4-11e5-9347-0c6a2890b376.png)

Related Trello ticket: https://trello.com/c/FxaabmPY/216-remove-detailed-guide-categories-from-whitehall


 