### PR TITLE
label-important has been replaced by label-danger

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -64,7 +64,7 @@
               <span class="force_published label label-danger">not reviewed</span>
             <% end %>
             <% if edition.access_limited? %>
-              <span class="access_limited label label-important">limited access</span>
+              <span class="access_limited label label-danger">limited access</span>
             <% end %>
           </td>
           <td class="author"><%= linked_author(edition.last_author) %></td>


### PR DESCRIPTION
In the upgrade from bootstrap 2 to 3, the class names for label-important
changed to label-danger. Looks like this one was missed, so this is the fix

Before:
![screen shot 2015-07-16 at 17 21 56](https://cloud.githubusercontent.com/assets/68009/8728810/3a99ebf8-2bdf-11e5-8141-68e82bb92d11.png)

After
![screen shot 2015-07-16 at 17 22 07](https://cloud.githubusercontent.com/assets/68009/8728812/3ceb0ad6-2bdf-11e5-9dda-3476aa6793a9.png)
