### PR TITLE
Expose analytics identifiers

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -15,6 +15,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
         content_id: model.content_id,
+        analytics_identifier: model.analytics_identifier,
       },
       parent_organisations: parent_organisations,
       child_organisations: child_organisations,

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -9,6 +9,7 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       details: {
         slug: model.slug,
         iso2: model.iso2,
+        analytics_identifier: model.analytics_identifier,
       },
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -8,6 +8,7 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       web_url: Whitehall.url_maker.worldwide_organisation_url(model),
       details: {
         slug: model.slug,
+        analytics_identifier: model.analytics_identifier,
       },
       offices: offices_as_json,
       sponsors: sponsors_as_json,

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -15,7 +15,7 @@ class PublishingApiPresenters::Placeholder
   end
 
   def as_json
-    {
+    json = {
       content_id: item.content_id,
       title: item.name,
       format: format,
@@ -31,6 +31,10 @@ class PublishingApiPresenters::Placeholder
       ],
       update_type: update_type,
     }
+    if item.respond_to?(:analytics_identifier)
+      json.merge!(details: { analytics_identifier: item.analytics_identifier })
+    end
+    json
   end
 
 private

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -64,6 +64,11 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     assert_equal "live", @presenter.as_json[:details][:govuk_status]
   end
 
+  test "json includes analytics_identifier in details hash" do
+    @organisation.stubs(:analytics_identifier).returns("O123")
+    assert_equal "O123", @presenter.as_json[:details][:analytics_identifier]
+  end
+
   test "json includes human organisation type as format" do
     assert_equal 'Ministerial department', @presenter.as_json[:format]
   end

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -52,6 +52,11 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
     assert_equal 'location-slug', @presenter.as_json[:details][:slug]
   end
 
+  test "json includes analytics_identifier in details hash" do
+    @location.stubs(:analytics_identifier).returns('WL123')
+    assert_equal 'WL123', @presenter.as_json[:details][:analytics_identifier]
+  end
+
   test "json includes display type as format" do
     @location.stubs(:display_type).returns('location-display-type')
     assert_equal 'location-display-type', @presenter.as_json[:format]

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -61,6 +61,11 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal 'world-org-slug', @presenter.as_json[:details][:slug]
   end
 
+  test "json includes analytics_identifier in details hash" do
+    @world_org.stubs(:analytics_identifier).returns('WO123')
+    assert_equal 'WO123', @presenter.as_json[:details][:analytics_identifier]
+  end
+
   test "json includes public world organisations url as web_url" do
     assert_equal Whitehall.url_maker.worldwide_organisation_url(@world_org), @presenter.as_json[:web_url]
   end

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -27,7 +27,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
   end
 
   test 'presents an Organisation ready for adding to the publishing API' do
-    organisation = create(:organisation, name: 'Organisation of Things')
+    organisation = create(:organisation, name: 'Organisation of Things', analytics_identifier: 'O123')
     public_path = Whitehall.url_maker.organisation_path(organisation)
 
     expected_hash = {
@@ -40,6 +40,9 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: organisation.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
+      details: {
+        analytics_identifier: "O123",
+      },
     }
 
     presented_hash = present(organisation)
@@ -69,7 +72,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
   end
 
   test 'presents a Worldwide Organisation ready for adding to the publishing API' do
-    worldwide_org = create(:worldwide_organisation, name: 'Locationia Embassy')
+    worldwide_org = create(:worldwide_organisation, name: 'Locationia Embassy', analytics_identifier: 'WO123')
     public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)
 
     expected_hash = {
@@ -82,6 +85,9 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: worldwide_org.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
+      details: {
+        analytics_identifier: "WO123",
+      },
     }
 
     presented_hash = present(worldwide_org)
@@ -90,7 +96,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
   end
 
   test 'presents a World Location ready for adding to the publishing API' do
-    world_location = create(:world_location, name: 'Locationia')
+    world_location = create(:world_location, name: 'Locationia', analytics_identifier: 'WL123')
     public_path = Whitehall.url_maker.world_location_path(world_location)
 
     expected_hash = {
@@ -103,6 +109,9 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: world_location.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
+      details: {
+        analytics_identifier: "WL123",
+      },
     }
 
     presented_hash = present(world_location)


### PR DESCRIPTION
We want to consistently tag pages in Google Analytics with:
* organisations
* world_locations
* world_organisations

The natural value to send would be the path or slug, however the limit on the
length of a dimension value in Google Analytics combined with the fact that
content is often tagged with multiple organisations/locations/etc means that
these would be truncated. Instead, we send a short code - the
analytics_identifier. Users of Google Analytics then translate these codes back
into meaningful values.

Whitehall mints these identifiers, so for content not published and rendered in
Whitehall to send this data to Google Analytics, the identifiers need to be
exposed to the other apps. This PR sends the data to publishing-api/content-store and exposes it so that it can be picked up by old-world publishing apps too.

Related: https://github.com/alphagov/govuk-content-schemas/pull/101