### PR TITLE
Republish all items with analytics identifiers

### DIFF
--- a/db/data_migration/20150723115938_republish_items_with_analytics_identifiers_to_publishing_api.rb
+++ b/db/data_migration/20150723115938_republish_items_with_analytics_identifiers_to_publishing_api.rb
@@ -1,0 +1,5 @@
+require 'data_hygiene/publishing_api_republisher'
+
+DataHygiene::PublishingApiRepublisher.new(Organisation.all).perform
+DataHygiene::PublishingApiRepublisher.new(WorldwideOrganisation.all).perform
+DataHygiene::PublishingApiRepublisher.new(WorldLocation.all).perform


### PR DESCRIPTION
Since 70c55752f70760ca0d8c09997fd79fc558820341, these items have their
analytics_identifiers sent to Publishing API, but we need to backfill existing
data.

Tested successfully in development.