### PR TITLE
Update accessible media player

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ end
 if ENV['FRONTEND_TOOLKIT_DEV']
   gem 'govuk_frontend_toolkit', path: '../govuk_frontend_toolkit_gem'
 else
-  gem 'govuk_frontend_toolkit', '3.1.0'
+  gem 'govuk_frontend_toolkit', '4.1.1'
 end
 
 gem 'sass', '3.4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_frontend_toolkit (3.1.0)
+    govuk_frontend_toolkit (4.1.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashery (2.1.1)
@@ -466,7 +466,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint (~> 0.2.0)
   govuk_admin_template (= 2.3.4)
-  govuk_frontend_toolkit (= 3.1.0)
+  govuk_frontend_toolkit (= 4.1.1)
   invalid_utf8_rejector (~> 0.0.1)
   isbn_validation
   jbuilder

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,6 @@
 //
 //= require jquery_ujs
 //= require vendor/jquery/jquery-ui-1.10.2.custom
-//= require vendor/jquery/jquery.player.min
 //= require vendor/jquery/magna-charta.min
 //= require vendor/sorttable
 //= require vendor/object-create-polyfill


### PR DESCRIPTION
* Bump frontend toolkit to pickup jQuery 1.11 compatible accessible media player
* Remove the media player from `application.js`, it's provided via static – the player itself is still referenced in `all.js` for tests and `admin.js` for previewing videos.