### PR TITLE
Provide `first_public_at` for draft case studies.

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -25,11 +25,19 @@ private
     super.merge({
       body: body,
       format_display_type: edition.display_type_key,
-      first_public_at: edition.first_public_at,
+      first_public_at: first_public_at,
       change_history: edition.change_history.as_json,
     }).tap do |json|
       json[:image] = image_details if image_available?
       json[:withdrawn_notice] = withdrawn_notice if edition.withdrawn?
+    end
+  end
+
+  def first_public_at
+    if edition.document.published?
+      edition.first_public_at
+    else
+      edition.document.created_at.iso8601
     end
   end
 

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -223,4 +223,10 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     assert_equivalent_html archive_notice[:explanation],
       present(case_study)[:details][:withdrawn_notice][:explanation]
   end
+
+  test "an unpublished document has a first_public_at of the document creation time" do
+    case_study = create(:draft_case_study)
+    presented_hash = present(case_study)
+    assert_equal case_study.document.created_at.iso8601, presented_hash[:details][:first_public_at]
+  end
 end


### PR DESCRIPTION
This avoids some confusion in the government
frontend where the short history would simply say
"Published" with no date.

https://trello.com/c/LdEETk1Z/277-bug-metadata-for-case-studies-looks-weird-for-draft-items