### PR TITLE
[Don't merge] Task to add Copyright to FatalityNotice images

### DIFF
--- a/lib/data_hygiene/copyright_image_captions.rb
+++ b/lib/data_hygiene/copyright_image_captions.rb
@@ -1,0 +1,46 @@
+# encoding: UTF-8
+
+require "csv"
+
+module DataHygiene
+  class CopyrightImageCaptions
+    def initialize(scope: nil, dry_run: true)
+      scope ||= FatalityNotice.published
+
+      @images = scope.joins(:images).includes(:images).map(&:images).flatten
+      @dry_run = dry_run
+    end
+
+    def run!
+      Image.transaction do
+        csv = CSV.open("fatality_notices.csv", "w",
+                       col_sep: ",", force_quotes: true) do |csv|
+          csv << ["url", "alt text", "old caption", "new caption"]
+          @images.each do |image|
+            old_caption = image.caption
+            sanitize_caption(image)
+            csv << [
+              "https://gov.uk#{image.edition.search_link}",
+              image.alt_text,
+              old_caption,
+              image.caption
+            ]
+            if !@dry_run && image.changed.include?("caption")
+              image.update_attribute(:caption, image.caption)
+            end
+          end
+        end
+      end
+    end
+
+    def sanitize_caption(image)
+      if image.caption =~ /all rights reserved|copyright|©/i ||
+         image.alt_text =~ /MOD (Announcement|crest)|Ministry of Defence|army/i
+        return image
+      else
+        image.caption = "#{image.caption.strip}\n© All rights reserved"
+        return image
+      end
+    end
+  end
+end

--- a/test/unit/data_hygiene/copyright_image_captions_test.rb
+++ b/test/unit/data_hygiene/copyright_image_captions_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+module DataHygiene
+  class CopyrightImageCaptionsTest < ActiveSupport::TestCase
+    def test_already_copyrighted
+      assert_caption "© Some paparazzi", caption: "© Some paparazzi"
+      assert_caption "Copyright Some paparazzi", caption: "Copyright Some paparazzi"
+      assert_caption "All rights reserved Some paparazzi", caption: "All rights reserved Some paparazzi"
+      assert_caption "All Rights Reserved.", caption: "All Rights Reserved."
+    end
+
+    def test_logo
+      assert_caption "", alt_text: "MOD Announcement", caption: ""
+      assert_caption "", alt_text: "MOD crest", caption: ""
+      assert_caption "", alt_text: "Ministry of Defence", caption: ""
+      assert_caption "", alt_text: "army", caption: ""
+    end
+
+    def test_add_copyright
+      assert_caption "Major Smith [Picture: MOD]\n© All rights reserved",
+                     caption: "Major Smith [Picture: MOD]"
+      assert_caption "Major Smith\n[Picture: MOD]\n© All rights reserved",
+                     caption: "Major Smith\n[Picture: MOD]"
+      assert_caption "Major Smith\n\n[Picture: MOD]\n© All rights reserved",
+                     caption: "Major Smith\n\n[Picture: MOD]"
+      assert_caption "Major Smith [Picture: MOD]\n© All rights reserved",
+                     caption: "Major Smith [Picture: MOD]\n"
+      assert_caption "Major Smith [Picture: via family]\n© All rights reserved",
+                     caption: "Major Smith [Picture: via family]\n"
+    end
+
+    private
+
+    def assert_caption(expected_caption, caption: nil, alt_text: nil)
+      result = CopyrightImageCaptions.new.sanitize_caption(
+        Image.new(caption: caption, alt_text: alt_text))
+      assert_equal expected_caption, result.caption
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Iio7yCyO/64-spike-could-we-add-copyright-symbol-and-generic-wording-to-images-in-fatality-notices-0-5-days

Adds “© All rights reserved” to all published image captions that don’t
already have something indicating copyright. Also ignores MOD
logos/crests.

Outputs a CSV for importing into Google Sheets so that MOD can check
the proposed changes. Runs in dry run mode by default, where it won’t
actually make the changes.

Don't merge yet, waiting on approval from MOD that this format is correct
- [ ] MOD approval