### PR TITLE
Correct the Panopticon arefact for deleted Detailed Guides

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -14,7 +14,7 @@ class RegisterableEdition
     # to be consistent with Panopticon's slug format.
     panopticon_slug = Whitehall.url_maker.public_document_path(edition).sub(/\A\//, "")
     if edition.deleted?
-      panopticon_slug.sub!(%r{/deleted-([^/]+)$}, '/\1')
+      panopticon_slug.sub!(%r{deleted-([^/]+)$}, '\1')
     end
     panopticon_slug
   end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -69,6 +69,20 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "government/publications/edition-title", registerable_edition.slug
   end
 
+  test "sets the correct slug and routes for a deleted detailed guide" do
+    edition = create(:draft_detailed_guide, title: 'Just A Test')
+
+    Whitehall.edition_services.deleter(edition).perform!
+    assert_equal 'deleted-just-a-test', edition.slug
+
+    registerable_edition = RegisterableEdition.new(edition)
+
+    assert_equal "just-a-test", registerable_edition.slug
+    assert_equal ["/just-a-test"], registerable_edition.paths
+    assert_equal [], registerable_edition.prefixes
+    assert_equal "archived", registerable_edition.state
+  end
+
   test "sets the state to draft if the edition isn't published" do
     edition = create(:draft_detailed_guide)
     registerable_edition = RegisterableEdition.new(edition)


### PR DESCRIPTION
Before this fix, deleted Detailed Guides were being registered under an incorrect slug and router path.

This is a prerequisite to fix the data issue in https://trello.com/c/oku0LGNO/67-detailed-guides-which-should-be-redirecting-display-a-410-page. Once this is available, we'll be creating a data migration to republish the routes for the withdrawn detailed guides.

The routes should go to Whitehall directly so that Whitehall can perform the correct redirect.

/cc @jamiecobbett @heathd 