### PR TITLE
Anchor slug regex to beginning or after a /

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -14,7 +14,7 @@ class RegisterableEdition
     # to be consistent with Panopticon's slug format.
     panopticon_slug = Whitehall.url_maker.public_document_path(edition).sub(/\A\//, "")
     if edition.deleted?
-      panopticon_slug.sub!(%r{deleted-([^/]+)$}, '\1')
+      panopticon_slug.sub!(%r{(\A|/)deleted-([^/]+)$}, '\1\2')
     end
     panopticon_slug
   end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -57,7 +57,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
   end
 
   test "sets the correct slug for a deleted edition" do
-    publication = create(:publication, title: "Edition title")
+    publication = create(:publication, title: "Edition about a deleted thing")
 
     Whitehall.edition_services.deleter(publication).perform!
 
@@ -65,8 +65,8 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(publication)
 
-    assert_equal "deleted-edition-title", whitehall_publication_slug
-    assert_equal "government/publications/edition-title", registerable_edition.slug
+    assert_equal "deleted-edition-about-a-deleted-thing", whitehall_publication_slug
+    assert_equal "government/publications/edition-about-a-deleted-thing", registerable_edition.slug
   end
 
   test "sets the correct slug and routes for a deleted detailed guide" do


### PR DESCRIPTION
As per notes here
https://github.com/alphagov/whitehall/pull/2291/files#r35861278,
anchoring the reggae to the beginning of the URL or after a / reduces
the risk of false positives.

This doesn’t account for paths that have “deleted” in the hierarchy,
but that seems unlikely.

/cc @alext @heathd 