### PR TITLE
Republish routes for Detailed Guides if ever published

### DIFF
--- a/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
+++ b/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
@@ -16,26 +16,26 @@ end
 router_api = GdsApi::Router.new(Plek.find('router-api'))
 url_arbiter = GdsApi::UrlArbiter.new(Plek.find('url-arbiter'))
 
-scope = Document.distinct.
-  joins(:editions).
-  where(document_type: "DetailedGuide",
-    editions: {state: Edition::POST_PUBLICATION_STATES})
+scope = Edition.unscoped.
+  where(type: "DetailedGuide").
+  where("first_published_at IS NOT NULL").
+  includes(:document).
+  joins(:document).
+  group(:document_id)
 
-count = scope.count
+count = scope.count.keys.size
 
-scope.each_with_index do |guide, i|
-  if guide.ever_published_editions.any?
-    slug = guide.slug.sub(%r{^deleted-}, '')
-    publishing_app = url_arbiter.publishing_app_for_path("/#{slug}")
-    if publishing_app && publishing_app != "whitehall"
-      puts "WARNING: Couldn't add route for /#{slug}, owned by #{publishing_app}"
-      next
-    elsif publishing_app.nil?
-      url_arbiter.set_publishing_app_for_path("/#{slug}", "whitehall")
-    end
-    puts "Adding route #{i+1}/#{count} for /#{slug}"
-    router_api.add_route("/#{slug}", "exact", "whitehall-frontend")
+scope.each_with_index do |edition, i|
+  slug = edition.document.slug.sub(%r{^deleted-}, '')
+  publishing_app = url_arbiter.publishing_app_for_path("/#{slug}")
+  if publishing_app && publishing_app != "whitehall"
+    puts "WARNING: Couldn't add route for /#{slug}, owned by #{publishing_app}"
+    next
+  elsif publishing_app.nil?
+    url_arbiter.set_publishing_app_for_path("/#{slug}", "whitehall")
   end
+  puts "Adding route #{i+1}/#{count} for /#{slug}"
+  router_api.add_route("/#{slug}", "exact", "whitehall-frontend")
 end
 
 router_api.commit_routes

--- a/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
+++ b/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
@@ -1,7 +1,20 @@
 require 'plek'
 require 'gds_api/router'
 
+class GdsApi::UrlArbiter < GdsApi::Base
+  def publishing_app_for_path(path)
+    response = get_json("#{endpoint}/paths#{path}")
+    response["publishing_app"] if response
+  end
+
+  def set_publishing_app_for_path(path, app)
+    put_json!("#{endpoint}/paths#{path}", "publishing_app" => app)
+  end
+end
+
+
 router_api = GdsApi::Router.new(Plek.find('router-api'))
+url_arbiter = GdsApi::UrlArbiter.new(Plek.find('url-arbiter'))
 
 scope = Document.distinct.
   joins(:editions).
@@ -13,6 +26,13 @@ count = scope.count
 scope.each_with_index do |guide, i|
   if guide.ever_published_editions.any?
     slug = guide.slug.sub(%r{^deleted-}, '')
+    publishing_app = url_arbiter.publishing_app_for_path("/#{slug}")
+    if publishing_app && publishing_app != "whitehall"
+      puts "WARNING: Couldn't add route for /#{slug}, owned by #{publishing_app}"
+      next
+    elsif publishing_app.nil?
+      url_arbiter.set_publishing_app_for_path("/#{slug}", "whitehall")
+    end
     puts "Adding route #{i+1}/#{count} for /#{slug}"
     router_api.add_route("/#{slug}", "exact", "whitehall-frontend")
   end

--- a/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
+++ b/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
@@ -1,0 +1,21 @@
+require 'plek'
+require 'gds_api/router'
+
+router_api = GdsApi::Router.new(Plek.find('router-api'))
+
+scope = Document.distinct.
+  joins(:editions).
+  where(document_type: "DetailedGuide",
+    editions: {state: Edition::POST_PUBLICATION_STATES})
+
+count = scope.count
+
+scope.each_with_index do |guide, i|
+  if guide.ever_published_editions.any?
+    slug = guide.slug.sub(%r{^deleted-}, '')
+    puts "Adding route #{i+1}/#{count} for /#{slug}"
+    router_api.add_route("/#{slug}", "exact", "whitehall-frontend")
+  end
+end
+
+router_api.commit_routes


### PR DESCRIPTION
Trello:
https://trello.com/c/oku0LGNO/67-detailed-guides-which-should-be-redirecting-display-a-410-page

A data migration in Content Store on 22nd December
(https://github.com/alphagov/content-store/pull/96) deleted all routes
for Whitehall content that had been redirected or withdrawn. This was
the correct thing to do for non Detailed Guides documents as everything
else is handled by the `/government` prefix route. As Detailed Guides
are located at the GOV.UK root, they require individual exact routes
per document, and thus shouldn’t have been removed. This resulted in a
number of [documents](https://docs.google.com/spreadsheets/d/122fXARoCtK4VOwA6ohGIwYwjZOKvc4zoQDFXIVQvMvM/edit#gid=141656079) not being accessible to the public, some of which
have been manually fixed by 2nd Line.

Whitehall itself handles returning a Redirect or Gone status for these
documents, so all Detailed Guide documents should have a backend route
to Whitehall.

This PR simply publishes backend routes for all Detailed Guides that
were ever in a published state.

/cc @jamiecobbett @heathd @alext @benilovj 