### PR TITLE
Gracefully handle really wide CSV attachments

### DIFF
--- a/app/views/attachments/_truncated_message.html.erb
+++ b/app/views/attachments/_truncated_message.html.erb
@@ -1,4 +1,4 @@
 <p class="truncated-message">
-  This preview only shows the first 1000 rows.
+  This preview only shows the first <%= number_with_delimiter(csv_preview.maximum_rows) %> rows and <%= number_with_delimiter(csv_preview.maximum_columns) %> columns.
   <%= link_to "Download the file to view its full contents.", attachment.url(preview: params[:preview]) %>
 </p>

--- a/app/views/attachments/preview.html.erb
+++ b/app/views/attachments/preview.html.erb
@@ -42,7 +42,7 @@
   </div>
 </header>
 <% if @csv_preview %>
-  <%= render(partial: 'truncated_message', locals: { attachment: @attachment }) if @csv_preview.truncated? %>
+  <%= render(partial: 'truncated_message', locals: { csv_preview: @csv_preview, attachment: @attachment }) if @csv_preview.truncated? %>
   <div class="csv-preview">
     <div class="csv-preview-inner">
       <table>
@@ -66,7 +66,7 @@
       </table>
     </div>
   </div>
-  <%= render(partial: 'truncated_message', locals: { attachment: @attachment }) if @csv_preview.truncated? %>
+  <%= render(partial: 'truncated_message', locals: { csv_preview: @csv_preview, attachment: @attachment }) if @csv_preview.truncated? %>
 <% else %>
   <p class="preview-error">
     This file could not be previewed.

--- a/test/unit/csv_preview_test.rb
+++ b/test/unit/csv_preview_test.rb
@@ -54,6 +54,10 @@ class CsvPreviewTest < ActiveSupport::TestCase
     assert_equal 1_000, csv_preview.maximum_rows
   end
 
+  test 'the size of the preview is limited to 50 columns of data by default' do
+    assert_equal 50, csv_preview.maximum_columns
+  end
+
   test 'the size of the preview can be overridden' do
     preview       = CsvPreview.new(File.open(Rails.root.join('test/fixtures/csv_encodings/utf-8.csv')), 1)
     expected_data = [['Office for Facial Hair Studies', '£12000000' , '£10000000']]
@@ -61,12 +65,22 @@ class CsvPreviewTest < ActiveSupport::TestCase
     assert_csv_data(expected_data, preview)
   end
 
-  test '#truncated? returns true if the preview does not show the entire file contents' do
+  test '#truncated? returns true if the preview does not include all the rows' do
     csv_preview.each_row {}
     refute csv_preview.truncated?
 
     truncated_preview = CsvPreview.new(Rails.root.join('test/fixtures/csv_encodings/utf-8.csv'), 1)
     truncated_preview.each_row {}
+    assert truncated_preview.truncated?
+  end
+
+  test '#truncated? returns true if the preview does not include all the columns' do
+    csv_preview.each_row {}
+    refute csv_preview.truncated?
+
+    truncated_preview = CsvPreview.new(Rails.root.join('test/fixtures/csv_encodings/utf-8.csv'), 10, 1)
+    truncated_preview.each_row {}
+
     assert truncated_preview.truncated?
   end
 


### PR DESCRIPTION
A CSV was uploaded which had ~300 rows and 16,000 columns. When this file was
"viewed online" (aka "preview"), Whitehall would consume huge amounts of memory
trying to render the HTML until it was killed by unicornherder.

The CSV was fixed to solve that particular instance, but it shouldn't be
possible to break Whitehall by uploading and viewing a document.

We already truncate CSVs that are too long, let's truncate them when they're
too wide.

/cc @jennyd 