### PR TITLE
Remove whitespace before the comma on "Last updated:" change note lines

### DIFF
--- a/app/views/documents/_change_notes.html.erb
+++ b/app/views/documents/_change_notes.html.erb
@@ -7,8 +7,7 @@
   <% unless history.newly_published? -%>
     <dt><%= t('change_notes.updated_at') %>:</dt>
     <dd>
-      <%= absolute_date(history.most_recent_change) %>
-      <% if footer_meta -%>, <a class="see-all-updates" href="#history"><%= t('change_notes.see_all_updates') %></a><% end -%>
+      <%= absolute_date(history.most_recent_change) %><% if footer_meta -%>, <a class="see-all-updates" href="#history"><%= t('change_notes.see_all_updates') %></a><% end -%>
     </dd>
   <% end %>
 <% end %>


### PR DESCRIPTION
- This looked weird and annoyed me.
- Tried every combination of <%- and -%> etc., to no avail, and joining
  the two lines into this really long one was the only solution that
  worked.

Before:

![screen shot 2015-07-31 at 13 41 32](https://cloud.githubusercontent.com/assets/355033/9008122/d4484f7c-378f-11e5-9093-8c1948868c23.png)


After:

![screen shot 2015-07-31 at 14 23 39](https://cloud.githubusercontent.com/assets/355033/9008114/ce59d644-378f-11e5-940d-ca011c9659f4.png)
