### PR TITLE
Always show works with on orgs list

### DIFF
--- a/app/views/organisations/_index_item_plain.html.erb
+++ b/app/views/organisations/_index_item_plain.html.erb
@@ -3,7 +3,5 @@
   <%= link_to organisation.name, organisation_path(organisation),
     id: organisation.slug, class: 'department-link' %>
   <%= govuk_status_meta_data_for(organisation) %>
-  <% if include_works_with %>
-    <%= render partial: 'works_with', locals: { organisation: organisation } %>
-  <% end %>
+  <%= render partial: 'works_with', locals: { organisation: organisation } %>
 <% end %>

--- a/app/views/organisations/_index_item_with_branding.html.erb
+++ b/app/views/organisations/_index_item_with_branding.html.erb
@@ -6,7 +6,5 @@
       <span><%= organisation_logo_name(organisation, false) %></span>
     <% end %>
   </h2>
-  <% if include_works_with %>
-    <%= render partial: 'works_with', locals: { organisation: organisation, link_to_homepage: true } %>
-  <% end %>
+  <%= render partial: 'works_with', locals: { organisation: organisation, link_to_homepage: true } %>
 <% end %>

--- a/app/views/organisations/_index_section.html.erb
+++ b/app/views/organisations/_index_section.html.erb
@@ -2,11 +2,10 @@
   block_class ||= 'other-departments'
   block_id ||= false
   header_text ||= nil
-  include_works_with ||= false
   hide_organisation_count_paragraph ||= false
 %>
 
-<div class="heading-block js-filter-block <%= "js-hide-department-children " if include_works_with %><%= block_class %>" <%= raw("id=\"#{block_id}\"") if block_id %>>
+<div class="heading-block js-filter-block js-hide-department-children <%= block_class %>" <%= raw("id=\"#{block_id}\"") if block_id %>>
   <% if header_text %>
     <header class="type-heading">
       <h1><%= raw(header_text) %></h1>
@@ -17,8 +16,7 @@
   <div class="content">
     <ol>
       <% organisations.each do |organisation| %>
-        <%= render list_item_partial, organisation: organisation,
-                                      include_works_with: include_works_with %>
+        <%= render list_item_partial, organisation: organisation %>
       <% end %>
     </ol>
   </div>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -24,13 +24,11 @@
                                   block_class:        'ministerial-departments',
                                   block_id:           'ministerial-departments',
                                   header_text:        'Ministerial departments',
-                                  include_works_with: true,
                                   list_item_partial:  'index_item_with_branding' %>
 
       <%= render 'index_section', organisations:      @organisations.non_ministerial_departments,
                                   header_text:        'Non ministerial departments',
                                   block_id:           'non-ministerial-departments',
-                                  include_works_with: true,
                                   list_item_partial:  'index_item_plain' %>
 
       <%= render 'index_section', organisations:      @organisations.agencies_and_government_bodies,


### PR DESCRIPTION
If any organisation works with other organisations we should be showing
their works with line.

We currently have a collection of organisations which work with other
organisations who have links on their org homepage to their space in the
org list. This is so you can see the orgs they work with. However, we
weren't currently showing who those orgs work with as we were only
showing it for some org types. This lets those links take you to
meaningful information.

<table>
<thead><tr><th>before</th><th>after</th></td></thead>
<tr><td><img src="https://cloud.githubusercontent.com/assets/35035/9061038/de94cc0c-3ab0-11e5-9627-bcbb11368876.png"></td><td><img src="https://cloud.githubusercontent.com/assets/35035/9061039/e08a3cb8-3ab0-11e5-9754-5a77ce5765ef.png"></td></tr></table>

https://trello.com/c/WkUXVowB/76-fix-bug-on-better-regulation-delivery-office-org-page-small