### PR TITLE
Add detailed guides routes under /guidance

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -89,6 +89,7 @@ private
   end
 
   def detailed_guide_paths
-    ["/#{slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" }
+    ["/#{slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" } +
+      ["/guidance/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -383,6 +383,7 @@ Whitehall::Application.routes.draw do
   get '/specialist/:id', constraints: {id: /[A-z0-9\-]+/}, to: redirect("/%{id}", prefix: '')
   # Detailed guidance lives at the root
   get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
+  get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, localised: true
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -16,7 +16,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "Edition summary", registerable_edition.description
     assert_equal "live", registerable_edition.state
     assert_equal [], registerable_edition.specialist_sectors
-    assert_equal ["/#{slug}"], registerable_edition.paths
+    assert_equal ["/#{slug}", "/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
   end
 
@@ -29,7 +29,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(edition)
 
-    assert_same_elements ["/#{slug}", "/#{slug}.cy", "/#{slug}.fr"], registerable_edition.paths
+    assert_same_elements ["/#{slug}", "/#{slug}.cy", "/#{slug}.fr", "/guidance/#{slug}", "/guidance/#{slug}.cy", "/guidance/#{slug}.fr"], registerable_edition.paths
   end
 
 
@@ -78,7 +78,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     registerable_edition = RegisterableEdition.new(edition)
 
     assert_equal "just-a-test", registerable_edition.slug
-    assert_equal ["/just-a-test"], registerable_edition.paths
+    assert_equal ["/just-a-test", "/guidance/just-a-test"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
     assert_equal "archived", registerable_edition.state
   end


### PR DESCRIPTION
This also changes the locations that the detailed guides are
registered at when in Panopticon.

This is part of our [plan](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=32604340) to move detailed guides paths from root to guidance/. See also detailed steps [here](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing).

cc @edds @boffbowsh @benilovj 