### PR TITLE
Change default url for detailed guides

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -89,7 +89,8 @@ private
   end
 
   def detailed_guide_paths
-    ["/#{slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" } +
-      ["/guidance/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
+    old_slug = slug.sub(%r{^guidance/}, '')
+    ["/#{old_slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" } +
+      ["/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,8 +382,8 @@ Whitehall::Application.routes.draw do
   # overridden further up in the routes
   get '/specialist/:id', constraints: {id: /[A-z0-9\-]+/}, to: redirect("/%{id}", prefix: '')
   # Detailed guidance lives at the root
-  get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
-  get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, localised: true
+  get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, localised: true
+  get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -10,7 +10,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(edition)
 
-    assert_equal slug, registerable_edition.slug
+    assert_equal "guidance/#{slug}", registerable_edition.slug
     assert_equal "Edition title", registerable_edition.title
     assert_equal "detailed_guide", registerable_edition.kind
     assert_equal "Edition summary", registerable_edition.description
@@ -77,7 +77,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(edition)
 
-    assert_equal "just-a-test", registerable_edition.slug
+    assert_equal "guidance/just-a-test", registerable_edition.slug
     assert_equal ["/just-a-test", "/guidance/just-a-test"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
     assert_equal "archived", registerable_edition.state

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -41,7 +41,7 @@ class UnpublishingTest < ActiveSupport::TestCase
   test 'alternative_url cannot be the same url as the edition' do
     document = create(:document, slug: 'document-path')
     edition = create(:detailed_guide, document: document)
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.dev.gov.uk/document-path', edition: edition)
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.dev.gov.uk/guidance/document-path', edition: edition)
 
     refute unpublishing.valid?
     assert unpublishing.errors[:alternative_url].include?("cannot redirect to itself")

--- a/test/unit/workers/panopticon_register_artefact_worker_test.rb
+++ b/test/unit/workers/panopticon_register_artefact_worker_test.rb
@@ -7,7 +7,7 @@ class PanopticonRegisterArtefactWorkerTest < ActiveSupport::TestCase
 
   test "registers an artefact with Panopticon" do
     edition = create(:published_detailed_guide)
-    request = stub_artefact_registration(edition.slug)
+    request = stub_artefact_registration("guidance/#{edition.slug}")
 
     PanopticonRegisterArtefactWorker.new.perform(edition.id)
 


### PR DESCRIPTION
Detailed guides url are getting moved from root to guidance/x.
This makes guidance/x the default url, while keeping the /x routes
active until the various redirects, artefact migrations and reindexes
are in place.

Full plan available [here](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing).

cc @boffbowsh @benilovj 