### PR TITLE
Fix bug in case study previewing

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -96,7 +96,8 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    if updater.can_perform? && @edition.edit_as(current_user, edition_params)
+    @edition.assign_attributes(edition_params)
+    if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
 
       if @edition.links_reports.last

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -78,12 +78,12 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def create
-    if @edition.save
+    if updater.can_perform? && @edition.save
       updater.perform!
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
       flash.now[:alert] = "There are some problems with the document"
-      extract_edition_information_from_errors
+      @information = updater.failure_reason
       build_edition_dependencies
       render action: "new"
     end
@@ -96,7 +96,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    if @edition.edit_as(current_user, edition_params)
+    if updater.can_perform? && @edition.edit_as(current_user, edition_params)
       updater.perform!
 
       if @edition.links_reports.last
@@ -110,7 +110,7 @@ class Admin::EditionsController < Admin::BaseController
       if speed_tagging?
         render :show
       else
-        extract_edition_information_from_errors
+        @information = updater.failure_reason
         build_edition_dependencies
         fetch_version_and_remark_trails
         render :edit
@@ -248,11 +248,6 @@ class Admin::EditionsController < Admin::BaseController
   def find_edition
     edition = edition_class.find(params[:id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
-  end
-
-  def extract_edition_information_from_errors
-    information = @edition.errors.delete(:information)
-    @information = information ? information.first : nil
   end
 
   def build_edition_dependencies

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -102,11 +102,6 @@ module Edition::Workflow
     end
   end
 
-  def edit_as(user, attributes = {})
-    assign_attributes(attributes)
-    save_as(user)
-  end
-
   def edition_has_no_unpublished_editions
     return unless document
     if existing_edition = document.non_published_edition

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -8,8 +8,8 @@ class DraftEditionUpdater < EditionService
   end
 
   def failure_reason
-    if !edition.draft?
-      "This edition is not draft."
+    if !edition.pre_publication?
+      "A #{edition.state} edition may not be updated."
     elsif !edition.valid?
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -18,4 +18,5 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_setting_first_published_at_during_speed_tagging :case_study
   should_allow_association_with_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
+  should_send_drafts_to_content_preview_environment_for :case_study
 end

--- a/test/unit/edition/workflow_test.rb
+++ b/test/unit/edition/workflow_test.rb
@@ -84,42 +84,6 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "#edit_as updates the edition" do
-    attributes = stub(:attributes)
-    edition = create(:publication)
-    edition.edit_as(create(:user), title: 'new-title')
-    assert_equal 'new-title', edition.reload.title
-  end
-
-  test "#edit_as records new creator if edit succeeds" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(true)
-    user = create(:user)
-    edition.edit_as(user, {})
-    assert_equal 2, edition.edition_authors.count
-    assert_equal user, edition.edition_authors.last.user
-  end
-
-  test "#edit_as returns true if edit succeeds" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(true)
-    assert edition.edit_as(create(:user), {})
-  end
-
-  test "#edit_as does not record new creator if edit fails" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(false)
-    user = create(:user)
-    edition.edit_as(user, {})
-    assert_equal 1, edition.edition_authors.count
-  end
-
-  test "#edit_as returns false if edit fails" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(false)
-    refute edition.edit_as(create(:user), {})
-  end
-
   test "#save_as saves the edition" do
     edition = create(:publication)
     edition.expects(:save)

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -215,16 +215,16 @@ class EditionTest < ActiveSupport::TestCase
   test ".authored_by includes editions edited by given user" do
     publication = create(:publication)
     writer = create(:writer)
-    publication.edit_as(writer, {})
+    publication.save_as(writer)
     assert Edition.authored_by(writer).include?(publication)
   end
 
   test ".authored_by includes editions only once no matter how many edits a user has made" do
     publication = create(:publication)
     writer = create(:writer)
-    publication.edit_as(writer, {})
-    publication.edit_as(writer, {})
-    publication.edit_as(writer, {})
+    publication.save_as(writer)
+    publication.save_as(writer)
+    publication.save_as(writer)
     assert_equal 1, Edition.authored_by(writer).size
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/yWNA28st/295-bug-case-studies-in-2i-don-t-appear-in-content-preview

## Background

Case studies were not getting sent to the draft environment on update if they were in the `submitted` or `rejected` states.

What happened in the case of this particular document was:

1. it was created with a certain title, and the document was sent to draft content store properly with path `/government/case-studies/honours-nominate-someone-who-has-improved-young-lives--2`
2. it was then submitted to 2nd eyes review moving it into the `submitted` state
3. whilst in the `submitted` state, the title was amended. Because this was the first draft of the document the slug changed. Because of this bug, the document with the new slug was not sent to the draft environment.

Now when the user clicked the preview button they would get the 404 error because the content was missing from the preview environment.

## Fix

The `edition.draft?` guard in the `DraftEditionUpdater` service object was too narrow. We should allow updates to editions in the `submitted` or `rejected` state as well.

This problem was compounded by the fact that there wasn't sufficient error handling around the call to `updater.perform!` in the `Admin::EditionController`. The consequence was that the `#perform!`
call would silently fail and the edition would be updated, but the draft would not be sent to the content preview environment.

Changing this required splitting up the `#edit_as` method, and rendered it redundant, so I've removed it completely.

I've tightend up the testing around this by adding a new functional test mixin for use in edition admin controllers `should_send_drafts_to_content_preview_environment_for`, and using this in the admin case study controller test.