### PR TITLE
Stop using root detailed guides path

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -89,8 +89,6 @@ private
   end
 
   def detailed_guide_paths
-    old_slug = slug.sub(%r{^guidance/}, '')
-    ["/#{old_slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" } +
-      ["/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
+    ["/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -381,8 +381,6 @@ Whitehall::Application.routes.draw do
   # XXX: we use a blank prefix here because redirect has been
   # overridden further up in the routes
   get '/specialist/:id', constraints: {id: /[A-z0-9\-]+/}, to: redirect("/%{id}", prefix: '')
-  # Detailed guidance lives at the root
-  get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, localised: true
   get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -86,7 +86,8 @@ end
 def mock_govuk_delivery_client
   @mock_client ||= RetrospectiveStub.new.tap { |mock_client|
     mock_client.stub :topic
-    mock_client.stub :signup_url, returns: public_url("/email_signup_url")
+    # FIXME: Actually send client to relevant email signup page
+    mock_client.stub :signup_url, returns: public_url("/government/organisations")
     mock_client.stub :notify
     Whitehall.stubs(govuk_delivery_client: mock_client)
   }

--- a/test/functional/hackable_url_test.rb
+++ b/test/functional/hackable_url_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class HackableUrlTest < ActiveSupport::TestCase
   # TODO: remove statistics_announcment exemptions after statistics have been given their own site area
-  EXEMPTIONS = ['statistics_announcements', 'statistics_announcement']
+  EXEMPT_ROUTE_NAMES = %w[ statistics_announcements statistics_announcement ]
+  EXEMPT_ROUTE_PATHS = ['/specialist/:id(.:format)', '/guidance/:id(.:locale)(.:format)']
 
   test "should always provide an index for resources that have a show action" do
     all_routes = Rails.application.routes.routes
@@ -43,7 +44,7 @@ class HackableUrlTest < ActiveSupport::TestCase
   end
 
   def exempt_route?(route)
-    EXEMPTIONS.include? route.name
+    EXEMPT_ROUTE_NAMES.include?(route.name) || EXEMPT_ROUTE_PATHS.include?(route.path.ast.to_s)
   end
 
   def all_possible_hackings_of(path)

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -16,7 +16,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "Edition summary", registerable_edition.description
     assert_equal "live", registerable_edition.state
     assert_equal [], registerable_edition.specialist_sectors
-    assert_equal ["/#{slug}", "/guidance/#{slug}"], registerable_edition.paths
+    assert_equal ["/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
   end
 
@@ -29,7 +29,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(edition)
 
-    assert_same_elements ["/#{slug}", "/#{slug}.cy", "/#{slug}.fr", "/guidance/#{slug}", "/guidance/#{slug}.cy", "/guidance/#{slug}.fr"], registerable_edition.paths
+    assert_same_elements ["/guidance/#{slug}", "/guidance/#{slug}.cy", "/guidance/#{slug}.fr"], registerable_edition.paths
   end
 
 
@@ -78,7 +78,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     registerable_edition = RegisterableEdition.new(edition)
 
     assert_equal "guidance/just-a-test", registerable_edition.slug
-    assert_equal ["/just-a-test", "/guidance/just-a-test"], registerable_edition.paths
+    assert_equal ["/guidance/just-a-test"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
     assert_equal "archived", registerable_edition.state
   end


### PR DESCRIPTION
Detailed guides are now served by default under guidance/(full plan [here](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing)), so root paths to detailed guides should no longer be served.

Deleting the root detailed guide path route made the hackable url test fail as that route was a catch all that stopped hackable url test from functioning properly. It now runs properly, exempting specialist and guidance documents.

cc @boffbowsh 