### PR TITLE
Fix bulk republishing

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:
+  - [bulk_republishing, 1]
   - [imports, 2]
   - [router, 4]
   - [panopticon, 4]

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,11 +1,28 @@
 namespace :publishing_api do
-  desc "export all whitehall content to draft environment of publishing api"
-  task :populate_draft_environment => :environment do
-    Whitehall::PublishingApi::DraftEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+  namespace :draft do
+    namespace :populate do
+      desc "export all whitehall content to draft environment of publishing api"
+      task :all => :environment do
+        Whitehall::PublishingApi::DraftEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+      end
+
+      desc "export Case studies to draft environment of publishing api"
+      task :case_studies => :environment do
+        Whitehall::PublishingApi::DraftEnvironmentPopulator.new(items: CaseStudy.latest_edition.find_each, logger: Logger.new(STDOUT)).call
+      end
+    end
   end
 
-  desc "export all published whitehall content to live environment of publishing api"
-  task :populate_live_environment => :environment do
-    Whitehall::PublishingApi::LiveEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+  namespace :live do
+    namespace :populate do
+      desc "export all published whitehall content to live environment of publishing api"
+      task :all => :environment do
+        Whitehall::PublishingApi::LiveEnvironmentPopulator.new(logger: Logger.new(STDOUT)).call
+      end
+
+      task :case_studies => :environment do
+        Whitehall::PublishingApi::LiveEnvironmentPopulator.new(items: CaseStudy.latest_published_edition.find_each, logger: Logger.new(STDOUT)).call
+      end
+    end
   end
 end

--- a/lib/whitehall/publishing_api/draft_environment_populator.rb
+++ b/lib/whitehall/publishing_api/draft_environment_populator.rb
@@ -1,9 +1,9 @@
 module Whitehall
   class PublishingApi
     class DraftEnvironmentPopulator < Populator
-      def initialize(logger: )
+      def initialize(items: nil, logger:)
         super(
-          items: self.class.default_items,
+          items: items || self.class.default_items,
           sender: self.class.method(:send_to_publishing_api),
           logger: logger
         )

--- a/lib/whitehall/publishing_api/live_environment_populator.rb
+++ b/lib/whitehall/publishing_api/live_environment_populator.rb
@@ -1,9 +1,9 @@
 module Whitehall
   class PublishingApi
     class LiveEnvironmentPopulator < Populator
-      def initialize(logger: )
+      def initialize(items: nil, logger:)
         super(
-          items: self.class.default_items,
+          items: items || self.class.default_items,
           sender: self.class.method(:send_to_publishing_api),
           logger: logger
         )

--- a/lib/whitehall/publishing_api/populator.rb
+++ b/lib/whitehall/publishing_api/populator.rb
@@ -55,7 +55,7 @@ module Whitehall
 
         def log(item)
           new_class = item.class
-          new_class = new_class.base_class if new_class.method_exists?(:base_class)
+          new_class = new_class.base_class if new_class.respond_to?(:base_class)
           if @type != new_class
             @type = new_class
             logger.info "Exporting items of class '#{@type}'..."


### PR DESCRIPTION
There were a bunch of issues with bulk republishing.

As part of [fixing the bug affecting case study previewing](https://trello.com/c/yWNA28st/295-bug-case-studies-in-2i-don-t-appear-in-content-preview) I want to re-send all of the case studies to the draft environment.

This fixes those issues:

* no sidekiq worker configured for the `bulk_republishing` queue
* bug in `Populator`
* populator couldn't be used with arbitrary list of things
