### PR TITLE
Stop registering detailed guide root paths

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -89,8 +89,6 @@ private
   end
 
   def detailed_guide_paths
-    old_slug = slug.sub(%r{^guidance/}, '')
-    ["/#{old_slug}"] + edition.non_english_translations.map { |t| "/#{edition.slug}.#{t.locale}" } +
-      ["/#{slug}"] + edition.non_english_translations.map { |t| "/guidance/#{edition.slug}.#{t.locale}" }
+    ["/#{slug}"] + edition.non_english_translations.map { |t| "/#{slug}.#{t.locale}" }
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -16,7 +16,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "Edition summary", registerable_edition.description
     assert_equal "live", registerable_edition.state
     assert_equal [], registerable_edition.specialist_sectors
-    assert_equal ["/#{slug}", "/guidance/#{slug}"], registerable_edition.paths
+    assert_equal ["/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
   end
 
@@ -29,7 +29,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
 
     registerable_edition = RegisterableEdition.new(edition)
 
-    assert_same_elements ["/#{slug}", "/#{slug}.cy", "/#{slug}.fr", "/guidance/#{slug}", "/guidance/#{slug}.cy", "/guidance/#{slug}.fr"], registerable_edition.paths
+    assert_same_elements ["/guidance/#{slug}", "/guidance/#{slug}.cy", "/guidance/#{slug}.fr"], registerable_edition.paths
   end
 
 
@@ -78,7 +78,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     registerable_edition = RegisterableEdition.new(edition)
 
     assert_equal "guidance/just-a-test", registerable_edition.slug
-    assert_equal ["/just-a-test", "/guidance/just-a-test"], registerable_edition.paths
+    assert_equal ["/guidance/just-a-test"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
     assert_equal "archived", registerable_edition.state
   end


### PR DESCRIPTION
This is part of our [plan](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing) to move detailed guides under guidance/.

cc @boffbowsh @benilovj 