### PR TITLE
Remove root detailed guide route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -379,10 +379,6 @@ Whitehall::Application.routes.draw do
   get 'healthcheck' => 'healthcheck#check'
   get 'healthcheck/overdue' => 'healthcheck#overdue'
 
-  # XXX: we use a blank prefix here because redirect has been
-  # overridden further up in the routes
-  get '/specialist/:id', constraints: {id: /[A-z0-9\-]+/}, to: redirect("/%{id}", prefix: '')
-
   get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,8 +382,7 @@ Whitehall::Application.routes.draw do
   # XXX: we use a blank prefix here because redirect has been
   # overridden further up in the routes
   get '/specialist/:id', constraints: {id: /[A-z0-9\-]+/}, to: redirect("/%{id}", prefix: '')
-  # Detailed guidance lives at the root
-  get ':id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, localised: true
+
   get '/guidance/:id' => 'detailed_guides#show', constraints: {id: /[A-z0-9\-]+/}, as: 'detailed_guide', localised: true
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -86,7 +86,8 @@ end
 def mock_govuk_delivery_client
   @mock_client ||= RetrospectiveStub.new.tap { |mock_client|
     mock_client.stub :topic
-    mock_client.stub :signup_url, returns: public_url("/email_signup_url")
+    # FIXME: Actually send client to relevant email signup page
+    mock_client.stub :signup_url, returns: public_url("/government/organisations")
     mock_client.stub :notify
     Whitehall.stubs(govuk_delivery_client: mock_client)
   }

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -9,7 +9,13 @@ When(/^I sign up for emails$/) do
     click_on 'email'
   end
 
-  click_on 'Create subscription'
+  # There is a bug which is causes external urls to get requested from the
+  # server. So catch the routing error and handle it so we can continue to
+  # assert that the right things have happened to generate the redirect.
+  begin
+    click_on 'Create subscription'
+  rescue ActionController::RoutingError
+  end
 end
 
 Then(/^I should be signed up for the all publications mailing list$/) do
@@ -86,8 +92,7 @@ end
 def mock_govuk_delivery_client
   @mock_client ||= RetrospectiveStub.new.tap { |mock_client|
     mock_client.stub :topic
-    # FIXME: Actually send client to relevant email signup page
-    mock_client.stub :signup_url, returns: public_url("/government/organisations")
+    mock_client.stub :signup_url, returns: 'http://govdelivery.url'
     mock_client.stub :notify
     Whitehall.stubs(govuk_delivery_client: mock_client)
   }

--- a/test/functional/hackable_url_test.rb
+++ b/test/functional/hackable_url_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class HackableUrlTest < ActiveSupport::TestCase
   # TODO: remove statistics_announcment exemptions after statistics have been given their own site area
   EXEMPT_ROUTE_NAMES = %w[ statistics_announcements statistics_announcement ]
-  EXEMPT_ROUTE_PATHS = ['/specialist/:id(.:format)', '/guidance/:id(.:locale)(.:format)']
+  EXEMPT_ROUTE_PATHS = ['/guidance/:id(.:locale)(.:format)']
 
   test "should always provide an index for resources that have a show action" do
     all_routes = Rails.application.routes.routes

--- a/test/functional/hackable_url_test.rb
+++ b/test/functional/hackable_url_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class HackableUrlTest < ActiveSupport::TestCase
   # TODO: remove statistics_announcment exemptions after statistics have been given their own site area
-  EXEMPTIONS = ['statistics_announcements', 'statistics_announcement']
+  EXEMPT_ROUTE_NAMES = %w[ statistics_announcements statistics_announcement ]
+  EXEMPT_ROUTE_PATHS = ['/specialist/:id(.:format)', '/guidance/:id(.:locale)(.:format)']
 
   test "should always provide an index for resources that have a show action" do
     all_routes = Rails.application.routes.routes
@@ -43,7 +44,7 @@ class HackableUrlTest < ActiveSupport::TestCase
   end
 
   def exempt_route?(route)
-    EXEMPTIONS.include? route.name
+    EXEMPT_ROUTE_NAMES.include?(route.name) || EXEMPT_ROUTE_PATHS.include?(route.path.ast.to_s)
   end
 
   def all_possible_hackings_of(path)

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -4,7 +4,7 @@ class DetailedGuideIntegrationTest < ActionDispatch::IntegrationTest
   test "meta data tag is present" do
     detailed_guide = create(:published_detailed_guide, summary: "This is a published detailed guide summary")
 
-    get "/#{detailed_guide.slug}"
+    get detailed_guide_path(detailed_guide.slug)
 
     assert response.body.include? "<meta name=\"description\" content=\"This is a published detailed guide summary\" />"
   end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -66,11 +66,6 @@ class RoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "visiting a detailed guidance document redirects you to the slug at root" do
-    get "/specialist/vat-tax-rates"
-    assert_redirected_to "/vat-tax-rates"
-  end
-
   test "redirects organisation groups index URL to organisation page" do
     organisation = create(:organisation)
     get "/government/organisations/#{organisation.to_param}/groups"


### PR DESCRIPTION
This is step 10 of our [plan](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing) to move detailed guides under guidance/. They are now available by default under guidance/.

However, removing the root route broke two unrelated tests which were only passing because the detailed guides root route was a catch all. 

This PR fixes the hackable url test by exempting /specialist and /guidance routes, and finds an alternative catch all route for the email sign up integration test, because I couldn't find the url to a whitehall sign up page. Left a "FIXME: replace mock_client url stub with email sign up page url" message to improve the test in the future.

cc @boffbowsh @benilovj 