### PR TITLE
Render govspeak for search description

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -167,7 +167,7 @@ class Organisation < ActiveRecord::Base
              acronym: :acronym,
              link: :search_link,
              content: :indexable_content,
-             description: :summary,
+             description: :description_for_search,
              boost_phrases: :acronym,
              slug: :slug,
              organisation_state: :searchable_govuk_status
@@ -353,6 +353,10 @@ class Organisation < ActiveRecord::Base
 
   def indexable_content
     Govspeak::Document.new("#{summary} #{body}").to_text
+  end
+
+  def description_for_search
+    Govspeak::Document.new(summary).to_text
   end
 
   def search_link

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -379,6 +379,20 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal 'live', organisation.search_index['organisation_state']
   end
 
+  test 'should return a rendered summary as description' do
+    organisation = create(:organisation)
+
+    page_params = {
+      organisation: organisation,
+      summary: "A [text-rendered](http://example.org/irrelevant) summary.",
+      corporate_information_page_type: CorporateInformationPageType.find('about')
+    }
+
+    page = create(:published_corporate_information_page, page_params)
+
+    assert_equal 'A text-rendered summary.', organisation.search_index['description']
+  end
+
   test 'should add organisation to search index on creating' do
     organisation = build(:organisation)
 
@@ -484,6 +498,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'link' => '/government/organisations/devolved-organisation',
                   'slug' => 'devolved-organisation',
                   'indexable_content' => '',
+                  'description' => '',
                   'format' => 'organisation',
                   'boost_phrases' => 'dev',
                   'organisation_state' => 'devolved'}, results[5])


### PR DESCRIPTION
Our search index doesn't render or sanitize govspeak, so applications sending things to search should only send plain text.

Rendering the description here before sending it to rummager will prevent the search results from showing govspeak.

![screen shot 2015-08-07 at 11 55 53](https://cloud.githubusercontent.com/assets/233676/9134364/48bc79d0-3cfb-11e5-8e3d-c83ca7a8ba25.png)

Trello: https://trello.com/c/4UvkEGVR

We will need to re-index all organisations after this change is merged.