### PR TITLE
Change guidance for lists

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -78,20 +78,15 @@ Stocks of some fish species are very low. For example, stocks of European Eel ha
 <h3><a data-toggle="collapse" href="#govspeak-bullets">Bullets</a></h3>
 <div class="collapse" id="govspeak-bullets">
   <pre>* item 1
-* item 2
-  * sub-item
-  * another sub-item
-(to indent, add 2 spaces)</pre>
+  * item 2
+  * item 3</pre>
 </div>
 
 <h3><a data-toggle="collapse" href="#govspeak-numbered-list">Numbered list</a></h3>
 <div class="collapse" id="govspeak-numbered-list">
   <pre>1. item 1
 2. item 2
-3. item 3
-  * sub-item
-  * another sub-item
-(to indent, add 2 spaces)</pre>
+3. item 3</pre>
 </div>
 
 <h3><a data-toggle="collapse" href="#govspeak-images">Images</a></h3>


### PR DESCRIPTION
Change the guidance for lists. The content team don't want to encourage content designers to create sub-lists. There is nothing in the content guidance for this reason.

Related ticket: https://govuk.zendesk.com/agent/tickets/1112338