### PR TITLE
Always strip govspeak for meta descriptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,6 +74,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_meta_description(description)
-    @meta_description = description
+    @meta_description = Govspeak::Document.new(description).to_text
   end
 end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -406,7 +406,7 @@ module DocumentControllerTestHelpers
 
     def should_set_meta_description_for(document_type)
       test "#{document_type} should set a meaningful meta description" do
-        edition = create("published_#{document_type}", summary: "My first #{document_type}")
+        edition = create("published_#{document_type}", summary: "My **first** #{document_type}")
 
         get :show, id: edition.document
 


### PR DESCRIPTION
Descriptions sometimes use govspeak, causing this to be shown in Google and other search engines. We can prevent this by always stripping the markup.

https://trello.com/c/4UvkEGVR

The specific case this is trying to solve is the [Queens Speech 2014](https://www.gov.uk/government/topical-events/queens-speech-2014).

![screen shot 2015-08-07 at 12 15 14](https://cloud.githubusercontent.com/assets/233676/9134640/fb5dd172-3cfd-11e5-88cf-f3ac0380298a.png)

An alternative fix is to only pass text without markup to `set_meta_description(description)` (like in the [topical events controller](https://github.com/alphagov/whitehall/blob/master/app/controllers/topical_events_controller.rb#L19)), but this would fix it for all whitehall pages everywhere always.

## Before

```html
...
<meta content="320" name="MobileOptimized">
<meta name="description" content="$CTA Visit [Queen's Speech 2015](http://bit.ly/QueensSpeech2015) for the latest information.$CTA 

The Queen’s Speech 2014 took place on 4 June. Read the speech and find out about the Bills that were announced.">
<meta name="csrf-param" content="authenticity_token">
...
```

## After

```html
...
<meta content="320" name="MobileOptimized">
<meta name="description" content="Visit Queen’s Speech 2015 for the latest information. The Queen’s Speech 2014 took place on 4 June. Read the speech and find out about the Bills that were announced.">
<meta name="csrf-param" content="authenticity_token">
...
```
