### PR TITLE
Live update search results when typing dates

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -314,7 +314,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
           $form.submit();
         });
 
-        $('#keyword-filter').add('#date-range-filter').find('input[type=text]').keyup(function () {
+        $('#keyword-filter').add('.date-range-filter').find('input[type=text]').keyup(function () {
           delay(function () {
             $form.submit();
           }, 600);


### PR DESCRIPTION
When a user types a date in the from date / until date box on [/government/publications](https://www.gov.uk/government/publications), the results should be live updated.

This behaviour was added in: https://github.com/alphagov/whitehall/commit/715360e237256255a6f6f02015418a510a70ee51

However, a cleanup commit removed `id="date-range-filter"` on which this feature depended, thus breaking it: https://github.com/alphagov/whitehall/commit/4c682d099fa0f77f042d01bcd39c5dd9d44f317d#diff-08e4a107c3401662ebf39b86de38b01cL91 (https://github.com/alphagov/whitehall/pull/1585).

Example: https://www.gov.uk/government/publications
Trello: https://trello.com/c/QPzwF68k
Pivotal: https://www.pivotaltracker.com/n/projects/1261204/stories/92349360