### PR TITLE
Rake task for moving Detailed Guides for search

### DIFF
--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -38,13 +38,12 @@ module Edition::SpecialistSectors
   end
 
   def specialist_sector_tags
-    Array(primary_specialist_sector_tag) + secondary_specialist_sector_tags
+    specialist_sectors.order("specialist_sectors.primary DESC").map(&:tag)
   end
 
   def live_specialist_sector_tags
-    specialist_sector_tags.select do |tag|
-      live_specialist_sector_tag_slugs.include?(tag)
-    end
+    specialist_sectors.order("specialist_sectors.primary DESC").
+      where(tag: live_specialist_sector_tag_slugs).pluck(:tag)
   end
 
 private

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -120,3 +120,34 @@ task :unpublish_statistics_announcement, [:slug] => :environment do |t, args|
     logger: Logger.new(STDOUT),
   ).call
 end
+
+# This task must be removed once the move of detailed guides to /guidance
+# is complete.
+desc "Rename detailed guides in Rummager individually"
+task :rummager_rename_detailed_guides => :environment do
+  index = Whitehall::SearchIndex.for(:detailed_guides)
+  live_specialist_sector_tag_slugs = nil
+  scope = DetailedGuide.published
+  count = scope.count
+  i = 0
+
+  scope.find_each do |dg|
+    # This injects a pre-memoised set of slugs for live specialist sector tags
+    # This is necessary as fetching these from Content API is expensive, and
+    # unnecessary. The memoisation is scoped only to the Edition instance, which
+    # is the correct behaviour in normal production running mode due to the
+    # need to ensure the list is up to date. As this is a one-shot task which
+    # will be removed, "external memoisation" seems like the most pragmatic
+    # approach.
+    # This saves approximately 1.5 seconds per published Detailed Guide, so
+    # around an hour and a half.
+    live_specialist_sector_tag_slugs ||=
+      SpecialistSector.live_subsectors.map(&:slug)
+    dg.instance_variable_set(:@live_specialist_sector_tag_slugs,
+      live_specialist_sector_tag_slugs)
+
+    index.add(dg.search_index)
+    index.delete("/#{dg.slug}")
+    puts "Renamed #{dg.slug} (#{i += 1}/#{count})"
+  end
+end


### PR DESCRIPTION
Iterates over every published Detailed Guide and adds it to Rummager
using the correct slug (`/guidance/foo`), then removes the old one
(`/foo`).

As this involves changing the `_id` of the record, we need to add and
delete, rather than amend. We talk directly to a `Rummagable::Index`
instance here as we want to perform the change synchronously rather
than via Sidekiq.

Once this work has been completed, this task will be removed.

This contains a relatively dirty hack to only call an expensive Content
API endpoint once per run, rather than once per document, saving
approximately an hour and a half. See the inline comment for details.

Also speeds up indexing of Editions by moving computation into SQL
instead of Ruby