### PR TITLE
Redirect more worldwide priority pages

### DIFF
--- a/db/data_migration/20150810101642_redirect_some_more_withdrawn_worldwide_priorities.csv
+++ b/db/data_migration/20150810101642_redirect_some_more_withdrawn_worldwide_priorities.csv
@@ -1,0 +1,6 @@
+slug,path_for_alternative_url
+reducing-conflict-in-burma,/government/world/burma
+improving-human-rights-in-burma,/government/world/burma
+supporting-democratic-reform-and-good-governance-in-burma,/government/world/burma
+supporting-development-in-burma,/government/world/burma
+increasing-business-with-burma,/government/world/burma

--- a/db/data_migration/20150810101642_redirect_some_more_withdrawn_worldwide_priorities.rb
+++ b/db/data_migration/20150810101642_redirect_some_more_withdrawn_worldwide_priorities.rb
@@ -1,0 +1,36 @@
+# This is the same data migration as 20150724130057, just with the
+# name of the CSV changed. I would have made this into a Rake task,
+# to avoid duplicating all of this, but this *should* be the last of
+# the world priorities we have to redirect.
+require "csv"
+
+csv_file = File.join(File.dirname(__FILE__), "20150810101642_redirect_some_more_withdrawn_worldwide_priorities.csv")
+
+csv = CSV.parse(File.open(csv_file), headers: true)
+
+puts "Trying to redirect #{csv.size} worldwide priorities"
+
+csv.each do |row|
+  slug = row["slug"]
+
+  public_uri = Plek.new.website_uri
+  public_uri.path = row["path_for_alternative_url"]
+  alternative_url = public_uri.to_s
+
+  wp = WorldwidePriority.published_as(slug, I18n.locale)
+
+  if wp && wp.unpublishing
+    puts "Redirecting #{slug} to #{alternative_url}"
+    unpublishing = wp.unpublishing
+
+    unpublishing.redirect = true
+    unpublishing.alternative_url = alternative_url
+    unpublishing.unpublishing_reason_id = UnpublishingReason::Consolidated.id
+    unpublishing.explanation = nil
+    unpublishing.save!
+
+    wp.update_attribute(:state, "draft")
+  else
+    puts "No unpublished worldwide priority found for slug #{slug}"
+  end
+end


### PR DESCRIPTION
- This is the same data migration as 20150724130057, just with the name
  of the CSV changed and an updated timestamp so we can run it again.
  I would have made this into a Rake task, to avoid duplicating all of this,
  but this *should* be the last of the world priorities we have to redirect.
- Tested this in dev and it works OK.
- Trello:
  https://trello.com/c/jJIyhtm8/79-more-worldwide-priority-redirects.

(For more context, see the explanation on #2286.)