### PR TITLE
Improve search results for roles and people

### DIFF
--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -29,9 +29,10 @@ class MinisterialRole < Role
       .limit(options[:limit])
   end
 
-  searchable title: :search_title,
+  searchable title: :to_s,
              link: :search_link,
              content: :current_person_biography,
+             description: :search_description,
              format: 'minister'
 
   def self.cabinet
@@ -40,10 +41,6 @@ class MinisterialRole < Role
 
   def ministerial?
     true
-  end
-
-  def search_title
-    current_person ? "#{current_person.name} (#{to_s})" : to_s
   end
 
   def destroyable?
@@ -55,6 +52,14 @@ class MinisterialRole < Role
     # the old value of the slug (e.g. nil for a new record) if the record is dirty, and apparently the record
     # is still marked as dirty during after_save callbacks.
     Whitehall.url_maker.ministerial_role_path(slug)
+  end
+
+  def search_description
+    if current_person
+      "Current role holder: #{current_person.name}."
+    else
+      ""
+    end
   end
 
 private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,6 +40,7 @@ class Person < ActiveRecord::Base
   searchable title: :name,
              link: :search_link,
              content: :biography_without_markup,
+             description: :biography_without_markup,
              slug: :slug
 
   extend FriendlyId

--- a/test/unit/ministerial_role_test.rb
+++ b/test/unit/ministerial_role_test.rb
@@ -82,9 +82,10 @@ class MinisterialRoleTest < ActiveSupport::TestCase
     ministerial_role = create(:ministerial_role_without_organisation, name: 'Prime Minister')
     create(:ministerial_role_appointment, role: ministerial_role, person: person)
 
-    assert_equal 'David Cameron (Prime Minister)', ministerial_role.search_index['title']
+    assert_equal 'Prime Minister', ministerial_role.search_index['title']
     assert_equal "/government/ministers/#{ministerial_role.slug}", ministerial_role.search_index['link']
     assert_equal 'David Cameron became Prime Minister in May 2010.', ministerial_role.search_index['indexable_content']
+    assert_equal 'Current role holder: David Cameron.', ministerial_role.search_index['description']
     assert_equal 'minister', ministerial_role.search_index['format']
   end
 
@@ -130,26 +131,26 @@ class MinisterialRoleTest < ActiveSupport::TestCase
     results = MinisterialRole.search_index.to_a
 
     assert_equal 4, results.length
-    assert_equal({'title' => 'Nick Clegg (Deputy Prime Minister)',
+    assert_equal({'title' => 'Deputy Prime Minister',
                   'link' => '/government/ministers/deputy-prime-minister',
                   'indexable_content' => 'Cleggy.',
                   'format' => 'minister',
-                  'description' => ''}, results[0])
-    assert_equal({'title' => 'Jeremy Hunt (Secretary of State for Culture)',
+                  'description' => 'Current role holder: Nick Clegg.'}, results[0])
+    assert_equal({'title' => 'Secretary of State for Culture',
                   'link' => '/government/ministers/secretary-of-state-for-culture',
                   'indexable_content' => 'Hunty.',
                   'format' => 'minister',
-                  'description' => ''}, results[1])
-    assert_equal({'title' => 'Edward Garnier (Solicitor General)',
+                  'description' => 'Current role holder: Jeremy Hunt.'}, results[1])
+    assert_equal({'title' => 'Solicitor General',
                   'link' => '/government/ministers/solicitor-general',
                   'indexable_content' => 'Garnerian.',
                   'format' => 'minister',
-                  'description' => ''}, results[2])
-    assert_equal({'title' => 'David Cameron (Prime Minister)',
+                  'description' => 'Current role holder: Edward Garnier.'}, results[2])
+    assert_equal({'title' => 'Prime Minister',
                   'link' => '/government/ministers/prime-minister',
                   'indexable_content' => 'Cameronian.',
                   'format' => 'minister',
-                  'description' => ''}, results[3])
+                  'description' => 'Current role holder: David Cameron.'}, results[3])
   end
 
   test "#current_person_name should return the role name when vacant" do

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -20,7 +20,7 @@ class PersonTest < ActiveSupport::TestCase
                   'link' => '/government/people/david-cameron',
                   'indexable_content' => 'David Cameron became Prime Minister in May 2010.',
                   'format' => 'person',
-                  'description' => '',
+                  'description' => 'David Cameron became Prime Minister in May 2010.',
                   'slug' => 'david-cameron'
                   }, person.search_index)
   end


### PR DESCRIPTION
Currently role pages (like https://www.gov.uk/government/ministers/minister-for-the-civil-service) and people pages (like https://www.gov.uk/government/people/david-cameron) have no descriptions for the search snippet. This makes the search results look a bit untidy.

Additionally, because we historically didn't index ministers (changed in https://github.com/alphagov/whitehall/pull/2165), the title of the search result for role pages also mentions the current role holder. This causes persons with multiple role to turn up many times in the search result titles, making it difficult for users looking for a _person_ to find the person page, and users looking for a _role_ to find the role page.

Trello: https://trello.com/c/vcojRtTK

### Before

![screen shot 2015-08-11 at 11 43 37](https://cloud.githubusercontent.com/assets/233676/9195891/324ff9b2-401e-11e5-9fc8-ed7eae856a72.png)

### After

![screen shot 2015-08-11 at 11 43 42](https://cloud.githubusercontent.com/assets/233676/9195890/324ececa-401e-11e5-8eed-960d5434b9e1.png)

cc @rboulton @jackscotti 