### PR TITLE
Tag organisations with self in search results

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -168,6 +168,7 @@ class Organisation < ActiveRecord::Base
              link: :search_link,
              content: :indexable_content,
              description: :description_for_search,
+             organisations: :search_organisations,
              boost_phrases: :acronym,
              slug: :slug,
              organisation_state: :searchable_govuk_status
@@ -363,6 +364,10 @@ class Organisation < ActiveRecord::Base
     Whitehall.url_maker.organisation_path(self)
   end
 
+  def search_organisations
+    [slug] + parent_organisations.map(&:slug)
+  end
+
   def published_speeches
     ministerial_roles.map { |mr| mr.speeches.published }.flatten.uniq
   end
@@ -488,5 +493,4 @@ class Organisation < ActiveRecord::Base
       end
     end
   end
-
 end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -377,6 +377,7 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal organisation.indexable_content, organisation.search_index['indexable_content']
     assert_equal 'organisation', organisation.search_index['format']
     assert_equal 'live', organisation.search_index['organisation_state']
+    assert_equal ['ministry-of-funk'], organisation.search_index['organisations']
   end
 
   test 'should return a rendered summary as description' do
@@ -391,6 +392,19 @@ class OrganisationTest < ActiveSupport::TestCase
     page = create(:published_corporate_information_page, page_params)
 
     assert_equal 'A text-rendered summary.', organisation.search_index['description']
+  end
+
+  test 'includes self in organisations for search index data' do
+    organisation = create(:organisation, name: "A Child Org")
+
+    assert_equal ['a-child-org'], organisation.search_index['organisations']
+  end
+
+  test 'includes self and parent in organisations for search index data' do
+    organisation = create(:organisation, name: "A Child Org")
+    create(:organisation, name: "A Parent Org", child_organisations: [organisation])
+
+    assert_equal ['a-child-org', 'a-parent-org'], organisation.search_index['organisations']
   end
 
   test 'should add organisation to search index on creating' do
@@ -467,6 +481,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'indexable_content' => 'Sporty. Some stuff',
                   'format' => 'organisation',
                   'description' => 'Sporty.',
+                  'organisations' => ["department-for-culture-and-sports"],
                   'organisation_state' => 'closed'}, results[0])
     assert_equal({'title' => 'Department of Education',
                   'link' => '/government/organisations/department-of-education',
@@ -474,6 +489,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'indexable_content' => 'Bookish. Some stuff',
                   'format' => 'organisation',
                   'description' => 'Bookish.',
+                  'organisations' => ["department-of-education"],
                   'organisation_state' => 'live'}, results[1])
     assert_equal({'title' => 'HMRC',
                   'acronym' => 'hmrc',
@@ -483,6 +499,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'format' => 'organisation',
                   'boost_phrases' => 'hmrc',
                   'description' => 'Taxing.',
+                  'organisations' => ["hmrc"],
                   'organisation_state' => 'live'}, results[2])
     assert_equal({'title' => 'Ministry of Defence',
                   'acronym' => 'mod',
@@ -492,6 +509,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'format' => 'organisation',
                   'boost_phrases' => 'mod',
                   'description' => 'Defensive.',
+                  'organisations' => ["ministry-of-defence"],
                   'organisation_state' => 'live'}, results[3])
     assert_equal({'title' => 'Devolved organisation',
                   'acronym' => 'dev',
@@ -499,6 +517,7 @@ class OrganisationTest < ActiveSupport::TestCase
                   'slug' => 'devolved-organisation',
                   'indexable_content' => '',
                   'description' => '',
+                  'organisations' => ["devolved-organisation"],
                   'format' => 'organisation',
                   'boost_phrases' => 'dev',
                   'organisation_state' => 'devolved'}, results[5])


### PR DESCRIPTION
Currently organisation pages are not tagged with themselves as `organisations`.

This causes odd behaviour when using facetted search: searching for HMRC will show the organisation page as the first result, but that org page disappears when selecting HMRC in the organisations filter.

Compare:

https://www.gov.uk/search?q=hmrc
https://www.gov.uk/search?q=hmrc&filter_organisations%5B%5D=hm-revenue-customs

Also tags the page with the parent organisation, so that child agencies like the Valuation Office Agency are also included in search results for HMRC.

## Before

![before-1](https://cloud.githubusercontent.com/assets/233676/9197140/a844ccaa-4029-11e5-8084-8653eea5588d.png)

![before-2](https://cloud.githubusercontent.com/assets/233676/9197142/ab23b814-4029-11e5-9a2e-aa3030ae71b0.png)

## After

![after-1](https://cloud.githubusercontent.com/assets/233676/9197143/aef24582-4029-11e5-9002-d79b7526d4a4.png)

![after-2](https://cloud.githubusercontent.com/assets/233676/9197144/b0e9192e-4029-11e5-8932-c8428ab8334c.png)

Trello: https://trello.com/c/2sOGuAhF/285-organisations-not-indexed-under-organisations