### PR TITLE
Lengthen change_note on StatisticsAnnouncementDates

### DIFF
--- a/db/migrate/20150811135445_lengthen_change_note_on_statistics_announcement_dates.rb
+++ b/db/migrate/20150811135445_lengthen_change_note_on_statistics_announcement_dates.rb
@@ -1,0 +1,9 @@
+class LengthenChangeNoteOnStatisticsAnnouncementDates < ActiveRecord::Migration
+  def up
+    change_column(:statistics_announcement_dates, :change_note, :text)
+  end
+
+  def down
+    change_column(:statistics_announcement_dates, :change_note, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150807112957) do
+ActiveRecord::Schema.define(version: 20150811135445) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1040,9 +1040,9 @@ ActiveRecord::Schema.define(version: 20150807112957) do
     t.datetime "release_date"
     t.integer  "precision",                  limit: 4
     t.boolean  "confirmed",                  limit: 1
-    t.string   "change_note",                limit: 255
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.text     "change_note",                limit: 65535
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.integer  "creator_id",                 limit: 4
   end
 


### PR DESCRIPTION
Users were frequently entering more than 255 characters. There isn't any
validation, so an unhandled Mysql2 error was raised:

`Data too long for column 'change_note' at row 1`

Given that change_note on Edition is 65535 characters, we should just up the
limit here too.

Errors in Errbit: https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/55c1ff16657863108e661e00