### PR TITLE
Revert "Solve circular dependency errors in Sidekiq workers"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,15 +30,6 @@ module Whitehall
       #{config.root}/app/concerns
     )
 
-    # In the context of Sidekiq workers in production mode, autoloading is
-    # disabled and instead Sidekiq uses eager loading. By default, eager
-    # loading only includes directories under app/ and not lib/. Therefore
-    # Sidkiq workers are (sometimes) unable to autoload constants which we've
-    # defined in files in lib/.
-    #
-    # https://github.com/mperham/sidekiq/wiki/FAQ#why-doesnt-sidekiq-autoload-my-rails-application-code
-    config.eager_load_paths += config.autoload_paths
-
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]


### PR DESCRIPTION
This reverts commit 7afc33640d31214db64e2ee7cd0133355a9aa5b0.

This caused an error at boot-time (on preview) when trying to load:
Rails::Generators::NamedBase
from:
https://github.com/alphagov/whitehall/blob/master/lib/generators/data_migration/data_migration_generator.rb

Our guess is that the file that defines Rails::Generators::NamedBase isn't
loaded during normal boot at all/by that point.