### PR TITLE
Ensure that admin users see permissions error pages

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,9 +3,9 @@ class Admin::BaseController < ApplicationController
   include PermissionsChecker
 
   layout 'admin'
+  prepend_before_filter :skip_slimmer
   prepend_before_filter :authenticate_user!
   before_filter :require_signin_permission!
-  before_filter :skip_slimmer
 
   def limit_edition_access!
     enforce_permission!(:see, @edition)


### PR DESCRIPTION
Before this change, if you did not have "signin" permission for Whitehall but
tried to visit it anyway, you would get the correct HTTP status code (403)
courtesy of gds-sso, but you would see a generic Slimmer/Static "We're sorry
something went wrong" page, branded like the GOV.UK frontend. This was because
slimmer hadn't been disabled before the authorisation check had been made.

This means that the app looked broken, when actually you needed to ask for
someone to give you permission to signin to Whitehall.

Users will now see a helpful message:
```
  Sorry, you don't have permission to access this application

  Please contact your Delivery Manager or main GDS contact if you need access.
```

Successfully reproduced and tested in development.

/cc @tijmenb 