### PR TITLE
Update print styles for detailed guides

### DIFF
--- a/app/assets/stylesheets/frontend/print/_document.scss
+++ b/app/assets/stylesheets/frontend/print/_document.scss
@@ -2,7 +2,7 @@ img {
   float: left;
   width: 25%;
   clear: both;
-  margin: 0 30px 30px 0px;
+  margin: 0 $gutter $gutter 0;
 }
 
 .document-footer-meta {
@@ -79,28 +79,28 @@ article {
   }
 
   table {
-    border: 1pt solid rgb(125,125,125);
+    border: 1pt solid $border-colour;
     border-collapse: collapse;
     width: 100%;
     margin: $gutter-half 0;
 
     th,
     td {
-      border: 1pt solid rgb(125,125,125);
-      padding: 0.25em 0.5em;
+      border: 1pt solid $border-colour;
+      padding: $gutter-one-third;
       text-align: left;
     }
 
     caption {
       @include core-19;
-      margin: 14pt 0;
+      margin: $gutter-half 0;
     }
   }
 
 }
 
 .call-to-action, .information-block {
-  border: 1px solid $border-colour;
+  border: 1pt solid $border-colour;
   padding: $gutter-half;
   margin: $gutter-half 0;
   h4 {

--- a/app/assets/stylesheets/frontend/print/_document.scss
+++ b/app/assets/stylesheets/frontend/print/_document.scss
@@ -52,31 +52,62 @@ article {
 .govspeak {
   h2 {
     clear: both;
-    padding-top: $gutter*2;
+  }
+  figure {
+    margin: 0;
   }
   .attachment {
     clear: both;
-    .attachment-thumb,
-    .attachment-details {
-      float: left;
-      width: 15%;
-    }
     .attachment-thumb {
-      margin: 0 $gutter*2 $gutter*2 0;
-      a {
-        img {
-          width: 100%;
-        }
-        &:after {
-          content: "";
-        }
-      }
+      display: none;
     }
     .attachment-details {
-      width: 80%;
       h3 {
         margin-top: 0;
       }
+      .accessibility-warning {
+        h2 {
+          @include core-14;
+          padding: 0;
+          margin: 0;
+        }
+        .toggler {
+          display: none;
+        }
+      }
     }
+  }
+
+  table {
+    border: 1pt solid rgb(125,125,125);
+    border-collapse: collapse;
+    width: 100%;
+    margin: $gutter-half 0;
+
+    th,
+    td {
+      border: 1pt solid rgb(125,125,125);
+      padding: 0.25em 0.5em;
+      text-align: left;
+    }
+
+    caption {
+      @include core-19;
+      margin: 14pt 0;
+    }
+  }
+
+}
+
+.call-to-action, .information-block {
+  border: 1px solid $border-colour;
+  padding: $gutter-half;
+  margin: $gutter-half 0;
+  h4 {
+    @include core-14;
+    margin-top: 0;
+  }
+  p {
+    margin: 0;
   }
 }

--- a/app/assets/stylesheets/frontend/print/_heading-block.scss
+++ b/app/assets/stylesheets/frontend/print/_heading-block.scss
@@ -15,7 +15,10 @@
       float: left;
       font-weight: bold;
       clear: both;
-      min-width: 100px;
+      min-width: 120px;
+    }
+    dd {
+      margin-left: 120px;
     }
     dd p {
       margin: 0;

--- a/app/assets/stylesheets/frontend/print/_print.scss
+++ b/app/assets/stylesheets/frontend/print/_print.scss
@@ -34,7 +34,7 @@ h5 {
   }
 }
 p {
-  @include copy-14;
+  @include core-14;
   margin: $gutter-half 0;
 }
 ol,
@@ -48,9 +48,8 @@ ul {
   list-style: disc;
 }
 li {
-  @include copy-14;
+  @include core-14;
   margin-left: $gutter*1.2;
-  
   li {
     margin-left: $gutter;
   }
@@ -88,10 +87,11 @@ figure {
     max-width: $full-width;
   }
   figcaption {
-    @include copy-14;
+    @include core-14;
   }
 }
+
+.back-to-content,
 .player-container {
   display: none;
 }
-


### PR DESCRIPTION
* Tighten margins on headings, paragraphs and lists
* Add styles for tables
* Box calls to action and information blocks
* Hide attachment thumbs
* Fix styling on heading blocks

Example:

![print comparison](https://cloud.githubusercontent.com/assets/7414/9252750/eaf5a9da-41d1-11e5-8912-b29fa321f497.png)

(I’ve made the crown black-on-white in [https://github.com/alphagov/govuk_template/pull/167]; this will need to be released and have the gem updated in Whitehall to come through.)