### PR TITLE
Send mainstream browse taggings to rummager

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -264,6 +264,7 @@ class Edition < ActiveRecord::Base
     attachments: nil,
     operational_field: nil,
     specialist_sectors: :live_specialist_sector_tags,
+    mainstream_browse_pages: :mainstream_browse_page_slugs,
     latest_change_note: :most_recent_change_note,
     is_political: :political?,
     is_historic: :historic?,
@@ -272,6 +273,17 @@ class Edition < ActiveRecord::Base
 
   def search_title
     title
+  end
+
+  def mainstream_browse_page_slugs
+    return unless persisted?
+    artefact = Whitehall.content_api.artefact(Whitehall.url_maker.public_document_path(self).sub(/\A\//, ""))
+    return unless artefact && artefact['tags'].any?
+
+    artefact['tags'].map { |tag|
+      next unless tag['details']['type'] == 'section'
+      tag['slug']
+    }.compact
   end
 
   def search_link

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -17,6 +17,7 @@ module Searchable
     :latest_change_note,
     :link,
     :metadata,
+    :mainstream_browse_pages,
     :news_article_type,
     :operational_field,
     :organisation_state,

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -13,6 +13,9 @@ Then /^I can tag it to some specialist sectors$/ do
 end
 
 Given(/^there is a document tagged to specialist sectors$/) do
+  # The factory is calling `refresh_index_if_required`, but in this case
+  # calling the content-api will blow up because we haven't stubbed that yet. 
+  Edition.any_instance.stubs(:refresh_index_if_required)
   @document = create_document_tagged_to_a_specialist_sector
   stub_content_api_tags(@document)
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -418,6 +418,32 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal government.name, publication.search_index["government_name"]
   end
 
+  test "should not include browse page taggings in search data if those are empty" do
+    publication = create(:published_publication, title: "publication-title")
+
+    search_data = publication.search_index
+
+    refute search_data.key?('mainstream_browse_pages')
+  end
+
+  test "should include browse page taggings in search data" do
+    publication = create(:published_publication, title: "publication-title")
+    Whitehall.content_api.expects(:artefact).with('government/publications/publication-title').returns({
+      "tags" => [{
+        "slug" => "driving/businesses",
+        "title" => "Driving and transport businesses",
+        "details" => {
+          "description" => "Includes setting up test stations, employing drivers and becoming a vehicle operator",
+          "short_description" => nil,
+          "type" => "section"
+        }
+    }]})
+
+    search_data = publication.search_index
+
+    assert_equal search_data['mainstream_browse_pages'], ["driving/businesses"]
+  end
+
   test 'search_format_types tags the edtion as an edition' do
     edition = build(:edition)
     assert edition.search_format_types.include?('edition')


### PR DESCRIPTION
Panopticon allows users to tag edition-content to mainstream browse pages. Tagging something to a mainstream browse page includes it in the list of links on a [/browse page](https://www.gov.uk/browse) such as https://www.gov.uk/browse/business/imports-exports.

![screen shot 2015-08-17 at 16 48 24](https://cloud.githubusercontent.com/assets/233676/9309178/dd1f3174-44ff-11e5-9fca-62562b094cd2.png)

We'd like to [make the collections application serve these lists of links from rummager](https://github.com/alphagov/collections/pull/151) instead of from content API. This works because publisher and specialist-publisher already send the browse pages to which the item is tagged to rummager. This allows us to filter with rummager:

https://www.gov.uk/api/search.json?filter_mainstream_browse_pages[]=business/imports-exports

Whitehall is the last application that doesn't send `mainstream_browse_pages` taggings to rummager. It doesn't even know about which browse pages are tagged to an edition, because tagging to `/browse` is
special and should be restricted to GDS. This is a bit unfortunate, because it requires us to fetch the taggings from the content api before we can send the document to rummager.

Trello: https://trello.com/c/7qw4TRiC