### PR TITLE
Move analytics identifier from details to root

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -15,8 +15,8 @@ class Api::OrganisationPresenter < Api::BasePresenter
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
         content_id: model.content_id,
-        analytics_identifier: model.analytics_identifier,
       },
+      analytics_identifier: model.analytics_identifier,
       parent_organisations: parent_organisations,
       child_organisations: child_organisations,
     }

--- a/app/presenters/api/world_location_presenter.rb
+++ b/app/presenters/api/world_location_presenter.rb
@@ -6,10 +6,10 @@ class Api::WorldLocationPresenter < Api::BasePresenter
       format: model.display_type,
       updated_at: model.updated_at,
       web_url: Whitehall.url_maker.world_location_url(model),
+      analytics_identifier: model.analytics_identifier,
       details: {
         slug: model.slug,
         iso2: model.iso2,
-        analytics_identifier: model.analytics_identifier,
       },
       organisations: {
         id: context.api_world_location_worldwide_organisations_url(model),

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -8,8 +8,8 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
       web_url: Whitehall.url_maker.worldwide_organisation_url(model),
       details: {
         slug: model.slug,
-        analytics_identifier: model.analytics_identifier,
       },
+      analytics_identifier: model.analytics_identifier,
       offices: offices_as_json,
       sponsors: sponsors_as_json,
     }

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -32,7 +32,7 @@ class PublishingApiPresenters::Placeholder
       update_type: update_type,
     }
     if item.respond_to?(:analytics_identifier)
-      json.merge!(details: { analytics_identifier: item.analytics_identifier })
+      json.merge!(analytics_identifier: item.analytics_identifier)
     end
     json
   end

--- a/db/data_migration/20150818084005_rerepublish_items_with_analytics_identifiers_to_publishing_api.rb
+++ b/db/data_migration/20150818084005_rerepublish_items_with_analytics_identifiers_to_publishing_api.rb
@@ -1,0 +1,5 @@
+require 'data_hygiene/publishing_api_republisher'
+
+DataHygiene::PublishingApiRepublisher.new(Organisation.all).perform
+DataHygiene::PublishingApiRepublisher.new(WorldwideOrganisation.all).perform
+DataHygiene::PublishingApiRepublisher.new(WorldLocation.all).perform

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -66,7 +66,7 @@ class Api::OrganisationPresenterTest < PresenterTestCase
 
   test "json includes analytics_identifier in details hash" do
     @organisation.stubs(:analytics_identifier).returns("O123")
-    assert_equal "O123", @presenter.as_json[:details][:analytics_identifier]
+    assert_equal "O123", @presenter.as_json[:analytics_identifier]
   end
 
   test "json includes human organisation type as format" do

--- a/test/unit/presenters/api/world_location_presenter_test.rb
+++ b/test/unit/presenters/api/world_location_presenter_test.rb
@@ -54,7 +54,7 @@ class Api::WorldLocationPresenterTest < PresenterTestCase
 
   test "json includes analytics_identifier in details hash" do
     @location.stubs(:analytics_identifier).returns('WL123')
-    assert_equal 'WL123', @presenter.as_json[:details][:analytics_identifier]
+    assert_equal 'WL123', @presenter.as_json[:analytics_identifier]
   end
 
   test "json includes display type as format" do

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -63,7 +63,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
 
   test "json includes analytics_identifier in details hash" do
     @world_org.stubs(:analytics_identifier).returns('WO123')
-    assert_equal 'WO123', @presenter.as_json[:details][:analytics_identifier]
+    assert_equal 'WO123', @presenter.as_json[:analytics_identifier]
   end
 
   test "json includes public world organisations url as web_url" do

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -40,9 +40,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: organisation.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
-      details: {
-        analytics_identifier: "O123",
-      },
+      analytics_identifier: "O123",
     }
 
     presented_hash = present(organisation)
@@ -85,9 +83,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: worldwide_org.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
-      details: {
-        analytics_identifier: "WO123",
-      },
+      analytics_identifier: "WO123",
     }
 
     presented_hash = present(worldwide_org)
@@ -109,9 +105,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: world_location.updated_at,
       routes: [ { path: public_path, type: "exact" } ],
       update_type: "major",
-      details: {
-        analytics_identifier: "WL123",
-      },
+      analytics_identifier: "WL123",
     }
 
     presented_hash = present(world_location)


### PR DESCRIPTION
So that analytics identifiers can be used by content-store to build
links hashes they have been moved to the root of the content-store
object. This makes that change.

https://trello.com/c/uXiRRmb1/74-send-organisation-data-to-google-analytics-for-pages-in-government-frontend-medium