### PR TITLE
Replace the existing datetime microformat with the HTML5 time element

### DIFF
--- a/app/assets/stylesheets/frontend/print/_documents-index.scss
+++ b/app/assets/stylesheets/frontend/print/_documents-index.scss
@@ -19,9 +19,6 @@
             font-weight: bold;
             padding-bottom: 0;
           }
-          abbr[class="public_timestamp"]:after {
-            content: none;
-          }
         }
       }
     }

--- a/app/assets/stylesheets/frontend/reset/_reset.scss
+++ b/app/assets/stylesheets/frontend/reset/_reset.scss
@@ -30,3 +30,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
   font-weight: normal;
 }
 
+abbr[title], acronym[title] {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -57,7 +57,7 @@
       p {
         span {
           display: block;
-          abbr {
+          time {
             @include core-24(1.4em);
             &.date {
               font-weight: bold;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -159,19 +159,19 @@ module ApplicationHelper
   end
 
   def render_datetime_microformat(object, method, &block)
-    content_tag(:abbr, class: method, title: object.send(method).iso8601, &block)
+    content_tag(:time, class: method, datetime: object.send(method).iso8601, &block)
   end
 
   def absolute_time(time, options = {})
     content_tag(:time, l(time, format: :long_ordinal),
                 class: [options[:class], "datetime"].compact.join(" "),
-                title: time.iso8601) if time
+                datetime: time.iso8601) if time
   end
 
   def absolute_date(time, options = {})
     content_tag(:time, l(time.to_date, format: :long_ordinal),
                 class: [options[:class], "date"].compact.join(" "),
-                title: time.iso8601) if time
+                datetime: time.iso8601) if time
   end
 
   def main_navigation_link_to(name, path, html_options = {}, &block)

--- a/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
@@ -42,7 +42,7 @@ class Admin::GenericEditionsController::RejectingDocumentsTest < ActionControlle
     assert_select ".editorial_remark" do
       assert_select ".body", text: /editorial-remark-body/
       assert_select ".actor", text: current_user.name
-      assert_select "time.created_at[title='#{remark.created_at.iso8601}']"
+      assert_select "time.created_at[datetime='#{remark.created_at.iso8601}']"
     end
   end
 end

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -55,7 +55,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index
 
     assert_select_object(speech) do
-      assert_select "abbr.public_timestamp[title=?]", first_published_at.to_datetime.iso8601
+      assert_select "time.public_timestamp[datetime=?]", first_published_at.to_datetime.iso8601
     end
   end
 
@@ -66,7 +66,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index
 
     assert_select_object(news_article) do
-      assert_select "abbr.public_timestamp[title=?]", first_published_at.iso8601
+      assert_select "time.public_timestamp[datetime=?]", first_published_at.iso8601
     end
   end
 

--- a/test/functional/case_studies_controller_test.rb
+++ b/test/functional/case_studies_controller_test.rb
@@ -43,7 +43,7 @@ class CaseStudiesControllerTest < ActionController::TestCase
     get :show, id: updated_case_study.document
 
     assert_select ".meta" do
-      assert_select ".date[title='#{updated_case_study.first_published_at.iso8601}']"
+      assert_select ".date[datetime='#{updated_case_study.first_published_at.iso8601}']"
     end
   end
 end

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -40,15 +40,15 @@ class ConsultationsControllerTest < ActionController::TestCase
     published_consultation = create(:published_consultation, opening_at: opening_at, closing_at: closing_at)
     get :show, id: published_consultation.document
 
-    assert_select ".opening-at[title='#{opening_at.iso8601}']"
-    assert_select ".closing-at[title='#{closing_at.iso8601}']"
+    assert_select ".opening-at[datetime='#{opening_at.iso8601}']"
+    assert_select ".closing-at[datetime='#{closing_at.iso8601}']"
   end
 
   view_test 'show displays consultation closing date on open consultation' do
     closing_at = Time.zone.now + 2.days
     published_consultation = create(:published_consultation, opening_at: DateTime.new(2010, 1, 1), closing_at: closing_at)
     get :show, id: published_consultation.document
-    assert_select ".closing-at[title='#{closing_at.iso8601}']"
+    assert_select ".closing-at[datetime='#{closing_at.iso8601}']"
   end
 
   view_test "should not explicitly say that consultation applies to the whole of the UK" do

--- a/test/functional/fatality_notices_controller_test.rb
+++ b/test/functional/fatality_notices_controller_test.rb
@@ -40,8 +40,8 @@ class FatalityNoticesControllerTest < ActionController::TestCase
     get :show, id: updated_fatality_notice.document
 
     assert_select ".meta" do
-      assert_select ".date[title='#{fatality_notice.first_published_at.iso8601}']"
-      assert_select ".date[title='#{updated_fatality_notice.public_timestamp.iso8601}']"
+      assert_select ".date[datetime='#{fatality_notice.first_published_at.iso8601}']"
+      assert_select ".date[datetime='#{updated_fatality_notice.public_timestamp.iso8601}']"
     end
   end
 

--- a/test/functional/news_articles_controller_test.rb
+++ b/test/functional/news_articles_controller_test.rb
@@ -42,8 +42,8 @@ class NewsArticlesControllerTest < ActionController::TestCase
     get :show, id: updated_news_article.document
 
     assert_select ".meta" do
-      assert_select ".date[title='#{news_article.first_published_at.iso8601}']"
-      assert_select ".date[title='#{updated_news_article.public_timestamp.iso8601}']"
+      assert_select ".date[datetime='#{news_article.first_published_at.iso8601}']"
+      assert_select ".date[datetime='#{updated_news_article.public_timestamp.iso8601}']"
     end
   end
 

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -416,11 +416,11 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     assert_select '#announcements' do
       assert_select_object(announcement_1) do
-        assert_select "abbr.public_timestamp[title=?]", 1.days.ago.iso8601
+        assert_select "time.public_timestamp[datetime=?]", 1.days.ago.iso8601
         assert_select ".document-type", "Press release"
       end
       assert_select_object(announcement_2) do
-        assert_select "abbr.public_timestamp[title=?]", 2.days.ago.to_date.to_datetime.iso8601
+        assert_select "time.public_timestamp[datetime=?]", 2.days.ago.to_date.to_datetime.iso8601
         assert_select ".document-type", "Written statement to Parliament"
       end
       refute_select_object(announcement_3)
@@ -452,11 +452,11 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     assert_select "#consultations" do
       assert_select_object consultation_1 do
-        assert_select '.publication-date abbr[title=?]', 3.days.ago.iso8601
+        assert_select '.publication-date time[datetime=?]', 3.days.ago.iso8601
         assert_select '.document-type', "Open consultation"
       end
       assert_select_object consultation_2 do
-        assert_select '.publication-date abbr[title=?]', 4.days.ago.iso8601
+        assert_select '.publication-date time[datetime=?]', 4.days.ago.iso8601
         assert_select '.document-type', "Closed consultation"
       end
       refute_select_object consultation_3
@@ -488,7 +488,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     assert_select "#publications" do
       assert_select_object publication_2 do
-        assert_select '.publication-date abbr[title=?]', 2.days.ago.to_date.to_datetime.iso8601
+        assert_select '.publication-date time[datetime=?]', 2.days.ago.to_date.to_datetime.iso8601
         assert_select '.document-type', "Policy paper"
       end
       assert_select_object publication_3
@@ -516,7 +516,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
-        assert_select '.publication-date abbr[title=?]', 1.days.ago.to_date.to_datetime.iso8601
+        assert_select '.publication-date time[datetime=?]', 1.days.ago.to_date.to_datetime.iso8601
         assert_select '.document-type', "Statistics - national statistics"
       end
       assert_select_object publication_2

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -331,7 +331,7 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_equal publication.id, json["id"]
     assert_equal publication_path(publication.document), json["url"]
     assert_equal "org-name and other-org", json["organisations"]
-    assert_equal %{<abbr class="public_timestamp" title="2012-03-14T00:00:00+00:00">14 March 2012</abbr>}, json["display_date_microformat"]
+    assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
     assert_equal "Corporate report", json["display_type"]
   end
 
@@ -353,7 +353,7 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_equal consultation.id, json["id"]
     assert_equal consultation_path(consultation.document), json["url"]
     assert_equal "org-name and other-org", json["organisations"]
-    assert_equal %{<abbr class="public_timestamp" title="2012-03-14T00:00:00+00:00">14 March 2012</abbr>}, json["display_date_microformat"]
+    assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
     assert_equal "Consultation", json["display_type"]
   end
 

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -132,7 +132,7 @@ class StatisticsControllerTest < ActionController::TestCase
     assert_equal statistics_publication.id, json["id"]
     assert_equal statistic_path(statistics_publication.document), json["url"]
     assert_equal "org-name and other-org", json["organisations"]
-    assert_equal %{<abbr class="public_timestamp" title="2012-03-14T00:00:00+00:00">14 March 2012</abbr>}, json["display_date_microformat"]
+    assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
     assert_equal "Statistics", json["display_type"]
   end
 

--- a/test/functional/world_location_news_articles_controller_test.rb
+++ b/test/functional/world_location_news_articles_controller_test.rb
@@ -46,8 +46,8 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
     get :show, id: updated_world_news_article.document
 
     assert_select ".meta" do
-      assert_select ".date[title='#{world_news_article.first_published_at.iso8601}']"
-      assert_select ".date[title='#{updated_world_news_article.public_timestamp.iso8601}']"
+      assert_select ".date[datetime='#{world_news_article.first_published_at.iso8601}']"
+      assert_select ".date[datetime='#{updated_world_news_article.public_timestamp.iso8601}']"
     end
   end
 

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -191,7 +191,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select "#announcements" do
       assert_select_object announcement_1 do
-        assert_select '.publication-date abbr[title=?]', 1.days.ago.iso8601
+        assert_select '.publication-date time[datetime=?]', 1.days.ago.iso8601
         assert_select '.document-type', "Press release"
       end
       assert_select_object announcement_2
@@ -225,7 +225,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select "#publications" do
       assert_select_object publication_2 do
-        assert_select '.publication-date abbr[title=?]', 2.days.ago.to_date.to_datetime.iso8601
+        assert_select '.publication-date time[datetime=?]', 2.days.ago.to_date.to_datetime.iso8601
         assert_select '.document-type', "Policy paper"
       end
       assert_select_object publication_3
@@ -253,7 +253,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
-        assert_select '.publication-date abbr[title=?]', 1.days.ago.to_date.to_datetime.iso8601
+        assert_select '.publication-date time[datetime=?]', 1.days.ago.to_date.to_datetime.iso8601
         assert_select '.document-type', "Statistics - national statistics"
       end
       assert_select_object publication_2

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -92,7 +92,7 @@ class ApplicationHelperTest < ActionView::TestCase
     created_at = Time.zone.now
     object = stub(created_at: created_at)
     html = render_datetime_microformat(object, :created_at) { "human-friendly" }
-    assert_select_within_html(html, "abbr.created_at[title='#{created_at.iso8601}']", text: "human-friendly")
+    assert_select_within_html(html, "time.created_at[datetime='#{created_at.iso8601}']", text: "human-friendly")
   end
 
   test "home page should be related to home main navigation" do

--- a/test/unit/presenters/document_filter_presenter_test.rb
+++ b/test/unit/presenters/document_filter_presenter_test.rb
@@ -72,7 +72,7 @@ class DocumentFilterPresenterTest < PresenterTestCase
       "title" => stub_publication.title,
       "url" => "/government/publications/some-doc",
       "organisations" => "Ministry of Silly",
-      "display_date_microformat" => "<abbr class=\"public_timestamp\" title=\"2011-11-08T11:11:11+00:00\"> 8 November 2011</abbr>",
+      "display_date_microformat" => "<time class=\"public_timestamp\" datetime=\"2011-11-08T11:11:11+00:00\"> 8 November 2011</time>",
       "public_timestamp" => 3.days.ago.as_json,
       "historic?" => false,
       "government_name" => nil,


### PR DESCRIPTION
The datetime microformat has been superceded by the [HTML5 time element](http://www.w3.org/TR/html51/semantics.html#the-time-element). They offer better automated parsing (time elements can be easily extracted), better semantics (no misuse of the abbr element) and better accessibility (users with title reading turned on in their screenreader hear effectively a random string of numbers and letters with datetime microformats).