### PR TITLE
Regenerate db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,18 +81,6 @@ ActiveRecord::Schema.define(version: 20150811135445) do
   add_index "attachments", ["attachment_data_id"], name: "index_attachments_on_attachment_data_id", using: :btree
   add_index "attachments", ["ordering"], name: "index_attachments_on_ordering", using: :btree
 
-  create_table "checksum", id: false, force: :cascade do |t|
-    t.string   "db",         limit: 64,  null: false
-    t.string   "tbl",        limit: 64,  null: false
-    t.integer  "chunk",      limit: 4,   null: false
-    t.string   "boundaries", limit: 100, null: false
-    t.string   "this_crc",   limit: 40,  null: false
-    t.integer  "this_cnt",   limit: 4,   null: false
-    t.string   "master_crc", limit: 40
-    t.integer  "master_cnt", limit: 4
-    t.datetime "ts",                     null: false
-  end
-
   create_table "classification_featuring_image_data", force: :cascade do |t|
     t.string   "carrierwave_image", limit: 255
     t.datetime "created_at"
@@ -440,7 +428,7 @@ ActiveRecord::Schema.define(version: 20150811135445) do
     t.string   "need_ids",                                    limit: 255
     t.string   "primary_locale",                              limit: 255,   default: "en",    null: false
     t.boolean  "political",                                   limit: 1,     default: false
-    t.string   "logo_url"
+    t.string   "logo_url",                                    limit: 255
   end
 
   add_index "editions", ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree


### PR DESCRIPTION
The extraneous 'checksums' table seems to have slipped in
b0354df9577163e5d0ab34b320849bb492d6bad1

The change to logo_url seems to be as a result of a change that was made before
the schema was regenerated with Rails 4.2 but not merged until afterwards. It
was changed here: d11bce7cc76c0dfd1486562365e51e16c455e3f2

/cc @boffbowsh 