### PR TITLE
Improve sending browse pages to rummager

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -274,13 +274,7 @@ class Edition < ActiveRecord::Base
 
   def mainstream_browse_page_slugs
     return unless persisted?
-    artefact = Whitehall.content_api.artefact(Whitehall.url_maker.public_document_path(self).sub(/\A\//, ""))
-    return unless artefact && artefact['tags'].any?
-
-    artefact['tags'].map { |tag|
-      next unless tag['details']['type'] == 'section'
-      tag['slug']
-    }.compact
+    MainstreamBrowseTags.new(self).tags
   end
 
   def search_link

--- a/app/models/mainstream_browse_tags.rb
+++ b/app/models/mainstream_browse_tags.rb
@@ -1,0 +1,25 @@
+class MainstreamBrowseTags
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def tags
+    entry = cached_artefacts_tagged_to_browse_pages.find do |entry|
+      entry['artefact_slug'] == artefact_slug
+    end
+
+    entry['mainstream_browse_page_slugs'] if entry
+  end
+
+private
+
+  def artefact_slug
+    @artefact_slug ||= Whitehall.url_maker.public_document_path(@edition).sub(/\A\//, "")
+  end
+
+  def cached_artefacts_tagged_to_browse_pages
+    Rails.cache.fetch 'artefacts_tagged_to_mainstream_browse_pages', expires_in: 5.minutes do
+      Whitehall.content_api.artefacts_tagged_to_mainstream_browse_pages.to_a
+    end
+  end
+end

--- a/config/initializers/content_api.rb
+++ b/config/initializers/content_api.rb
@@ -12,6 +12,16 @@ class GdsApi::ContentApi::Fake
   def artefact(*args)
     nil
   end
+
+  def artefacts_tagged_to_mainstream_browse_pages
+    []
+  end
+end
+
+class GdsApi::ContentApi
+  def artefacts_tagged_to_mainstream_browse_pages
+    get_json!("#{base_url}/whitehall-artefacts-tagged-to-mainstream-browse-pages.json")
+  end
 end
 
 if Rails.env.test?

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -428,16 +428,12 @@ class EditionTest < ActiveSupport::TestCase
 
   test "should include browse page taggings in search data" do
     publication = create(:published_publication, title: "publication-title")
-    Whitehall.content_api.expects(:artefact).with('government/publications/publication-title').returns({
-      "tags" => [{
-        "slug" => "driving/businesses",
-        "title" => "Driving and transport businesses",
-        "details" => {
-          "description" => "Includes setting up test stations, employing drivers and becoming a vehicle operator",
-          "short_description" => nil,
-          "type" => "section"
-        }
-    }]})
+    Whitehall.content_api.expects(:artefacts_tagged_to_mainstream_browse_pages).returns([
+      {
+        "artefact_slug" => "government/publications/publication-title",
+        "mainstream_browse_page_slugs" => ["driving/businesses"]
+      }
+    ])
 
     search_data = publication.search_index
 


### PR DESCRIPTION
Currently whitehall asks content-api for the browse pages tagged to an artefact. This was added in PR #2322. However, it does so by asking the content-api for each edition during indexing, about 130.000 times currently. This commit uses the new endpoint on content-api that was [added specially for this use-case](https://github.com/alphagov/govuk_content_api/pull/226):

https://www.gov.uk/api/whitehall-artefacts-tagged-to-mainstream-browse-pages.json

This endpoint returns all artefacts tagged to mainstream browse pages, so that we can do one request to get them all. We use the standard Rails caching mechanism here to cache the response.

We extend `GdsApi::ContentApi` in this app because no other clients may use the `artefacts_tagged_to_mainstream_browse_pages` endpoint. This is a pattern [used by the publishing API](https://github.com/alphagov/publishing-api/blob/560112fc1019d77f4dce4f93061165a574d5d7eb/lib/clients/content_store_writer.rb).

Trello: https://trello.com/c/7qw4TRiC