### PR TITLE
Fix document collection `Add` button

### DIFF
--- a/app/assets/stylesheets/admin/views/_document_collection_groups.scss
+++ b/app/assets/stylesheets/admin/views/_document_collection_groups.scss
@@ -2,8 +2,6 @@
   &.index {
 
     .reorder-buttons {
-      position: absolute;
-      right: 20px;
       button {
         display: none;
       }

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -10,9 +10,6 @@
   <%= form_tag admin_document_collection_new_member_path(@collection), class: 'document-finder' do %>
     <h2>Add a document</h2>
     <div id="document-finder" class="form-inline well remove-top-margin">
-      <div class="reorder-buttons">
-        <%= button_tag 'Reorder groups', class: 'btn btn-sm btn-info js-reorder' %><%= button_tag 'Finish reordering', class: 'btn btn-sm btn-success js-finish-reorder' %>
-      </div>
       <label for="title">Add</label>
       <div class="document-finder-fields">
         <%= search_field_tag :title, '', placeholder: 'Title or slug&hellip;'.html_safe, results: 5, autosave: 'unique', autofocus: true, class: 'form-control input-sm' %>
@@ -30,6 +27,9 @@
     </div>
   <% end %>
   <div class="js-group-container">
+    <div class="reorder-buttons">
+      <%= button_tag 'Reorder groups', class: 'btn btn-sm btn-info js-reorder' %><%= button_tag 'Finish reordering', class: 'btn btn-sm btn-success js-finish-reorder' %>
+    </div>
     <% @groups.each do |group| %>
       <section class="group">
         <header class="js-group-header">

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -8,7 +8,7 @@
 
 <%= edition_editing_tabs(@collection) do %>
   <%= form_tag admin_document_collection_new_member_path(@collection), class: 'document-finder' do %>
-    <h2>Add a document</h2>
+    <h2>Add document to a group</h2>
     <div id="document-finder" class="form-inline well remove-top-margin">
       <label for="title">Add</label>
       <div class="document-finder-fields">

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -27,7 +27,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     @collection.groups << build(:document_collection_group)
     group1, group2 = @collection.groups
     get :index, document_collection_id: @collection
-    assert_select 'section.group:nth-child(1)' do
+    assert_select 'section.group' do
       assert_select "option[value='#{group1.id}']", count: 0
       assert_select "option[value='#{group2.id}']", group2.heading
     end


### PR DESCRIPTION
Work for Zendesk ticket: https://govuk.zendesk.com/tickets/1127310

The `Add` button for collection documents gets covered up by the `Reorder groups` button if:
  1. a document collection group heading is long
  2. the browser width is reduced

This PR moves the `Reorder groups` button out of the Add form. @fofr also suggested a copy change for the `Add document` form.

Before:
![full width, can see both buttons](https://cloud.githubusercontent.com/assets/184071/9497443/e13a4a6e-4c0c-11e5-85b7-70a43a6dd892.png)

Can't see Add button:
![reduced width, can't see add button](https://cloud.githubusercontent.com/assets/184071/9497464/0347f49e-4c0d-11e5-90ce-d314c35ba8d0.png)


Move reorder button outside of `Add document` form:
![Reorder button separated](https://cloud.githubusercontent.com/assets/184071/9497486/1fb69374-4c0d-11e5-9b40-ff23aaad0d76.png)