### PR TITLE
Add meta data to detailed guides

### DIFF
--- a/app/controllers/detailed_guides_controller.rb
+++ b/app/controllers/detailed_guides_controller.rb
@@ -6,6 +6,8 @@ class DetailedGuidesController < DocumentsController
   def show
     @topics = @document.topics
     @related_policies = document_related_policies
+
+    set_meta_description(@document.summary)
   end
 
 private

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class DetailedGuideIntegrationTest < ActionDispatch::IntegrationTest
+  test "meta data tag is present" do
+    detailed_guide = create(:published_detailed_guide, summary: "This is a published detailed guide summary")
+
+    get "/#{detailed_guide.slug}"
+
+    assert response.body.include? "<meta name=\"description\" content=\"This is a published detailed guide summary\" />"
+  end
+end


### PR DESCRIPTION
Part of improving search result snippets shown on external search
engines. The lack of a meta-description tag makes some search result
snippets unhelpful, confusing, or misleading. Ticket:
https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types