### PR TITLE
Add some length validations for alt_text fields

### DIFF
--- a/app/models/classification_featuring.rb
+++ b/app/models/classification_featuring.rb
@@ -7,6 +7,7 @@ class ClassificationFeaturing < ActiveRecord::Base
   accepts_nested_attributes_for :image, reject_if: :all_blank
 
   validates :image, :alt_text, presence: true
+  validates :alt_text, length: { maximum: 255 }
 
   validates :classification, :ordering, presence: true
 

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -8,6 +8,7 @@ class Feature < ActiveRecord::Base
   validates :document, presence: true, unless: -> feature { feature.topical_event_id.present? || feature.offsite_link_id.present? }
   validates :started_at, presence: true
   validates :image, :alt_text, presence: true, on: :create
+  validates :alt_text, length: { maximum: 255 }
   validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 
   before_validation :set_started_at!, on: :create

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@ class Image < ActiveRecord::Base
   belongs_to :image_data
   belongs_to :edition
 
-  validates :alt_text, presence: true, unless: :skip_main_validation?
+  validates :alt_text, presence: true, length: { maximum: 255 }, unless: :skip_main_validation?
   validates :image_data, presence: { message: 'must be present' }
 
   after_destroy :destroy_image_data_if_required


### PR DESCRIPTION
In the past, these fields would simply have been silently truncated by MySQL.

Now, if the user sends too many characters, an error is raised, such as:

  Mysql2::Error: Data too long for column 'alt_text' at row 1

This means the user sees an unhelpful 5xx error page. If we have a validation,
they should see the form they were using with a helpful message.

There are lots of fields with length constraints without validations, I just
chose these because I have seen [some Errbit reports](https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/55dedd5c657863475f800200) from users trying to enter
too much data.