### PR TITLE
Set inheritance for medium stacked custom logos

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_organisations.scss
+++ b/app/assets/stylesheets/frontend/helpers/_organisations.scss
@@ -932,7 +932,8 @@ img.organisation-logo-custom {
 }
 
 // Custom logos Medium
-.organisation-logo-custom-medium {
+.organisation-logo-custom-medium,
+.organisation-logo-stacked-custom-medium {
   @extend .organisation-logo-identity-medium;
   border-left: none;
 }


### PR DESCRIPTION
Without this inheritance the custom medium stacked logos don't get any
font-size set on them. This makes them really small rather than the same
size as the single identity logos.

Remove the border that gets added during the inheritance call.

<table>
<tr><th>before</th><th>after</th></tr>
<tr><td><img src="https://cloud.githubusercontent.com/assets/35035/9544235/c1709cfe-4d76-11e5-8882-eb1d75f57508.png"></td><td><img src="https://cloud.githubusercontent.com/assets/35035/9544243/cf231b4c-4d76-11e5-8b4b-87c59f74c78a.png"></td></tr>
</table>

https://trello.com/c/CKqkyseM/80-bespoke-logos-display-small-text-small
