### PR TITLE
Send static pages to rummager

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -274,7 +274,8 @@ class Edition < ActiveRecord::Base
 
   def mainstream_browse_page_slugs
     return unless persisted?
-    MainstreamBrowseTags.new(self).tags
+    artefact_slug = Whitehall.url_maker.public_document_path(self).sub(/\A\//, "")
+    MainstreamBrowseTags.new(artefact_slug).tags
   end
 
   def search_link

--- a/app/models/mainstream_browse_tags.rb
+++ b/app/models/mainstream_browse_tags.rb
@@ -1,6 +1,8 @@
 class MainstreamBrowseTags
-  def initialize(edition)
-    @edition = edition
+  attr_reader :artefact_slug
+
+  def initialize(artefact_slug)
+    @artefact_slug = artefact_slug
   end
 
   def tags
@@ -12,10 +14,6 @@ class MainstreamBrowseTags
   end
 
 private
-
-  def artefact_slug
-    @artefact_slug ||= Whitehall.url_maker.public_document_path(@edition).sub(/\A\//, "")
-  end
 
   def cached_artefacts_tagged_to_browse_pages
     Rails.cache.fetch 'artefacts_tagged_to_mainstream_browse_pages', expires_in: 5.minutes do

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -1,0 +1,31 @@
+class PublishStaticPages
+  def publish
+    index = Whitehall::SearchIndex.for(:government)
+    pages.each { |page| index.add(page) }
+  end
+
+private
+
+  def pages
+    [
+      {
+        _id: "/government/how-government-works",
+        link: "/government/how-government-works",
+        format: "edition",
+        title: "How government works",
+        description: "About the UK system of government. Understand who runs government, and how government is run.",
+        indexable_content: "government, parliament, coalition, civil service, civil servants, policies, policy, minister, ministers, MP, rt hon, right honourable, department, ndpb, agency, executive agency, agencies, organisation, public bodies, public body, FOI, freedom of information, transparency, democracy, westminster, whitehall, house of commons, house of lords",
+        mainstream_browse_pages: MainstreamBrowseTags.new('government/how-government-works').tags,
+      },
+      {
+        _id: "/government/get-involved",
+        link: "/government/get-involved",
+        format: "edition",
+        title: "Get involved",
+        description: "Find out how you can engage with government directly, and take part locally, nationally or internationally.",
+        indexable_content: "changing government policies, consultations, government departments",
+        mainstream_browse_pages: MainstreamBrowseTags.new('government/get-involved').tags,
+      }
+    ]
+  end
+end

--- a/lib/tasks/publish_static_pages.rake
+++ b/lib/tasks/publish_static_pages.rake
@@ -1,0 +1,3 @@
+task :publish_static_pages => [:environment] do
+  PublishStaticPages.new.publish
+end

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class PublishStaticPagesTest < ActiveSupport::TestCase
+  test 'sends static pages to rummager' do
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add).twice.with(kind_of(Hash))
+
+    PublishStaticPages.new.publish
+  end
+
+  test "should include browse page taggings in search data" do
+    Whitehall.content_api.expects(:artefacts_tagged_to_mainstream_browse_pages).twice.returns([
+      {
+        "artefact_slug" => "government/how-government-works",
+        "mainstream_browse_page_slugs" => ["some/browse-page"]
+      }
+    ])
+
+    pages = PublishStaticPages.new.send(:pages)
+
+    assert_equal pages.first[:mainstream_browse_pages], ["some/browse-page"]
+  end
+end


### PR DESCRIPTION
["How government works"](https://www.gov.uk/government/how-government-works) and ["Get involved"](https://www.gov.uk/government/get-involved) are currently not indexed in rummager, because they are static pages without entries in the database. 

We need to index these now because they've been [tagged to a mainstream browse page in content-api](https://www.gov.uk/api/whitehall-artefacts-tagged-to-mainstream-browse-pages.json). The collections app is switching from using content-api to rummager to fetch the content (https://github.com/alphagov/collections/pull/151), so rummager now needs to now about these pages too.

The rake task should be run after each deploy.

Trello: https://trello.com/c/7qw4TRiC
