### PR TITLE
Use relative, not absolute, path to image

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -33,7 +33,7 @@ module DocumentHelper
   def national_statistics_logo(edition)
     if edition.national_statistic?
       content_tag :div, class: 'national-statistic' do
-        image_tag '/government/assets/national-statistics.png', alt: t('national_statistics.heading'), class: 'national-statistics-logo'
+        image_tag 'national-statistics.png', alt: t('national_statistics.heading'), class: 'national-statistics-logo'
       end
     end
   end


### PR DESCRIPTION
__NOTE: This is untested. I have no local development VM.__

When testing the new production environment on Carrenza using the /random
route, I stumbled upon a national statistics announcement in Whitehall that
had no ONS logo displayed, because the image itself 404d on the new
production asset master, as well as on the staging asset master which is
also in Carrenza.

After some digging, and help from @elliotcm and others, it looks like this is a
Rails-ism, where image_tag with a value of relative path does get the hash
added to the end of it during asset precompilation, and image_tag with a
value of absolute path does not. Since Rails replaces the image referenced
with the image's correct filename in the HTML it renders, any image without
a hash on the end was never going to display, which explains the original
behaviour.

In the existing production environment, this likely worked because the image
existed both with the hash and without, so it was always available to be
served, however when the app was deployed to the new production and staging
environments, the files with the hash suffixed worked weren't available and
then 404d. The question about why the unsuffixed images existed in existing
production is still unanswered, but I think it might be related to a Rails
upgrade earlier this year (since the unsuffixed image was last modified back
then), but that might be wrong.

I have no local development VM to test this on right now, and I'd appreciate pairing
if anything needs changing so I can see what's what :)