### PR TITLE
Send Editions' content_id to gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '4.6.2'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '2.5.1'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '23.2.2'
+gem 'gds-api-adapters', '24.2.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (23.2.2)
+    gds-api-adapters (24.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -450,7 +450,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 23.2.2)
+  gds-api-adapters (= 24.2.0)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.3.0)

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -18,6 +18,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal [], registerable_edition.specialist_sectors
     assert_equal ["/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
+    assert edition.content_id
   end
 
   test "prepares a translated detailed guide for registration with Panopticon" do


### PR DESCRIPTION
We want to use content IDs instead of slugs to represent items in curated
lists, so that things like slug changes don't break the linkage. In order to do
this, we need to ensure that all content in publisher has a content-id, and
these content-ids are published to the publishing API.

This newly added test check that RegisterableEdition has a content_id.
I can't manually set a content_id. This test checks only for its presence.

Part of:
https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id