### PR TITLE
Rake task to re-register content in panopticon

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -78,6 +78,10 @@ class RegisterableEdition
     end
   end
 
+  def content_id
+    edition.content_id
+  end
+
 private
 
   def no_longer_published?

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -18,7 +18,7 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal [], registerable_edition.specialist_sectors
     assert_equal ["/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
-    assert edition.content_id
+    assert_equal edition.content_id, registerable_edition.content_id
   end
 
   test "prepares a translated detailed guide for registration with Panopticon" do


### PR DESCRIPTION
Now gds-api-adapters and panopticon are happy with handling documents with a
content id. This rake task re-sends editions to panopticon along with their
content id.

Tested locally. After running for few seconds, we went from 0 to:
![screen shot 2015-09-09 at 12 16 37](https://cloud.githubusercontent.com/assets/5038475/9760407/b0152fa4-56ec-11e5-8212-8dee06d2ffa2.png)

