### PR TITLE
Use Rummager by default in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,17 +144,6 @@ indexing, and the
 [GOV.UK frontend application](https://github.com/alphagov/frontend) to
 serve results.
 
-To use a local copy of Rummager you'll need to:
-
-* [elasticsearch](http://www.elasticsearch.org/);
-* Set the environment variable `RUMMAGER_HOST` to point to the local
-  instance of Rummager (e.g. `export
-  RUMMAGER_HOST=http://search.dev.gov.uk` in `.powrc`);
-* You'll also need to set `RUMMAGER_HOST` when using the Rummager rake
-  tasks (ie. when building search index)
-* Run the `rummager` and `frontend` applications to view results. You
-  just need the `rummager` app to index results.
-
 ### Rebuilding whitehall search index
 
 The easiest way to get a search index is to replicate it from the preview

--- a/config/initializers/search_backend.rb
+++ b/config/initializers/search_backend.rb
@@ -1,5 +1,5 @@
-if Rails.env.production? || ENV["RUMMAGER_HOST"]
-  Whitehall.search_backend = Whitehall::DocumentFilter::Rummager
-else
+if Rails.env.test?
   Whitehall.search_backend = Whitehall::DocumentFilter::Mysql
+else
+  Whitehall.search_backend = Whitehall::DocumentFilter::Rummager
 end

--- a/config/initializers/statistics_announcement_search_client.rb
+++ b/config/initializers/statistics_announcement_search_client.rb
@@ -1,4 +1,4 @@
-Whitehall.statistics_announcement_search_client = if Rails.env.test? || (Rails.env.development? && ENV['RUMMAGER_HOST'].nil?)
+Whitehall.statistics_announcement_search_client = if Rails.env.test?
   DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncements
 else
   GdsApi::Rummager.new(Whitehall::SearchIndex.rummager_host + Whitehall.government_search_index_path)

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -2,22 +2,16 @@ namespace :rummager do
   desc "indexes all published searchable whitehall content"
   task :index => ['rummager:index:detailed', 'rummager:index:government']
 
-  task :warn_about_no_op do
-    if Rails.env.development? && ENV["RUMMAGER_HOST"].blank?
-      puts "Note: not actually submitting content to Rummager. Set RUMMAGER_HOST if you want to do so."
-    end
-  end
-
   namespace :index do
     desc "indexes all published searchable content for the main government index (i.e. excluding detailed guides)"
-    task :government => [:environment, :warn_about_no_op] do
+    task :government => :environment do
       index = Whitehall::SearchIndex.for(:government)
       index.add_batch(Whitehall.government_search_index)
       index.commit
     end
 
     desc "indexes all published detailed guiudes"
-    task :detailed => [:environment, :warn_about_no_op] do
+    task :detailed => :environment do
       index = Whitehall::SearchIndex.for(:detailed_guides)
       index.add_batch(Whitehall.detailed_guidance_search_index)
       index.commit
@@ -25,7 +19,7 @@ namespace :rummager do
 
     # NOTE: Run daily to ensure consultation state is reflected in the search results
     desc "indexes consultations which closed in the past day"
-    task :closed_consultations => [:environment, :warn_about_no_op] do
+    task :closed_consultations => :environment do
       index = Whitehall::SearchIndex.for(:government)
       index.add_batch(Consultation.published.closed_since(25.hours.ago).map(&:search_index))
       index.commit
@@ -36,12 +30,12 @@ namespace :rummager do
   task :reset => ['rummager:reset:detailed', 'rummager:reset:government']
 
   namespace :reset do
-    task :government => [:environment, :warn_about_no_op] do
+    task :government => :environment do
       Whitehall::SearchIndex.for(:government).delete_all
       Rake::Task["rummager:index:government"].invoke
     end
 
-    task :detailed => [:environment, :warn_about_no_op] do
+    task :detailed => :environment do
       Whitehall::SearchIndex.for(:detailed_guides).delete_all
       Rake::Task["rummager:index:detailed"].invoke
     end

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -10,15 +10,15 @@ module Whitehall
     end
 
     def self.indexer_class
-      if ENV.has_key?('RUMMAGER_HOST') || Rails.env.production?
-        Rummageable::Index
-      else
+      if Rails.env.test?
         FakeRummageableIndex
+      else
+        Rummageable::Index
       end
     end
 
     def self.rummager_host
-      ENV.fetch('RUMMAGER_HOST', Plek.find('search'))
+      Plek.find('search')
     end
 
     def self.add(instance)


### PR DESCRIPTION
This stems from the days when Whitehall was mostly separate from the GOV.UK
stack.

The development repo already starts Rummager for Whitehall when using bowler.