### PR TITLE
Update copy at the bottom of the organisations page

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -54,7 +54,7 @@
     <div class="js-filter-no-results">
       <p>No departments match that filter.</p>
     </div>
-    <p class="omissions">Errors or omissions? <a href="https://www.gov.uk/contact/govuk">Tell us here</a>. For an official list of non&ndash;departmental public bodies (accurate as at December 2013) see <a href="https://www.gov.uk/government/publications/public-bodies-2013">Public Bodies 2013</a>
+    <p class="omissions">Errors or omissions? <a href="https://www.gov.uk/contact/govuk">Tell us here</a>. For official lists of non&ndash;departmental public bodies see <a href="https://www.gov.uk/government/collections/public-bodies">public bodies</a>.
     </p>
   </div>
 </div>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -54,7 +54,7 @@
     <div class="js-filter-no-results">
       <p>No departments match that filter.</p>
     </div>
-    <p class="omissions">Errors or omissions? <a href="https://www.gov.uk/feedback/contact">Tell us here</a>. For an official list of non&ndash;departmental public bodies (accurate as at December 2013) see <a href="https://www.gov.uk/government/publications/public-bodies-2013">Public Bodies 2013</a>
+    <p class="omissions">Errors or omissions? <a href="https://www.gov.uk/contact/govuk">Tell us here</a>. For an official list of non&ndash;departmental public bodies (accurate as at December 2013) see <a href="https://www.gov.uk/government/publications/public-bodies-2013">Public Bodies 2013</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
As suggested by Alan in Zendesk: https://govuk.zendesk.com/tickets/1139513

> To future proof this and make it more useful it should maybe point to
> https://www.gov.uk/government/collections/public-bodies as a static
> URL for up to date lists of public bodies.