### PR TITLE
Add "All services and Information" link to Defra

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -480,6 +480,7 @@ class Organisation < ActiveRecord::Base
     %w{
       charity-commission
       department-for-education
+      department-for-environment-food-rural-affairs
       driver-and-vehicle-standards-agency
       environment-agency
       high-speed-two-limited


### PR DESCRIPTION
Defra would like a link to "Services and information" on the organisation page. Adding their slug to the whitelist will show this.

There doesn't seem to be a way to test this, except manually (https://github.com/alphagov/whitehall/pull/1900 didn't have tests).

### Before

![screen shot 2015-09-15 at 15 30 28](https://cloud.githubusercontent.com/assets/233676/9879459/65be9b20-5bbf-11e5-9cca-5c0d83f5dae2.png)

### After

![screen shot 2015-09-15 at 15 30 41](https://cloud.githubusercontent.com/assets/233676/9879470/6d56a274-5bbf-11e5-961d-ce24bde33a2c.png)

Don't mind the missing images and slightly wacky layout, my local database is not up to date. Preview will show the correct design.

Trello: https://trello.com/c/dBou6m4R