### PR TITLE
Display warning when removing a column without `DeprecatedColumns`

### DIFF
--- a/config/initializers/warn_on_unguarded_column_removals.rb
+++ b/config/initializers/warn_on_unguarded_column_removals.rb
@@ -1,0 +1,25 @@
+module ActiveRecord::ConnectionAdapters::SchemaStatements
+  def remove_column_with_column_warning(table_name, column_name, type = nil, options = {})
+    puts column_deprecation_status(table_name, column_name)
+    remove_column_without_column_warning(table_name, column_name, type, options)
+  end
+
+  alias_method_chain :remove_column, :column_warning
+
+  def column_deprecation_status(table_name, column_name)
+    begin
+      klass = table_name.to_s.singularize.camelize.constantize
+    rescue NameError
+      return "WARNING: Couldn't find model for table #{table_name}. I can't tell " +
+             "if column #{column_name} has been deprecated."
+    end
+
+    if klass.try(:deprecated_column_list).to_a.include?(column_name.to_s)
+      "OK: #{table_name}.#{column_name} has been deprecated."
+    else
+      "WARNING: #{table_name}.#{column_name} has not been deprecated. Please " +
+      "use the `DeprecatedColumns` mixin to avoid crashing Whitehall in " +
+      "production."
+    end
+  end
+end

--- a/test/db/warn_on_unguarded_column_removals_test.rb
+++ b/test/db/warn_on_unguarded_column_removals_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ModelWithoutDeprecation
+end
+
+class ModelWithDeprecation
+  extend DeprecatedColumns
+  deprecated_columns :my_column
+end
+
+class WarnOnColumnRemovalTest < ActiveSupport::TestCase
+  def test_remove_column_without_deprecation
+    out = message_for(:model_without_deprecation, :title)
+
+    assert out.starts_with? "WARNING: model_without_deprecation.title has not been deprecated"
+  end
+
+  def test_remove_column_from_non_existing_table
+    out = message_for(:does_not_exist, :title)
+
+    assert out.starts_with? "WARNING: Couldn't find model for table does_not_exist."
+  end
+
+  def test_remove_column_with_deprecation
+    out = message_for(:model_with_deprecation, :my_column)
+
+    assert out.starts_with? "OK: model_with_deprecation.my_column has been deprecated."
+  end
+
+private
+
+  def message_for(table_name, column_name)
+    # ActiveRecord::Migration wraps `say_with_time` around all method calls, but
+    # we don't want that output in test-mode.
+    silence_stream $stdout do
+      ActiveRecord::Migration.new.column_deprecation_status(table_name, column_name)
+    end
+  end
+end


### PR DESCRIPTION
Whitehall runs on multiple servers. When we're removing a column with `remove_column`, the database migration is run after the new code is deployed and Rails has restarted. This will result in exceptions being raised when ActiveRecord tries to load the just-removed column. We solve this by using a mixin ([`DeprecatedColumns`](https://github.com/alphagov/whitehall/blob/master/lib/deprecated_columns.rb)) that prevents Rails from using the removed column.

However, this is a manual process not known to all developers, so we still get burned sometimes (https://github.com/alphagov/whitehall/pull/2309 was the one that bit us last). 

This commit monkey patches `ActiveRecord::ConnectionAdapters::SchemaStatements` to provide the developer with a warning whenever a "unprotected" migration is run.

<img width="1145" alt="screen shot 2015-09-15 at 18 08 17" src="https://cloud.githubusercontent.com/assets/233676/9883896/ca6e942a-5bd4-11e5-8a47-5ef47b807286.png">

Trello: https://trello.com/c/y1FByxVB.

I'm not 100% sure of the approach taken here. The monkey patching doesn't feel very clean, and I don't know `ActiveRecord` enough to be super confident that this works in all situations. However, I think that this is better than nothing. Thoughts anyone? 

@rboulton @alext  