### PR TITLE
Update alphagov domain name in production

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -20,7 +20,7 @@ class Admin::EditionsController < Admin::BaseController
   def forbid_editing_of_historic_content!
     unless can?(:modify, @edition)
       redirect_to [:admin, @edition],
-        alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please <a href="https://support.production.alphagov.co.uk/content_change_request/new">contact GDS</a> if you need to change it.}
+        alert: %{This document is in <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode">history mode</a>. Please <a href="https://support.publishing.service.gov.uk/content_change_request/new">contact GDS</a> if you need to change it.}
     end
   end
 

--- a/lib/collection_data_reporter.rb
+++ b/lib/collection_data_reporter.rb
@@ -70,6 +70,6 @@ private
   end
 
   def admin_link(path)
-    "https://whitehall-admin.production.alphagov.co.uk" + path
+    "https://whitehall-admin.publishing.service.gov.uk" + path
   end
 end

--- a/lib/whitehall/broken_link_reporter.rb
+++ b/lib/whitehall/broken_link_reporter.rb
@@ -107,7 +107,7 @@ module Whitehall
       end
 
       def admin_host
-        'whitehall-admin.production.alphagov.co.uk'
+        'whitehall-admin.publishing.service.gov.uk'
       end
 
       def run_links_report

--- a/test/integration/broken_link_reporter_test.rb
+++ b/test/integration/broken_link_reporter_test.rb
@@ -40,7 +40,7 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
     assert_equal 2, embassy_csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], embassy_csv[0]
     assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.world_location_news_article_path(news_article.slug)}",
-                   "https://whitehall-admin.production.alphagov.co.uk#{Whitehall.url_maker.admin_world_location_news_article_path(news_article)}",
+                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_world_location_news_article_path(news_article)}",
                    news_article.public_timestamp.to_s,
                    'WorldLocationNewsArticle',
                    '1',
@@ -50,13 +50,13 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
     assert_equal 3, hmrc_csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], hmrc_csv[0]
     assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
-                   "https://whitehall-admin.production.alphagov.co.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
                    publication.public_timestamp.to_s,
                    'Publication',
                    '1',
                    "https://www.gov.uk/bad-link"], hmrc_csv[1]
     assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
-                   "https://whitehall-admin.production.alphagov.co.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
                    detailed_guide.public_timestamp.to_s,
                    'DetailedGuide',
                    '2',
@@ -81,7 +81,7 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
     assert_equal 2, csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], csv[0]
     assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.speech_path(speech.slug)}",
-                   "https://whitehall-admin.production.alphagov.co.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
+                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
                    speech.public_timestamp.to_s,
                    'Speech',
                    '1',

--- a/test/unit/whitehall/broken_link_reporter_test.rb
+++ b/test/unit/whitehall/broken_link_reporter_test.rb
@@ -13,7 +13,7 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
       detailed_guide = create(:detailed_guide)
       checker = Whitehall::BrokenLinkReporter::EditionChecker.new(detailed_guide)
 
-      assert_equal "https://whitehall-admin.production.alphagov.co.uk/government/admin/detailed-guides/#{detailed_guide.id}",
+      assert_equal "https://whitehall-admin.publishing.service.gov.uk/government/admin/detailed-guides/#{detailed_guide.id}",
         checker.admin_url
     end
 


### PR DESCRIPTION
We've changed the domain name that we're using in production. The old one is being redirected but we should update these links anyway.

(It feels like we should be using the `GOVUK_APP_DOMAIN` environment variable here but I don't know whitehall well enough to know whether that's a good idea.)

(Also I've not run the tests for this locally because I was going to let a Jenkins do it for me.)