### PR TITLE
Add beta label to farming topical events page

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -53,6 +53,10 @@ class TopicalEvent < Classification
     end
   end
 
+  def beta?
+    slug.in?(%w[farming])
+  end
+
   def search_link
     Whitehall.url_maker.topical_event_path(slug)
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -4,6 +4,14 @@
 
 <%= content_tag_for(:div, @classification, class: "classification #{@classification.class.name.underscore}") do %>
 
+  <% if @classification.beta? %>
+    <div class="inner-block">
+      <%= render 'govuk_component/beta_label',
+            message: "This page is in <a href='/help/beta'>beta</a>. " +
+            "We'll be updating it regularly and welcome <a href='/contact/govuk'>your feedback</a>." %>
+    </div>
+  <% end %>
+
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',


### PR DESCRIPTION
DEFRA wants a beta label on [their new "farming" topical events page](https://www.gov.uk/government/topical-events/farming). There currently is no way to do this. In the interest of speed, we chose for a temporary variable on the TopicalEvent model.

If it turns out that more topical events need a beta label, we can replace this method by a proper column in the table.

Trello: https://trello.com/c/nXsxrLLc

## Before 

![screen shot 2015-09-29 at 13 18 41](https://cloud.githubusercontent.com/assets/233676/10163819/4c170b8c-66ad-11e5-9077-66ceee5c3900.png)

## After

![screen shot 2015-09-29 at 13 19 43](https://cloud.githubusercontent.com/assets/233676/10163822/4f855dfa-66ad-11e5-966d-5c3effff980d.png)

Tested locally with another page because the https://www.gov.uk/government/topical-events/farming isn't in my database yet.