### PR TITLE
Rename topics to policy areas

### DIFF
--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -41,7 +41,7 @@ private
     # the parent topic is valid. We need to use #empty? here as ActiveRecord
     # overrides it to avoid caching the topics association.
     if classification_memberships.empty? && topics.empty?
-      errors.add(:topics, "at least one required")
+      errors.add(:policy_area, "at least one required")
     end
   end
 end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title @classification.name, "Topics" %>
+<% page_title @classification.name, "Policy areas" %>
 <% page_class "topics-show" %>
 <% atom_discovery_link_tag atom_feed_url_for(@classification), "Latest activity on #{@classification.name}" %>
 

--- a/lib/whitehall/form_builder.rb
+++ b/lib/whitehall/form_builder.rb
@@ -28,16 +28,19 @@ module Whitehall
 
     def errors
        return unless object.errors.any?
-       error_list = @template.content_tag(:ul, "class" => "errors disc") do
-         object.errors.full_messages.each do |msg|
-           @template.concat @template.content_tag(:li, msg)
-         end
-       end
        @template.content_tag(:div, "class" => "alert alert-danger form-errors") do
          @template.concat @template.content_tag(:p, "To save the #{object.class.name.demodulize.underscore.humanize.downcase} please fix the following issues:")
          @template.concat error_list
        end
      end
+
+    def error_list
+      @template.content_tag(:ul, "class" => "errors disc") do
+        object.errors.full_messages.each do |msg|
+          @template.concat @template.content_tag(:li, msg)
+        end
+      end
+    end
 
     def form_actions(options = {})
       @template.content_tag(:div, "class" => "form-actions") {

--- a/test/unit/edition/topics_test.rb
+++ b/test/unit/edition/topics_test.rb
@@ -27,7 +27,7 @@ class Edition::TopicsTest < ActiveSupport::TestCase
     edition = EditionWithTopics.new(attributes_for_edition)
 
     refute edition.valid?, "Edition should not be valid"
-    assert_match /at least one required/, edition.errors[:topics].first
+    assert_match /at least one required/, edition.errors[:policy_area].first
   end
 
   test "imported editions are valid without any topics" do


### PR DESCRIPTION
~3 months ago we renamed "topics" to "policy areas" but these instances have been missed.

The PR fixes this incongruence: 
![screen shot 2015-10-01 at 11 22 59](https://cloud.githubusercontent.com/assets/5038475/10219911/db5a9316-683a-11e5-8db6-79fbe6d7e5ca.png)
