### PR TITLE
Update contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ Frontend code should follow the [css](https://github.com/alphagov/whitehall/tree
   branch
 - You *may* rebase your branch after feedback if it's to include include relevant updates to the master branch. We prefer a rebase here to a merge commit as we prefer a clean and straight history on master with discrete merge commits for features
 
+#### Before merging:
+
+1. Someone must review your code and give you a "thumbs up"
+2. Someone else must product/design review your changes and give you another "thumbs up"
+3. Merge your PR and delete the branch
+
 ## Copy ##
 
 - Titles and navigation links should only capitalise first letter, not every word.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Frontend code should follow the [css](https://github.com/alphagov/whitehall/tree
 
 ## Git workflow ##
 
-- Make a feature branch
+- Make a branch
 - Work in any way you like
 - Rebase your branch into logical commits before sending a pull request -
   follow our [Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ Frontend code should follow the [css](https://github.com/alphagov/whitehall/tree
   which will report back on whether the tests still pass on your
   branch
 - You *may* rebase your branch after feedback if it's to include include relevant updates to the master branch. We prefer a rebase here to a merge commit as we prefer a clean and straight history on master with discrete merge commits for features
-- When merging a pull request, include the Pivotal ticket in the merge commit details.
 
 ## Copy ##
 


### PR DESCRIPTION
The instructions are not up-to-date and new developers might not know that we need to product review every change we deploy (in Whitehall).
This because several teams contribute to this repository and they should not be blocked because some non-product reviewed work has been merged on master. 
As per: https://github.com/alphagov/whitehall/pull/2349