### PR TITLE
Fix ‘Tribunals Service’ copy and link

### DIFF
--- a/app/views/organisations/courts_index.html.erb
+++ b/app/views/organisations/courts_index.html.erb
@@ -5,7 +5,7 @@
   <div class="block-1">
     <div class="inner-block">
       <%= render partial: 'govuk_component/beta_label' , locals: {
-        message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals')}'>HM Courts and Tribunals service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
+        message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals-service')}'>HM Courts and Tribunals Service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
       <header class="page-header">
         <h1 class="title">Courts and Tribunals</h1>
       </header>
@@ -29,4 +29,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -6,7 +6,7 @@
 <%= organisation_wrapper(@organisation) do %>
 <% if @organisation.court_or_hmcts_tribunal? %>
   <%= render partial: 'govuk_component/beta_label' , locals: {
-    message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals')}'>HM Courts and Tribunals service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
+    message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals-service')}'>HM Courts and Tribunals Service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
 <% end %>
 
   <div class="block-1 headings-block<%= " service-priority" if @organisation.service_priority_homepage? %>">


### PR DESCRIPTION
* It’s Service not service
* The organisation link slug should include “-service”

https://trello.com/c/pZl55BfL/128-update-incorrect-text-and-link-in-beta-message-small