### PR TITLE
Whitehall: Don't remove default parsers

### DIFF
--- a/config/initializers/disable_parsers.rb
+++ b/config/initializers/disable_parsers.rb
@@ -1,4 +1,0 @@
-# Turn off XML and JSON parsing:
-# https://groups.google.com/forum/#!topic/rubyonrails-security/61bkgvnSGTQ/discussion
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::JSON)


### PR DESCRIPTION
This app is on Rails 4, which doesn't configure the XML parser by default.

The JSON parser is deemed safe, and having it configured is the Rails 4 default.
There's no obvious reason to deviate from the default for this app.