### PR TITLE
Fix press release layout on tablet when the sidebar image has a caption

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_lead-image.scss
+++ b/app/assets/stylesheets/frontend/helpers/_lead-image.scss
@@ -1,6 +1,5 @@
 .lead-image-sidebar {
-  img {
-    max-width: $full-width;
+  .image {
     @include media(tablet) {
       float: right;
       margin: $gutter-one-third 0 $gutter $gutter;
@@ -11,5 +10,8 @@
       margin: 0;
       width: auto;
     }
+  }
+  img {
+    max-width: $full-width;
   }
 }

--- a/app/views/case_studies/_document_sidebar.html.erb
+++ b/app/views/case_studies/_document_sidebar.html.erb
@@ -1,6 +1,6 @@
 <aside class="lead-image-sidebar sidebar">
   <figure class="image embedded">
-    <%= image_tag document.lead_image_path, alt: document.lead_image_alt_text %>
+    <div class="img"><%= image_tag document.lead_image_path, alt: document.lead_image_alt_text %></div>
     <% if document.lead_image_caption.present? %>
       <figcaption><%= document.lead_image_caption %></figcaption>
     <% end %>

--- a/app/views/fatality_notices/_document_sidebar.html.erb
+++ b/app/views/fatality_notices/_document_sidebar.html.erb
@@ -1,5 +1,7 @@
 <aside class="lead-image-sidebar sidebar">
-  <div class="img">
-    <%= image_tag 'fatality-notice-crest.png', alt: 'The MOD crest' %>
-  </div>
+  <figure class="image embedded">
+    <div class="img">
+      <%= image_tag 'fatality-notice-crest.png', alt: 'The MOD crest' %>
+    </div>
+  </figure>
 </aside>


### PR DESCRIPTION
As an example of broken behaviour, look at https://www.gov.uk/government/news/rugby-world-cup-to-thrust-cardiff-into-the-global-sporting-spotlight at a horizontal viewport width of between 480 and 700px. The image’s caption stays on the left while the image floats to the right.

This fixes the issue by normalising occurrences of that pattern and then floating the container, not the image.