### PR TITLE
Fix unexpected changes in HTML attachment slugs

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -79,6 +79,7 @@ class HtmlAttachment < Attachment
 
   def deep_clone
     super.tap do |clone|
+      clone.slug = slug
       clone.govspeak_content = govspeak_content.dup
     end
   end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -73,6 +73,27 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "an-html-attachment", attachment.slug
   end
 
+  test "slug is not updated when the title has been changed in a prior published edition" do
+    edition = create(:published_publication, attachments: [
+      build(:html_attachment, title: "an-html-attachment")
+    ])
+    draft = edition.create_draft(create(:writer))
+    attachment = draft.attachments.first
+
+    attachment.title = "a-new-title"
+    attachment.save
+    attachment.reload
+
+    draft.change_note = 'Edited HTML attachment title'
+    force_publish(draft)
+
+    second_draft = draft.create_draft(create(:writer))
+    second_draft_attachment = second_draft.attachments.first
+
+    assert_equal "an-html-attachment", attachment.slug
+    assert_equal "an-html-attachment", second_draft_attachment.slug
+  end
+
   test "slug is not created for non-english attachments" do
     # Additional attachment to ensure the duplicate detection behaviour isn't triggered
     create(:html_attachment, locale: "fr")

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -20,7 +20,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     refute GovspeakContent.exists?(govspeak_content.id)
   end
 
-  test '#deep_clone deep clones the HTML attachment and body' do
+  test '#deep_clone deep clones the HTML attachment, body and slug' do
     attachment = create(:html_attachment)
 
     clone = attachment.deep_clone
@@ -29,6 +29,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert clone.new_record?
     assert_equal attachment.title, clone.title
     assert_equal attachment.govspeak_content_body, clone.govspeak_content_body
+    assert_equal attachment.slug, clone.slug
   end
 
   test '#url returns absolute path' do


### PR DESCRIPTION
HTML publication slugs change unexpectedly given the following scenario:
* Create a new edition of a published document and alter the HTML attachment title
* Publish the document, at this point the HTML attachment slug is still correct
* Create another new edition, when this edition is created the attachment slug changes to one based on the edited title.

Because the slug comes from an extended class it is not included when running `dup`. Whenever a new edition with an HTML attachment is created, because the slug is `nil`, a new one is generated based on the title. If the attachment title changed then subsequent editions would have different slugs.

* Demonstrate this with two failing tests
* Explicitly copy the slug when deep cloning the attachment so a new one isn't generated and the slug doesn't unexpectedly change.

> "When using dup, any modules that the object has been extended with will not be copied."
http://ruby-doc.org/core-2.1.6/Object.html#method-i-dup

https://trello.com/c/Y2rdmCTE/132-changing-the-title-of-an-html-pub-changes-the-slug-but-doesn-t-automatically-create-a-redirect-medium