### PR TITLE
Capitalise statistics format labels

### DIFF
--- a/app/models/frontend/statistics_announcement.rb
+++ b/app/models/frontend/statistics_announcement.rb
@@ -31,7 +31,7 @@ class Frontend::StatisticsAnnouncement < InflatableModel
   end
 
   def national_statistic?
-    document_type == "National statistics"
+    document_type == "National Statistics"
   end
 
 private

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -18,7 +18,7 @@ class PublicationType
     12 => "<p>Responses to Freedom of Information requests. Ensure the title describes specifically what the request is about.</p>",
     13 =>"<p>Leaflets, posters, fact sheets and marketing collateral.</p>",
     14 => "<p>Reviews, inquiries and other reports commissioned from or conducted by independent (ie non-governmental) bodies for consideration by the government.</p>",
-    15 => "<p>Official statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.</p>",
+    15 => "<p>Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.</p>",
     17 => "<p>Drawn maps and geographical data.</p>",
     18 => "<p>Treaties and memoranda of understanding between the UK and other nations.</p>",
     19 => "<p>Guidance which relevant users are legally obliged to follow. (For non-statutory guidance publications, use the “guidance” sub-type).</p>",
@@ -96,8 +96,8 @@ class PublicationType
   Guidance               = create(id: 3, key: "guidance", singular_name: "Guidance", plural_name: "Guidance", prevalence: :primary, additional_search_format_types: ['publicationesque-guidance', 'publication-statutory_guidance'])
   StatutoryGuidance      = create(id: 19, key: "statutory_guidance", singular_name: "Statutory guidance", plural_name: "Statutory guidance", prevalence: :primary, additional_search_format_types: ['publicationesque-guidance'])
   Form                   = create(id: 4, key: "form", singular_name: "Form", plural_name: "Forms", prevalence: :primary)
-  OfficialStatistics     = create(id: 5, key: "official_statistics", singular_name: "Official statistics", plural_name: "Official statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: ['publicationesque-statistics'], detailed_format: "statistics")
-  NationalStatistics     = create(id: 15, key: "national_statistics", singular_name: "National statistics", plural_name: "National statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: ['publicationesque-statistics'], detailed_format: "statistics-national-statistics")
+  OfficialStatistics     = create(id: 5, key: "official_statistics", singular_name: "Official Statistics", plural_name: "Official Statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: ['publicationesque-statistics'], detailed_format: "statistics")
+  NationalStatistics     = create(id: 15, key: "national_statistics", singular_name: "National Statistics", plural_name: "National Statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: ['publicationesque-statistics'], detailed_format: "statistics-national-statistics")
   ResearchAndAnalysis    = create(id: 6, key: "research", singular_name: "Research and analysis", plural_name: "Research and analysis", prevalence: :primary)
   CorporateReport        = create(id: 7, key: "corporate_report", singular_name: "Corporate report", plural_name: "Corporate reports", prevalence: :primary)
   Map                    = create(id: 17, key: "map", singular_name: "Map", plural_name: "Maps", prevalence: :primary)

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -6,13 +6,13 @@
     <%= form.label  :publication_type_id, 'Statistics type', required: true %>
     <label class="block-label">
       <%= form.radio_button(:publication_type_id, PublicationType::OfficialStatistics.id) %>
-      <span class="label-title">Official statistics</span>
+      <span class="label-title">Official Statistics</span>
       <span class="text-muted">Statistics governed by the UK Statistics Authority.</span>
     </label>
     <label class="block-label">
       <%= form.radio_button(:publication_type_id, PublicationType::NationalStatistics.id) %>
       <span class="label-title">National Statistics</span>
-      <span class="text-muted">Official statistics approved by the UK Statistics Authority.<br/>
+      <span class="text-muted">Official Statistics approved by the UK Statistics Authority.<br/>
       The National Statistics logo will display on this announcement.</span>
     </label>
   </div>

--- a/app/views/admin/statistics_announcements/_warning.html.erb
+++ b/app/views/admin/statistics_announcements/_warning.html.erb
@@ -1,3 +1,3 @@
 <p class="warning remove-top-margin add-bottom-margin">
-Statistics announcements are only for official statistics governed by the UK Statistics Authority.
+Statistics announcements are only for Official Statistics governed by the UK Statistics Authority.
 </p>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -242,13 +242,13 @@
             <p><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases') %></p>
 
             <h4 class="with-gutter">Statistics</h4>
-            <p>Government produces official statistics about most areas of
+            <p>Government produces Official Statistics about most areas of
             public life. Statistics are used by people inside and outside
             government to make informed decisions and to measure the success of
             government policies and services. <a
               href="https://www.gov.uk/government/publications/how-national-and-official-statistics-are-assured">Find
               out about the legislation</a> that governs the publication of UK
-            national and official statistics.</p>
+            national and Official Statistics.</p>
             <p><%= link_to "See statistics publications on GOV.UK", publications_filter_path(:publication_filter_option => 'statistics') %></p>
 
           </div>

--- a/app/views/statistics/_impartiality.html.erb
+++ b/app/views/statistics/_impartiality.html.erb
@@ -1,1 +1,1 @@
-<p class="stats-impartiality">Official statistics are produced impartially and free from political influence.</p>
+<p class="stats-impartiality">Official Statistics are produced impartially and free from political influence.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,8 +175,8 @@ en:
         one: World priority
         other: World priorities
       national_statistics:
-        one: National statistics
-        other: National statistics
+        one: National Statistics
+        other: National Statistics
       news_article:
         one: News article
         other: News articles
@@ -223,8 +223,8 @@ en:
         one: Statistical data set
         other: Statistical data sets
       official_statistics:
-        one: Official statistics
-        other: Official statistics
+        one: Official Statistics
+        other: Official Statistics
       transcript:
         one: Transcript
         other: Transcripts
@@ -378,7 +378,7 @@ en:
     heading: Announcements
     view_all: View all announcements
   national_statistics:
-    heading: National statistics
+    heading: National Statistics
   policies:
     heading: Policies
     view_all: View all policies
@@ -467,7 +467,7 @@ en:
     notice: See all our notices
     decision: See all our decisions
     worldwide_priority: See all our world priorities
-    national_statistics: See all our national statistics
+    national_statistics: See all our National Statistics
     news_article: See all our news articles
     news_story: See all our news stories
     open_consultation: See all our open consultations

--- a/features/filtering-documents.feature
+++ b/features/filtering-documents.feature
@@ -53,16 +53,16 @@ Feature: Filtering Documents
     Then I should see only announcements which have French translations
     And I should be able to filter them by country (or 'Pays' in French)
 
-  Scenario: User filters by "Statistics" which returns official statistics and national statistics
-    Given a published publication "Road accidents" with type "Official statistics"
-    And a published publication "National road accidents" with type "National statistics"
+  Scenario: User filters by "Statistics" which returns Official Statistics and National statistics
+    Given a published publication "Road accidents" with type "Official Statistics"
+    And a published publication "National road accidents" with type "National Statistics"
     When I filter the publications list by "Statistics"
     Then I should see "Road accidents" in the result list
     And I should see "National road accidents" in the result list
 
   @javascript
-  Scenario: User filters by "Statistics" which returns statistics and national statistics
-    Given a published publication "Road accidents" with type "Official statistics"
+  Scenario: User filters by "Statistics" which returns Official Statistics and National statistics
+    Given a published publication "Road accidents" with type "Official Statistics"
     When I visit the publications index page
     When I select the Statistics publication type option without clicking any button
     Then I should be notified that statistics have moved

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -517,7 +517,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
         assert_select '.publication-date time[datetime=?]', 1.days.ago.to_date.to_datetime.iso8601
-        assert_select '.document-type', "National statistics"
+        assert_select '.document-type', "National Statistics"
       end
       assert_select_object publication_2
       refute_select_object publication_3

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -91,7 +91,7 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_select '.meta a', text: appointment.person.name
   end
 
-  view_test "#show not link ministers to national statistics publications" do
+  view_test "#show not link ministers to National Statistics publications" do
     appointment = create(:ministerial_role_appointment)
     publication = create(:published_publication, publication_type_id: PublicationType::NationalStatistics.id, role_appointments: [appointment])
     get :show, id: publication.document

--- a/test/functional/statistics_announcements_controller_test.rb
+++ b/test/functional/statistics_announcements_controller_test.rb
@@ -55,7 +55,7 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
       list_item = rendered.css('.document-list li').first
 
       assert_string_includes "Average beard lengths 2015", list_item.text
-      assert_string_includes "National statistics", list_item.text
+      assert_string_includes "National Statistics", list_item.text
       assert_string_includes "1 January 2050 9:30am", list_item.text
       assert_has_link organisation.name, organisation_path(organisation), list_item
       assert_has_link topic.name, topic_path(topic), list_item

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -133,7 +133,7 @@ class StatisticsControllerTest < ActionController::TestCase
     assert_equal statistic_path(statistics_publication.document), json["url"]
     assert_equal "org-name and other-org", json["organisations"]
     assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
-    assert_equal "Official statistics", json["display_type"]
+    assert_equal "Official Statistics", json["display_type"]
   end
 
   view_test '#index should show relevant document collection information' do
@@ -189,17 +189,17 @@ class StatisticsControllerTest < ActionController::TestCase
     end
   end
 
-  view_test "#show displays a badge when the publication is national statistics" do
+  view_test "#show displays a badge when the publication is National Statistics" do
     publication = create(:published_publication, publication_type_id: PublicationType::NationalStatistics.id)
     get :show, id: publication.document
 
-    assert_match /National statistics/, response.body
+    assert_match /National Statistics/, response.body
   end
 
-  view_test "#show does not show a badge when publication is not national statistics" do
+  view_test "#show does not show a badge when publication is not National Statistics" do
     publication = create(:published_publication, publication_type_id: PublicationType::OfficialStatistics.id)
     get :show, id: publication.document
 
-    refute_match /National statistics/, response.body
+    refute_match /National Statistics/, response.body
   end
 end

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -254,7 +254,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
         assert_select '.publication-date time[datetime=?]', 1.days.ago.to_date.to_datetime.iso8601
-        assert_select '.document-type', "National statistics"
+        assert_select '.document-type', "National Statistics"
       end
       assert_select_object publication_2
       refute_select_object publication_3

--- a/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
+++ b/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
@@ -41,7 +41,7 @@ class DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncementsTest < Acti
     assert_equal "The title", returned_announcement_hash["title"]
     assert_equal "The summary", returned_announcement_hash["description"]
     assert_equal "the-title", returned_announcement_hash["slug"]
-    assert_equal "Official statistics", returned_announcement_hash["display_type"]
+    assert_equal "Official Statistics", returned_announcement_hash["display_type"]
     assert_equal ["statistics_announcement"], returned_announcement_hash["search_format_types"]
     assert_equal "statistics_announcement", returned_announcement_hash["format"]
     assert_equal announcement.organisations_slugs, returned_announcement_hash["organisations"]

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -19,14 +19,14 @@ class DocumentHelperTest < ActionView::TestCase
     assert_equal 'unknown_organisation', edition_organisation_class(edition)
   end
 
-  test "should generate a national statistics logo for a national statistic" do
+  test "should generate a National Statistics logo for a national statistic" do
     publication = create(:publication, publication_type_id: PublicationType::NationalStatistics.id)
-    assert_match /National statistics/, national_statistics_logo(publication)
+    assert_match /National Statistics/, national_statistics_logo(publication)
   end
 
-  test "should generate no national statistics logo for an edition that is not a national statistic" do
+  test "should generate no National Statistics logo for an edition that is not a national statistic" do
     publication = create(:publication)
-    refute_match /National statistics/, national_statistics_logo(publication)
+    refute_match /National Statistics/, national_statistics_logo(publication)
   end
 
   test "should generate list of links to inapplicable nations with alternative URL" do

--- a/test/unit/models/frontend/statistics_announcement_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_test.rb
@@ -36,8 +36,8 @@ class Frontend::StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal 'a-slug', build_announcement(slug: 'a-slug').to_param
   end
 
-  test "#national_statistic? is true if the document_type is 'National statistics'" do
-    assert build_announcement(document_type: "National statistics").national_statistic?
+  test "#national_statistic? is true if the document_type is 'National Statistics'" do
+    assert build_announcement(document_type: "National Statistics").national_statistic?
     refute build_announcement(document_type: "Statistics").national_statistic?
   end
 end

--- a/test/unit/publication_type_test.rb
+++ b/test/unit/publication_type_test.rb
@@ -26,7 +26,7 @@ class PublicationTypeTest < ActiveSupport::TestCase
                  PublicationType.ordered_by_prevalence
   end
 
-  test "should limit access by default for statistics or national statistics, but not other types" do
+  test "should limit access by default for Official or National Statistics, but not other types" do
     PublicationType.all.each do |type|
       case type
       when PublicationType::NationalStatistics, PublicationType::OfficialStatistics

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -280,7 +280,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     )
   end
 
-  test "#subscription_urls for a statistics publication returns atom feed urls for both publications and statistics" do
+  test "#subscription_urls for an Official Statistics publication returns atom feed urls for both publications and statistics" do
     @edition = create(:publication, publication_type: PublicationType::OfficialStatistics)
 
     assert_subscription_urls_for_edition_include(
@@ -291,7 +291,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     )
   end
 
-  test "#subscription_urls for a national statistics publication returns atom feed urls for both publications and statistics" do
+  test "#subscription_urls for a National Statistics publication returns atom feed urls for both publications and statistics" do
     @edition = create(:publication, publication_type: PublicationType::NationalStatistics)
 
     assert_subscription_urls_for_edition_include(


### PR DESCRIPTION
Changes to bring label in line with the [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#statistics), following feedback from the Content team.
