### PR TITLE
Update rake task to re-register documents in Panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -91,6 +91,7 @@ namespace :panopticon do
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
 
     documents = Document.all.published
+    unregistered_documents = []
 
     documents.find_each do |document|
 
@@ -103,7 +104,16 @@ namespace :panopticon do
           registerer.register(artefact)
         rescue GdsApi::HTTPErrorResponse => e
           logger.error "Failed to register /#{edition.slug} with #{e.code}: #{e.error_details}"
+          unregistered_documents << edition.slug
+        rescue
+          logger.error "Failed to register /#{edition.slug}"
+          unregistered_documents << edition.slug
         end
+
+        puts
+        puts "*******************************"
+        puts "Slugs of unregistered documents:"
+        puts unregistered_documents
       end
     end
   end


### PR DESCRIPTION
The rake task requires about 4/5 hours to run and it should not crash half way
through just because the slug of an artifact is invalid.

This PR adds:

- a generic rescue option for unknown errors
- a memory array for keeping track of unregistered documents
- a puts at the end of the rake task to print the list of unregistered
  documents

Ticket: https://trello.com/c/6ENzZmpT/381-re-register-whitehall-editions-in-panopticon