### PR TITLE
Update rake task to re-register documents in Panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -92,6 +92,8 @@ namespace :panopticon do
 
     documents = Document.all.published
 
+    unregistered_documents = []
+
     documents.find_each do |document|
 
       if edition = document.published_edition
@@ -103,7 +105,16 @@ namespace :panopticon do
           registerer.register(artefact)
         rescue GdsApi::HTTPErrorResponse => e
           logger.error "Failed to register /#{edition.slug} with #{e.code}: #{e.error_details}"
+          unregistered_documents << "#{edition.slug}, error code: #{e.code}, error details: #{e.error_details}"
+        rescue StandardError => e
+          logger.error "Failed to register /#{edition.slug}, error: #{e}"
+          unregistered_documents << "#{edition.slug}, error: #{e}"
         end
+
+        puts
+        puts "*******************************"
+        puts "Slugs of unregistered documents along with the errors:"
+        puts unregistered_documents
       end
     end
   end


### PR DESCRIPTION
The rake task requires about 4/5 hours to run and it should not crash half way
through just because the slug of an artifact is invalid.

This PR adds:

- a generic rescue option for unknown errors
- a memory array for keeping track of unregistered documents
- a puts at the end of the rake task to print the list of unregistered
  documents

ticket: https://trello.com/c/6ENzZmpT/381-re-register-whitehall-editions-in-panopticon