### PR TITLE
Rake task to export a publication's html attachments

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -135,4 +135,18 @@ namespace :export do
     end
   end
 
+  desc "Exports HTML attachments for a particular publication as JSON"
+  task :html_attachments, [:slug] => :environment do |t, args|
+    edition = Document.find_by(slug: args[:slug]).published_edition
+
+    result = edition.html_attachments.map do |a|
+      {
+        title: a.title,
+        body: a.govspeak_content_body,
+        issued_date: a.created_at.strftime("%Y-%m-%d"),
+        summary: edition.summary
+      }
+    end
+    puts result.to_json
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/qJrl6Usv/153-silently-migrate-mhra-s-old-field-safety-notices-and-company-led-drug-alerts-to-their-drug-device-alerts-finder

For use with the MHRA alert importer in specialist publisher. Can
probably be used for other things too.

Example usage:

```
$ bundle exec rake export:html_attachments[safety-information-from-manufacturers-field-safety-notices] > ~/safety-information-from-manufacturers-field-safety-notices.json
```