### PR TITLE
Update rake task's output

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -110,12 +110,12 @@ namespace :panopticon do
           logger.error "Failed to register /#{edition.slug}, error: #{e}"
           unregistered_documents << "#{edition.slug}, error: #{e}"
         end
-
-        puts
-        puts "*******************************"
-        puts "Slugs of unregistered documents along with the errors:"
-        puts unregistered_documents
       end
     end
+
+    puts
+    puts "*******************************"
+    puts "Slugs of unregistered documents along with the errors:"
+    puts unregistered_documents
   end
 end


### PR DESCRIPTION
The total amount of unregistered documents should be printed only once

https://github.com/alphagov/whitehall/pull/2363/files#r43145409

@jamiecobbett  thank you for spotting it!