### PR TITLE
Stop long email addresses from wrapping

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_govspeak.scss
+++ b/app/assets/stylesheets/frontend/helpers/_govspeak.scss
@@ -344,14 +344,6 @@
         font-weight: bold;
         margin-bottom: $gutter-one-sixth;
       }
-      .adr,
-      .email-url-number,
-      .comments {
-        @include media(tablet) {
-          width: $half;
-          float: left;
-        }
-      }
       .email-url-number {
         p {
           margin: 0;

--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -302,14 +302,6 @@
           @include copy-19;
           margin: 0;
         }
-        .adr,
-        .email-url-number,
-        .comments {
-          @include media(tablet) {
-            width: $half;
-            float: left;
-          }
-        }
         .email-url-number {
           p {
             margin: 0;


### PR DESCRIPTION
Rather than splitting address and email into two columns, show them as a single column. This makes wrapping much less likely and emails addresses can be more easily copy and pasted.

https://trello.com/c/vzPTVOl4/157-fix-display-of-long-email-addresses-in-whitehall-small
https://govuk.zendesk.com/agent/tickets/1133547

## Before
<img width="691" alt="screen shot 2015-10-29 at 17 56 37" src="https://cloud.githubusercontent.com/assets/319055/10827382/820259a6-7e66-11e5-9a77-2fe36e50588c.png">

## After
<img width="672" alt="screen shot 2015-10-29 at 17 52 43" src="https://cloud.githubusercontent.com/assets/319055/10827380/80401bbc-7e66-11e5-8ca7-2c8c28eac12d.png">