### PR TITLE
Fix document_filter.js typo

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -292,7 +292,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
     this.each(function(){
       if (window.GOVUK.support.history()) {
         var $form = $(this);
-        $(window).on('popstate', function(evet) {
+        $(window).on('popstate', function(event) {
           documentFilter.onPopState(event);
         });
         documentFilter.$form = $form;


### PR DESCRIPTION
It was causing an issue, in Firefox at least, when navigating back after filtering documents.