### PR TITLE
Data migration to fix dates on HMRC Notice

### DIFF
--- a/db/data_migration/20151104171038_fix_dates_and_change_note_on_hmrc_notice.rb
+++ b/db/data_migration/20151104171038_fix_dates_and_change_note_on_hmrc_notice.rb
@@ -1,0 +1,26 @@
+document = Document.find_by(slug: 'excise-notice-476-tobacco-products-duty')
+
+wrong_edition = document.editions[3]
+wrong_edition.update_columns(
+  published_major_version: 1,
+  published_minor_version: 3,
+  change_note: "",
+  minor_change: true,
+)
+
+published_edition = document.published_edition
+published_edition.update_columns(
+  first_published_at: "2012-08-01 09:00:00",
+  major_change_published_at: "2014-01-01 09:00:00",
+  public_timestamp: "2014-01-01 09:00:00",
+  published_major_version: 1,
+  published_minor_version: 4,
+)
+
+artefact = RegisterableEdition.new(published_edition)
+registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+puts "Registering /#{artefact.slug} with Panopticon..."
+registerer.register(artefact)
+
+puts "Registering /#{artefact.slug} with Search..."
+Whitehall::SearchIndex.add(document.published_edition)


### PR DESCRIPTION
This change

- removes an unwanted change note from the document history and fixes up timestamps
- changes the 'first publication' date on the published edition

The change note removal and timestamp shifting is for legal reasons.

Trello: https://trello.com/c/rIKcgjU0/143-change-last-updated-date-on-notice-and-html-attachment-medium
Zendesk: https://govuk.zendesk.com/agent/tickets/1128311