### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'sprockets', '~> 3.0'
 gem 'rinku', require: 'rails_rinku'
 gem 'parallel', '1.4.1'
 gem 'responders', '~> 2.0'
+gem 'sidekiq-statsd', '0.1.5'
 
 if ENV['GLOBALIZE_DEV']
   gem 'globalize', path: '../globalize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,10 @@ GEM
       redis-namespace (>= 1.3.1)
     sidekiq-logging-json (0.0.14)
       sidekiq (~> 3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.9.1)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -498,6 +502,7 @@ DEPENDENCIES
   shared_mustache (~> 0.2.1)
   sidekiq (~> 3.3.0)
   sidekiq-logging-json (= 0.0.14)
+  sidekiq-statsd (= 0.1.5)
   simplecov
   simplecov-rcov
   slimmer (= 9.0.0)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,9 +5,14 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
   config.error_handlers << lambda do |exception, context|
      Airbrake.notify(exception, parameters: context)
-   end
+  end
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.whitehall', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq