### PR TITLE
Return `content_id` in /api/organisations response

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -2,6 +2,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
   def as_json(options = {})
     {
       id: context.api_organisation_url(model),
+      content_id: model.content_id,
       title: model.name,
       format: model.organisation_type.name,
       updated_at: model.updated_at,

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -38,6 +38,11 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     assert_equal 'organisation-name', @presenter.as_json[:title]
   end
 
+  test "json includes content_id" do
+    @organisation.stubs(:content_id).returns('MY-CONTENT-ID')
+    assert_equal 'MY-CONTENT-ID', @presenter.as_json[:content_id]
+  end
+
   test "json includes organisation updated_at as updated_at" do
     now = Time.current
     @organisation.stubs(:updated_at).returns(now)


### PR DESCRIPTION
This endpoint is called by panopticon to update it's database for the organisation tags. It currently doesn't contain `content_ids`. We need those to migrate to the new tagging architecture.

https://trello.com/c/1JkpLaTD/421-add-content-id-to-organisation-tags-in-panopticon