### PR TITLE
Content ids for unpublishings and coming soon

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 class Unpublishing < ActiveRecord::Base
   belongs_to :edition
 
@@ -9,6 +11,7 @@ class Unpublishing < ActiveRecord::Base
   validate :redirect_not_circular
 
   after_update :publish_to_publishing_api
+  after_initialize :ensure_presence_of_content_id
 
   def self.from_slug(slug, type)
     where(slug: slug, document_type: type.to_s).last
@@ -63,5 +66,9 @@ private
 
   def publish_to_publishing_api
     Whitehall::PublishingApi.publish_async(self, 'minor')
+  end
+
+  def ensure_presence_of_content_id
+    self.content_id ||= SecureRandom.uuid
   end
 end

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -13,15 +13,15 @@
 # Note this format becomes redundant once the caching infrasture is able to
 # honour caching headers on upstream 404 responses.
 class PublishingApiPresenters::ComingSoon
-  attr_reader :edition, :locale
-
-  def initialize(edition, locale)
+  def initialize(edition, locale, content_id)
     @edition = edition
     @locale = locale
+    @content_id = content_id
   end
 
   def as_json
     {
+      content_id: content_id,
       publishing_app: 'whitehall',
       rendering_app: edition.rendering_app,
       format: 'coming_soon',
@@ -32,10 +32,15 @@ class PublishingApiPresenters::ComingSoon
       routes: [ { path: base_path, type: "exact" } ],
       # We don't store when the coming_soon was created, so use the last time the record was updated
       public_updated_at: edition.updated_at,
+      links: {
+        can_be_replaced_by: [edition.content_id]
+      }
     }
   end
 
 private
+  attr_reader :edition, :locale, :content_id
+
   def base_path
     Whitehall.url_maker.public_document_path(edition, locale: locale)
   end

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -22,18 +22,20 @@ private
 
   def redirect_hash
     {
+      content_id: unpublishing.content_id,
       format: 'redirect',
       publishing_app: 'whitehall',
       redirects: [
         { path: base_path, type: 'exact', destination: alternative_path }
       ],
       update_type: update_type,
+      links: links,
     }
   end
 
   def unpublishing_hash
     {
-      content_id: edition.content_id,
+      content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,
       format: 'unpublishing',
@@ -46,6 +48,7 @@ private
       routes: [ { path: base_path, type: 'exact' } ],
       redirects: [],
       details: details,
+      links: links,
     }
   end
 
@@ -67,6 +70,12 @@ private
       explanation: unpublishing_explanation,
       unpublished_at: unpublishing.created_at,
       alternative_url: unpublishing.alternative_url
+    }
+  end
+
+  def links
+    {
+      can_be_replaced_by: [edition.content_id]
     }
   end
 

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -23,6 +23,7 @@ private
   def redirect_hash
     {
       content_id: unpublishing.content_id,
+      base_path: base_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       redirects: [

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,9 +1,11 @@
+require "securerandom"
+
 class PublishingApiComingSoonWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
   def perform(edition_id, locale)
     edition = Edition.find(edition_id)
-    coming_soon = PublishingApiPresenters::ComingSoon.new(edition, locale)
+    coming_soon = PublishingApiPresenters::ComingSoon.new(edition, locale, SecureRandom.uuid)
 
     base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
     Whitehall.publishing_api_client.put_content_item(base_path, coming_soon.as_json)

--- a/db/migrate/20151111101103_add_content_id_to_unpublishing.rb
+++ b/db/migrate/20151111101103_add_content_id_to_unpublishing.rb
@@ -1,0 +1,15 @@
+require "securerandom"
+
+class AddContentIdToUnpublishing < ActiveRecord::Migration
+  def up
+    add_column :unpublishings, :content_id, :string
+    Unpublishing.find_each do |unpublishing|
+      unpublishing.update_columns(content_id: SecureRandom.uuid)
+    end
+    change_column_null :unpublishings, :content_id, false
+  end
+
+  def down
+    remove_column :unpublishings, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150821143729) do
+ActiveRecord::Schema.define(version: 20151111101103) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1106,6 +1106,7 @@ ActiveRecord::Schema.define(version: 20150821143729) do
     t.string   "document_type",          limit: 255
     t.string   "slug",                   limit: 255
     t.boolean  "redirect",               limit: 1,     default: false
+    t.string   "content_id",             limit: 255,                   null: false
   end
 
   add_index "unpublishings", ["edition_id"], name: "index_unpublishings_on_edition_id", using: :btree

--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -10,6 +10,7 @@ module Whitehall
 
       def as_json
         {
+          base_path: base_path,
           format: "redirect",
           publishing_app: "whitehall",
           update_type: "major",

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -1,31 +1,49 @@
 require 'test_helper'
+require 'securerandom'
 
 class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
+  setup do
+    @locale = 'en'
+    @publish_timestamp = 1.day.from_now
+    @content_id = SecureRandom.uuid
+    @edition = create(:scheduled_case_study,
+                       title: 'Case study title',
+                       summary: 'The summary',
+                       body: 'Some content',
+                       scheduled_publication: @publish_timestamp,
+                     )
+  end
 
   test 'presents a valid "coming_soon" content item' do
-    locale            = 'en'
-    publish_timestamp = 1.day.from_now
-    edition           = create(:scheduled_case_study,
-                                title: 'Case study title',
-                                summary: 'The summary',
-                                body: 'Some content',
-                                scheduled_publication: publish_timestamp)
-
     expected_hash = {
+      content_id: @content_id,
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',
       format: 'coming_soon',
       title: 'Coming soon',
-      locale: locale,
+      locale: @locale,
       update_type: 'major',
-      details: { publish_time: publish_timestamp },
+      details: { publish_time: @publish_timestamp },
       routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ],
-      public_updated_at: edition.updated_at,
+      public_updated_at: @edition.updated_at,
+      links: {
+        can_be_replaced_by: [@edition.document.content_id]
+      }
     }
 
-    presenter = PublishingApiPresenters::ComingSoon.new(edition, locale)
+    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale, @content_id)
 
     assert_equal expected_hash, presenter.as_json
     assert_valid_against_schema(presenter.as_json, 'coming_soon')
+  end
+
+  test "includes content IDs" do
+    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale, @content_id)
+
+    coming_soon_content_id = presenter.as_json.fetch(:content_id)
+    assert_equal @content_id, coming_soon_content_id
+
+    can_be_replaced_by_id = presenter.as_json.fetch(:links).fetch(:can_be_replaced_by)
+    assert_equal [@edition.document.content_id], can_be_replaced_by_id
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -162,6 +162,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
       content_id: unpublishing.content_id,
+      base_path: public_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',
@@ -186,6 +187,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
       content_id: unpublishing.content_id,
+      base_path: public_path,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -1,13 +1,12 @@
 require 'test_helper'
 
 class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
-
   test '#as_json returns a valid representation of an Unpublishing' do
     unpublishing = create(:unpublishing)
     edition      = unpublishing.edition
     public_path  = unpublishing.document_path
     expected_hash = {
-      content_id: edition.content_id,
+      content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,
       format: 'unpublishing',
@@ -25,6 +24,9 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         explanation: nil,
         unpublished_at: unpublishing.created_at,
         alternative_url: nil
+      },
+      links: {
+        can_be_replaced_by: [edition.content_id]
       }
     }
 
@@ -100,7 +102,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     edition      = unpublishing.edition
     public_path  = unpublishing.document_path
     expected_hash = {
-      content_id: edition.content_id,
+      content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,
       format: 'unpublishing',
@@ -118,6 +120,9 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         explanation: nil,
         unpublished_at: unpublishing.created_at,
         alternative_url: nil
+      },
+      links: {
+        can_be_replaced_by: [edition.content_id]
       }
     }
 
@@ -156,12 +161,16 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     public_path      = unpublishing.document_path
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
+      content_id: unpublishing.content_id,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',
       redirects: [
         { path: public_path, type: 'exact', destination: alternative_path }
-      ]
+      ],
+      links: {
+        can_be_replaced_by: [unpublishing.edition.content_id]
+      }
     }
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -176,12 +185,16 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     public_path      = unpublishing.document_path
     alternative_path = URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
+      content_id: unpublishing.content_id,
       format: 'redirect',
       publishing_app: 'whitehall',
       update_type: 'major',
       redirects: [
         { path: public_path, type: 'exact', destination: alternative_path }
-      ]
+      ],
+      links: {
+        can_be_replaced_by: [unpublishing.edition.content_id]
+      }
     }
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -199,5 +212,19 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     presented_hash = presenter.as_json
 
     assert_equal alternative_path, presented_hash[:redirects][0][:destination]
+  end
+
+  test "redirect representations containt content IDs" do
+    unpublishing = create(:redirect_unpublishing)
+
+    presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
+    presented_hash = presenter.as_json
+
+    assert_equal unpublishing.content_id, presented_hash[:content_id]
+
+    links_hash = {
+      can_be_replaced_by: [unpublishing.edition.content_id]
+    }
+    assert_equal links_hash, presented_hash[:links]
   end
 end

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -143,6 +143,16 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing.update_attribute(:explanation, new_explanation)
   end
 
+  test "generates its own content ID on creation" do
+    assert_not_nil Unpublishing.new.content_id
+  end
+
+  test "does not overwrite a provided content ID" do
+    content_id = SecureRandom.uuid
+    unpublishing = Unpublishing.new(content_id: content_id)
+    assert_equal content_id, unpublishing.content_id
+  end
+
   def reason
     UnpublishingReason::PublishedInError
   end

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
+  setup do
+    @uuid = "a-uuid"
+    SecureRandom.stubs(uuid: @uuid)
+  end
+
   test 'publishes a "coming_soon" format to the Publishing API' do
     base_path    = '/government/case-studies/case-study-title.fr'
     publish_time = 2.days.from_now
@@ -12,6 +17,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
                            scheduled_publication: publish_time)
 
     expected_payload = {
+      content_id: @uuid,
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',
       format: 'coming_soon',
@@ -21,6 +27,9 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       details: { publish_time: publish_time },
       routes: [ { path: base_path, type: 'exact' } ],
       public_updated_at: edition.updated_at,
+      links: {
+        can_be_replaced_by: [edition.content_id]
+      }
     }
 
     expected_request = stub_publishing_api_put_item(base_path, expected_payload)


### PR DESCRIPTION
- Send content IDs for Coming Soon pseudo-format.
- Add content IDs to unpublishings.
- Add base path to redirects.

Part of https://trello.com/c/pULByuHs/393-fix-invalid-content-store-data