### PR TITLE
Update alternative URL for MoD Unpublishing

### DIFF
--- a/db/data_migration/20151117114538_change_mod_unpublishing_url.rb
+++ b/db/data_migration/20151117114538_change_mod_unpublishing_url.rb
@@ -1,0 +1,2 @@
+Unpublishing.find_by(edition_id: 536210).
+  update_attribute(:alternative_url, "https://www.gov.uk/government/publications/veterans-uk-compensation-forms")


### PR DESCRIPTION
As per https://govuk.zendesk.com/agent/tickets/1177951 and
https://trello.com/c/rclet4lw/168-november-redirect-requests