### PR TITLE
Bump and pin babosa gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'transitions', require: ['transitions', 'active_record/transitions']
 gem 'carrierwave', '0.9.0'
 gem 'validates_email_format_of'
 gem 'friendly_id', '5.0.4'
-gem 'babosa'
+gem 'babosa', '1.0.2'
 gem 'nokogiri'
 gem 'slimmer', '9.0.0'
 gem 'plek', '1.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     autoprefixer-rails (6.0.3)
       execjs
       json
-    babosa (0.3.11)
+    babosa (1.0.2)
     better_errors (2.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -440,7 +440,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (= 4.1.0)
-  babosa
+  babosa (= 1.0.2)
   better_errors
   binding_of_caller
   bootstrap-kaminari-views (= 0.0.5)


### PR DESCRIPTION
This was causing "warning: duplicated key" warnings, which have been
resolved in the latest version.

I think this started appearing after the [ruby bump to 2.2.x](https://github.com/alphagov/whitehall/pull/2377) /cc @benlovell 