### PR TITLE
Remove duplicate hash key in test

### DIFF
--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -155,7 +155,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   test "index should redirect to remembered filtered options if available" do
     organisation = create(:organisation)
-    get :index, state: :draft, organisation: organisation, state: :submitted
+    get :index, organisation: organisation, state: :submitted
 
     get :index
     assert_redirected_to admin_editions_path(state: :submitted, organisation: organisation)


### PR DESCRIPTION
This generated a warning after upgrading to ruby 2.2.x