### PR TITLE
Improvements to Publishing API code

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -208,7 +208,6 @@ private
     redirects = [
       { path: public_path, destination: URI.parse(redirect_url).path, type: "exact" }
     ]
-    redirect_item = Whitehall::PublishingApi::Redirect.new(public_path, redirects)
-    Whitehall::PublishingApi.publish_redirect(redirect_item)
+    Whitehall::PublishingApi.publish_redirect_async(public_path, redirects)
   end
 end

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 # A temporary content format used as a splash page for scheduled documents.
 #
 # When a piece of content is scheduled for publication, a "coming_soon" content
@@ -13,15 +15,14 @@
 # Note this format becomes redundant once the caching infrasture is able to
 # honour caching headers on upstream 404 responses.
 class PublishingApiPresenters::ComingSoon
-  def initialize(edition, locale, content_id)
+  def initialize(edition, locale)
     @edition = edition
     @locale = locale
-    @content_id = content_id
   end
 
   def as_json
     {
-      content_id: content_id,
+      content_id: SecureRandom.uuid,
       publishing_app: 'whitehall',
       rendering_app: edition.rendering_app,
       format: 'coming_soon',
@@ -39,7 +40,7 @@ class PublishingApiPresenters::ComingSoon
   end
 
 private
-  attr_reader :edition, :locale, :content_id
+  attr_reader :edition, :locale
 
   def base_path
     Whitehall.url_maker.public_document_path(edition, locale: locale)

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -12,7 +12,7 @@ require "securerandom"
 # preventing a 404 page from being cached for up to 30 minutes from the point
 # the document was published.
 #
-# Note this format becomes redundant once the caching infrasture is able to
+# Note this format becomes redundant once the caching infrastructure is able to
 # honour caching headers on upstream 404 responses.
 class PublishingApiPresenters::ComingSoon
   def initialize(edition, locale)

--- a/app/presenters/publishing_api_presenters/gone.rb
+++ b/app/presenters/publishing_api_presenters/gone.rb
@@ -1,0 +1,21 @@
+require "securerandom"
+
+class PublishingApiPresenters::Gone
+  def initialize(base_path, edition_content_id)
+    @base_path = base_path
+    @edition_content_id = edition_content_id
+  end
+
+  def as_json
+    {
+      content_id: SecureRandom.uuid,
+      format: 'gone',
+      publishing_app: 'whitehall',
+      update_type: 'major',
+      routes: [{ path: @base_path, type: 'exact' }],
+      links: {
+        can_be_replaced_by: [@edition_content_id],
+      },
+    }
+  end
+end

--- a/app/presenters/publishing_api_presenters/publish_intent.rb
+++ b/app/presenters/publishing_api_presenters/publish_intent.rb
@@ -1,0 +1,15 @@
+class PublishingApiPresenters::PublishIntent
+  def initialize(base_path, publish_timestamp)
+    @base_path = base_path
+    @publish_timestamp = publish_timestamp
+  end
+
+  def as_json
+    {
+      publish_time: @publish_timestamp,
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      routes: [{ path: @base_path, type: 'exact' }],
+    }
+  end
+end

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,13 +1,9 @@
-require "securerandom"
-
-class PublishingApiComingSoonWorker < WorkerBase
-  sidekiq_options queue: "publishing_api"
-
+class PublishingApiComingSoonWorker < PublishingApiWorker
   def perform(edition_id, locale)
     edition = Edition.find(edition_id)
-    coming_soon = PublishingApiPresenters::ComingSoon.new(edition, locale, SecureRandom.uuid)
-
+    coming_soon = PublishingApiPresenters::ComingSoon.new(edition, locale)
     base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
-    Whitehall.publishing_api_client.put_content_item(base_path, coming_soon.as_json)
+
+    send_item(base_path, coming_soon.as_json)
   end
 end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,24 +1,8 @@
 require "securerandom"
 
-class PublishingApiGoneWorker < WorkerBase
-  sidekiq_options queue: "publishing_api"
-
+class PublishingApiGoneWorker < PublishingApiWorker
   def perform(base_path, edition_content_id)
-    Whitehall.publishing_api_client.put_content_item(base_path, gone_item_for(base_path, edition_content_id))
-  end
-
-private
-
-  def gone_item_for(base_path, edition_content_id)
-    {
-      content_id: SecureRandom.uuid,
-      format: 'gone',
-      publishing_app: 'whitehall',
-      update_type: 'major',
-      routes: [{path: base_path, type: 'exact'}],
-      links: {
-        can_be_replaced_by: [edition_content_id],
-      },
-    }
+    gone_item = PublishingApiPresenters::Gone.new(base_path, edition_content_id)
+    send_item(base_path, gone_item.as_json)
   end
 end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,3 @@
-require "securerandom"
-
 class PublishingApiGoneWorker < PublishingApiWorker
   def perform(base_path, edition_content_id)
     gone_item = PublishingApiPresenters::Gone.new(base_path, edition_content_id)

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,0 +1,6 @@
+class PublishingApiRedirectWorker < PublishingApiWorker
+  def perform(base_path, redirects, edition_content_id)
+    redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects, edition_content_id)
+    send_item(base_path, redirect.as_json)
+  end
+end

--- a/app/workers/publishing_api_schedule_worker.rb
+++ b/app/workers/publishing_api_schedule_worker.rb
@@ -2,17 +2,8 @@ class PublishingApiScheduleWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
   def perform(base_path, publish_timestamp)
-    publish_intent = build_publish_intent(base_path, publish_timestamp)
+    publish_intent = PublishingApiPresenters::PublishIntent.new(base_path, publish_timestamp)
 
-    Whitehall.publishing_api_client.put_intent(base_path, publish_intent)
-  end
-
-  def build_publish_intent(base_path, publish_timestamp)
-    {
-      publish_time: publish_timestamp,
-      publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
-      routes: [ { path: base_path, type: 'exact'} ]
-    }
+    Whitehall.publishing_api_client.put_intent(base_path, publish_intent.as_json)
   end
 end

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -78,8 +78,7 @@ module DataHygiene
     end
 
     def register_redirect
-      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
-      Whitehall::PublishingApi.publish_redirect(redirect_item)
+      Whitehall::PublishingApi.publish_redirect_async(old_base_path, redirects)
     end
   end
 end

--- a/lib/data_hygiene/person_reslugger.rb
+++ b/lib/data_hygiene/person_reslugger.rb
@@ -52,8 +52,7 @@ module DataHygiene
     end
 
     def register_redirect
-      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
-      Whitehall::PublishingApi.publish_redirect(redirect_item)
+      Whitehall::PublishingApi.publish_redirect_async(old_base_path, redirects)
     end
 
     def republish_dependencies

--- a/lib/data_hygiene/role_reslugger.rb
+++ b/lib/data_hygiene/role_reslugger.rb
@@ -51,8 +51,7 @@ module DataHygiene
     end
 
     def register_redirect
-      redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects)
-      Whitehall::PublishingApi.publish_redirect(redirect_item)
+      Whitehall::PublishingApi.publish_redirect_async(old_base_path, redirects)
     end
   end
 end

--- a/lib/tasks/detailed_guides.rake
+++ b/lib/tasks/detailed_guides.rake
@@ -92,8 +92,7 @@ namespace :detailed_guides do
       redirect_items = redirects.map do |from, to|
         {path: from, destination: to, type: "exact"}
       end
-      redirect_payload = Whitehall::PublishingApi::Redirect.new("/#{slug}", redirect_items)
-      Whitehall::PublishingApi.publish_redirect(redirect_payload)
+      Whitehall::PublishingApi.publish_redirect_async("/#{slug}", redirect_items)
     rescue GdsApi::HTTPClientError => e
       puts "Couldn't publish redirect for #{slug}: #{e.message}"
     end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -47,8 +47,8 @@ module Whitehall
       end
     end
 
-    def self.publish_redirect(redirect)
-      Whitehall.publishing_api_client.put_content_item(redirect.base_path, redirect.as_json)
+    def self.publish_redirect_async(base_path, redirects, edition_content_id = nil)
+      PublishingApiRedirectWorker.perform_async(base_path, redirects, edition_content_id)
     end
 
   private

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -6,6 +6,7 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
     @locale = 'en'
     @publish_timestamp = 1.day.from_now
     @content_id = SecureRandom.uuid
+    SecureRandom.stubs(uuid: @content_id)
     @edition = create(:scheduled_case_study,
                        title: 'Case study title',
                        summary: 'The summary',
@@ -31,14 +32,14 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
       }
     }
 
-    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale, @content_id)
+    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale)
 
     assert_equal expected_hash, presenter.as_json
     assert_valid_against_schema(presenter.as_json, 'coming_soon')
   end
 
   test "includes content IDs" do
-    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale, @content_id)
+    presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale)
 
     coming_soon_content_id = presenter.as_json.fetch(:content_id)
     assert_equal @content_id, coming_soon_content_id

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -99,12 +99,12 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement.update!(publishing_state: "unpublished", redirect_url: "https://www.test.alphagov.co.uk/foo")
   end
 
-  test 'a redirect item is published to content-store after being unpublished' do
+  test 'a redirect item is published to Publishing API after being unpublished' do
     announcement = create(:statistics_announcement)
 
-    Whitehall::PublishingApi.expects(:publish_redirect).with do |instance|
-      instance.is_a?(Whitehall::PublishingApi::Redirect) &&
-        assert_valid_against_schema(instance.as_json, "redirect")
+    Whitehall.publishing_api_client.expects(:put_content_item).with do |base_path, payload|
+      base_path == announcement.public_path &&
+        assert_valid_against_schema(payload, "redirect")
     end
 
     announcement.update!(publishing_state: "unpublished", redirect_url: 'https://www.test.alphagov.co.uk/foo')

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -335,9 +335,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
         destination: "/government/poeple/milli-vanilli"
       }
     ]
-    redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects)
-    expected_request = stub_publishing_api_put_item(redirect.base_path, redirect.as_json)
-    Whitehall::PublishingApi.publish_redirect(redirect)
+    expected_request = stub_publishing_api_put_item(base_path, Whitehall::PublishingApi::Redirect.new(base_path, redirects).as_json)
+    Whitehall::PublishingApi.publish_redirect_async(base_path, redirects)
 
     assert_requested expected_request
   end


### PR DESCRIPTION
The highlights:

- publishing of redirects to Publishing API is now done asynchronously, like for the other formats
- the Publishing API workers contain less presentation logic (that has been moved to dedicated presenters, which is in line with existing patterns in the code)
- the Publishing API workers subclass `PublishingApiWorker`, so that the actual publishing happens through the same path of the code

This PR is best reviewed commit-by-commit.

/cc @benlovell 