### PR TITLE
Fix broken 'assert_select' statement

### DIFF
--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -82,7 +82,7 @@ module DocumentControllerTestHelpers
           refute_select ".title a[aria-describedby='attachment-#{attachment_1.id}-accessibility-help']"
         end
         assert_select_object(attachment_2) do
-          assert_select "title. a[aria-describedby='attachment-#{attachment_2.id}-accessibility-help']"
+          assert_select ".title a[aria-describedby='attachment-#{attachment_2.id}-accessibility-help']"
           assert_select '.accessibility-warning'
         end
       end


### PR DESCRIPTION
This error was causing a deprecation warning while running tests and
causing the assertion to be skipped.