### PR TITLE
Send gone items for non-edition deletions

### DIFF
--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -33,9 +33,6 @@ class PublishingApiPresenters::ComingSoon
       routes: [ { path: base_path, type: "exact" } ],
       # We don't store when the coming_soon was created, so use the last time the record was updated
       public_updated_at: edition.updated_at,
-      links: {
-        can_be_replaced_by: [edition.content_id]
-      }
     }
   end
 

--- a/app/presenters/publishing_api_presenters/gone.rb
+++ b/app/presenters/publishing_api_presenters/gone.rb
@@ -1,9 +1,8 @@
 require "securerandom"
 
 class PublishingApiPresenters::Gone
-  def initialize(base_path, edition_content_id)
+  def initialize(base_path)
     @base_path = base_path
-    @edition_content_id = edition_content_id
   end
 
   def as_json
@@ -13,9 +12,6 @@ class PublishingApiPresenters::Gone
       publishing_app: 'whitehall',
       update_type: 'major',
       routes: [{ path: @base_path, type: 'exact' }],
-      links: {
-        can_be_replaced_by: [@edition_content_id],
-      },
     }
   end
 end

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -30,7 +30,6 @@ private
         { path: base_path, type: 'exact', destination: alternative_path }
       ],
       update_type: update_type,
-      links: links,
     }
   end
 
@@ -49,7 +48,6 @@ private
       routes: [ { path: base_path, type: 'exact' } ],
       redirects: [],
       details: details,
-      links: links,
     }
   end
 
@@ -71,12 +69,6 @@ private
       explanation: unpublishing_explanation,
       unpublished_at: unpublishing.created_at,
       alternative_url: unpublishing.alternative_url
-    }
-  end
-
-  def links
-    {
-      can_be_replaced_by: [edition.content_id]
     }
   end
 

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(base_path, edition_content_id)
-    gone_item = PublishingApiPresenters::Gone.new(base_path, edition_content_id)
+  def perform(base_path)
+    gone_item = PublishingApiPresenters::Gone.new(base_path)
     send_item(base_path, gone_item.as_json)
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
   def perform(base_path, redirects, edition_content_id)
-    redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects, edition_content_id)
+    redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects)
     send_item(base_path, redirect.as_json)
   end
 end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -5,6 +5,7 @@ module PublishesToPublishingApi
     before_validation :generate_content_id, on: :create
     validates :content_id, presence: true
     after_commit :publish_to_publishing_api, if: :can_publish_to_publishing_api?
+    after_commit :publish_gone_to_publishing_api, on: :destroy
   end
 
 
@@ -18,5 +19,9 @@ module PublishesToPublishingApi
 
   def publish_to_publishing_api
     Whitehall::PublishingApi.publish_async(self)
+  end
+
+  def publish_gone_to_publishing_api
+    Whitehall::PublishingApi.publish_gone(search_link)
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -43,12 +43,16 @@ module Whitehall
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)
-        PublishingApiGoneWorker.perform_async(base_path, edition.content_id) unless edition.document.published?
+        self.publish_gone(base_path) unless edition.document.published?
       end
     end
 
     def self.publish_redirect_async(base_path, redirects, edition_content_id = nil)
       PublishingApiRedirectWorker.perform_async(base_path, redirects, edition_content_id)
+    end
+
+    def self.publish_gone(base_path)
+      PublishingApiGoneWorker.perform_async(base_path)
     end
 
   private

--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -5,14 +5,13 @@ module Whitehall
     class Redirect
       attr_reader :base_path
 
-      def initialize(base_path, redirects, edition_content_id = nil)
+      def initialize(base_path, redirects)
         @redirects = redirects
         @base_path = base_path
-        @edition_content_id = edition_content_id
       end
 
       def as_json
-        data = {
+        {
           content_id: SecureRandom.uuid,
           base_path: base_path,
           format: "redirect",
@@ -20,12 +19,10 @@ module Whitehall
           update_type: "major",
           redirects: redirects,
         }
-        data.merge!(links: {can_be_replaced_by: [edition_content_id]}) if edition_content_id.present?
-        data
       end
 
     private
-      attr_reader :redirects, :edition_content_id
+      attr_reader :redirects
     end
   end
 end

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -65,4 +65,12 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
     assert_requested expected_publish_request
   end
+
+  test "destroy publishes a Gone item to Publishing API" do
+    organisation = create(:organisation)
+    path = Whitehall.url_maker.polymorphic_path(organisation)
+    Whitehall::PublishingApi.expects(:publish_gone).with(path)
+    Whitehall::PublishingApi.expects(:publish_async).never
+    organisation.destroy
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -27,9 +27,6 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
       details: { publish_time: @publish_timestamp },
       routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ],
       public_updated_at: @edition.updated_at,
-      links: {
-        can_be_replaced_by: [@edition.document.content_id]
-      }
     }
 
     presenter = PublishingApiPresenters::ComingSoon.new(@edition, @locale)
@@ -43,8 +40,5 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
 
     coming_soon_content_id = presenter.as_json.fetch(:content_id)
     assert_equal @content_id, coming_soon_content_id
-
-    can_be_replaced_by_id = presenter.as_json.fetch(:links).fetch(:can_be_replaced_by)
-    assert_equal [@edition.document.content_id], can_be_replaced_by_id
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -25,9 +25,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         unpublished_at: unpublishing.created_at,
         alternative_url: nil
       },
-      links: {
-        can_be_replaced_by: [edition.content_id]
-      }
     }
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -121,9 +118,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         unpublished_at: unpublishing.created_at,
         alternative_url: nil
       },
-      links: {
-        can_be_replaced_by: [edition.content_id]
-      }
     }
 
     EditionDeleter.new(edition).perform!
@@ -169,9 +163,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       redirects: [
         { path: public_path, type: 'exact', destination: alternative_path }
       ],
-      links: {
-        can_be_replaced_by: [unpublishing.edition.content_id]
-      }
     }
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -194,9 +185,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
       redirects: [
         { path: public_path, type: 'exact', destination: alternative_path }
       ],
-      links: {
-        can_be_replaced_by: [unpublishing.edition.content_id]
-      }
     }
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -223,10 +211,5 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     presented_hash = presenter.as_json
 
     assert_equal unpublishing.content_id, presented_hash[:content_id]
-
-    links_hash = {
-      can_be_replaced_by: [unpublishing.edition.content_id]
-    }
-    assert_equal links_hash, presented_hash[:links]
   end
 end

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -27,9 +27,6 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       details: { publish_time: publish_time },
       routes: [ { path: base_path, type: 'exact' } ],
       public_updated_at: edition.updated_at,
-      links: {
-        can_be_replaced_by: [edition.content_id]
-      }
     }
 
     expected_request = stub_publishing_api_put_item(base_path, expected_payload)

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -8,7 +8,6 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
   test "publishes a 'gone' item for the supplied base path" do
     base_path = '/government/this-never-existed-honest'
-    edition_content_id = "some-edition-uuid"
 
     gone_payload = {
       content_id: @uuid,
@@ -16,14 +15,11 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
       publishing_app: 'whitehall',
       update_type: 'major',
       routes: [{path: base_path, type: 'exact'}],
-      links: {
-        can_be_replaced_by: [edition_content_id]
-      }
     }
 
     expected_request = stub_publishing_api_put_item(base_path, gone_payload)
 
-    PublishingApiGoneWorker.new.perform(base_path, edition_content_id)
+    PublishingApiGoneWorker.new.perform(base_path)
 
     assert_requested expected_request
   end


### PR DESCRIPTION
Non-edition items have no workflow and can be arbitrarily deleted; we need to
send a Gone item to publishing-item, which replaces the existing contentitem
at that base_path, when they are deleted.

In addition this removes the `can_be_replaced_by` items that were added to links; publishing-api has now changed so that it allows content items to be arbitrarily replaced by gones/redirects published by the same app, and vice versa.