### PR TITLE
Tag offsite consultations with topical events

### DIFF
--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -50,7 +50,11 @@
 
       <div class="js-external-url-set">
         <%= render 'appointment_fields', form: form, edition: edition %>
-        <%= render 'topical_event_fields', form: form, edition: edition %>
+      </div>
+
+      <%= render 'topical_event_fields', form: form, edition: edition %>
+
+      <div class="js-external-url-set">
         <%= render 'nation_fields', form: form, edition: edition %>
       </div>
 

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -32,3 +32,11 @@ Scenario: Adding public feedback to a closed consultation
   When I add public feedback to the consultation
   And I save and publish the amended consultation
   Then the public feedback should be viewable
+
+@javascript
+Scenario: Associating an offsite consultation with topical events
+  Given I am an editor
+  And a draft consultation "Beard Length Review" exists
+  When I am on the edit page for consultation "Beard Length Review"
+  And I mark the consultation as offsite
+  Then the consultation can be associated with topical events

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -82,3 +82,11 @@ When /^I draft a new consultation "([^"]*)" relating it to the worldwide_priorit
   select second_priority, from: "Worldwide priorities"
   click_button "Save"
 end
+
+When(/^I mark the consultation as offsite$/) do
+  check 'This consultation is held on another website'
+end
+
+Then(/^the consultation can be associated with topical events$/) do
+  assert has_css?('label', text: 'Topical events')
+end


### PR DESCRIPTION
Trello: https://trello.com/c/e1mvOIbo

Permits offsite consultations to be tagged with topical events. Prior to
this change, when checking the 'This consultation is held on another
website' box, the topical events field was hidden with a JS toggle. It's
now displayed whether or not the consultation is held offsite.

There is no validation logic around the value of the 'offsite' flag and
the presence of topical event tags, so this just works (tm). Persisting
consultations is well covered elsewhere.