### PR TITLE
Fix bug in updating Panopticon when unwithdrawing

### DIFF
--- a/lib/data_hygiene/edition_unwithdrawer.rb
+++ b/lib/data_hygiene/edition_unwithdrawer.rb
@@ -21,7 +21,7 @@ module DataHygiene
         draft.editorial_remarks << EditorialRemark.create(author: @user, edition: @edition, body: "Unwithdrawn")
 
         Edition::AuditTrail.acting_as(user) do
-          EditionForcePublisher.new(draft).perform!
+          Whitehall.edition_services.force_publisher(draft).perform!
         end
 
         draft.reload

--- a/test/unit/data_hygiene/edition_unwithdrawer_test.rb
+++ b/test/unit/data_hygiene/edition_unwithdrawer_test.rb
@@ -17,7 +17,7 @@ module DataHygiene
       assert_equal @edition, EditionUnwithdrawer.new(@edition.id).edition
     end
 
-    test "initialize finds the correct user for unarchiving" do
+    test "initialize finds the correct user for unwithdrawing" do
       assert_equal @user, EditionUnwithdrawer.new(@edition.id).user
     end
 
@@ -46,22 +46,22 @@ module DataHygiene
     end
 
     test "unwithdraw publishes a draft of the withdrawn edition" do
-      unwithdrawen_edition = EditionUnwithdrawer.new(@edition.id).unwithdraw!
-      assert unwithdrawen_edition.published?
-      assert unwithdrawen_edition.minor_change
-      assert_equal @edition.document, unwithdrawen_edition.document
-      assert_equal @user, unwithdrawen_edition.editorial_remarks.first.author
-      assert_equal "Unwithdrawn", unwithdrawen_edition.editorial_remarks.first.body
+      unwithdrawn_edition = EditionUnwithdrawer.new(@edition.id).unwithdraw!
+      assert unwithdrawn_edition.published?
+      assert unwithdrawn_edition.minor_change
+      assert_equal @edition.document, unwithdrawn_edition.document
+      assert_equal @user, unwithdrawn_edition.editorial_remarks.first.author
+      assert_equal "Unwithdrawn", unwithdrawn_edition.editorial_remarks.first.body
     end
 
     test "unwithdraw handles legacy withdrawn editions" do
       edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
-      unwithdrawen_edition = EditionUnwithdrawer.new(edition.id).unwithdraw!
-      assert unwithdrawen_edition.published?
-      assert unwithdrawen_edition.minor_change
-      assert_equal edition.document, unwithdrawen_edition.document
-      assert_equal @user, unwithdrawen_edition.editorial_remarks.first.author
-      assert_equal "Unwithdrawn", unwithdrawen_edition.editorial_remarks.first.body
+      unwithdrawn_edition = EditionUnwithdrawer.new(edition.id).unwithdraw!
+      assert unwithdrawn_edition.published?
+      assert unwithdrawn_edition.minor_change
+      assert_equal edition.document, unwithdrawn_edition.document
+      assert_equal @user, unwithdrawn_edition.editorial_remarks.first.author
+      assert_equal "Unwithdrawn", unwithdrawn_edition.editorial_remarks.first.body
     end
   end
 end

--- a/test/unit/data_hygiene/edition_unwithdrawer_test.rb
+++ b/test/unit/data_hygiene/edition_unwithdrawer_test.rb
@@ -1,10 +1,20 @@
 require 'test_helper'
+require 'gds_api/test_helpers/panopticon'
 
 module DataHygiene
   class EditionUnwithdrawerTest < ActiveSupport::TestCase
+    include GdsApi::TestHelpers::Panopticon
+
+    def stub_live_artefact_registration(edition)
+      # We use RegisterableEdition to ensure we get the same slug mangling
+      registerable = RegisterableEdition.new(edition)
+      request = stub_artefact_registration(registerable.slug, hash_including(state: "live"), true)
+    end
+
     setup do
       @edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
       @user = FactoryGirl.create(:user, id: 406)
+      @panopticon_request = stub_live_artefact_registration(@edition)
     end
 
     test "initialize with a non-existent edition id errors" do
@@ -56,12 +66,21 @@ module DataHygiene
 
     test "unwithdraw handles legacy withdrawn editions" do
       edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
+      stub_live_artefact_registration(edition)
+
       unwithdrawn_edition = EditionUnwithdrawer.new(edition.id).unwithdraw!
+
       assert unwithdrawn_edition.published?
       assert unwithdrawn_edition.minor_change
       assert_equal edition.document, unwithdrawn_edition.document
       assert_equal @user, unwithdrawn_edition.editorial_remarks.first.author
       assert_equal "Unwithdrawn", unwithdrawn_edition.editorial_remarks.first.body
+    end
+
+    test "unwithdraw handles re-registration with Panopticon" do
+      unwithdrawn_edition = EditionUnwithdrawer.new(@edition.id).unwithdraw!
+
+      assert_requested @panopticon_request
     end
   end
 end


### PR DESCRIPTION
The first two commits do some tidying - the bugfix is in the last commit. Best reviewed commit-by-commit.

@binaryberry noticed the bug and did the hard work here, and we paired on the final commit.