### PR TITLE
Fix Civil Service Resourcing displayed name

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -138,7 +138,7 @@ module OrganisationHelper
   end
 
   def needs_definite_article?(phrase)
-    exceptions = [/^hm/, /ordnance survey/, /civil service resourcing/]
+    exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]
     !has_definite_article?(phrase) && !(exceptions.any? { |e| e =~ phrase.downcase })
   end
 

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -138,7 +138,7 @@ module OrganisationHelper
   end
 
   def needs_definite_article?(phrase)
-    exceptions = [/^hm/, /ordnance survey/]
+    exceptions = [/^hm/, /ordnance survey/, /civil service resourcing/]
     !has_definite_article?(phrase) && !(exceptions.any? { |e| e =~ phrase.downcase })
   end
 

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -322,6 +322,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test 'definite article skipped for certain parent organisations' do
+    assert_definite_article_skipped 'Civil Service Resourcing'
     assert_definite_article_skipped 'HM Treasury'
     assert_definite_article_skipped 'Ordnance Survey'
   end


### PR DESCRIPTION
The name of the organisation Civil Service Resourcing is being incorrectly prefixed with the definite article **the** when used in a sentence eg

    "Civil Service Fast Stream is part of the Civil Service Resourcing."

This PR adds it as an exception to the rule and includes the corresponding test.