### PR TITLE
Downgrade to 2.1.7

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,1 +1,3 @@
-2.2.3
+2.1.7
+# DO NOT UPGRADE past 2.1.X until we resolve the following in Govspeak:
+# https://github.com/alphagov/whitehall/pull/2234


### PR DESCRIPTION
Unfortunately, we had missed the #2234 thing when the 2.2.3 change got
merged. Let's keep it at the latest known good version of the 2.1 series
for now.