### PR TITLE
Publishing API redirect worker: remove unnecessary param

### DIFF
--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
-  def perform(base_path, redirects, edition_content_id)
+  def perform(base_path, redirects)
     redirect = Whitehall::PublishingApi::Redirect.new(base_path, redirects)
     send_item(base_path, redirect.as_json)
   end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -47,8 +47,8 @@ module Whitehall
       end
     end
 
-    def self.publish_redirect_async(base_path, redirects, edition_content_id = nil)
-      PublishingApiRedirectWorker.perform_async(base_path, redirects, edition_content_id)
+    def self.publish_redirect_async(base_path, redirects)
+      PublishingApiRedirectWorker.perform_async(base_path, redirects)
     end
 
     def self.publish_gone(base_path)


### PR DESCRIPTION
This isn't used anywhere