### PR TITLE
Don't index empty groups on collections pages

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -33,7 +33,7 @@ class DocumentCollection < Edition
   def indexable_content
     [
       Govspeak::Document.new(body).to_text,
-      groups.map do |group|
+      groups.visible.map do |group|
         [group.heading, Govspeak::Document.new(group.body).to_text]
       end
     ].flatten.join("\n")

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -105,9 +105,14 @@ class DocumentCollectionTest < ActiveSupport::TestCase
   end
 
   test 'indexes the group headings and body copy without markup as indexable_content' do
-    group = create(:document_collection_group, heading: 'The Heading', body: 'The *Body*')
-    collection = create(:document_collection, groups: [group])
+    doc = create(:published_news_article).document
+    empty_group = create(:document_collection_group, heading: 'Empty Heading', body: 'The *Body*')
+    visible_group = create(:document_collection_group, heading: 'The Heading', body: 'The *Body*', documents: [doc])
+
+    collection = create(:document_collection, groups: [empty_group, visible_group])
+
     assert_match /^The Heading$/, collection.search_index['indexable_content']
+    refute_match /^Empty Heading$/, collection.search_index['indexable_content']
     assert_match /^The Body$/, collection.search_index['indexable_content']
   end
 


### PR DESCRIPTION
Document collections are pages on GOV.UK like this:

https://www.gov.uk/government/collections/future-of-cities

These collections have multiple "groups" of documents. When these contain no documents they are hidden on the site.

However, the empty groups are still being sent to the search index. This has caused some content to be unexpectedly indexed, like the above mentioned page, which contains multiple empty groups with Lorem ipsum placeholder text.

This commit changes the data sent to search, so that only content visible on the page is indexed.

Thanks @tommorris for reporting a search result for "lorem ipsum".

![screen shot 2015-11-25 at 12 07 27](https://cloud.githubusercontent.com/assets/233676/11396916/204ed308-936d-11e5-9b5d-971a8c64e83e.png)
