### PR TITLE
Support RVM when there's comments in .ruby-version

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,3 +1,3 @@
-2.1.7
+ruby-2.1.7
 # DO NOT UPGRADE past 2.1.X until we resolve the following in Govspeak:
 # https://github.com/alphagov/whitehall/pull/2234


### PR DESCRIPTION
Comments in .ruby-version files are not supported
by RVM, but providing the full `ruby-2.x.x` string
allows RVM to pick out the ruby version and work
as intended.

This can be removed when the comments are removed.

cc @benlovell 