### PR TITLE
Fix dependent deletion of Corporate Information Pages

### DIFF
--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -4,7 +4,7 @@ module HasCorporateInformationPages
   included do
     has_many :corporate_information_pages, through: "edition_#{table_name}".to_sym, source: :edition, class_name: "CorporateInformationPage"
     before_destroy do |record|
-      record.corporate_information_pages.map { |cip| cip.document.destroy }
+      record.corporate_information_pages.map(&:document).uniq.each(&:destroy)
     end
   end
 

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -13,4 +13,9 @@ FactoryGirl.define do
   factory :about_corporate_information_page, parent: :published_corporate_information_page do
     corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
   end
+
+  factory :published_worldwide_organisation_corporate_information_page, parent: :corporate_information_page, traits: [:published] do
+    organisation nil
+    association :worldwide_organisation, factory: :worldwide_organisation
+  end
 end

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -77,6 +77,14 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "destroys an existing object" do
     organisation = create(:worldwide_organisation)
+
+    page = create(:published_worldwide_organisation_corporate_information_page,
+                  worldwide_organisation: organisation)
+
+    create(:published_worldwide_organisation_corporate_information_page,
+           worldwide_organisation: organisation,
+           document: page.document)
+
     count = WorldwideOrganisation.count
     delete :destroy, id: organisation.id
     assert_equal count - 1, WorldwideOrganisation.count


### PR DESCRIPTION
When an object with Corporate Information Pages is deleted, we first
attempt to delete the CIPs. This was broken as it deleted each document
once for each edition of that document. The second iteration of this
loop would call `destroy` on `nil` as the document no longer exists.

Uniquifying the list of documents first before destroying them fixes
this issue.

Raised in https://govuk.zendesk.com/agent/tickets/1198839