### PR TITLE
Revert "Nokogiri 1.6.6.5 pre release"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'carrierwave', '0.9.0'
 gem 'validates_email_format_of'
 gem 'friendly_id', '5.0.4'
 gem 'babosa', '1.0.2'
-gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
+gem 'nokogiri'
 gem 'slimmer', '9.0.0'
 gem 'plek', '1.10.0'
 gem 'isbn_validation'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: git://github.com/alphagov/nokogiri.git
-  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
-  branch: v1.6.6.5.rc
-  specs:
-    nokogiri (1.6.6.5.20151124112525)
-      mini_portile (~> 0.6.0)
-
-GIT
   remote: git://github.com/alphagov/test_track.git
   revision: 1f997082e2f1be94274d294c2f8d34ab0b21bb7f
   specs:
@@ -240,6 +232,8 @@ GEM
     mysql2 (0.3.17)
     netrc (0.10.3)
     newrelic_rpm (3.9.9.275)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -485,7 +479,7 @@ DEPENDENCIES
   mocha (= 1.1.0)
   mysql2
   newrelic_rpm
-  nokogiri!
+  nokogiri
   parallel (= 1.4.1)
   parallel_tests
   pdf-reader (= 1.3.3)


### PR DESCRIPTION
Reverts alphagov/whitehall#2389

Nokogiri will be cutting an [official release soon](https://github.com/sparklemotion/nokogiri/pull/1378#issuecomment-159447729) after more testing. This hacked together release is causing some developers issues with building Nokogiri, and the security vulnerabilities are no longer thought to be too severe.

Reverting all PRs that use this temporary release.

/cc @bradwright 