### PR TITLE
Delete content from publishing API on discard.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '26.0.0'
+gem 'gds-api-adapters', '26.2.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.0.0)
+    gds-api-adapters (26.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -462,7 +462,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.0.0)
+  gds-api-adapters (= 26.2.0)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.0)

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,0 +1,5 @@
+class PublishingApiDiscardDraftWorker < PublishingApiWorker
+  def perform(content_id, locale)
+    Whitehall.publishing_api_v2_client.discard_draft(content_id, locale: locale)
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -16,6 +16,7 @@ Whitehall.edition_services.tap do |es|
   es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
   es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }
   es.subscribe("unschedule")                  { |_, edition, _| Whitehall::PublishingApi.unschedule_async(edition) }
+  es.subscribe("delete")                      { |_, edition, _| Whitehall::PublishingApi.discard_draft_async(edition) }
 
   # handling edition's dependency on other content
   es.subscribe(/^(force_publish|publish)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -55,6 +55,12 @@ module Whitehall
       PublishingApiGoneWorker.perform_async(base_path)
     end
 
+    def self.discard_draft_async(edition)
+      locales_for(edition).each do |locale|
+        PublishingApiDiscardDraftWorker.perform_async(edition.content_id, locale)
+      end
+    end
+
   private
 
     def self.locales_for(model_instance)

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class RegisterableEditionTest < ActiveSupport::TestCase
+  setup do
+    stub_any_publishing_api_call
+  end
 
   test "prepares a detailed guide for registration with Panopticon" do
     edition = create(:published_detailed_guide,


### PR DESCRIPTION
Reissuing https://github.com/alphagov/whitehall/pull/2400 against master.

https://trello.com/c/sPUPz6FN/436-have-whitehall-delete-discarded-drafts