### PR TITLE
Fix publishing_api integration

### DIFF
--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -22,6 +22,7 @@ class PublishingApiPresenters::ComingSoon
 
   def as_json
     {
+      base_path: base_path,
       content_id: SecureRandom.uuid,
       publishing_app: 'whitehall',
       rendering_app: edition.rendering_app,

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -32,6 +32,7 @@ module PublishingApiPresenters
 
     def standard_fields
       {
+        base_path: base_path,
         content_id: edition.content_id,
         title: edition.title,
         description: edition.summary,

--- a/app/presenters/publishing_api_presenters/gone.rb
+++ b/app/presenters/publishing_api_presenters/gone.rb
@@ -7,6 +7,7 @@ class PublishingApiPresenters::Gone
 
   def as_json
     {
+      base_path: @base_path,
       content_id: SecureRandom.uuid,
       format: 'gone',
       publishing_app: 'whitehall',

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -16,6 +16,7 @@ class PublishingApiPresenters::Placeholder
 
   def as_json
     json = {
+      base_path: base_path,
       content_id: item.content_id,
       title: item.name,
       format: format,

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -35,6 +35,7 @@ private
 
   def unpublishing_hash
     {
+      base_path: base_path,
       content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -33,6 +33,7 @@ module OrganisationResluggerTest
       content_item = PublishingApiPresenters.presenter_for(@organisation).as_json
       old_base_path = @organisation.search_link
       new_base_path = "#{base_path}/corrected-slug"
+      content_item[:base_path] = new_base_path
       content_item[:routes][0][:path] = new_base_path
       redirect_uuid = SecureRandom.uuid
       SecureRandom.stubs(uuid: redirect_uuid)

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -29,6 +29,7 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
     content_item = PublishingApiPresenters.presenter_for(@person).as_json
     old_base_path = @person.search_link
     new_base_path = "/government/people/updated-slug"
+    content_item[:base_path] = new_base_path
     content_item[:routes][0][:path] = new_base_path
     redirects = [
       { path: old_base_path, type: "exact", destination: new_base_path },

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -27,6 +27,7 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     content_item = PublishingApiPresenters.presenter_for(@ministerial_role).as_json
     old_base_path = @ministerial_role.search_link
     new_base_path = "/government/ministers/corrected-slug"
+    content_item[:base_path] = new_base_path
     content_item[:routes][0][:path] = new_base_path
     redirects = [
       { path: old_base_path, type: "exact", destination: new_base_path },

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -15,6 +15,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
     public_path = Whitehall.url_maker.public_document_path(case_study)
     expected_hash = {
+      base_path: public_path,
       content_id: case_study.document.content_id,
       title: 'Case study title',
       description: 'The summary',

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -16,7 +16,9 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
   end
 
   test 'presents a valid "coming_soon" content item' do
+    public_path = '/government/case-studies/case-study-title'
     expected_hash = {
+      base_path: public_path,
       content_id: @content_id,
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',
@@ -25,7 +27,7 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
       locale: @locale,
       update_type: 'major',
       details: { publish_time: @publish_timestamp },
-      routes: [ { path: '/government/case-studies/case-study-title', type: 'exact' } ],
+      routes: [{ path: public_path, type: 'exact' }],
       public_updated_at: @edition.updated_at,
     }
 

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -19,6 +19,7 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.public_document_path(edition)
 
     expected_hash = {
+      base_path: public_path,
       content_id: edition.document.content_id,
       title: 'The title',
       description: 'The summary',
@@ -58,6 +59,7 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.public_document_path(edition)
 
     expected_hash = {
+      base_path: public_path,
       content_id: edition.document.content_id,
       title: 'The title',
       description: 'The summary',

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -10,6 +10,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.ministerial_role_path(ministerial_role)
 
     expected_hash = {
+      base_path: public_path,
       content_id: ministerial_role.content_id,
       title: "Secretary of State for Silly Walks",
       format: "placeholder_ministerial_role",
@@ -31,6 +32,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.organisation_path(organisation)
 
     expected_hash = {
+      base_path: public_path,
       content_id: organisation.content_id,
       title: "Organisation of Things",
       format: "placeholder_organisation",
@@ -53,6 +55,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.person_path(person)
 
     expected_hash = {
+      base_path: public_path,
       content_id: person.content_id,
       title: "Winston",
       format: "placeholder_person",
@@ -74,6 +77,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.worldwide_organisation_path(worldwide_org)
 
     expected_hash = {
+      base_path: public_path,
       content_id: worldwide_org.content_id,
       title: "Locationia Embassy",
       format: "placeholder_worldwide_organisation",
@@ -96,6 +100,7 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     public_path = Whitehall.url_maker.world_location_path(world_location)
 
     expected_hash = {
+      base_path: public_path,
       content_id: world_location.content_id,
       title: "Locationia",
       format: "placeholder_world_location",

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -6,6 +6,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     edition      = unpublishing.edition
     public_path  = unpublishing.document_path
     expected_hash = {
+      base_path: public_path,
       content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,
@@ -99,6 +100,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     edition      = unpublishing.edition
     public_path  = unpublishing.document_path
     expected_hash = {
+      base_path: public_path,
       content_id: unpublishing.content_id,
       title: edition.title,
       description: edition.summary,

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -5,8 +5,10 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
     group = create(:policy_group,
       name: "Government Digital Service"
     )
+    public_path = '/government/groups/government-digital-service'
 
     expected_hash = {
+      base_path: public_path,
       content_id: group.content_id,
       publishing_app: "whitehall",
       rendering_app: "whitehall-frontend",
@@ -16,7 +18,7 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
       update_type: "major",
       routes: [
         {
-          path: '/government/groups/government-digital-service',
+          path: public_path,
           type: 'exact'
         }
       ],

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -19,6 +19,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
                            scheduled_publication: publish_time)
 
     expected_payload = {
+      base_path: base_path,
       content_id: @uuid,
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -13,6 +13,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
     base_path = '/government/this-never-existed-honest'
 
     payload = {
+      base_path: base_path,
       content_id: @uuid,
       format: 'gone',
       publishing_app: 'whitehall',


### PR DESCRIPTION
base_path is a required field with v2 of the publishing-api, but is
optional in the v1 endpoints.

govuk-content-schemas currently don't require base_path in the publisher
schemas, but @steventux is working on making v1 and v2 variants of the
schemas soon. This would [enable us to make it required](https://github.com/alphagov/govuk-content-schemas/compare/make_base_path_required?expand=1) for v2 but still
optional for v1.

I found these test failures by making base_path required in my local copy of
govuk-content-schemas and then running the tests against them.