### PR TITLE
Handle deletion of already deleted draft items in Publishing API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '26.2.0'
+gem 'gds-api-adapters', '26.3.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.2.0)
+    gds-api-adapters (26.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -456,7 +456,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.2.0)
+  gds-api-adapters (= 26.3.0)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.0)

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,5 +1,9 @@
 class PublishingApiDiscardDraftWorker < PublishingApiWorker
   def perform(content_id, locale)
     Whitehall.publishing_api_v2_client.discard_draft(content_id, locale: locale)
+  rescue GdsApi::HTTPNotFound
+    # nothing to do here as the draft has already been deleted
+    # this shouldn't really happen but can still occur due to inconsistencies
+    # between this app's data and what's in the Content Store/Publishing API
   end
 end

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -12,4 +12,13 @@ class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "gracefully handles the deletion of an already-deleted draft edition" do
+    edition = create(:draft_case_study)
+    request = stub_any_publishing_api_call_to_return_not_found
+
+    PublishingApiDiscardDraftWorker.new.perform(edition.content_id, 'en')
+
+    assert_requested request
+  end
 end

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  test "registers a draft edition with the publishing api" do
+    edition = create(:draft_case_study)
+    request = stub_publishing_api_discard_draft(edition.content_id)
+
+    PublishingApiDiscardDraftWorker.new.perform(edition.content_id, 'en')
+
+    assert_requested request
+  end
+end


### PR DESCRIPTION
This will need a fix-up after https://github.com/alphagov/gds-api-adapters/pull/399 is reviewed and merged.