### PR TITLE
Correctly send locale and update_type in publishing-api publish call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '26.3.0'
+gem 'gds-api-adapters', '26.3.1'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.3.0)
+    gds-api-adapters (26.3.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -456,7 +456,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.3.0)
+  gds-api-adapters (= 26.3.1)
   gds-sso (~> 10.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.0)

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -26,7 +26,7 @@ class PublishingApiWorker < WorkerBase
 
   def send_item(payload, locale = payload[:locale])
     save_draft(payload)
-    Whitehall.publishing_api_v2_client.publish(payload[:content_id], locale: locale, update_type: payload[:update_type])
+    Whitehall.publishing_api_v2_client.publish(payload[:content_id], payload[:update_type], locale: locale)
   end
 
   def save_draft(payload)

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -68,8 +68,8 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublish(@published_edition, unpublishing_params)
 
     assert_publishing_api_put_content(@published_edition.unpublishing.content_id, { format: 'unpublishing' }, 2)
-    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "update_type" => { "locale" => "en", "update_type" => "major" } })
-    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "update_type" => { "locale" => "fr", "update_type" => "major" } })
+    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "locale" => "en", "update_type" => "major" })
+    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "locale" => "fr", "update_type" => "major" })
   end
 
   test 'when a translated edition is unpublished as a redirect, redirects are published to the Publishing API for each translation' do
@@ -90,8 +90,8 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublish(@published_edition, unpublishing_redirect_params)
 
     assert_publishing_api_put_content(redirect_uuid, { format: 'redirect' }, 2)
-    assert_publishing_api_publish(redirect_uuid, { "update_type" => { "locale" => "en", "update_type" => "major" } })
-    assert_publishing_api_publish(redirect_uuid, { "update_type" => { "locale" => "fr", "update_type" => "major" } })
+    assert_publishing_api_publish(redirect_uuid, { "locale" => "en", "update_type" => "major" })
+    assert_publishing_api_publish(redirect_uuid, { "locale" => "fr", "update_type" => "major" })
   end
 
 private

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -18,8 +18,7 @@ module PublishingApiTestHelpers
           has_entries(content_id: edition.content_id, update_type: 'major',
             publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
       Whitehall.publishing_api_v2_client.expects(:publish)
-        .with(edition.content_id,
-          has_entries(update_type: 'major'))
+        .with(edition.content_id, 'major', locale: "en")
     end
   end
 
@@ -30,8 +29,7 @@ module PublishingApiTestHelpers
           has_entries(content_id: edition.content_id, update_type: 'republish',
             publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
       Whitehall.publishing_api_v2_client.expects(:publish)
-        .with(edition.content_id,
-          has_entries(update_type: 'republish'))
+        .with(edition.content_id, 'republish', locale: "en")
     end
   end
 

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -51,7 +51,7 @@ module OrganisationResluggerTest
       redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
 
       expected_publish_requests = stub_publishing_api_put_content_links_and_publish(content_item)
-      expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, update_type: { update_type: 'major', locale: 'en' })
+      expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, update_type: 'major', locale: 'en')
 
       @reslugger.run!
 

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -38,7 +38,7 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
     redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
 
     expected_publish_requests = stub_publishing_api_put_content_links_and_publish(content_item)
-    expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, { update_type: { update_type: 'major', locale: 'en' } })
+    expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, { update_type: 'major', locale: 'en' })
 
     @reslugger.run!
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -36,7 +36,7 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     redirect_item = Whitehall::PublishingApi::Redirect.new(old_base_path, redirects).as_json
 
     expected_publish_requests = stub_publishing_api_put_content_links_and_publish(content_item)
-    expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, { update_type: { update_type: 'major', locale: 'en' } })
+    expected_redirect_requests = stub_publishing_api_put_content_links_and_publish(redirect_item, redirect_uuid, { update_type: 'major', locale: 'en' })
 
     @reslugger.run!
 

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -152,7 +152,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   test "publishes a redirect unpublishing" do
     unpublishing = create(:redirect_unpublishing)
     payload      = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish").as_json
-    requests     = stub_publishing_api_put_content_links_and_publish(payload, payload["content_id"], { update_type: { update_type: "republish", locale: 'en' } })
+    requests     = stub_publishing_api_put_content_links_and_publish(payload, payload["content_id"], { update_type: "republish", locale: 'en' })
 
     Whitehall::PublishingApi.republish_async(unpublishing)
     assert_all_requested(requests)
@@ -341,7 +341,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       }
     ]
     expected_content_request = stub_publishing_api_put_content(redirect_uuid, Whitehall::PublishingApi::Redirect.new(base_path, redirects).as_json)
-    expected_publish_request = stub_publishing_api_publish(redirect_uuid, update_type: { update_type: 'major', locale: 'en' })
+    expected_publish_request = stub_publishing_api_publish(redirect_uuid, { update_type: 'major', locale: 'en' })
     Whitehall::PublishingApi.publish_redirect_async(base_path, redirects)
 
     assert_requested expected_content_request

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -33,7 +33,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
     }
 
     content_request = stub_publishing_api_put_content(@uuid, expected_payload)
-    publish_request = stub_publishing_api_publish(@uuid, { update_type: { locale: "fr", update_type: "major" } })
+    publish_request = stub_publishing_api_publish(@uuid, { locale: "fr", update_type: "major" })
 
     PublishingApiComingSoonWorker.new.perform(edition.id, locale)
 

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -47,7 +47,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     requests        = stub_publishing_api_put_content_links_and_publish(presenter.as_json)
     payload         = presenter.as_json
     content_request = stub_publishing_api_put_content(payload[:content_id], payload)
-    publish_request = stub_publishing_api_publish(payload[:content_id], { update_type: { locale: "en", update_type: "republish" } })
+    publish_request = stub_publishing_api_publish(payload[:content_id], { locale: "en", update_type: "republish" })
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id, update_type)
 
@@ -64,7 +64,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       organisation.save!
 
       @spanish_request = stub_publishing_api_put_content(presenter.as_json[:content_id], presenter.as_json)
-      @publish_request = stub_publishing_api_publish(presenter.as_json[:content_id], { update_type: { locale: "es", update_type: "major" } })
+      @publish_request = stub_publishing_api_publish(presenter.as_json[:content_id], { locale: "es", update_type: "major" })
     end
 
     PublishingApiWorker.new.perform(organisation.class.name, organisation.id, nil, 'es')


### PR DESCRIPTION
These keys were being ignored because they were nested in an additional
`update_type` key.

Don't merge until the [gds-api-adapters dependency](https://github.com/alphagov/gds-api-adapters/pull/401) has been pointed at a released version.

/cc @elliotcm @benilovj 