### PR TITLE
Unique path for worldwide org about pages.

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -85,10 +85,10 @@ module PublicDocumentRoutesHelper
   def build_url_for_corporate_information_page(edition, options)
     org = edition.owning_organisation
     # About pages are actually shown on the CIP index for an Organisation.
-    # But worldwide orgs show the about text on the org page itself.
+    # We generate a unique path for them anyway, but this is always redirected.
     if edition.about_page?
       if org.is_a?(WorldwideOrganisation)
-        polymorphic_url([org], options)
+        polymorphic_url([org, edition.slug], options)
       else
         polymorphic_url([org, CorporateInformationPage], options)
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,16 +130,18 @@ Whitehall::Application.routes.draw do
 
     resources :policy_groups, path: 'groups', only: [:index, :show]
     resources :operational_fields, path: 'fields-of-operation', only: [:index, :show]
+    get 'world/organisations/:organisation_id/office' => redirect('/world/organisations/%{organisation_id}')
+    get 'world/organisations/:organisation_id/about' => redirect('/world/organisations/%{organisation_id}')
     resources :worldwide_organisations, path: 'world/organisations', only: [:show, :index], localised: true do
       resources :corporate_information_pages, only: [:show], path: 'about', localised: true
+      # Dummy path for the sake of polymorphic_path: will always be directed above.
+      get :about
       resources :worldwide_offices, path: 'office', only: [:show]
     end
 
     resources :embassies, path: 'world/embassies', only: [:index]
 
     resources :world_locations, path: 'world', only: [:index, :show], localised: true
-    get 'world/organisations/:organisation_id/office' => redirect('/world/organisations/%{organisation_id}')
-    get 'world/organisations/:organisation_id/about' => redirect('/world/organisations/%{organisation_id}')
 
     constraints(AdminRequest) do
       namespace :admin do

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -54,6 +54,25 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     assert_equal organisation_corporate_information_pages_path(cip.organisation), public_document_path(cip)
   end
 
+  test 'returns correct path for organisation About Us pages' do
+    org = build(:organisation, slug: 'an-organisation')
+    cip = build(:corporate_information_page,
+                organisation: org,
+                corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id)
+
+    assert_equal "/government/organisations/#{org.slug}/about", public_document_path(cip)
+  end
+
+  test 'returns correct path for world organisation About Us pages' do
+    world_org = build(:worldwide_organisation, slug: 'a-worldwide-org')
+    cip = build(:corporate_information_page,
+                organisation: nil,
+                worldwide_organisation: world_org,
+                corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id)
+
+    assert_equal "/government/world/organisations/#{world_org.slug}/about", public_document_path(cip)
+  end
+
   test 'returns the document URL using Whitehall public_host and protocol' do
     Whitehall.stubs(public_host: 'some.host')
     Whitehall.stubs(public_protocol: 'http')


### PR DESCRIPTION
The "about us" content for WorldwideOrganisations is displayed on the same page
as the organisation itself, which means we have two items with the same path.
This causes conflicts when the items are exported to publishing_api. For now,
fix this by giving the about us page its own slug, and always redirecting back
to the organisation home page. When these pages are properly migrated to
publishing-api, we will address the underlying issue.