### PR TITLE
Add missing translations

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -196,6 +196,13 @@ ar:
         few:
         many:
         other:
+      official_statistics:
+        zero:
+        one: "إحصائية"
+        two:
+        few:
+        many:
+        other: "إحصائيات"
       open_consultation:
         zero:
         one: "مشاورة جارية"
@@ -280,13 +287,6 @@ ar:
         few:
         many:
         other: "مجموعات بيانات إحصائية"
-      official_statistics:
-        zero:
-        one: "إحصائية"
-        two:
-        few:
-        many:
-        other: "إحصائيات"
       statutory_guidance:
         zero:
         one:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -12,6 +12,7 @@ ar:
       field_of_operation: "مجال العمل"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -208,6 +208,9 @@ az:
       notice:
         one:
         other:
+      official_statistics:
+        one: statistika
+        other: statistika
       open_consultation:
         one: açıq məsləhətləşmələr
         other: açıq məsləhətləşmələr
@@ -244,9 +247,6 @@ az:
       statistical_data_set:
         one: statistik məlumatlar bazası
         other: statistik məlumatlar bazaları
-      official_statistics:
-        one: statistika
-        other: statistika
       statutory_guidance:
         one:
         other:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -117,6 +117,7 @@ az:
       field_of_operation: "əməliyyat sahəsi"
       from:
       location:
+      organisations:
       part_of:
     published: dərc olunub
     read:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -10,6 +10,7 @@ be:
       field_of_operation: "Сфера дзейнасці"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -142,6 +142,11 @@ be:
         few:
         many:
         other:
+      official_statistics:
+        one: "Статыстыка"
+        few:
+        many:
+        other: "Статыстыка"
       open_consultation:
         one: "Адкрытая кансультацыя"
         few:
@@ -202,11 +207,6 @@ be:
         few:
         many:
         other: "Статыстычныя дадзеныя"
-      official_statistics:
-        one: "Статыстыка"
-        few:
-        many:
-        other: "Статыстыка"
       statutory_guidance:
         one:
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -88,6 +88,9 @@ bg:
       notice:
         one:
         other:
+      official_statistics:
+        one: "Статистики"
+        other: "Статистики"
       open_consultation:
         one: "Отворена консултация"
         other: "Отворени консултации"
@@ -124,9 +127,6 @@ bg:
       statistical_data_set:
         one: "Набор от статистически данни"
         other: "Набори от статистически данни"
-      official_statistics:
-        one: "Статистики"
-        other: "Статистики"
       statutory_guidance:
         one:
         other:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -8,6 +8,7 @@ bg:
       field_of_operation: "Поле на операцията"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -8,6 +8,7 @@ bn:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -88,6 +88,9 @@ bn:
       notice:
         one:
         other:
+      official_statistics:
+        one:
+        other:
       open_consultation:
         one:
         other:
@@ -122,9 +125,6 @@ bn:
         one:
         other:
       statistical_data_set:
-        one:
-        other:
-      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -9,6 +9,7 @@ cs:
       field_of_operation: Oblast působnosti
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -115,6 +115,10 @@ cs:
         one:
         few:
         other:
+      official_statistics:
+        one: Statistika
+        few:
+        other: Statistiky
       open_consultation:
         one: Otevřená konzultace
         few:
@@ -163,10 +167,6 @@ cs:
         one: Statistická data
         few:
         other: Statistická data
-      official_statistics:
-        one: Statistika
-        few:
-        other: Statistiky
       statutory_guidance:
         one:
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -196,6 +196,13 @@ cy:
         few:
         many:
         other:
+      official_statistics:
+        zero:
+        one: Ystadegau
+        two:
+        few:
+        many:
+        other: Ystadegau
       open_consultation:
         zero:
         one: Ymgynghoriad ar agor
@@ -280,13 +287,6 @@ cy:
         few:
         many:
         other: Setiau data ystadegol
-      official_statistics:
-        zero:
-        one: Ystadegau
-        two:
-        few:
-        many:
-        other: Ystadegau
       statutory_guidance:
         zero:
         one:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -12,6 +12,7 @@ cy:
       field_of_operation: Maes gweithredu
       from: O
       location:
+      organisations:
       part_of: Rhan o
     type:
       announcement:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -88,6 +88,9 @@ de:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistik
+        other: Statistiken
       open_consultation:
         one: Laufende Konsultation
         other: Laufende Konsultationen
@@ -124,9 +127,6 @@ de:
       statistical_data_set:
         one: Statistischer Datensatz
         other: Statistische Datensätze
-      official_statistics:
-        one: Statistik
-        other: Statistiken
       statutory_guidance:
         one:
         other:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -8,6 +8,7 @@ de:
       field_of_operation: Einsatzbereich
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -8,6 +8,7 @@ dr:
       field_of_operation: "بخش عملیاتی"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -88,6 +88,9 @@ dr:
       notice:
         one:
         other:
+      official_statistics:
+        one: "احصائیه ها"
+        other: "احصائیه ها"
       open_consultation:
         one: "مشاورت باز"
         other: "مشاورت های باز"
@@ -124,9 +127,6 @@ dr:
       statistical_data_set:
         one: "ارقام احصائیوی"
         other: "ارقام احصائیوی"
-      official_statistics:
-        one: "احصائیه ها"
-        other: "احصائیه ها"
       statutory_guidance:
         one:
         other:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -8,6 +8,7 @@ el:
       field_of_operation: "Πεδίο δράσης"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -88,6 +88,9 @@ el:
       notice:
         one:
         other:
+      official_statistics:
+        one: "Στατιστικά στοιχεία"
+        other: "Στατιστικά στοιχεία"
       open_consultation:
         one: "Ανοιχτή διαβούλευση"
         other: "Ανοιχτές διαβουλεύσεις"
@@ -122,9 +125,6 @@ el:
         one: "Δήλωση στη Βουλή"
         other: "Δηλώσεις στη Βουλή "
       statistical_data_set:
-        one: "Στατιστικά στοιχεία"
-        other: "Στατιστικά στοιχεία"
-      official_statistics:
         one: "Στατιστικά στοιχεία"
         other: "Στατιστικά στοιχεία"
       statutory_guidance:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
       applies_to_nations: Applies to
       part_of: Part of
       from: From
+      organisations: Organisations
       location: Location
       attachments:
         one: Document

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -88,6 +88,9 @@ es-419:
       notice:
         one:
         other:
+      official_statistics:
+        one: Estadísticas
+        other: Estadísticas
       open_consultation:
         one: Consulta abierta
         other: Consultas abiertas
@@ -124,9 +127,6 @@ es-419:
       statistical_data_set:
         one: Conjunto de datos estadísticos
         other: Conjuntos de datos estadísticos
-      official_statistics:
-        one: Estadísticas
-        other: Estadísticas
       statutory_guidance:
         one:
         other:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -8,6 +8,7 @@ es-419:
       field_of_operation: Terreno de operaciones
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -88,6 +88,9 @@ es:
       notice:
         one:
         other:
+      official_statistics:
+        one: Estadísticas
+        other: Estadísticas
       open_consultation:
         one: Consulta abierta
         other: Consultas abiertas
@@ -124,9 +127,6 @@ es:
       statistical_data_set:
         one: Conjunto de datos estadísticos
         other: Conjuntos de datos estadísticos
-      official_statistics:
-        one: Estadísticas
-        other: Estadísticas
       statutory_guidance:
         one:
         other:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,6 +8,7 @@ es:
       field_of_operation: "Ãmbito de actuación"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -8,6 +8,7 @@ et:
       field_of_operation: Tegevusvaldkond
       from: Kellelt
       location: Asukoht
+      organisations:
       part_of: Osa
     type:
       announcement:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -88,6 +88,9 @@ et:
       notice:
         one: Teade
         other: Teated
+      official_statistics:
+        one: 'Statistika '
+        other: Statistika
       open_consultation:
         one: Avatud konsultatsioon
         other: Avatud konsultatsioonid
@@ -124,9 +127,6 @@ et:
       statistical_data_set:
         one: Statistiline andmekogu
         other: Statistilised andmekogud
-      official_statistics:
-        one: 'Statistika '
-        other: Statistika
       statutory_guidance:
         one: Seadusejärgne juhis
         other: Seadusejärgne juhis

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -119,6 +119,7 @@ fa:
       field_of_operation: "میدان عمل"
       from:
       location:
+      organisations:
       part_of:
     published: "منتشر شده"
     read: "مقاله  %{title} را بخوانید"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -210,6 +210,9 @@ fa:
       notice:
         one:
         other:
+      official_statistics:
+        one: "آمار"
+        other: "آمار"
       open_consultation:
         one: "رایزنی باز"
         other: "رایزنی های باز"
@@ -246,9 +249,6 @@ fa:
       statistical_data_set:
         one: "بسته ی داده های آماری"
         other: "بسته های داده های آماری"
-      official_statistics:
-        one: "آمار"
-        other: "آمار"
       statutory_guidance:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -88,6 +88,9 @@ fr:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistiques
+        other: Statistiques
       open_consultation:
         one: Consultation ouverte
         other: Consultations ouvertes
@@ -124,9 +127,6 @@ fr:
       statistical_data_set:
         one: Ensemble de données statistiques
         other: Ensembles de données statistiques
-      official_statistics:
-        one: Statistiques
-        other: Statistiques
       statutory_guidance:
         one:
         other:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,6 +8,7 @@ fr:
       field_of_operation: Domaine d'activité
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -10,6 +10,7 @@ he:
       field_of_operation: "שדה פעולה"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -142,6 +142,11 @@ he:
         two:
         many:
         other:
+      official_statistics:
+        one: "נתונים"
+        two:
+        many:
+        other: "נתונים"
       open_consultation:
         one: "דיון פתוח"
         two:
@@ -202,11 +207,6 @@ he:
         two:
         many:
         other: "מידע סטטיסטי"
-      official_statistics:
-        one: "נתונים"
-        two:
-        many:
-        other: "נתונים"
       statutory_guidance:
         one:
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -8,6 +8,7 @@ hi:
       field_of_operation: "प्रचालन क्षेत्र"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -88,6 +88,9 @@ hi:
       notice:
         one:
         other:
+      official_statistics:
+        one: "आंकड़े"
+        other: "आंकड़े"
       open_consultation:
         one: "खुला परामर्श"
         other: "खुले परामर्श"
@@ -124,9 +127,6 @@ hi:
       statistical_data_set:
         one: "सांख्यिकीय आंकड़े का समूह"
         other: "सांख्यिकीय आंकड़े का समूह"
-      official_statistics:
-        one: "आंकड़े"
-        other: "आंकड़े"
       statutory_guidance:
         one:
         other:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -120,6 +120,7 @@ hu:
       field_of_operation: Működési terület
       from:
       location:
+      organisations:
       part_of:
     published: közzététel dátuma
     read: 'Olvassa el a következő cikket: %{title}'

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -211,6 +211,9 @@ hu:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statisztika
+        other: Statisztikák
       open_consultation:
         one: Nyílt konzultáció
         other: Nyílt konzultációk
@@ -247,9 +250,6 @@ hu:
       statistical_data_set:
         one: Statisztikai adatcsoport
         other: Statisztikai adatcsoportok
-      official_statistics:
-        one: Statisztika
-        other: Statisztikák
       statutory_guidance:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -88,6 +88,9 @@ hy:
       notice:
         one:
         other:
+      official_statistics:
+        one: "Վիճակագրություն"
+        other: "Վիճակագրություն"
       open_consultation:
         one: "Բաց խորհրդատվություն"
         other: "Բաց խորհրդատվություններ"
@@ -124,9 +127,6 @@ hy:
       statistical_data_set:
         one: "Վիճակագրական տվյալ"
         other: "Վիճակագրական տվյալներ"
-      official_statistics:
-        one: "Վիճակագրություն"
-        other: "Վիճակագրություն"
       statutory_guidance:
         one:
         other:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -8,6 +8,7 @@ hy:
       field_of_operation: "Գործունեության ոլորտ"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -119,6 +119,7 @@ id:
       field_of_operation: Area operasi
       from:
       location:
+      organisations:
       part_of:
     published: Diterbitkan
     read: Baca artikel %{title}

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -210,6 +210,9 @@ id:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistik
+        other: Statistik-statistik
       open_consultation:
         one: Konsultasi terbuka
         other: Konsultasi-konsultasi terbuka
@@ -246,9 +249,6 @@ id:
       statistical_data_set:
         one: Set data statistik
         other: Set data statistik
-      official_statistics:
-        one: Statistik
-        other: Statistik-statistik
       statutory_guidance:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -88,6 +88,9 @@ it:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistica
+        other: Statistiche
       open_consultation:
         one: Consultazione aperta
         other: Consultazioni aperte
@@ -124,9 +127,6 @@ it:
       statistical_data_set:
         one: Dati statistici
         other: Dati stitistici
-      official_statistics:
-        one: Statistica
-        other: Statistiche
       statutory_guidance:
         one:
         other:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -8,6 +8,7 @@ it:
       field_of_operation: Settore di lavoro
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -209,6 +209,9 @@ ja:
       notice:
         one:
         other:
+      official_statistics:
+        one: "統計"
+        other: "統計"
       open_consultation:
         one: "公開協議"
         other: "公開協議"
@@ -245,9 +248,6 @@ ja:
       statistical_data_set:
         one: "統計データセット"
         other: "統計データセット"
-      official_statistics:
-        one: "統計"
-        other: "統計"
       statutory_guidance:
         one:
         other:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -118,6 +118,7 @@ ja:
       field_of_operation: "担当分野"
       from:
       location:
+      organisations:
       part_of:
     published: "掲載日"
     read: "%{title} の記事を読む"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -117,6 +117,7 @@ ka:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     published:
     read:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -208,6 +208,9 @@ ka:
       notice:
         one:
         other:
+      official_statistics:
+        one:
+        other:
       open_consultation:
         one:
         other:
@@ -242,9 +245,6 @@ ka:
         one:
         other:
       statistical_data_set:
-        one:
-        other:
-      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -118,6 +118,7 @@ ko:
       field_of_operation: "오퍼레이션 필드"
       from:
       location:
+      organisations:
       part_of:
     published: "발행"
     read: "%{title} 기사를 확인하세요"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -209,6 +209,9 @@ ko:
       notice:
         one:
         other:
+      official_statistics:
+        one: "통계"
+        other: "통계"
       open_consultation:
         one: "오픈 컨설테이션"
         other: "오픈 컨설테이션"
@@ -245,9 +248,6 @@ ko:
       statistical_data_set:
         one: "통계 데이터 세트"
         other: "통계 데이터 세트"
-      official_statistics:
-        one: "통계"
-        other: "통계"
       statutory_guidance:
         one:
         other:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -9,6 +9,7 @@ lt:
       field_of_operation: Veiklos laukas
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -115,6 +115,10 @@ lt:
         one:
         few:
         other:
+      official_statistics:
+        one: Statistika
+        few:
+        other: Statistika
       open_consultation:
         one: Atvira konsultacija
         few:
@@ -163,10 +167,6 @@ lt:
         one: Statistiniai duomenys
         few:
         other: Statistiniai duomenys
-      official_statistics:
-        one: Statistika
-        few:
-        other: Statistika
       statutory_guidance:
         one:
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -8,6 +8,7 @@ lv:
       field_of_operation: Darbības lauks
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -88,6 +88,9 @@ lv:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistika
+        other: Statistika
       open_consultation:
         one: Atklāta konsultācija
         other: Atklātas konsultācijas
@@ -124,9 +127,6 @@ lv:
       statistical_data_set:
         one: Statistiskas datu kopums
         other: Statistikas datu kopumi
-      official_statistics:
-        one: Statistika
-        other: Statistika
       statutory_guidance:
         one:
         other:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -117,6 +117,7 @@ ms:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     published:
     read:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -208,6 +208,9 @@ ms:
       notice:
         one:
         other:
+      official_statistics:
+        one:
+        other:
       open_consultation:
         one:
         other:
@@ -242,9 +245,6 @@ ms:
         one:
         other:
       statistical_data_set:
-        one:
-        other:
-      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -142,6 +142,11 @@ pl:
         few:
         many:
         other:
+      official_statistics:
+        one: Statystyki
+        few:
+        many:
+        other: Statystyki
       open_consultation:
         one: Konsultacje otwarte
         few:
@@ -202,11 +207,6 @@ pl:
         few:
         many:
         other: Zestawy danych statystycznych
-      official_statistics:
-        one: Statystyki
-        few:
-        many:
-        other: Statystyki
       statutory_guidance:
         one:
         few:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -10,6 +10,7 @@ pl:
       field_of_operation: Obszar działania
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -88,6 +88,9 @@ ps:
       notice:
         one:
         other:
+      official_statistics:
+        one: "شمیرنه"
+        other: "شمیرنه"
       open_consultation:
         one: "آزاده مشوره"
         other: "آزادې مشورې"
@@ -124,9 +127,6 @@ ps:
       statistical_data_set:
         one: "د شمیرنې اطلاعات"
         other: "د شمیرنې اطلاعات"
-      official_statistics:
-        one: "شمیرنه"
-        other: "شمیرنه"
       statutory_guidance:
         one:
         other:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -8,6 +8,7 @@ ps:
       field_of_operation: "د کړنو څانګه"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -8,6 +8,7 @@ pt:
       field_of_operation: Campo de Operação
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -88,6 +88,9 @@ pt:
       notice:
         one:
         other:
+      official_statistics:
+        one: Estatística
+        other: Estatísticas
       open_consultation:
         one: Consulta aberta
         other: Consultas abertas
@@ -124,9 +127,6 @@ pt:
       statistical_data_set:
         one: Conjunto de dados estastísticos
         other: Conjuntos de dados estatísticos
-      official_statistics:
-        one: Estatística
-        other: Estatísticas
       statutory_guidance:
         one:
         other:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -9,6 +9,7 @@ ro:
       field_of_operation: Domeniu de activitate
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -115,6 +115,10 @@ ro:
         one:
         few:
         other:
+      official_statistics:
+        one: Statistici
+        few:
+        other: Statistici
       open_consultation:
         one: Dezbatere
         few:
@@ -163,10 +167,6 @@ ro:
         one: Date statistice
         few:
         other: Date statistice
-      official_statistics:
-        one: Statistici
-        few:
-        other: Statistici
       statutory_guidance:
         one:
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -142,6 +142,11 @@ ru:
         few:
         many:
         other:
+      official_statistics:
+        one: "Статистика"
+        few:
+        many:
+        other: "Статистика"
       open_consultation:
         one: "Открытая консультация"
         few:
@@ -202,11 +207,6 @@ ru:
         few:
         many:
         other: "Статистические данные"
-      official_statistics:
-        one: "Статистика"
-        few:
-        many:
-        other: "Статистика"
       statutory_guidance:
         one:
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -10,6 +10,7 @@ ru:
       field_of_operation: "Сфера деятельности"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -8,6 +8,7 @@ si:
       field_of_operation: "ක්‍රියාත්මකවන ක්ෂස්ත්‍රය"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -88,6 +88,9 @@ si:
       notice:
         one:
         other:
+      official_statistics:
+        one: "සංඛ්යාන"
+        other: "සංඛ්යාන"
       open_consultation:
         one: "විවෘත මත විමසුම"
         other: "විවෘත මත විමසුම්"
@@ -124,9 +127,6 @@ si:
       statistical_data_set:
         one: "සංඛ්යාන දත්ත සමූහය  "
         other: "සංඛ්යාන දත්ත සමූහ"
-      official_statistics:
-        one: "සංඛ්යාන"
-        other: "සංඛ්යාන"
       statutory_guidance:
         one:
         other:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -9,6 +9,7 @@ sk:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -115,6 +115,10 @@ sk:
         one:
         few:
         other:
+      official_statistics:
+        one:
+        few:
+        other:
       open_consultation:
         one:
         few:
@@ -160,10 +164,6 @@ sk:
         few:
         other:
       statistical_data_set:
-        one:
-        few:
-        other:
-      official_statistics:
         one:
         few:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -88,6 +88,9 @@ so:
       notice:
         one:
         other:
+      official_statistics:
+        one: Istaatistik
+        other: Istaatistik
       open_consultation:
         one: Wada-tashi furan
         other: Wada-tashiyo furan
@@ -124,9 +127,6 @@ so:
       statistical_data_set:
         one: Xirmo xog istaatistik ah
         other: Xirmooyin xog istaatistik ah
-      official_statistics:
-        one: Istaatistik
-        other: Istaatistik
       statutory_guidance:
         one:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -8,6 +8,7 @@ so:
       field_of_operation: Nooca hawlgalka
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -8,6 +8,7 @@ sq:
       field_of_operation: Fusha e veprimit
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -88,6 +88,9 @@ sq:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistika
+        other: Statistika
       open_consultation:
         one: Konsultim i hapur
         other: Konsultime te hapur
@@ -124,9 +127,6 @@ sq:
       statistical_data_set:
         one: Grup te dhenash statistikore
         other: Grupe te dhenash stasistikore
-      official_statistics:
-        one: Statistika
-        other: Statistika
       statutory_guidance:
         one:
         other:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -142,6 +142,11 @@ sr:
         few:
         many:
         other:
+      official_statistics:
+        one: statistika
+        few:
+        many:
+        other: statistika
       open_consultation:
         one: Otvorene konsultacije
         few:
@@ -202,11 +207,6 @@ sr:
         few:
         many:
         other: set statističkih podataka
-      official_statistics:
-        one: statistika
-        few:
-        many:
-        other: statistika
       statutory_guidance:
         one:
         few:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -10,6 +10,7 @@ sr:
       field_of_operation: polje delovanja
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -8,6 +8,7 @@ sw:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -88,6 +88,9 @@ sw:
       notice:
         one:
         other:
+      official_statistics:
+        one:
+        other:
       open_consultation:
         one:
         other:
@@ -122,9 +125,6 @@ sw:
         one:
         other:
       statistical_data_set:
-        one:
-        other:
-      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -8,6 +8,7 @@ ta:
       field_of_operation: "செயற்பாட்டுத் துறை"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -88,6 +88,9 @@ ta:
       notice:
         one:
         other:
+      official_statistics:
+        one: "புள்ளிவிபரம்"
+        other: "புள்ளிவிபரம்"
       open_consultation:
         one: "திறந்த கலந்தாலோசனை"
         other: "திறந்த கலந்தாலோசனைகள்"
@@ -124,9 +127,6 @@ ta:
       statistical_data_set:
         one: "புள்ளிவிபர தரவுத் தொகுதி"
         other: "புள்ளிவிபர தரவுத் தொகுதிகள்"
-      official_statistics:
-        one: "புள்ளிவிபரம்"
-        other: "புள்ளிவிபரம்"
       statutory_guidance:
         one:
         other:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -118,6 +118,7 @@ th:
       field_of_operation: "ลักษณะงาน"
       from:
       location:
+      organisations:
       part_of:
     published: "ตีพิมพ์"
     read: "อ่าน%{title}บทความ"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -209,6 +209,9 @@ th:
       notice:
         one:
         other:
+      official_statistics:
+        one: "สถิติ"
+        other: "สถิติ"
       open_consultation:
         one: "การให้คำปรึกษาเปิด"
         other: "การให้คำปรึกษาเปิด"
@@ -245,9 +248,6 @@ th:
       statistical_data_set:
         one: "ชุดข้อมูลสถิติ"
         other: "ชุดข้อมูลสถิติ"
-      official_statistics:
-        one: "สถิติ"
-        other: "สถิติ"
       statutory_guidance:
         one:
         other:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -8,6 +8,7 @@ tk:
       field_of_operation:
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -88,6 +88,9 @@ tk:
       notice:
         one:
         other:
+      official_statistics:
+        one:
+        other:
       open_consultation:
         one:
         other:
@@ -122,9 +125,6 @@ tk:
         one:
         other:
       statistical_data_set:
-        one:
-        other:
-      official_statistics:
         one:
         other:
       statutory_guidance:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -119,6 +119,7 @@ tr:
       field_of_operation: Faaliyet Alanı
       from:
       location:
+      organisations:
       part_of:
     published: Yayında
     read: "%{title} makalesini okuyunuz"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -210,6 +210,9 @@ tr:
       notice:
         one:
         other:
+      official_statistics:
+        one: "İstatistikler"
+        other: "İstatistikler"
       open_consultation:
         one: Devam eden çalışma
         other: Devam eden çalışmalar
@@ -246,9 +249,6 @@ tr:
       statistical_data_set:
         one: "İstatiksel veri setleri"
         other: "İstatiksel veri setleri"
-      official_statistics:
-        one: "İstatistikler"
-        other: "İstatistikler"
       statutory_guidance:
         one:
         other:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -142,6 +142,11 @@ uk:
         few:
         many:
         other:
+      official_statistics:
+        one: "Статистика"
+        few:
+        many:
+        other: "Статистика"
       open_consultation:
         one: "Відкрите обговорення"
         few:
@@ -202,11 +207,6 @@ uk:
         few:
         many:
         other: "Набори статистичних даних"
-      official_statistics:
-        one: "Статистика"
-        few:
-        many:
-        other: "Статистика"
       statutory_guidance:
         one:
         few:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -10,6 +10,7 @@ uk:
       field_of_operation: "Сфера діяльності"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -8,6 +8,7 @@ ur:
       field_of_operation: "کارروائی کا میدان"
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -88,6 +88,9 @@ ur:
       notice:
         one:
         other:
+      official_statistics:
+        one: "اعدادوشمار"
+        other: "اعدادو شمار"
       open_consultation:
         one: "جاری مشاورت"
         other: "جاری مشاورت"
@@ -124,9 +127,6 @@ ur:
       statistical_data_set:
         one: "شماریاتی ڈیٹا سیٹ"
         other: " شماریاتی ڈیٹا سیٹس"
-      official_statistics:
-        one: "اعدادوشمار"
-        other: "اعدادو شمار"
       statutory_guidance:
         one:
         other:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -8,6 +8,7 @@ uz:
       field_of_operation: Faoliyat sohasi
       from:
       location:
+      organisations:
       part_of:
     type:
       announcement:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -88,6 +88,9 @@ uz:
       notice:
         one:
         other:
+      official_statistics:
+        one: Statistika
+        other: Statistika
       open_consultation:
         one: Ochiq fikr almashish
         other: Ochiq fikr almashishlar
@@ -124,9 +127,6 @@ uz:
       statistical_data_set:
         one: Statistika ma'lumot to'plami
         other: Statistika ma'lumot to'plamlari
-      official_statistics:
-        one: Statistika
-        other: Statistika
       statutory_guidance:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -210,6 +210,9 @@ vi:
       notice:
         one:
         other:
+      official_statistics:
+        one: Thống kê
+        other: Thống kê
       open_consultation:
         one: Tham vấn mở rộng
         other: Tham vấn mở rộng
@@ -246,9 +249,6 @@ vi:
       statistical_data_set:
         one: Bộ dữ liệu thống kê
         other: Bộ dữ liệu thống kê
-      official_statistics:
-        one: Thống kê
-        other: Thống kê
       statutory_guidance:
         one:
         other:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -119,6 +119,7 @@ vi:
       field_of_operation: Lĩnh vực hoạt động
       from:
       location:
+      organisations:
       part_of:
     published: "Đã xuất bản"
     read: "Đọc bài có  %{title}"

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -208,6 +208,9 @@ zh-hk:
       notice:
         one:
         other:
+      official_statistics:
+        one: "統計資料"
+        other: "其他統計資料"
       open_consultation:
         one: "公開諮詢"
         other: "其他公開諮詢"
@@ -244,9 +247,6 @@ zh-hk:
       statistical_data_set:
         one: "統計數據資料"
         other: "其他統計數據資料"
-      official_statistics:
-        one: "統計資料"
-        other: "其他統計資料"
       statutory_guidance:
         one:
         other:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -117,6 +117,7 @@ zh-hk:
       field_of_operation: "運用領域"
       from:
       location:
+      organisations:
       part_of:
     published: "已發布"
     read: "閱讀%{title}文章"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -117,6 +117,7 @@ zh-tw:
       field_of_operation: "運用領域"
       from:
       location:
+      organisations:
       part_of:
     published: "發行"
     read: "閱讀%{title}文章"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -208,6 +208,9 @@ zh-tw:
       notice:
         one:
         other:
+      official_statistics:
+        one: "統計"
+        other: "統計"
       open_consultation:
         one: "公開諮詢"
         other: "其他公開諮詢"
@@ -244,9 +247,6 @@ zh-tw:
       statistical_data_set:
         one: "統計數據資料"
         other: "其他統計數據料"
-      official_statistics:
-        one: "統計"
-        other: "統計"
       statutory_guidance:
         one:
         other:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -117,6 +117,7 @@ zh:
       field_of_operation: "操作区域"
       from:
       location:
+      organisations:
       part_of:
     published: "已发布"
     read: "阅读%{title}文章"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -208,6 +208,9 @@ zh:
       notice:
         one:
         other:
+      official_statistics:
+        one: "统计数据"
+        other: "统计数据"
       open_consultation:
         one: "公开咨询"
         other: "公开咨询"
@@ -244,9 +247,6 @@ zh:
       statistical_data_set:
         one: "统计数据集"
         other: "统计数据集"
-      official_statistics:
-        one: "统计数据"
-        other: "统计数据"
       statutory_guidance:
         one:
         other:


### PR DESCRIPTION
World Location News Articles also have a key for Organisations.
The alternative would be to change them all to use "From". Perhaps @bradwright has context on why we might want it to be different?

This key being missing manifests itself in the hover text:
https://www.gov.uk/government/topics/public-health
https://www.gov.uk/government/topical-events/first-world-war-centenary