### PR TITLE
Validate the length of attachment fields in the model

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -13,7 +13,7 @@ class Attachment < ActiveRecord::Base
 
   validates_with AttachmentValidator
   validates :attachable, presence: true
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true
   validates :command_paper_number, format: {
     with: /\A(#{VALID_COMMAND_PAPER_NUMBER_PREFIXES.join('|')}) ?\d+/,

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -1,5 +1,5 @@
 class ExternalAttachment < Attachment
-  validates :external_url, presence: true, uri: true
+  validates :external_url, presence: true, uri: true, length: { maximum: 255 }
 
   def accessible?
     true


### PR DESCRIPTION
Rather than letting the database (driver) raise an error (now that we have a MySQL
version which doesn't silently truncate), let's validate it in the model and
show the user a helpful validation message, not a 5xx error page.

Examples in production: https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56658960657863060cb91d00
