### PR TITLE
Validate the length of fields in Offsite Links

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,6 +1,6 @@
 class OffsiteLink < ActiveRecord::Base
   belongs_to :parent, polymorphic: true
-  validates :title, :summary, :link_type, :url, presence: true
+  validates :title, :summary, :link_type, :url, presence: true, length: { maximum: 255 }
   validate :url_is_govuk
   validates :link_type, presence: true, inclusion: {in: %w{alert blog_post campaign careers service}}
 


### PR DESCRIPTION
Rather than letting the database raise an error (now that we have a MySQL
version which doesn't silently truncate), let's validate it in the model and
show the user a helpful validation message, not a 5xx error page.

Example of this happening in production: https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/5669211065786305bb340300

Here are [the relevant lines from schema.rb](https://github.com/alphagov/whitehall/blob/master/db/schema.rb#L724-L728)