### PR TITLE
Send a request to the Publishing API when creating/updating translations

### DIFF
--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -13,6 +13,7 @@ module TranslationControllerConcern
 
   def update
     if translatable_item.update_attributes(translation_params)
+      put_translation_async(translatable_item, translation_locale.code)
       redirect_to update_redirect_path, notice: notice_message("saved")
     else
       render action: 'edit'
@@ -30,5 +31,9 @@ module TranslationControllerConcern
 
   def notice_message(action)
     %{#{translation_locale.english_language_name} translation for "#{translated_item_name}" #{action}.}
+  end
+
+  def put_translation_async(model, locale)
+    Whitehall::PublishingApi.save_draft_translation_async(model, locale)
   end
 end

--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -13,7 +13,7 @@ module TranslationControllerConcern
 
   def update
     if translatable_item.update_attributes(translation_params)
-      put_translation_async(translatable_item, translation_locale.code)
+      save_draft_translation_async if send_downstream?
       redirect_to update_redirect_path, notice: notice_message("saved")
     else
       render action: 'edit'
@@ -33,7 +33,11 @@ module TranslationControllerConcern
     %{#{translation_locale.english_language_name} translation for "#{translated_item_name}" #{action}.}
   end
 
-  def put_translation_async(model, locale)
-    Whitehall::PublishingApi.save_draft_translation_async(model, locale)
+  def save_draft_translation_async
+    Whitehall::PublishingApi.save_draft_translation_async(translatable_item, translation_locale.code)
+  end
+
+  def send_downstream?
+    translatable_item.respond_to?(:publish_to_publishing_api)
   end
 end

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -43,4 +43,12 @@ private
   def translation_params
     params.require(:edition).permit(:title, :summary, :body)
   end
+
+  def save_draft_translation_async
+    Whitehall.edition_services.draft_translation_updater(translatable_item, locale: translation_locale.code).perform!
+  end
+
+  def send_downstream?
+    true
+  end
 end

--- a/app/services/draft_translation_updater.rb
+++ b/app/services/draft_translation_updater.rb
@@ -1,0 +1,20 @@
+class DraftTranslationUpdater < EditionService
+  def perform!
+    if can_perform?
+      notify!
+      true
+    end
+  end
+
+  def failure_reason
+    if !edition.pre_publication?
+      "A #{edition.state} edition may not be updated."
+    elsif !edition.valid?
+      "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
+    end
+  end
+
+  def verb
+    'update_draft_translation'
+  end
+end

--- a/app/services/edition_service_coordinator.rb
+++ b/app/services/edition_service_coordinator.rb
@@ -19,6 +19,10 @@ class EditionServiceCoordinator
     ::DraftEditionUpdater.new(edition, options.merge(notifier: self))
   end
 
+  def draft_translation_updater(edition, options = {})
+    ::DraftTranslationUpdater.new(edition, options.merge(notifier: self))
+  end
+
   def scheduler(edition, options = {})
     ::EditionScheduler.new(edition, options.merge(notifier: self))
   end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -12,7 +12,8 @@ Whitehall.edition_services.tap do |es|
   # publishing API
   es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition) }
   es.subscribe("update_draft")                { |_, edition, _| Whitehall::PublishingApi.save_draft_async(edition) }
-  es.subscribe("withdraw")                     { |_, edition, _| Whitehall::PublishingApi.republish_async(edition) }
+  es.subscribe("update_draft_translation")    { |_, edition, options| Whitehall::PublishingApi.save_draft_translation_async(edition, options.fetch(:locale)) }
+  es.subscribe("withdraw")                    { |_, edition, _| Whitehall::PublishingApi.republish_async(edition) }
   es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
   es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }
   es.subscribe("unschedule")                  { |_, edition, _| Whitehall::PublishingApi.unschedule_async(edition) }

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -17,8 +17,12 @@ module Whitehall
     def self.save_draft_async(model_instance, update_type_override = nil, queue_override = nil)
       return if skip_sending_to_content_store?(model_instance)
       locales_for(model_instance).each do |locale|
-        PublishingApiDraftWorker.perform_async_in_queue(queue_override, model_instance.class.name, model_instance.id, update_type_override, locale)
+        save_draft_translation_async(model_instance, locale, update_type_override, queue_override)
       end
+    end
+
+    def self.save_draft_translation_async(model_instance, locale, update_type_override = nil, queue_override = nil)
+      PublishingApiDraftWorker.perform_async_in_queue(queue_override, model_instance.class.name, model_instance.id, update_type_override, locale)
     end
 
     def self.republish_async(model_instance)

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -136,6 +136,22 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     assert_select '.form-errors'
   end
 
+  view_test "#update puts the translation to the publishing API" do
+    edition = create(:draft_edition)
+
+    put :update, edition_id: edition, id: "fr", edition: {
+      title: "translated-title",
+      summary: "translated-summary",
+      body: "translated-body",
+    }
+
+    assert_publishing_api_put_content(edition.content_id, {
+      title: "translated-title",
+      description: "translated-summary",
+      locale: "fr",
+    })
+  end
+
   test "should limit access to translations of editions that aren't accessible to the current user" do
     protected_edition = create(:draft_publication, :access_limited)
 

--- a/test/unit/services/draft_translation_updater_test.rb
+++ b/test/unit/services/draft_translation_updater_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class DraftTranslationUpdaterTest < ActiveSupport::TestCase
+  test "#perform! calls notify! without modifying the edition" do
+    edition = create(:draft_edition)
+    edition.freeze
+    updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:notify!).once
+
+    updater.perform!
+  end
+
+  test "cannot perform if edition is invalid" do
+    edition = Edition.new
+    updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:notify!).never
+
+    updater.perform!
+  end
+
+  test "cannot perform if edition is not draft" do
+    edition = create(:published_edition)
+    updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:notify!).never
+
+    updater.perform!
+  end
+end


### PR DESCRIPTION
https://trello.com/c/wxLC6dkH/445-whitehall-put-content-item-when-creating-editing-a-translation

We need to send a request downstream to the publishing api when creating/updating translations for translatable content.