### PR TITLE
Improve contextual nav styles for older browsers

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
+++ b/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
@@ -1,4 +1,3 @@
-    
 .contextual-info {
   position: relative;
   clear: both;
@@ -7,12 +6,12 @@
 
   nav {
     overflow: hidden;
-    
+
     li {
       list-style-position: inside;
       padding-right: $gutter-half;
       padding-top: $gutter-one-sixth;
-    
+
       @media (min-width: 1px ){ // target modern browsers
         margin-left: $gutter-half;
         list-style: none;
@@ -25,7 +24,7 @@
         }
       }
     }
-    
+
     @include media(tablet){
       overflow: visible;
 

--- a/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
+++ b/app/assets/stylesheets/frontend/helpers/_contextual-info.scss
@@ -8,13 +8,13 @@
     overflow: hidden;
 
     li {
-      list-style-position: inside;
+      list-style-type: disc;
+      margin-left: $gutter-half;
       padding-right: $gutter-half;
       padding-top: $gutter-one-sixth;
 
       @media (min-width: 1px ){ // target modern browsers
-        margin-left: $gutter-half;
-        list-style: none;
+        list-style-type: none;
         &:before {
           content: "-";
           position: relative;


### PR DESCRIPTION
Addresses https://govuk.zendesk.com/agent/tickets/1208617

We’re using a media min-width hack to apply some styles to browsers that support media queries. These style use pseudo elements to create a list item with a dash.

In older browsers, IE8 and below, users were seeing a numbered list, which would render poorly when numbers got into double digits.

* Use a `disc` style rather than numbers to match intention of modern browser styles
* Make the list position outside (the default), move the margin clause outside of the media query as it now applies to both, and simplify the list-style reset to only affect the type not the position.

## Modern browsers
<img width="310" alt="screen shot 2015-12-17 at 12 43 07" src="https://cloud.githubusercontent.com/assets/319055/11869985/c24611c6-a4bb-11e5-9873-d2913490f633.png">

## Before (IE8)
<img width="349" alt="screen shot 2015-12-17 at 12 33 11" src="https://cloud.githubusercontent.com/assets/319055/11869951/8b0f3926-a4bb-11e5-8798-d0492850f842.png">

## After (IE8)
<img width="326" alt="screen shot 2015-12-17 at 12 32 47" src="https://cloud.githubusercontent.com/assets/319055/11869955/90c84e5c-a4bb-11e5-9b83-124e2eb73174.png">

## Before (IE7)
<img width="317" alt="screen shot 2015-12-17 at 12 41 11" src="https://cloud.githubusercontent.com/assets/319055/11869960/98f42a6a-a4bb-11e5-9671-6e01fb46a3eb.png">

## After (IE7)
<img width="271" alt="screen shot 2015-12-17 at 12 41 33" src="https://cloud.githubusercontent.com/assets/319055/11869966/9f981110-a4bb-11e5-86f7-4736e3458bba.png">