### PR TITLE
Reduce the number of Whitehall publishing api retries...

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -11,7 +11,7 @@ class PublishingApiWorker < WorkerBase
 
       begin
         send_item(payload, locale)
-      rescue => e
+      rescue GdsApi::HTTPErrorResponse => e
         handle_error(e)
       end
 


### PR DESCRIPTION
https://trello.com/c/ksvShgYu/463-from-2nd-line-investigate-cause-of-race-condition-errors-when-bulk-publishing-worldwide-organisations-from-whitehall

Certain requests to the publishing api fail validation and are then
retried needlessly, this creates noise in monitoring tools. So this change
conditionally reports errors via Airbrake based on the response code.

\cc @jamiecobbett 