### PR TITLE
History of Lancaster House email contact address

### DIFF
--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -55,7 +55,7 @@
         <span>The Senior Event Manager</span>
         <p class="tel">Tel: 020 7008 2711</p>
         <p class="tel">Fax: 020 7008 8206</p>
-        <p class="email"><a href="mailto:fcoevents@cvg.gov.uk">fcoevents@cvg.gov.uk</a> </p>
+        <p class="email"><a href="mailto:lancasterhouse.enquiries@fco.gov.uk">lancasterhouse.enquiries@fco.gov.uk</a> </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
FCO have requested a change to the History of Lancaster House page:

* https://www.gov.uk/government/history/lancaster-house

The events contact email address is changing from:

* fcoevents@cvg.gov.uk

to:

* lancasterhouse.enquiries@fco.gov.uk
