### PR TITLE
Add length validations to Edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -37,9 +37,9 @@ class Edition < ActiveRecord::Base
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
 
   validates :creator, presence: true
-  validates :title, presence: true, if: :title_required?
-  validates :body, presence: true, if: :body_required?
-  validates :summary, presence: true, if: :summary_required?
+  validates :title, presence: true, if: :title_required?, length: 255
+  validates :body, presence: true, if: :body_required?, length: 16777215
+  validates :summary, presence: true, if: :summary_required?, length: 65535
   validates :first_published_at, recent_date: true, allow_blank: true
   validate :need_ids_are_six_digit_integers?
 


### PR DESCRIPTION
It's better to show the user a validation error than a 5xx page if they've
written too much into a text field.

Real example of a user encountering this for the `title` attribute:
https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56823d676578630684b42b00

Relevant lines from the schema:
https://github.com/alphagov/whitehall/blob/a569ce2102cdc9db82b258282f9d9ab736dbd29f/db/schema.rb#L358-L360