### PR TITLE
Add rake task to update attachment

### DIFF
--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -9,4 +9,13 @@ namespace :development do
     FileUtils.rm_r(Whitehall.incoming_uploads_root + '/system') if File.exists?(Whitehall.incoming_uploads_root + '/system')
     puts "#{file_paths.size} files/folders moved to clean-uploads"
   end
+
+  task :change_attachment, [:attachment_id, :path_to_file] => :environment do |_task, args|
+    puts "reading file"
+    file = File.open(args[:path_to_file], "rb")
+    attachment_data = AttachmentData.create(file: file)
+    puts "uploading attachment"
+    Attachment.find("#{args[:attachment_id]}").update_attribute(:attachment_data_id, attachment_data.id)
+    puts "file attached successfully"
+  end
 end


### PR DESCRIPTION
Large attachments cannot be added through the UI as there is a timeout. This rake task allows to manually update files for an attachment, which means devs can upload files that are around 100MB.

cc @boffbowsh 