### PR TITLE
Upgrade Ruby to 2.2.3

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,3 +1,1 @@
-2.1.7
-# DO NOT UPGRADE past 2.1.X until we resolve the following in Govspeak:
-# https://github.com/alphagov/whitehall/pull/2234
+2.2.3

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'plek', '1.10.0'
 gem 'isbn_validation'
 gem 'gds-sso', '~> 11.0'
 gem 'rummageable', '1.2.0'
-gem 'addressable'
+gem 'addressable', ">= 2.3.7"
 gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
@@ -60,7 +60,7 @@ end
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '~> 3.5.0'
+  gem 'govspeak', '~> 3.5.1'
 end
 
 if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.7)
+    addressable (2.3.8)
     afm (0.2.0)
     airbrake (4.1.0)
       builder
@@ -157,7 +157,8 @@ GEM
     globalize (5.0.1)
       activemodel (>= 4.2.0, < 4.3)
       activerecord (>= 4.2.0, < 4.3)
-    govspeak (3.5.0)
+    govspeak (3.5.1)
+      addressable (~> 2.3.8)
       htmlentities (~> 4)
       kramdown (~> 1.5.0)
       nokogiri (~> 1.5)
@@ -442,7 +443,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  addressable
+  addressable (>= 2.3.7)
   airbrake (= 4.1.0)
   babosa (= 1.0.2)
   better_errors
@@ -462,7 +463,7 @@ DEPENDENCIES
   gds-api-adapters (= 26.3.1)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
-  govspeak (~> 3.5.0)
+  govspeak (~> 3.5.1)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint (~> 0.2.0)
   govuk_admin_template (= 3.0.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -294,7 +294,7 @@ module ApplicationHelper
   end
 
   def is_external?(href)
-    if host = URI.parse(href).host
+    if host = Addressable::URI.parse(href).host
       Whitehall.public_host != host
     end
   end

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -6,7 +6,10 @@ class OffsiteLink < ActiveRecord::Base
 
   def url_is_govuk
     begin
-      host = URI.parse(url).host
+      if (uri = Addressable::URI.parse(url))
+        host = uri.host
+      end
+
       split_host = host.split(".") if host
       if !host || split_host[split_host.length - 1] != "uk" || split_host[split_host.length - 2] != "gov"
         errors.add(:base, "Please enter a valid GOV.UK URL, such as https://www.gov.uk/jobsearch")

--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -44,7 +44,7 @@ private
   end
 
   def self.slug_for_sector_tag(tag)
-    URI.unescape(tag.id.match(%r{/([^/]*)\.json})[1])
+    Addressable::URI.unescape(tag.id.match(%r{/([^/]*)\.json})[1])
   end
 
   class DataUnavailable < StandardError; end

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -206,7 +206,7 @@ private
 
   def publish_redirect_item
     redirects = [
-      { path: public_path, destination: URI.parse(redirect_url).path, type: "exact" }
+      { path: public_path, destination: Addressable::URI.parse(redirect_url).path, type: "exact" }
     ]
     Whitehall::PublishingApi.publish_redirect_async(public_path, redirects)
   end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -59,7 +59,7 @@ private
   end
 
   def alternative_path
-    URI.parse(alternative_url).path
+    Addressable::URI.parse(alternative_url).path
   rescue URI::InvalidURIError
     nil
   end

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -57,12 +57,14 @@ private
   end
 
   def alternative_path
-    uri = URI.parse(unpublishing.alternative_url)
-    URI::Generic.build(
-      path: uri.path,
-      query: uri.query,
-      fragment: uri.fragment
-    ).to_s
+    full_uri = Addressable::URI.parse(unpublishing.alternative_url)
+
+    path_uri = Addressable::URI.new
+    path_uri.path = full_uri.path
+    path_uri.query = full_uri.query
+    path_uri.fragment = full_uri.fragment
+
+    path_uri.to_s
   end
 
   def details

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -1,5 +1,3 @@
-require 'uri'
-
 Given(/^govuk delivery exists$/) do
   mock_govuk_delivery_client
 end

--- a/features/support/assertions.rb
+++ b/features/support/assertions.rb
@@ -1,6 +1,12 @@
 module Assertions
   def assert_current_url(url, message = nil)
-    assert_equal URI.split(url)[3..-1], URI.split(current_url)[3..-1], message
+    uri = Addressable::URI.parse(url)
+    current_uri = Addressable::URI.parse(current_url)
+
+    assert_equal uri.port, current_uri.port, message
+    assert_equal uri.path, current_uri.path, message
+    assert_equal uri.query, current_uri.query, message
+    assert_equal uri.fragment, current_uri.fragment, message
   end
 
   def assert_path(path)

--- a/lib/links_checker.rb
+++ b/lib/links_checker.rb
@@ -36,7 +36,7 @@ class LinksChecker
 private
 
   def options_for_link(link)
-    host = URI.parse(link).host
+    host = Addressable::URI.parse(link).host
 
     if userpwd_for(host)
       default_options.merge(userpwd: userpwd_for(host))

--- a/lib/long_life_redirect.rb
+++ b/lib/long_life_redirect.rb
@@ -17,7 +17,7 @@ class LongLifeRedirect
     params = req.path_parameters
     path_and_filename = [params[:path], params[:extension]].join(".")
 
-    uri = URI.parse(@root_path + path_and_filename)
+    uri = Addressable::URI.parse(@root_path + path_and_filename)
     uri.scheme ||= req.scheme
     uri.host   ||= req.host
     uri.port   ||= req.port unless req.standard_port?

--- a/lib/tasks/describe_filters.rake
+++ b/lib/tasks/describe_filters.rake
@@ -1,7 +1,5 @@
-
 desc "Takes a file containing a list of filter page urls and outputs the descriptions of the filter options"
 task :describe_filters, [:topic_list_csv] => :environment do |t, args|
-  require 'uri'
   require 'rack'
   require 'json'
 
@@ -13,7 +11,7 @@ task :describe_filters, [:topic_list_csv] => :environment do |t, args|
   end
 
   def parse_params(line)
-    uri = URI.parse(line.gsub(';', "%#{';'.ord.to_s(16).upcase}"))
+    uri = Addressable::URI.parse(line.gsub(';', "%#{';'.ord.to_s(16).upcase}"))
 
     params = HashWithIndifferentAccess.new(Rack::Utils.parse_nested_query(uri.query))
     params['topics'] = params['topics'].map {|t| t.split(";")}.flatten
@@ -49,5 +47,4 @@ task :describe_filters, [:topic_list_csv] => :environment do |t, args|
     params = parse_params(line)
     puts describe(params).reverse_merge(url: line.strip).to_json
   end
-
 end

--- a/lib/tasks/detailed_guides.rake
+++ b/lib/tasks/detailed_guides.rake
@@ -123,7 +123,7 @@ namespace :detailed_guides do
         paths = unpublishing.edition.translated_locales.map do |locale|
           "/#{slug}.#{locale}".chomp(".en")
         end
-        alternative_path = URI.parse(unpublishing.alternative_url).path
+        alternative_path = Addressable::URI.parse(unpublishing.alternative_url).path
         puts "Redirecting #{paths.join(", ")} to #{alternative_path}"
         redirects = Hash[paths.map { |path| [path, alternative_path] }]
         publish_redirects(slug, redirects)

--- a/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
+++ b/lib/whitehall/gov_uk_delivery/feed_url_validator.rb
@@ -1,5 +1,4 @@
 require 'whitehall/document_filter/options'
-require 'uri'
 require 'cgi'
 
 module Whitehall
@@ -81,7 +80,7 @@ module Whitehall
 
       def uri
         @uri ||= begin
-          URI.parse(feed_url)
+          Addressable::URI.parse(feed_url)
         rescue URI::InvalidURIError
           nil
         end

--- a/test/integration/document_locale_param_canonicalisation_test.rb
+++ b/test/integration/document_locale_param_canonicalisation_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
-require 'uri'
 
 class DocumentLocaleParamCanonicalisationTest < ActionDispatch::IntegrationTest
   # we need this because locale param might be stripped by our path
   # helpers and routing, need to test what happens if it is actually
   # there
   def with_locale_param(path, locale)
-    u = URI.parse(path)
+    u = Addressable::URI.parse(path)
     u.query = "locale=#{locale}"
     u.to_s
   end

--- a/test/unit/helpers/filter_helper_test.rb
+++ b/test/unit/helpers/filter_helper_test.rb
@@ -82,7 +82,7 @@ class FilterHelperTest::FilterDescriptionTest < ActionView::TestCase
     assert link.present?, "No link with data-field=\"#{field}\""
     assert_equal expected_value, link[:"data-value"]
     assert_equal "Remove #{expected_text}", link[:title]
-    assert_equal expected_query_params, Rack::Utils.parse_nested_query(URI.parse(link[:href]).query).symbolize_keys
+    assert_equal expected_query_params, Rack::Utils.parse_nested_query(Addressable::URI.parse(link[:href]).query).symbolize_keys
   end
 
   test "It renders links to remove search parameters" do

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -77,7 +77,7 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     Whitehall.stubs(public_host: 'some.host')
     Whitehall.stubs(public_protocol: 'http')
     edition = create(:published_publication)
-    uri = URI.parse(public_document_url(edition))
+    uri = Addressable::URI.parse(public_document_url(edition))
     assert_equal 'some.host', uri.host
     assert_equal 'http', uri.scheme
     assert_equal public_document_path(edition), uri.path

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class OffsiteLinkTest < ActiveSupport::TestCase
-
   test 'should be invalid without a title' do
     offsite_link = build(:offsite_link, title: nil)
     refute offsite_link.valid?

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -155,7 +155,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
   test '#as_json returns a redirect representation for Unpublishings that are set to auto-redirect' do
     unpublishing     = create(:redirect_unpublishing)
     public_path      = unpublishing.document_path
-    alternative_path = URI.parse(unpublishing.alternative_url).path
+    alternative_path = Addressable::URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
       content_id: unpublishing.content_id,
       base_path: public_path,
@@ -177,7 +177,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
     alternative_path = '/government/some/page'
     unpublishing     = create(:consolidated_unpublishing)
     public_path      = unpublishing.document_path
-    alternative_path = URI.parse(unpublishing.alternative_url).path
+    alternative_path = Addressable::URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
       content_id: unpublishing.content_id,
       base_path: public_path,


### PR DESCRIPTION
The issue with Govspeak which prevented this upgrade
were fixed in version 3.5.1 according to this
comment: https://github.com/alphagov/govspeak/issues/57#issuecomment-158916181