### PR TITLE
Split school funding accountability policy in two

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -1,6 +1,16 @@
 module Edition::RelatedPolicies
   extend ActiveSupport::Concern
 
+  def delete_policy(content_id)
+    edition_policies.where(policy_content_id: content_id).delete_all
+  end
+
+  def add_policy(content_id)
+    unless policy_content_ids.include?(content_id)
+      edition_policies.create!(policy_content_id: content_id)
+    end
+  end
+
   class Trait < Edition::Traits::Trait
     def process_associations_after_save(edition)
       edition.policy_content_ids = @edition.policy_content_ids

--- a/lib/data_hygiene/policy_tagger.rb
+++ b/lib/data_hygiene/policy_tagger.rb
@@ -1,0 +1,81 @@
+class PolicyTagger
+  def self.process_from_csv(csv_location, logger: Logger.new(nil))
+    CSV.foreach(csv_location, headers: true) do |row|
+      new(
+        slug:               row.fetch("slug"),
+        policies_to_remove: sanitised_policies(row.fetch("policies_to_remove")),
+        policies_to_add:    sanitised_policies(row.fetch("policies_to_add")),
+        logger:             logger,
+      ).process
+    end
+  end
+
+  def initialize(slug:,
+                 policies_to_remove:,
+                 policies_to_add:,
+                 logger: Logger.new(nil)
+                )
+    @slug = slug
+    @policies_to_remove = policies_to_remove
+    @policies_to_add = policies_to_add
+    @logger = logger
+  end
+
+  def process
+    unless document
+      log "warning: failed to find #{@document_type} document with slug" +
+        " #{@document_slug} - skipping"
+      return
+    end
+
+    document.editions.each do |edition|
+      @policies_to_remove.each do |id|
+        edition.delete_policy(id)
+        log "Policy removed: #{id}"
+      end
+
+      @policies_to_add.each do |id|
+        edition.add_policy(id)
+        log "Policy added: #{id}"
+      end
+    end
+
+    if document.published_edition.present?
+      register_edition(document.published_edition)
+    end
+  end
+
+private
+
+  private_class_method def self.sanitised_policies(policies)
+    policies ? policies.split : []
+  end
+
+  def document
+    @document ||= Document.where(slug: @slug).last
+  end
+
+  def register_edition(edition)
+    log "registering '#{edition.slug}' #{document.document_type}"
+    edition.reload
+    register_with_panopticon(edition)
+    register_with_publishing_api(edition)
+    register_with_search(edition)
+  end
+
+  def register_with_panopticon(edition)
+    ServiceListeners::PanopticonRegistrar.new(edition).register!
+  end
+
+  def register_with_publishing_api(edition)
+    Whitehall::PublishingApi.republish_async(edition)
+  end
+
+  def register_with_search(edition)
+    ServiceListeners::SearchIndexer.new(edition).index!
+  end
+
+  def log(message)
+    @logger.info message
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -108,6 +108,20 @@ task process_topic_tagging_csv: :environment do
   SpecialistSectorTagger.process_from_csv(csv_location, logger: Logger.new(STDOUT))
 end
 
+desc "Process CSV for policy tagging"
+task process_policy_tagging_csv: :environment do
+  require "data_hygiene/policy_tagger"
+
+  csv_location = ENV['CSV_LOCATION']
+
+  unless csv_location
+    $stderr.puts "No CSV path specified: please pass CSV_LOCATION"
+    exit 1
+  end
+
+  PolicyTagger.process_from_csv(csv_location, logger: Logger.new(STDOUT))
+end
+
 desc "Unwithdraw an edition (creates and publishes a draft with audit trail)"
 task :unwithdraw_edition, [:edition_id] => :environment do |t,args|
   DataHygiene::EditionUnwithdrawer.new(args[:edition_id], Logger.new(STDOUT)).unwithdraw!

--- a/test/integration/data_hygiene/policy_tagger_integration_test.rb
+++ b/test/integration/data_hygiene/policy_tagger_integration_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+require 'data_hygiene/policy_tagger'
+require 'gds_api/panopticon'
+require 'gds_api/test_helpers/panopticon'
+
+class PolicyTaggerTest < ActiveSupport::TestCase
+  include DataHygiene
+  include GdsApi::TestHelpers::Panopticon
+
+  setup do
+    @csv_file = Tempfile.new('policy_changes')
+    @content_id_1 = SecureRandom.uuid
+    @content_id_2 = SecureRandom.uuid
+    @content_id_3 = SecureRandom.uuid
+
+    @edition = create(:news_article, policy_content_ids: [@content_id_1])
+    @document = @edition.document
+
+    stub_registration
+  end
+
+  def tear_down
+    @csv_file.unlink
+  end
+
+  test "#process - processes the csv file" do
+    @csv_file.write("policies_to_remove,policies_to_add,slug\n")
+    @csv_file.write("#{@content_id_1},#{@content_id_2} #{@content_id_3},#{@document.slug}")
+    @csv_file.rewind
+
+    assert_equal [@content_id_1], @edition.reload.policy_content_ids
+
+    PolicyTagger.process_from_csv(@csv_file.path)
+
+    assert_equal [@content_id_2, @content_id_3], @edition.reload.policy_content_ids
+
+    tear_down
+  end
+
+  def stub_registration
+    Whitehall::PublishingApi.stubs(:republish_async)
+    ServiceListeners::SearchIndexer.any_instance.stubs(:index!)
+    ServiceListeners::PanopticonRegistrar.any_instance.stubs(:register!)
+  end
+end

--- a/test/unit/data_hygiene/policy_tagger_test.rb
+++ b/test/unit/data_hygiene/policy_tagger_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+require "data_hygiene/policy_tagger"
+
+class PolicyTaggerTest < ActiveSupport::TestCase
+  setup do
+    @content_id_1 = SecureRandom.uuid
+    @content_id_2 = SecureRandom.uuid
+
+    @my_document = create(:document)
+    @published_edition = create(:published_detailed_guide, document: @my_document)
+    @draft_edition = create(:draft_detailed_guide, document: @my_document)
+
+    stub_registration
+  end
+
+  test "updates policies for all editions of the document" do
+    assert_equal [], @published_edition.reload.policy_content_ids
+    assert_equal [], @draft_edition.reload.policy_content_ids
+
+    policies_to_add = [@content_id_1, @content_id_2]
+    PolicyTagger.new(
+      slug:               @my_document.slug,
+      policies_to_remove: [],
+      policies_to_add:    policies_to_add,
+    ).process
+
+    assert_equal [@content_id_1, @content_id_2], @published_edition.reload.policy_content_ids
+    assert_equal [@content_id_1, @content_id_2], @draft_edition.reload.policy_content_ids
+
+    policies_to_remove = [@content_id_1, @content_id_2]
+    PolicyTagger.new(
+      slug:               @my_document.slug,
+      policies_to_remove: policies_to_remove,
+      policies_to_add:    [],
+    ).process
+
+    assert_equal [], @published_edition.reload.policy_content_ids
+    assert_equal [], @draft_edition.reload.policy_content_ids
+  end
+
+  test "logs a warning and returns if a document cannot be found" do
+    log_output = StringIO.new("")
+    assert_nothing_raised do
+      PolicyTagger.new(
+        slug: "foo",
+        policies_to_remove: [],
+        policies_to_add: [],
+        logger: Logger.new(log_output)
+      ).process
+    end
+
+    assert_match /warning/, log_output.string
+  end
+
+  test "re-registers the published edition" do
+    Whitehall::PublishingApi.expects(:republish_async).with(@published_edition)
+    ServiceListeners::SearchIndexer.expects(:new).with(@published_edition)
+      .returns(mock(index!: true))
+    ServiceListeners::PanopticonRegistrar.expects(:new).with(@published_edition)
+      .returns(mock(register!: true))
+
+    policies_to_add = [@content_id_1, @content_id_2]
+    PolicyTagger.new(
+      slug:               @my_document.slug,
+      policies_to_remove: [],
+      policies_to_add:    policies_to_add,
+    ).process
+  end
+
+  test "registers nothing if there are no published editions" do
+    @published_edition.destroy
+    Whitehall::PublishingApi.expects(:republish_async).never
+    ServiceListeners::SearchIndexer.expects(:new).never
+    ServiceListeners::PanopticonRegistrar.expects(:new).never
+
+    PolicyTagger.new(slug: @my_document.slug, policies_to_remove: [], policies_to_add: []).process
+  end
+
+  def stub_registration
+    Whitehall::PublishingApi.stubs(:republish_async)
+    ServiceListeners::SearchIndexer.any_instance.stubs(:index!)
+    ServiceListeners::PanopticonRegistrar.any_instance.stubs(:register!)
+  end
+end

--- a/test/unit/edition/related_policies_test.rb
+++ b/test/unit/edition/related_policies_test.rb
@@ -86,4 +86,51 @@ class Edition::RelatedPoliciesTest < ActiveSupport::TestCase
     assert_equal 1, edition.policies.size
     assert_equal policy.title, edition.policies[0].title
   end
+
+  [:news_article,
+   :document_collection,
+   :consultation,
+   :publication,
+   :detailed_guide,
+   :speech,
+  ].each do |document_with_policies|
+    test "can add a policy by content id to a #{document_with_policies}" do
+      content_id_1 = SecureRandom.uuid
+      content_id_2 = SecureRandom.uuid
+
+      edition = create(document_with_policies, policy_content_ids: [content_id_1])
+
+      assert_equal [content_id_1], edition.policy_content_ids
+
+      edition.add_policy(content_id_2)
+
+      assert_equal [content_id_1, content_id_2], edition.reload.policy_content_ids
+    end
+
+    test "can remove a policy by content id to a #{document_with_policies}" do
+      content_id_1 = SecureRandom.uuid
+      content_id_2 = SecureRandom.uuid
+      edition = create(document_with_policies, policy_content_ids: [content_id_1, content_id_2])
+
+      assert_equal [content_id_1, content_id_2], edition.policy_content_ids
+
+      edition.delete_policy(content_id_2)
+
+      assert_equal [content_id_1], edition.reload.policy_content_ids
+    end
+  end
+
+  test "does not add a policy twice" do
+    content_id_1 = SecureRandom.uuid
+    content_id_2 = SecureRandom.uuid
+
+    edition = create(:speech, policy_content_ids: [content_id_1])
+
+    assert_equal [content_id_1], edition.policy_content_ids
+
+    edition.add_policy(content_id_2)
+    edition.add_policy(content_id_2)
+
+    assert_equal [content_id_1, content_id_2], edition.reload.policy_content_ids
+  end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -105,7 +105,7 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 'My new version', version_3.most_recent_change_note
   end
 
-    test "can find editions due for publication" do
+  test "can find editions due for publication" do
     due_in_one_day = create(:edition, :scheduled, scheduled_publication: 1.day.from_now)
     due_in_two_days = create(:edition, :scheduled, scheduled_publication: 2.days.from_now)
     already_published = create(:edition, :published, scheduled_publication: 1.day.from_now)


### PR DESCRIPTION
## Why:
A policy has a too wide scope and requires to be split into two. We will need to untag editions from the old policy and tag it to the new ones accordingly to the owning department specifications.

## What:
"School and college funding and accountability" will be split into:
- School and college accountability
- School and college funding

## How:
- Adding the functionality to Editions to have policies added and removed
- Adding a rake task to update Editions' policies
- A CSV will be used to specify to which policy the editions should be retagged to. How it will look like:

CSV header: `policies_to_remove,policies_to_add,slug`
Where:
- `policies_to_remove`: space delimited list of content ids
- `policies_to_add`: space delimited list of content ids
- `slug`: the slug of the document you want to update

Examples:
Case where edition should only be untagged by old policy and not tagged to any other:
`old-edition-content-id,,edition-slug`
Case where edition should be untagged and tagged to 2 new policies:
`old-edition-content-id,new-edition-content-id-1 new-edition-content-id-2,edition-slug`


https://trello.com/c/5re0DXMD/288-split-dfe-policy