### PR TITLE
Republish documents with no content item

### DIFF
--- a/db/data_migration/20160108173056_republish_docs_with_no_content_item.rb
+++ b/db/data_migration/20160108173056_republish_docs_with_no_content_item.rb
@@ -1,0 +1,17 @@
+dodgy_slugs = %w{
+  progress-check-at-age-2-and-eyfs-profile
+  2-year-old-early-education-entitlement-local-authority-guide
+  a-year-until-first-working-parents-receive-doubled-free-childcare
+  early-years-pupil-premium-guide-for-local-authorities
+  local-authority-moderation-of-the-eyfs-profile
+  key-stage-2-tests-how-to-apply-for-special-consideration
+  pshe-and-sre-in-schools-government-response
+  gcse-results-show-surge-in-pupils-taking-valuable-stem-subjects
+  phonics-screening-check-how-to-administer-the-check
+}
+
+dodgy_slugs.each do |slug|
+  puts "Republishing #{slug}"
+  Whitehall::PublishingApi.republish_async(Document.where(slug: slug).first.published_edition)
+end
+


### PR DESCRIPTION
Finding Things is currently working on tagging content with taxonomy
data. Several Whitehall documents have no content item in the content
store. This data migration republishes those documents so that they can be
updated with links to their respective taxons.