### PR TITLE
Use the v2 API for publishing special routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '26.3.1'
+gem 'gds-api-adapters', '26.7.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.3.1)
+    gds-api-adapters (26.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -459,7 +459,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.3.1)
+  gds-api-adapters (= 26.7.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.0)


### PR DESCRIPTION
gds-api-adapters has been updated to use v2 inside the SpecialRoutePublisher.