### PR TITLE
Add task for untagging from given policy

### DIFF
--- a/lib/data_hygiene/policy_tagger.rb
+++ b/lib/data_hygiene/policy_tagger.rb
@@ -1,3 +1,11 @@
+# PolicyTagger is expecting to be fed a csv with the following header:
+# policies_to_remove,policies_to_add,slug
+#
+# Where:
+# - policies_to_remove: space delimited list of content ids
+# - policies_to_add: space delimited list of content ids
+# - slug: the slug of the document you want to update
+
 class PolicyTagger
   def self.process_from_csv(csv_location, logger: Logger.new(nil))
     CSV.foreach(csv_location, headers: true) do |row|

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -122,6 +122,21 @@ task process_policy_tagging_csv: :environment do
   PolicyTagger.process_from_csv(csv_location, logger: Logger.new(STDOUT))
 end
 
+desc "Untag all editions from a policy"
+task untag_editions_from_policy: :environment do
+  policy_content_id = ENV['POLICY_CONTENT_ID']
+
+  unless policy_content_id
+    $stderr.puts "No policy content id specified: please pass POLICY_CONTENT_ID"
+    exit 1
+  end
+
+  edition_policies = EditionPolicy.where(policy_content_id: policy_content_id)
+  puts "Deleting #{edition_policies.count} edition policies."
+  edition_policies.delete_all
+  puts "Complete."
+end
+
 desc "Unwithdraw an edition (creates and publishes a draft with audit trail)"
 task :unwithdraw_edition, [:edition_id] => :environment do |t,args|
   DataHygiene::EditionUnwithdrawer.new(args[:edition_id], Logger.new(STDOUT)).unwithdraw!


### PR DESCRIPTION
This work adds a rake task for untag all documents from a given policy.

Necessary to untag all documents from School and college funding and accountability [policy](https://www.gov.uk/government/policies/school-and-college-funding-and-accountability).

Ticket: https://trello.com/c/5re0DXMD/288-split-dfe-policy
Prior work: https://github.com/alphagov/whitehall/pull/2423
