### PR TITLE
Publish TakePart items to the Publishing API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '26.7.0'
+  gem 'gds-api-adapters', '27.0.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'
 gem 'govuk_admin_template', '3.0.0'
 gem 'bootstrap-kaminari-views', '0.0.5'
-gem 'gds-api-adapters', '26.7.0'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '0.9.4', require: false
 gem 'mini_magick'
@@ -50,6 +49,12 @@ gem 'responders', '~> 2.0'
 gem 'sidekiq-statsd', '0.1.5'
 
 gem 'deprecated_columns', '0.1.0'
+
+if ENV['GDS_API_ADAPTERS_DEV']
+  gem 'gds-api-adapters', path: '../gds-api-adapters'
+else
+  gem 'gds-api-adapters', '26.7.0'
+end
 
 if ENV['GLOBALIZE_DEV']
   gem 'globalize', path: '../globalize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (26.7.0)
+    gds-api-adapters (27.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -460,7 +460,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 26.7.0)
+  gds-api-adapters (= 27.0.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.1)

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -24,6 +24,8 @@ class TakePartPage < ActiveRecord::Base
              description: :summary,
              format: 'take_part'
 
+  include PublishesToPublishingApi
+
   def search_link
     Whitehall.url_maker.take_part_page_path(self.slug)
   end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -18,6 +18,8 @@ private
       PublishingApiPresenters::Unpublishing
     when PolicyGroup
       PublishingApiPresenters::WorkingGroup
+    when TakePartPage
+      PublishingApiPresenters::TakePart
     else
       PublishingApiPresenters::Placeholder
     end

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -1,0 +1,52 @@
+module PublishingApiPresenters
+  class TakePart
+    attr_reader :take_part_page, :update_type
+
+    def initialize(take_part_page, options = {})
+      @take_part_page = take_part_page
+      @update_type = options[:update_type] || 'major'
+    end
+
+    def base_path
+      take_part_page.search_link
+    end
+
+    def public_updated_at
+      take_part_page.updated_at
+    end
+
+    def as_json
+      {
+        base_path: base_path,
+        content_id: take_part_page.content_id,
+        title: take_part_page.title,
+        description: take_part_page.summary,
+        format: "take_part",
+        locale: I18n.locale.to_s,
+        public_updated_at: public_updated_at,
+        update_type: update_type,
+        publishing_app: "whitehall",
+        rendering_app: "whitehall-frontend",
+        routes: [{ path: base_path, type: "exact" }],
+        redirects: [],
+        details: details
+      }
+    end
+
+  private
+
+    def details
+      {
+        body: body,
+        image: {
+          url: Whitehall.asset_root + take_part_page.image_url(:s300),
+          alt_text: take_part_page.image_alt_text,
+        }
+      }
+    end
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(take_part_page.body)
+    end
+  end
+end

--- a/db/migrate/20160111120144_add_content_id_to_take_part_pages.rb
+++ b/db/migrate/20160111120144_add_content_id_to_take_part_pages.rb
@@ -1,0 +1,5 @@
+class AddContentIdToTakePartPages < ActiveRecord::Migration
+  def change
+    add_column :take_part_pages, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111101103) do
+ActiveRecord::Schema.define(version: 20160111120144) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1091,6 +1091,7 @@ ActiveRecord::Schema.define(version: 20151111101103) do
     t.integer  "ordering",          limit: 4,        null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_id",        limit: 255
   end
 
   add_index "take_part_pages", ["ordering"], name: "index_take_part_pages_on_ordering", using: :btree

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -145,11 +145,11 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
       body: "translated-body",
     }
 
-    assert_publishing_api_put_content(edition.content_id, {
+    assert_publishing_api_put_content(edition.content_id, request_json_includes({
       title: "translated-title",
       description: "translated-summary",
       locale: "fr",
-    })
+    }))
   end
 
   test "should limit access to translations of editions that aren't accessible to the current user" do

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -18,7 +18,8 @@ class SchedulingTest < ActiveSupport::TestCase
 
     path = Whitehall.url_maker.public_document_path(@submitted_edition)
     schedule(@submitted_edition)
-    assert_publishing_api_put_content(coming_soon_uuid, format: 'coming_soon')
+    assert_publishing_api_put_content(coming_soon_uuid,
+                                      request_json_includes(format: 'coming_soon'))
     assert_publishing_api_put_intent(path, publish_time: @submitted_edition.scheduled_publication.as_json)
   end
 
@@ -66,7 +67,7 @@ class SchedulingTest < ActiveSupport::TestCase
     unscheduler.perform!
 
     assert_requested destroy_intent_request
-    assert_publishing_api_put_content(gone_uuid, format: 'gone')
+    assert_publishing_api_put_content(gone_uuid, request_json_includes(format: 'gone'))
   end
 
   test "unscheduling a scheduled subsequent edition removes the publish intent but doesn't publish a 'gone' item" do

--- a/test/integration/take_part_page_test.rb
+++ b/test/integration/take_part_page_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+require "gds_api/test_helpers/panopticon"
+
+class TakePartPageTest < ActiveSupport::TestCase
+  #api calls happen in after commit so we need to disable transactions
+  self.use_transactional_fixtures = false
+
+  setup do
+    DatabaseCleaner.clean_with :truncation
+    stub_any_publishing_api_call
+    @take_part_page = build(:take_part_page)
+  end
+
+  test "TakePartPage is published to the Publishing API on save" do
+    presenter = PublishingApiPresenters.presenter_for(@take_part_page)
+    @take_part_page.save!
+
+    expected_json = presenter.as_json.merge(
+      # This is to simulate what the time public timestamp will be after the
+      # page has been published
+      public_updated_at: Time.zone.now.as_json
+    )
+
+    assert_publishing_api_put_content(@take_part_page.content_id, expected_json)
+    assert_publishing_api_publish(@take_part_page.content_id, { update_type: 'major',
+                                                               locale: 'en' }, 1)
+  end
+
+  test "TakePartPage is published gone  to the Publishing API on destroy" do
+    @take_part_page.save!
+
+    new_content_id = SecureRandom.uuid
+    SecureRandom.stubs(uuid: new_content_id)
+
+    presenter = PublishingApiPresenters::Gone.new(@take_part_page.search_link)
+    expected_json = presenter.as_json
+
+    @take_part_page.destroy
+    assert_publishing_api_put_content(new_content_id, expected_json)
+  end
+
+  test "TakePartPage is published to the Publishing API when updated" do
+    @take_part_page.save!
+    @take_part_page.attributes = {title: "New Title"}
+    @take_part_page.save!
+    presenter = PublishingApiPresenters.presenter_for(@take_part_page)
+
+    expected_json = presenter.as_json.merge(
+      # This is to simulate what the time public timestamp will be after the
+      # page has been published
+      public_updated_at: Time.zone.now.as_json
+    )
+
+    assert_publishing_api_put_content(@take_part_page.content_id, expected_json)
+    assert_publishing_api_publish(@take_part_page.content_id, { update_type: 'major',
+                                                               locale: 'en' }, 2)
+  end
+end

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -38,7 +38,8 @@ class UnpublishingTest < ActiveSupport::TestCase
     path = Whitehall.url_maker.public_document_path(@published_edition)
     stub_panopticon_registration(@published_edition)
     unpublish(@published_edition, unpublishing_params)
-    assert_publishing_api_put_content(@published_edition.unpublishing.content_id, format: 'unpublishing')
+    assert_publishing_api_put_content(@published_edition.unpublishing.content_id,
+                                      request_json_includes(format: 'unpublishing'))
   end
 
   test 'When a case study is unpublished, a job is queued to republish the draft to the draft stack' do
@@ -67,9 +68,13 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublish(@published_edition, unpublishing_params)
 
-    assert_publishing_api_put_content(@published_edition.unpublishing.content_id, { format: 'unpublishing' }, 2)
-    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "locale" => "en", "update_type" => "major" })
-    assert_publishing_api_publish(@published_edition.unpublishing.content_id, { "locale" => "fr", "update_type" => "major" })
+    assert_publishing_api_put_content(@published_edition.unpublishing.content_id,
+                                      request_json_includes({ format: 'unpublishing' }),
+                                      2)
+    assert_publishing_api_publish(@published_edition.unpublishing.content_id,
+                                  { locale: "en", update_type: "major" })
+    assert_publishing_api_publish(@published_edition.unpublishing.content_id,
+                                  { locale: "fr", update_type: "major" })
   end
 
   test 'when a translated edition is unpublished as a redirect, redirects are published to the Publishing API for each translation' do
@@ -89,9 +94,11 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublish(@published_edition, unpublishing_redirect_params)
 
-    assert_publishing_api_put_content(redirect_uuid, { format: 'redirect' }, 2)
-    assert_publishing_api_publish(redirect_uuid, { "locale" => "en", "update_type" => "major" })
-    assert_publishing_api_publish(redirect_uuid, { "locale" => "fr", "update_type" => "major" })
+    assert_publishing_api_put_content(redirect_uuid,
+                                      request_json_includes({ format: 'redirect' }),
+                                      2)
+    assert_publishing_api_publish(redirect_uuid, { locale: "en", update_type: "major" })
+    assert_publishing_api_publish(redirect_uuid, { locale: "fr", update_type: "major" })
   end
 
 private

--- a/test/unit/presenters/publishing_api_presenters/take_part_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/take_part_test.rb
@@ -5,8 +5,7 @@ class PublishingApiPresenters::TakePartTest < ActiveSupport::TestCase
     PublishingApiPresenters::TakePart.new(record).as_json
   end
 
-  test "case study presentation includes the correct values" do
-    # TODO move setting content_id to model
+  test "take part presentation includes the correct values" do
     take_part_page = create(:take_part_page, content_id: SecureRandom.uuid)
 
     image_url = Whitehall.asset_root + take_part_page.image_url(:s300)
@@ -37,9 +36,6 @@ class PublishingApiPresenters::TakePartTest < ActiveSupport::TestCase
     presented_hash = present(take_part_page)
 
     assert_valid_against_schema(presented_hash, 'take_part')
-
-    assert_equal expected_hash.except(:details),
-      presented_hash.except(:details)
 
     # We test for HTML equivalance rather than string equality to get around
     # inconsistencies with line breaks between different XML libraries

--- a/test/unit/presenters/publishing_api_presenters/take_part_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/take_part_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class PublishingApiPresenters::TakePartTest < ActiveSupport::TestCase
+  def present(record)
+    PublishingApiPresenters::TakePart.new(record).as_json
+  end
+
+  test "case study presentation includes the correct values" do
+    # TODO move setting content_id to model
+    take_part_page = create(:take_part_page, content_id: SecureRandom.uuid)
+
+    image_url = Whitehall.asset_root + take_part_page.image_url(:s300)
+
+    expected_hash = {
+      base_path: take_part_page.search_link,
+      content_id: take_part_page.content_id,
+      title: 'A take part page title',
+      description: 'Summary text',
+      format: 'take_part',
+      locale: 'en',
+      public_updated_at: take_part_page.updated_at,
+      update_type: 'major',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      routes: [
+        { path: take_part_page.search_link, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        body: "<div class=\"govspeak\"><p>Some govspeak body text</p></div>",
+        image: {
+          url: image_url,
+          alt_text: "Image alt text"
+        }
+      }
+    }
+    presented_hash = present(take_part_page)
+
+    assert_valid_against_schema(presented_hash, 'take_part')
+
+    assert_equal expected_hash.except(:details),
+      presented_hash.except(:details)
+
+    # We test for HTML equivalance rather than string equality to get around
+    # inconsistencies with line breaks between different XML libraries
+    assert_equivalent_html expected_hash[:details].delete(:body),
+      presented_hash[:details].delete(:body)
+
+    assert_equal expected_hash[:details], presented_hash[:details]
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -9,6 +9,14 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     assert_equal case_study, presenter.edition
   end
 
+  test ".presenter_for returns a presenter for a Take Part page" do
+    take_part_page = TakePartPage.new
+    presenter = PublishingApiPresenters.presenter_for(take_part_page)
+
+    assert_equal PublishingApiPresenters::TakePart, presenter.class
+    assert_equal take_part_page, presenter.take_part_page
+  end
+
   test ".presenter_for returns an Unpublishing presenter for an Unpublishing" do
     unpublishing = create(:unpublishing)
     presenter = PublishingApiPresenters.presenter_for(unpublishing)


### PR DESCRIPTION
With this PR `TakePartPage` now publishes to the publishing API. This has been implemented in after_commit callbacks which causes some artefacts in the tests but it was done like this after discussion as this will keep the calls to `save`, `update`, `destroy` consistent when the move to solely 'saving' to the Publishing API is made.

This PR depends on [this version](https://github.com/alphagov/gds-api-adapters/pull/416) of `gds_api_adapters` which has some breaking changes.

[trello](https://trello.com/c/jZdFxvgs)