### PR TITLE
Add 'force published' status to document exporter presenter

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -44,7 +44,7 @@ class DocumentListExportPresenter
       edition.updated_at,
       content_type,
       sub_content_type,
-      edition.state,
+      state,
       attachment_types,
       policies,
       specialist_sectors,
@@ -94,6 +94,14 @@ class DocumentListExportPresenter
 
   def supporting_organisations
     edition.supporting_organisations.map(&:name) if edition.respond_to? :supporting_organisations
+  end
+
+  def state
+    if edition.force_published?
+      "force published"
+    else
+      edition.state
+    end
   end
 
   def policies

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -66,4 +66,11 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
     pr = DocumentListExportPresenter.new(news)
     assert_equal [policy_1['title']], pr.policies
   end
+
+  test '#state returns `force published` when a document is force published' do
+    publication = create(:published_publication, force_published: true)
+
+    pub = DocumentListExportPresenter.new(publication)
+    assert_equal "force published", pub.state
+  end
 end


### PR DESCRIPTION
Knowing whether a document has been force published is an important metric that
external departments require.

These changes come through a Zendesk request, ticket number: 1229758.
https://govuk.zendesk.com/agent/tickets/1229758