### PR TITLE
Take part: switch rendering app to 'government-frontend'

### DIFF
--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -26,7 +26,7 @@ module PublishingApiPresenters
         public_updated_at: public_updated_at,
         update_type: update_type,
         publishing_app: "whitehall",
-        rendering_app: "whitehall-frontend",
+        rendering_app: "government-frontend",
         routes: [{ path: base_path, type: "exact" }],
         redirects: [],
         details: details

--- a/test/unit/presenters/publishing_api_presenters/take_part_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/take_part_test.rb
@@ -20,7 +20,7 @@ class PublishingApiPresenters::TakePartTest < ActiveSupport::TestCase
       public_updated_at: take_part_page.updated_at,
       update_type: 'major',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       routes: [
         { path: take_part_page.search_link, type: 'exact' }
       ],


### PR DESCRIPTION
This is the final step of the migration.

Don't merge this until we've done the comparison between the output generated by `whitehall-frontend` and `government-frontend`. After deploying this, a republish of the take part pages is required.

/cc @gpeng