### PR TITLE
Change text colour to sass variable

### DIFF
--- a/app/assets/stylesheets/frontend/views/_how-gov-works.scss
+++ b/app/assets/stylesheets/frontend/views/_how-gov-works.scss
@@ -108,7 +108,7 @@
   .feature-ministers{
     p {
       text-align: center;
-      color: #999;
+      color: $secondary-text-colour;
       @include ig-core-48;
       padding: $gutter-half 0 $gutter;
     }


### PR DESCRIPTION
This PR changes the colour used by the pluses graphic to our SASS variable for secondary text colour.

This improves the contrast from  2.85:1 to 4.56:1. 