### PR TITLE
Extract `HasContentId` from `PublishesToPublishesApi`

### DIFF
--- a/lib/has_content_id.rb
+++ b/lib/has_content_id.rb
@@ -1,0 +1,10 @@
+module HasContentId
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation do
+      self.content_id ||= SecureRandom.uuid
+    end
+    validates :content_id, presence: true
+  end
+end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -1,16 +1,10 @@
 module PublishesToPublishingApi
   extend ActiveSupport::Concern
+  include HasContentId
 
   included do
-    before_validation :generate_content_id, on: :create
-    validates :content_id, presence: true
     after_commit :publish_to_publishing_api, if: :can_publish_to_publishing_api?
     after_commit :publish_gone_to_publishing_api, on: :destroy
-  end
-
-
-  def generate_content_id
-    self.content_id ||= SecureRandom.uuid
   end
 
   def can_publish_to_publishing_api?

--- a/test/unit/models/has_content_id_test.rb
+++ b/test/unit/models/has_content_id_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class HasContentIdTest < ActiveSupport::TestCase
+  class TestObject
+    include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
+    include HasContentId
+
+    attr_accessor :content_id
+  end
+
+  test "it generates a uuid content id" do
+    expected_content_id = SecureRandom.uuid
+    SecureRandom.stubs(uuid: expected_content_id)
+    object = TestObject.new
+
+    object.validate
+
+    assert_equal object.content_id, expected_content_id
+  end
+end


### PR DESCRIPTION
This functionality for generating and validating `content_id` is
required during work prior to actually publishing to the Publishing API.
This makes adding the functionality more convenient and reusable.