### PR TITLE
`PublishingApiWorker` uses `unscoped`

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -2,7 +2,7 @@ class PublishingApiWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
   def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
-    return unless model = class_for(model_name).find_by(id: id)
+    return unless model = class_for(model_name).unscoped.find_by(id: id)
 
     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)
 


### PR DESCRIPTION
When finding the object to push to the PublishingApi
`PublishingApiWorker` now uses `unscoped` to ensure that objects sullied
by `default_scope` are still found and pushed to the API.

An example of this is an unpublished `StatisticsAnnouncement`.