### PR TITLE
Topical event about page publishing

### DIFF
--- a/app/models/about_page.rb
+++ b/app/models/about_page.rb
@@ -1,5 +1,6 @@
 class AboutPage < ActiveRecord::Base
   include Searchable
+  include PublishesToPublishingApi
 
   belongs_to :topical_event
 

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -5,6 +5,7 @@ require 'publishing_api_presenters/placeholder'
 require 'publishing_api_presenters/unpublishing'
 require 'publishing_api_presenters/redirect'
 require 'publishing_api_presenters/policy_area_placeholder'
+require 'publishing_api_presenters/topical_event_about_page'
 
 module PublishingApiPresenters
   def self.presenter_for(model, options={})
@@ -18,6 +19,8 @@ private
       presenter_class_for_edition(model)
     when ::Unpublishing
       PublishingApiPresenters::Unpublishing
+    when AboutPage
+      PublishingApiPresenters::TopicalEventAboutPage
     when PolicyGroup
       PublishingApiPresenters::WorkingGroup
     when TakePartPage

--- a/app/presenters/publishing_api_presenters/topical_event_about_page.rb
+++ b/app/presenters/publishing_api_presenters/topical_event_about_page.rb
@@ -1,0 +1,46 @@
+module PublishingApiPresenters
+  class TopicalEventAboutPage < Item
+    def links
+      {
+        parent: [item.topical_event.content_id]
+      }
+    end
+
+  private
+
+    def document_format
+      "topical_event_about_page"
+    end
+
+    def base_path
+      Whitehall.url_maker.topical_event_about_pages_path(item.topical_event)
+    end
+
+    def details
+      {
+        body: body,
+        read_more: item.read_more_link_text
+      }
+    end
+
+    def title
+      item.name
+    end
+
+    def description
+      item.summary
+    end
+
+    def public_updated_at
+      item.updated_at
+    end
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body)
+    end
+
+    def rendering_app
+      "whitehall"
+    end
+  end
+end

--- a/db/data_migration/20160204110535_generate_content_ids_on_about_pages.rb
+++ b/db/data_migration/20160204110535_generate_content_ids_on_about_pages.rb
@@ -1,0 +1,5 @@
+require 'securerandom'
+
+AboutPage.where(content_id: nil).each do |about_page|
+  about_page.update_column(:content_id, SecureRandom.uuid)
+end

--- a/db/migrate/20160203145841_add_content_id_to_about_page.rb
+++ b/db/migrate/20160203145841_add_content_id_to_about_page.rb
@@ -1,0 +1,5 @@
+class AddContentIdToAboutPage < ActiveRecord::Migration
+  def change
+    add_column :about_pages, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160201171846) do
+ActiveRecord::Schema.define(version: 20160203145841) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20160201171846) do
     t.string   "read_more_link_text", limit: 255
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
+    t.string   "content_id",          limit: 255
   end
 
   create_table "access_and_opening_times", force: :cascade do |t|

--- a/test/factories/about_page.rb
+++ b/test/factories/about_page.rb
@@ -5,4 +5,8 @@ FactoryGirl.define do
     summary 'Summary'
     body 'Body'
   end
+
+  factory :topical_event_about_page, parent: :about_page do
+    topical_event
+  end
 end

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+require "gds_api/test_helpers/panopticon"
+
+class TopicalEventAboutPageTest < ActiveSupport::TestCase
+  #api calls happen in after commit so we need to disable transactions
+  self.use_transactional_fixtures = false
+
+  setup do
+    DatabaseCleaner.clean_with :truncation
+    stub_any_publishing_api_call
+    @topical_event_about_page = build(:topical_event_about_page)
+  end
+
+  test "TopicalEventAboutPage is published to the Publishing API on save" do
+    presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
+    @topical_event_about_page.save!
+
+    expected_json = presenter.content.merge(
+      # This is to simulate what the time public timestamp will be after the
+      # page has been published
+      public_updated_at: Time.zone.now.as_json
+    )
+
+    assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
+    assert_publishing_api_publish(
+      @topical_event_about_page.content_id,
+      {
+        update_type: 'major',
+        locale: 'en'
+      },
+      1
+    )
+  end
+
+  test "TopicalEventAboutPage publishes gone route to the Publishing API on destroy" do
+    @topical_event_about_page.save!
+
+    new_content_id = SecureRandom.uuid
+    SecureRandom.stubs(uuid: new_content_id)
+
+    presenter = PublishingApiPresenters::Gone.new(@topical_event_about_page.search_link)
+    expected_json = presenter.content
+
+    @topical_event_about_page.destroy
+    assert_publishing_api_put_content(new_content_id, expected_json)
+  end
+
+  test "TopicalEventAboutPage is published to the Publishing API when updated" do
+    @topical_event_about_page.save!
+    @topical_event_about_page.read_more_link_text = "New read more link text"
+    @topical_event_about_page.save!
+    presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
+
+    expected_json = presenter.content.merge(
+      # This is to simulate what the time public timestamp will be after the
+      # page has been published
+      public_updated_at: Time.zone.now.as_json
+    )
+
+    assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
+    assert_publishing_api_publish(
+      @topical_event_about_page.content_id,
+      {
+        update_type: 'major',
+        locale: 'en'
+      },
+      2
+    )
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class PublishingApiPresenters::TopicalEventAboutPageTest < ActiveSupport::TestCase
+  def present(record)
+    PublishingApiPresenters::TopicalEventAboutPage.new(record)
+  end
+
+  test "topical event about page presentation includes the correct values" do
+    topical_event_about_page = create(:topical_event_about_page)
+
+    expected_hash = {
+      base_path: topical_event_about_page.search_link,
+      content_id: topical_event_about_page.content_id,
+      title: topical_event_about_page.topical_event.name,
+      description: 'Summary',
+      format: 'topical_event_about_page',
+      need_ids: [],
+      locale: 'en',
+      public_updated_at: topical_event_about_page.updated_at,
+      update_type: 'major',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      routes: [
+        { path: topical_event_about_page.search_link, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        body: "<div class=\"govspeak\"><p>Body</p></div>",
+        read_more: 'Read more'
+      }
+    }
+    presented_item = present(topical_event_about_page)
+
+    assert_valid_against_schema(presented_item.content, 'topical_event_about_page')
+    assert_valid_against_links_schema({ links: presented_item.links }, 'topical_event_about_page')
+    assert_equal topical_event_about_page.topical_event.content_id, presented_item.links[:parent][0]
+
+    # We test for HTML equivalance rather than string equality to get around
+    # inconsistencies with line breaks between different XML libraries
+    assert_equivalent_html expected_hash[:details].delete(:body),
+      presented_item.content[:details].delete(:body)
+
+    assert_equal expected_hash[:details], presented_item.content[:details].except(:body)
+  end
+end


### PR DESCRIPTION
Work to get topical event pages published through the publishing api. I worked on it with @boffbowsh.

[Trello](https://trello.com/c/eJZdGeQ1/266-3-topical-event-about-page-implement-publishing-of-format-to-publishing-api-medium)