### PR TITLE
Revert "Merge pull request #2449 from alphagov/publishing_api_worker_…

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -2,7 +2,7 @@ class PublishingApiWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
   def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
-    return unless model = class_for(model_name).unscoped.find_by(id: id)
+    return unless model = class_for(model_name).find_by(id: id)
 
     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)
 


### PR DESCRIPTION
…unscoped"

This reverts commit d87ce9f5f98668a27b07082e50582e631d64939a, reversing
changes made to 19106203365d4ab82069573528840cb77a048316.

This may not be necessary and could cause issues for `Edition` that has
soft delete functionality that utilitises a `default_scope`.