### PR TITLE
Send duration for topical events to publishing-api

### DIFF
--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -27,6 +27,8 @@ private
       PublishingApiPresenters::TakePart
     when Topic
       PublishingApiPresenters::PolicyAreaPlaceholder
+    when ::TopicalEvent
+      PublishingApiPresenters::TopicalEvent
     else
       PublishingApiPresenters::Placeholder
     end

--- a/app/presenters/publishing_api_presenters/topical_event.rb
+++ b/app/presenters/publishing_api_presenters/topical_event.rb
@@ -1,0 +1,10 @@
+module PublishingApiPresenters
+  class TopicalEvent < Placeholder
+    def details
+      super.tap do |details|
+        details[:start_date] = item.start_date.to_datetime if item.end_date
+        details[:end_date] = item.end_date.to_datetime if item.start_date
+      end
+    end
+  end
+end

--- a/db/data_migration/20160205105837_republish_topical_events_to_publishing_api.rb
+++ b/db/data_migration/20160205105837_republish_topical_events_to_publishing_api.rb
@@ -1,0 +1,1 @@
+TopicalEvent.where.not(content_id: nil).each(&:publish_to_publishing_api)

--- a/db/data_migration/README.md
+++ b/db/data_migration/README.md
@@ -22,6 +22,14 @@ changes.
 They are implemented by reusing Rails' data migration code, but they have their
 own rake task and database table for tracking which ones have been run.
 
+## How to add one
+
+Just like a normal migration, there is a Rails command:
+
+```
+  be rails g data_migration MyDataMigrationName
+```
+
 ## How to run them
 
 Data migrations don't run automatically, they have to be run manually in all

--- a/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class PublishingApiPresenters::TopicalEventTest < ActiveSupport::TestCase
+  test 'presents a valid placeholder "topical_event" content item' do
+    topical_event = create(:topical_event, :active, name: "Humans going to Mars")
+    public_path = '/government/topical-events/humans-going-to-mars'
+
+    expected_hash = {
+      base_path: public_path,
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      format: "placeholder_topical_event",
+      title: "Humans going to Mars",
+      description: nil,
+      locale: "en",
+      need_ids: [],
+      routes: [
+        {
+          path: public_path,
+          type: 'exact'
+        }
+      ],
+      redirects: [],
+      update_type: 'major',
+      public_updated_at: topical_event.updated_at,
+      details: {
+        start_date: topical_event.start_date,
+        end_date: topical_event.end_date,
+      }
+    }
+
+    presenter = PublishingApiPresenters::TopicalEvent.new(topical_event)
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_schema(presenter.content, 'placeholder')
+  end
+
+  test 'handles topical events without dates' do
+    topical_event = create(:topical_event, name: "Humans going to Mars")
+    public_path = '/government/topical-events/humans-going-to-mars'
+
+    expected_hash = {
+      base_path: public_path,
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      format: "placeholder_topical_event",
+      title: "Humans going to Mars",
+      description: nil,
+      locale: "en",
+      need_ids: [],
+      routes: [
+        {
+          path: public_path,
+          type: 'exact'
+        }
+      ],
+      redirects: [],
+      update_type: 'major',
+      public_updated_at: topical_event.updated_at,
+      details: {}
+    }
+
+    presenter = PublishingApiPresenters::TopicalEvent.new(topical_event)
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_schema(presenter.content, 'placeholder')
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -51,11 +51,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     assert_equal PublishingApiPresenters::WorkingGroup, presenter.class
   end
 
-  test ".presenter_for returns a Placeholder presenter for classifications" do
-    [Classification, TopicalEvent].each do |model|
-      presenter = PublishingApiPresenters.presenter_for(model.new)
-      assert_equal PublishingApiPresenters::Placeholder, presenter.class
-    end
+  test ".presenter_for returns TopicalEvent placeholder for a TopicalEvent" do
+    presenter = PublishingApiPresenters.presenter_for(TopicalEvent.new)
+    assert_equal PublishingApiPresenters::TopicalEvent, presenter.class
   end
 
   test ".presenter_for returns a special-case presenter for `Topic`" do


### PR DESCRIPTION
We can't migrate topical events yet, because they are complex.

Topical event about pages can be migrated, but they need the end_date of the
topical event they are a part of in order to render the page.

The build is failing pending the merge of https://github.com/alphagov/govuk-content-schemas/pull/229. Tests pass locally against those changes.