### PR TITLE
Bump gds-api-adapters to get better errors back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '27.0.0'
+  gem 'gds-api-adapters', '27.2.1'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,11 +150,11 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (27.0.0)
+    gds-api-adapters (27.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (11.2.1)
@@ -301,7 +301,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -480,7 +480,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 27.0.0)
+  gds-api-adapters (= 27.2.1)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.1)


### PR DESCRIPTION
Since 27.1.0, gds-api-adapters includes the request body in the error message,
allowing you to see much more detail by default. This is particularly helpful
when trying to debug Whitehall pushing to the publishing-api.

I've bumped to the latest gds-api-adapters because there's no reason not to,
and it includes some useful changes.