### PR TITLE
Fix TopicalEvent publishing-api datetime error

### DIFF
--- a/app/presenters/publishing_api_presenters/topical_event.rb
+++ b/app/presenters/publishing_api_presenters/topical_event.rb
@@ -2,8 +2,8 @@ module PublishingApiPresenters
   class TopicalEvent < Placeholder
     def details
       super.tap do |details|
-        details[:start_date] = item.start_date.to_datetime if item.end_date
-        details[:end_date] = item.end_date.to_datetime if item.start_date
+        details[:start_date] = item.start_date.to_datetime if item.start_date
+        details[:end_date] = item.end_date.to_datetime if item.end_date
       end
     end
   end

--- a/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
@@ -65,4 +65,13 @@ class PublishingApiPresenters::TopicalEventTest < ActiveSupport::TestCase
     assert_equal expected_hash, presenter.content
     assert_valid_against_schema(presenter.content, 'placeholder')
   end
+
+  test "handles topical events without an end_date" do
+    topical_event = create(:topical_event, start_date: Date.today)
+
+    presenter = PublishingApiPresenters::TopicalEvent.new(topical_event)
+
+    assert_equal({ start_date: Date.today }, presenter.content[:details])
+    assert_valid_against_schema(presenter.content, 'placeholder')
+  end
 end


### PR DESCRIPTION
When republishing these in integration, we were seeing an error:
```
  NoMethodError: undefined method `to_datetime' for nil:NilClass
```
This is because the checks where each checking the wrong thing.

I've added a test against regressions. I can't test the other way around
because the TopicalEvent model prevents that.