### PR TITLE
Use constants for rendering_app values

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -12,7 +12,7 @@ class CaseStudy < Edition
   validates :first_published_at, presence: true, if: -> e { e.trying_to_convert_to_draft == true }
 
   def rendering_app
-    'government-frontend'
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
   def display_type_key

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -493,7 +493,7 @@ class Edition < ActiveRecord::Base
   end
 
   def rendering_app
-    "whitehall-frontend"
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 
   def format_name

--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -40,7 +40,7 @@ module PublishingApiPresenters
     attr_accessor :item
 
     def rendering_app
-      "whitehall-frontend"
+      Whitehall::RenderingApp::WHITEHALL_FRONTEND
     end
 
     def routes

--- a/app/presenters/publishing_api_presenters/publish_intent.rb
+++ b/app/presenters/publishing_api_presenters/publish_intent.rb
@@ -8,7 +8,7 @@ class PublishingApiPresenters::PublishIntent
     {
       publish_time: @publish_timestamp,
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
       routes: [{ path: @base_path, type: 'exact' }],
     }
   end

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -29,7 +29,7 @@ module PublishingApiPresenters
     end
 
     def rendering_app
-      "government-frontend"
+      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
     end
   end
 end

--- a/app/presenters/publishing_api_presenters/topical_event_about_page.rb
+++ b/app/presenters/publishing_api_presenters/topical_event_about_page.rb
@@ -40,7 +40,7 @@ module PublishingApiPresenters
     end
 
     def rendering_app
-      "whitehall-frontend"
+      Whitehall::RenderingApp::WHITEHALL_FRONTEND
     end
   end
 end

--- a/db/data_migration/20150730091021_re_register_editions_with_erroneous_topics_in_panopticon.rb
+++ b/db/data_migration/20150730091021_re_register_editions_with_erroneous_topics_in_panopticon.rb
@@ -11,7 +11,7 @@ CSV.foreach(csv_filename, headers: true) do |row|
   raise "No published edition found for #{slug}" if edition.nil?
 
   artefact = RegisterableEdition.new(edition)
-  registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+  registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: artefact.kind)
 
   puts "Registering /#{artefact.slug} with Panopticon..."
   registerer.register(artefact)

--- a/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
+++ b/db/data_migration/20150730134022_republish_routes_for_all_detailed_guides.rb
@@ -35,7 +35,7 @@ scope.each_with_index do |edition, i|
     url_arbiter.set_publishing_app_for_path("/#{slug}", "whitehall")
   end
   puts "Adding route #{i+1}/#{count} for /#{slug}"
-  router_api.add_route("/#{slug}", "exact", "whitehall-frontend")
+  router_api.add_route("/#{slug}", "exact", Whitehall::RenderingApp::WHITEHALL_FRONTEND)
 end
 
 router_api.commit_routes

--- a/db/data_migration/20151104171038_fix_dates_and_change_note_on_hmrc_notice.rb
+++ b/db/data_migration/20151104171038_fix_dates_and_change_note_on_hmrc_notice.rb
@@ -18,7 +18,7 @@ published_edition.update_columns(
 )
 
 artefact = RegisterableEdition.new(published_edition)
-registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: artefact.kind)
 puts "Registering /#{artefact.slug} with Panopticon..."
 registerer.register(artefact)
 

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -8,7 +8,7 @@ namespace :panopticon do
   task :register => :environment do
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
 
-    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend')
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND)
     logger.info "Registering application with Panopticon..."
 
     record = OpenStruct.new(
@@ -25,7 +25,7 @@ namespace :panopticon do
   task :register_guidance => :environment do
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
     logger.info "Registering detailed guides with Panopticon..."
-    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: 'detailed_guide')
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: 'detailed_guide')
 
     Document.where(document_type: "DetailedGuide").published.each do |document|
       guide = document.published_edition
@@ -56,7 +56,7 @@ namespace :panopticon do
 
     published_editions.each do |edition|
       artefact = RegisterableEdition.new(edition)
-      registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+      registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: artefact.kind)
       logger.info "Registering /#{artefact.slug} with Panopticon..."
 
       begin
@@ -74,7 +74,7 @@ namespace :panopticon do
     registerable_editions = RegisterableEditionBuilderForUnpublishedEditions.build
 
     registerable_editions.each do |registerable_edition|
-      registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: registerable_edition.kind)
+      registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: registerable_edition.kind)
 
       begin
         logger.info "About to register #{registerable_edition.edition.id}"
@@ -98,7 +98,7 @@ namespace :panopticon do
 
       if edition = document.published_edition
         artefact = RegisterableEdition.new(edition)
-        registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: 'whitehall-frontend', kind: artefact.kind)
+        registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'whitehall', rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND, kind: artefact.kind)
         logger.info "Registering /#{artefact.slug} with Panopticon..."
 
         begin

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -25,7 +25,7 @@ namespace :publishing_api do
       publisher.publish(route.merge(
         format: "special_route",
         publishing_app: "whitehall",
-        rendering_app: "whitehall-frontend",
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         update_type: "major",
         type: "prefix",
         public_updated_at: Time.zone.now.iso8601,

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -97,7 +97,7 @@ module Whitehall
     end
 
     def self.served_from_content_store?(edition)
-      edition.rendering_app == "government-frontend"
+      edition.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
     end
 
     # We want to avoid sending unpublishings for content types which are not

--- a/lib/whitehall/rendering_app.rb
+++ b/lib/whitehall/rendering_app.rb
@@ -1,0 +1,6 @@
+module Whitehall
+  module RenderingApp
+    WHITEHALL_FRONTEND = 'whitehall-frontend'
+    GOVERNMENT_FRONTEND = 'government-frontend'
+  end
+end


### PR DESCRIPTION
We have these values in lots of places, and it would be easy to make a typo. So
let's use constants for them instead.

Here's an example of where we used the wrong value: 89bc08d343a8c026194a09f00767eb5cdded3e2b

The only thing I'm not entirely happy about is the naming - it is now quite long.

I left the references under `test/` because it felt like we should be asserting the real value, rather than using part of the implementation.