### PR TITLE
Downgrade rack-cache to non-yanked 1.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.6.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
rack-cache 1.6.0 was rudely yanked and will be fixed by
https://github.com/rtomayko/rack-cache/pull/135.