### PR TITLE
Index withdrawn documents

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -134,10 +134,6 @@ class Edition < ActiveRecord::Base
     where(arel_table[:type].not_in(edition_classes.map(&:name)))
   end
 
-  def self.published_and_available_in_english
-    with_translations(:en).published
-  end
-
   def self.format_name
     @format_name ||= model_name.human.downcase
   end
@@ -279,8 +275,12 @@ class Edition < ActiveRecord::Base
     [Edition.search_format_type]
   end
 
+  def self.publicly_visible_and_available_in_english
+    with_translations(:en).publicly_visible
+  end
+
   def self.search_only
-    published_and_available_in_english
+    publicly_visible_and_available_in_english
   end
 
   def refresh_index_if_required

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -49,7 +49,7 @@ class Edition < ActiveRecord::Base
   POST_PUBLICATION_STATES = %w(published superseded withdrawn).freeze
   PUBLICLY_VISIBLE_STATES = %w(published withdrawn).freeze
 
-  scope :with_title_or_summary_containing, -> *keywords {
+  scope :with_title_or_summary_containing, -> (*keywords) {
     pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
     in_default_locale.where("edition_translations.title REGEXP :pattern OR edition_translations.summary REGEXP :pattern", pattern: pattern)
   }
@@ -126,6 +126,7 @@ class Edition < ActiveRecord::Base
   def self.in_chronological_order
     order(arel_table[:public_timestamp].asc, arel_table[:document_id].asc)
   end
+
   def self.in_reverse_chronological_order
     order(arel_table[:public_timestamp].desc, arel_table[:document_id].desc, arel_table[:id].desc)
   end
@@ -196,21 +197,21 @@ class Edition < ActiveRecord::Base
   end
 
   def self.search_format_type
-    self.name.underscore.gsub('_', '-')
+    self.name.underscore.tr('_', '-')
   end
 
   def self.concrete_descendants
-    descendants.reject { |model| model.descendants.any? }.sort_by { |model| model.name }
+    descendants.reject { |model| model.descendants.any? }.sort_by(&:name)
   end
 
   def self.concrete_descendant_search_format_types
-    concrete_descendants.map { |model| model.search_format_type }
+    concrete_descendants.map(&:search_format_type)
   end
 
   # NOTE: this scope becomes redundant once Admin::EditionFilterer is backed by an admin-only rummager index
   def self.with_classification(classification)
     joins('INNER JOIN classification_memberships ON classification_memberships.edition_id = editions.id').
-    where("classification_memberships.classification_id" => classification.id)
+      where("classification_memberships.classification_id" => classification.id)
   end
 
   def self.due_for_publication(within_time = 0)
@@ -239,7 +240,7 @@ class Edition < ActiveRecord::Base
     id: :id,
     title: :search_title,
     link: :search_link,
-    format: -> d { d.format_name.gsub(" ", "_") },
+    format: -> (d) { d.format_name.tr(" ", "_") },
     content: :indexable_content,
     description: :summary,
     organisations: nil,
@@ -374,7 +375,7 @@ class Edition < ActiveRecord::Base
     false
   end
 
-  def image_disallowed_in_body_text?(i)
+  def image_disallowed_in_body_text?(_)
     false
   end
 
@@ -408,8 +409,17 @@ class Edition < ActiveRecord::Base
     unless published?
       raise "Cannot create new edition based on edition in the #{state} state"
     end
-    draft_attributes = attributes.except(*%w{id type state created_at updated_at change_note
-      minor_change force_published scheduled_publication})
+    draft_attributes = attributes.except(*%w{
+      id
+      type
+      state
+      created_at
+      updated_at
+      change_note
+      minor_change
+      force_published
+      scheduled_publication
+    })
     self.class.new(draft_attributes.merge('state' => 'draft', 'creator' => user)).tap do |draft|
       traits.each { |t| t.process_associations_before_save(draft) }
       if draft.valid? || !draft.errors.keys.include?(:base)
@@ -580,7 +590,7 @@ class Edition < ActiveRecord::Base
   def need_ids_are_six_digit_integers?
     invalid_need_ids = need_ids.reject { |need_id| need_id =~ /\A\d{6}\z/ }
     unless invalid_need_ids.empty?
-      errors.add(:need_ids, "are invalid: #{invalid_need_ids.join(", ")}")
+      errors.add(:need_ids, "are invalid: #{invalid_need_ids.join(', ')}")
     end
   end
 
@@ -608,7 +618,7 @@ class Edition < ActiveRecord::Base
     if @previously_published.nil?
       errors[:base] << 'You must specify whether the document has been published before'
       @has_first_published_error = true
-    elsif previously_published == 'true'  # not a real field, so isn't converted to bool
+    elsif previously_published == 'true' # not a real field, so isn't converted to bool
       errors.add(:first_published_at, "can't be blank") if first_published_at.blank?
       @has_first_published_error = true
     end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -260,6 +260,7 @@ class Edition < ActiveRecord::Base
     latest_change_note: :most_recent_change_note,
     is_political: :political?,
     is_historic: :historic?,
+    is_withdrawn: :withdrawn?,
     government_name: :search_government_name
   )
 
@@ -625,6 +626,10 @@ class Edition < ActiveRecord::Base
     return false unless government
 
     political? && !government.current?
+  end
+
+  def withdrawn?
+    self.state == 'withdrawn'
   end
 
   def detailed_format

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -45,7 +45,7 @@ module Searchable
       include Searchable::Mixin
 
       self.searchable_options = options.reverse_merge \
-        format:         -> o { o.class.model_name.element },
+        format:         -> (o) { o.class.model_name.element },
         index_after:    :save,
         unindex_after:  :destroy,
         only:           :all,
@@ -65,7 +65,7 @@ module Searchable
             value.to_proc
           else
             # treat other objects (e.g. strings) as constants
-            -> _ { value }
+            -> (_) { value }
           end
       end
 
@@ -95,9 +95,7 @@ module Searchable
     end
 
     def update_in_search_index
-      if can_index_in_search?
-        Whitehall::SearchIndex.add(self)
-      end
+      Whitehall::SearchIndex.add(self) if can_index_in_search?
     end
 
     def remove_from_search_index
@@ -112,7 +110,7 @@ module Searchable
       def reindex_all
         searchable_instances
           .select { |instance| Whitehall.searchable_classes.include?(instance.class) }
-          .each { |instance|  Whitehall::SearchIndex.add(instance) }
+          .each { |instance| Whitehall::SearchIndex.add(instance) }
       end
 
       def searchable_instances

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -13,6 +13,7 @@ module Searchable
     :government_name,
     :id,
     :is_historic,
+    :is_withdrawn,
     :is_political,
     :latest_change_note,
     :link,

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -6,7 +6,7 @@ Whitehall.edition_services.tap do |es|
   es.subscribe(/^(force_publish|publish)$/)                   { |_, edition, _| ServiceListeners::AnnouncementClearer.new(edition).clear! }
 
   # search
-  es.subscribe(/^(force_publish|publish)$/) { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).index! }
+  es.subscribe(/^(force_publish|publish|withdraw)$/) { |_, edition, _| ServiceListeners::SearchIndexer.new(edition).index! }
   es.subscribe("unpublish")                 { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 
   # publishing API

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,17 +1,17 @@
 namespace :rummager do
   desc "indexes all published searchable whitehall content"
-  task :index => ['rummager:index:detailed', 'rummager:index:government']
+  task index: ['rummager:index:detailed', 'rummager:index:government']
 
   namespace :index do
     desc "indexes all published searchable content for the main government index (i.e. excluding detailed guides)"
-    task :government => :environment do
+    task government: :environment do
       index = Whitehall::SearchIndex.for(:government)
       index.add_batch(Whitehall.government_search_index)
       index.commit
     end
 
     desc "indexes all published detailed guiudes"
-    task :detailed => :environment do
+    task detailed: :environment do
       index = Whitehall::SearchIndex.for(:detailed_guides)
       index.add_batch(Whitehall.detailed_guidance_search_index)
       index.commit
@@ -19,14 +19,14 @@ namespace :rummager do
 
     # NOTE: Run daily to ensure consultation state is reflected in the search results
     desc "indexes consultations which closed in the past day"
-    task :closed_consultations => :environment do
+    task closed_consultations: :environment do
       index = Whitehall::SearchIndex.for(:government)
       index.add_batch(Consultation.published.closed_since(25.hours.ago).map(&:search_index))
       index.commit
     end
 
     desc "indexes all withdrawn content"
-    task :withdrawn => :environment do
+    task withdrawn: :environment do
       Edition.where(state: "withdrawn").each do |ed|
         puts "Indexing: #{ed.content_id}"
         Whitehall::SearchIndex.add(ed)
@@ -36,15 +36,15 @@ namespace :rummager do
   end
 
   desc "removes and re-indexes all searchable whitehall content"
-  task :reset => ['rummager:reset:detailed', 'rummager:reset:government']
+  task reset: ['rummager:reset:detailed', 'rummager:reset:government']
 
   namespace :reset do
-    task :government => :environment do
+    task government: :environment do
       Whitehall::SearchIndex.for(:government).delete_all
       Rake::Task["rummager:index:government"].invoke
     end
 
-    task :detailed => :environment do
+    task detailed: :environment do
       Whitehall::SearchIndex.for(:detailed_guides).delete_all
       Rake::Task["rummager:index:detailed"].invoke
     end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -24,6 +24,15 @@ namespace :rummager do
       index.add_batch(Consultation.published.closed_since(25.hours.ago).map(&:search_index))
       index.commit
     end
+
+    desc "indexes all withdrawn content"
+    task :withdrawn => :environment do
+      Edition.where(state: "withdrawn").each do |ed|
+        puts "Indexing: #{ed.content_id}"
+        Whitehall::SearchIndex.add(ed)
+      end
+      puts "Complete."
+    end
   end
 
   desc "removes and re-indexes all searchable whitehall content"

--- a/test/unit/edition/searchable_test.rb
+++ b/test/unit/edition/searchable_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Edition::SearchableTest < ActiveSupport::TestCase
 
-  test "should return search index suitable for Rummageable" do
+  test "should return search index suitable for Rummageable when published" do
     edition = create(:published_edition, title: "edition-title")
 
     assert_equal "edition-title", edition.search_index["title"]
@@ -17,9 +17,29 @@ class Edition::SearchableTest < ActiveSupport::TestCase
     assert_equal nil, edition.search_index["people"]
     assert_equal nil, edition.search_index["publication_type"]
     assert_equal nil, edition.search_index["speech_type"]
-
     assert_equal edition.public_timestamp, edition.search_index["public_timestamp"]
     assert_equal nil, edition.search_index["topics"]
+    assert_equal false, edition.search_index["is_withdrawn"]
+  end
+
+  test "should return search index suitable for Rummageable when withdrawn" do
+    edition = create(:withdrawn_edition, title: "edition-title")
+
+    assert_equal "edition-title", edition.search_index["title"]
+    assert_equal routes_helper.public_document_path(edition), edition.search_index["link"]
+    assert_equal edition.body, edition.search_index["indexable_content"]
+    assert_equal "generic_edition", edition.search_index["format"]
+    assert_equal edition.summary, edition.search_index["description"]
+    assert_equal edition.id, edition.search_index["id"]
+    assert_equal edition.live_specialist_sector_tags, edition.search_index["specialist_sectors"]
+    assert_equal edition.most_recent_change_note, edition.search_index["latest_change_note"]
+    assert_equal nil, edition.search_index["organisations"]
+    assert_equal nil, edition.search_index["people"]
+    assert_equal nil, edition.search_index["publication_type"]
+    assert_equal nil, edition.search_index["speech_type"]
+    assert_equal edition.public_timestamp, edition.search_index["public_timestamp"]
+    assert_equal nil, edition.search_index["topics"]
+    assert_equal true, edition.search_index["is_withdrawn"]
   end
 
   test "#indexable_content should return the body without markup by default" do

--- a/test/unit/edition/searchable_test.rb
+++ b/test/unit/edition/searchable_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class Edition::SearchableTest < ActiveSupport::TestCase
-
   test "should return search index suitable for Rummageable when published" do
     edition = create(:published_edition, title: "edition-title")
 

--- a/test/unit/searchable_test.rb
+++ b/test/unit/searchable_test.rb
@@ -8,9 +8,9 @@ class SearchableTest < ActiveSupport::TestCase
     self.table_name = 'classifications'
 
     include Searchable
-    searchable  link: :name, only: :published, index_after: [:save], unindex_after: [:destroy]
+    searchable  link: :name, only: :publicly_visible, index_after: [:save], unindex_after: [:destroy]
 
-    scope :published, -> { where(state: 'published') }
+    scope :publicly_visible, -> { where(state: ['published', 'withdrawn']) }
   end
 
   def setup
@@ -25,6 +25,12 @@ class SearchableTest < ActiveSupport::TestCase
 
   test 'will request indexing on save if it is in searchable_instances' do
     s = SearchableTestTopic.create(name: 'woo', state: 'published')
+    Whitehall::SearchIndex.expects(:add).with(s)
+    s.save
+  end
+
+  test 'will request indexing on save if it is in searchable_instances and withrawn' do
+    s = SearchableTestTopic.create(name: 'woo', state: 'withdrawn')
     Whitehall::SearchIndex.expects(:add).with(s)
     s.save
   end

--- a/test/unit/searchable_test.rb
+++ b/test/unit/searchable_test.rb
@@ -8,9 +8,9 @@ class SearchableTest < ActiveSupport::TestCase
     self.table_name = 'classifications'
 
     include Searchable
-    searchable  link: :name, only: :publicly_visible, index_after: [:save], unindex_after: [:destroy]
+    searchable link: :name, only: :publicly_visible, index_after: [:save], unindex_after: [:destroy]
 
-    scope :publicly_visible, -> { where(state: ['published', 'withdrawn']) }
+    scope :publicly_visible, -> { where(state: %w(published withdrawn)) }
   end
 
   def setup
@@ -58,7 +58,7 @@ class SearchableTest < ActiveSupport::TestCase
   test '#reindex_all will not request indexing for an instance whose class is not in Whitehall.searchable_classes' do
     class NonExistentClass; end
     Whitehall.stubs(:searchable_classes).returns([NonExistentClass])
-    s = SearchableTestTopic.create(name: 'woo', state: 'published')
+    SearchableTestTopic.create(name: 'woo', state: 'published')
     Whitehall::SearchIndex.expects(:add).never
     SearchableTestTopic.reindex_all
   end


### PR DESCRIPTION
Documents in whitehall can be marked as withdrawn on the site because they are no longer current (but they are still "correct" so are not removed).

For example: https://www.gov.uk/government/publications/schools-forums-operational-and-good-practice-guide

These documents currently mostly don't appear in the search index (though many do - we believe that this is because they're not currently being removed when withdrawn until a full index rebuild happens). The search index doesn't indicate whether the documents are withdrawn.

In order to help the content inventory, we want to include these in the search index, and make it possible to get them returned in search results. This will allow us and organisations to identify withdrawn content that is still fulfilling a user need, and create appropriate new content.

We think that users should ultimately be able to find these in search, but should be informed that they are old (and weighting should be set appropriately to avoid serving old content above current content). However, to start with we want to hide the content in search results by default, so that we can measure the effect of adding the content. The content should therefore be hidden from rummager by default, and there should be a flag (perhaps a debug flag) to cause the items to be returned.

[Trello](https://trello.com/c/RkrlGszq/473-keep-items-in-search-index-when-withdrawn-but-not-redirected)

### Why did I add a new rake task?

The only rake task available that I could have used reindexes the all of Whitehall meaning that:
- it takes several hours to run 
- while it runs no changes can be made to the search index

From the [Ops Manual](https://github.gds/pages/gds/opsmanual/2nd-line/reindexing-search.html#reindexing-all-of-whitehall).

Also, non-withdrawn documents don't need to be re-indexed right now. After these changes reindexing them would add a `is_withdrawn: false` to their searchable data. This won't affect Rummager expected behaviour that is to hide by default documents with `is_withdrawn` set to `true`.