### PR TITLE
Change topical event about page rendering app

### DIFF
--- a/app/presenters/publishing_api_presenters/topical_event_about_page.rb
+++ b/app/presenters/publishing_api_presenters/topical_event_about_page.rb
@@ -40,7 +40,7 @@ module PublishingApiPresenters
     end
 
     def rendering_app
-      Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
     end
   end
 end

--- a/db/data_migration/20160211164516_republish_topical_event_about_pages_to_publishing_api.rb
+++ b/db/data_migration/20160211164516_republish_topical_event_about_pages_to_publishing_api.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(AboutPage.all)
+republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
@@ -18,7 +18,7 @@ class PublishingApiPresenters::TopicalEventAboutPageTest < ActiveSupport::TestCa
       public_updated_at: topical_event_about_page.updated_at,
       update_type: 'major',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       routes: [
         { path: topical_event_about_page.search_link, type: 'exact' }
       ],


### PR DESCRIPTION
Topical Event About Pages are getting migrated, and should
therefore be rendered using government-frontend, not
whitehall-frontend.

This includes a data migration that republishes Topical Event 
About Pages.

I pushed my branch to integration and ran the content of the data migration
on integration in the console. There were no related errors in Errbit and the 
Topical Event About Pages looked good on integration.

To know more about the frontend changes, refer to [this government-frontend PR](https://github.com/alphagov/government-frontend/pull/92)