### PR TITLE
Make Document content_id not nullable

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,6 +37,8 @@ class Document < ActiveRecord::Base
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document
 
+  validates_presence_of :content_id
+
   delegate :topics, to: :latest_edition
 
   after_create :ensure_document_has_a_slug

--- a/db/migrate/20160212160106_make_document_content_id_not_null.rb
+++ b/db/migrate/20160212160106_make_document_content_id_not_null.rb
@@ -1,0 +1,9 @@
+class MakeDocumentContentIdNotNull < ActiveRecord::Migration
+  def change
+    Document.where(content_id: nil).find_each do |document|
+      document.update_column(:content_id, SecureRandom.uuid)
+    end
+
+    change_column_null(:documents, :content_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160203145841) do
+ActiveRecord::Schema.define(version: 20160212160106) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -281,7 +281,7 @@ ActiveRecord::Schema.define(version: 20160203145841) do
     t.datetime "updated_at"
     t.string   "slug",          limit: 255
     t.string   "document_type", limit: 255
-    t.string   "content_id",    limit: 255
+    t.string   "content_id",    limit: 255, null: false
   end
 
   add_index "documents", ["document_type"], name: "index_documents_on_document_type", using: :btree

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :document do
+    sequence(:content_id) { SecureRandom.uuid }
     sequence(:slug) { |index| "slug-#{index}" }
   end
 end


### PR DESCRIPTION
It was the intent that all Documents should have content_ids: ab71140021975b474f8804b67538f1b7414109fd

There's one Document record in production which doesn't have one - a News
Article. Let's preempt problems migrating it by filling in the missing value.