### PR TITLE
Fix "View on website" link for non-editioned topical events and get involved content

### DIFF
--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -1,0 +1,13 @@
+module Admin::UrlOptionsHelper
+  def public_url_options
+    { host: Whitehall.public_host, protocol: Whitehall.public_protocol }
+  end
+
+  def cachebust_url_options
+    { cachebust: Time.zone.now.getutc.to_i }
+  end
+
+  def public_and_cachebusted_url_options
+    public_url_options.merge(cachebust_url_options)
+  end
+end

--- a/app/helpers/classification_routes_helper.rb
+++ b/app/helpers/classification_routes_helper.rb
@@ -7,18 +7,6 @@ module ClassificationRoutesHelper
     polymorphic_url(classification_model_name(classification), options.merge(id: classification))
   end
 
-  def public_classification_url(classification, options = {})
-    classification_url(classification, public_url_options.merge(options))
-  end
-
-  def public_url_options
-    { host: Whitehall.public_host, protocol: Whitehall.public_protocol }
-  end
-
-  def cachebust_options
-    { cachebust: Time.zone.now.getutc.to_i }
-  end
-
 private
 
   # NOTE: This method could (possibly) be dropped once Draper has been removed/replaced.

--- a/app/helpers/classification_routes_helper.rb
+++ b/app/helpers/classification_routes_helper.rb
@@ -7,7 +7,19 @@ module ClassificationRoutesHelper
     polymorphic_url(classification_model_name(classification), options.merge(id: classification))
   end
 
-  private
+  def public_classification_url(classification, options = {})
+    classification_url(classification, public_url_options.merge(options))
+  end
+
+  def public_url_options
+    { host: Whitehall.public_host, protocol: Whitehall.public_protocol }
+  end
+
+  def cachebust_options
+    { cachebust: Time.zone.now.getutc.to_i }
+  end
+
+private
 
   # NOTE: This method could (possibly) be dropped once Draper has been removed/replaced.
   def classification_model_name(classification)

--- a/app/views/admin/classifications/_tab_wrapper.html.erb
+++ b/app/views/admin/classifications/_tab_wrapper.html.erb
@@ -1,7 +1,7 @@
 <header class="row add-bottom-margin">
   <div class="col-md-8">
     <h1><%= model.name %></h1>
-    <%= link_to "View on website", public_classification_url(model, cachebust_options) %>
+    <%= link_to "View on website", classification_url(model, public_and_cachebusted_url_options) %>
   </div>
 </header>
 

--- a/app/views/admin/classifications/_tab_wrapper.html.erb
+++ b/app/views/admin/classifications/_tab_wrapper.html.erb
@@ -1,7 +1,7 @@
 <header class="row add-bottom-margin">
   <div class="col-md-8">
     <h1><%= model.name %></h1>
-    <%= link_to "View on website", classification_path(model) %>
+    <%= link_to "View on website", public_classification_url(model, cachebust_options) %>
   </div>
 </header>
 

--- a/app/views/admin/get_involved/index.html.erb
+++ b/app/views/admin/get_involved/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="get-involved-header">
   <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_path %>
+  <%= link_to "View on website", get_involved_url(public_and_cachebusted_url_options) %>
 </div>
 <section class="get-involved">
   <%= get_involved_tab_navigation %>

--- a/app/views/admin/take_part_pages/index.html.erb
+++ b/app/views/admin/take_part_pages/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="get-involved-header">
   <h1>Get involved</h1>
-  <%= link_to "View on website", get_involved_path %>
+  <%= link_to "View on website", get_involved_url(public_and_cachebusted_url_options) %>
 </div>
 
 <section class="get-involved">


### PR DESCRIPTION
When clicking “View on website” for classifications it shows the whitehall admin rendered version of it.

Viewing a topical event page from `whitehall-admin. …` means the relative link to its about page also points to `whitehall-admin`, however that is now served by government front-end and this route errors.

It's a similar story for get involved/take part pages.

Classification and get involved changes go live immediately. Instead send users to the public host with a cache bust query parameter.

This will continue to be a problem as we migrate more formats. A story to solve this more completely is being added to the Core backlog.

Unblocks deploy of:
https://trello.com/c/H8mRXMTV/268-3-topical-event-about-page-migration-final-tasks-for-each-format-deploy-2-medium