### PR TITLE
Update defra green

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ end
 if ENV['FRONTEND_TOOLKIT_DEV']
   gem 'govuk_frontend_toolkit', path: '../govuk_frontend_toolkit_gem'
 else
-  gem 'govuk_frontend_toolkit', '4.1.1'
+  gem 'govuk_frontend_toolkit', '4.8.1'
 end
 
 gem 'sass', '3.4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_frontend_toolkit (4.1.1)
+    govuk_frontend_toolkit (4.8.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashdiff (0.2.3)
@@ -487,7 +487,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (= 1.4.0)
   govuk-lint (~> 0.5.1)
   govuk_admin_template (= 3.0.0)
-  govuk_frontend_toolkit (= 4.1.1)
+  govuk_frontend_toolkit (= 4.8.1)
   invalid_utf8_rejector (~> 0.0.1)
   isbn_validation
   jbuilder

--- a/app/assets/stylesheets/frontend/styleguide/_colours.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_colours.scss
@@ -12,14 +12,12 @@ $detailed-guidance-brand: $light-blue;
 $detailed-guidance-background: #fff;
 
 $inside-gov-brand: #2E3191;
-//$inside-gov-secondary: adjust-hue(lighten($inside-gov-brand, 40%), -25%);
 $inside-gov-secondary: #57da95;
 $inside-gov-nav: #0B0C0C;
 $inside-gov-nav-dropdown: #888;
 
 $coalition-green: #85994b;
 $g8-brand: #c10019;
-
 
 // Web safe department colours
 $attorney-generals-office-websafe: #a03a88;
@@ -81,7 +79,6 @@ $wales-office-websafe: #7a242a;
 //       @include organisation-brand-colour("a", border-color);
 //     }
 
-
 // All organisation colours as list of (class_name, colour, websafe colour)
 $all-organisation-brand-colours:
   'attorney-generals-office' $attorney-generals-office $attorney-generals-office-websafe,
@@ -126,5 +123,3 @@ $all-organisation-brand-colours:
     }
   }
 }
-
-

--- a/app/assets/stylesheets/frontend/styleguide/_colours.scss
+++ b/app/assets/stylesheets/frontend/styleguide/_colours.scss
@@ -26,7 +26,6 @@ $department-for-business-innovation-skills-websafe: #347da4;
 $department-for-communities-and-local-government-websafe: #37836e;
 $department-for-culture-media-sport-websafe: #a03155;
 $department-for-education-websafe: #347ca9;
-$department-for-environment-food-rural-affairs-websafe: #67650f;
 $department-for-international-development-websafe: #405e9a;
 $department-for-transport-websafe: #398373;
 $department-for-work-pensions-websafe: #37807b;
@@ -88,7 +87,7 @@ $all-organisation-brand-colours:
   'department-for-communities-and-local-government' $department-for-communities-and-local-government $department-for-communities-and-local-government-websafe,
   'department-for-culture-media-sport' $department-for-culture-media-sport $department-for-culture-media-sport-websafe,
   'department-for-education' $department-for-education $department-for-education-websafe,
-  'department-for-environment-food-rural-affairs' $department-for-environment-food-rural-affairs $department-for-environment-food-rural-affairs-websafe,
+  'department-for-environment-food-rural-affairs' $department-for-environment-food-rural-affairs $department-for-environment-food-rural-affairs,
   'department-for-international-development' $department-for-international-development $department-for-international-development-websafe,
   'department-for-transport' $department-for-transport $department-for-transport-websafe,
   'department-for-work-pensions' $department-for-work-pensions $department-for-work-pensions-websafe,


### PR DESCRIPTION
Switch to the new green, which is more neon and is web safe by default.
https://trello.com/c/p3BYq1Rd/295-defra-colour-change-to-brand

![screen shot 2016-02-16 at 14 14 23](https://cloud.githubusercontent.com/assets/319055/13078537/9cbeab76-d4b7-11e5-9cf1-a54723a40cca.png)

![defra-green](https://cloud.githubusercontent.com/assets/319055/13142267/edd12b74-d633-11e5-947c-76d76455bc05.png)
![screen shot 2016-02-18 at 10 43 01](https://cloud.githubusercontent.com/assets/319055/13142266/edcf36fc-d633-11e5-85cd-08db98f96065.png)

