### PR TITLE
Reslug DCLG management board group

### DIFF
--- a/db/data_migration/20160218122043_reslug_dclg_management_board_group.rb
+++ b/db/data_migration/20160218122043_reslug_dclg_management_board_group.rb
@@ -1,0 +1,2 @@
+dclg_departmental_board = Group.find('dclg-management-board')
+dclg_departmental_board.update_attributes!(slug: 'dclg-departmental-board')


### PR DESCRIPTION
For: https://trello.com/c/1it1np1S/293-change-dclg-management-board-url

The Title has already been changed to DCLG Departmental Board so we
need to change the slug to match.

This requires a redirect in place to point the old slug to this new slug which is in a PR on router-data. See: https://github.gds/gds/router-data/pull/513