### PR TITLE
Improve spacing of stat headlines

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -357,7 +357,11 @@
       }
 
       .stat-headline {
-        margin-bottom: $gutter;
+        margin-bottom: $gutter-half;
+
+        @include media(tablet) {
+          margin-bottom: $gutter;
+        }
 
         p {
           @include bold-19;
@@ -368,6 +372,14 @@
           display: block;
           @include bold-80;
           margin: 3px 0 -5px;
+        }
+      }
+
+      & > .stat-headline:first-child {
+        margin-top: $gutter;
+
+        @include media(tablet) {
+          margin-top: ($gutter * 2) + $gutter-two-thirds;
         }
       }
     }


### PR DESCRIPTION
* Reduce the bottom margin of stat headlines at smaller page widths to better match page flow (30px down to 15px)
* Add a top margin to stat headlines when they are the very first piece of content. Match the margins used for h2s and h3s. Use `>` and `first-child` to be sure this only applies when shown first. (eg not
first in a call to action)

# Top of HTML publication

## Before
<img width="1017" alt="screen shot 2016-02-18 at 20 41 58" src="https://cloud.githubusercontent.com/assets/319055/13157934/5d44f866-d682-11e5-9894-f7d2bc8eeca4.png">

## After
<img width="1009" alt="screen shot 2016-02-18 at 20 49 15" src="https://cloud.githubusercontent.com/assets/319055/13157935/5d45956e-d682-11e5-9ca5-48db7f4fbb8e.png">

# Mobile spacing

## Before
<img width="450" alt="screen shot 2016-02-18 at 20 51 31" src="https://cloud.githubusercontent.com/assets/319055/13157936/5d46961c-d682-11e5-8277-ca68d36a4ea6.png">

## After
<img width="532" alt="screen shot 2016-02-18 at 20 49 30" src="https://cloud.githubusercontent.com/assets/319055/13157937/5d47bf42-d682-11e5-8486-c778abd72bcf.png">
