### PR TITLE
Validate the length of contact number labels

### DIFF
--- a/app/models/contact_number.rb
+++ b/app/models/contact_number.rb
@@ -1,6 +1,6 @@
 class ContactNumber < ActiveRecord::Base
   belongs_to :contact
-  validates :label, :number, presence: true
+  validates :label, :number, presence: true, length: { maximum: 255 }
 
   include TranslatableModel
   translates :label, :number


### PR DESCRIPTION
Rather than show the user a 5xx page, let's redisplay the form with a
validation message.

Here's a user encountering the problem (repeatedly): https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56c4682d657863070f0c0800