### PR TITLE
Ask rummager for "policy_areas" instead of "topics"

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,3 +1,4 @@
+# NB: Topic is being renamed to "Policy Area" across GOV.UK.
 class TopicsController < ClassificationsController
   enable_request_formats show: :atom
 

--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -1,3 +1,4 @@
+# NB: Topic is being renamed to "Policy Area" across GOV.UK.
 module Edition::Topics
   extend ActiveSupport::Concern
   include Edition::Classifications

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,4 @@
+# NB: Topic is being renamed to "Policy Area" across GOV.UK.
 class Topic < Classification
   has_many :featured_links, -> { order(:created_at) },  as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :featured_links, reject_if: -> attributes { attributes['url'].blank? }, allow_destroy: true

--- a/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
+++ b/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
@@ -1,4 +1,5 @@
 module PublishingApiPresenters
+  # Note that "Policy Area" is the new name for "Topic".
   class PolicyAreaPlaceholder < Placeholder
   private
 

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,7 +1,21 @@
 require 'gds_api/rummager'
 
 Whitehall.government_search_client = GdsApi::Rummager.new(
-    Whitehall::SearchIndex.rummager_host + Whitehall.government_search_index_path)
+  Plek.find('search') + Whitehall.government_search_index_path
+)
 
 Whitehall.unified_search_client = GdsApi::Rummager.new(
-    Whitehall::SearchIndex.rummager_host)
+  Plek.find('search')
+)
+
+def statistics_announcement_search_client
+  if Rails.env.test?
+    DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncements
+  else
+    GdsApi::Rummager.new(
+      Plek.find('search') + Whitehall.government_search_index_path
+    )
+  end
+end
+
+Whitehall.statistics_announcement_search_client = statistics_announcement_search_client

--- a/config/initializers/statistics_announcement_search_client.rb
+++ b/config/initializers/statistics_announcement_search_client.rb
@@ -1,5 +1,0 @@
-Whitehall.statistics_announcement_search_client = if Rails.env.test?
-  DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncements
-else
-  GdsApi::Rummager.new(Whitehall::SearchIndex.rummager_host + Whitehall.government_search_index_path)
-end

--- a/features/topic-assigment.feature
+++ b/features/topic-assigment.feature
@@ -1,3 +1,4 @@
+# NB: Topic is being renamed to "Policy Area" across GOV.UK.
 Feature: Assigning editions to topics, via policies
 
   Background:

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -47,9 +47,11 @@ module Whitehall::DocumentFilter
       end
     end
 
+    # Note that "Topics" are called "Policy Areas" in Rummager. That's why we
+    # use `policy_areas` as the filter key here.
     def filter_by_topics
       if selected_topics.any?
-        {topics: selected_topics.map(&:slug)}
+        { policy_areas: selected_topics.map(&:slug) }
       else
         {}
       end

--- a/test/unit/topic_test.rb
+++ b/test/unit/topic_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# NB: Topic is being renamed to "Policy Area" across GOV.UK.
 class TopicTest < ActiveSupport::TestCase
   include ContentRegisterHelpers
 


### PR DESCRIPTION
Whitehall has a concept called Topic, which is being renamed to "Policy Area" (see https://github.com/alphagov/whitehall/pull/2349 https://github.com/alphagov/whitehall/pull/2249). Rummager currently has support to ask it for `policy_areas` instead of `topics` (https://github.com/alphagov/rummager/pull/557).

Once this PR is deployed, we can query Kibana to see if any other app is asking Rummager for "topics". If that is not the case, we can remove the legacy support for topics in rummager.

Trello: https://trello.com/c/bDFlehc5