### PR TITLE
Robustly generate edition preview URLs 

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -45,8 +45,8 @@ module PublicDocumentRoutesHelper
   end
 
   def preview_document_url(edition, options = {})
-    if edition.is_a?(CaseStudy) && Whitehall.case_study_preview_host.present?
-      options[:host] = Whitehall.case_study_preview_host
+    if edition.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+      options[:host] = Plek.find_uri("draft-origin").host
     else
       options.merge!(preview: edition.latest_edition.id, cachebust: Time.zone.now.getutc.to_i)
     end

--- a/config/initializers/case_study_preview_host.rb
+++ b/config/initializers/case_study_preview_host.rb
@@ -1,4 +1,0 @@
-# This file is overwritten on deploy.
-# Set to `nil` to use request.host.
-#
-Whitehall.case_study_preview_host = nil

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -27,6 +27,7 @@ module Whitehall
   mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
   mattr_accessor :case_study_publishing_api_rendering_app
+  # TODO remove when no longer being set in alphagov-deployment
   mattr_accessor :case_study_preview_host
 
   revision_file = "#{Rails.root}/REVISION"

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -125,11 +125,10 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
     assert_equal "http://test.host/government/publications/#{edition.slug}?cachebust=#{Time.zone.now.getutc.to_i}&preview=#{edition.id}", preview_url
   end
 
-  test "Creates a preview URL without parameters for case studies" do
-    Whitehall.stubs(case_study_preview_host: 'content.preview')
+  test "Creates a preview URL without parameters for edition formats that have migrated" do
     edition = create(:draft_case_study)
     preview_url = preview_document_url(edition)
-    assert_equal "http://content.preview/government/case-studies/#{edition.slug}", preview_url
+    assert_equal "http://draft-origin.test.alphagov.co.uk/government/case-studies/#{edition.slug}", preview_url
   end
 
   test "organisations have the correct path generated" do


### PR DESCRIPTION
With this change, we:
* no longer depend on a file being correctly overwritten at deploy-time
* simplify the code
* automatically handle preview URLs for edition formats as they are migrated

Related PR on alphagov-deployment: https://github.gds/gds/alphagov-deployment/pull/1147

I suspect that when this was first done, the content-preview host wasn't known,
so it was made configurable.