### PR TITLE
Update attachment accessibility toggler markup

### DIFF
--- a/app/assets/javascripts/application/on_ready.js
+++ b/app/assets/javascripts/application/on_ready.js
@@ -8,8 +8,6 @@ jQuery(function($) {
   $('.js-toggle-change-notes').toggler({actLikeLightbox: true});
   $('.js-toggle-footer-change-notes').toggler();
 
-  $('.js-toggle-accessibility-warning').toggler({header: ".toggler", content: ".help-block"})
-
   $(".js-document-filter").enableDocumentFilter();
 
   $('.js-hide-extra-social-media').hideExtraRows({ rows: 5 });

--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -9,16 +9,6 @@ $thumbnail-width: 99px;
     padding: $gutter-half ($thumbnail-width + $gutter) 0 0;
   }
 
-  &.inline {
-    background: transparent;
-    position: static;
-    padding: 0;
-    margin: 0;
-    &:after {
-      display: none;
-    }
-  }
-
   .attachment-thumb {
     position: relative;
     float: left;

--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -107,16 +107,6 @@ $thumbnail-width: 99px;
       margin: 0;
       color: $text-colour;
     }
-    .toggler {
-      display: inline-block;
-      color: $link-colour;
-      cursor: pointer;
-      &:hover,
-      &:focus {
-        outline: none;
-        text-decoration: underline;
-      }
-    }
   }
   &:first-child {
     margin-top: 0;

--- a/app/assets/stylesheets/frontend/helpers/_attachment.scss
+++ b/app/assets/stylesheets/frontend/helpers/_attachment.scss
@@ -65,11 +65,6 @@ $thumbnail-width: 99px;
       font-weight: bold;
     }
 
-    .extra-description {
-      @include ig-core-19;
-      margin: 0;
-    }
-
     .metadata {
       @include ig-core-14;
       margin: 0;

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -2,6 +2,7 @@
   extra_description ||= ""
   published_on ||= ""
   help_block_id = "attachment-#{attachment.id}-accessibility-help"
+  help_block_toggle_id = "attachment-#{attachment.id}-accessibility-request"
   thumbnail_link_options = { "aria-hidden" => true, class: 'thumbnail' }
 
   title_link_options = {}
@@ -70,11 +71,11 @@
     <% end %>
 
     <% unless attachment.accessible? %>
-      <div class="accessibility-warning js-toggle-accessibility-warning" id="<%= help_block_id %>">
+      <div data-module="toggle" class="accessibility-warning" id="<%= help_block_id %>">
         <h2><%= t('attachment.accessibility.heading') %>
-          <span class="toggler"><%= t('attachment.accessibility.request_a_different_format') %></span>
+          <a class="toggler" href="#<%= help_block_toggle_id %>" data-controls="<%= help_block_toggle_id %>" data-expanded="false"><%= t('attachment.accessibility.request_a_different_format') %></a>
         </h2>
-        <p class="help-block">
+        <p id="<%= help_block_toggle_id %>" class="js-hidden">
           <%= t('attachment.accessibility.full_help_html',
                 email: alternative_format_order_link(attachment, alternative_format_contact_email),
                 title: attachment.title,

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -1,5 +1,4 @@
 <%
-  extra_description ||= ""
   published_on ||= ""
   help_block_id = "attachment-#{attachment.id}-accessibility-help"
   help_block_toggle_id = "attachment-#{attachment.id}-accessibility-request"
@@ -17,9 +16,6 @@
   </div>
   <div class="attachment-details">
     <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), title_link_options %></h2>
-    <% unless extra_description.empty? %>
-      <p class="extra-description"><%= extra_description %></p>
-    <% end %>
     <p class="metadata">
       <% if attachment.isbn.present? or attachment.unique_reference.present? or attachment.command_paper_number.present? or attachment.hoc_paper_number.present? %>
         <span class="references">

--- a/app/views/documents/_inline_attachment.html.erb
+++ b/app/views/documents/_inline_attachment.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for(:span, attachment.becomes(Attachment), class: "inline") do %>
+<span id="attachment_<%= attachment.id %>" class="attachment-inline">
   <%= link_to attachment.title, attachment.url %>
   (<%= attachment_attributes(attachment) %>)
-<% end %>
+</span>

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -140,7 +140,7 @@ class GovspeakHelperTest < ActionView::TestCase
     document = build(:published_detailed_guide, :with_file_attachment, body: text)
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h1"
-    assert_select_within_html html, ".attachment.inline"
+    assert_select_within_html html, ".attachment-inline"
   end
 
   test "should ignore missing block attachments" do
@@ -157,7 +157,7 @@ class GovspeakHelperTest < ActionView::TestCase
     document = build(:published_detailed_guide, :with_file_attachment, body: text)
     html = govspeak_edition_to_html(document)
     assert_select_within_html html, "h1"
-    refute_select_within_html html, ".attachment.inline"
+    refute_select_within_html html, ".attachment-inline"
   end
 
   test "should not convert documents with no block attachments" do
@@ -171,7 +171,7 @@ class GovspeakHelperTest < ActionView::TestCase
     text = "#Heading\n\nText about my [InlineAttachment:2]."
     document = build(:published_detailed_guide, body: text)
     html = govspeak_edition_to_html(document)
-    refute_select_within_html html, ".attachment.inline"
+    refute_select_within_html html, ".attachment-inline"
   end
 
   test "should convert multiple block attachments" do


### PR DESCRIPTION
We want to migrate formats with attachments to `content-store`, to be rendered by `government-frontend`, where the govspeak is rendered by the `govspeak` component from static.

To do this we need to port the styling and behaviour of attachments to the `govspeak` component. This is easily done for SCSS, but the JS that powers the "toggle request alternative format" is quite WH specific, and it doens't make sense to port it to static, especially as the current implementation has some accessibility issues itself.

Instead, we're updating the attachment markup in the WH template to use a new Module based toggler, that is [being added to static](https://github.com/alphagov/static/pull/740) (this PR shouldn't be merged/deployed until that is)

As WH formats being published to the content store will push the Govspeak body, including the full attachment markup rendered by `app/views/documents/_attachment.html.erb` and making changes to that template will require republishing the documents to content store, so we're making the change to the markup in advance of publishing to content store.

The new markup/JS will continue to work within WH, as we migrate formats to `content-store` / `government-frontend`.

**Mergable when**

- [ ] https://github.com/alphagov/static/pull/740 is deployed
