### PR TITLE
Bump gds-api-adapters to pass on Original URL header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '27.2.1'
+  gem 'gds-api-adapters', '~> 28.2.1'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (27.2.1)
+    gds-api-adapters (28.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -301,7 +301,7 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -480,7 +480,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (= 27.2.1)
+  gds-api-adapters (~> 28.2.1)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.1)


### PR DESCRIPTION
This version of api-adapters contains a change to pass on the `HTTP_GOVUK_ORIGINAL_URL` header to API calls. This allows us to get better visibility on the data flow between applications.

Trello: https://trello.com/c/JVZPH4S9/410

@rboulton 