### PR TITLE
Scripts for checking that content published successfully to the Content Store

### DIFF
--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -15,7 +15,7 @@
 # pagination, so it won't (reliably) handle lots of items...
 module DataHygiene
   class PublishingApiSyncCheck
-    attr_reader :hydra, :scope, :expectations, :successes, :failures
+    attr_reader :hydra, :scope, :expectations, :successes, :failures, :base_path_builder
 
     def initialize(scope)
       @scope = scope
@@ -24,10 +24,16 @@ module DataHygiene
       @expectations = []
       @successes = []
       @failures = []
+
+      @base_path_builder = lambda { |whitehall_model| Whitehall.url_maker.polymorphic_path(whitehall_model) }
     end
 
     def add_expectation(&block)
       expectations << block
+    end
+
+    def override_base_path(&base_path_builder)
+      @base_path_builder = base_path_builder
     end
 
     def perform(output: true)
@@ -68,7 +74,7 @@ module DataHygiene
     end
 
     def base_path_for(whitehall_model)
-      Whitehall.url_maker.polymorphic_path(whitehall_model)
+      @base_path_builder.call(whitehall_model)
     end
   end
 end

--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -50,7 +50,13 @@ module DataHygiene
       @successes = []
       @failures = []
 
-      @base_path_builder = lambda { |whitehall_model| Whitehall.url_maker.polymorphic_path(whitehall_model) }
+      @base_path_builder = lambda do |model|
+        if model.is_a?(Edition)
+          Whitehall.url_maker.public_document_path(model)
+        else
+          Whitehall.url_maker.polymorphic_path(model)
+        end
+      end
     end
 
     def add_expectation(description, &block)

--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -1,0 +1,74 @@
+# Check to see how complete the (live) content-store's copies of data are.
+#
+#   pasc = DataHygiene::PublishingApiSyncCheck.new(StatisticsAnnouncement.limit(100))
+#   pasc.add_expectation { |json, model| json.fetch("format") == "statistics_announcement" }
+#   pasc.perform
+#
+# The disadvantages of running against content-store are that you can't inspect
+# things like rendering_app.
+#
+# On the other hand, if you don't trust publishing-api's ability to push to
+# content-store...
+#
+# If we used publishing-api, we could use its index endpoint to do this all in
+# a single request. The problem is that that endpoint currently doesn't do
+# pagination, so it won't (reliably) handle lots of items...
+module DataHygiene
+  class PublishingApiSyncCheck
+    attr_reader :hydra, :scope, :expectations, :successes, :failures
+
+    def initialize(scope)
+      @scope = scope
+      Ethon.logger = Logger.new(nil) # disable Typhoeus/Ethon debug logging
+      @hydra = Typhoeus::Hydra.new(max_concurrency: 20)
+      @expectations = []
+      @successes = []
+      @failures = []
+    end
+
+    def add_expectation(&block)
+      expectations << block
+    end
+
+    def perform(output: true)
+      scope.find_each do |whitehall_model|
+        url = Plek.find('content-store') + "/content" + base_path_for(whitehall_model)
+        request = Typhoeus::Request.new(url)
+        request.on_complete do |response|
+          print "." if output
+          compare_content(response, whitehall_model)
+        end
+        hydra.queue(request)
+      end
+      hydra.run
+      print_results if output
+    end
+
+  private
+
+    def compare_content(response, whitehall_model)
+      base_path = base_path_for(whitehall_model)
+      if response.success?
+        json = JSON.parse(response.body)
+        if expectations.all? { |expectation| expectation.call(json, whitehall_model) } # should return true if expectations is empty
+          successes << base_path
+        else
+          failures << base_path
+        end
+      else
+        failures << base_path
+      end
+    end
+
+    def print_results
+      puts "\nCheck complete"
+      puts "Successes: #{successes.count}"
+      puts "Failures: #{failures.count}"
+      puts "Failure paths:\n#{failures.join("\n")}" unless failures.empty?
+    end
+
+    def base_path_for(whitehall_model)
+      Whitehall.url_maker.polymorphic_path(whitehall_model)
+    end
+  end
+end

--- a/script/publishing-api-sync-checks/case_study_sync_check.rb
+++ b/script/publishing-api-sync-checks/case_study_sync_check.rb
@@ -1,0 +1,14 @@
+case_studies = CaseStudy.latest_published_edition
+check = DataHygiene::PublishingApiSyncCheck.new(case_studies)
+
+check.add_expectation("format") do |content_store_payload, _|
+  content_store_payload["format"] == "case_study"
+end
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == record.search_link
+end
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.title
+end
+
+check.perform

--- a/script/publishing-api-sync-checks/take_part_sync_check.rb
+++ b/script/publishing-api-sync-checks/take_part_sync_check.rb
@@ -1,0 +1,14 @@
+take_part_pages = TakePartPage.all
+check = DataHygiene::PublishingApiSyncCheck.new(take_part_pages)
+
+check.add_expectation("format") do |content_store_payload, _|
+  content_store_payload["format"] == "take_part"
+end
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == record.search_link
+end
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.title
+end
+
+check.perform

--- a/script/publishing-api-sync-checks/topical_event_about_page_sync_check.rb
+++ b/script/publishing-api-sync-checks/topical_event_about_page_sync_check.rb
@@ -1,0 +1,15 @@
+about_pages = AboutPage.all
+check = DataHygiene::PublishingApiSyncCheck.new(about_pages)
+check.override_base_path { |model| model.search_link }
+
+check.add_expectation("format") do |content_store_payload, _|
+  content_store_payload["format"] == 'topical_event_about_page'
+end
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == record.search_link
+end
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.name
+end
+
+check.perform

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+require 'gds_api/test_helpers/content_store'
+
+class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  test "checks that the format published in the content store matches the persisted model" do
+    create(
+      :take_part_page,
+      title: "Title of a take part page",
+      slug: "take-part-slug",
+    )
+    payload = {
+      format: "take_part",
+      title: "Title of a take part page",
+      base_path: "/government/get-involved/take-part/take-part-slug",
+    }
+    content_store_has_item("/government/get-involved/take-part/take-part-slug", payload)
+
+    check = check_take_part
+    check.perform(output: false)
+
+    assert_equal(["/government/get-involved/take-part/take-part-slug"], check.successes)
+    assert_empty(check.failures)
+  end
+
+  test "detects when the format published in the Content Store does not match the persisted model" do
+    create(
+      :take_part_page,
+      title: "Title of a take part page",
+      slug: "take-part-slug",
+    )
+    payload = {
+      format: "placeholder", # unexpected format in Content Store
+      title: "Title of a take part page",
+      base_path: "/government/get-involved/take-part/take-part-slug",
+    }
+    content_store_has_item("/government/get-involved/take-part/take-part-slug", payload)
+
+    check = check_take_part
+    check.perform(output: false)
+
+    assert_empty(check.successes)
+    assert_equal(["/government/get-involved/take-part/take-part-slug"], check.failures)
+  end
+
+  test "detects when the content item is missing from the Content Store" do
+    create(
+      :take_part_page,
+      title: "Title of a take part page",
+      slug: "take-part-slug",
+    )
+    content_store_does_not_have_item("/government/get-involved/take-part/take-part-slug")
+
+    check = check_take_part
+    check.perform(output: false)
+
+    assert_empty(check.successes)
+    assert_equal(["/government/get-involved/take-part/take-part-slug"], check.failures)
+  end
+
+  def check_take_part
+    check = DataHygiene::PublishingApiSyncCheck.new(TakePartPage.all)
+
+    check.add_expectation do |content_store_payload, _|
+      content_store_payload["format"] == 'take_part'
+    end
+    check.add_expectation do |content_store_payload, model|
+      content_store_payload["base_path"] == Whitehall.url_maker.polymorphic_path(model)
+    end
+    check.add_expectation do |content_store_payload, model|
+      content_store_payload["title"] == model.title
+    end
+
+    check
+  end
+end

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -59,6 +59,25 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     assert_equal(["/government/get-involved/take-part/take-part-slug"], check.failures)
   end
 
+  test "overriding the base path fetching for formats that don't follow the conventions" do
+    event = create(:topical_event, slug: 'example-event')
+    create(:about_page, topical_event: event, name: "About page")
+
+    payload = {
+      format: "topical_event_about_page",
+      title: "About page",
+      base_path: "/government/topical-events/example-event/about",
+    }
+    content_store_has_item("/government/topical-events/example-event/about", payload)
+
+    check = check_about_pages
+    check.override_base_path(&:search_link)
+    check.perform(output: false)
+
+    assert_equal(["/government/topical-events/example-event/about"], check.successes)
+    assert_empty(check.failures)
+  end
+
   def check_take_part
     check = DataHygiene::PublishingApiSyncCheck.new(TakePartPage.all)
 
@@ -70,6 +89,22 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     end
     check.add_expectation do |content_store_payload, model|
       content_store_payload["title"] == model.title
+    end
+
+    check
+  end
+
+  def check_about_pages
+    check = DataHygiene::PublishingApiSyncCheck.new(AboutPage.all)
+
+    check.add_expectation do |content_store_payload, _|
+      content_store_payload["format"] == 'topical_event_about_page'
+    end
+    check.add_expectation do |content_store_payload, model|
+      content_store_payload["base_path"] == model.search_link
+    end
+    check.add_expectation do |content_store_payload, model|
+      content_store_payload["title"] == model.name
     end
 
     check

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -18,7 +18,9 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     content_store_has_item("/government/get-involved/take-part/take-part-slug", payload)
 
     check = check_take_part
-    check.perform(output: false)
+    assert_output(/Successes: 1\nFailures: 0/m) do
+      check.perform
+    end
 
     assert_equal(["/government/get-involved/take-part/take-part-slug"], check.successes)
     assert_empty(check.failures)
@@ -38,7 +40,9 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     content_store_has_item("/government/get-involved/take-part/take-part-slug", payload)
 
     check = check_take_part
-    check.perform(output: false)
+    assert_output(/Successes: 0\nFailures: 1/m) do
+      check.perform
+    end
 
     assert_empty(check.successes)
     assert_equal(["/government/get-involved/take-part/take-part-slug"], check.failures)


### PR DESCRIPTION
There are many moving parts between Whitehall pushing a payload to the Publishing API and it landing in the Content Store. These scripts are the beginning of a tool for comparing what's in the Whitehall DB with what's in the Content Store.

The intention is that as more formats are migrated across to the new publishing stack, new checker scripts are written to make sure that the republishing and backfilling process was successful.

@jamiecobbett, @binaryberry and I worked on this story.

Trello: https://trello.com/c/crXRkrHV/301-tool-for-validating-migrated-content-medium