### PR TITLE
Publish working groups to publishing api

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,14 +285,6 @@ module ApplicationHelper
     end
   end
 
-  def path_to_image(source)
-    if source && source.starts_with?("/government/uploads") && user_signed_in?
-      source
-    else
-      super(source)
-    end
-  end
-
   def is_external?(href)
     if host = Addressable::URI.parse(href).host
       Whitehall.public_host != host

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -106,6 +106,10 @@ class Attachment < ActiveRecord::Base
     ''
   end
 
+  def url
+    raise NotImplementedError, "Subclasses must implement the url method"
+  end
+
   private
 
   def store_price_in_pence

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -22,7 +22,7 @@ private
 
   def body
     # It looks 'wrong' using the description as the body, but it isn't
-    Whitehall::GovspeakRenderer.new.govspeak_to_html(item.description)
+    Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.description, item.attachments)
   end
 
   def public_updated_at

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -1,7 +1,31 @@
-class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Placeholder
-  private
+class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Item
+private
+
+  def title
+    item.name
+  end
 
   def document_format
-    "placeholder_working_group"
+    "working_group"
+  end
+
+  def description
+    item.summary # This is deliberately the 'wrong' way around
+  end
+
+  def details
+    {
+      email: item.email,
+      body: body,
+    }
+  end
+
+  def body
+    # It looks 'wrong' using the description as the body, but it isn't
+    Whitehall::GovspeakRenderer.new.govspeak_to_html(item.description)
+  end
+
+  def public_updated_at
+    item.updated_at
   end
 end

--- a/app/views/documents/_attachment.html.erb
+++ b/app/views/documents/_attachment.html.erb
@@ -7,15 +7,21 @@
   title_link_options = {}
   title_link_options['rel'] = 'external' if attachment.external?
   title_link_options["aria-describedby"] = help_block_id unless attachment.accessible?
+
+  # This partial is rendered when sending to the publishing-api, so needs to
+  # work outside of a request/controller context. The preview param, which exists
+  # to bust cache and view a specific edition, isn't applicable when publishing
+  # to publishing-api.
+  preview = controller.nil? ? nil : params[:preview]
 %>
 <%= content_tag_for(:section, attachment.becomes(Attachment), class: attachment.external? ? "hosted-externally" : "embedded") do %>
   <div class="attachment-thumb">
     <% unless defined?(hide_thumbnail) && hide_thumbnail %>
-      <%= link_to_unless previewable?(attachment), attachment_thumbnail(attachment), attachment.url(preview: params[:preview]), thumbnail_link_options %>
+      <%= link_to_unless previewable?(attachment), attachment_thumbnail(attachment), attachment.url(preview: preview), thumbnail_link_options %>
     <% end %>
   </div>
   <div class="attachment-details">
-    <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: params[:preview]), title_link_options %></h2>
+    <h2 class="title"><%= link_to_unless previewable?(attachment), attachment.title, attachment.url(preview: preview), title_link_options %></h2>
     <p class="metadata">
       <% if attachment.isbn.present? or attachment.unique_reference.present? or attachment.command_paper_number.present? or attachment.hoc_paper_number.present? %>
         <span class="references">
@@ -41,7 +47,7 @@
           </strong>
         </span>
         <span class="download">
-          <%= link_to attachment.url(preview: params[:preview]) do %>
+          <%= link_to attachment.url(preview: preview) do %>
             <strong>Download <%= attachment.file_extension.upcase %></strong>
             <%= number_to_human_size(attachment.file_size) %>
           <% end %>

--- a/db/data_migration/20160219145627_republish_working_groups.rb
+++ b/db/data_migration/20160219145627_republish_working_groups.rb
@@ -1,0 +1,32 @@
+# working_group is the name used for PolicyGroup in publishing-api land see:
+# https://github.com/alphagov/whitehall/commit/0bf9ce56fa4a9f82552e7eb551a1cc3c95b7ec39
+# for more detail.
+
+# Enable (re)publishing of "/government/groups/criminal-justice-board".
+#
+# In production and integration, in content-store/publishing-api, there is a
+# content_item with this base_path and the content_id:
+# "8fd0b07e-c37a-4b99-9696-52323ad34c48". This doesn't match the content_id in
+# Whitehall's database, which is: "3dd40620-7d1d-4344-820c-f051683be5fb". The
+# consequence of that is that we aren't able to republish the working group
+# because we're trying to overwrite a content_item but with a different
+# content_id. That is only allowed if the item being replaced or doing the
+# replacing is one of a few special types, such as "gone" or "redirect". See
+# https://github.com/alphagov/publishing-api/blob/27ae02862e4705953a053c74bd94ce759a41544d/app/substitution_helper.rb
+#
+# Therefore, to be able to publish the criminal-justice-board content_item, we
+# can publish a Gone item and then (re)publish the real thing over the top.
+#
+# I suspect this happened when a PolicyGroup with the slug was created,
+# deleted and then recreated. Then it would have ended up with a different
+# content_id. At the time, the PolicyGroup model was wired up to publish to
+# publishing-api (via the PublishesToPublishingApi module) but deletes weren't
+# handled. See:
+# https://github.com/alphagov/whitehall/commit/0bf9ce56fa4a9f82552e7eb551a1cc3c95b7ec39
+#
+# and from the time:
+# https://github.com/alphagov/whitehall/blob/0bf9ce56fa4a9f82552e7eb551a1cc3c95b7ec39/lib/publishes_to_publishing_api.rb
+PublishingApiGoneWorker.new.perform("/government/groups/criminal-justice-board")
+
+republisher = DataHygiene::PublishingApiRepublisher.new(PolicyGroup.all)
+republisher.perform

--- a/lib/whitehall/govspeak_renderer.rb
+++ b/lib/whitehall/govspeak_renderer.rb
@@ -1,7 +1,7 @@
 # Helper class to render govspeak outside of the view contexts.
 module Whitehall
   class GovspeakRenderer
-    delegate :govspeak_edition_to_html, :govspeak_to_html, to: :helpers
+    delegate :govspeak_edition_to_html, :govspeak_to_html, :govspeak_with_attachments_to_html, to: :helpers
 
   private
     # Because the govspeak helpers in whitehall rely on rendering partials, we

--- a/script/publishing-api-sync-checks/working_group_check.rb
+++ b/script/publishing-api-sync-checks/working_group_check.rb
@@ -1,0 +1,16 @@
+# Working Groups are called PolicyGroup in the code as they have been partially
+# renamed
+take_part_pages = PolicyGroup.all
+check = DataHygiene::PublishingApiSyncCheck.new(take_part_pages)
+
+check.add_expectation("format") do |content_store_payload, _|
+  content_store_payload["format"] == "working_group"
+end
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == record.search_link
+end
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.name
+end
+
+check.perform

--- a/test/factories/policy_groups.rb
+++ b/test/factories/policy_groups.rb
@@ -2,5 +2,12 @@ FactoryGirl.define do
   factory :policy_group do
     sequence(:email) { |n| "policy-group-#{n}@example.com" }
     name 'policy-group-name'
+
+    trait(:with_file_attachment) do
+      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      after :create do |edition, _evaluator|
+        VirusScanHelpers.simulate_virus_scan(edition.attachments.first.attachment_data.file)
+      end
+    end
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -6,21 +6,6 @@ class ApplicationHelperTest < ActionView::TestCase
   include ERB::Util
   include Rails.application.routes.url_helpers
 
-  class TestView
-    module RailsPathToImage
-      def path_to_image(source)
-        'assets.example.com' + source
-      end
-    end
-
-    def user_signed_in?
-      false
-    end
-
-    include RailsPathToImage
-    include ApplicationHelper
-  end
-
   # Exposes request object to helper in tests
   def request
     controller.request
@@ -180,24 +165,6 @@ class ApplicationHelperTest < ActionView::TestCase
     refute classes.include?("active")
     assert classes.include?("class-1")
     assert classes.include?("class-2")
-  end
-
-  test "skips asset host for image paths if user signed in and image in uploads" do
-    view = TestView.new
-    view.stubs(:user_signed_in?).returns(true)
-    assert_equal '/government/uploads/path/to/my/image', view.path_to_image('/government/uploads/path/to/my/image')
-  end
-
-  test "uses asset host for image paths if user signed in but image not in uploads" do
-    view = TestView.new
-    view.stubs(:user_signed_in?).returns(true)
-    assert_equal 'assets.example.com/path/to/another/image', view.path_to_image('/path/to/another/image')
-  end
-
-  test "uses asset standard rails image paths if user not signed in" do
-    view = TestView.new
-    view.stubs(:user_signed_in?).returns(false)
-    assert_equal 'assets.example.com/government/uploads/path/to/my/image', view.path_to_image('/government/uploads/path/to/my/image')
   end
 
   test "correctly identifies external links" do

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -39,4 +39,14 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
     assert_equal expected_hash, presenter.content
     assert_valid_against_schema(presenter.content, 'working_group')
   end
+
+  test "renders attachments in the body" do
+    group = create(:policy_group, :with_file_attachment, description: "#Heading\n\n!@1\n\n##Subheading")
+
+    presenter = PublishingApiPresenters::WorkingGroup.new(group)
+
+    body = Nokogiri::HTML.parse(presenter.content[:details][:body])
+    assert_not_nil body.at_css("section.attachment")
+    assert_match %r{#{group.attachments.first.title}}, body.at_css("section.attachment")
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
   test 'presents a valid placeholder "working_group" content item' do
     group = create(:policy_group,
-      name: "Government Digital Service"
+      name: "Government Digital Service",
+      email: "group-1@example.com",
+      summary: "This is some plaintext in the summary field",
+      description: "This is some *Govspeak* in the description field",
                   )
     public_path = '/government/groups/government-digital-service'
 
@@ -11,9 +14,9 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
       base_path: public_path,
       publishing_app: "whitehall",
       rendering_app: "whitehall-frontend",
-      format: "placeholder_working_group",
+      format: "working_group",
       title: "Government Digital Service",
-      description: nil,
+      description: "This is some plaintext in the summary field", # This is deliberately the 'wrong' way around
       locale: "en",
       need_ids: [],
       routes: [
@@ -25,12 +28,15 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
       redirects: [],
       update_type: 'major',
       public_updated_at: group.updated_at,
-      details: {}
+      details: {
+        email: "group-1@example.com",
+        body: "<div class=\"govspeak\"><p>This is some <em>Govspeak</em> in the description field</p>\n</div>", # This is deliberately the 'wrong' way around
+      }
     }
 
     presenter = PublishingApiPresenters::WorkingGroup.new(group)
 
     assert_equal expected_hash, presenter.content
-    assert_valid_against_schema(presenter.content, 'placeholder')
+    assert_valid_against_schema(presenter.content, 'working_group')
   end
 end

--- a/test/unit/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/whitehall/govspeak_renderer_test.rb
@@ -28,6 +28,20 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
     assert_select_within_html html, "#attachment_#{attachment_2.id}"
   end
 
+  test "converts block attachments and handles thumbnails for PDFs" do
+    body = "#Heading\n\nText. \n\n!@1\n\n Fooble"
+    edition = create(:published_detailed_guide, :with_file_attachment, body: body, attachments: [
+      attachment = build(:file_attachment, id: 1),
+    ])
+
+    # The content_type doesn't get set for some reason, so set it manually
+    ad = edition.attachments.first.attachment_data
+    ad.update_column(:content_type, 'application/pdf')
+
+    html = render_govspeak(edition)
+    assert_select_within_html html, "#attachment_#{attachment.id}"
+  end
+
   def render_govspeak(edition)
     Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(edition)
   end


### PR DESCRIPTION
We should probably wait for either https://github.com/alphagov/whitehall/pull/2478 or https://github.com/alphagov/publishing-api/pull/213 to be merged, so that we can be confident that the republishing step completes successfully, but I wanted to open this up for feedback now.