### PR TITLE
Serve fraction assets via the public asset host

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -91,7 +91,7 @@ module GovspeakHelper
   def fraction_image(numerator, denominator)
     denominator.downcase! if %w{X Y}.include? denominator
     if numerator.present? && denominator.present? && Rails.application.assets.find_asset("fractions/#{numerator}_#{denominator}.png")
-      "fractions/#{numerator}_#{denominator}.png"
+      asset_path("fractions/#{numerator}_#{denominator}.png", host: Whitehall.public_asset_host)
     end
   end
 

--- a/test/integration/fraction_assets_test.rb
+++ b/test/integration/fraction_assets_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class FractionAssetsTest < ActiveSupport::TestCase
+  test "fraction assets directory and contents are fixed" do
+    hash = `git rev-parse HEAD^{tree}:app/assets/images/fractions`.chomp
+    assert_equal hash, "e6ecee075e5215f9a7820ae82ff56925222b1298"
+  end
+end

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -353,6 +353,14 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, "table.sortable.js-barchart-table"
   end
 
+  test "fraction image paths include the public asset host and configured asset prefix" do
+    prefix = Rails.application.config.assets.prefix
+    path   = "#{Whitehall.public_asset_host}#{prefix}/fractions/1_2.png"
+    html   = govspeak_to_html("I'm [Fraction:1/2] a person")
+
+    assert_select_within_html(html, "img[src='#{path}']")
+  end
+
   test 'will create bespoke fractions' do
     input = "Some text [Fraction:1/72] and some text"
     html = govspeak_to_html(input)


### PR DESCRIPTION
Fraction assets were being served using paths relative to the whitehall root.
This change is necessary preparation for publishing HTML publications to the
content store. The paths now include the configured public asset host and asset
prefix.

Since these are now going to be depended on externally, we also make sure
nobody changes the contents of the fraction assets directory.