### PR TITLE
Link to all latest news for organisations allowed promotional features

### DIFF
--- a/app/views/organisations/show-promotional.html.erb
+++ b/app/views/organisations/show-promotional.html.erb
@@ -22,8 +22,7 @@
       <%= render partial: 'featured_items',
                 locals: { feature_list: @feature_list,
                           recently_updated: @recently_updated,
-                          organisation: @organisation,
-                          see_all_link: announcements_filter_path(@organisation) } %>
+                          organisation: @organisation } %>
     </div>
   </div>
 


### PR DESCRIPTION
- Only the Civil Service and Number 10 'organisations' are allowed
  promotional features.
- The `see_all` link was going to the Announcements page specifically,
  not ALL of the latest news for that organisation. This changes it
  so that links to ALL of their publications, so that eg policy papers
  are visible.

Trello: https://trello.com/c/csHn2Dt7/312-add-no10-civil-service-to-the-full-list-of-latest-news

(Paired with @brenetic.)