### PR TITLE
Remove duplicate `StatisticsAnnouncement` records

### DIFF
--- a/db/data_migration/20160301142319_remove_duplicate_statistics_announcements.rb
+++ b/db/data_migration/20160301142319_remove_duplicate_statistics_announcements.rb
@@ -1,0 +1,2 @@
+#These are duplicates of 2026 and 1976 respectively
+StatisticsAnnouncement.delete [2025, 1975]


### PR DESCRIPTION
Whilst checking the results of `StatisticsAnnouncement` migration these two where found to be duplicates. This data migration deletes them.

It isn't clear how they occurred but they appear relatively isolated incidences (2 of > 8000 currently) so I've not investigated further.