### PR TITLE
Remove some disused settings

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -23,12 +23,7 @@ module Whitehall
   mattr_accessor :uploads_cache_max_age
   mattr_accessor :document_collections_cache_max_age
 
-  # TODO: Remove visualisation feature flag when no longer being set by alphagov-deployment
-  mattr_accessor :organisations_transition_visualisation_feature_enabled
   mattr_accessor :unified_search_client
-  mattr_accessor :case_study_publishing_api_rendering_app
-  # TODO remove when no longer being set in alphagov-deployment
-  mattr_accessor :case_study_preview_host
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)


### PR DESCRIPTION
These stopped being set in:
https://github.gds/gds/alphagov-deployment/pull/1148

and:
https://github.gds/gds/alphagov-deployment/pull/1147

Those changes have been promoted to the alphagov-deployment "release" branch,
so we should be safe to stop providing them.