### PR TITLE
Check draft content store sync with publishing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 28.2.1'
+  gem 'gds-api-adapters', '~> 29.2.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (28.2.1)
+    gds-api-adapters (29.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -480,7 +480,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 28.2.1)
+  gds-api-adapters (~> 29.2.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.1)

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -35,7 +35,7 @@ class PublishingApiWorker < WorkerBase
 
   def save_draft(payload)
     Whitehall.publishing_api_v2_client.put_content(payload.content_id, payload.content)
-    Whitehall.publishing_api_v2_client.put_links(payload.content_id, links: payload.links)
+    Whitehall.publishing_api_v2_client.patch_links(payload.content_id, links: payload.links)
   end
 
   def save_draft_of_unpublished_edition(unpublishing)

--- a/features/support/publishing_api.rb
+++ b/features/support/publishing_api.rb
@@ -3,5 +3,5 @@ require 'gds_api/publishing_api_v2'
 Before do
   GdsApi::PublishingApiV2.any_instance.stubs(:publish)
   GdsApi::PublishingApiV2.any_instance.stubs(:put_content)
-  GdsApi::PublishingApiV2.any_instance.stubs(:put_links)
+  GdsApi::PublishingApiV2.any_instance.stubs(:patch_links)
 end

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -15,7 +15,7 @@ class PublishingTest < ActiveSupport::TestCase
   test "When an edition is published, it gets published with the Publishing API" do
     requests = [
       stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
-      stub_publishing_api_put_links(@presenter.content_id, links: @presenter.links),
+      stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
@@ -40,7 +40,7 @@ class PublishingTest < ActiveSupport::TestCase
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
-    links_request = stub_publishing_api_put_links(@presenter.content_id, links: @presenter.links)
+    links_request = stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links)
 
     perform_force_publishing_for(@draft_edition)
 

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -18,7 +18,7 @@ class WithdrawingTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(presenter.content_id, content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -8,7 +8,7 @@ module PublishingApiTestHelpers
     Array(editions).each do |edition|
       presenter = PublishingApiPresenters::Edition.new(edition)
       stub_publishing_api_put_content(presenter.content_id, presenter.content)
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links)
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'major')
     end
   end
@@ -18,7 +18,7 @@ module PublishingApiTestHelpers
       Whitehall.publishing_api_v2_client.expects(:put_content)
         .with(edition.content_id,
           has_entries(publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
-      Whitehall.publishing_api_v2_client.stubs(:put_links)
+      Whitehall.publishing_api_v2_client.stubs(:patch_links)
         .with(edition.content_id,
           has_entries(links: {}))
       Whitehall.publishing_api_v2_client.expects(:publish)
@@ -31,7 +31,7 @@ module PublishingApiTestHelpers
       Whitehall.publishing_api_v2_client.expects(:put_content)
         .with(edition.content_id,
           has_entries(publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
-      Whitehall.publishing_api_v2_client.stubs(:put_links)
+      Whitehall.publishing_api_v2_client.stubs(:patch_links)
         .with(edition.content_id,
           has_entries(links: {}))
       Whitehall.publishing_api_v2_client.expects(:publish)

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -57,13 +57,13 @@ module OrganisationResluggerTest
 
       expected_publish_requests = [
         stub_publishing_api_put_content(content_item.content_id, content_item.content),
-        stub_publishing_api_put_links(content_item.content_id, links: content_item.links),
+        stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
         stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
       ]
 
       expected_redirect_requests = [
         stub_publishing_api_put_content(redirect_item.content_id, redirect_item.content),
-        stub_publishing_api_put_links(redirect_item.content_id, links: redirect_item.links),
+        stub_publishing_api_patch_links(redirect_item.content_id, links: redirect_item.links),
         stub_publishing_api_publish(redirect_item.content_id, locale: 'en', update_type: 'major')
       ]
 

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -44,13 +44,13 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
-      stub_publishing_api_put_links(content_item.content_id, links: content_item.links),
+      stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
     expected_redirect_requests = [
       stub_publishing_api_put_content(redirect_item.content_id, redirect_item.content),
-      stub_publishing_api_put_links(redirect_item.content_id, links: redirect_item.links),
+      stub_publishing_api_patch_links(redirect_item.content_id, links: redirect_item.links),
       stub_publishing_api_publish(redirect_item.content_id, locale: 'en', update_type: 'major')
     ]
 

--- a/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
@@ -8,7 +8,7 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
 
     expected_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 

--- a/test/unit/data_hygiene/publishing_api_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_republisher_test.rb
@@ -12,7 +12,7 @@ class DataHygiene::PublishingApiRepublisherTest < ActiveSupport::TestCase
 
     expected_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -42,13 +42,13 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
-      stub_publishing_api_put_links(content_item.content_id, links: content_item.links),
+      stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
     expected_redirect_requests = [
       stub_publishing_api_put_content(redirect_item.content_id, redirect_item.content),
-      stub_publishing_api_put_links(redirect_item.content_id, links: redirect_item.links),
+      stub_publishing_api_patch_links(redirect_item.content_id, links: redirect_item.links),
       stub_publishing_api_publish(redirect_item.content_id, locale: 'en', update_type: 'major')
     ]
 

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -60,7 +60,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     national_statistics = create(:draft_national_statistics)
     policy_paper        = create(:draft_policy_paper)
 
-    announcement   = build(:statistics_announcement, publication_type_id: PublicationType::OfficialStatistics.id)
+    announcement = build(:statistics_announcement, publication_type_id: PublicationType::OfficialStatistics.id)
 
     announcement.publication = statistics
     assert announcement.valid?

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -12,7 +12,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     # In the case of unpublishings, we trigger a job to save the draft edition.
     # That job runs inline because we're in test mode, so we need to stub it.
     stub_any_publishing_api_put_content
-    stub_any_publishing_api_put_links
+    stub_any_publishing_api_patch_links
   end
 
   test "#publish publishes an Edition with the Publishing API" do
@@ -20,7 +20,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
@@ -35,7 +35,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(organisation)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
@@ -51,7 +51,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
@@ -75,7 +75,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
@@ -89,7 +89,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(take_part_page, update_type: 'republish')
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
@@ -103,7 +103,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(take_part_page, update_type: 'republish')
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
@@ -130,7 +130,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: 'republish')
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
@@ -159,7 +159,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
-    links_request = stub_publishing_api_put_links(presenter.content_id, links: presenter.links)
+    links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
     Whitehall::PublishingApi.publish_async(organisation)
 
@@ -188,7 +188,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 
-    links_request = stub_publishing_api_put_links(presenter.content_id, links: presenter.links)
+    links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
     Whitehall::PublishingApi.republish_async(organisation)
 
@@ -209,7 +209,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish")
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
@@ -222,7 +222,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish")
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: "en", update_type: 'republish')
     ]
 
@@ -251,7 +251,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
-    links_request = stub_publishing_api_put_links(presenter.content_id, links: presenter.links)
+    links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
     Whitehall::PublishingApi.publish_async(unpublishing)
 

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -35,7 +35,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(uuid, expected_payload),
-      stub_publishing_api_put_links(uuid, links: {}),
+      stub_publishing_api_patch_links(uuid, links: {}),
       stub_publishing_api_publish(uuid, { locale: "fr", update_type: "major" })
     ]
 

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -12,7 +12,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(published, update_type: 'republish')
     requests = [
       stub_publishing_api_put_content(document.content_id, presenter.content),
-      stub_publishing_api_put_links(document.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(document.content_id, links: presenter.links),
       stub_publishing_api_publish(document.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
     Whitehall::PublishingApi.expects(:save_draft_async).with(draft, 'republish')
@@ -38,11 +38,11 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     # Have to separate this as we need to manually assert it was done twice. If
     # we split the pushing of links into a separate job, then we would only push
     # links once and could put this back into the array.
-    put_links_request = stub_publishing_api_put_links(document.content_id, links: {})
+    patch_links_request = stub_publishing_api_patch_links(document.content_id, links: {})
 
     PublishingApiDocumentRepublishingWorker.new.perform(edition.id, nil)
 
     assert_all_requested(requests)
-    assert_requested(put_links_request, times: 2)
+    assert_requested(patch_links_request, times: 2)
   end
 end

--- a/test/unit/workers/publishing_api_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_draft_worker_test.rb
@@ -10,7 +10,7 @@ class PublishingApiDraftWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links)
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
     ]
 
     PublishingApiDraftWorker.new.perform(edition.class.name, edition.id)

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -18,7 +18,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(uuid, content),
-      stub_publishing_api_put_links(uuid, links: {}),
+      stub_publishing_api_patch_links(uuid, links: {}),
       stub_publishing_api_publish(uuid, update_type: 'major', locale: 'en')
     ]
 

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -9,7 +9,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
 
@@ -23,7 +23,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
 
@@ -38,7 +38,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
 
@@ -58,7 +58,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: update_type)
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: update_type, locale: "en")
     ]
 
@@ -77,7 +77,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
 
       [
         stub_publishing_api_put_content(presenter.content_id, presenter.content),
-        stub_publishing_api_put_links(presenter.content_id, links: presenter.links),
+        stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
         stub_publishing_api_publish(presenter.content_id, { locale: "es", update_type: "major" })
       ]
     end


### PR DESCRIPTION
With this change, for each base path and locale the publishing api sync check
makes one request to the content store, and another one to the draft content-store.

The check will generate a failure if the content item is missing from either content stores,
and the failure description will specify which content store(s) it is missing from.

Worked on this with @benilovj and @gpeng.