### PR TITLE
Use bulk_republishing queue when bulk republishing

### DIFF
--- a/lib/data_hygiene/publishing_api_republisher.rb
+++ b/lib/data_hygiene/publishing_api_republisher.rb
@@ -26,7 +26,7 @@ module DataHygiene
   private
 
     def republish(instance)
-      Whitehall::PublishingApi.republish_async(instance)
+      Whitehall::PublishingApi.bulk_republish_async(instance)
       logger << '.'
       @queued += 1
     end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -32,6 +32,13 @@ module Whitehall
       push_live(model_instance, 'republish')
     end
 
+    def self.bulk_republish_async(model_instance)
+      if model_instance.class < Edition
+        raise ArgumentError, "This method does not support Editions"
+      end
+      push_live(model_instance, 'republish', 'bulk_republishing')
+    end
+
     # Synchronise the published and/or draft documents in publishing-api with
     # the contents of Whitehall's database.
     def self.republish_document_async(document)
@@ -39,6 +46,7 @@ module Whitehall
       pre_publication_edition_id = document.pre_publication_edition.try(:id)
       PublishingApiDocumentRepublishingWorker.perform_async(published_edition_id, pre_publication_edition_id)
     end
+
 
     def self.schedule_async(edition)
       return unless served_from_content_store?(edition)


### PR DESCRIPTION
By default the `PublishingApiWorker` used by many of the publishing actions uses the `publishing_api` Sidekiq queue. This PR adds a `bulk_republish_async` method to `Whitehall::PublishingApi` that avoids blocking this queue during bulk republishing by using the lowest priority `bulk_republishing` queue..