### PR TITLE
Add check for `StatisticsAnnouncement`

### DIFF
--- a/script/publishing-api-sync-checks/statistics_announcements_sync_check.rb
+++ b/script/publishing-api-sync-checks/statistics_announcements_sync_check.rb
@@ -1,0 +1,34 @@
+statistics_announcements = StatisticsAnnouncement.unscoped.includes(:publication).all
+check = DataHygiene::PublishingApiSyncCheck.new(statistics_announcements)
+
+def has_been_redirected?(statistics_announcement)
+  publication_published?(statistics_announcement) || statistics_announcement.unpublished?
+end
+
+def publication_published?(statistics_announcement)
+  statistics_announcement.publication && statistics_announcement.publication.published?
+end
+
+check.add_expectation("base_path") do |content_store_payload, model|
+  content_store_payload["base_path"] == model.public_path
+end
+
+check.add_expectation("format") do |content_store_payload, model|
+  if has_been_redirected?(model)
+    content_store_payload["format"] == "redirect"
+  else
+    content_store_payload["format"] == "statistics_announcement"
+  end
+end
+
+check.add_expectation("title") do |content_store_payload, model|
+  if has_been_redirected?(model)
+    #announcements that relate to published statistics have 'null' title
+    #so we can ignore
+    true
+  else
+    content_store_payload["title"] == model.title
+  end
+end
+
+check.perform


### PR DESCRIPTION
This check compares `StatisticsAnnouncement` in Whitehall with its migrated representation from ContentStore.

It checks `title`, `base_path` and `format` taking into account redirects caused by the publication of the associated statistics document and redirects as a result of unpublishing the announcement.