### PR TITLE
Rescue from Addressable's exceptions for broken link checker

### DIFF
--- a/test/unit/links_checker_test.rb
+++ b/test/unit/links_checker_test.rb
@@ -40,9 +40,8 @@ class LinkCheckerTest < ActiveSupport::TestCase
   end
 
   test 'bad URIs do not cause link checker to fall over' do
-    bad_link = 'http://wales.gov.uk/?lang=en}'
-    stub_link_check(bad_link, 500)
-    checker   = LinksChecker.new([bad_link], NullLogger.instance)
+    bad_link = 'http://:wales.gov.uk/?lang=en}'
+    checker = LinksChecker.new([bad_link], NullLogger.instance)
     checker.run
 
     assert_equal [bad_link], checker.broken_links


### PR DESCRIPTION
Since the upgrade to Ruby 2.2, the broken link checker has been
failing. This was due to a malformed link causing Addressable’s parsing
to fail. In this instance, we want to carry on with the rest of the
report but report this link as broken.

We can’t stub this link in Webmock as it uses Addressable under the
hood, but it’s enough to make sure that it wouldn’t be parsed and
ensure it gets returned as a broken link.

Trello: https://trello.com/c/C1Nz1hBR/331-broken-link-in-the-broken-link-report-medium