### PR TITLE
Don't send update_type in content payload

### DIFF
--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -25,7 +25,6 @@ class PublishingApiPresenters::Item
       routes: routes,
       redirects: [],
       details: details,
-      update_type: update_type
     }.tap do |content_hash|
       if item.respond_to?(:analytics_identifier)
         content_hash.merge!(analytics_identifier: item.analytics_identifier)

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -28,7 +28,6 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: 'major',
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: 'case_study',

--- a/test/unit/presenters/publishing_api_presenters/classification_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/classification_test.rb
@@ -21,7 +21,6 @@ class PublishingApiPresenters::ClassificationTest < ActiveSupport::TestCase
         }
       ],
       redirects: [],
-      update_type: "major",
       public_updated_at: topic.updated_at,
       details: {}
     }

--- a/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/coming_soon_test.rb
@@ -25,7 +25,6 @@ class PublishingApiPresenters::ComingSoonTest < ActiveSupport::TestCase
       description: 'Coming soon',
       locale: 'en',
       need_ids: [],
-      update_type: 'major',
       details: { publish_time: @publish_timestamp },
       routes: [{ path: public_path, type: 'exact' }],
       redirects: [],

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -32,7 +32,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: 'major',
       details: {
         change_note: nil,
         tags: {
@@ -71,7 +70,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: 'major',
       details: {
         change_note: nil,
         tags: {
@@ -105,7 +103,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
   test 'minor changes are a "minor" update type' do
     edition = create(:case_study, minor_change: true)
     assert_equal 'minor', present(edition).update_type
-    assert_equal 'minor', present(edition).content[:update_type]
   end
 
   test 'update type can be overridden by passing an update_type option' do
@@ -113,7 +110,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     edition = create(:case_study)
     presented_item = present(edition, update_type: update_type_override)
     assert_equal update_type_override, presented_item.update_type
-    assert_equal update_type_override, presented_item.content[:update_type]
   end
 
   test 'is locale aware' do

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -20,7 +20,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: ministerial_role.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      update_type: 'major',
       need_ids: [],
       details: {},
     }
@@ -50,7 +49,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: organisation.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      update_type: 'major',
       need_ids: [],
       details: {},
       analytics_identifier: "O123",
@@ -81,7 +79,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: person.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      update_type: 'major',
       need_ids: [],
       details: {},
     }
@@ -111,7 +108,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      update_type: 'major',
       need_ids: [],
       details: {},
       analytics_identifier: "WO123",
@@ -142,7 +138,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       public_updated_at: world_location.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      update_type: 'major',
       need_ids: [],
       details: {},
       analytics_identifier: "WL123",
@@ -163,7 +158,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     organisation = create(:organisation)
     presented_item = present(organisation, update_type: update_type_override)
     assert_equal update_type_override, presented_item.update_type
-    assert_equal update_type_override, presented_item.content[:update_type]
   end
 
   test 'is locale aware' do

--- a/test/unit/presenters/publishing_api_presenters/take_part_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/take_part_test.rb
@@ -18,7 +18,6 @@ class PublishingApiPresenters::TakePartTest < ActiveSupport::TestCase
       format: 'take_part',
       locale: 'en',
       public_updated_at: take_part_page.updated_at,
-      update_type: 'major',
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',
       routes: [

--- a/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_about_page_test.rb
@@ -16,7 +16,6 @@ class PublishingApiPresenters::TopicalEventAboutPageTest < ActiveSupport::TestCa
       need_ids: [],
       locale: 'en',
       public_updated_at: topical_event_about_page.updated_at,
-      update_type: 'major',
       publishing_app: 'whitehall',
       rendering_app: 'government-frontend',
       routes: [

--- a/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/topical_event_test.rb
@@ -21,7 +21,6 @@ class PublishingApiPresenters::TopicalEventTest < ActiveSupport::TestCase
         }
       ],
       redirects: [],
-      update_type: 'major',
       public_updated_at: topical_event.updated_at,
       details: {
         start_date: topical_event.start_date,
@@ -55,7 +54,6 @@ class PublishingApiPresenters::TopicalEventTest < ActiveSupport::TestCase
         }
       ],
       redirects: [],
-      update_type: 'major',
       public_updated_at: topical_event.updated_at,
       details: {}
     }

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -19,7 +19,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: 'major',
       details: {
         explanation: nil,
         unpublished_at: unpublishing.created_at,
@@ -116,7 +115,6 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: 'major',
       details: {
         explanation: nil,
         unpublished_at: unpublishing.created_at,

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -26,7 +26,6 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
         }
       ],
       redirects: [],
-      update_type: 'major',
       public_updated_at: group.updated_at,
       details: {
         email: "group-1@example.com",

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -29,7 +29,6 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       details: { publish_time: publish_time },
       routes: [ { path: base_path, type: 'exact' } ],
       redirects: [],
-      update_type: 'major',
       public_updated_at: edition.updated_at,
     }
 


### PR DESCRIPTION
`update_type` is supposed to be sent as an argument to the publish action.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/259