### PR TITLE
Remove published_at from consultation outcome attachments

### DIFF
--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -41,10 +41,11 @@
           <%= content_tag_for(:div, @document.outcome, class: 'consultation-response') do %>
             <% if @document.outcome.attachments.any? %>
               <%= render partial: "documents/attachment_full_width",
-                        locals: { document: @document.outcome,
-                          title: "Download the full outcome",
-                          published_on: @document.outcome_published_on,
-                          summary: nil } %>
+                         locals: {
+                           document: @document.outcome,
+                           title: "Download the full outcome",
+                           summary: nil
+                         } %>
             <% end %>
             <% if @document.outcome.summary.present? %>
               <section class="consultation-response-summary">


### PR DESCRIPTION
The date an attachment is added to an outcome isn’t accurate - it gets
updated on every change to attachments. Similarly, using the published
date of the outcome itself is misleading for documents that are
published on different days. We should remove the date so as not to be
misleading to the public and policy teams.

Trello:
https://trello.com/c/gzLsPhhS/323-metadata-for-consultation-outcomes-doc
uments-displaying-incorrectly-small

Before
![screen shot 2016-03-08 at 14 01 28](https://cloud.githubusercontent.com/assets/18276/13603602/5728f2c6-e536-11e5-9a82-54bec0460139.png)

After
![screen shot 2016-03-08 at 14 01 38](https://cloud.githubusercontent.com/assets/18276/13603605/5cb1ef68-e536-11e5-9fd6-dae34cfc07e6.png)
