### PR TITLE
Send tags to Publishing API on publish

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -1,19 +1,22 @@
 require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
-  def links
-    {
-      lead_organisations: item.lead_organisations.map(&:content_id),
-      related_policies: policy_content_ids,
-      supporting_organisations: item.supporting_organisations.map(&:content_id),
-      document_collections: item.published_document_collections.map(&:content_id),
-      world_locations: item.world_locations.map(&:content_id),
-      worldwide_organisations: item.worldwide_organisations.map(&:content_id),
-      worldwide_priorities: item.worldwide_priorities.map(&:content_id),
-    }
-  end
 
 private
+
+  def filter_links
+    [
+      :document_collections,
+      :lead_organisations,
+      :related_policies,
+      :supporting_organisations,
+      :topics,
+      :world_locations,
+      :worldwide_organisations,
+      :worldwide_priorities,
+    ]
+  end
+
   def document_format
     "case_study"
   end

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -23,6 +23,10 @@ class PublishingApiPresenters::ComingSoon < PublishingApiPresenters::Item
 
   private
 
+  def filter_links
+    []
+  end
+
   def document_format
     'coming_soon'
   end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -15,11 +15,11 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
     end
   end
 
-  def links
-    {}
-  end
+private
 
-  private
+  def filter_links
+    [:topics]
+  end
 
   def rendering_app
     item.rendering_app

--- a/app/presenters/publishing_api_presenters/gone.rb
+++ b/app/presenters/publishing_api_presenters/gone.rb
@@ -23,6 +23,6 @@ class PublishingApiPresenters::Gone
   end
 
   def links
-    {}
+    {} # Gone Item. no links
   end
 end

--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -33,7 +33,7 @@ class PublishingApiPresenters::Item
   end
 
   def links
-    {}
+    PublishingApiPresenters::LinkExtractor.new(item).extract(filter_links)
   end
 
 private

--- a/app/presenters/publishing_api_presenters/link_extractor.rb
+++ b/app/presenters/publishing_api_presenters/link_extractor.rb
@@ -1,0 +1,84 @@
+module PublishingApiPresenters
+  class LinkExtractor
+    LINK_NAMES_TO_METHODS_MAP = {
+      document_collections: :document_collection_ids,
+      lead_organisations: :lead_organisation_ids,
+      organisations: :organisation_ids,
+      policy_areas: :policy_area_ids,
+      related_policies: :related_policy_ids,
+      statistical_data_set_documents: :statistical_data_set_ids,
+      supporting_organisations: :supporting_organisation_ids,
+      topics: :topic_content_ids,
+      world_locations: :world_location_ids,
+      worldwide_organisations: :worldwide_organisation_ids,
+      worldwide_priorities: :worldwide_priority_ids,
+    }
+
+    def initialize(item)
+      @item = item
+    end
+
+    def extract(filter_links)
+      filter_links.reduce(Hash.new) do |links, link_name|
+        private_method_name = LINK_NAMES_TO_METHODS_MAP[link_name]
+        links[link_name] = send(private_method_name)
+        links
+      end
+    end
+
+  private
+
+    attr_reader :item
+
+    def document_collection_ids
+      (item.try(:published_document_collections) || []).map(&:content_id)
+    end
+
+    def lead_organisation_ids
+      (item.try(:lead_organisations) || []).map(&:content_id)
+    end
+
+    def policy_area_ids
+      (item.try(:topics) || []).map(&:content_id)
+    end
+
+    def related_policy_ids
+      item.try(:policy_content_ids) || []
+    end
+
+    def statistical_data_set_ids
+      (item.try(:statistical_data_sets) || []).map(&:content_id)
+    end
+
+    def supporting_organisation_ids
+      (item.try(:supporting_organisations) || []).map(&:content_id)
+    end
+
+    def organisation_ids
+      (item.try(:organisations) || []).map(&:content_id)
+    end
+
+    def topic_content_ids
+      secondaries = item.try(:secondary_specialist_sector_tags) || []
+      primary = item.try(:primary_specialist_sector_tag)
+      (secondaries.unshift(primary))
+        .compact
+        .map do |tag|
+          Whitehall.content_store.content_item!("/topic/#{tag}").content_id
+        end
+    end
+
+    def world_location_ids
+      (item.try(:world_locations) || []).map(&:content_id)
+    end
+
+    def worldwide_organisation_ids
+      (item.try(:worldwide_organisations) || []).map(&:content_id)
+    end
+
+    # FIXME: these tags will be discontinued
+    def worldwide_priority_ids
+      (item.try(:worldwide_priorities) || []).map(&:content_id)
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -6,6 +6,12 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::Placeholder < PublishingApiPresenters::Item
 private
 
+  def filter_links
+    [
+      :topics,
+    ]
+  end
+
   def title
     item.name
   end

--- a/app/presenters/publishing_api_presenters/redirect.rb
+++ b/app/presenters/publishing_api_presenters/redirect.rb
@@ -19,11 +19,12 @@ class PublishingApiPresenters::Redirect
     }
   end
 
-  def links
-    {}
-  end
-
   def update_type
     'major'
+  end
+
+  def links
+    # no tags
+    {}
   end
 end

--- a/app/presenters/publishing_api_presenters/statistics_announcement.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement.rb
@@ -1,14 +1,15 @@
 require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::StatisticsAnnouncement < PublishingApiPresenters::Item
-  def links
-    {
-      organisations: item.organisations.map(&:content_id),
-      policy_areas: item.topics.map(&:content_id)
-    }
-  end
-
 private
+
+  def filter_links
+    [
+      :organisations,
+      :policy_areas,
+      :topics,
+    ]
+  end
 
   def details
     {

--- a/app/presenters/publishing_api_presenters/statistics_announcement_redirect.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement_redirect.rb
@@ -27,12 +27,13 @@ class PublishingApiPresenters::StatisticsAnnouncementRedirect
     }
   end
 
-  def links
-    {}
-  end
-
   def update_type
     "major"
+  end
+
+  def links
+    # no tags
+    {}
   end
 
 private

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -3,6 +3,14 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::TakePart < PublishingApiPresenters::Item
 private
 
+  def filter_links
+    [
+      :lead_organisations,
+      :policy_areas,
+      :topics,
+    ]
+  end
+
   def document_format
     "take_part"
   end

--- a/app/presenters/publishing_api_presenters/topical_event_about_page.rb
+++ b/app/presenters/publishing_api_presenters/topical_event_about_page.rb
@@ -2,6 +2,7 @@ require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::TopicalEventAboutPage < PublishingApiPresenters::Item
   def links
+    # about pages aren't tagged
     {
       parent: [item.topical_event.content_id]
     }

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -7,6 +7,11 @@ class PublishingApiPresenters::Unpublishing < PublishingApiPresenters::Item
 
 private
 
+  def filter_links
+    # nothing to tag
+    []
+  end
+
   def document_format
     item.redirect? ? 'redirect' : 'unpublishing'
   end

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -1,6 +1,10 @@
 class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Item
 private
 
+  def filter_links
+    [] # nothing to tag
+  end
+
   def title
     item.name
   end

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -31,11 +31,11 @@ class PublishingApiWorker < WorkerBase
   def send_item(payload, locale)
     save_draft(payload)
     Whitehall.publishing_api_v2_client.publish(payload.content_id, payload.update_type, locale: locale)
+    Whitehall.publishing_api_v2_client.patch_links(payload.content_id, links: payload.links)
   end
 
   def save_draft(payload)
     Whitehall.publishing_api_v2_client.put_content(payload.content_id, payload.content)
-    Whitehall.publishing_api_v2_client.patch_links(payload.content_id, links: payload.links)
   end
 
   def save_draft_of_unpublished_edition(unpublishing)

--- a/config/initializers/content_store.rb
+++ b/config/initializers/content_store.rb
@@ -1,0 +1,14 @@
+require 'gds_api/content_store'
+
+class GdsApi::ContentStore::Fake
+  def content_item!(tag)
+    Struct.new("ContentItem", :content_id)
+    Struct::ContentItem.new("#{tag}-content-id")
+  end
+end
+
+Whitehall.content_store = if Rails.env.test?
+                            GdsApi::ContentStore::Fake.new
+                          else
+                            GdsApi::ContentStore.new(Plek.find('content-store'))
+                          end

--- a/features/support/content_api.rb
+++ b/features/support/content_api.rb
@@ -1,7 +1,9 @@
 Before('@real_content_api') do
   Whitehall.content_api = GdsApi::ContentApi.new(Plek.find('contentapi'))
+  Whitehall.content_store = GdsApi::ContentStore.new(Plek.find('content-store'))
 end
 
 After('@real_content_api') do
   Whitehall.content_api = GdsApi::ContentApi::Fake.new
+  Whitehall.content_store = GdsApi::ContentStore::Fake.new
 end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -12,6 +12,7 @@ module Whitehall
   mattr_accessor :government_search_client
   mattr_accessor :statistics_announcement_search_client
   mattr_accessor :content_api
+  mattr_accessor :content_store
   mattr_accessor :publishing_api_client
   mattr_accessor :publishing_api_v2_client
   mattr_accessor :skip_safe_html_validation

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -19,8 +19,7 @@ module PublishingApiTestHelpers
         .with(edition.content_id,
           has_entries(publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
       Whitehall.publishing_api_v2_client.stubs(:patch_links)
-        .with(edition.content_id,
-          has_entries(links: {}))
+        .with(edition.content_id, has_entries(links: anything))
       Whitehall.publishing_api_v2_client.expects(:publish)
         .with(edition.content_id, 'major', locale: "en")
     end
@@ -32,8 +31,7 @@ module PublishingApiTestHelpers
         .with(edition.content_id,
           has_entries(publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'))
       Whitehall.publishing_api_v2_client.stubs(:patch_links)
-        .with(edition.content_id,
-          has_entries(links: {}))
+        .with(edition.content_id, has_entries(links: anything))
       Whitehall.publishing_api_v2_client.expects(:publish)
         .with(edition.content_id, 'republish', locale: "en")
     end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -43,10 +43,11 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     }
 
     expected_links = {
+      document_collections: [],
       lead_organisations: [case_study.lead_organisations.first.content_id],
       related_policies: [],
       supporting_organisations: [],
-      document_collections: [],
+      topics: [],
       world_locations: [],
       worldwide_organisations: [],
       worldwide_priorities: [],
@@ -126,10 +127,11 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
                         supporting_organisations: [supporting_org])
     presented_item = present(case_study)
     expected_links_hash = {
+      document_collections: [],
       lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
       related_policies: [],
       supporting_organisations: [supporting_org.content_id],
-      document_collections: [],
+      topics: [],
       world_locations: [],
       worldwide_organisations: [],
       worldwide_priorities: [],

--- a/test/unit/presenters/publishing_api_presenters/link_extractor_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/link_extractor_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class PublishingApiPresenters::LinkExtractorTest < ActionView::TestCase
+  ALL_LINK_TYPES = [
+    :document_collections,
+    :lead_organisations,
+    :policy_areas,
+    :related_policies,
+    :statistical_data_set_documents,
+    :supporting_organisations,
+    :topics,
+    :world_locations,
+    :worldwide_organisations,
+    :worldwide_priorities,
+  ]
+
+  def links_for(item, filter_links = ALL_LINK_TYPES)
+    LinkExtractor.new(item).extract(filter_links)
+  end
+
+  test 'nil returns a set of tags that are defaulted to []' do
+    links = links_for(nil)
+
+    ALL_LINK_TYPES.each do |link_type|
+      assert_equal links[link_type], []
+    end
+  end
+
+  test 'extracts content_ids from a detailed guide' do
+    document = create(:detailed_guide)
+    links = links_for(document)
+
+    assert_equal document.lead_organisations.map(&:content_id), links[:lead_organisations]
+    # whitehall names and publishing api names don't necessarily match...
+    assert_equal document.topics.map(&:content_id), links[:policy_areas]
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/organisation_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/organisation_test.rb
@@ -37,11 +37,12 @@ class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
       },
       analytics_identifier: "O123",
     }
+    expected_links = { topics: [] }
 
     presented_item = present(organisation)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
+    assert_equal expected_links, presented_item.links
     assert_equal "major", presented_item.update_type
     assert_equal organisation.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -23,11 +23,12 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       need_ids: [],
       details: {},
     }
+    expected_links = { topics: [] }
 
     presented_item = present(ministerial_role)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
+    assert_equal expected_links, presented_item.links
     assert_equal "major", presented_item.update_type
     assert_equal ministerial_role.content_id, presented_item.content_id
 
@@ -52,11 +53,12 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       need_ids: [],
       details: {},
     }
+    expected_links = { topics: [] }
 
     presented_item = present(person)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
+    assert_equal expected_links, presented_item.links
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 
@@ -82,11 +84,12 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       details: {},
       analytics_identifier: "WO123",
     }
+    expected_links = { topics: [] }
 
     presented_item = present(worldwide_org)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
+    assert_equal expected_links, presented_item.links
     assert_equal "major", presented_item.update_type
     assert_equal worldwide_org.content_id, presented_item.content_id
 
@@ -112,11 +115,12 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       details: {},
       analytics_identifier: "WL123",
     }
+    expected_links = { topics: [] }
 
     presented_item = present(world_location)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
+    assert_equal expected_links, presented_item.links
     assert_equal "major", presented_item.update_type
     assert_equal world_location.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
@@ -26,7 +26,8 @@ class PublishingApiPresenters::StatisticsAnnouncementTest < ActiveSupport::TestC
       },
       links: {
         organisations: statistics_announcement.organisations.map(&:content_id),
-        policy_areas: statistics_announcement.topics.map(&:content_id)
+        policy_areas: statistics_announcement.topics.map(&:content_id),
+        topics: [],
       }
     }
 

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -32,10 +32,12 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       public_updated_at: edition.updated_at,
     }
 
+    expected_links = PublishingApiPresenters::ComingSoon.new(edition).links
+
     requests = [
       stub_publishing_api_put_content(uuid, expected_payload),
-      stub_publishing_api_patch_links(uuid, links: {}),
-      stub_publishing_api_publish(uuid, { locale: "fr", update_type: "major" })
+      stub_publishing_api_publish(uuid, { locale: "fr", update_type: "major" }),
+      stub_publishing_api_patch_links(uuid, links: expected_links),
     ]
 
     PublishingApiComingSoonWorker.new.perform(edition.id, locale)

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -38,7 +38,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     # Have to separate this as we need to manually assert it was done twice. If
     # we split the pushing of links into a separate job, then we would only push
     # links once and could put this back into the array.
-    patch_links_request = stub_publishing_api_patch_links(document.content_id, links: {})
+    patch_links_request = stub_publishing_api_patch_links(document.content_id, links: presenter.links)
 
     PublishingApiDocumentRepublishingWorker.new.perform(edition.id, nil)
 

--- a/test/unit/workers/publishing_api_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_draft_worker_test.rb
@@ -10,7 +10,6 @@ class PublishingApiDraftWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
     ]
 
     PublishingApiDraftWorker.new.perform(edition.class.name, edition.id)


### PR DESCRIPTION
See https://trello.com/c/mtYIToz9/527-whitehall-migration-send-topics-to-publishing-api-as-links
Part of: https://trello.com/c/5dGZjzlm/541-sub-epic-migrate-the-tagging-in-whitehall

This first PR is to have the topics currently tagged in Whitehall to be sent to publishing-api on publishing.