### PR TITLE
Don't retry 422 errors for discard draft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 29.2.0'
+  gem 'gds-api-adapters', '~> 29.5.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (29.2.0)
+    gds-api-adapters (29.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -480,7 +480,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 29.2.0)
+  gds-api-adapters (~> 29.5.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.1)

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,9 +1,10 @@
 class PublishingApiDiscardDraftWorker < PublishingApiWorker
   def perform(content_id, locale)
     Whitehall.publishing_api_v2_client.discard_draft(content_id, locale: locale)
-  rescue GdsApi::HTTPNotFound
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as the draft has already been deleted
     # this shouldn't really happen but can still occur due to inconsistencies
     # between this app's data and what's in the Content Store/Publishing API
+    nil
   end
 end

--- a/test/unit/workers/publishing_api_discard_draft_worker_test.rb
+++ b/test/unit/workers/publishing_api_discard_draft_worker_test.rb
@@ -15,6 +15,16 @@ class PublishingApDiscardDraftiWorkerTest < ActiveSupport::TestCase
 
   test "gracefully handles the deletion of an already-deleted draft edition" do
     edition = create(:draft_case_study)
+    request = stub_any_publishing_api_call
+      .to_return(status: 422)
+
+    PublishingApiDiscardDraftWorker.new.perform(edition.content_id, 'en')
+
+    assert_requested request
+  end
+
+  test "gracefully handles the deletion of a non-existant content item" do
+    edition = create(:draft_case_study)
     request = stub_any_publishing_api_call_to_return_not_found
 
     PublishingApiDiscardDraftWorker.new.perform(edition.content_id, 'en')


### PR DESCRIPTION
The publishing api will return a 422 error if there’s no draft for a
content item, or a 404 if the content item doesn’t exist at all.
Neither error should be retried.

Bumps the api adapters version to provide an explicit exception for the
422 error code.