### PR TITLE
Present placeholder organisations

### DIFF
--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -18,6 +18,8 @@ private
       PublishingApiPresenters::TakePart
     when Topic
       PublishingApiPresenters::PolicyAreaPlaceholder
+    when ::Organisation
+      PublishingApiPresenters::Organisation
     when ::TopicalEvent
       PublishingApiPresenters::TopicalEvent
     when ::StatisticsAnnouncement

--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -6,11 +6,18 @@ class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placehold
   def details
     super.tap do |d|
       d[:brand] = brand
-      d[:logo]  = { formatted_title: formatted_title }
+      d[:logo]  = {
+        formatted_title: formatted_title,
+        crest: crest,
+      }
     end
   end
 
 private
+
+  def crest
+    item.organisation_logo_type.class_name
+  end
 
   def formatted_title
     format_with_html_line_breaks(item.logo_formatted_name)

--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -1,0 +1,16 @@
+require_relative '../publishing_api_presenters'
+
+class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placeholder
+  def details
+    super.tap do |d|
+      d[:brand] = brand
+    end
+  end
+
+private
+
+  def brand
+    brand_colour = item.organisation_brand_colour
+    brand_colour ? brand_colour.class_name : nil
+  end
+end

--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -1,13 +1,20 @@
 require_relative '../publishing_api_presenters'
 
 class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placeholder
+  include ApplicationHelper
+
   def details
     super.tap do |d|
       d[:brand] = brand
+      d[:logo]  = { formatted_title: formatted_title }
     end
   end
 
 private
+
+  def formatted_title
+    format_with_html_line_breaks(item.logo_formatted_name)
+  end
 
   def brand
     brand_colour = item.organisation_brand_colour

--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -4,13 +4,13 @@ class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placehold
   include ApplicationHelper
 
   def details
-    super.tap do |d|
-      d[:brand] = brand
-      d[:logo]  = {
+    super.merge(
+      brand: brand,
+      logo: {
         formatted_title: formatted_title,
         crest: crest,
-      }
-    end
+      },
+    )
   end
 
 private

--- a/db/data_migration/20160309153708_republish_organisations.rb
+++ b/db/data_migration/20160309153708_republish_organisations.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(Organisation.all)
+republisher.perform

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :organisation, traits: [:translated] do
     sequence(:name) { |index| "organisation-#{index}" }
-    sequence(:logo_formatted_name) { |index| "organisation-#{index} logo text".split(" ").join("\n") }
+    logo_formatted_name { name.to_s.split.join("\n") }
     organisation_type_key :other
     sequence(:analytics_identifier) { |index| "T#{index}" }
     organisation_logo_type_id { OrganisationLogoType::SingleIdentity.id }

--- a/test/unit/presenters/publishing_api_presenters/organisation_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/organisation_test.rb
@@ -29,7 +29,10 @@ class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
       redirects: [],
       need_ids: [],
       details: {
-        brand: nil
+        brand: nil,
+        logo: {
+          formatted_title: "Organisation<br/>of<br/>Things",
+        },
       },
       analytics_identifier: "O123",
     }

--- a/test/unit/presenters/publishing_api_presenters/organisation_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/organisation_test.rb
@@ -32,6 +32,7 @@ class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
         brand: nil,
         logo: {
           formatted_title: "Organisation<br/>of<br/>Things",
+          crest: "single-identity",
         },
       },
       analytics_identifier: "O123",

--- a/test/unit/presenters/publishing_api_presenters/organisation_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/organisation_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
+  def present(model_instance, options = {})
+    PublishingApiPresenters::Organisation.new(model_instance, options)
+  end
+
+  test 'presents an organisation with a brand colour' do
+    organisation = create(:organisation, organisation_brand_colour_id: 1)
+    presented_item = present(organisation)
+
+    assert_equal presented_item.content[:details][:brand], organisation.organisation_brand_colour.class_name
+  end
+
+  test 'presents an Organisation ready for adding to the publishing API' do
+    organisation = create(:organisation, name: 'Organisation of Things', analytics_identifier: 'O123')
+    public_path = Whitehall.url_maker.organisation_path(organisation)
+
+    expected_hash = {
+      base_path: public_path,
+      title: "Organisation of Things",
+      description: nil,
+      format: "placeholder_organisation",
+      locale: 'en',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: organisation.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      need_ids: [],
+      details: {
+        brand: nil
+      },
+      analytics_identifier: "O123",
+    }
+
+    presented_item = present(organisation)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal Hash.new, presented_item.links
+    assert_equal "major", presented_item.update_type
+    assert_equal organisation.content_id, presented_item.content_id
+
+    assert_valid_against_schema(presented_item.content, 'placeholder')
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -34,36 +34,6 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
     assert_valid_against_schema(presented_item.content, 'placeholder')
   end
 
-  test 'presents an Organisation ready for adding to the publishing API' do
-    organisation = create(:organisation, name: 'Organisation of Things', analytics_identifier: 'O123')
-    public_path = Whitehall.url_maker.organisation_path(organisation)
-
-    expected_hash = {
-      base_path: public_path,
-      title: "Organisation of Things",
-      description: nil,
-      format: "placeholder_organisation",
-      locale: 'en',
-      publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
-      public_updated_at: organisation.updated_at,
-      routes: [{ path: public_path, type: "exact" }],
-      redirects: [],
-      need_ids: [],
-      details: {},
-      analytics_identifier: "O123",
-    }
-
-    presented_item = present(organisation)
-
-    assert_equal expected_hash, presented_item.content
-    assert_equal Hash.new, presented_item.links
-    assert_equal "major", presented_item.update_type
-    assert_equal organisation.content_id, presented_item.content_id
-
-    assert_valid_against_schema(presented_item.content, 'placeholder')
-  end
-
   test 'presents a Person ready for adding to the publishing API' do
     person = create(:person, forename: "Winston")
     public_path = Whitehall.url_maker.person_path(person)

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -50,7 +50,7 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     organisation = Organisation.new
     presenter  = PublishingApiPresenters.presenter_for(organisation)
 
-    assert_equal PublishingApiPresenters::Placeholder, presenter.class
+    assert_equal PublishingApiPresenters::Organisation, presenter.class
   end
 
   test ".presenter_for returns a Placeholder presenter for a world location" do


### PR DESCRIPTION
Presents the organisation brand and logo information.

Probably easier to review commit by commit.

Relates to https://github.com/alphagov/govuk-content-schemas/pull/262.

https://trello.com/c/cJGrtnc1