### PR TITLE
Self-serve unwithdrawing for managing editors

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -36,6 +36,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
       enforce_permission!(:force_publish, @edition)
     when 'unpublish', 'confirm_unpublish'
       enforce_permission!(:unpublish, @edition)
+    when 'unwithdraw', 'confirm_unwithdraw'
+      enforce_permission!(:unwithdraw, @edition)
     when 'approve_retrospectively'
       enforce_permission!(:approve, @edition)
     else
@@ -93,6 +95,20 @@ class Admin::EditionWorkflowController < Admin::BaseController
       @unpublishing = @edition.unpublishing
       flash.now[:alert] = @service_object.failure_reason
       render :confirm_unpublish
+    end
+  end
+
+  def confirm_unwithdraw
+  end
+
+  def unwithdraw
+    edition_unwithdrawer = Whitehall.edition_services.unwithdrawer(@edition, user: current_user)
+    if edition_unwithdrawer.perform!
+      new_edition = @edition.document.published_edition
+      redirect_to admin_edition_path(new_edition), notice: "This document has been unwithdrawn"
+    else
+      flash.now[:alert] = edition_unwithdrawer.failure_reason
+      render :confirm_unwithdraw
     end
   end
 

--- a/app/views/admin/edition_workflow/_unwithdraw_modal.html.erb
+++ b/app/views/admin/edition_workflow/_unwithdraw_modal.html.erb
@@ -1,0 +1,28 @@
+<% modal ||= false %>
+
+<% if modal %>
+  <div id="unwithdraw-modal" class="modal" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h3 class="modal-title">Are you sure you want to unwithdraw this?</h3>
+        </div>
+        <div class="modal-body">
+          <p>This will create a new edition from the withdrawn edition and immediately publish it.</p>
+        </div>
+        <%= form_tag unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version), class: 'unwithdraw-form' do %>
+          <div class="modal-footer">
+            <%= submit_tag 'Unwithdraw', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <h1>Are you sure you want to unwithdraw this?</h1>
+  <%= form_tag unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version), class: 'unwithdraw-form' do %>
+    <p>This will create a new edition from the withdrawn edition and immediately publish it.</p>
+    <%= submit_tag 'Unwithdraw', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
+  <% end %>
+<% end %>

--- a/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unwithdraw.html.erb
@@ -1,0 +1,3 @@
+<% page_title "Unwithdraw: #{@edition.title}" %>
+<% page_class "edition-unwithdraw" %>
+<%= render partial: "unwithdraw_modal" %>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -42,6 +42,10 @@
           <%= link_to "Edit #{withdrawal_or_unpublishing(@edition)} explanation", edit_admin_edition_unpublishing_path(@edition), class: "btn btn-primary" %>
         <% end %>
       <% end %>
+      <% if can?(:unwithdraw, @edition) && @edition.can_unwithdraw? %>
+        <%= render partial: "admin/edition_workflow/unwithdraw_modal", locals: { modal: true } %>
+        <%= link_to 'Unwithdraw', confirm_unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version), class: "btn btn-danger", "data-module" => "linked-modal", "data-target" => "#unwithdraw-modal" %>
+      <% end %>
     </section>
 
     <%= render('similar_slug_warning') if show_similar_slugs_warning?(@edition) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,8 @@ Whitehall::Application.routes.draw do
             post :force_publish, to: 'edition_workflow#force_publish'
             get  :confirm_unpublish, to: 'edition_workflow#confirm_unpublish'
             post :unpublish, to: 'edition_workflow#unpublish'
+            get  :confirm_unwithdraw, to: 'edition_workflow#confirm_unwithdraw'
+            post :unwithdraw, to: 'edition_workflow#unwithdraw'
             post :schedule, to: 'edition_workflow#schedule'
             post :force_schedule, to: 'edition_workflow#force_schedule'
             post :unschedule, to: 'edition_workflow#unschedule'

--- a/features/step_definitions/unpublishing_published_documents_steps.rb
+++ b/features/step_definitions/unpublishing_published_documents_steps.rb
@@ -20,7 +20,7 @@ When(/^I unpublish the duplicate, marking it as consolidated into the other page
   end
 end
 
-When(/^I withdraw the publication because it is no longer government publication$/) do
+When(/^I withdraw the publication because it no longer reflects current government policy$/) do
   @publication = Publication.last
   visit admin_edition_path(@publication)
   click_on 'Withdraw or unpublish'

--- a/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
+++ b/features/step_definitions/unwithdrawing_withdrawn_documents_steps.rb
@@ -1,0 +1,22 @@
+When(/^I unwithdraw the publication$/) do
+  publication = Publication.last
+  visit admin_edition_path(publication)
+
+  click_link 'Unwithdraw'
+  click_button 'Unwithdraw'
+
+  @latest_published_edition = publication.document.published_edition
+
+  assert_equal :superseded, publication.reload.current_state
+  assert_equal :published, @latest_published_edition.current_state
+end
+
+Then(/^I should be redirected to the latest edition of the publication$/) do
+  assert_path admin_edition_path(@latest_published_edition)
+end
+
+Then(/^the unwithdrawn publication is accessible on the website$/) do
+  click_on "View on website"
+  assert_path public_document_path(@latest_published_edition)
+  assert page.has_content?(@latest_published_edition.title)
+end

--- a/features/unpublishing-published-documents.feature
+++ b/features/unpublishing-published-documents.feature
@@ -39,13 +39,13 @@ Feature: Unpublishing published documents
   Scenario: Withdraw a document that is no longer current
     Given I am a managing editor
     And a published publication "Shaving kits for all" exists
-    When I withdraw the publication because it is no longer government publication
+    When I withdraw the publication because it no longer reflects current government policy
     Then there should be an editorial remark recording the fact that the document was withdrawn
     And the publication should be marked as withdrawn on the public site
 
   Scenario: Change the public explanation for archiving a document
     Given I am a managing editor
     And a published publication "Shaving kits for all" exists
-    And I withdraw the publication because it is no longer government publication
+    And I withdraw the publication because it no longer reflects current government policy
     When I edit the public explanation for withdrawal
     Then I should see the updated explanation on the public site

--- a/features/unwithdrawing-withdrawn-documents.feature
+++ b/features/unwithdrawing-withdrawn-documents.feature
@@ -1,0 +1,12 @@
+Feature: Unpublishing published documents
+  As a Managing Editor
+  I can unwithdraw unwithdrawn documents
+  So that I can adjust them with banners or annotations and withdraw them again
+
+  Scenario: Unwithdrawing a withdrawn document
+    Given I am a managing editor
+    And a published publication "Shaving kits for all" exists
+    When I withdraw the publication because it no longer reflects current government policy
+    And I unwithdraw the publication
+    Then I should be redirected to the latest edition of the publication
+    And the unwithdrawn publication is accessible on the website

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -121,10 +121,3 @@ task process_policy_tagging_csv: :environment do
 
   PolicyTagger.process_from_csv(csv_location, logger: Logger.new(STDOUT))
 end
-
-desc "Unwithdraw an edition (creates and publishes a draft with audit trail)"
-task :unwithdraw_edition, [:edition_id] => :environment do |t,args|
-  edition = Edition.find(args[:edition_id])
-  gds_inside_gov_user = User.find(406)
-  Whitehall.edition_services.unwithdrawer(edition, user: gds_inside_gov_user).perform!
-end

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -6,7 +6,7 @@ module Whitehall::Authority::Rules
         :approve, :publish, :force_publish,
         :reject, :make_fact_check, :review_fact_check,
         :make_editorial_remark, :review_editorial_remark,
-        :limit_access, :unpublish, :export, :confirm_export,
+        :limit_access, :unpublish, :unwithdraw, :export, :confirm_export,
         :mark_political
       ]
     end
@@ -38,6 +38,8 @@ module Whitehall::Authority::Rules
       elsif !can_see?
         return false
       elsif action == :unpublish && actor.managing_editor?
+        return true
+      elsif action == :unwithdraw && actor.managing_editor?
         return true
       elsif action == :modify && @subject.historic?
         return actor.gds_editor? || actor.gds_admin?


### PR DESCRIPTION
With this PR, managing editors can unwithdraw editions through the Whitehall Admin. Since #2489, unwithdrawing is a service within Whitehall.

After this change, unwithdrawing using the rake task will no longer be possible.

Considerations for the review:

- is the microcopy appropriate? (see the screenshots below)
- there is no Google Analytics instrumentation yet for the unwithdraw action, but this probably should be added on a separate PR ( @dsingleton are you aware of any helpers in Whitehall to make sending events to GA easier?)

## Button in the admin view

![image](https://cloud.githubusercontent.com/assets/23801/13663290/656fa5ba-e698-11e5-80d0-8a4c02c47a7d.png)

## Modal prompt

![image](https://cloud.githubusercontent.com/assets/23801/13670752/90ca750c-e6c3-11e5-8135-0b6fe726df98.png)

## Full-page prompt

![image](https://cloud.githubusercontent.com/assets/23801/13670727/70108bc6-e6c3-11e5-9c23-531b3bc0497e.png)

## Remarks on the edition

![image](https://cloud.githubusercontent.com/assets/23801/13663519/f978021a-e699-11e5-8ecc-5439b44291dc.png)

[Story in Trello](https://trello.com/c/jkI34gB3/303-build-a-self-service-option-for-un-withdrawing-documents-in-whitehall-for-managing-editors-medium)