### PR TITLE
Add `content_id` to attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,6 @@
 # Abstract base class for Attachments.
 class Attachment < ActiveRecord::Base
+  include HasContentId
   belongs_to :attachable, polymorphic: true
   has_one :attachment_source
 

--- a/db/data_migration/20160311093609_generate_content_ids_on_attachments.rb
+++ b/db/data_migration/20160311093609_generate_content_ids_on_attachments.rb
@@ -1,0 +1,6 @@
+require 'securerandom'
+
+Attachment.where(content_id: nil).pluck(:id).each do |id|
+  print "."
+  Attachment.where(id: id).update_all(content_id: SecureRandom.uuid)
+end

--- a/db/migrate/20160311090953_add_content_id_field_to_attachments.rb
+++ b/db/migrate/20160311090953_add_content_id_field_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddContentIdFieldToAttachments < ActiveRecord::Migration
+  def change
+    add_column :attachments, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160212160106) do
+ActiveRecord::Schema.define(version: 20160311090953) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20160212160106) do
     t.string   "slug",                     limit: 255
     t.string   "locale",                   limit: 255
     t.string   "external_url",             limit: 255
+    t.string   "content_id",               limit: 255
   end
 
   add_index "attachments", ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type", using: :btree

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -205,4 +205,11 @@ class AttachmentTest < ActiveSupport::TestCase
     refute build(:html_attachment, locale: nil).rtl_locale?
     refute build(:html_attachment, locale: "").rtl_locale?
   end
+
+  test '#content_id is set on save' do
+    attachment = build(:html_attachment)
+    assert attachment.content_id.nil?
+    attachment.save
+    assert attachment.content_id =~ /^[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}$/
+  end
 end


### PR DESCRIPTION
To allow us to publish `HtmlAttachment` content items to the Publishing API they need a `content_id`. `HtmlAttachment` is an STI model stored in the `attachments` table.

This PR adds `content_id` to the table, sets it on existing records and adds functionality to `Attachment` to set it for newly created records.

As there are >1.2 million rows in the DB, the data migration takes a while (~15 minutes on my VM). Outline of various attempts at speeding this up in 0cec90d.

[Trello](https://trello.com/c/uwsLR1xU/285-5-html-publications-implement-publishing-of-format-to-publishing-api-large)