### PR TITLE
Track admin notices as Google Analytics events

### DIFF
--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -1,0 +1,11 @@
+module Admin
+  module AnalyticsHelper
+    def track_analytics_data(type, message)
+      {
+        'module' => 'auto-track-event',
+        'track-action' => "alert-#{type}",
+        'track-label' => message,
+      }
+    end
+  end
+end

--- a/app/views/shared/_notices.html.erb
+++ b/app/views/shared/_notices.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:alert] %>
-  <div class="flash alert"><%= flash[:alert].html_safe %></div>
+  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data(:danger, strip_tags(flash[:alert])) %>
 <% end %>
 <% if flash[:notice] %>
-  <div class="flash notice"><%= flash[:notice] %></div>
+  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data(:success, strip_tags(flash[:notice])) %>
 <% end %>


### PR DESCRIPTION
After this change, any notice in Whitehall admin (eg "This document has been withdrawn") will be sent to Google Analytics as an event.

This will allow us to count:

- how many times specific publishing transitions occur
- the frequency of errors encountered by publishers

The most immediate motivation for this work is from wanting to track how many times unwithdrawing is done within GA (see #2497 for details).

This relies on the module mechanism from `govuk_admin_template`, and follows the [pattern used in Signon](https://github.com/alphagov/signonotron2/search?utf8=%E2%9C%93&q=track_analytics_data).

One thing to consider is that the events are being sent with the URL as the category. This isn't particularly helpful; the GA user interface uses them for high-level aggregation (which obviously doesn't work too well where the category is an individual edition URL), and in any case, it's more useful to know **what** happened, before **where** it happened. Unfortunately the "category as URL" assumption is [hard-coded deep within `govuk_admin_template`](https://github.com/alphagov/govuk_admin_template/blob/7a4e8d2b82f7dc6ac3f7754f77dfac47e776eb3d/app/assets/javascripts/govuk-admin-template/govuk-admin.js#L97) and cannot be easily changed. I would advocate revisiting this assumption (but not in the scope of this PR). /cc @fofr @boffbowsh 