### PR TITLE
Final steps for migrating statistics announcements to the new publishing pipeline

### DIFF
--- a/app/presenters/publishing_api_presenters/statistics_announcement.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement.rb
@@ -23,6 +23,10 @@ private
     "statistics_announcement"
   end
 
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
   def description
     item.summary
   end

--- a/db/data_migration/20160315114700_republish_statistics_announcements_to_publishing_api.rb
+++ b/db/data_migration/20160315114700_republish_statistics_announcements_to_publishing_api.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(StatisticsAnnouncement.unscoped)
+republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
@@ -18,7 +18,7 @@ class PublishingApiPresenters::StatisticsAnnouncementTest < ActiveSupport::TestC
       need_ids: [],
       public_updated_at: statistics_announcement.updated_at,
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,


### PR DESCRIPTION
- switch Publishing API rendering app to `government-frontend`
- republish all stats announcements to the Publishing API

Story: https://trello.com/c/G5hpdYqY/271-2-statistics-announcement-migration-final-tasks-for-each-format-deploy-1-medium