### PR TITLE
Add content IDs for unpublished statistics announcements

### DIFF
--- a/db/data_migration/20160315100000_generate_content_ids_for_unpublished_statistics_announcements.rb
+++ b/db/data_migration/20160315100000_generate_content_ids_for_unpublished_statistics_announcements.rb
@@ -1,0 +1,5 @@
+require 'securerandom'
+
+StatisticsAnnouncement.unscoped.where(content_id: "").find_each do |statistics_announcement|
+  statistics_announcement.update_column(:content_id, SecureRandom.uuid)
+end


### PR DESCRIPTION
Content IDs were added to almost all statistics announcements as
part of https://github.com/alphagov/whitehall/pull/2457. However,
the ActiveRecord query used in the data migration wasn't `unscoped`
and `StatisticsAnnouncement` has a default scope.

This data migration generates content IDs for the remaining records.

/cc @gpeng 