### PR TITLE
Strengthen the UUID validation on the HasContentId module

### DIFF
--- a/lib/has_content_id.rb
+++ b/lib/has_content_id.rb
@@ -5,6 +5,6 @@ module HasContentId
     before_validation do
       self.content_id ||= SecureRandom.uuid
     end
-    validates :content_id, presence: true
+    validates :content_id, presence: true, format: { with: /[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}/ }
   end
 end

--- a/test/unit/models/has_content_id_test.rb
+++ b/test/unit/models/has_content_id_test.rb
@@ -18,4 +18,12 @@ class HasContentIdTest < ActiveSupport::TestCase
 
     assert_equal object.content_id, expected_content_id
   end
+
+  test "it rejects invalid uuids" do
+    object = TestObject.new(content_id: "abcde")
+
+    object.validate
+
+    assert_equal ["is invalid"], object.errors[:content_id]
+  end
 end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -34,7 +34,7 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test "should be valid if legacy image isn't 960x640px" do
-    person = build(:person, slug: 'stubbed', image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')), content_id: "a-content-id")
+    person = build(:person, slug: 'stubbed', image: File.open(Rails.root.join('test/fixtures/horrible-image.64x96.jpg')))
     person.save(validate: false)
     assert person.reload.valid?
   end


### PR DESCRIPTION
It's good to tighten this validation, as this module will be used
in many places in the app.

As suggested by @benlovell on https://github.com/alphagov/whitehall/pull/2501.