### PR TITLE
Final steps for migrating policy/working groups to the new publishing pipeline

### DIFF
--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -32,4 +32,8 @@ private
   def public_updated_at
     item.updated_at
   end
+
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
 end

--- a/db/data_migration/20160317111700_republish_working_group_to_publishing_api.rb
+++ b/db/data_migration/20160317111700_republish_working_group_to_publishing_api.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(PolicyGroup.all)
+republisher.perform

--- a/script/publishing-api-sync-checks/working_group_check.rb
+++ b/script/publishing-api-sync-checks/working_group_check.rb
@@ -1,7 +1,7 @@
 # Working Groups are called PolicyGroup in the code as they have been partially
 # renamed
-take_part_pages = PolicyGroup.all
-check = DataHygiene::PublishingApiSyncCheck.new(take_part_pages)
+working_groups = PolicyGroup.all
+check = DataHygiene::PublishingApiSyncCheck.new(working_groups)
 
 check.add_expectation("format") do |content_store_payload, _|
   content_store_payload["format"] == "working_group"

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -13,7 +13,7 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
     expected_hash = {
       base_path: public_path,
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "government-frontend",
       format: "working_group",
       title: "Government Digital Service",
       description: "This is some plaintext in the summary field", # This is deliberately the 'wrong' way around

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
-  test 'presents a valid placeholder "working_group" content item' do
+  test 'presents a valid "working_group" content item' do
     group = create(:policy_group,
       name: "Government Digital Service",
       email: "group-1@example.com",


### PR DESCRIPTION
This switches working groups' rendering app to government-frontend, and includes a data migration to republish all working groups.

I have tried running the data migration and the sync check in integration and it all went smoothly - 645 successes, 0 failures.

This also includes two minor corrections on the sync check script and a test. I paired on this with @mgrassotti .

[Trello ticket](https://trello.com/c/yV5zFIpl/289-7-policy-working-group-migration-final-tasks-deploy-1-medium)