### PR TITLE
Add data migration to fix Edition.need_ids.

### DIFF
--- a/db/data_migration/20160317151451_fix_edition_need_ids.rb
+++ b/db/data_migration/20160317151451_fix_edition_need_ids.rb
@@ -1,0 +1,7 @@
+sql = <<-SQL
+  UPDATE editions
+  SET need_ids = NULL
+  WHERE need_ids = "--- []\n";
+SQL
+
+ActiveRecord::Base.connection.execute(sql)


### PR DESCRIPTION
Recent changes to Rails have made it so that calling `Edition#need_ids` will automatically rewrite it. This will make Rails think the record has `#changes`.

Because we can't unschedule things if Rails thinks there are changes, this broke unscheduling of scheduled documents.

A quick solution is to simply `NULL`ify the relevant column. This is equivalent to what Rails would do anyway when the records will be resaved at some point.

```
vagrant@development:/var/govuk/whitehall$ bundle exec rails c --sandbox
Loading development environment in sandbox (Rails 4.2.5.2)
Any modifications you make will be rolled back on exit
irb(main):001:0> e = Edition.find(497375); e.need_ids; e.changes
  Edition Load (0.8ms)  SELECT  `editions`.* FROM `editions` WHERE
(`editions`.`state` != 'deleted') AND `editions`.`id` = 497375 LIMIT 1
=> {"need_ids"=>[[], []]}
irb(main):002:0> sql = <<-SQL
irb(main):003:0"   UPDATE editions
irb(main):004:0"   SET need_ids = NULL
irb(main):005:0"   WHERE need_ids = "--- []\n";
irb(main):006:0" SQL
=> "  UPDATE editions\n  SET need_ids = NULL\n  WHERE need_ids = \"---
[]\n\";\n"
irb(main):007:0> ActiveRecord::Base.connection.execute(sql)
   (4492.0ms)    UPDATE editions
  SET need_ids = NULL
  WHERE need_ids = "--- []
";

=> nil
irb(main):008:0> e = Edition.find(497375); e.need_ids; e.changes
  Edition Load (1.0ms)  SELECT  `editions`.* FROM `editions` WHERE
(`editions`.`state` != 'deleted') AND `editions`.`id` = 497375 LIMIT 1
=> {}
irb(main):009:0>
```

Relevant Trello ticket: https://trello.com/c/pKOxsyQg/333-un-schedule-scheduled-documents-in-whitehall-for-publishers-rails-conflict-large