### PR TITLE
Fix cancelled stats announcements

### DIFF
--- a/app/presenters/publishing_api_presenters/statistics_announcement.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement.rb
@@ -16,7 +16,12 @@ private
       display_date: item.current_release_date.display_date,
       state: item.state,
       format_sub_type: item.national_statistic? ? "national" : "official"
-    }
+    }.tap do |d|
+      d.merge!(
+        cancellation_reason: item.cancellation_reason,
+        cancelled_at: cancelled_at
+      ) if item.cancelled?
+    end
   end
 
   def document_format
@@ -33,5 +38,10 @@ private
 
   def public_updated_at
     item.updated_at
+  end
+
+  def cancelled_at
+    return nil unless item.cancelled_at
+    item.cancelled_at.to_datetime
   end
 end

--- a/db/data_migration/20160318114847_republish_cancelled_statistics_announcements.rb
+++ b/db/data_migration/20160318114847_republish_cancelled_statistics_announcements.rb
@@ -1,0 +1,4 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(
+    StatisticsAnnouncement.unscoped.where("cancelled_at is not null")
+  )
+republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
@@ -5,7 +5,7 @@ class PublishingApiPresenters::StatisticsAnnouncementTest < ActiveSupport::TestC
     PublishingApiPresenters::StatisticsAnnouncement.new(record)
   end
 
-  test "statistics announcement presents the correct values" do
+  test "a scheduled statistics announcement presents the correct values" do
     statistics_announcement = create(:statistics_announcement)
 
     expected = {
@@ -23,6 +23,43 @@ class PublishingApiPresenters::StatisticsAnnouncementTest < ActiveSupport::TestC
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,
         format_sub_type: 'official'
+      },
+      links: {
+        organisations: statistics_announcement.organisations.map(&:content_id),
+        policy_areas: statistics_announcement.topics.map(&:content_id),
+        topics: [],
+      }
+    }
+
+    presented = present(statistics_announcement)
+
+    assert_valid_against_schema(presented.content, 'statistics_announcement')
+    assert_valid_against_links_schema({ links: presented.links }, 'statistics_announcement')
+
+    assert_equal expected[:details], presented.content[:details].except(:body)
+    assert_equal expected[:links], presented.links
+  end
+
+  test "a cancelled statistics announcement presents the correct values" do
+    statistics_announcement = create(:cancelled_statistics_announcement)
+
+    expected = {
+      content_id: statistics_announcement.content_id,
+      base_path: statistics_announcement.slug,
+      description: statistics_announcement.summary,
+      title: statistics_announcement.title,
+      format: 'statistics_announcement',
+      locale: 'en',
+      need_ids: [],
+      public_updated_at: statistics_announcement.updated_at,
+      publishing_app: 'whitehall',
+      rendering_app: 'government-frontend',
+      details: {
+        display_date: statistics_announcement.current_release_date.display_date,
+        state: statistics_announcement.state,
+        format_sub_type: 'official',
+        cancelled_at: statistics_announcement.cancelled_at,
+        cancellation_reason: 'Cancelled for a reason'
       },
       links: {
         organisations: statistics_announcement.organisations.map(&:content_id),


### PR DESCRIPTION
Cancellation dates and reasons weren’t being included in the published
content item.

/cc @gpeng @benilovj 