### PR TITLE
Rename `publish_gone` to `publish_gone_async`

### DIFF
--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -20,7 +20,7 @@ module PublishesToPublishingApi
 
   def publish_gone_to_publishing_api
     run_callbacks :published_gone do
-      Whitehall::PublishingApi.publish_gone(search_link)
+      Whitehall::PublishingApi.publish_gone_async(search_link)
     end
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -66,7 +66,7 @@ module Whitehall
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)
-        self.publish_gone(base_path) unless edition.document.published?
+        self.publish_gone_async(base_path) unless edition.document.published?
       end
     end
 
@@ -74,7 +74,7 @@ module Whitehall
       PublishingApiRedirectWorker.perform_async(base_path, redirects, locale)
     end
 
-    def self.publish_gone(base_path)
+    def self.publish_gone_async(base_path)
       PublishingApiGoneWorker.perform_async(base_path)
     end
 

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -71,7 +71,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "publish gone to publishing api publishes async" do
     test_object = include_module(TestObject.new)
-    Whitehall::PublishingApi.expects(:publish_gone).with("test_link")
+    Whitehall::PublishingApi.expects(:publish_gone_async).with("test_link")
     test_object.publish_gone_to_publishing_api
   end
 
@@ -90,7 +90,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
   end
 
   test "defines and executes published_gone callback when published gone" do
-    Whitehall::PublishingApi.stubs(:publish_gone)
+    Whitehall::PublishingApi.stubs(:publish_gone_async)
     test_object = TestObject.new
     class << test_object
       include PublishesToPublishingApi


### PR DESCRIPTION
All of the other enqueueing methods in `Whitehall::PublishingApi` are
named `_async`. This change makes `publish_gone` consistent with that
naming.