### PR TITLE
Strip out emails from flash messages sent to GA

### DIFF
--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -4,8 +4,15 @@ module Admin
       {
         'module' => 'auto-track-event',
         'track-action' => "alert-#{type}",
-        'track-label' => message,
+        'track-label' => flash_text_without_email_addresses(message),
       }
+    end
+
+    def flash_text_without_email_addresses(message)
+      text_message = strip_tags(message)
+
+      # redact email addresses so they aren't passed to GA
+      text_message.gsub(/\S+@\S+/, '[email]')
     end
   end
 end


### PR DESCRIPTION
From https://github.com/alphagov/whitehall/pull/2502, this app has started
sending GA events containing flash messages displayed in the admin.

Unfortunately, some of these flash messages contain publishers' email addresses.
This change strips the emails out.

/cc @fofr 