### PR TITLE
Tidy up Whitehall::PublishingApi tests

### DIFF
--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -15,7 +15,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     stub_any_publishing_api_patch_links
   end
 
-  test "#publish publishes an Edition with the Publishing API" do
+  test ".publish_async publishes an Edition with the Publishing API" do
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
@@ -29,7 +29,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#publish publishes non-Edition instances with the Publishing API" do
+  test ".publish_async publishes non-Edition instances with the Publishing API" do
     organisation = create(:organisation)
     WebMock.reset! # because creating an organisation also pushes to Publishing API
     presenter = PublishingApiPresenters.presenter_for(organisation)
@@ -44,7 +44,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#publish sends unpublishing for case studies to the content store" do
+  test ".publish_async sends unpublishing for case studies to the content store" do
     edition = create(:draft_case_study)
     unpublishing = create(:unpublishing, edition: edition)
 
@@ -60,7 +60,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#publish skips sending unpublishings for formats other than case study" do
+  test ".publish_async skips sending unpublishings for formats other than case study" do
     edition = create(:draft_publication)
     unpublishing = create(:unpublishing, edition: edition)
 
@@ -69,7 +69,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_not_requested :put, %r{/content/}
   end
 
-  test "#publish sends case studies to the content store" do
+  test ".publish_async sends case studies to the content store" do
     edition = create(:published_case_study)
 
     presenter = PublishingApiPresenters.presenter_for(edition)
@@ -84,7 +84,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#republish publishes to the Publishing API as a 'republish' update_type" do
+  test ".republish_async publishes to the Publishing API as a 'republish' update_type" do
     take_part_page = create(:take_part_page)
     presenter = PublishingApiPresenters.presenter_for(take_part_page, update_type: 'republish')
     requests = [
@@ -98,7 +98,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#bulk_republish_async publishes to the Publishing API as a 'republish'" do
+  test ".bulk_republish_async publishes to the Publishing API as a 'republish'" do
     take_part_page = create(:take_part_page)
     presenter = PublishingApiPresenters.presenter_for(take_part_page, update_type: 'republish')
     requests = [
@@ -112,7 +112,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#bulk_republish_async queues the job on the bulk_republishing queue" do
+  test ".bulk_republish_async queues the job on the bulk_republishing queue" do
     take_part_page = create(:take_part_page)
     PublishingApiWorker.expects(:perform_async_in_queue)
       .with(
@@ -125,7 +125,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.bulk_republish_async(take_part_page)
   end
 
-  test "#republish_document_async publishes to the publishing API as a 'republish' update_type" do
+  test ".republish_document_async publishes to the publishing API as a 'republish' update_type" do
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: 'republish')
     requests = [
@@ -139,7 +139,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "#publish publishes all available translations of a translatable model" do
+  test ".publish_async publishes all available translations of a translatable model" do
     organisation = create(:organisation)
     presenter = PublishingApiPresenters.presenter_for(organisation)
 
@@ -168,7 +168,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested(links_request, times: 2)
   end
 
-  test "#republish republishes all available translations of a translatable model" do
+  test ".republish_async republishes all available translations of a translatable model" do
     organisation = create(:organisation)
     presenter = PublishingApiPresenters.presenter_for(organisation, update_type: 'republish')
 
@@ -197,14 +197,14 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested(links_request, times: 2)
   end
 
-  test "#republish raises an error when passed an Edition type" do
+  test ".republish_async raises an error when passed an Edition type" do
     edition = create(:published_edition)
     assert_raise(ArgumentError, "Use republish_document_async for republishing Editions") do
       Whitehall::PublishingApi.republish_async(edition)
     end
   end
 
-  test "republishes an unpublishing" do
+  test ".republish_async republishes an unpublishing" do
     unpublishing = create(:unpublishing)
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish")
     requests = [
@@ -217,7 +217,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "publishes a redirect unpublishing" do
+  test ".republish_async publishes a redirect unpublishing" do
     unpublishing = create(:redirect_unpublishing)
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish")
     requests = [
@@ -230,7 +230,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test "publishes a translated edition that has been unpublished" do
+  test ".publish_async publishes a translated edition that has been unpublished" do
     unpublishing     = create(:unpublishing)
     edition          = unpublishing.edition
 
@@ -260,7 +260,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested(links_request, times: 2)
   end
 
-  test "schedule for a first edition served from Whitehall doesn't queue jobs to push publish intents and 'coming_soon' items" do
+  test ".schedule_async for a first edition served from Whitehall doesn't queue jobs to push publish intents and 'coming_soon' items" do
     timestamp = 12.hours.from_now
     edition   = create(:draft_edition, scheduled_publication: timestamp)
 
@@ -272,7 +272,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "schedule for a first edition served from the content store queues jobs to push publish intents and 'coming_soon' items" do
+  test ".schedule_async for a first edition served from the content store queues jobs to push publish intents and 'coming_soon' items" do
     timestamp = 12.hours.from_now
     edition   = create(:draft_case_study, scheduled_publication: timestamp)
 
@@ -295,7 +295,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "schedule for a subsequent edition served from the content store queues jobs to push publish intents, but not to publish 'coming_soon' items" do
+  test ".schedule_async for a subsequent edition served from the content store queues jobs to push publish intents, but not to publish 'coming_soon' items" do
     timestamp = 2.hours.from_now
     existing_edition = create(:published_case_study)
     updated_edition = create(:draft_case_study, scheduled_publication: timestamp, document: existing_edition.document)
@@ -318,7 +318,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "unschedule for a first edition served from Whitehall doesn't queue jobs to remove publish intents and publish 'gone' items" do
+  test ".unschedule_async for a first edition served from Whitehall doesn't queue jobs to remove publish intents and publish 'gone' items" do
     edition = create(:scheduled_edition)
 
     Sidekiq::Testing.fake! do
@@ -329,7 +329,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "unschedule for a first edition served from the content store queues jobs to remove publish intents and publish 'gone' items" do
+  test ".unschedule_async for a first edition served from the content store queues jobs to remove publish intents and publish 'gone' items" do
     edition = create(:scheduled_case_study)
 
     I18n.with_locale(:de) do
@@ -351,7 +351,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "unschedule for a subsequent edition served from the content store queues jobs to remove publish intents, but not to publish 'gone' items" do
+  test ".unschedule_async for a subsequent edition served from the content store queues jobs to remove publish intents, but not to publish 'gone' items" do
     existing_edition = create(:published_case_study)
     updated_edition = create(:scheduled_case_study, document: existing_edition.document)
 
@@ -373,7 +373,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  test "#save_draft_async publishes a draft edition" do
+  test ".save_draft_async publishes a draft edition" do
     draft_edition = create(:draft_case_study)
     payload = PublishingApiPresenters.presenter_for(draft_edition)
     request = stub_publishing_api_put_content(payload.content_id, payload.content)
@@ -383,7 +383,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested request
   end
 
-  test "#publish_async propagates update_type and queue overrides to worker" do
+  test ".publish_async propagates update_type and queue overrides to worker" do
     queue_name = "bang"
     update_type = "whizzo"
 
@@ -396,7 +396,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.publish_async(edition, update_type, queue_name)
   end
 
-  test "#save_draft_async propagates update_type and queue overrides to worker" do
+  test ".save_draft_async propagates update_type and queue overrides to worker" do
     queue_name = "bang"
     update_type = "whizzo"
 
@@ -409,7 +409,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.save_draft_async(draft_edition, update_type, queue_name)
   end
 
-  test "#publish_redirect publishes a redirect to the Publishing API" do
+  test ".publish_redirect_async publishes a redirect to the Publishing API" do
     redirect_uuid = SecureRandom.uuid
     SecureRandom.stubs(uuid: redirect_uuid)
 


### PR DESCRIPTION
Fixes test naming to use correct method syntax and names. Also reorders the tests to group them by method. Probably best reviewed by commit as the reordering commit has a messy diff.