### PR TITLE
Don't strip tags twice on admin notices sent to GA

### DIFF
--- a/app/views/shared/_notices.html.erb
+++ b/app/views/shared/_notices.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:alert] %>
-  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data(:danger, strip_tags(flash[:alert])) %>
+  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data(:danger, flash[:alert]) %>
 <% end %>
 <% if flash[:notice] %>
-  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data(:success, strip_tags(flash[:notice])) %>
+  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data(:success, flash[:notice]) %>
 <% end %>


### PR DESCRIPTION
The HTML tags are stripped both in the view and in the helper `flash_text_without_email_addresses`
which is called from `track_analytics_data`.
Once is enough; this change makes the view simpler.

(cleaning up something introduced on https://github.com/alphagov/whitehall/pull/2512, hat tip to @fofr for [pointing this out](https://github.com/alphagov/whitehall/pull/2512/files/12bacb6e59bbe8a879be0161aa8850a3ce25f49c#r56811487))