### PR TITLE
Add save draft redirect and gone items

### DIFF
--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,6 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(base_path, draft = false)
+  def perform(base_path, options = {})
+    draft = options.fetch("draft", false)
     gone_item = PublishingApiPresenters::Gone.new(base_path)
     draft ? save_draft(gone_item) : send_item(gone_item, 'en')
   end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(base_path)
+  def perform(base_path, draft = false)
     gone_item = PublishingApiPresenters::Gone.new(base_path)
-    send_item(gone_item, 'en')
+    draft ? save_draft(gone_item) : send_item(gone_item, 'en')
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,6 +1,6 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
-  def perform(base_path, redirects, locale)
+  def perform(base_path, redirects, locale, draft = false)
     redirect = PublishingApiPresenters::Redirect.new(base_path, redirects)
-    send_item(redirect, locale)
+    draft ? save_draft(redirect) : send_item(redirect, locale)
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,5 +1,6 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
-  def perform(base_path, redirects, locale, draft = false)
+  def perform(base_path, redirects, locale, options = {})
+    draft = options.fetch("draft", false)
     redirect = PublishingApiPresenters::Redirect.new(base_path, redirects)
     draft ? save_draft(redirect) : send_item(redirect, locale)
   end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -82,6 +82,10 @@ module Whitehall
       PublishingApiRedirectWorker.perform_async(base_path, redirects, locale, true)
     end
 
+    def self.save_draft_gone_async(base_path)
+      PublishingApiGoneWorker.perform_async(base_path, true)
+    end
+
     def self.discard_draft_async(edition)
       locales_for(edition).each do |locale|
         PublishingApiDiscardDraftWorker.perform_async(edition.content_id, locale)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -79,11 +79,16 @@ module Whitehall
     end
 
     def self.save_draft_redirect_async(base_path, redirects, locale = I18n.default_locale.to_s)
-      PublishingApiRedirectWorker.perform_async(base_path, redirects, locale, true)
+      PublishingApiRedirectWorker.perform_async(
+        base_path,
+        redirects,
+        locale,
+        draft: true
+      )
     end
 
     def self.save_draft_gone_async(base_path)
-      PublishingApiGoneWorker.perform_async(base_path, true)
+      PublishingApiGoneWorker.perform_async(base_path, draft: true)
     end
 
     def self.discard_draft_async(edition)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -78,6 +78,10 @@ module Whitehall
       PublishingApiGoneWorker.perform_async(base_path)
     end
 
+    def self.save_draft_redirect_async(base_path, redirects, locale = I18n.default_locale.to_s)
+      PublishingApiRedirectWorker.perform_async(base_path, redirects, locale, true)
+    end
+
     def self.discard_draft_async(edition)
       locales_for(edition).each do |locale|
         PublishingApiDiscardDraftWorker.perform_async(edition.content_id, locale)

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -456,4 +456,21 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     not_expected_publish_request = stub_publishing_api_publish(@redirect_uuid, update_type: 'major', locale: 'en')
     assert_not_requested not_expected_publish_request
   end
+
+  test ".publish_gone_async publishes a gone to the Publishing API" do
+    gone_uuid = SecureRandom.uuid
+    SecureRandom.stubs(uuid: gone_uuid)
+
+    base_path = "/government/people/milly-vanilly"
+    presenter = PublishingApiPresenters::Gone.new(base_path)
+
+    assert_valid_against_schema(presenter.content, "gone")
+
+    expected_content_request = stub_publishing_api_put_content(gone_uuid, presenter.content)
+    expected_publish_request = stub_publishing_api_publish(gone_uuid, update_type: 'major', locale: 'en')
+    Whitehall::PublishingApi.publish_gone_async(base_path)
+
+    assert_requested expected_content_request
+    assert_requested expected_publish_request
+  end
 end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'gds_api/test_helpers/publishing_api_v2'
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
 
 class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -34,7 +34,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_put_content(@uuid, @content),
     ]
 
-    PublishingApiGoneWorker.new.perform(@base_path, true)
+    PublishingApiGoneWorker.new.perform(@base_path, draft: true)
 
     assert_all_requested requests
   end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -4,25 +4,37 @@ require "gds_api/test_helpers/publishing_api_v2"
 class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
-  test "publishes a 'gone' item for the supplied base path" do
-    uuid = "a-uuid"
-    SecureRandom.stubs(uuid: uuid)
-    base_path = '/government/this-never-existed-honest'
+  setup do
+    @uuid = "a-uuid"
+    SecureRandom.stubs(uuid: @uuid)
+    @base_path = '/government/this-never-existed-honest'
 
-    content = {
-      base_path: base_path,
+    @content = {
+      base_path: @base_path,
       format: 'gone',
       publishing_app: 'whitehall',
-      routes: [{path: base_path, type: 'exact'}],
+      routes: [{path: @base_path, type: 'exact'}],
     }
+  end
 
+  test "publishes a 'gone' item for the supplied base path" do
     requests = [
-      stub_publishing_api_put_content(uuid, content),
-      stub_publishing_api_patch_links(uuid, links: {}),
-      stub_publishing_api_publish(uuid, update_type: 'major', locale: 'en')
+      stub_publishing_api_put_content(@uuid, @content),
+      stub_publishing_api_patch_links(@uuid, links: {}),
+      stub_publishing_api_publish(@uuid, update_type: 'major', locale: 'en')
     ]
 
-    PublishingApiGoneWorker.new.perform(base_path)
+    PublishingApiGoneWorker.new.perform(@base_path)
+
+    assert_all_requested requests
+  end
+
+  test "saves a draft 'gone' item for the supplied base path if draft == true" do
+    requests = [
+      stub_publishing_api_put_content(@uuid, @content),
+    ]
+
+    PublishingApiGoneWorker.new.perform(@base_path, true)
 
     assert_all_requested requests
   end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -48,7 +48,12 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_put_content(@uuid, @content),
     ]
 
-    PublishingApiRedirectWorker.new.perform(@base_path, @redirects, "en", true)
+    PublishingApiRedirectWorker.new.perform(
+      @base_path,
+      @redirects,
+      "en",
+      draft: true,
+    )
 
     assert_all_requested requests
   end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  setup do
+    @uuid = "a-uuid"
+    SecureRandom.stubs(uuid: @uuid)
+    @base_path = "/government/this-needs-redirecting"
+
+    @content = {
+      base_path: "/government/this-needs-redirecting",
+      format: "redirect",
+      publishing_app: "whitehall",
+      redirects: [
+        {
+          path: "/government/this-needs-redirecting",
+          type: "exact",
+          destination: "/government/has-been-redirected"
+        },
+      ],
+    }
+
+    @redirects = [
+      {
+        path: @base_path,
+        type: "exact",
+        destination: "/government/has-been-redirected",
+      },
+    ]
+  end
+
+  test "publishes a 'redirect' item for the supplied base path" do
+    requests = [
+      stub_publishing_api_put_content(@uuid, @content),
+      stub_publishing_api_patch_links(@uuid, links: {}),
+      stub_publishing_api_publish(@uuid, update_type: 'major', locale: 'en')
+    ]
+
+    PublishingApiRedirectWorker.new.perform(@base_path, @redirects, "en")
+
+    assert_all_requested requests
+  end
+
+  test "saves a draft 'redirect' item for the supplied base path if draft == true" do
+    requests = [
+      stub_publishing_api_put_content(@uuid, @content),
+    ]
+
+    PublishingApiRedirectWorker.new.perform(@base_path, @redirects, "en", true)
+
+    assert_all_requested requests
+  end
+end


### PR DESCRIPTION
This commit allows us to create draft redirect and gone items. This requirement has come to light whilst migrating the `HtmlAttachment` (HtmlPublication) format. This format does not have draft functionality as such but is attached to formats that do. 

When deleting an `HtmlAttachment` from a draft `Edition` that has been previously published we need to save a redirect to the draft content store so that it can be published with the `Edition` and the redirect activated.

This is a step towards that functionality.

[Trello](https://trello.com/c/uwsLR1xU/285-5-html-publications-implement-publishing-of-format-to-publishing-api-large)
