### PR TITLE
Add rake task to re-index one Document

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,4 +1,9 @@
 namespace :rummager do
+  desc "Re-index one Document. Takes a `content_id` as argument."
+  task :resend_document, [:content_id] => [:environment] do |_, args|
+    Document.find_by(content_id: args[:content_id]).published_edition.update_in_search_index
+  end
+
   desc "indexes all published searchable whitehall content"
   task index: ['rummager:index:detailed', 'rummager:index:government']
 


### PR DESCRIPTION
We sometimes get reports that documents are not in search. These are typically documents published over 6 months ago, and we can't really figure out why they haven't been sent to rummager.

In these situations we just send the document to rummager again. This rake task makes that process a little easier and better documented.

Run the rake task with:

https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=whitehall&MACHINE=whitehall-backend-1.backend&RAKE_TASK=rummager:resend_document[CONTENT_ID]

Example Zendesk ticket: https://govuk.zendesk.com/tickets/1281713