### PR TITLE
Soft deleting HTML attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -49,7 +49,7 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def destroy
-    attachment.destroy
+    attachment.update(deleted: true)
     redirect_to attachable_attachments_path(attachable), notice: 'Attachment deleted'
   end
 

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -3,11 +3,11 @@ module Attachable
 
   included do
     has_many :attachments,
-             -> { order('attachments.ordering, attachments.id') },
+             -> { not_deleted.order('attachments.ordering, attachments.id') },
              as: :attachable,
              inverse_of: :attachable
     has_many :html_attachments,
-             -> { order('attachments.ordering, attachments.id') },
+             -> { not_deleted.order('attachments.ordering, attachments.id') },
              as: :attachable
 
     if respond_to?(:add_trait)
@@ -110,7 +110,7 @@ module Attachable
   end
 
   def next_ordering
-    max = Attachment.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
+    max = Attachment.not_deleted.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
     max ? max + 1 : 0
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -38,6 +38,8 @@ class Attachment < ActiveRecord::Base
 
   scope :for_current_locale, -> { where(locale: [nil, I18n.locale]) }
 
+  scope :not_deleted, -> { where(deleted: false) }
+
   def self.parliamentary_sessions
     (1951..Time.zone.now.year).to_a.reverse.map do |year|
       starts = Date.new(year).strftime('%Y')

--- a/db/migrate/20160318154626_add_is_deleted_to_attachments.rb
+++ b/db/migrate/20160318154626_add_is_deleted_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddIsDeletedToAttachments < ActiveRecord::Migration
+  def change
+    add_column :attachments, :deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311090953) do
+ActiveRecord::Schema.define(version: 20160318154626) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20160311090953) do
     t.string   "order_url",                limit: 255
     t.integer  "price_in_pence",           limit: 4
     t.integer  "attachment_data_id",       limit: 4
-    t.integer  "ordering",                 limit: 4,   null: false
+    t.integer  "ordering",                 limit: 4,                   null: false
     t.string   "hoc_paper_number",         limit: 255
     t.string   "parliamentary_session",    limit: 255
     t.boolean  "unnumbered_command_paper"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20160311090953) do
     t.string   "locale",                   limit: 255
     t.string   "external_url",             limit: 255
     t.string   "content_id",               limit: 255
+    t.boolean  "deleted",                              default: false, null: false
   end
 
   add_index "attachments", ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type", using: :btree

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -78,7 +78,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
       delete :destroy, param_name => attachable.id, id: attachment.id
 
       assert_response :redirect
-      refute Attachment.exists?(attachment.id), 'attachment should have been deleted'
+      assert Attachment.find(attachment.id).deleted?, 'attachment should have been soft-deleted'
     end
   end
 
@@ -124,7 +124,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     delete :destroy, edition_id: @edition, id: attachment.id
 
     assert_response :redirect
-    refute Attachment.exists?(attachment.id), 'attachment should have been deleted'
+    assert Attachment.find(attachment.id).deleted?, 'attachment should have been deleted'
   end
 
   view_test 'GET :index shows external attachments' do

--- a/test/functional/html_attachments_controller_test.rb
+++ b/test/functional/html_attachments_controller_test.rb
@@ -46,6 +46,20 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
     end
   end
 
+  test '#show returns 404 if the attachment is marked as deleted' do
+    # when an HTML attachment has been published with a previous edition, and deleted
+    # on a subsequent edition, fetching the attachment's slug ideally shouldn't
+    # result in a 404. However, this is the system's current behaviour and this
+    # test documents this fact. The behaviour is likely to change when HTML attachments
+    # are moved to the new publishing stack
+    consultation, attachment = create_edition_and_attachment(type: :consultation)
+    attachment.update(deleted: true)
+
+    assert_raise ActiveRecord::RecordNotFound do
+      get :show, consultation_id: consultation.document, id: attachment
+    end
+  end
+
   test '#show returns 404 if the trying to preview a non-existent document' do
     login_as create(:departmental_editor)
     attachment = create(:html_attachment)

--- a/test/functional/html_attachments_controller_test.rb
+++ b/test/functional/html_attachments_controller_test.rb
@@ -129,12 +129,7 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
   end
 
 private
-  def create_edition_and_attachment(options = {})
-    type = options.fetch(:type, :publication)
-    state = options.fetch(:state, :published)
-    build_unpublishing = options.fetch(:build_unpublishing, false)
-    locale = options.fetch(:locale, nil)
-
+  def create_edition_and_attachment(type: :publication, state: :published, build_unpublishing: false, locale: nil)
     publication = create("#{state}_#{type}", translated_into: [locale].compact, attachments: [
       attachment = build(:html_attachment, title: 'HTML Attachment Title', locale: locale)
     ])

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -168,6 +168,24 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal [attachment_2, attachment_3], publication.html_attachments(true)
   end
 
+  test 'attachment association excludes soft-deleted Attachments' do
+    publication = create(:publication, :with_file_attachment, attachments: [
+      attachment_1 = build(:file_attachment),
+      build(:html_attachment, title: "HTML attachment", deleted: true),
+    ])
+
+    assert_equal [attachment_1], publication.attachments(true)
+  end
+
+  test 'html_attachment association excludes soft-deleted HtmlAttachments' do
+    publication = create(:publication, attachments: [
+      attachment_1 = build(:html_attachment, title: "Test HTML attachment"),
+      build(:html_attachment, title: "Another HTML attachment", deleted: true),
+    ])
+
+    assert_equal [attachment_1], publication.html_attachments(true)
+  end
+
   test '#has_command_paper? is true if an attachment is a command paper' do
     pub = build(:publication)
     pub.stubs(:attachments).returns([


### PR DESCRIPTION
Publishers can currently hard-delete HTML attachments, even those that were published with previous editions. When the edition with the deleted attachment is published, fetching by the attachment's slug starts returning 404, instead of redirecting or returning 410 gone. This results in broken journeys for users who follow those outdated attachment URLs.

The first step to rectifying this issue is to stop hard-deleting attachments; when HTML attachments are migrated to the single publishing stack, deletion of previously published attachments can result in a redirect item.

[Trello](https://trello.com/c/KVyrnAEy/336-broken-urls-to-deleted-html-attachments)