### PR TITLE
Discard attachments when the parent attachable is discarded

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -114,6 +114,10 @@ module Attachable
     max ? max + 1 : 0
   end
 
+  def delete_all_attachments
+    attachments.each { |attachment| attachment.update(deleted: true) }
+  end
+
   def reorder_attachments(ordered_attachment_ids)
     return if ordered_attachment_ids.empty?
 

--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -16,5 +16,6 @@ private
     edition.public_send(verb)
     edition.save(validate: false)
     edition.clear_slug
+    edition.delete_all_attachments if edition.respond_to?(:delete_all_attachments)
   end
 end

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -218,4 +218,16 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal html_attachment.govspeak_content.body, attachment_2.govspeak_content.body
     assert_equal html_attachment.title, attachment_2.title
   end
+
+  test '#delete_all_attachments soft-deletes any attachments that the edition has' do
+    publication = create(:draft_publication, :with_file_attachment, attachments: [
+      attachment_1 = build(:file_attachment, ordering: 0),
+      attachment_2 = build(:html_attachment, title: "Test HTML attachment", ordering: 1),
+    ])
+
+    publication.delete_all_attachments
+
+    assert Attachment.find(attachment_1.id).deleted?
+    assert Attachment.find(attachment_2.id).deleted?
+  end
 end

--- a/test/unit/services/edition_deleter_test.rb
+++ b/test/unit/services/edition_deleter_test.rb
@@ -51,4 +51,16 @@ class EditionDeleterTest < ActiveSupport::TestCase
     edition.reload
     assert_equal 'deleted-just-a-test', edition.slug
   end
+
+  test '#perform! soft-deletes any attachments that the edition has' do
+    publication = create(:draft_publication, :with_file_attachment, attachments: [
+      attachment_1 = build(:file_attachment, ordering: 0),
+      attachment_2 = build(:html_attachment, title: "Test HTML attachment", ordering: 1),
+    ])
+
+    assert EditionDeleter.new(publication).perform!
+
+    assert Attachment.find(attachment_1.id).deleted?
+    assert Attachment.find(attachment_2.id).deleted?
+  end
 end


### PR DESCRIPTION
Before this change, if a draft edition with attachments was
discarded, the attachments would be orphaned in the database.
It doesn't feel right to keep the attachments around without the parent.

After this change, discarding (soft-deleting) the edition will soft-delete
the attachments.