### PR TITLE
ComingSoon PublishingAPI presenter returns stable content_id

### DIFF
--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -17,8 +17,11 @@ require_relative "../publishing_api_presenters"
 # honour caching headers on upstream 404 responses.
 
 class PublishingApiPresenters::ComingSoon < PublishingApiPresenters::Item
-  def content_id
-    SecureRandom.uuid
+  attr_reader :content_id
+
+  def initialize(item, update_type: nil)
+    super
+    @content_id = SecureRandom.uuid
   end
 
   private


### PR DESCRIPTION
`PublishingApiPresenters::ComingSoon` should memoise the `content_id`;
otherwise calling `presenter#content_id` in the publishing API worker
returns different content_ids for the `put_content` and `publish`
Publishing API actions.

This fixes https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56f2b1e06578637659df0400
and friends.