### PR TITLE
Remove composite unique index on `attachments`

### DIFF
--- a/db/migrate/20160323162210_remove_attachments_order_unique_constraint.rb
+++ b/db/migrate/20160323162210_remove_attachments_order_unique_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveAttachmentsOrderUniqueConstraint < ActiveRecord::Migration
+  def change
+    remove_index :attachments, name: "no_duplicate_attachment_orderings"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318154626) do
+ActiveRecord::Schema.define(version: 20160323162210) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -80,7 +80,6 @@ ActiveRecord::Schema.define(version: 20160318154626) do
   end
 
   add_index "attachments", ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type", using: :btree
-  add_index "attachments", ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true, using: :btree
   add_index "attachments", ["attachment_data_id"], name: "index_attachments_on_attachment_data_id", using: :btree
   add_index "attachments", ["ordering"], name: "index_attachments_on_ordering", using: :btree
 


### PR DESCRIPTION
There was a composite unique constraint on attachments composed of
`attachable_type`, `attachable_id` and `order` that had been added,
seemingly, to prevent attachments with duplicate `order` being added to
an `Attachable`.

Since implementing soft delete functionality in
https://github.com/alphagov/whitehall/pull/2518, violations of this
constraint have begun to occur causing exceptions. [Errbit](https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56f2aa9e6578637df10d0200)

This commit removes the constraint which appears to be redundant in any
case as the ordering is done via ajax drag and drop (so there is no
explicit user input to guard against) and then takes place within a
transaction [here](https://github.com/alphagov/whitehall/blob/master/app/models/attachable.rb#L117-L139) so should be safe. The consequences of a duplicate order field are
minor in any case and the necessity of the soft delete functionality for
`HtmlAttachment` would outweigh this.

cc: @benilovj @boffbowsh 