### PR TITLE
Revert soft delete of attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -49,7 +49,7 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def destroy
-    attachment.update(deleted: true)
+    attachment.destroy
     redirect_to attachable_attachments_path(attachable), notice: 'Attachment deleted'
   end
 

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -3,11 +3,11 @@ module Attachable
 
   included do
     has_many :attachments,
-             -> { not_deleted.order('attachments.ordering, attachments.id') },
+             -> { order('attachments.ordering, attachments.id') },
              as: :attachable,
              inverse_of: :attachable
     has_many :html_attachments,
-             -> { not_deleted.order('attachments.ordering, attachments.id') },
+             -> { order('attachments.ordering, attachments.id') },
              as: :attachable
 
     if respond_to?(:add_trait)
@@ -110,7 +110,7 @@ module Attachable
   end
 
   def next_ordering
-    max = Attachment.not_deleted.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
+    max = Attachment.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
     max ? max + 1 : 0
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -10,6 +10,8 @@ class Attachment < ActiveRecord::Base
   before_save :nilify_locale_if_blank
   before_save :prevent_saving_of_abstract_base_class
 
+  deprecated_columns :deleted
+
   VALID_COMMAND_PAPER_NUMBER_PREFIXES = ['C.', 'Cd.', 'Cmd.', 'Cmnd.', 'Cm.']
 
   validates_with AttachmentValidator
@@ -37,8 +39,6 @@ class Attachment < ActiveRecord::Base
   scope :files, -> { where(type: FileAttachment) }
 
   scope :for_current_locale, -> { where(locale: [nil, I18n.locale]) }
-
-  scope :not_deleted, -> { where(deleted: false) }
 
   def self.parliamentary_sessions
     (1951..Time.zone.now.year).to_a.reverse.map do |year|

--- a/db/migrate/20160323170917_delete_soft_deleted_attachments.rb
+++ b/db/migrate/20160323170917_delete_soft_deleted_attachments.rb
@@ -1,0 +1,7 @@
+class DeleteSoftDeletedAttachments < ActiveRecord::Migration
+  class Attachment < ActiveRecord::Base; end
+
+  def change
+    Attachment.destroy_all(deleted: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318154626) do
+ActiveRecord::Schema.define(version: 20160323170917) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -78,7 +78,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
       delete :destroy, param_name => attachable.id, id: attachment.id
 
       assert_response :redirect
-      assert Attachment.find(attachment.id).deleted?, 'attachment should have been soft-deleted'
+      refute Attachment.exists?(attachment.id), 'attachment should have been deleted'
     end
   end
 
@@ -124,7 +124,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     delete :destroy, edition_id: @edition, id: attachment.id
 
     assert_response :redirect
-    assert Attachment.find(attachment.id).deleted?, 'attachment should have been deleted'
+    refute Attachment.exists?(attachment.id), 'attachment should have been deleted'
   end
 
   view_test 'GET :index shows external attachments' do

--- a/test/functional/html_attachments_controller_test.rb
+++ b/test/functional/html_attachments_controller_test.rb
@@ -46,20 +46,6 @@ class HtmlAttachmentsControllerTest < ActionController::TestCase
     end
   end
 
-  test '#show returns 404 if the attachment is marked as deleted' do
-    # when an HTML attachment has been published with a previous edition, and deleted
-    # on a subsequent edition, fetching the attachment's slug ideally shouldn't
-    # result in a 404. However, this is the system's current behaviour and this
-    # test documents this fact. The behaviour is likely to change when HTML attachments
-    # are moved to the new publishing stack
-    consultation, attachment = create_edition_and_attachment(type: :consultation)
-    attachment.update(deleted: true)
-
-    assert_raise ActiveRecord::RecordNotFound do
-      get :show, consultation_id: consultation.document, id: attachment
-    end
-  end
-
   test '#show returns 404 if the trying to preview a non-existent document' do
     login_as create(:departmental_editor)
     attachment = create(:html_attachment)

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -168,24 +168,6 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal [attachment_2, attachment_3], publication.html_attachments(true)
   end
 
-  test 'attachment association excludes soft-deleted Attachments' do
-    publication = create(:publication, :with_file_attachment, attachments: [
-      attachment_1 = build(:file_attachment),
-      build(:html_attachment, title: "HTML attachment", deleted: true),
-    ])
-
-    assert_equal [attachment_1], publication.attachments(true)
-  end
-
-  test 'html_attachment association excludes soft-deleted HtmlAttachments' do
-    publication = create(:publication, attachments: [
-      attachment_1 = build(:html_attachment, title: "Test HTML attachment"),
-      build(:html_attachment, title: "Another HTML attachment", deleted: true),
-    ])
-
-    assert_equal [attachment_1], publication.html_attachments(true)
-  end
-
   test '#has_command_paper? is true if an attachment is a command paper' do
     pub = build(:publication)
     pub.stubs(:attachments).returns([


### PR DESCRIPTION
Soft deletes for attachments were introduced with #2518 but have caused problems on Production; publishers are having trouble reordering attachments on editions with deleted attachments (see #2522 and [errbit](https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56f2aa9e6578637df10d0200)).

This commit backs out the changes from #2518. The plan is to re-introduce soft-deleting when the issues around the uniqueness constraints have been resolved.