### PR TITLE
Fix attachment reordering bugs

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -110,7 +110,7 @@ module Attachable
   end
 
   def next_ordering
-    max = Attachment.not_deleted.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
+    max = Attachment.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
     max ? max + 1 : 0
   end
 
@@ -125,7 +125,7 @@ module Attachable
 
       # To get around it, we check that we can start at 0 and fit all the
       # ordering values below the current lowest ordering.
-      if ordered_attachment_ids.count < attachments.minimum(:ordering)
+      if ordered_attachment_ids.count < attachments.unscoped.minimum(:ordering)
         start_at = 0
 
       # Otherwise, we start reordering at the next available number

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -156,6 +156,30 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal [b, a, c], attachable.reload.attachments
   end
 
+  test '#reorder_attachments handles deleted attachments that had high ordering values' do
+    attachable = create(:consultation)
+    a = create(:file_attachment, attachable: attachable, ordering: 0)
+    b = create(:file_attachment, attachable: attachable, ordering: 1)
+    create(:file_attachment, attachable: attachable, ordering: 2, deleted: true)
+
+    attachable.reload.reorder_attachments([b.id, a.id])
+
+    assert_equal [b, a], attachable.reload.attachments
+  end
+
+  test '#reorder_attachments handles deleted attachments that had low ordering values' do
+    attachable = create(:consultation)
+    create(:file_attachment, attachable: attachable, ordering: 0, deleted: true)
+    create(:file_attachment, attachable: attachable, ordering: 1, deleted: true)
+    create(:file_attachment, attachable: attachable, ordering: 2, deleted: true)
+    a = create(:file_attachment, attachable: attachable, ordering: 3)
+    b = create(:file_attachment, attachable: attachable, ordering: 4)
+
+    attachable.reload.reorder_attachments([b.id, a.id])
+
+    assert_equal [b, a], attachable.reload.attachments
+  end
+
   test 'has html_attachments association to fetch only HtmlAttachments' do
     publication = create(:publication, :with_file_attachment, attachments: [
       attachment_1 = build(:file_attachment, ordering: 0),


### PR DESCRIPTION
The implementation of attachment soft-deletion (https://github.com/alphagov/whitehall/pull/2518)
broke attachment re-ordering for drafts with deleted attachments.

There is a uniqueness constraint on the attachments (attachable_type, attachable_id, ordering)
and this was being violated because the code which calculated ordering
numbers wasn't taking deleted attachments into account. This commit
rectifies the issue by unscoping appropriately.

I believe that this fixes [errbit errors from Production](https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/56f2aa9e6578637df10d0200); the alternative to this change would roll back soft-deletions of attachments (see https://github.com/alphagov/whitehall/pull/2523).