### PR TITLE
Change organisation presenter, update crests.

### DIFF
--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -16,7 +16,12 @@ class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placehold
 private
 
   def crest
-    item.organisation_logo_type.class_name
+    crest_is_publishable? ? item.organisation_logo_type.class_name : nil
+  end
+
+  def crest_is_publishable?
+    class_name = item.organisation_logo_type.class_name
+    class_name != "no-identity" && class_name != "custom"
   end
 
   def formatted_title

--- a/db/data_migration/20160324153301_republish_organisations_with_updated_crests.rb
+++ b/db/data_migration/20160324153301_republish_organisations_with_updated_crests.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(Organisation.all)
+republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/organisation_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/organisation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
+class PublishingApiPresenters::OrganisationTest < ActionView::TestCase
   def present(model_instance, options = {})
     PublishingApiPresenters::Organisation.new(model_instance, options)
   end
@@ -47,5 +47,28 @@ class PublishingApiPresenters::OrganisationTest < ActiveSupport::TestCase
     assert_equal organisation.content_id, presented_item.content_id
 
     assert_valid_against_schema(presented_item.content, 'placeholder')
+  end
+
+  test 'presents an organisation with a custom logo with a nil crest' do
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      organisation_logo_type_id: 14,
+      logo: fixture_file_upload('images/960x640_jpeg.jpg', 'image/jpeg')
+    )
+    presented_item = present(organisation)
+
+    assert_equal presented_item.content[:details][:logo][:crest], nil
+  end
+
+  test 'presents an organisation with no identity with a nil crest' do
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      organisation_logo_type_id: 1
+    )
+    presented_item = present(organisation)
+
+    assert_equal presented_item.content[:details][:logo][:crest], nil
   end
 end


### PR DESCRIPTION
Organisations that have the `no-identity` or `custom` OrganisationLogoTypes are currently publishing those class_names as crests, which doesn't make sense for our frontends.

After discussing with @dsingleton and @fofr, we've decided to publish `null` instead. It's preferable to work around it in whitehall than in our frontends.

This will fix an issue in `government-frontend`, which is displaying the "Environment Agency" crest incorrectly.

Related PR: https://github.com/alphagov/govuk-content-schemas/pull/272

Relevant Trello ticket:
https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large