### PR TITLE
Enable sassc for stylesheet compilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ else
 end
 
 gem 'sass', '3.4.9'
-gem 'sass-rails' # required by bootstrap-sass, but not listed as a dependency of it
+gem 'sassc-rails'
 gem 'uglifier'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,12 +358,17 @@ GEM
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.4.9)
-    sass-rails (5.0.3)
-      railties (>= 4.0.0, < 5.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (~> 1.1)
+    sassc (1.8.5)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sassc-rails (1.2.0)
+      railties (>= 4.0.0)
+      sass
+      sassc (~> 1.6)
+      sprockets (> 2.11)
+      sprockets-rails
+      tilt
     shared_mustache (0.2.1)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
@@ -407,7 +412,7 @@ GEM
       rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.2)
     timecop (0.7.1)
     tins (1.6.0)
     transitions (0.2.0)
@@ -509,7 +514,7 @@ DEPENDENCIES
   ruby-prof
   rummageable (= 1.2.0)
   sass (= 3.4.9)
-  sass-rails
+  sassc-rails
   shared_mustache (~> 0.2.1)
   sidekiq (~> 4.0)
   sidekiq-logging-json!

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -1,69 +1,69 @@
 
 // STYLEGUIDE
 // From the https://github.com/alphagov/govuk_frontend_toolkit
-@import "_colours.scss";
-@import "_conditionals.scss";
-@import "_measurements.scss";
-@import "_css3.scss";
-@import "_shims.scss";
-@import "_typography.scss";
+@import "_colours";
+@import "_conditionals";
+@import "_measurements";
+@import "_css3";
+@import "_shims";
+@import "_typography";
 
 // Frontend styleguide is used for rendering govspeak and some other things
 // it probably shouldn't be used for (e.g. $gutter).
-@import "frontend/styleguide/_dimensions.scss";
-@import "frontend/styleguide/_typography.scss";
-@import "frontend/styleguide/_colours.scss";
-@import "frontend/styleguide/_right-to-left.scss";
+@import "frontend/styleguide/_dimensions";
+@import "frontend/styleguide/_typography";
+@import "frontend/styleguide/_colours";
+@import "frontend/styleguide/_right-to-left";
 
 
-@import "govuk_admin_template/emulate/_forms.scss";
+@import "govuk_admin_template/emulate/_forms";
 
 // COMPONENTS
-@import "alerts.scss";
-@import "document.scss";
-@import "environment.scss";
-@import "forms.scss";
-@import "layout.scss";
-@import "preview.scss";
-@import "sortable.scss";
-@import "audit_trail.scss";
-@import "fact_check_requests.scss";
-@import "govspeak_help.scss";
-@import "organisation.scss";
-@import "classifications.scss";
-@import "person.scss";
-@import "sidebar.scss";
-@import "lists.scss";
-@import "get_involved.scss";
+@import "alerts";
+@import "document";
+@import "environment";
+@import "forms";
+@import "layout";
+@import "preview";
+@import "sortable";
+@import "audit_trail";
+@import "fact_check_requests";
+@import "govspeak_help";
+@import "organisation";
+@import "classifications";
+@import "person";
+@import "sidebar";
+@import "lists";
+@import "get_involved";
 
 // GLOBAL
 // Styles that apply to all of admin.
-@import "global/_boostrap-overrides.scss";
-@import "global/_js-hidden.scss";
+@import "global/_boostrap-overrides";
+@import "global/_js-hidden";
 
 // HELPERS
 // Objects that can be used in more than one place throughout the admin
-@import "helpers/_broken_links_report.scss";
-@import "helpers/_document_finder.scss";
-@import "helpers/_document_list.scss";
-@import "helpers/_navigation_controls.scss";
-@import "helpers/_jquery_ui_overrides.scss";
-@import "helpers/_statistics_announcements.scss";
-@import "helpers/_words_to_avoid_highlighter.scss";
-@import "helpers/bootstrap/_button_dropdown.scss";
+@import "helpers/_broken_links_report";
+@import "helpers/_document_finder";
+@import "helpers/_document_list";
+@import "helpers/_navigation_controls";
+@import "helpers/_jquery_ui_overrides";
+@import "helpers/_statistics_announcements";
+@import "helpers/_words_to_avoid_highlighter";
+@import "helpers/bootstrap/_button_dropdown";
 
 // helpers shared with frontend
-@import "../shared/helpers/_player-container.scss";
+@import "../shared/helpers/_player-container";
 
 // VIEWS
 // Controller specific styles. Usually named after the controller whos views
 // they relate to
-@import "views/_dashboard.scss";
-@import "views/_edition_form.scss";
-@import "views/_edition_show.scss";
-@import "views/_editions-index.scss";
-@import "views/_edition_edit_help.scss";
-@import "views/_document_collection_groups.scss";
-@import "views/_organisation.scss";
-@import "views/editions/confirm_unpublish.scss";
-@import "views/editions/_filter_options.scss";
+@import "views/_dashboard";
+@import "views/_edition_form";
+@import "views/_edition_show";
+@import "views/_editions-index";
+@import "views/_edition_edit_help";
+@import "views/_document_collection_groups";
+@import "views/_organisation";
+@import "views/editions/confirm_unpublish";
+@import "views/editions/_filter_options";

--- a/app/assets/stylesheets/admin/document.scss
+++ b/app/assets/stylesheets/admin/document.scss
@@ -41,8 +41,8 @@
       margin-right: 0.2em;
       margin-left: -0.2em;
     }
-    @import "../frontend/helpers/_govspeak.scss";
-    @import "../frontend/helpers/_attachment.scss";
+    @import "../frontend/helpers/_govspeak";
+    @import "../frontend/helpers/_attachment";
 
   }
 

--- a/app/assets/stylesheets/frontend/base-ie6.scss
+++ b/app/assets/stylesheets/frontend/base-ie6.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 6;
 
-@import "base.scss";
+@import "base";

--- a/app/assets/stylesheets/frontend/base-ie7.scss
+++ b/app/assets/stylesheets/frontend/base-ie7.scss
@@ -3,6 +3,6 @@
 $is-ie: true;
 $ie-version: 7;
 
-@import "base.scss";
+@import "base";
 
 

--- a/app/assets/stylesheets/frontend/base-ie8.scss
+++ b/app/assets/stylesheets/frontend/base-ie8.scss
@@ -3,5 +3,5 @@
 $is-ie: true;
 $ie-version: 8;
 
-@import "base.scss";
+@import "base";
 

--- a/app/assets/stylesheets/frontend/base-ie9.scss
+++ b/app/assets/stylesheets/frontend/base-ie9.scss
@@ -3,5 +3,5 @@
 $is-ie: true;
 $ie-version: 9;
 
-@import "base.scss";
+@import "base";
 

--- a/app/assets/stylesheets/frontend/base-rtl-ie6.scss
+++ b/app/assets/stylesheets/frontend/base-rtl-ie6.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 6;
 
-@import "base-rtl.scss";
+@import "base-rtl";

--- a/app/assets/stylesheets/frontend/base-rtl-ie7.scss
+++ b/app/assets/stylesheets/frontend/base-rtl-ie7.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 7;
 
-@import "base-rtl.scss";
+@import "base-rtl";

--- a/app/assets/stylesheets/frontend/base-rtl-ie8.scss
+++ b/app/assets/stylesheets/frontend/base-rtl-ie8.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 8;
 
-@import "base-rtl.scss";
+@import "base-rtl";

--- a/app/assets/stylesheets/frontend/base-rtl-ie9.scss
+++ b/app/assets/stylesheets/frontend/base-rtl-ie9.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 9;
 
-@import "base-rtl.scss";
+@import "base-rtl";

--- a/app/assets/stylesheets/frontend/base-rtl.scss
+++ b/app/assets/stylesheets/frontend/base-rtl.scss
@@ -2,4 +2,4 @@
 
 $right-to-left: true;
 
-@import "base.scss";
+@import "base";

--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -7,26 +7,26 @@
 // files can be used in the view files.
 
 // From the https://github.com/alphagov/govuk_frontend_toolkit
-@import "_colours.scss";
-@import "_conditionals.scss";
-@import "_css3.scss";
-@import "_grid_layout.scss";
-@import "_measurements.scss";
-@import "_typography.scss";
-@import "_shims.scss";
+@import "_colours";
+@import "_conditionals";
+@import "_css3";
+@import "_grid_layout";
+@import "_measurements";
+@import "_typography";
+@import "_shims";
 
-@import "styleguide/_dimensions.scss";
-@import "styleguide/_typography.scss";
-@import "styleguide/_colours.scss";
-@import "styleguide/_button.scss";
-@import "styleguide/_float-fix.scss";
-@import "styleguide/_hidpi.scss";
-@import "styleguide/_right-to-left.scss";
+@import "styleguide/_dimensions";
+@import "styleguide/_typography";
+@import "styleguide/_colours";
+@import "styleguide/_button";
+@import "styleguide/_float-fix";
+@import "styleguide/_hidpi";
+@import "styleguide/_right-to-left";
 
 // RESET
 // Flatten exising styles
 
-@import "reset/_reset.scss";
+@import "reset/_reset";
 // reset styles applied to #whitehall-wrapper & #whitehall-wrapper *
 // so as to override global styles being set by gov.uk chrome. When
 // gov.uk styles are scoped, will want to change these selectors to
@@ -36,57 +36,57 @@
 // Styles that apply to all of whitehall.
 
 #whitehall-wrapper {
-  @import "global/_links.scss";
+  @import "global/_links";
 }
 
 // HELPERS
 // Styles for comment page elements
 
 #whitehall-wrapper {
-  @import "helpers/_activity-nav.scss";
-  @import "helpers/_announcements.scss";
-  @import "helpers/_withdrawal-notice.scss";
-  @import "helpers/_attachment.scss";
-  @import "helpers/_available_languages.scss";
-  @import "helpers/_browse.scss";
-  @import "helpers/_change-notes.scss";
-  @import "helpers/_collection_list.scss";
-  @import "helpers/_contextual-info.scss";
-  @import "helpers/_corporate-information.scss";
-  @import "helpers/_dash-list.scss";
-  @import "helpers/_document.scss";
-  @import "helpers/_document_footer_meta.scss";
-  @import "helpers/_document_list.scss";
-  @import "helpers/_document-share-links.scss";
-  @import "helpers/_documents-grid.scss";
-  @import "helpers/_headings.scss";
-  @import "helpers/_featured-links.scss";
-  @import "helpers/_featured_news.scss";
-  @import "helpers/_feeds.scss";
-  @import "helpers/_filtered-index.scss";
-  @import "helpers/_govspeak.scss";
-  @import "helpers/_heading-block.scss";
-  @import "helpers/_historic-people-list.scss";
-  @import "helpers/_holding.scss";
-  @import "helpers/_index-list.scss";
-  @import "helpers/_js-list-items.scss";
-  @import "helpers/_lead-image.scss";
-  @import "helpers/_metadata-list.scss";
-  @import "helpers/_organisations.scss";
-  @import "helpers/_organisation-news.scss";
-  @import "helpers/_page-header.scss";
-  @import "helpers/_pagination.scss";
-  @import "helpers/_person.scss";
-  @import "helpers/_recently_updated.scss";
-  @import "helpers/_simple-alphabetical-list.scss";
-  @import "helpers/_social-media-accounts.scss";
-  @import "helpers/_status-block.scss";
-  @import "helpers/_sub-navigation.scss";
-  @import "helpers/_worldwide-organisation-header.scss";
+  @import "helpers/_activity-nav";
+  @import "helpers/_announcements";
+  @import "helpers/_withdrawal-notice";
+  @import "helpers/_attachment";
+  @import "helpers/_available_languages";
+  @import "helpers/_browse";
+  @import "helpers/_change-notes";
+  @import "helpers/_collection_list";
+  @import "helpers/_contextual-info";
+  @import "helpers/_corporate-information";
+  @import "helpers/_dash-list";
+  @import "helpers/_document";
+  @import "helpers/_document_footer_meta";
+  @import "helpers/_document_list";
+  @import "helpers/_document-share-links";
+  @import "helpers/_documents-grid";
+  @import "helpers/_headings";
+  @import "helpers/_featured-links";
+  @import "helpers/_featured_news";
+  @import "helpers/_feeds";
+  @import "helpers/_filtered-index";
+  @import "helpers/_govspeak";
+  @import "helpers/_heading-block";
+  @import "helpers/_historic-people-list";
+  @import "helpers/_holding";
+  @import "helpers/_index-list";
+  @import "helpers/_js-list-items";
+  @import "helpers/_lead-image";
+  @import "helpers/_metadata-list";
+  @import "helpers/_organisations";
+  @import "helpers/_organisation-news";
+  @import "helpers/_page-header";
+  @import "helpers/_pagination";
+  @import "helpers/_person";
+  @import "helpers/_recently_updated";
+  @import "helpers/_simple-alphabetical-list";
+  @import "helpers/_social-media-accounts";
+  @import "helpers/_status-block";
+  @import "helpers/_sub-navigation";
+  @import "helpers/_worldwide-organisation-header";
 
   // helpers shared with admin
-  @import "../shared/helpers/_magna-charta.scss";
-  @import "../shared/helpers/_player-container.scss";
+  @import "../shared/helpers/_magna-charta";
+  @import "../shared/helpers/_player-container";
 }
 
 
@@ -96,55 +96,55 @@
 // Styles scoped to each template in /views
 
 #whitehall-wrapper {
-  @import "views/_biographical-page.scss";
-  @import "views/_consultations.scss";
-  @import "views/_corporate-information-pages-worldwide-organisation.scss";
-  @import "views/_detailed_guides.scss";
-  @import "views/_document-collection.scss";
-  @import "views/_email-signup.scss";
-  @import "views/_email-signup-information.scss";
-  @import "views/_embassies.scss";
-  @import "views/_get-involved.scss";
-  @import "views/_groups.scss";
-  @import "views/_history.scss";
-  @import "views/_history-buildings.scss";
-  @import "views/_history-people.scss";
-  @import "views/_historic-appointments.scss";
-  @import "views/_how-gov-works.scss";
-  @import "views/_layouts.scss";
-  @import "views/_ministerial-roles.scss";
-  @import "views/_new-document-page.scss";
-  @import "views/_operational-field.scss";
-  @import "views/_organisations.scss";
-  @import "views/_people.scss";
-  @import "views/_policy_groups.scss";
-  @import "views/_publications.scss";
-  @import "views/_search.scss";
-  @import "views/_services-and-information.scss";
-  @import "views/_site-index.scss";
-  @import "views/_speeches.scss";
-  @import "views/_statistical-data-sets.scss";
-  @import "views/_topic.scss";
-  @import "views/_world_locations.scss";
-  @import "views/_worldwide_organisations.scss";
-  @import "views/_worldwide_priorities.scss";
-  @import "views/_topical-events.scss";
-  @import "views/corporate_information_pages/show.scss";
-  @import "views/publications/_index.scss";
-  @import "views/statistics/_index.scss";
-  @import "views/statistics_announcements/_index.scss";
-  @import "views/statistics_announcements/_show.scss";
+  @import "views/_biographical-page";
+  @import "views/_consultations";
+  @import "views/_corporate-information-pages-worldwide-organisation";
+  @import "views/_detailed_guides";
+  @import "views/_document-collection";
+  @import "views/_email-signup";
+  @import "views/_email-signup-information";
+  @import "views/_embassies";
+  @import "views/_get-involved";
+  @import "views/_groups";
+  @import "views/_history";
+  @import "views/_history-buildings";
+  @import "views/_history-people";
+  @import "views/_historic-appointments";
+  @import "views/_how-gov-works";
+  @import "views/_layouts";
+  @import "views/_ministerial-roles";
+  @import "views/_new-document-page";
+  @import "views/_operational-field";
+  @import "views/_organisations";
+  @import "views/_people";
+  @import "views/_policy_groups";
+  @import "views/_publications";
+  @import "views/_search";
+  @import "views/_services-and-information";
+  @import "views/_site-index";
+  @import "views/_speeches";
+  @import "views/_statistical-data-sets";
+  @import "views/_topic";
+  @import "views/_world_locations";
+  @import "views/_worldwide_organisations";
+  @import "views/_worldwide_priorities";
+  @import "views/_topical-events";
+  @import "views/corporate_information_pages/show";
+  @import "views/publications/_index";
+  @import "views/statistics/_index";
+  @import "views/statistics_announcements/_index";
+  @import "views/statistics_announcements/_show";
 }
 
 
 // LAYOUTS
 // Styles scoped to a layout. Be careful.
 
-@import "layouts/_main.scss";
-@import "layouts/detailed-guidance.scss";
+@import "layouts/_main";
+@import "layouts/detailed-guidance";
 
 #whitehall-wrapper {
-  @import "layouts/two_column_page.scss";
+  @import "layouts/two_column_page";
 }
 
 

--- a/app/assets/stylesheets/frontend/html-publication-ie6.scss
+++ b/app/assets/stylesheets/frontend/html-publication-ie6.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 6;
 
-@import "html-publication.scss";
+@import "html-publication";

--- a/app/assets/stylesheets/frontend/html-publication-ie7.scss
+++ b/app/assets/stylesheets/frontend/html-publication-ie7.scss
@@ -3,6 +3,6 @@
 $is-ie: true;
 $ie-version: 7;
 
-@import "html-publication.scss";
+@import "html-publication";
 
 

--- a/app/assets/stylesheets/frontend/html-publication-ie8.scss
+++ b/app/assets/stylesheets/frontend/html-publication-ie8.scss
@@ -3,5 +3,5 @@
 $is-ie: true;
 $ie-version: 8;
 
-@import "html-publication.scss";
+@import "html-publication";
 

--- a/app/assets/stylesheets/frontend/html-publication-ie9.scss
+++ b/app/assets/stylesheets/frontend/html-publication-ie9.scss
@@ -3,5 +3,5 @@
 $is-ie: true;
 $ie-version: 9;
 
-@import "html-publication.scss";
+@import "html-publication";
 

--- a/app/assets/stylesheets/frontend/html-publication-rtl-ie6.scss
+++ b/app/assets/stylesheets/frontend/html-publication-rtl-ie6.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 6;
 
-@import "html-publication-rtl.scss";
+@import "html-publication-rtl";

--- a/app/assets/stylesheets/frontend/html-publication-rtl-ie7.scss
+++ b/app/assets/stylesheets/frontend/html-publication-rtl-ie7.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 7;
 
-@import "html-publication-rtl.scss";
+@import "html-publication-rtl";

--- a/app/assets/stylesheets/frontend/html-publication-rtl-ie8.scss
+++ b/app/assets/stylesheets/frontend/html-publication-rtl-ie8.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 8;
 
-@import "html-publication-rtl.scss";
+@import "html-publication-rtl";

--- a/app/assets/stylesheets/frontend/html-publication-rtl-ie9.scss
+++ b/app/assets/stylesheets/frontend/html-publication-rtl-ie9.scss
@@ -3,4 +3,4 @@
 $is-ie: true;
 $ie-version: 9;
 
-@import "html-publication-rtl.scss";
+@import "html-publication-rtl";

--- a/app/assets/stylesheets/frontend/html-publication-rtl.scss
+++ b/app/assets/stylesheets/frontend/html-publication-rtl.scss
@@ -2,4 +2,4 @@
 
 $right-to-left: true;
 
-@import "html-publication.scss";
+@import "html-publication";

--- a/app/assets/stylesheets/frontend/html-publication.scss
+++ b/app/assets/stylesheets/frontend/html-publication.scss
@@ -8,24 +8,24 @@
 // files can be used in the view files.
 
 // From the https://github.com/alphagov/govuk_frontend_toolkit
-@import "_colours.scss";
-@import "_conditionals.scss";
-@import "_css3.scss";
-@import "_grid_layout.scss";
-@import "_measurements.scss";
-@import "_typography.scss";
+@import "_colours";
+@import "_conditionals";
+@import "_css3";
+@import "_grid_layout";
+@import "_measurements";
+@import "_typography";
 
-@import "styleguide/_dimensions.scss";
-@import "styleguide/_colours.scss";
-@import "styleguide/_float-fix.scss";
-@import "styleguide/_hidpi.scss";
-@import "styleguide/_typography.scss";
-@import "styleguide/_right-to-left.scss";
+@import "styleguide/_dimensions";
+@import "styleguide/_colours";
+@import "styleguide/_float-fix";
+@import "styleguide/_hidpi";
+@import "styleguide/_typography";
+@import "styleguide/_right-to-left";
 
 // RESET
 // Flatten exising styles
 
-@import "reset/_reset.scss";
+@import "reset/_reset";
 // reset styles applied to #whitehall-wrapper & #whitehall-wrapper *
 // so as to override global styles being set by gov.uk chrome. When
 // gov.uk styles are scoped, will want to change these selectors to
@@ -35,25 +35,25 @@
 // HELPERS
 // Styles for comment page elements
 #whitehall-wrapper {
-  @import "helpers/_govspeak.scss";
-  @import "helpers/_organisations.scss";
+  @import "helpers/_govspeak";
+  @import "helpers/_organisations";
 
   // helpers shared with frontend and admin
-  @import "../shared/helpers/_player-container.scss";
+  @import "../shared/helpers/_player-container";
 
   // Support for bar charts
-  @import "../shared/helpers/_magna-charta.scss";
+  @import "../shared/helpers/_magna-charta";
 }
 
 
 // VIEWS
 // Styles scoped to each template in /views
 #whitehall-wrapper {
-  @import "views/attachments/_preview.scss";
-  @import "views/_html-publications.scss";
+  @import "views/attachments/_preview";
+  @import "views/_html-publications";
 }
 
 
 // LAYOUTS
 // Styles scoped to a layout. Be careful.
-@import "layouts/html-publication.scss";
+@import "layouts/html-publication";

--- a/app/assets/stylesheets/frontend/print.scss
+++ b/app/assets/stylesheets/frontend/print.scss
@@ -21,14 +21,14 @@ $gutter-one-sixth:  $gutter-one-third*0.5; // equivalent to 8px
 $is-print: true;
 
 // From the https://github.com/alphagov/govuk_frontend_toolkit
-@import "_colours.scss";
-@import "_conditionals.scss";
-@import "_css3.scss";
-@import "_typography.scss";
-@import "_measurements.scss";
+@import "_colours";
+@import "_conditionals";
+@import "_css3";
+@import "_typography";
+@import "_measurements";
 
-@import "styleguide/_colours.scss";
-@import "styleguide/_right-to-left.scss";
+@import "styleguide/_colours";
+@import "styleguide/_right-to-left";
 
 html {
   font-size: 62.5%;
@@ -38,12 +38,12 @@ html {
 // Styles for comment page elements
 
 #whitehall-wrapper {
-  @import "print/document.scss";
-  @import "print/documents-index.scss";
-  @import "print/heading-block.scss";
-  @import "print/html-publication.scss";
-  @import "print/index-list.scss";
-  @import "print/ministerial-roles.scss";
-  @import "print/organisations.scss";
-  @import "print/print.scss";
+  @import "print/document";
+  @import "print/documents-index";
+  @import "print/heading-block";
+  @import "print/html-publication";
+  @import "print/index-list";
+  @import "print/ministerial-roles";
+  @import "print/organisations";
+  @import "print/print";
 }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,6 +21,8 @@ Whitehall::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+  config.assets.cache_store = :null_store
+  config.sass.cache = false
 
   config.slimmer.asset_host = ENV['STATIC_DEV'] || Plek.find('static')
 


### PR DESCRIPTION
This is a resurrection of #2176, which was reverted because scss partials weren't being recompiled when changed in development mode. This is fixed by just disabling the cache for assets. The performance win of sassc outweighs the need for the cache. This shaves about 4 minutes off the CI and deploy times for Whitehall, and does seem to speed up development mode a bit.