### PR TITLE
Performance improvements for admin

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -18,6 +18,7 @@ module Admin
       return @editions[locale] if @editions[locale]
 
       requested_editions = editions_with_translations(locale)
+        .includes(:last_author)
         .page(options[:page])
         .per(options.fetch(:per_page) { default_page_size })
 


### PR DESCRIPTION
A couple of performance improvements focussed on the Documents index page in Whitehall Admin. 
The first commit speeds up the rendering of the filters on the left hand side of the screen as they were instantiating at least 4000 ActiveRecord objects, when we only need a few attributes so we should use `pluck`.

The second commit preloads authors of editions so the authorisation engine doesn't need to load them later.