### PR TITLE
[For discussion] Improve speed and accuracy of searching for documents by title in Admin

### DIFF
--- a/db/data_migration/20160326231739_populate_title_terms.rb
+++ b/db/data_migration/20160326231739_populate_title_terms.rb
@@ -1,0 +1,15 @@
+values = []
+Edition
+  .joins(:translations)
+  .where(state: [:published, :draft, :withdrawn])
+  .pluck(:edition_id, :title)
+  .each do |e|
+    next if e[1].blank?
+    e[1].parameterize.split('-').uniq.each do |component|
+      values << "(#{e[0]}, '#{component}')"
+    end
+  end
+
+values.each_slice(1000) do |v|
+  Edition.connection.insert("INSERT INTO edition_title_terms VALUES#{v.join(', ')}")
+end

--- a/db/migrate/20160326184221_add_edition_title_terms.rb
+++ b/db/migrate/20160326184221_add_edition_title_terms.rb
@@ -1,0 +1,11 @@
+class AddEditionTitleTerms < ActiveRecord::Migration
+  def change
+    create_table :edition_title_terms, id: false do |t|
+      t.integer :edition_id
+      t.string :term
+
+      t.index :edition_id
+      t.index :term
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318154626) do
+ActiveRecord::Schema.define(version: 20160326184221) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -354,6 +354,14 @@ ActiveRecord::Schema.define(version: 20160318154626) do
 
   add_index "edition_statistical_data_sets", ["document_id"], name: "index_edition_statistical_data_sets_on_document_id", using: :btree
   add_index "edition_statistical_data_sets", ["edition_id"], name: "index_edition_statistical_data_sets_on_edition_id", using: :btree
+
+  create_table "edition_title_terms", id: false, force: :cascade do |t|
+    t.integer "edition_id", limit: 4
+    t.string  "term",       limit: 255
+  end
+
+  add_index "edition_title_terms", ["edition_id"], name: "index_edition_title_terms_on_edition_id", using: :btree
+  add_index "edition_title_terms", ["term"], name: "index_edition_title_terms_on_term", using: :btree
 
   create_table "edition_translations", force: :cascade do |t|
     t.integer  "edition_id", limit: 4

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -566,10 +566,10 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_nasty_characters], Edition.with_title_or_summary_containing("[stuff")
   end
 
-  test "should find editions with title containing keyword" do
-    edition_with_first_keyword = create(:edition, title: "klingons")
+  test "should find editions with title containing keywords" do
+    edition_with_first_keyword = create(:edition, title: "klingons rule the galaxy")
     edition_without_first_keyword = create(:edition, title: "this document is about muppets")
-    assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons")
+    assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons galaxy")
   end
 
   test "should find editions with slug containing keyword" do


### PR DESCRIPTION
For review of the approach only.

The title search interface in Whitehall Admin relies on `LIKE '%title%'`, which is slow and restrictive. If a user was to search for '2016 budget', because it uses an exact phrase it wouldn't match the actual budget document, which is "Budget 2016: Documents". The search also takes a while on a cold MySQL query cache or Rails cache because there's no fulltext index on the title field.

This PR addresses this by maintaining a separate terms table which contains the individual terms used in the titles of each edition. It searches this for a set of edition IDs to limit the further query by. 

One possible further extension would be to stem the terms before indexing or querying, so e.g. "budget" matches "budgets" or "budgeted". 

For deployment, this PR would be split into 3 different deployments, one for each commit in their current order.

The tests also need fixing, but will see if this approach is approved before I do that.