### PR TITLE
Update "View on website" links

### DIFF
--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -10,4 +10,12 @@ module Admin::UrlOptionsHelper
   def public_and_cachebusted_url_options
     public_url_options.merge(cachebust_url_options)
   end
+
+  def show_url_with_public_and_cachebusted_options(model)
+    send("#{model.class.to_s.underscore}_url", model, public_and_cachebusted_url_options)
+  end
+
+  def view_on_website_link_for(model, options = {})
+    link_to "View on website", show_url_with_public_and_cachebusted_options(model), options
+  end
 end

--- a/app/views/admin/classifications/_tab_wrapper.html.erb
+++ b/app/views/admin/classifications/_tab_wrapper.html.erb
@@ -1,7 +1,7 @@
 <header class="row add-bottom-margin">
   <div class="col-md-8">
     <h1><%= model.name %></h1>
-    <%= link_to "View on website", classification_url(model, public_and_cachebusted_url_options) %>
+    <%= view_on_website_link_for model %>
   </div>
 </header>
 

--- a/app/views/admin/contacts/index.html.erb
+++ b/app/views/admin/contacts/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @contactable.name %>
 <div class="organisation-header">
   <h1><%= @contactable.name %></h1>
-  <%= link_to "View on website", @contactable %>
+  <%= view_on_website_link_for @contactable %>
 </div>
 
 <%= tab_navigation_for(@contactable) do %>

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", url_for(@organisation) %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <section class="organisation-details">

--- a/app/views/admin/featured_policies/index.html.erb
+++ b/app/views/admin/featured_policies/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_path(@organisation) %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <section class="organisation-details">

--- a/app/views/admin/financial_reports/edit.html.erb
+++ b/app/views/admin/financial_reports/edit.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name + " financial reports" %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", @organisation%>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/financial_reports/index.html.erb
+++ b/app/views/admin/financial_reports/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name + " financial reports" %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", @organisation%>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/financial_reports/new.html.erb
+++ b/app/views/admin/financial_reports/new.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name + " financial reports" %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", @organisation%>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_url(@organisation, public_and_cachebusted_url_options) %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_path(@organisation) %>
+  <%= link_to "View on website", organisation_url(@organisation, public_and_cachebusted_url_options) %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @person) do %>
   <div class="organisation-header">
     <h1><%= @person.name %></h1>
-    <%= link_to "View on website", url_for(@person) %>
+    <%= link_to "View on website", url_for(@person, public_and_cachebusted_url_options) %>
   </div>
 
   <section class="organisation-details">

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @person) do %>
   <div class="organisation-header">
     <h1><%= @person.name %></h1>
-    <%= link_to "View on website", url_for(@person, public_and_cachebusted_url_options) %>
+    <%= view_on_website_link_for @person %>
   </div>
 
   <section class="organisation-details">

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name + " translations" %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", @organisation%>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_path(@organisation) %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/organisations/people.html.erb
+++ b/app/views/admin/organisations/people.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_path(@organisation) %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <section class="organisation-details">

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -1,7 +1,7 @@
 <% page_title @organisation.name %>
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", organisation_path(@organisation), target: "blank" %>
+  <%= view_on_website_link_for @organisation, target: "blank" %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@organisation) do %>

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @person) do %>
   <div class="person-header">
     <h1><%= @person.name %></h1>
-    <%= link_to "View on website", url_for(@person) %>
+    <%= view_on_website_link_for @person %>
   </div>
 
   <section class="person-details">

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @person) do %>
   <div class="person-header">
     <h1><%= @person.name %></h1>
-    <%= link_to "View on website", url_for(@person) %>
+    <%= link_to "View on website", url_for(@person, public_and_cachebusted_url_options) %>
   </div>
   <section class="person-details">
     <%= tab_navigation_for(@person) %>

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @person) do %>
   <div class="person-header">
     <h1><%= @person.name %></h1>
-    <%= link_to "View on website", url_for(@person, public_and_cachebusted_url_options) %>
+    <%= view_on_website_link_for @person %>
   </div>
   <section class="person-details">
     <%= tab_navigation_for(@person) %>

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="organisation-header">
   <h1><%= @organisation.name %></h1>
-  <%= link_to "View on website", @organisation %>
+  <%= view_on_website_link_for @organisation %>
 </div>
 
 <section class="organisation-details">

--- a/app/views/admin/social_media_accounts/index.html.erb
+++ b/app/views/admin/social_media_accounts/index.html.erb
@@ -1,7 +1,7 @@
 <% page_title @socialable.name %>
 <div class="organisation-header">
   <h1><%= @socialable.name %></h1>
-  <%= link_to "View on website", @socialable %>
+  <%= view_on_website_link_for @socialable %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@socialable) do %>

--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= link_to "View on website", url_for(@world_location, public_and_cachebusted_url_options)%></p>
+    <p><%= view_on_website_link_for @world_location %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= link_to "View on website", @world_location %></p>
+    <p><%= link_to "View on website", url_for(@world_location, public_and_cachebusted_url_options)%></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -6,7 +6,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= link_to "View on website", @world_location %></p>
+    <p><%= view_on_website_link_for @world_location %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_locations/show.html.erb
+++ b/app/views/admin/world_locations/show.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= link_to "View on website", @world_location %></p>
+    <p><%= view_on_website_link_for @world_location %></p>
   </div>
 
   <section class="world-location-details">

--- a/app/views/admin/worldwide_offices/index.html.erb
+++ b/app/views/admin/worldwide_offices/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @worldwide_organisation) do %>
   <div class="organisation-header">
     <h1><%= @worldwide_organisation.name %></h1>
-    <%= link_to "View on website", url_for(@worldwide_organisation) %>
+    <%= view_on_website_link_for @worldwide_organisation %>
   </div>
 
   <section class="organisation-details">

--- a/app/views/admin/worldwide_organisations/access_info.html.erb
+++ b/app/views/admin/worldwide_organisations/access_info.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @worldwide_organisation) do %>
 <div class="organisation-header">
   <h1><%= @worldwide_organisation.name %></h1>
-  <%= link_to "View on website", url_for(@worldwide_organisation) %>
+  <%= view_on_website_link_for @worldwide_organisation %>
 </div>
 <section class="organisation-details">
   <%= tab_navigation_for(@worldwide_organisation) do %>

--- a/app/views/admin/worldwide_organisations/show.html.erb
+++ b/app/views/admin/worldwide_organisations/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @worldwide_organisation) do %>
   <div class="organisation-header">
     <h1><%= @worldwide_organisation.name %></h1>
-    <%= link_to "View on website", url_for(@worldwide_organisation) %>
+    <%= view_on_website_link_for @worldwide_organisation %>
   </div>
 
   <section class="organisation-details">

--- a/app/views/admin/worldwide_organisations_translations/index.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @worldwide_organisation) do %>
   <div class="organisation-header">
     <h1><%= @worldwide_organisation.name %></h1>
-    <%= link_to "View on website", url_for(@worldwide_organisation, public_and_cachebusted_url_options) %>
+    <%= view_on_website_link_for @worldwide_organisation %>
   </div>
 
   <section class="organisation-details">

--- a/app/views/admin/worldwide_organisations_translations/index.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_tag_for(:div, @worldwide_organisation) do %>
   <div class="organisation-header">
     <h1><%= @worldwide_organisation.name %></h1>
-    <%= link_to "View on website", url_for(@worldwide_organisation) %>
+    <%= link_to "View on website", url_for(@worldwide_organisation, public_and_cachebusted_url_options) %>
   </div>
 
   <section class="organisation-details">


### PR DESCRIPTION
Updating "View on website" links for non-editioned formats, i.e. models which are not inheriting from Edition. These links allow editors to see the page on the live site. These pages will not be rendered by whitehall anymore, but from Government Frontend instead, so the simple path has been substituted by the full url path, as already done here: 
https://github.com/alphagov/whitehall/pull/2469. 

The first list of non-editioned formats has been grab from here:
https://docs.google.com/spreadsheets/d/17jmUukUhb-bg3L-Kspvtogo-4eEek3IVk_qxRA1r3D0/edit#gid=0
The other links were found inside the code. 

This PR refers to:
https://trello.com/c/gWmhOmVB/342-update-view-on-website-links-for-non-editioned-documents