### PR TITLE
Move publishing api call to worker

### DIFF
--- a/app/workers/publishing_api_links_worker.rb
+++ b/app/workers/publishing_api_links_worker.rb
@@ -1,0 +1,13 @@
+# Worker for batch sending of links to the publishing api
+class PublishingApiLinksWorker < WorkerBase
+  sidekiq_options queue: "bulk_republishing"
+
+  def perform(edition_id)
+    item = Edition.find(edition_id)
+    content_id = item.content_id
+    links = PublishingApiPresenters.presenter_for(item).links
+    if links && !links.empty?
+      Whitehall.publishing_api_v2_client.patch_links(content_id, {links: links})
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to parallelise the work of presenting links
and making the patch_links call to the publishing api.

I've removed the non-edition branch as it may not be needed. I'll create a separate task for this if we do.