### PR TITLE
Move Publishing API edition pushing to service listener

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -1,0 +1,36 @@
+module ServiceListeners
+  class PublishingApiPusher
+    attr_reader :edition
+
+    def initialize(edition)
+      @edition = edition
+    end
+
+    def push(event:, options: {})
+      case event
+      when "force_publish", "publish"
+        api.publish_async(edition)
+      when "update_draft"
+        api.save_draft_async(edition)
+      when "update_draft_translation"
+        api.save_draft_translation_async(edition, options.fetch(:locale))
+      when "withdraw"
+        api.republish_document_async(edition.document)
+      when "unpublish"
+        api.publish_async(edition.unpublishing)
+      when "force_schedule", "schedule"
+        api.schedule_async(edition)
+      when "unschedule"
+        api.unschedule_async(edition)
+      when "delete"
+        api.discard_draft_async(edition)
+      end
+    end
+
+  private
+
+    def api
+      Whitehall::PublishingApi
+    end
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -10,14 +10,7 @@ Whitehall.edition_services.tap do |es|
   es.subscribe("unpublish")                 { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 
   # publishing API
-  es.subscribe(/^(force_publish|publish)$/)   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition) }
-  es.subscribe("update_draft")                { |_, edition, _| Whitehall::PublishingApi.save_draft_async(edition) }
-  es.subscribe("update_draft_translation")    { |_, edition, options| Whitehall::PublishingApi.save_draft_translation_async(edition, options.fetch(:locale)) }
-  es.subscribe("withdraw")                    { |_, edition, _| Whitehall::PublishingApi.republish_document_async(edition.document) }
-  es.subscribe("unpublish")                   { |_, edition, _| Whitehall::PublishingApi.publish_async(edition.unpublishing) }
-  es.subscribe(/^(force_schedule|schedule)$/) { |_, edition, _| Whitehall::PublishingApi.schedule_async(edition) }
-  es.subscribe("unschedule")                  { |_, edition, _| Whitehall::PublishingApi.unschedule_async(edition) }
-  es.subscribe("delete")                      { |_, edition, _| Whitehall::PublishingApi.discard_draft_async(edition) }
+  es.subscribe { |event, edition, options| ServiceListeners::PublishingApiPusher.new(edition).push(event: event, options: options) }
 
   # handling edition's dependency on other content
   es.subscribe(/^(force_publish|publish)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+module ServiceListeners
+  class PublishingApiPusherTest < ActiveSupport::TestCase
+    test "saves draft async for update_draft" do
+      edition = build(:draft_publication)
+      Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "update_draft")
+    end
+
+    test "publish publishes" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "publish")
+    end
+
+    test "force_publish publishes" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "force_publish")
+    end
+  end
+end

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -19,5 +19,47 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       PublishingApiPusher.new(edition).push(event: "force_publish")
     end
+
+    test "update_draft_translation saves draft translation" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
+      PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
+    end
+
+    test "withdraw republishes" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:republish_document_async).with(edition.document)
+      PublishingApiPusher.new(edition).push(event: "withdraw")
+    end
+
+    test "unpublish publishes the unpublishing" do
+      edition = build(:unpublished_publication)
+      Whitehall::PublishingApi.expects(:publish_async).with(edition.unpublishing)
+      PublishingApiPusher.new(edition).push(event: "unpublish")
+    end
+
+    test "force_schedule schedules" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:schedule_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "force_schedule")
+    end
+
+    test "schedule schedules" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:schedule_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "schedule")
+    end
+
+    test "unschedule unschedules" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "unschedule")
+    end
+
+    test "delete discards draft" do
+      edition = build(:publication)
+      Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "delete")
+    end
   end
 end


### PR DESCRIPTION
This change:

- reduces the amount of logic that lives in an initializer (which doesn't
seem like a good place to put logic)
- prepares the ground for publishing HTML attachments to Publishing API

/cc @gpeng 