### PR TITLE
WIP - DO NOT MERGE - Update publishing API LinksPresenter to resolve parent link

### DIFF
--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -18,7 +18,7 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
 private
 
   def filter_links
-    [:topics]
+    [:topics, :parent]
   end
 
   def rendering_app

--- a/app/presenters/publishing_api_presenters/links_presenter.rb
+++ b/app/presenters/publishing_api_presenters/links_presenter.rb
@@ -12,6 +12,7 @@ module PublishingApiPresenters
       world_locations: :world_location_ids,
       worldwide_organisations: :worldwide_organisation_ids,
       worldwide_priorities: :worldwide_priority_ids,
+      parent: :parent_content_id,
     }
 
     def initialize(item)
@@ -63,6 +64,13 @@ module PublishingApiPresenters
       base_paths = specialist_sector_tags.compact.map { |tag| "/topic/#{tag}" }
       return [] unless base_paths.any?
       Whitehall.publishing_api_v2_client.lookup_content_ids(base_paths: base_paths).values
+    end
+
+    def parent_content_id
+      primary_specialist_sector_tag = item.try(:primary_specialist_sector_tag)
+      return [] unless primary_specialist_sector_tag
+      base_path = "/topic/#{primary_specialist_sector_tag}"
+      Array(Whitehall.publishing_api_v2_client.lookup_content_id(base_path: base_path))
     end
 
     def world_location_ids

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -204,4 +204,14 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     edition = create(:publication, :submitted, access_limited: true)
     refute_nil present(edition).content[:access_limited]
   end
+
+  test "it exposes specific fields in the document's links hash" do
+    edition = create(:published_publication)
+    mock_links_presenter = MiniTest::Mock.new
+    PublishingApiPresenters::LinksPresenter.stubs(:new).returns(mock_links_presenter)
+
+    mock_links_presenter.expect :extract, nil, [[:topics, :parent]]
+
+    present(edition).links
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
@@ -1,18 +1,7 @@
 require 'test_helper'
 
 class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
-  ALL_LINK_TYPES = [
-    :document_collections,
-    :lead_organisations,
-    :policy_areas,
-    :related_policies,
-    :statistical_data_set_documents,
-    :supporting_organisations,
-    :topics,
-    :world_locations,
-    :worldwide_organisations,
-    :worldwide_priorities,
-  ]
+  ALL_LINK_TYPES = PublishingApiPresenters::LinksPresenter::LINK_NAMES_TO_METHODS_MAP.keys
 
   def links_for(item, filter_links = ALL_LINK_TYPES)
     LinksPresenter.new(item).extract(filter_links)
@@ -35,7 +24,6 @@ class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
     assert_equal document.topics.map(&:content_id), links[:policy_areas]
   end
 
-
   test 'extracts content_ids from a tagged edition' do
     edition = create(:edition)
     create(:specialist_sector, tag: "oil-and-gas/offshore", edition: edition, primary: true)
@@ -49,5 +37,18 @@ class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
     links = links_for(edition)
 
     assert_equal links[:topics], %w(content_id_1 content_id_2)
+  end
+
+  test 'treats the primary specialist sector as the parent link of the item' do
+    edition = create(:edition)
+    create(:specialist_sector, tag: "oil-and-gas/offshore", edition: edition, primary: true)
+    create(:specialist_sector, tag: "oil-and-gas/onshore", edition: edition, primary: false)
+
+    publishing_api_has_lookups({
+      "/topic/oil-and-gas/offshore" => "content_id_1",
+      "/topic/oil-and-gas/onshore" => "content_id_2",
+    })
+
+    assert_equal links_for(edition)[:parent], %w(content_id_1)
   end
 end


### PR DESCRIPTION
This PR is for discussion of the approach being taken here. Would welcome any feedback on whether this is a reasonable way forward.

## What?

Use the primary specialist sector of an edition as the linked 'parent' in the edition's content store representation.

## Why?

As part of the tagging migration, we want to update the way docs are tagged in Whitehall. Chiefly, this involves removing any dependency on Whitehall's DB when reading/writing tags, and using the content store as the sole source of truth for taggings.

This specific set of commits focuses on changing how "specialist sector tags" are read in the user-facing frontend bits of Whitehall. As far as I've been able to gather, the only place these tags are surfaced is in [the document _header partial](https://github.com/alphagov/whitehall/blob/master/app/views/documents/_header.html.erb) - specifically where it renders `_heading` and `_metadata`. A [SpecialistTagFinder](https://github.com/alphagov/whitehall/blob/master/lib/specialist_tag_finder.rb) wraps the document and helps retrieve the tags. This class fetches all the specialist_sector tags from the content API (yay), but in `#primary_subsector_tag`it does a comparison against the DB to determine which tag is 'primary' (boo).

What I'd like to do is publish editions to the content store with the primary_specialist_sector set in `links.parent`. We can then rewrite `SpecialistTagFinder` to fetch these tags from the content store, removing the need to read from the DB.

Sane? Reasonable?