### PR TITLE
Reimplement soft delete on attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -49,7 +49,7 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def destroy
-    attachment.update(deleted: true)
+    attachment.destroy
     redirect_to attachable_attachments_path(attachable), notice: 'Attachment deleted'
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -113,6 +113,19 @@ class Attachment < ActiveRecord::Base
     raise NotImplementedError, "Subclasses must implement the url method"
   end
 
+  def delete
+    update_column(:deleted, true)
+  end
+
+  def destroy
+    callbacks_result = transaction do
+      run_callbacks(:destroy) do
+        delete
+      end
+    end
+    callbacks_result ? self : false
+  end
+
   private
 
   def store_price_in_pence

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -30,7 +30,7 @@ private
 
   # Only destroy the associated attachment_data record if no other attachments are using it
   def destroy_unused_attachment_data
-    if attachment_data && Attachment.where(attachment_data_id: attachment_data.id).empty?
+    if attachment_data && Attachment.not_deleted.where(attachment_data_id: attachment_data.id).empty?
       attachment_data.destroy
     end
   end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -74,11 +74,13 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     test "DELETE :destroy handles file attachments for #{type} as attachable" do
       attachable = create(type)
       attachment = create(:file_attachment, attachable: attachable)
+      attachment_data = attachment.attachment_data
 
       delete :destroy, param_name => attachable.id, id: attachment.id
 
       assert_response :redirect
       assert Attachment.find(attachment.id).deleted?, 'attachment should have been soft-deleted'
+      assert AttachmentData.find_by(id: attachment_data.id).nil?, 'attachment data should have been deleted'
     end
   end
 

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -212,4 +212,16 @@ class AttachmentTest < ActiveSupport::TestCase
     attachment.save
     assert attachment.content_id =~ /^[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}$/
   end
+
+  test 'delete sets deleted true' do
+    attachment = create(:file_attachment)
+    attachment.delete
+    assert attachment.deleted?
+  end
+
+  test 'destroy sets deleted true' do
+    attachment = create(:file_attachment)
+    attachment.destroy
+    assert attachment.deleted?
+  end
 end

--- a/test/unit/file_attachment_test.rb
+++ b/test/unit/file_attachment_test.rb
@@ -43,18 +43,20 @@ class FileAttachmentTest < ActiveSupport::TestCase
   end
 
   test "does not destroy attachment_data when more attachments are associated" do
-    attachment_data = attachment.attachment_data
+    saved_attachment = create(:file_attachment)
+    attachment_data = saved_attachment.attachment_data
     other_attachment = create(:file_attachment, attachment_data: attachment_data)
 
     attachment_data.expects(:destroy).never
-    attachment.destroy
+    saved_attachment.destroy
   end
 
   test "destroys attachment_data when no attachments are associated" do
-    attachment_data = attachment.attachment_data
+    saved_attachment = create(:file_attachment)
+    attachment_data = saved_attachment.attachment_data
 
     attachment_data.expects(:destroy)
-    attachment.destroy
+    saved_attachment.destroy
   end
 
   test "update with empty nested attachment data attributes still works" do


### PR DESCRIPTION
Override `destroy` method to set `deleted` and call from the controller to
ensure callbacks are executed.