### PR TITLE
Data migration to destroy un-attached `AttachmentData` objects

### DIFF
--- a/db/data_migration/20160401131852_destroy_attachment_data_objects_that_are_no_longer_attached.rb
+++ b/db/data_migration/20160401131852_destroy_attachment_data_objects_that_are_no_longer_attached.rb
@@ -1,0 +1,13 @@
+all_attachment_datas_on_deleted_attachments = AttachmentData.joins(
+  :attachments
+).where(attachments: { deleted: true })
+
+#AttachmentData objects can be shared across multiple attachments
+#So we only delete those that aren't related to any undeleted attachments
+attachment_datas_to_delete = all_attachment_datas_on_deleted_attachments.reject do |attachment_data|
+  Attachment.not_deleted.where(attachment_data_id: attachment_data.id).exists?
+end
+
+attachment_datas_to_delete.each(&:destroy)
+
+


### PR DESCRIPTION
Due to an issue fixed in https://github.com/alphagov/whitehall/pull/2536 some `AttachmentData` objects have been orphaned when their `Attachment` has been marked deleted. This data migration destroys them.