### PR TITLE
Set Sidekiq to use single thread

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 :verbose: true
-:concurrency:  2
+# This is set to single-threaded due to an issue with thread
+# safety in GovspeakRenderer.
+:concurrency: 1
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [bulk_republishing, 1]


### PR DESCRIPTION
We’re working on an issue at the moment where govspeak rendering gets
corrupted when processed by two different threads at once. We don’t
have a solution yet, so until we do we should remove thread-based
concurrency.

There’s not enough traffic on the queues in production that will make
us miss half the workers.

/cc @fofr @benilovj 