### PR TITLE
Make GovspeakRenderer threadsafe

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,5 @@
 :verbose: true
-# This is set to single-threaded due to an issue with thread
-# safety in GovspeakRenderer.
-:concurrency: 1
+:concurrency: 2
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [bulk_republishing, 1]

--- a/lib/whitehall/govspeak_renderer.rb
+++ b/lib/whitehall/govspeak_renderer.rb
@@ -1,17 +1,21 @@
 # Helper class to render govspeak outside of the view contexts.
 module Whitehall
   class GovspeakRenderer
-    delegate :govspeak_edition_to_html, :govspeak_to_html, :govspeak_with_attachments_to_html, to: :helpers
+    delegate :govspeak_edition_to_html, :govspeak_to_html, :govspeak_with_attachments_to_html, to: :view_context
 
   private
+
     # Because the govspeak helpers in whitehall rely on rendering partials, we
     # need to make sure the view paths are set, otherwise the helpers can't find
     # the partials.
-    def helpers
-      @helpers ||= begin
-        helpers = ApplicationController.helpers
-        helpers.view_paths = ApplicationController.view_paths
-        helpers
+    def view_context
+      @view_context ||= begin
+        view_context = ActionView::Base.new
+        ApplicationController.modules_for_helpers([:all]).each do |mod|
+          view_context.extend mod
+        end
+        view_context.view_paths = ApplicationController.view_paths
+        view_context
       end
     end
   end


### PR DESCRIPTION
The reference to `ApplicationController.helpers` was a singleton
instance of `ActionView::Base`. This class is used to contain the
context for rendering a single view at a time.

Instead, we need a new instance of `ActionView::Base` for each instance
of the `GovspeakRenderer`. We also need to extend this instance with
all the helper methods that would normally be part of the view context.

This fixes an issue with multiple govspeak bodies being rendered by
different threads at the same time having corrupted output.

Additionally, the `helpers` private method is now called `view_context`
in order to more accurately signify it’s use.