### PR TITLE
Publish placeholders for static pages

### DIFF
--- a/db/data_migration/20160405102519_static_page_links.rb
+++ b/db/data_migration/20160405102519_static_page_links.rb
@@ -1,0 +1,23 @@
+pages = [
+  {
+    content_id: "f56cfe74-8e5c-432d-bfcf-fd2521c5919c",
+    links: {
+      mainstream_browse_pages: [
+        "abc8dd38-bbb7-40a9-b5a2-4b8a2b0db699", # citizenship/government
+      ],
+    }
+  },
+  {
+    content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
+    links: {
+      mainstream_browse_pages: [
+        "abc8dd38-bbb7-40a9-b5a2-4b8a2b0db699", # citizenship/government
+        "7ef2c175-8a4b-4eb9-969b-304c6b9a1452", # citizenship/charities-honours
+      ],
+    }
+  }
+]
+
+pages.each do |page|
+  PublishStaticPages.new.patch_links(page[:content_id], { links: page[:links] })
+end

--- a/db/data_migration/README.md
+++ b/db/data_migration/README.md
@@ -27,7 +27,7 @@ own rake task and database table for tracking which ones have been run.
 Just like a normal migration, there is a Rails command:
 
 ```
-  be rails g data_migration MyDataMigrationName
+  bundle exec rails g data_migration MyDataMigrationName
 ```
 
 ## How to run them

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -1,29 +1,74 @@
 class PublishStaticPages
   def publish
     index = Whitehall::SearchIndex.for(:government)
-    pages.each { |page| index.add(page) }
+    pages.each do |page|
+      index.add(present_for_rummager(page))
+
+      payload = present_for_publishing_api(page)
+      publishing_api.put_content(payload[:content_id], payload[:content])
+      publishing_api.publish(payload[:content_id], "minor", locale: "en")
+    end
   end
 
-private
+  def patch_links(content_id, links)
+    publishing_api.patch_links(content_id, links)
+  end
 
   def pages
     [
       {
-        _id: "/government/how-government-works",
-        link: "/government/how-government-works",
-        format: "edition",
+        content_id: "f56cfe74-8e5c-432d-bfcf-fd2521c5919c",
         title: "How government works",
         description: "About the UK system of government. Understand who runs government, and how government is run.",
         indexable_content: "government, parliament, coalition, civil service, civil servants, policies, policy, minister, ministers, MP, rt hon, right honourable, department, ndpb, agency, executive agency, agencies, organisation, public bodies, public body, FOI, freedom of information, transparency, democracy, westminster, whitehall, house of commons, house of lords",
+        base_path: "/government/how-government-works",
       },
       {
-        _id: "/government/get-involved",
-        link: "/government/get-involved",
-        format: "edition",
+        content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
         title: "Get involved",
         description: "Find out how you can engage with government directly, and take part locally, nationally or internationally.",
         indexable_content: "changing government policies, consultations, government departments",
+        base_path: "/government/get-involved",
       }
     ]
+  end
+
+  def present_for_rummager(page)
+    {
+      _id: page[:base_path],
+      link: page[:base_path],
+      format: "edition", # Used for the rummager document type
+      title: page[:title],
+      description: page[:description],
+      indexable_content: page[:indexable_content],
+    }
+  end
+
+  def present_for_publishing_api(page)
+    {
+      content_id: page[:content_id],
+      content: {
+        title: page[:title],
+        description: page[:description],
+        format: "placeholder", # This content will never be rendered by content store
+        locale: "en",
+        base_path: page[:base_path],
+        publishing_app: "whitehall",
+        rendering_app: "whitehall",
+        routes: [
+          {
+            path: page[:base_path],
+            type: "exact",
+          },
+        ],
+        public_updated_at: Time.zone.now.iso8601,
+      }
+    }
+  end
+
+private
+
+  def publishing_api
+    @publishing_api ||= Whitehall.publishing_api_v2_client
   end
 end

--- a/lib/tasks/publish_static_pages.rake
+++ b/lib/tasks/publish_static_pages.rake
@@ -1,3 +1,4 @@
+desc "Publish of static pages to rummager and publishing api. This is called manually when needed."
 task :publish_static_pages => [:environment] do
   PublishStaticPages.new.publish
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ require 'slimmer/test'
 require 'factories'
 require 'webmock/minitest'
 require 'whitehall/not_quite_as_fake_search'
+require 'whitehall/search_index'
 require 'sidekiq/testing/inline'
 require 'govuk-content-schema-test-helpers/test_unit'
 

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -1,9 +1,60 @@
 require "test_helper"
+require "govuk-content-schema-test-helpers"
 
 class PublishStaticPagesTest < ActiveSupport::TestCase
-  test 'sends static pages to rummager' do
+  test 'sends static pages to rummager and publishing api' do
     Whitehall::FakeRummageableIndex.any_instance.expects(:add).twice.with(kind_of(Hash))
+    publisher = PublishStaticPages.new
+    expect_publishing(publisher.pages)
 
     PublishStaticPages.new.publish
+  end
+
+  test 'static pages presented to the publishing api are valid placeholders' do
+    publisher = PublishStaticPages.new
+    presented = publisher.present_for_publishing_api(publisher.pages.first)
+    expect_valid_placeholder(presented[:content])
+  end
+
+  test 'base paths do not change' do
+    base_paths = PublishStaticPages.new.pages.map { |page| page[:base_path] }
+    assert_equal(
+      base_paths,
+      ["/government/how-government-works", "/government/get-involved"],
+      "Base paths for static content should not be changed without first setting up a redirect"
+    )
+  end
+
+  def expect_patch_links(pages)
+    pages.each do |page|
+      Whitehall.publishing_api_v2_client.expects(:patch_links)
+        .with(page[:content_id], { links: page[:links] })
+    end
+  end
+
+  def expect_publishing(pages)
+    pages.each do |page|
+      Whitehall.publishing_api_v2_client.expects(:put_content)
+        .with(
+          page[:content_id],
+          has_entries(
+            format: "placeholder",
+            base_path: page[:base_path],
+            title: page[:title]
+          )
+        )
+
+      Whitehall.publishing_api_v2_client.expects(:publish)
+        .with(page[:content_id], 'minor', locale: "en")
+    end
+  end
+
+  def expect_valid_placeholder(presented_page)
+    validator = GovukContentSchemaTestHelpers::Validator.new(
+      "placeholder",
+      "schema",
+      presented_page
+    )
+    assert validator.valid?, validator.errors.join("\n")
   end
 end


### PR DESCRIPTION
Currently the static pages are not present in the new publishing platform and
do not have content ids. This ensures they are present as placeholder_[format], and mainstream_browses_pages are included.

There will be some follow up work to add other static pages that are not currently in rummager.

https://trello.com/c/PbHiHeBa/576-add-how-government-works-and-get-involved-to-publishing-api

cc @jackscotti 