### PR TITLE
Update links presentation in publishing API presenters

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -2,10 +2,8 @@ require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
 
-private
-
-  def filter_links
-    [
+  def links
+    extract_links([
       :document_collections,
       :lead_organisations,
       :related_policies,
@@ -14,8 +12,10 @@ private
       :world_locations,
       :worldwide_organisations,
       :worldwide_priorities,
-    ]
+    ])
   end
+
+private
 
   def document_format
     "case_study"

--- a/app/presenters/publishing_api_presenters/coming_soon.rb
+++ b/app/presenters/publishing_api_presenters/coming_soon.rb
@@ -24,11 +24,11 @@ class PublishingApiPresenters::ComingSoon < PublishingApiPresenters::Item
     @content_id = SecureRandom.uuid
   end
 
-  private
-
-  def filter_links
-    []
+  def links
+    {}
   end
+
+private
 
   def document_format
     'coming_soon'

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -15,11 +15,11 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
     end
   end
 
-private
-
-  def filter_links
-    [:topics]
+  def links
+    extract_links([:topics])
   end
+
+private
 
   def rendering_app
     item.rendering_app

--- a/app/presenters/publishing_api_presenters/gone.rb
+++ b/app/presenters/publishing_api_presenters/gone.rb
@@ -23,6 +23,6 @@ class PublishingApiPresenters::Gone
   end
 
   def links
-    {} # Gone Item. no links
+    {}
   end
 end

--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -32,8 +32,8 @@ class PublishingApiPresenters::Item
     end
   end
 
-  def links
-    PublishingApiPresenters::LinksPresenter.new(item).extract(filter_links)
+  def extract_links(link_types)
+    PublishingApiPresenters::LinksPresenter.new(item).extract(link_types)
   end
 
 private

--- a/app/presenters/publishing_api_presenters/organisation.rb
+++ b/app/presenters/publishing_api_presenters/organisation.rb
@@ -3,6 +3,10 @@ require_relative '../publishing_api_presenters'
 class PublishingApiPresenters::Organisation < PublishingApiPresenters::Placeholder
   include ApplicationHelper
 
+  def links
+    extract_links([:topics])
+  end
+
   def details
     super.merge(
       brand: brand,

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -4,13 +4,11 @@ require_relative "../publishing_api_presenters"
 # items using content_ids and have their basic information expanded
 # out when read back out from the content store.
 class PublishingApiPresenters::Placeholder < PublishingApiPresenters::Item
-private
-
-  def filter_links
-    [
-      :topics,
-    ]
+  def links
+    extract_links([:topics])
   end
+
+private
 
   def title
     item.name

--- a/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
+++ b/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
@@ -1,5 +1,9 @@
 # Note that "Policy Area" is the new name for "Topic".
 class PublishingApiPresenters::PolicyAreaPlaceholder < PublishingApiPresenters::Placeholder
+  def links
+    extract_links([:topics])
+  end
+
   private
 
   def document_format

--- a/app/presenters/publishing_api_presenters/redirect.rb
+++ b/app/presenters/publishing_api_presenters/redirect.rb
@@ -24,7 +24,6 @@ class PublishingApiPresenters::Redirect
   end
 
   def links
-    # no tags
     {}
   end
 end

--- a/app/presenters/publishing_api_presenters/statistics_announcement.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement.rb
@@ -1,15 +1,15 @@
 require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::StatisticsAnnouncement < PublishingApiPresenters::Item
-private
-
-  def filter_links
-    [
+  def links
+    extract_links([
       :organisations,
       :policy_areas,
       :topics,
-    ]
+    ])
   end
+
+private
 
   def details
     {

--- a/app/presenters/publishing_api_presenters/statistics_announcement_redirect.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement_redirect.rb
@@ -32,7 +32,6 @@ class PublishingApiPresenters::StatisticsAnnouncementRedirect
   end
 
   def links
-    # no tags
     {}
   end
 

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -1,15 +1,15 @@
 require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::TakePart < PublishingApiPresenters::Item
-private
-
-  def filter_links
-    [
+  def links
+    extract_links([
       :lead_organisations,
       :policy_areas,
       :topics,
-    ]
+    ])
   end
+
+private
 
   def document_format
     "take_part"

--- a/app/presenters/publishing_api_presenters/topical_event.rb
+++ b/app/presenters/publishing_api_presenters/topical_event.rb
@@ -7,4 +7,8 @@ class PublishingApiPresenters::TopicalEvent < PublishingApiPresenters::Placehold
       details[:end_date] = item.end_date.to_datetime if item.end_date
     end
   end
+
+  def links
+    extract_links([:topics])
+  end
 end

--- a/app/presenters/publishing_api_presenters/topical_event_about_page.rb
+++ b/app/presenters/publishing_api_presenters/topical_event_about_page.rb
@@ -2,10 +2,7 @@ require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::TopicalEventAboutPage < PublishingApiPresenters::Item
   def links
-    # about pages aren't tagged
-    {
-      parent: [item.topical_event.content_id]
-    }
+    { parent: [item.topical_event.content_id] }
   end
 
 private

--- a/app/presenters/publishing_api_presenters/unpublishing.rb
+++ b/app/presenters/publishing_api_presenters/unpublishing.rb
@@ -5,12 +5,11 @@ class PublishingApiPresenters::Unpublishing < PublishingApiPresenters::Item
     item.redirect? ? redirect_hash : super
   end
 
-private
-
-  def filter_links
-    # nothing to tag
-    []
+  def links
+    {}
   end
+
+private
 
   def document_format
     item.redirect? ? 'redirect' : 'unpublishing'

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -1,9 +1,9 @@
 class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Item
-private
-
-  def filter_links
-    [] # nothing to tag
+  def links
+    {}
   end
+
+private
 
   def title
     item.name


### PR DESCRIPTION
Add a '#links' method to each presenter, replacing the '#filter_links'
convention. This:

- allows for flexibility in determining how links are presented,
  decoupling this behaviour from the implementation in
  PublishingApiPresenters::LinksPresenter.
- makes it a little clearer and more obvious how links are set in a
  given presenter.

Taking this approach allows the LinksPresenter to be used as a sensible
default but permits, for example - setting multiple links in the links
hash based on several content IDs retrieved from the publishing API in a
single network call. This specific use case will be required in a
followup commit that changes how Edition links are presented.