### PR TITLE
Migrate `HtmlAttachments` Part One

### DIFF
--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -28,6 +28,8 @@ private
       else
         PublishingApiPresenters::StatisticsAnnouncement
       end
+    when ::HtmlAttachment
+      PublishingApiPresenters::HtmlAttachment
     else
       PublishingApiPresenters::Placeholder
     end

--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -1,0 +1,68 @@
+require_relative "../publishing_api_presenters"
+
+class PublishingApiPresenters::HtmlAttachment < PublishingApiPresenters::Item
+  def links
+    {
+      parent: [
+        parent.content_id
+      ],
+      organisations: parent.organisations.map(&:content_id),
+    }
+  end
+
+private
+
+  def document_format
+    "html_publication"
+  end
+
+  def details
+    {
+      body: body,
+      headings: headings,
+      public_timestamp: public_timestamp,
+      first_published_version: first_published_version?
+    }
+  end
+
+
+  def base_path
+    item.url
+  end
+
+  def description
+    #not used in this format
+  end
+
+  def public_updated_at
+    item.updated_at
+  end
+
+  def body
+    Whitehall::GovspeakRenderer.new.govspeak_to_html(govspeak_content.body)
+  end
+
+  def headings
+    govspeak_content.computed_headers_html
+  end
+
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
+  def first_published_version?
+    parent.first_published_version?
+  end
+
+  def public_timestamp
+    parent.public_timestamp
+  end
+
+  def parent
+    item.attachable
+  end
+
+  def govspeak_content
+    item.govspeak_content
+  end
+end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -9,28 +9,105 @@ module ServiceListeners
     def push(event:, options: {})
       case event
       when "force_publish", "publish"
-        api.publish_async(edition)
+        perform_publishing_api_action_on_pushable_items(
+          action: :publish_async
+        )
       when "update_draft"
-        api.save_draft_async(edition)
+        perform_publishing_api_action_on_pushable_items(
+          action: :save_draft_async
+        )
       when "update_draft_translation"
-        api.save_draft_translation_async(edition, options.fetch(:locale))
-      when "withdraw"
-        api.republish_document_async(edition.document)
+        pushable_items.each do |record|
+          api.save_draft_translation_async(record, options.fetch(:locale))
+        end
       when "unpublish"
         api.publish_async(edition.unpublishing)
+        edition_html_attachments.each do |attachment|
+          redirect_if_required(attachment)
+        end
+      when "withdraw"
+        api.republish_document_async(edition.document)
+        edition_html_attachments.each do |attachment|
+          api.republish_async(attachment)
+        end
       when "force_schedule", "schedule"
         api.schedule_async(edition)
+        #ignore attachments
       when "unschedule"
         api.unschedule_async(edition)
+        #ignore attachments
       when "delete"
-        api.discard_draft_async(edition)
+        perform_publishing_api_action_on_pushable_items(
+          action: :discard_draft_async
+        )
       end
     end
 
   private
 
+    def perform_publishing_api_action_on_pushable_items(action:)
+      pushable_items.each do |record|
+        api.send(action, record)
+      end
+    end
+
+    def pushable_items
+      pushable_items = [@edition]
+      pushable_items + edition_html_attachments
+    end
+
+    def edition_html_attachments
+      @edition.respond_to?(:html_attachments) ? @edition.html_attachments : []
+    end
+
     def api
       Whitehall::PublishingApi
+    end
+
+    def redirect_if_required(attachment)
+      if attachment.is_a?(HtmlAttachment)
+        if requires_redirect_to_alternative?(attachment)
+          redirect_to_unpublishing_alternative(attachment)
+        else
+          redirect_to_parent(attachment)
+        end
+      end
+    end
+
+    def requires_redirect_to_alternative?(attachment)
+      unpublishing = attachment.attachable.unpublishing
+      unpublishing.unpublishing_reason_id == UnpublishingReason::Consolidated.id ||
+        unpublishing.redirect
+    end
+
+    def redirect_to_parent(attachment)
+      publish_redirect(
+        attachment.url,
+        Whitehall.url_maker.public_document_path(edition)
+      )
+    end
+
+    def redirect_to_unpublishing_alternative(attachment)
+      edition = attachment.attachable
+      publish_redirect(
+        attachment.url,
+        Addressable::URI.parse(
+          edition.unpublishing.alternative_url
+        ).path
+      )
+    end
+
+    def publish_redirect(path, destination)
+      api.publish_redirect_async(
+        path,
+        [
+          {
+            path: path,
+            destination: destination,
+            type: "exact",
+          }
+        ]
+      )
     end
   end
 end

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -21,13 +21,15 @@ FactoryGirl.define do
     end
   end
 
-  factory :html_attachment, traits: [:abstract_attachment] do
+  factory :html_attachment do
     sequence(:title) { |index| "html-attachment-title-#{index}" }
 
     transient do
       body "Attachment body"
       manually_numbered_headings false
     end
+
+    attachable { build :edition }
 
     # body and numbering method boolean can be passed directly into the factory
     # and is automatically set on the internal GovspeakContent instance.

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -125,6 +125,24 @@ FactoryGirl.define do
         edition.unpublishing = build(:unpublishing, edition: edition)
       end
     end
+
+    trait(:published_in_error_redirect) do
+      after(:create) do |edition|
+        edition.unpublishing = build(:published_in_error_redirect_unpublishing, edition: edition)
+      end
+    end
+
+    trait(:published_in_error_no_redirect) do
+      after(:create) do |edition|
+        edition.unpublishing = build(:published_in_error_no_redirect_unpublishing, edition: edition)
+      end
+    end
+
+    trait(:consolidated_redirect) do
+      after(:create) do |edition|
+        edition.unpublishing = build(:consolidated_unpublishing, edition: edition)
+      end
+    end
   end
 
   factory :imported_edition, parent: :edition, traits: [:imported]

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -68,6 +68,12 @@ FactoryGirl.define do
   factory :superseded_publication, parent: :publication, traits: [:superseded]
   factory :scheduled_publication, parent: :publication, traits: [:scheduled]
   factory :unpublished_publication, parent: :publication, traits: [:draft, :unpublished]
+  factory :unpublished_publication_in_error_no_redirect,
+    parent: :publication, traits: [:draft, :published_in_error_no_redirect]
+  factory :unpublished_publication_in_error_redirect,
+    parent: :publication, traits: [:draft, :published_in_error_redirect]
+  factory :unpublished_publication_consolidated,
+    parent: :publication, traits: [:draft, :consolidated_redirect]
 
   factory :draft_corporate_publication, parent: :publication, traits: [:draft, :corporate]
   factory :submitted_corporate_publication, parent: :publication, traits: [:submitted, :corporate]

--- a/test/factories/unpublishings.rb
+++ b/test/factories/unpublishings.rb
@@ -9,13 +9,19 @@ FactoryGirl.define do
     end
   end
 
-  factory :redirect_unpublishing, parent: :unpublishing do
+  factory :published_in_error_redirect_unpublishing, parent: :unpublishing do
     redirect true
-    alternative_url (Whitehall.public_root + '/government/another/page')
+    alternative_url Whitehall.public_root + '/government/another/page'
+  end
+
+  factory :published_in_error_no_redirect_unpublishing, parent: :unpublishing do
+    redirect false
+    explanation "published in error"
+    alternative_url Whitehall.public_root + '/government/another/page'
   end
 
   factory :consolidated_unpublishing, parent: :unpublishing do
     unpublishing_reason_id UnpublishingReason::Consolidated.id
-    alternative_url (Whitehall.public_root + '/government/another/page')
+    alternative_url Whitehall.public_root + '/government/another/page'
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PublishingApiPresenters::HtmlAttachmentTest < ActiveSupport::TestCase
+  def present(record)
+    PublishingApiPresenters::HtmlAttachment.new(record)
+  end
+
+  test "HtmlAttachment presentation includes the correct values" do
+    edition = create(:publication, :with_html_attachment, :published)
+    html_attachment = HtmlAttachment.last
+
+    expected_hash = {
+      base_path: html_attachment.slug,
+      content_id: html_attachment.content_id,
+      title: html_attachment.title,
+      format: 'html_publication',
+      locale: 'en',
+      public_updated_at: html_attachment.updated_at,
+      update_type: 'major',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall',
+      routes: [
+        { path: html_attachment.url, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        body: Whitehall::GovspeakRenderer.new
+          .govspeak_to_html(html_attachment.govspeak_content.body),
+        headings: html_attachment.govspeak_content.computed_headers_html,
+        public_timestamp: edition.public_timestamp,
+        first_published_version: html_attachment.attachable.first_published_version?,
+      },
+      need_ids: [],
+      updated_at: html_attachment.updated_at
+    }
+    presented_item = present(html_attachment)
+
+    assert_valid_against_schema(presented_item.content, 'html_publication')
+    assert_valid_against_links_schema({ links: presented_item.links }, 'html_publication')
+
+    # We test for HTML equivalance rather than string equality to get around
+    # inconsistencies with line breaks between different XML libraries
+    assert_equivalent_html expected_hash[:details].delete(:body),
+      presented_item.content[:details].delete(:body)
+
+    assert_equal expected_hash[:details], presented_item.content[:details].except(:body)
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/unpublishing_test.rb
@@ -154,7 +154,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
   end
 
   test '#as_json returns a redirect representation for Unpublishings that are set to auto-redirect' do
-    unpublishing     = create(:redirect_unpublishing)
+    unpublishing     = create(:published_in_error_redirect_unpublishing)
     public_path      = unpublishing.document_path
     alternative_path = Addressable::URI.parse(unpublishing.alternative_url).path
     expected_hash    = {
@@ -196,7 +196,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
 
   test 'redirect representations can contain query paramters and anchor tags' do
     alternative_path = '/page?param=1#subheading'
-    unpublishing     = create(:redirect_unpublishing,
+    unpublishing     = create(:published_in_error_redirect_unpublishing,
       alternative_url: Whitehall.public_root + alternative_path)
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
@@ -206,7 +206,7 @@ class PublishingApiPresenters::UnpublishingTest < ActiveSupport::TestCase
   end
 
   test "redirect representations contain content IDs" do
-    unpublishing = create(:redirect_unpublishing)
+    unpublishing = create(:published_in_error_redirect_unpublishing)
 
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing)
 

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -76,4 +76,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(Topic.new)
     assert_equal PublishingApiPresenters::PolicyAreaPlaceholder, presenter.class
   end
+
+  test ".presenter_for returns a HtmlAttachment presenter for `HtmlAttachment`" do
+    presenter = PublishingApiPresenters.presenter_for(HtmlAttachment.new)
+    assert_equal PublishingApiPresenters::HtmlAttachment, presenter.class
+  end
 end

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -8,9 +8,29 @@ module ServiceListeners
       PublishingApiPusher.new(edition).push(event: "update_draft")
     end
 
+    test "saves attachments draft" do
+      edition = build(
+        :draft_publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
+      Whitehall::PublishingApi.expects(:save_draft_async).with(attachment)
+      PublishingApiPusher.new(edition).push(event: "update_draft")
+    end
+
     test "publish publishes" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      PublishingApiPusher.new(edition).push(event: "publish")
+    end
+
+    test "publish publishes attachments" do
+      edition = build(
+        :publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      Whitehall::PublishingApi.expects(:publish_async).with(attachment)
       PublishingApiPusher.new(edition).push(event: "publish")
     end
 
@@ -20,9 +40,29 @@ module ServiceListeners
       PublishingApiPusher.new(edition).push(event: "force_publish")
     end
 
+    test "force_publish publishes attachments" do
+      edition = build(
+        :publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+      PublishingApiPusher.new(edition).push(event: "force_publish")
+    end
+
     test "update_draft_translation saves draft translation" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
+      PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
+    end
+
+    test "update_draft_translation updates the attachments" do
+      edition = build(
+        :publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
+      Whitehall::PublishingApi.expects(:save_draft_translation_async).with(attachment, 'en')
       PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
     end
 
@@ -43,24 +83,85 @@ module ServiceListeners
     end
 
     test "unpublish publishes the unpublishing" do
-      edition = build(:unpublished_publication)
+      edition = create(:unpublished_publication)
       Whitehall::PublishingApi.expects(:publish_async).with(edition.unpublishing)
       PublishingApiPusher.new(edition).push(event: "unpublish")
     end
 
-    test "force_schedule schedules" do
+    test "unpublish redirects the attachments to the alternative_url if in
+      error with redirect" do
+      edition = create(
+        :unpublished_publication_in_error_redirect,
+      )
+      attachment = edition.attachments.first
+      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+        attachment.url,
+        [
+          {
+            path: attachment.url,
+            destination: Addressable::URI.parse(
+              edition.unpublishing.alternative_url
+            ).path,
+            type: 'exact',
+          }
+        ]
+      )
+      PublishingApiPusher.new(edition).push(event: "unpublish")
+    end
+
+    test "unpublish redirects the attachments to the parent if in error
+      and !redirect" do
+      edition = create(
+        :unpublished_publication_in_error_no_redirect
+      )
+      attachment = edition.attachments.first
+      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+        attachment.url,
+        [
+          {
+            path: attachment.url,
+            destination: Whitehall.url_maker.public_document_path(edition),
+            type: 'exact',
+          }
+        ]
+      )
+      PublishingApiPusher.new(edition).push(event: "unpublish")
+    end
+
+    test "unpublish redirects the attachments to the alternative_url if
+      unpublished consolidated" do
+      edition = create(
+        :unpublished_publication_consolidated,
+      )
+      attachment = edition.attachments.first
+      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+        attachment.url,
+        [
+          {
+            path: attachment.url,
+            destination: Addressable::URI.parse(
+              edition.unpublishing.alternative_url
+            ).path,
+            type: 'exact',
+          }
+        ]
+      )
+      PublishingApiPusher.new(edition).push(event: "unpublish")
+    end
+
+    test "force_schedule schedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       PublishingApiPusher.new(edition).push(event: "force_schedule")
     end
 
-    test "schedule schedules" do
+    test "schedule schedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       PublishingApiPusher.new(edition).push(event: "schedule")
     end
 
-    test "unschedule unschedules" do
+    test "unschedule unschedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
       PublishingApiPusher.new(edition).push(event: "unschedule")
@@ -70,6 +171,21 @@ module ServiceListeners
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
       PublishingApiPusher.new(edition).push(event: "delete")
+    end
+
+    test "delete discards draft attachments" do
+      edition = build(
+        :publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
+      Whitehall::PublishingApi.expects(:discard_draft_async).with(attachment)
+      PublishingApiPusher.new(edition).push(event: "delete")
+    end
+
+    test "does not raise an error if the edition has no html_attachments association" do
+      edition = create(:published_document_collection)
+      PublishingApiPusher.new(edition).push(event: "publish")
     end
   end
 end

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -32,6 +32,16 @@ module ServiceListeners
       PublishingApiPusher.new(edition).push(event: "withdraw")
     end
 
+    test "withdraw republishes the attachments" do
+      edition = build(
+        :publication,
+        html_attachments: [attachment = build(:html_attachment)]
+      )
+      Whitehall::PublishingApi.expects(:republish_document_async).with(edition.document)
+      Whitehall::PublishingApi.expects(:republish_async).with(attachment)
+      PublishingApiPusher.new(edition).push(event: "withdraw")
+    end
+
     test "unpublish publishes the unpublishing" do
       edition = build(:unpublished_publication)
       Whitehall::PublishingApi.expects(:publish_async).with(edition.unpublishing)

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -220,7 +220,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
   end
 
   test ".republish_async publishes a redirect unpublishing" do
-    unpublishing = create(:redirect_unpublishing)
+    unpublishing = create(:published_in_error_redirect_unpublishing)
     presenter = PublishingApiPresenters::Unpublishing.new(unpublishing, update_type: "republish")
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),


### PR DESCRIPTION
This is the first PR proper on the arduous journey towards migrating the `HtmlPublication` nee `HtmlAttachment` format to the Publishing API/Content Store.

`HtmlAttachment` has proved to be somewhat complicated to migrate largely due to it living in a grey area between `Edition` based content and non-`Edition` based content. Its publishing 'state' is very dependent on the state of its `attachable` and must be updated when the `attachable` state is changed but it also handles its own CRUD actions outside of its parent which need to trigger Publishing API calls.

This PR deals with hooking up `HtmlAttachment` to the state changes of its `attachable` `Edition` via a newly created service listener. There is still further work to do on this but I've split it up to keep the PRs reviewable.

What this PR doesn't currently handle is:
* ensuring that the `GovspeakContent` has rendered its HTML before the attachment is sent. This is currently done on a delayed Sidekiq queue [here](https://github.com/alphagov/whitehall/blob/master/app/models/govspeak_content.rb#L20-L28) and is going to need to be deasychroniserated :tm: So... for now, chances are, there will be little or no HTML in the payload sent to Publishing API
* updating Publishing API outside of the `Edition` state changes to handle 'direct' CRUD operations `HtmlAttachment`

These can be done in separate PR/deployments as the format will be republished once everything is complete and it is not currently rendered from the Content Store in any case.

[trello](https://trello.com/c/uwsLR1xU/285-5-html-publications-implement-publishing-of-format-to-publishing-api-large)