### PR TITLE
Use `GovspeakRenderer` in `GovspeakContentWorker`

### DIFF
--- a/app/workers/govspeak_content_worker.rb
+++ b/app/workers/govspeak_content_worker.rb
@@ -19,11 +19,11 @@ private
       images = []
     end
 
-    helpers.govspeak_to_html(body, images, options)
+    renderer.govspeak_to_html(body, images, options)
   end
 
   def generate_headers(govspeak_content)
-    helpers.html_attachment_govspeak_headers_html(govspeak_content.html_attachment)
+    renderer.html_attachment_govspeak_headers_html(govspeak_content.html_attachment)
   end
 
   def govspeak_options(govspeak_content)
@@ -31,14 +31,7 @@ private
     { heading_numbering: method, contact_heading_tag: 'h4' }
   end
 
-  # Because the govspeak helpers in whitehall rely on rendering partials, we
-  # need to make sure the view paths are set, otherwise the helpers can't find
-  # the partials.
-  def helpers
-    @helpers ||= begin
-      helpers = ApplicationController.helpers
-      helpers.view_paths = ApplicationController.view_paths
-      helpers
-    end
+  def renderer
+    @renderer ||= Whitehall::GovspeakRenderer.new
   end
 end

--- a/lib/whitehall/govspeak_renderer.rb
+++ b/lib/whitehall/govspeak_renderer.rb
@@ -1,7 +1,11 @@
 # Helper class to render govspeak outside of the view contexts.
 module Whitehall
   class GovspeakRenderer
-    delegate :govspeak_edition_to_html, :govspeak_to_html, :govspeak_with_attachments_to_html, to: :view_context
+    delegate :govspeak_edition_to_html,
+      :govspeak_to_html,
+      :govspeak_with_attachments_to_html,
+      :html_attachment_govspeak_headers_html,
+      to: :view_context
 
   private
 

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -104,6 +104,27 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_equal expected_headings, html_attachment_govspeak_headers(attachment)
   end
 
+  test "#html_attachment_govspeak_headers_html renders an <ol>" do
+    attachment = build(
+      :html_attachment,
+      body: "## 1. First\n\n## 2. Second\n\n### 2.1 Sub",
+      manually_numbered_headings: true
+    )
+    expected = <<-HTML
+      <ol class=\"unnumbered\">
+        <li class=\"numbered\">
+          <a href=\"#first\"><span class=\"heading-number\">1.</span> First</a>
+        </li>
+        <li class=\"numbered\">
+          <a href=\"#second\"><span class=\"heading-number\">2.</span> Second</a>
+        </li>
+      </ol>
+      HTML
+
+    rendered_attachment_headers = html_attachment_govspeak_headers_html(attachment)
+    assert_equivalent_html expected, rendered_attachment_headers
+  end
+
   test "should raise exception when extracting header hierarchy with orphaned level 3 headings" do
     e = assert_raise(OrphanedHeadingError) { govspeak_header_hierarchy("### Heading 3") }
     assert_equal "Heading 3", e.heading


### PR DESCRIPTION
This PR tidies up `GovspeakContentWorker` using the now thread safe `GovspeakRenderer` introduced in https://github.com/alphagov/whitehall/pull/2540

This is preparatory work on the way to moving all of this rendering functionality into the `GovspeakContent` class so as it can also be called synchronously when presenting `HtmlAttachment` objects for the Publishing API.

[trello](https://trello.com/c/uwsLR1xU/285-5-html-publications-implement-publishing-of-format-to-publishing-api-large)