### PR TITLE
Add parent tag to the links hash of an edition

### DIFF
--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -16,7 +16,25 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
   end
 
   def links
-    extract_links([:topics])
+    topic_tags = item.specialist_sector_tags
+    return {} unless topic_tags.present?
+
+    parent_tag = item.primary_specialist_sector_tag
+    base_paths = topic_tags.map { |tag| topic_path_from(tag) }
+    content_id_lookup = Whitehall.publishing_api_v2_client.lookup_content_ids(base_paths: base_paths)
+
+    if parent_tag
+      parent_content_id = content_id_lookup[topic_path_from(parent_tag)]
+      { topics: content_id_lookup.values, parent: [parent_content_id] }
+    else
+      { topics: content_id_lookup.values }
+    end
+  end
+
+private
+
+  def topic_path_from(tag)
+    "/topic/#{tag}"
   end
 
 private

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -37,15 +37,15 @@ namespace :publishing_api do
   task publishing_api_patch_links: :environment do
     editions = Edition.published
     count = editions.count
-    $stdout.puts "# Sending #{count} published editions to Publishing API"
+    puts "# Sending #{count} published editions to Publishing API"
 
     editions.pluck(:id).each_with_index do |item_id, i|
       PublishingApiLinksWorker.perform_async(item_id)
 
-      $stdout.puts "Queuing #{i}-#{i + 99} of #{count} items" if i % 100 == 0
+      puts "Queuing #{i}-#{i + 99} of #{count} items" if i % 100 == 0
     end
 
-    $stdout.puts "Finished queuing items for Publishing API"
+    puts "Finished queuing items for Publishing API"
   end
 end
 

--- a/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
@@ -23,20 +23,4 @@ class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
     # whitehall names and publishing api names don't necessarily match...
     assert_equal document.topics.map(&:content_id), links[:policy_areas]
   end
-
-
-  test 'extracts content_ids from a tagged edition' do
-    edition = create(:edition)
-    create(:specialist_sector, tag: "oil-and-gas/offshore", edition: edition, primary: true)
-    create(:specialist_sector, tag: "oil-and-gas/onshore", edition: edition, primary: false)
-
-    publishing_api_has_lookups({
-      "/topic/oil-and-gas/offshore" => "content_id_1",
-      "/topic/oil-and-gas/onshore" => "content_id_2",
-    })
-
-    links = links_for(edition)
-
-    assert_equal links[:topics], %w(content_id_1 content_id_2)
-  end
 end

--- a/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
@@ -1,18 +1,7 @@
 require 'test_helper'
 
 class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
-  ALL_LINK_TYPES = [
-    :document_collections,
-    :lead_organisations,
-    :policy_areas,
-    :related_policies,
-    :statistical_data_set_documents,
-    :supporting_organisations,
-    :topics,
-    :world_locations,
-    :worldwide_organisations,
-    :worldwide_priorities,
-  ]
+  ALL_LINK_TYPES = PublishingApiPresenters::LinksPresenter::LINK_NAMES_TO_METHODS_MAP.keys
 
   def links_for(item, filter_links = ALL_LINK_TYPES)
     LinksPresenter.new(item).extract(filter_links)


### PR DESCRIPTION
- Override #links implementation in PublishingApiPresenters::Edition, as
  the `extract_links`/`LinksPresenter` implementation in the Item parent class isn't flexible
  enough. We want to be able to set both topics and parent content IDs
  with a single publishing API call per edition.
- Clear testing of this behaviour from LinksPresenter test.