### PR TITLE
Add rake task to update `StatisticsAnnouncement` publish intent

### DIFF
--- a/lib/tasks/statistics_announcements_intents.rake
+++ b/lib/tasks/statistics_announcements_intents.rake
@@ -1,0 +1,17 @@
+namespace :statistics_announcements do
+  desc "Updates the publish intent for StatisticsAnnouncements scheduled for release in the future"
+  task put_intents_for_scheduled: :environment do
+    latest_join_sql = <<-SQL
+      statistics_announcement_dates.created_at = (
+        select max(statistics_announcement_dates.created_at)
+        from statistics_announcement_dates
+        where statistics_announcement_dates.statistics_announcement_id = statistics_announcements.id
+      )
+    SQL
+    statistics_announcements = StatisticsAnnouncement
+      .joins(:statistics_announcement_dates)
+      .where("statistics_announcement_dates.release_date > ?", Date.current)
+      .where(latest_join_sql)
+    statistics_announcements.each(&:update_publish_intent)
+  end
+end


### PR DESCRIPTION
This rake task is required to send a `publish_intent` to the PublishingAPI for any existing `StatisticsAnnouncement` with a release date in the future. It is a follow up commit to https://github.com/alphagov/whitehall/pull/2538