### PR TITLE
Explain current biography logic to users

### DIFF
--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -25,6 +25,12 @@
   <fieldset>
     <%= person_form.text_area :biography, rows: 20, class: "previewable" %>
   </fieldset>
+
+  <div class="alert alert-info">
+    <p>The full biography will show only if a person has been appointed to a <%= link_to "current role", admin_roles_path, class: 'link-inherit' %>.</p>
+    <p>A person without a current role will show just the first paragraph.</p>
+  </div>
+
   <p class="warning">
     <% if show_instantly_live_warning %>
       Warning: changes to people appear instantly on the live site.


### PR DESCRIPTION
The current process for creating or editing people is confusing. We have some logic that shows a truncated biography for any person without a current role. If you’re creating a new person, they have no role – when you enter your full biography and check it on the live site, it’s not clear why the whole thing isn’t showing.

This is a simple change to try and explain that. The decision to do the truncation should be re-assessed.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1298476
Original PR to add truncation: https://github.com/alphagov/whitehall/pull/2058

![screen shot 2016-04-07 at 12 29 12](https://cloud.githubusercontent.com/assets/319055/14350121/51ff358a-fcbf-11e5-85df-5d71ab29751d.png)
