### PR TITLE
Refactor `GovspeakContent` and `GovspeakContentWorker`

### DIFF
--- a/app/workers/govspeak_content_worker.rb
+++ b/app/workers/govspeak_content_worker.rb
@@ -1,37 +1,6 @@
 class GovspeakContentWorker < WorkerBase
-
   def perform(id)
     return unless govspeak_content = GovspeakContent.find_by(id: id)
-
-    govspeak_content.computed_body_html = generate_govspeak(govspeak_content)
-    govspeak_content.computed_headers_html = generate_headers(govspeak_content)
-    govspeak_content.save!
-  end
-
-private
-
-  def generate_govspeak(govspeak_content)
-    body = govspeak_content.body
-    options = govspeak_options(govspeak_content)
-    if govspeak_content.html_attachment.attachable.respond_to?(:images)
-      images = govspeak_content.html_attachment.attachable.images
-    else
-      images = []
-    end
-
-    renderer.govspeak_to_html(body, images, options)
-  end
-
-  def generate_headers(govspeak_content)
-    renderer.html_attachment_govspeak_headers_html(govspeak_content.html_attachment)
-  end
-
-  def govspeak_options(govspeak_content)
-    method = govspeak_content.manually_numbered_headings? ? :manual : :auto
-    { heading_numbering: method, contact_heading_tag: 'h4' }
-  end
-
-  def renderer
-    @renderer ||= Whitehall::GovspeakRenderer.new
+    govspeak_content.render_govspeak!
   end
 end

--- a/test/unit/govspeak_content_test.rb
+++ b/test/unit/govspeak_content_test.rb
@@ -61,6 +61,56 @@ class GovspeakContentTest < ActiveSupport::TestCase
     end
   end
 
+  test "#render_govspeak sets computed_headers_html correctly" do
+    govspeak_content = create(:html_attachment,
+                        manually_numbered_headings: false,
+                        body: "## 1.0 A heading\nSome content").govspeak_content
+    govspeak_content.render_govspeak!
+    expected_headers_html = <<-HTML
+      <ol>
+        <li>
+          <a href="#a-heading">1.0 A heading</a>
+        </li>
+      </ol>
+      HTML
+    assert_equivalent_html expected_headers_html, govspeak_content.computed_headers_html
+  end
+
+  test "#render_govspeak sets computed_headers_html correctly when manually
+    numbered headings is true" do
+    govspeak_content = create(:html_attachment,
+                        manually_numbered_headings: true,
+                        body: "## 1.0 A heading\nSome content").govspeak_content
+    govspeak_content.render_govspeak!
+    expected_headers_html = <<-HTML
+      <ol class="unnumbered">
+        <li class="numbered">
+          <a href="#a-heading">
+            <span class="heading-number">1.0</span>
+            A heading
+          </a>
+        </li>
+      </ol>
+      HTML
+    assert_equivalent_html expected_headers_html, govspeak_content.computed_headers_html
+  end
+
+  test "#render_govspeak sets computed_body_html correctly" do
+    govspeak_content = create(:html_attachment,
+                        manually_numbered_headings: false,
+                        body: "## 1.0 A heading\nSome content").govspeak_content
+    govspeak_content.render_govspeak!
+    expected_body_html = <<-HTML
+      <div class="govspeak">
+        <h2 id="a-heading">
+          <span class="number">1. </span>
+          1.0 A heading
+        </h2>
+        <p>Some content</p>
+      </div>
+    HTML
+    assert_equivalent_html expected_body_html, govspeak_content.computed_body_html
+  end
 private
 
   def compute_govspeak(govspeak_content)


### PR DESCRIPTION
This PR moves all of the govspeak -> html rendering logic into the `GovspeakContent` class. This will allow it to be called elsewhere e.g. when the `HtmlAttachment` is being presented for the Publishing API. When that is done we may be able to get rid of the `GovspeakContentWorker` altogether which I'll do in a further PR if possible.

This is related to https://github.com/alphagov/whitehall/pull/2543 and is mentioned there.