### PR TITLE
Exclude `cancelled?` and `unpublished?`

### DIFF
--- a/lib/tasks/statistics_announcements_intents.rake
+++ b/lib/tasks/statistics_announcements_intents.rake
@@ -1,4 +1,8 @@
 namespace :statistics_announcements do
+  def no_update_required?(statistics_announcement)
+    statistics_announcement.unpublished? || statistics_announcement.cancelled?
+  end
+
   desc "Updates the publish intent for StatisticsAnnouncements scheduled for release in the future"
   task put_intents_for_scheduled: :environment do
     latest_join_sql = <<-SQL
@@ -8,10 +12,16 @@ namespace :statistics_announcements do
         where statistics_announcement_dates.statistics_announcement_id = statistics_announcements.id
       )
     SQL
+
     statistics_announcements = StatisticsAnnouncement
       .joins(:statistics_announcement_dates)
       .where("statistics_announcement_dates.release_date > ?", Date.current)
       .where(latest_join_sql)
-    statistics_announcements.each(&:update_publish_intent)
+
+    statistics_announcements.each do |statistics_announcement|
+      unless no_update_required?(statistics_announcement)
+        statistics_announcement.update_publish_intent
+      end
+    end
   end
 end


### PR DESCRIPTION
Running this task previously was causing a lot of `500` responses from the publishing stack due to the way `404` responses returned by the `publish_intents` endpoint on Content Store are handled on their way back through the stack. This change stops `unpublished?` and `cancelled?` `StatisticsAnnouncement` being sent. These states cause a delete publish intent call to be made resulting in the error when it isn't found on the content store.