### PR TITLE
Render Govspeak Synchronously for HtmlAttachments

### DIFF
--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -1,6 +1,11 @@
 require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::HtmlAttachment < PublishingApiPresenters::Item
+  def initialize(item, update_type: nil)
+    super
+    item.govspeak_content.render_govspeak!
+  end
+
   def links
     {
       parent: [

--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -44,7 +44,7 @@ private
   end
 
   def body
-    Whitehall::GovspeakRenderer.new.govspeak_to_html(govspeak_content.body)
+    govspeak_content.computed_body_html
   end
 
   def headings

--- a/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
@@ -5,6 +5,12 @@ class PublishingApiPresenters::HtmlAttachmentTest < ActiveSupport::TestCase
     PublishingApiPresenters::HtmlAttachment.new(record)
   end
 
+  test "the constructor calls HtmlAttachment#render_govspeak!" do
+    html_attachment = build(:html_attachment)
+    html_attachment.govspeak_content.expects(:render_govspeak!)
+    PublishingApiPresenters::HtmlAttachment.new(html_attachment)
+  end
+
   test "HtmlAttachment presentation includes the correct values" do
     edition = create(:publication, :with_html_attachment, :published)
     html_attachment = HtmlAttachment.last

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -78,7 +78,7 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   end
 
   test ".presenter_for returns a HtmlAttachment presenter for `HtmlAttachment`" do
-    presenter = PublishingApiPresenters.presenter_for(HtmlAttachment.new)
+    presenter = PublishingApiPresenters.presenter_for(build(:html_attachment))
     assert_equal PublishingApiPresenters::HtmlAttachment, presenter.class
   end
 end


### PR DESCRIPTION
Currently, the Govspeak on an `HtmlAttachment` is rendered within a Sidekiq worker some time ~10 seconds after the attachment has been saved ([here](https://github.com/alphagov/whitehall/blob/master/app/models/govspeak_content.rb#L26-L34)). We need it before then when sending the `HtmlAttachment` to the Publishing API.

This PR calls `#render_govspeak!` within the constructor of the `PublishingApiPresenters::HtmlAttachment` to ensure that we have the HTML when the payload is sent. The presenter is instantiated within a Sidekiq worker so any performance issues are still mitigated and nothing will be blocked should there be a particularly large body.

This effectively makes the `GovspeakContentWorker` redundant as any changes to the `HtmlAttachment` will be sent to the Publishing API and the HTML will be generated. The original reason for the delayed queue should no longer be an issue as the events that cause the Publishing API update are fired after the parent `Edition` is committed to the DB. My only concern is that this step will now be 'hidden' within the presenter where it is much less obvious/explicit than it currently is. I'll remove the `GovspeakContentWorker` in a subsequent PR unless anybody has any better ideas.

This is part of the ongoing work for [trello](https://trello.com/c/uwsLR1xU/285-5-html-publications-implement-publishing-of-format-to-publishing-api-large)