### PR TITLE
Present previous date for stats announcements

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -95,7 +95,7 @@ class StatisticsAnnouncement < ActiveRecord::Base
 
   def previous_display_date
     if last_major_change
-      major_change_index = statistics_announcement_dates.index(last_major_change)
+      major_change_index = statistics_announcement_dates.order(:created_at).index(last_major_change)
       statistics_announcement_dates.at(major_change_index - 1).try(:display_date)
     end
   end

--- a/app/presenters/publishing_api_presenters/statistics_announcement.rb
+++ b/app/presenters/publishing_api_presenters/statistics_announcement.rb
@@ -21,6 +21,10 @@ private
         cancellation_reason: item.cancellation_reason,
         cancelled_at: cancelled_at
       ) if item.cancelled?
+      d.merge!(
+        previous_display_date: item.previous_display_date,
+        latest_change_note: item.last_change_note
+      ) if item.previous_display_date
     end
   end
 

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   factory :statistics_announcement do
     transient do
       release_date nil
+      previous_display_date nil
+      change_note nil
     end
 
     sequence(:title) { |index| "Stats announcement #{index}" }
@@ -16,6 +18,17 @@ FactoryGirl.define do
     after :build do |announcement, evaluator|
       if evaluator.release_date.present?
         announcement.current_release_date.release_date = evaluator.release_date
+      end
+
+      if evaluator.change_note.present?
+        announcement.current_release_date.change_note = evaluator.change_note
+      end
+
+      if evaluator.previous_display_date.present?
+        announcement.statistics_announcement_dates <<
+          create(:statistics_announcement_date_change,
+                 current_release_date: announcement.current_release_date,
+                 release_date: evaluator.previous_display_date)
       end
     end
   end

--- a/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
+++ b/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
@@ -26,7 +26,7 @@ class DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncementsTest < Acti
                           summary: "The summary",
                           publication_type_id: PublicationType.find_by_slug("official-statistics").id,
                           statistics_announcement_dates: [build(:statistics_announcement_date,
-                                                                 release_date:  "2050-03-01",
+                                                                 release_date: Time.zone.parse("2050-03-01"),
                                                                  precision: StatisticsAnnouncementDate::PRECISION[:two_month],
                                                                  confirmed: false,
                                                                  change_note: nil),

--- a/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/statistics_announcement_test.rb
@@ -76,4 +76,43 @@ class PublishingApiPresenters::StatisticsAnnouncementTest < ActiveSupport::TestC
     assert_equal expected[:details], presented.content[:details].except(:body)
     assert_equal expected[:links], presented.links
   end
+
+  test "a statistics announcement with a date change presents both dates and a notice" do
+    statistics_announcement = create(:statistics_announcement,
+      previous_display_date: 7.days.from_now,
+      change_note: "Reasons")
+
+    expected = {
+      content_id: statistics_announcement.content_id,
+      base_path: statistics_announcement.slug,
+      description: statistics_announcement.summary,
+      title: statistics_announcement.title,
+      format: 'statistics_announcement',
+      locale: 'en',
+      need_ids: [],
+      public_updated_at: statistics_announcement.updated_at,
+      publishing_app: 'whitehall',
+      rendering_app: 'government-frontend',
+      details: {
+        display_date: statistics_announcement.current_release_date.display_date,
+        previous_display_date: 7.days.from_now.to_s(:date_with_time),
+        latest_change_note: "Reasons",
+        state: statistics_announcement.state,
+        format_sub_type: 'official',
+      },
+      links: {
+        organisations: statistics_announcement.organisations.map(&:content_id),
+        policy_areas: statistics_announcement.topics.map(&:content_id),
+        topics: [],
+      }
+    }
+
+    presented = present(statistics_announcement)
+
+    assert_valid_against_schema(presented.content, 'statistics_announcement')
+    assert_valid_against_links_schema({ links: presented.links }, 'statistics_announcement')
+
+    assert_equal expected[:details], presented.content[:details].except(:body)
+    assert_equal expected[:links], presented.links
+  end
 end


### PR DESCRIPTION
If a major change occurred for a stats announcement, it needs to be
pushed to the content store. A major change is identified by a new date
with a change note.

The content schemas, examples and frontend supports this already, it
just needs to be presented to the publishing-api.

Zendesk: https://govuk.zendesk.com/agent/tickets/1299969

/cc @elliotcm @gpeng 