### PR TITLE
Add DetailedGuide presenter.

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -32,6 +32,10 @@ class DetailedGuide < Edition
     related_to_editions.where(type: 'DetailedGuide').map(&:id)
   end
 
+  def related_detailed_guide_content_ids
+    related_to_editions.where(type: 'DetailedGuide').map(&:content_id)
+  end
+
   # Ensure that we set related detailed guides without stomping on other related documents
   def related_detailed_guide_ids=(detailed_guide_ids)
     detailed_guide_ids        = Array.wrap(detailed_guide_ids).reject(&:blank?)

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -86,7 +86,17 @@ class DetailedGuide < Edition
     parse_base_path_from_related_mainstream_url(url)
   end
 
-  private
+  def government
+    @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
+  end
+
+private
+
+  def date_for_government
+    published_edition_date = first_public_at.try(:to_date)
+    draft_edition_date = updated_at.try(:to_date)
+    published_edition_date || draft_edition_date
+  end
 
   def parse_base_path_from_related_mainstream_url(url)
     return nil if url.nil? || url.empty?

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -76,7 +76,25 @@ class DetailedGuide < Edition
     true
   end
 
+  def related_mainstream_base_path
+    url = related_mainstream_content_url
+    parse_base_path_from_related_mainstream_url(url)
+  end
+
+  def additional_related_mainstream_base_path
+    url = additional_related_mainstream_content_url
+    parse_base_path_from_related_mainstream_url(url)
+  end
+
   private
+
+  def parse_base_path_from_related_mainstream_url(url)
+    return nil if url.nil? || url.empty?
+    parsed_url = URI.parse(url)
+    url_is_invalid = !['gov.uk', 'www.gov.uk'].include?(parsed_url.host)
+    return nil if url_is_invalid
+    URI.parse(url).path
+  end
 
   # Returns the published edition of any detailed guide documents that this edition is related to.
   def published_outbound_related_detailed_guides

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -41,6 +41,8 @@ private
       PublishingApiPresenters::CaseStudy
     when ::DocumentCollection
       PublishingApiPresenters::DocumentCollectionPlaceholder
+    when ::DetailedGuide
+      PublishingApiPresenters::DetailedGuide
     else
       PublishingApiPresenters::Edition
     end

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -25,7 +25,7 @@ private
       body: body,
       format_display_type: item.display_type_key,
       first_public_at: first_public_at,
-      change_history: item.change_history.as_json,
+      change_history: item.change_history.as_json
     }).tap do |json|
       json[:image] = image_details if image_available?
       json[:withdrawn_notice] = withdrawn_notice if item.withdrawn?

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -21,7 +21,9 @@ private
       body: body,
       first_public_at: first_public_at,
       change_history: item.change_history.as_json,
-      related_mainstream_content: related_mainstream
+      related_mainstream_content: related_mainstream,
+      political: item.political?,
+      government: government
     )
   end
 
@@ -56,5 +58,15 @@ private
     else
       []
     end
+  end
+
+  # Detailed Guides need a government to publish successfully.
+  def government
+    gov = item.government
+    {
+      title: gov.name,
+      slug: gov.slug,
+      current: gov.current?
+    }
   end
 end

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -40,8 +40,7 @@ private
   end
 
   def related_guides
-    # TODO: Return real related guide content_ids.
-    []
+    item.related_detailed_guide_content_ids
   end
 
   def related_mainstream

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -1,0 +1,36 @@
+require_relative "../publishing_api_presenters"
+
+class PublishingApiPresenters::DetailedGuide < PublishingApiPresenters::Edition
+  def links
+    extract_links [
+      :lead_organisations,
+      :related_guides
+    ]
+  end
+
+private
+
+  def document_format
+    "detailed_guide"
+  end
+
+  def details
+    super.merge(
+      body: body,
+      first_public_at: first_public_at,
+      change_history: item.change_history.as_json
+    )
+  end
+
+  def body
+    Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+  end
+
+  def first_public_at
+    if item.document.published?
+      item.first_public_at
+    else
+      item.document.created_at.iso8601
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -2,10 +2,12 @@ require_relative "../publishing_api_presenters"
 
 class PublishingApiPresenters::DetailedGuide < PublishingApiPresenters::Edition
   def links
-    extract_links [
-      :lead_organisations,
-      :related_guides
-    ]
+    extract_links([
+      :lead_organisations
+    ]).merge(
+      related_guides: related_guides,
+      related_mainstream: related_mainstream
+    )
   end
 
 private
@@ -18,7 +20,8 @@ private
     super.merge(
       body: body,
       first_public_at: first_public_at,
-      change_history: item.change_history.as_json
+      change_history: item.change_history.as_json,
+      related_mainstream_content: related_mainstream
     )
   end
 
@@ -31,6 +34,27 @@ private
       item.first_public_at
     else
       item.document.created_at.iso8601
+    end
+  end
+
+  def related_guides
+    # TODO: Return real related guide content_ids.
+    []
+  end
+
+  def related_mainstream
+    base_paths = []
+    base_paths.push(item.related_mainstream_base_path)
+    base_paths.push(item.additional_related_mainstream_base_path)
+    base_paths.compact!
+
+    if base_paths.any?
+      Whitehall.publishing_api_v2_client
+        .lookup_content_ids(base_paths: base_paths)
+        .values
+        .compact
+    else
+      []
     end
   end
 end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -62,7 +62,6 @@ private
 
   def details
     {
-      change_note: item.most_recent_change_note,
       # These tags are used downstream for sending email alerts.
       # For more details please see https://gov-uk.atlassian.net/wiki/display/TECH/Email+alerts+2.0
       tags: {

--- a/app/presenters/publishing_api_presenters/links_presenter.rb
+++ b/app/presenters/publishing_api_presenters/links_presenter.rb
@@ -5,7 +5,6 @@ module PublishingApiPresenters
       lead_organisations: :lead_organisation_ids,
       organisations: :organisation_ids,
       policy_areas: :policy_area_ids,
-      related_guides: :related_guides_ids,
       related_policies: :related_policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
       supporting_organisations: :supporting_organisation_ids,
@@ -40,10 +39,6 @@ module PublishingApiPresenters
 
     def policy_area_ids
       (item.try(:topics) || []).map(&:content_id)
-    end
-
-    def related_guides_ids
-      item.try(:related_detailed_guide_ids) || []
     end
 
     def related_policy_ids

--- a/app/presenters/publishing_api_presenters/links_presenter.rb
+++ b/app/presenters/publishing_api_presenters/links_presenter.rb
@@ -5,6 +5,7 @@ module PublishingApiPresenters
       lead_organisations: :lead_organisation_ids,
       organisations: :organisation_ids,
       policy_areas: :policy_area_ids,
+      related_guides: :related_guides_ids,
       related_policies: :related_policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
       supporting_organisations: :supporting_organisation_ids,
@@ -39,6 +40,10 @@ module PublishingApiPresenters
 
     def policy_area_ids
       (item.try(:topics) || []).map(&:content_id)
+    end
+
+    def related_guides_ids
+      item.try(:related_detailed_guide_ids) || []
     end
 
     def related_policy_ids

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -1,15 +1,18 @@
 Given /^a published detailed guide "([^"]*)" related to published detailed guides "([^"]*)" and "([^"]*)"$/ do |title, first_related_title, second_related_title|
+  create(:government)
   first_related = create(:published_detailed_guide, title: first_related_title)
   second_related = create(:published_detailed_guide, title: second_related_title)
   guide = create(:published_detailed_guide, title: title, related_documents: [first_related.document, second_related.document], topics: [create(:topic)])
 end
 
 Given /^a published detailed guide "([^"]*)" for the organisation "([^"]*)"$/ do |title, organisation|
+  create(:government)
   organisation = create(:organisation, name: organisation)
   create(:published_detailed_guide, title: title, organisations: [organisation])
 end
 
 When /^I draft a new detailed guide "([^"]*)"$/ do |title|
+  create(:government)
   begin_drafting_document type: 'detailed_guide', title: title, previously_published: false
   click_button "Save"
 end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -6,6 +6,7 @@ Given /^a draft (document|publication|news article|consultation|speech) "([^"]*)
 end
 
 Given /^a published (publication|news article|consultation|speech|detailed guide) "([^"]*)" exists$/ do |document_type, title|
+  create(:government) if Government.first.nil?
   create("published_#{document_class(document_type).name.underscore}".to_sym, title: title)
 end
 
@@ -19,6 +20,7 @@ Given /^a draft (publication|news article|consultation) "([^"]*)" exists in the 
 end
 
 Given /^a submitted (publication|news article|consultation|detailed guide) "([^"]*)" exists in the "([^"]*)" topic$/ do |document_type, title, topic_name|
+  create(:government)
   topic = Topic.find_by!(name: topic_name)
   create("submitted_#{document_class(document_type).name.underscore}".to_sym, title: title, topics: [topic])
 end

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
 
   setup do
     login_as create(:writer, organisation: create(:organisation))
+    create(:government)
   end
 
   should_be_an_admin_controller

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -11,6 +11,7 @@ module TestsForNationalApplicability
     end
 
     test 'create should create a new edition with nation inapplicabilities' do
+      create(:government)
       attributes = attributes_for_edition
 
       post :create, edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/"))
@@ -59,6 +60,7 @@ module TestsForNationalApplicability
     end
 
     test 'updating should save modified edition with nation inapplicabilities' do
+      create(:government)
       attributes = attributes_for_edition
       edition = create_edition(attributes)
       northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -111,4 +111,14 @@ class DetailedGuideTest < ActiveSupport::TestCase
     assert_equal detailed_guide.related_mainstream_base_path, '/content'
     assert_equal detailed_guide.additional_related_mainstream_base_path, '/additional-content'
   end
+
+  test 'related_detailed_guide_ids works correctly' do
+    some_detailed_guide = create(:detailed_guide)
+    detailed_guide = create(
+      :detailed_guide,
+      related_editions: [some_detailed_guide]
+    )
+
+    assert_equal detailed_guide.related_detailed_guide_content_ids, [some_detailed_guide.content_id]
+  end
 end

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -100,4 +100,15 @@ class DetailedGuideTest < ActiveSupport::TestCase
     detailed_guide = build(:detailed_guide)
     assert detailed_guide.search_format_types.include?('detailed-guidance')
   end
+
+  test 'should return base paths for related mainstream content urls' do
+    detailed_guide = build(
+      :detailed_guide,
+      related_mainstream_content_url: "http://gov.uk/content",
+      additional_related_mainstream_content_url: "http://gov.uk/additional-content"
+    )
+
+    assert_equal detailed_guide.related_mainstream_base_path, '/content'
+    assert_equal detailed_guide.additional_related_mainstream_base_path, '/additional-content'
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -30,7 +30,6 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: 'case_study',
         first_public_at: case_study.first_public_at,
-        change_note: nil,
         change_history: [
           { public_timestamp: case_study.public_timestamp, note: 'change-note' }.as_json
         ],

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -9,6 +9,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
   end
 
   test "DetailedGuide presenter passes schema tests" do
+    create(:government)
     detailed_guide = create(
       :detailed_guide,
       title: "Some detailed guide",
@@ -23,6 +24,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
   end
 
   test "DetailedGuide presents correct information" do
+    government = create(:government)
     detailed_guide = create(
       :detailed_guide,
       title: "Some detailed guide",
@@ -54,6 +56,12 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
           topics: [],
           policies: []
         },
+        political: false,
+        government: {
+          title: government.name,
+          slug: government.slug,
+          current: government.current?
+        },
         related_mainstream_content: [],
       },
     }
@@ -78,6 +86,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     }
 
     publishing_api_has_lookups(lookup_hash)
+    create(:government)
     detailed_guide = create(
       :detailed_guide,
       title: "Some detailed guide",
@@ -110,6 +119,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     }
     publishing_api_has_lookups(lookup_hash)
 
+    create(:government)
     detailed_guide = create(
       :detailed_guide,
       title: "Some detailed guide",
@@ -130,6 +140,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     lookup_hash = {}
     publishing_api_has_lookups(lookup_hash)
 
+    create(:government)
     detailed_guide = create(
       :detailed_guide,
       title: "Some detailed guide",
@@ -146,5 +157,27 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     expected_ids = []
 
     assert_equal expected_ids.sort, links[:related_mainstream].sort
+  end
+
+  test 'DetailedGuide presents political information correctly' do
+    government = create(:government)
+    detailed_guide = create(
+      :published_detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content",
+      political: true
+    )
+
+    presented_item = present(detailed_guide)
+    details = presented_item.content[:details]
+
+    expected_government = {
+      title: government.name,
+      slug: government.slug,
+      current: government.current?
+    }
+    assert_equal details[:political], true
+    assert_equal details[:government], expected_government
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -180,4 +180,25 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     assert_equal details[:political], true
     assert_equal details[:government], expected_government
   end
+
+  test 'DetailedGuide presents related_guides correctly' do
+    create(:government)
+    some_detailed_guide = create(:detailed_guide)
+    detailed_guide = create(
+      :published_detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content",
+      related_editions: [some_detailed_guide]
+    )
+
+    presented_item = present(detailed_guide)
+    related_guides = presented_item.links[:related_guides]
+
+    expected_related_guides = [
+      some_detailed_guide.content_id
+    ]
+
+    assert_equal related_guides, expected_related_guides
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
+  def present(edition)
+    PublishingApiPresenters::DetailedGuide.new(edition)
+  end
+
+  test "DetailedGuide presenter passes schema tests" do
+    detailed_guide = create(
+      :detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content"
+    )
+
+    presented_item = present(detailed_guide)
+
+    assert_valid_against_schema(presented_item.content, "detailed_guide")
+    assert_valid_against_links_schema({ links: presented_item.links }, "detailed_guide")
+  end
+
+  test "DetailedGuide presents correct information" do
+    detailed_guide = create(
+      :detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content"
+    )
+
+    public_path = Whitehall.url_maker.public_document_path(detailed_guide)
+    expected_content = {
+      base_path: public_path,
+      title: "Some detailed guide",
+      description: "Some summary",
+      public_updated_at: detailed_guide.updated_at,
+      format: "detailed_guide",
+      locale: "en",
+      need_ids: [],
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      routes: [
+        { path: public_path, type: "exact" }
+      ],
+      redirects: [],
+      details: {
+        body: "<div class=\"govspeak\"><p>Some content</p></div>",
+        first_public_at: detailed_guide.created_at.iso8601,
+        change_note: nil,
+        change_history: [],
+        tags: {
+          browse_pages: [],
+          topics: [],
+          policies: []
+        }
+      }
+    }
+    expected_links = {
+      lead_organisations: [detailed_guide.lead_organisations.first.content_id],
+      related_guides: [],
+    }
+    presented_item = present(detailed_guide)
+
+    assert_equal expected_content.except(:details), presented_item.content.except(:details)
+    assert_equivalent_html expected_content[:details].delete(:body), presented_item.content[:details].delete(:body)
+    assert_equal expected_content[:details], presented_item.content[:details].except(:body)
+    assert_equal expected_links, presented_item.links
+    assert_equal detailed_guide.document.content_id, presented_item.content_id
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -45,7 +45,6 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         first_public_at: detailed_guide.created_at.iso8601,
-        change_note: nil,
         change_history: [],
         tags: {
           browse_pages: [],

--- a/test/unit/presenters/publishing_api_presenters/document_collection_placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/document_collection_placeholder_test.rb
@@ -37,7 +37,6 @@ class PublishingApiPresenters::DocumentCollectionPlaceholderTest < ActiveSupport
       redirects: [],
       need_ids: [],
       details: {
-        change_note: nil,
         tags: {
           browse_pages: [],
           policies: [],

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -31,7 +31,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
       ],
       redirects: [],
       details: {
-        change_note: nil,
         tags: {
           browse_pages: [],
           policies: [],
@@ -69,7 +68,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
       ],
       redirects: [],
       details: {
-        change_note: nil,
         tags: {
           browse_pages: [],
           policies: [],
@@ -81,21 +79,6 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     presented_item = present(edition)
     assert_equal expected_hash, presented_item.content
     assert_valid_against_schema(presented_item.content, 'placeholder')
-  end
-
-  test 'includes the most recent change note even when the edition is only a minor change' do
-    user  = create(:gds_editor)
-    first = create(:published_edition)
-
-    major = first.create_draft(user)
-    major.change_note = 'This was a major change'
-    force_publish(major)
-
-    minor = major.create_draft(user)
-    minor.minor_change = true
-    minor.change_note = nil
-
-    assert_equal 'This was a major change', present(minor).content[:details][:change_note]
   end
 
   test 'minor changes are a "minor" update type' do

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -3,9 +3,16 @@ require 'test_helper'
 class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a presenter for a case study" do
     case_study = CaseStudy.new
-    presenter  = PublishingApiPresenters.presenter_for(case_study)
+    presenter = PublishingApiPresenters.presenter_for(case_study)
 
     assert_equal PublishingApiPresenters::CaseStudy, presenter.class
+  end
+
+  test ".presenter_for returns a presenter for a detailed guide" do
+    detailed_guide = DetailedGuide.new
+    presenter = PublishingApiPresenters.presenter_for(detailed_guide)
+
+    assert_equal PublishingApiPresenters::DetailedGuide, presenter.class
   end
 
   test ".presenter_for returns a presenter for a Take Part page" do

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -5,6 +5,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   test "registers an edition with the publishing api" do
+    create(:government)
     edition = create(:published_detailed_guide)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
@@ -54,6 +55,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
   test "passes the update_type option to the presenter" do
     update_type = "republish"
 
+    create(:government)
     edition = create(:published_detailed_guide)
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: update_type)
     requests = [


### PR DESCRIPTION
This is implemented very similarly to the `CaseStudy` presenter, which inherits from the same base `Edition` presenter.

Some of the methods (`first_public_at`, `body`) can potentially be refactored into the parent presenter.

Depends on a content-schema update, and will fail until it's merged. (https://github.com/alphagov/govuk-content-schemas/pull/279)

Relevant Trello ticket: https://trello.com/c/yAU5zVvg/315-6-detailed-guides-migration-implement-publishing-of-format-to-publishing-api-large