### PR TITLE
Remove rendering app from `HtmlAttachment` presenter

### DIFF
--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -46,10 +46,6 @@ private
     govspeak_content.computed_headers_html
   end
 
-  def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-  end
-
   def first_published_version?
     parent.first_published_version?
   end


### PR DESCRIPTION
Was set to `GOVERNMENT_FRONTEND` prematurely. Should be Whitehall as the `HtmlPublication` government frontend has not been deployed yet.

This PR removes the override of `rendering_app` in the `HtmlAttachment` presenter.