### PR TITLE
Set `body` to return an empty string

### DIFF
--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -39,7 +39,7 @@ private
   end
 
   def body
-    Whitehall::GovspeakRenderer.new.govspeak_to_html(govspeak_content.body)
+    ""
   end
 
   def headings

--- a/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
@@ -24,8 +24,7 @@ class PublishingApiPresenters::HtmlAttachmentTest < ActiveSupport::TestCase
       ],
       redirects: [],
       details: {
-        body: Whitehall::GovspeakRenderer.new
-          .govspeak_to_html(html_attachment.govspeak_content.body),
+        body: '',
         headings: html_attachment.govspeak_content.computed_headers_html,
         public_timestamp: edition.public_timestamp,
         first_published_version: html_attachment.attachable.first_published_version?,


### PR DESCRIPTION
This will allow republishing and isn't necessary at the moment as we're not serving from Content Store as yet.