### PR TITLE
Rework whitehall-frontend breadcrumb to use content store

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -217,8 +217,11 @@ Please tell us:
       part_of += array_of_links_to_topical_events(document.topical_events)
     end
 
-    if sector_tag_finder && (all_sectors = sector_tag_finder.sectors_and_subsectors).any?
-      part_of += array_of_links_to_sectors(all_sectors)
+    if sector_tag_finder && (tagged_topics = sector_tag_finder.topics).any?
+      links_to_topics = tagged_topics.map do |topic|
+        link_to topic.title, topic.web_url, class: 'sector-link'
+      end
+      part_of += links_to_topics
     end
 
     if policies.any?

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -202,7 +202,7 @@ Please tell us:
     link_to native_language_name_for(locale), locale: locale
   end
 
-  def part_of_metadata(document, policies = [], sector_tag_finder = nil)
+  def part_of_metadata(document, policies = [], sector_tag_finder = SpecialistTagFinder::Null.new)
     part_of = []
 
     if document.respond_to?(:part_of_published_collection?) && document.part_of_published_collection?
@@ -217,12 +217,10 @@ Please tell us:
       part_of += array_of_links_to_topical_events(document.topical_events)
     end
 
-    if sector_tag_finder && (tagged_topics = sector_tag_finder.topics).any?
-      links_to_topics = tagged_topics.map do |topic|
-        link_to topic.title, topic.web_url, class: 'sector-link'
-      end
-      part_of += links_to_topics
+    links_to_topics = sector_tag_finder.topics.map do |topic|
+      link_to topic.title, topic.web_url, class: 'sector-link'
     end
+    part_of += links_to_topics
 
     if policies.any?
       part_of += array_of_links_to_policies(policies)

--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -1,17 +1,10 @@
 module SpecialistSectorHelper
 
-  def add_sector_name(title, sector_tag)
-    if sector_tag
-      "#{link_to(sector_tag.title, sector_tag.web_url)} &ndash; #{title.downcase}".html_safe
+  def add_sector_name(title, grandparent_topic)
+    if grandparent_topic
+      "#{link_to(grandparent_topic.title, grandparent_topic.web_url)} &ndash; #{title.downcase}".html_safe
     else
       title
     end
   end
-
-  def array_of_links_to_sectors(sectors_and_subsectors)
-    sectors_and_subsectors.map { |sector|
-      link_to sector.title, sector.web_url, class: 'sector-link'
-    }
-  end
-
 end

--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -1,8 +1,8 @@
 module SpecialistSectorHelper
 
-  def add_sector_name(title, grandparent_topic)
-    if grandparent_topic
-      "#{link_to(grandparent_topic.title, grandparent_topic.web_url)} &ndash; #{title.downcase}".html_safe
+  def add_sector_name(title, top_level_topic)
+    if top_level_topic
+      "#{link_to(top_level_topic.title, top_level_topic.web_url)} &ndash; #{title.downcase}".html_safe
     else
       title
     end

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -31,20 +31,18 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
     end
   end
 
+  def base_path
+    Whitehall.url_maker.public_document_path(item)
+  end
+
 private
 
   def topic_path_from(tag)
     "/topic/#{tag}"
   end
 
-private
-
   def rendering_app
     item.rendering_app
-  end
-
-  def base_path
-    Whitehall.url_maker.public_document_path(item)
   end
 
   def public_updated_at

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -11,7 +11,7 @@
   render(
     partial: 'shared/heading',
     locals: {
-      type: add_sector_name(header_title, specialist_tag_finder.grandparent_topic),
+      type: add_sector_name(header_title, specialist_tag_finder.top_level_topic),
       heading: document.title,
       extra: true
     }

--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -7,10 +7,16 @@
   policies ||= nil
   specialist_tag_finder = SpecialistTagFinder.new(@document)
 %>
-<%= render partial: 'shared/heading',
-          locals: { type: add_sector_name(header_title, specialist_tag_finder.primary_sector_tag),
-                    heading: document.title,
-                    extra: true } %>
+<%=
+  render(
+    partial: 'shared/heading',
+    locals: {
+      type: add_sector_name(header_title, specialist_tag_finder.grandparent_topic),
+      heading: document.title,
+      extra: true
+    }
+  )
+%>
 
 <%= render('documents/withdrawn_notice', document: document, type: document.format_name) if document.withdrawn? %>
 

--- a/config/initializers/content_store.rb
+++ b/config/initializers/content_store.rb
@@ -1,0 +1,4 @@
+require "gds_api/content_store"
+
+Whitehall.content_store = GdsApi::ContentStore.new(Plek.new.find('content-store'))
+

--- a/features/specialist-sectors.feature
+++ b/features/specialist-sectors.feature
@@ -10,10 +10,7 @@ Feature: Tagging content with specialist sectors
     When I start editing a draft document
     Then I can tag it to some specialist sectors
 
-  @real_content_api
   Scenario: sectors are shown on tagged content
-    Given there are some specialist sectors
-    And there is a document tagged to specialist sectors
+    Given there is a document tagged to specialist sectors
     When I view the document
     Then I should see the specialist sub-sector and its parent sector
-    And I should not see draft specialist sectors

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -28,8 +28,8 @@ Given(/^there is a document tagged to specialist sectors$/) do
   parent_content_item = content_item_for_base_path(parent_base_path).merge!({
     "links" => {
       "parent" => [{
-        "title" => "Grandparent Topic",
-        "web_url" => "http://gov.uk/grandparent-topic"
+        "title" => "Top Level Topic",
+        "web_url" => "http://gov.uk/top-level-topic"
       }]
     }
   })
@@ -40,7 +40,7 @@ end
 
 Then(/^I should see the specialist sub\-sector and its parent sector$/) do
   header = find("article header")
-  assert header.has_content?("Grandparent Topic")
+  assert header.has_content?("Top Level Topic")
   assert header.has_css?('dd', text: "Topic 1 and Topic 2", exact: false)
 end
 

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -13,15 +13,34 @@ Then /^I can tag it to some specialist sectors$/ do
 end
 
 Given(/^there is a document tagged to specialist sectors$/) do
-  @document = create_document_tagged_to_a_specialist_sector
-  stub_content_api_tags(@document)
+  unstub_tag_finder # we're testing topic tags, remove any existing stubs
+
+  @document = create(:published_publication, :guidance)
+  document_base_path = PublishingApiPresenters.presenter_for(@document).base_path
+  parent_base_path = "/parent-topic"
+
+  document_content_item = content_item_for_base_path(document_base_path).merge!({
+    "links" => {
+      "parent" => [{ "base_path" => parent_base_path }],
+      "topics" => [{ "title" => "Topic 1" }, { "title" => "Topic 2"  }]
+    }
+  })
+  parent_content_item = content_item_for_base_path(parent_base_path).merge!({
+    "links" => {
+      "parent" => [{
+        "title" => "Grandparent Topic",
+        "web_url" => "http://gov.uk/grandparent-topic"
+      }]
+    }
+  })
+
+  content_store_has_item(document_base_path, document_content_item)
+  content_store_has_item(parent_base_path, parent_content_item)
 end
 
 Then(/^I should see the specialist sub\-sector and its parent sector$/) do
-  check_for_primary_sector_in_heading
-  check_for_sectors_and_subsectors_in_metadata
+  header = find("article header")
+  assert header.has_content?("Grandparent Topic")
+  assert header.has_css?('dd', text: "Topic 1 and Topic 2", exact: false)
 end
 
-Then(/^I should not see draft specialist sectors$/) do
-  check_for_absence_of_draft_sectors_and_subsectors_in_metadata
-end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -57,13 +57,6 @@ module SpecialistSectorHelper
   def save_document
     click_button 'Save'
   end
-
-  def create_document_tagged_to_a_specialist_sector
-    create(:published_publication, :guidance,
-            primary_specialist_sector_tag: 'oil-and-gas/wells',
-            secondary_specialist_sector_tags: ['oil-and-gas/offshore', 'oil-and-gas/fields']
-    )
-  end
 end
 
 World(SpecialistSectorHelper)

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -1,14 +1,20 @@
 require 'gds_api/test_helpers/content_api'
+require "gds_api/test_helpers/content_store"
 
 Before do
   # Assume documents rendered in these features have no topic tags.
-  # Stub can be overriden in individual features if required.
+  # Stub can be removed in individual features if required.
   SpecialistTagFinder.any_instance.stubs(:grandparent_topic).returns(nil)
   SpecialistTagFinder.any_instance.stubs(:topics).returns([])
 end
 
 module SpecialistSectorHelper
   include GdsApi::TestHelpers::ContentApi
+  include GdsApi::TestHelpers::ContentStore
+
+  def unstub_tag_finder
+    SpecialistTagFinder.any_instance.unstub(:grandparent_topic, :topics)
+  end
 
   def stub_specialist_sectors
     oil_and_gas = { slug: 'oil-and-gas', title: 'Oil and Gas' }
@@ -57,20 +63,6 @@ module SpecialistSectorHelper
             primary_specialist_sector_tag: 'oil-and-gas/wells',
             secondary_specialist_sector_tags: ['oil-and-gas/offshore', 'oil-and-gas/fields']
     )
-  end
-
-  def check_for_primary_sector_in_heading
-    assert find("article header").has_content?("Oil and gas")
-  end
-
-  def check_for_sectors_and_subsectors_in_metadata
-    ['Oil and gas', 'Wells', 'Offshore', 'Fields'].each do |sector_name|
-      assert has_css?('dd', text: sector_name, exact: false)
-    end
-  end
-
-  def check_for_absence_of_draft_sectors_and_subsectors_in_metadata
-    assert has_no_css?('dd', text: 'Distillation', exact: false)
   end
 end
 

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -1,5 +1,12 @@
 require 'gds_api/test_helpers/content_api'
 
+Before do
+  # Assume documents rendered in these features have no topic tags.
+  # Stub can be overriden in individual features if required.
+  SpecialistTagFinder.any_instance.stubs(:grandparent_topic).returns(nil)
+  SpecialistTagFinder.any_instance.stubs(:topics).returns([])
+end
+
 module SpecialistSectorHelper
   include GdsApi::TestHelpers::ContentApi
 

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -4,8 +4,7 @@ require "gds_api/test_helpers/content_store"
 Before do
   # Assume documents rendered in these features have no topic tags.
   # Stub can be removed in individual features if required.
-  SpecialistTagFinder.any_instance.stubs(:grandparent_topic).returns(nil)
-  SpecialistTagFinder.any_instance.stubs(:topics).returns([])
+  SpecialistTagFinder.stubs(:new).returns(SpecialistTagFinder::Null.new)
 end
 
 module SpecialistSectorHelper
@@ -13,7 +12,7 @@ module SpecialistSectorHelper
   include GdsApi::TestHelpers::ContentStore
 
   def unstub_tag_finder
-    SpecialistTagFinder.any_instance.unstub(:grandparent_topic, :topics)
+    SpecialistTagFinder.unstub(:new)
   end
 
   def stub_specialist_sectors

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -1,7 +1,7 @@
 class SpecialistTagFinder
 
-  def initialize(document)
-    @document = document
+  def initialize(edition)
+    @edition = edition
   end
 
   def primary_sector_tag
@@ -9,7 +9,7 @@ class SpecialistTagFinder
   end
 
   def primary_subsector_tag
-    if primary_tag_slug = @document.primary_specialist_sector_tag
+    if primary_tag_slug = @edition.primary_specialist_sector_tag
       specialist_sector_tags.find {|t| t.slug == primary_tag_slug }
     end
   end
@@ -21,7 +21,7 @@ class SpecialistTagFinder
 private
 
   def artefact
-    @artefact ||= Whitehall.content_api.artefact(RegisterableEdition.new(@document).slug)
+    @artefact ||= Whitehall.content_api.artefact(RegisterableEdition.new(@edition).slug)
   end
 
   def specialist_sector_tags

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -4,6 +4,14 @@ class SpecialistTagFinder
     @edition = edition
   end
 
+  def topics
+    presented_edition = PublishingApiPresenters::Edition.new(@edition)
+    edition_path = presented_edition.base_path
+    content_item = Whitehall.content_store.content_item(edition_path)
+    return [] unless content_item
+    Array(content_item.links["topics"])
+  end
+
   def primary_sector_tag
     primary_subsector_tag.parent if primary_subsector_tag
   end
@@ -28,5 +36,4 @@ private
     return [] if artefact.nil?
     artefact.tags.select {|t| t.details['type'] == 'specialist_sector' }
   end
-
 end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -34,7 +34,7 @@ class SpecialistTagFinder
   end
 
   def primary_subsector_tag
-    if primary_tag_slug = @edition.primary_specialist_sector_tag
+    if (primary_tag_slug = @edition.primary_specialist_sector_tag)
       specialist_sector_tags.find {|t| t.slug == primary_tag_slug }
     end
   end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -12,6 +12,23 @@ class SpecialistTagFinder
     Array(content_item.links["topics"])
   end
 
+  def grandparent_topic
+    presented_edition = PublishingApiPresenters::Edition.new(@edition)
+    edition_path = presented_edition.base_path
+    edition_content_item = Whitehall.content_store.content_item(edition_path)
+    return unless edition_content_item
+    parents = Array(edition_content_item.links["parent"])
+    return unless parents.any?
+
+    # FIXME: We now need to fetch the parent topic from the content store to
+    # retrieve its parent. We should replace this implementation with the
+    # publishing API's links expansion / dependency resolution, which is
+    # currently WIP.
+    parent_path = parents.first["base_path"]
+    parent_content_item = Whitehall.content_store.content_item(parent_path)
+    Array(parent_content_item.links["parent"]).first
+  end
+
   def primary_sector_tag
     primary_subsector_tag.parent if primary_subsector_tag
   end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -8,6 +8,7 @@ class SpecialistTagFinder
     presented_edition = PublishingApiPresenters::Edition.new(@edition)
     edition_path = presented_edition.base_path
     content_item = Whitehall.content_store.content_item(edition_path)
+
     return [] unless content_item
     Array(content_item.links["topics"])
   end
@@ -16,6 +17,7 @@ class SpecialistTagFinder
     presented_edition = PublishingApiPresenters::Edition.new(@edition)
     edition_path = presented_edition.base_path
     edition_content_item = Whitehall.content_store.content_item(edition_path)
+
     return unless edition_content_item
     parents = Array(edition_content_item.links["parent"])
     return unless parents.any?

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -26,12 +26,17 @@ class SpecialistTagFinder
       end
   end
 
-  def grandparent_topic
-    @grandparent_topic ||=
-      begin
-        presented_edition = PublishingApiPresenters::Edition.new(@edition)
-        edition_path = presented_edition.base_path
-        edition_content_item = Whitehall.content_store.content_item(edition_path)
+  def top_level_topic
+    # Topics in GOVUK (called 'Specialist Sectors' in  Whitehall admin and
+    # throughout this codebase) exist in a 2-level hierarchy.  Editions may be
+    # tagged with a parent - this is always one of the 2nd level topics.  The
+    # top level topic (i.e. - the parent of the edition's parent) is required
+    # in the frontend when rendering an Edition's breadcrumb.
+
+    @top_level_topic ||= begin
+      presented_edition = PublishingApiPresenters::Edition.new(@edition)
+      edition_path = presented_edition.base_path
+      edition_content_item = Whitehall.content_store.content_item(edition_path)
 
         return unless edition_content_item
         parents = Array(edition_content_item.links["parent"])

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -15,15 +15,10 @@ class SpecialistTagFinder
   end
 
   def topics
-    @topics ||=
-      begin
-        presented_edition = PublishingApiPresenters::Edition.new(@edition)
-        edition_path = presented_edition.base_path
-        content_item = Whitehall.content_store.content_item(edition_path)
-
-        return [] unless content_item
-        Array(content_item.links["topics"])
-      end
+    @topics ||= begin
+      return [] unless edition_content_item
+      Array(edition_content_item.links["topics"])
+    end
   end
 
   def top_level_topic
@@ -34,21 +29,27 @@ class SpecialistTagFinder
     # in the frontend when rendering an Edition's breadcrumb.
 
     @top_level_topic ||= begin
+      return unless edition_content_item
+      parents = Array(edition_content_item.links["parent"])
+      return unless parents.any?
+
+      # FIXME: We now need to fetch the parent topic from the content store to
+      # retrieve its parent. We should replace this implementation with the
+      # publishing API's links expansion / dependency resolution, which is
+      # currently WIP.
+      parent_path = parents.first["base_path"]
+      parent_content_item = Whitehall.content_store.content_item(parent_path)
+      Array(parent_content_item.links["parent"]).first
+    end
+  end
+
+private
+
+  def edition_content_item
+    @edition_content_item ||= begin
       presented_edition = PublishingApiPresenters::Edition.new(@edition)
       edition_path = presented_edition.base_path
-      edition_content_item = Whitehall.content_store.content_item(edition_path)
-
-        return unless edition_content_item
-        parents = Array(edition_content_item.links["parent"])
-        return unless parents.any?
-
-        # FIXME: We now need to fetch the parent topic from the content store to
-        # retrieve its parent. We should replace this implementation with the
-        # publishing API's links expansion / dependency resolution, which is
-        # currently WIP.
-        parent_path = parents.first["base_path"]
-        parent_content_item = Whitehall.content_store.content_item(parent_path)
-        Array(parent_content_item.links["parent"]).first
-      end
+      Whitehall.content_store.content_item(edition_path)
+    end
   end
 end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -1,5 +1,15 @@
 class SpecialistTagFinder
 
+  class Null
+    def topics
+      []
+    end
+
+    def top_level_topic
+      nil
+    end
+  end
+
   def initialize(edition)
     @edition = edition
   end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -5,29 +5,35 @@ class SpecialistTagFinder
   end
 
   def topics
-    presented_edition = PublishingApiPresenters::Edition.new(@edition)
-    edition_path = presented_edition.base_path
-    content_item = Whitehall.content_store.content_item(edition_path)
+    @topics ||=
+      begin
+        presented_edition = PublishingApiPresenters::Edition.new(@edition)
+        edition_path = presented_edition.base_path
+        content_item = Whitehall.content_store.content_item(edition_path)
 
-    return [] unless content_item
-    Array(content_item.links["topics"])
+        return [] unless content_item
+        Array(content_item.links["topics"])
+      end
   end
 
   def grandparent_topic
-    presented_edition = PublishingApiPresenters::Edition.new(@edition)
-    edition_path = presented_edition.base_path
-    edition_content_item = Whitehall.content_store.content_item(edition_path)
+    @grandparent_topic ||=
+      begin
+        presented_edition = PublishingApiPresenters::Edition.new(@edition)
+        edition_path = presented_edition.base_path
+        edition_content_item = Whitehall.content_store.content_item(edition_path)
 
-    return unless edition_content_item
-    parents = Array(edition_content_item.links["parent"])
-    return unless parents.any?
+        return unless edition_content_item
+        parents = Array(edition_content_item.links["parent"])
+        return unless parents.any?
 
-    # FIXME: We now need to fetch the parent topic from the content store to
-    # retrieve its parent. We should replace this implementation with the
-    # publishing API's links expansion / dependency resolution, which is
-    # currently WIP.
-    parent_path = parents.first["base_path"]
-    parent_content_item = Whitehall.content_store.content_item(parent_path)
-    Array(parent_content_item.links["parent"]).first
+        # FIXME: We now need to fetch the parent topic from the content store to
+        # retrieve its parent. We should replace this implementation with the
+        # publishing API's links expansion / dependency resolution, which is
+        # currently WIP.
+        parent_path = parents.first["base_path"]
+        parent_content_item = Whitehall.content_store.content_item(parent_path)
+        Array(parent_content_item.links["parent"]).first
+      end
   end
 end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -28,29 +28,4 @@ class SpecialistTagFinder
     parent_content_item = Whitehall.content_store.content_item(parent_path)
     Array(parent_content_item.links["parent"]).first
   end
-
-  def primary_sector_tag
-    primary_subsector_tag.parent if primary_subsector_tag
-  end
-
-  def primary_subsector_tag
-    if (primary_tag_slug = @edition.primary_specialist_sector_tag)
-      specialist_sector_tags.find {|t| t.slug == primary_tag_slug }
-    end
-  end
-
-  def sectors_and_subsectors
-    specialist_sector_tags.map { |t| [t, t.parent] }.flatten.compact.uniq
-  end
-
-private
-
-  def artefact
-    @artefact ||= Whitehall.content_api.artefact(RegisterableEdition.new(@edition).slug)
-  end
-
-  def specialist_sector_tags
-    return [] if artefact.nil?
-    artefact.tags.select {|t| t.details['type'] == 'specialist_sector' }
-  end
 end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -9,6 +9,7 @@ module Whitehall
   autoload :GovspeakRenderer, 'whitehall/govspeak_renderer'
 
   mattr_accessor :content_api
+  mattr_accessor :content_store
   mattr_accessor :default_cache_max_age
   mattr_accessor :document_collections_cache_max_age
   mattr_accessor :government_search_client

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -8,21 +8,20 @@ module Whitehall
   autoload :GovUkDelivery, 'whitehall/gov_uk_delivery'
   autoload :GovspeakRenderer, 'whitehall/govspeak_renderer'
 
-  mattr_accessor :search_backend
-  mattr_accessor :government_search_client
-  mattr_accessor :statistics_announcement_search_client
   mattr_accessor :content_api
+  mattr_accessor :default_cache_max_age
+  mattr_accessor :document_collections_cache_max_age
+  mattr_accessor :government_search_client
+  mattr_accessor :govuk_delivery_client
+  mattr_accessor :maslow
+  mattr_accessor :need_api
   mattr_accessor :publishing_api_client
   mattr_accessor :publishing_api_v2_client
+  mattr_accessor :search_backend
   mattr_accessor :skip_safe_html_validation
-  mattr_accessor :govuk_delivery_client
-  mattr_accessor :need_api
-  mattr_accessor :maslow
-  mattr_accessor :default_cache_max_age
-  mattr_accessor :uploads_cache_max_age
-  mattr_accessor :document_collections_cache_max_age
-
+  mattr_accessor :statistics_announcement_search_client
   mattr_accessor :unified_search_client
+  mattr_accessor :uploads_cache_max_age
 
   revision_file = "#{Rails.root}/REVISION"
   if File.exists?(revision_file)

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -145,6 +145,7 @@ FactoryGirl.define do
     end
   end
 
+  factory :edition_with_document, parent: :edition, traits: [:with_document]
   factory :imported_edition, parent: :edition, traits: [:imported]
   factory :draft_edition, parent: :edition, traits: [:draft]
   factory :submitted_edition, parent: :edition, traits: [:submitted]

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -14,22 +14,4 @@ class DetailedGuideIntegrationTest < ActionDispatch::IntegrationTest
 
     assert response.body.include? "<meta name=\"description\" content=\"This is a published detailed guide summary\" />"
   end
-
-  test "the page header is rendered with correct topic tags" do
-    detailed_guide = create(:published_detailed_guide)
-    detailed_guide_base_path = PublishingApiPresenters.presenter_for(detailed_guide).base_path
-    parent_base_path = "/parent-item"
-    detailed_guide_content_item = content_item_for_base_path(detailed_guide_base_path).merge!({
-      "links" => { "parent" => [{ "base_path" => parent_base_path }] }
-    })
-    parent_content_item = content_item_for_base_path(parent_base_path).merge!({
-      "links" => { "parent" => [{ "title" => "Grandpa", "web_url" => "http://grandpa.com" }] }
-    })
-    content_store_has_item(detailed_guide_base_path, detailed_guide_content_item)
-    content_store_has_item(parent_base_path, parent_content_item)
-
-    get detailed_guide_path(detailed_guide.slug)
-
-    assert response.body.include? '<p class="type"><a href="http://grandpa.com">Grandpa</a> &ndash; guidance</p>'
-  end
 end

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -7,7 +7,7 @@ class DetailedGuideIntegrationTest < ActionDispatch::IntegrationTest
   test "meta data tag is present" do
     detailed_guide = create(:published_detailed_guide, summary: "This is a published detailed guide summary")
     stubbed_topics_finder = SpecialistTagFinder.new(detailed_guide)
-    stubbed_topics_finder.stubs(grandparent_topic: nil, topics: [])
+    stubbed_topics_finder.stubs(top_level_topic: nil, topics: [])
     SpecialistTagFinder.stubs(:new).returns(stubbed_topics_finder)
 
     get detailed_guide_path(detailed_guide.slug)

--- a/test/integration/detailed_guide_test.rb
+++ b/test/integration/detailed_guide_test.rb
@@ -1,11 +1,35 @@
 require 'test_helper'
+require "gds_api/test_helpers/content_store"
 
 class DetailedGuideIntegrationTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::ContentStore
+
   test "meta data tag is present" do
     detailed_guide = create(:published_detailed_guide, summary: "This is a published detailed guide summary")
+    stubbed_topics_finder = SpecialistTagFinder.new(detailed_guide)
+    stubbed_topics_finder.stubs(grandparent_topic: nil, topics: [])
+    SpecialistTagFinder.stubs(:new).returns(stubbed_topics_finder)
 
     get detailed_guide_path(detailed_guide.slug)
 
     assert response.body.include? "<meta name=\"description\" content=\"This is a published detailed guide summary\" />"
+  end
+
+  test "the page header is rendered with correct topic tags" do
+    detailed_guide = create(:published_detailed_guide)
+    detailed_guide_base_path = PublishingApiPresenters.presenter_for(detailed_guide).base_path
+    parent_base_path = "/parent-item"
+    detailed_guide_content_item = content_item_for_base_path(detailed_guide_base_path).merge!({
+      "links" => { "parent" => [{ "base_path" => parent_base_path }] }
+    })
+    parent_content_item = content_item_for_base_path(parent_base_path).merge!({
+      "links" => { "parent" => [{ "title" => "Grandpa", "web_url" => "http://grandpa.com" }] }
+    })
+    content_store_has_item(detailed_guide_base_path, detailed_guide_content_item)
+    content_store_has_item(parent_base_path, parent_content_item)
+
+    get detailed_guide_path(detailed_guide.slug)
+
+    assert response.body.include? '<p class="type"><a href="http://grandpa.com">Grandpa</a> &ndash; guidance</p>'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -180,6 +180,11 @@ class ActionController::TestCase
 
   setup do
     request.env['warden'] = stub(authenticate!: false, authenticated?: false, user: nil)
+
+    # In controller tests, assume by default that the resource being rendered
+    # does not have any topic tags.
+    SpecialistTagFinder.any_instance.stubs(:grandparent_topic).returns(nil)
+    SpecialistTagFinder.any_instance.stubs(:topics).returns([])
   end
 
   def login_as(role_or_user)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -183,8 +183,7 @@ class ActionController::TestCase
 
     # In controller tests, assume by default that the resource being rendered
     # does not have any topic tags.
-    SpecialistTagFinder.any_instance.stubs(:grandparent_topic).returns(nil)
-    SpecialistTagFinder.any_instance.stubs(:topics).returns([])
+    SpecialistTagFinder.stubs(:new).returns(SpecialistTagFinder::Null.new)
   end
 
   def login_as(role_or_user)

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class SpecialistTagFinderTest < ActiveSupport::TestCase
   setup do
-    @document = stub
-    @tag_finder = SpecialistTagFinder.new(@document)
+    @edition = stub
+    @tag_finder = SpecialistTagFinder.new(@edition)
 
     @parent_tag = stub(details: {'type' => 'specialist_sector'}, slug: 'super')
     @primary_tag = stub(details: {'type' => 'specialist_sector'},
@@ -35,13 +35,13 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
   end
 
   test "#primary_subsector_tag returns the specialist sector tag whose slug matches the primary" do
-    @document.stubs(primary_specialist_sector_tag: 'super/primary')
+    @edition.stubs(primary_specialist_sector_tag: 'super/primary')
 
     assert_equal @primary_tag, @tag_finder.primary_subsector_tag
   end
 
   test "#primary_subsector_tag returns nil if no primary specialist sector tag" do
-    @document.stubs(primary_specialist_sector_tag: nil)
+    @edition.stubs(primary_specialist_sector_tag: nil)
 
     assert_equal nil, @tag_finder.primary_subsector_tag
   end

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -41,6 +41,24 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     assert_equal ["topic-1", "topic-2"], SpecialistTagFinder.new(edition).topics.map { |topic| topic["title"] }
   end
 
+  test "#grandparent_topic returns the parent of the edition's parent topic" do
+    edition = create(:edition_with_document)
+    edition_base_path = PublishingApiPresenters::Edition.new(edition).base_path
+    parent_base_path = "/parent-item"
+    edition_content_item = content_item_for_base_path(edition_base_path).merge!({
+      "links" => { "parent" => [{ "base_path" => parent_base_path }] }
+    })
+    parent_content_item = content_item_for_base_path(parent_base_path).merge!({
+      "links" => { "parent" => [{ "base_path" => "/grandpa" }] }
+    })
+
+    content_store_has_item(edition_base_path, edition_content_item)
+    content_store_has_item(parent_base_path, parent_content_item)
+
+
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition).grandparent_topic.base_path
+  end
+
   test "#primary_sector_tag returns the primary subsector tag's parent" do
     subsector_tag = mock(parent: 'parent_tag')
     @tag_finder.stubs(primary_subsector_tag: subsector_tag)

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -4,26 +4,6 @@ require "gds_api/test_helpers/content_store"
 class SpecialistTagFinderTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
 
-  setup do
-    @edition = stub
-    @tag_finder = SpecialistTagFinder.new(@edition)
-
-    @parent_tag = stub(details: {'type' => 'specialist_sector'}, slug: 'super')
-    @primary_tag = stub(details: {'type' => 'specialist_sector'},
-                        slug: 'super/primary', parent: @parent_tag)
-    @secondary_tag = stub(details: {'type' => 'specialist_sector'},
-                          slug: 'super/secondary', parent: @parent_tag)
-    @irrelevant_tag = stub(details: {'type' => 'something_else'})
-
-    @artefact = stub(tags: [
-      @primary_tag,
-      @secondary_tag,
-      @irrelevant_tag
-    ])
-
-    @tag_finder.stubs(artefact: @artefact)
-  end
-
   test "#topics returns all linked topics" do
     edition = create(:edition_with_document)
     edition_base_path = PublishingApiPresenters::Edition.new(edition).base_path
@@ -57,35 +37,5 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
 
 
     assert_equal "/grandpa", SpecialistTagFinder.new(edition).grandparent_topic.base_path
-  end
-
-  test "#primary_sector_tag returns the primary subsector tag's parent" do
-    subsector_tag = mock(parent: 'parent_tag')
-    @tag_finder.stubs(primary_subsector_tag: subsector_tag)
-
-    assert_equal 'parent_tag', @tag_finder.primary_sector_tag
-  end
-
-  test "#primary_sector_tag returns nil if no primary subsector tag" do
-    @tag_finder.stubs(primary_subsector_tag: nil)
-
-    assert_equal nil, @tag_finder.primary_sector_tag
-  end
-
-  test "#primary_subsector_tag returns the specialist sector tag whose slug matches the primary" do
-    @edition.stubs(primary_specialist_sector_tag: 'super/primary')
-
-    assert_equal @primary_tag, @tag_finder.primary_subsector_tag
-  end
-
-  test "#primary_subsector_tag returns nil if no primary specialist sector tag" do
-    @edition.stubs(primary_specialist_sector_tag: nil)
-
-    assert_equal nil, @tag_finder.primary_subsector_tag
-  end
-
-  test "#sectors_and_subsectors returns all relevant tags and parent tags" do
-    assert_equal [@parent_tag, @primary_tag, @secondary_tag].to_set,
-                 @tag_finder.sectors_and_subsectors.to_set
   end
 end

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -21,7 +21,7 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     assert_equal ["topic-1", "topic-2"], SpecialistTagFinder.new(edition).topics.map { |topic| topic["title"] }
   end
 
-  test "#grandparent_topic returns the parent of the edition's parent topic" do
+  test "#top_level_topic returns the parent of the edition's parent topic" do
     edition = create(:edition_with_document)
     edition_base_path = PublishingApiPresenters::Edition.new(edition).base_path
     parent_base_path = "/parent-item"
@@ -36,6 +36,6 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     content_store_has_item(parent_base_path, parent_content_item)
 
 
-    assert_equal "/grandpa", SpecialistTagFinder.new(edition).grandparent_topic.base_path
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition).top_level_topic.base_path
   end
 end


### PR DESCRIPTION
Use content store instead of content API. Core logic that needs reworking is in SpecialistTagFinder.

This is intended to lead up to work to remove specialist_sector related DB fields in the Whitehall DB, and to migrate the source of truth for all documents to being the publishing API.

https://trello.com/c/f6coMIbz