### PR TITLE
Allow for missing primary specialist sectors

### DIFF
--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -25,7 +25,13 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
 
     if parent_tag
       parent_content_id = content_id_lookup[topic_path_from(parent_tag)]
-      { topics: content_id_lookup.values, parent: [parent_content_id] }
+
+      if parent_content_id.nil?
+        Rails.logger.info "#{item.content_id} has non-existing primary_specialist_sector_tag: #{parent_tag}"
+        { topics: content_id_lookup.values }
+      else
+        { topics: content_id_lookup.values, parent: [parent_content_id] }
+      end
     else
       { topics: content_id_lookup.values }
     end

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -228,4 +228,17 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     assert_equal({ topics: %w(content_id_1 content_id_2), parent: %w(content_id_1) }, links)
   end
+
+  test '#links.parent will not be set if the specialist sector is not found' do
+    edition = create(:edition)
+    create(:specialist_sector, tag: "oil-and-gas/primary", edition: edition, primary: true)
+    create(:specialist_sector, tag: "oil-and-gas/secondary", edition: edition, primary: false)
+    publishing_api_has_lookups({
+      "/topic/oil-and-gas/secondary" => "content_id_1",
+    })
+
+    links = present(edition).links
+
+    assert_equal({ topics: %w(content_id_1) }, links)
+  end
 end


### PR DESCRIPTION
We've run into cases where the whitehall database refers to non-existing primary specialist sectors. This causes our PATCH links call to publishing-api to fail.

We've considered fixing this data in the database, but decided against it because the data in the database will be removed soon. Updating the records in the database now would require manual intervention and could have unforeseen side-effects.