### PR TITLE
Remove inconsistent data

### DIFF
--- a/db/data_migration/20160419091436_remove_inconsistent_editions.rb
+++ b/db/data_migration/20160419091436_remove_inconsistent_editions.rb
@@ -1,0 +1,5 @@
+# Remove editions that do not have an associated documents.
+# This is not enforced in the database via a foreign key.
+# Edition.where("not exists (select 1 from documents where documents.id = document_id)")
+
+CorporateInformationPage.delete(336520)


### PR DESCRIPTION
While migrating links data, we noticed an edition that belongs
to a document that no longer exists.

```
irb(main):001:0> Edition.where("not exists (select 1 from documents where documents.id = document_id)")
  Edition Load (1524.2ms)  SELECT `editions`.* FROM `editions` WHERE (`editions`.`state` != 'deleted') AND (not exists (select 1 from documents where documents.id = document_id))
=> #<ActiveRecord::Relation [#<CorporateInformationPage id: 336520, created_at: "2014-05-21 14:31:33", updated_at: "2014-02-13 15:46:53", lock_version: 0, document_id: 237265, state: "published", type: "CorporateInformationPage", role_appointment_id: nil, location: nil, delivered_on: nil, major_change_published_at: "2014-02-13 15:46:53", first_published_at: nil, speech_type_id: nil, stub: false, change_note: nil, force_published: nil, minor_change: false, publication_type_id: nil, related_mainstream_content_url: nil, related_mainstream_content_title: nil, additional_related_mainstream_content_url: nil, additional_related_mainstream_content_title: nil, alternative_format_provider_id: nil, public_timestamp: nil, scheduled_publication: nil, replaces_businesslink: false, access_limited: false, published_major_version: nil, published_minor_version: nil, operational_field_id: nil, roll_call_introduction: nil, news_article_type_id: nil, relevant_to_local_government: false, person_override: nil, external: false, external_url: nil, opening_at: nil, closing_at: nil, corporate_information_page_type_id: 20, need_ids: [], primary_locale: "en", political: false, logo_url: nil>]>
```

This is a corporate information page with an "about" slug.

We're not addressing the root cause in this PR (not using foreign keys for our associations)
but this migration will ensure all editions are consistent.

I discussed this with @tijmenb and we are planning to follow this up by investigating adding missing foreign keys.