### PR TITLE
Data migration to remove an org created in error

### DIFF
--- a/db/data_migration/20160420084323_remove_appointed_person_for_england_and_wales_organisation.rb
+++ b/db/data_migration/20160420084323_remove_appointed_person_for_england_and_wales_organisation.rb
@@ -1,0 +1,21 @@
+organisation = Organisation.find_by(slug: 'appointed-person-for-england-and-wales-under-the-proceeds-of-crime-act-2002')
+if organisation.present?
+  # This association does have a dependent destroy, but if there are documents
+  # we probably need to do some more 410/404 stuff
+  raise "Can't remove #{organisation.name} - it has editions" if organisation.editions.count > 0
+
+  # This association doesn't have a dependent option, but isn't simple enough
+  # to just destroy them all so we halt execution
+  raise "Can't remove #{organisation.name} - it has groups" if organisation.groups.count > 0
+
+  # These associations don't have a dependent option, but are simple enough
+  # that we can just destroy_all them and continue
+  organisation.organisation_roles.destroy_all
+  organisation.financial_reports.destroy_all
+  organisation.offsite_links.destroy_all
+  organisation.featured_policies.destroy_all
+  organisation.promotional_features.destroy_all
+
+  Whitehall::SearchIndex.delete(organisation)
+  organisation.destroy
+end


### PR DESCRIPTION
This org was created in error and we are removing it.  The traffic is very low so we're not issuing a 410, just removing it (it should never have existed so a 404 is really what we want).

This is PR 1 of 5 for removing this org.

For more detail: https://trello.com/c/jbImjyLP/359-delete-an-org-page-5

