### PR TITLE
Send `organisations` in the links hash

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -6,6 +6,7 @@ class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
     extract_links([
       :document_collections,
       :lead_organisations,
+      :organisations,
       :related_policies,
       :supporting_organisations,
       :topics,

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -16,6 +16,12 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
   end
 
   def links
+    extract_links([:organisations]).merge(topic_and_parent_links_payload)
+  end
+
+private
+
+  def topic_and_parent_links_payload
     topic_tags = item.specialist_sector_tags
     return {} unless topic_tags.present?
 
@@ -37,13 +43,9 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
     end
   end
 
-private
-
   def topic_path_from(tag)
     "/topic/#{tag}"
   end
-
-private
 
   def rendering_app
     item.rendering_app

--- a/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
+++ b/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
@@ -1,7 +1,7 @@
 # Note that "Policy Area" is the new name for "Topic".
 class PublishingApiPresenters::PolicyAreaPlaceholder < PublishingApiPresenters::Placeholder
   def links
-    extract_links([:topics])
+    extract_links([:topics, :organisations])
   end
 
   private

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -1,3 +1,4 @@
+# Presents a `PolicyGroup` model.
 class PublishingApiPresenters::WorkingGroup < PublishingApiPresenters::Item
   def links
     {}


### PR DESCRIPTION
This makes Whitehall send the `organisations` of the items in the links hash. It does so for case studies, editions (almost everything) and policy areas.

This is needed to make the publishing-api an accurate source of links.

cc @MatMoore @mobaig