### PR TITLE
Worker request tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 30.0.0'
+  gem 'gds-api-adapters', '~> 30.2.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (30.0.0)
+    gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -467,7 +467,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 30.0.0)
+  gds-api-adapters (~> 30.2.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.5.2)
@@ -537,4 +537,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -1,6 +1,6 @@
 class DocumentListExportWorker < WorkerBase
 
-  def perform(filter_options, user_id)
+  def call(filter_options, user_id)
     user = User.find(user_id)
     filter = create_filter(filter_options, user)
     csv = generate_csv(filter)

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -1,5 +1,4 @@
 class DocumentListExportWorker < WorkerBase
-
   def call(filter_options, user_id)
     user = User.find(user_id)
     filter = create_filter(filter_options, user)

--- a/app/workers/govspeak_content_worker.rb
+++ b/app/workers/govspeak_content_worker.rb
@@ -1,5 +1,5 @@
 class GovspeakContentWorker < WorkerBase
-  def perform(id)
+  def call(id)
     return unless govspeak_content = GovspeakContent.find_by(id: id)
     govspeak_content.render_govspeak!
   end

--- a/app/workers/links_report_worker.rb
+++ b/app/workers/links_report_worker.rb
@@ -1,5 +1,4 @@
 class LinksReportWorker < WorkerBase
-
   def call(id)
     links_report = LinksReport.find(id)
     link_checker = LinksChecker.new(links_report.links)

--- a/app/workers/links_report_worker.rb
+++ b/app/workers/links_report_worker.rb
@@ -1,6 +1,6 @@
 class LinksReportWorker < WorkerBase
 
-  def perform(id)
+  def call(id)
     links_report = LinksReport.find(id)
     link_checker = LinksChecker.new(links_report.links)
     link_checker.run

--- a/app/workers/panopticon_register_artefact_worker.rb
+++ b/app/workers/panopticon_register_artefact_worker.rb
@@ -4,7 +4,7 @@ require 'gds_api/panopticon'
 class PanopticonRegisterArtefactWorker < WorkerBase
   sidekiq_options queue: :panopticon
 
-  def perform(edition_id, options = {})
+  def call(edition_id)
     edition = Edition.find(edition_id)
 
     if edition.present?

--- a/app/workers/publishing_api_coming_soon_worker.rb
+++ b/app/workers/publishing_api_coming_soon_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiComingSoonWorker < PublishingApiWorker
-  def perform(edition_id, locale)
+  def call(edition_id, locale)
     edition = Edition.find(edition_id)
 
     I18n.with_locale(locale) do

--- a/app/workers/publishing_api_discard_draft_worker.rb
+++ b/app/workers/publishing_api_discard_draft_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiDiscardDraftWorker < PublishingApiWorker
-  def perform(content_id, locale)
+  def call(content_id, locale)
     Whitehall.publishing_api_v2_client.discard_draft(content_id, locale: locale)
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as the draft has already been deleted

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -12,7 +12,7 @@
 # and sending it again after republishing. This also changes the version
 # numbering and would probably appear in the version history.
 class PublishingApiDocumentRepublishingWorker < WorkerBase
-  def perform(published_edition_id, pre_publication_edition_id)
+  def call(published_edition_id, pre_publication_edition_id)
     if published_edition_id
       published_edition = Edition.find(published_edition_id)
       Whitehall::PublishingApi.locales_for(published_edition).each do |locale|

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(base_path, options = {})
+  def call(base_path, options = {})
     draft = options.fetch("draft", false)
     gone_item = PublishingApiPresenters::Gone.new(base_path)
     draft ? save_draft(gone_item) : send_item(gone_item, 'en')

--- a/app/workers/publishing_api_links_worker.rb
+++ b/app/workers/publishing_api_links_worker.rb
@@ -2,7 +2,7 @@
 class PublishingApiLinksWorker < WorkerBase
   sidekiq_options queue: "bulk_republishing"
 
-  def perform(edition_id)
+  def call(edition_id)
     item = Edition.find(edition_id)
     content_id = item.content_id
     links = PublishingApiPresenters.presenter_for(item).links

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
-  def perform(base_path, redirects, locale, options = {})
+  def call(base_path, redirects, locale, options = {})
     draft = options.fetch("draft", false)
     redirect = PublishingApiPresenters::Redirect.new(base_path, redirects)
     draft ? save_draft(redirect) : send_item(redirect, locale)

--- a/app/workers/publishing_api_schedule_worker.rb
+++ b/app/workers/publishing_api_schedule_worker.rb
@@ -1,7 +1,7 @@
 class PublishingApiScheduleWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
-  def perform(base_path, publish_timestamp)
+  def call(base_path, publish_timestamp)
     publish_intent = PublishingApiPresenters::PublishIntent.new(base_path, publish_timestamp)
 
     Whitehall.publishing_api_client.put_intent(base_path, publish_intent.as_json)

--- a/app/workers/publishing_api_unschedule_worker.rb
+++ b/app/workers/publishing_api_unschedule_worker.rb
@@ -1,7 +1,7 @@
 class PublishingApiUnscheduleWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
-  def perform(base_path)
+  def call(base_path)
     Whitehall.publishing_api_client.destroy_intent(base_path)
   end
 end

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -1,7 +1,7 @@
 class PublishingApiWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
-  def perform(model_name, id, update_type = nil, locale=I18n.default_locale.to_s)
+  def call(model_name, id, update_type = nil, locale = I18n.default_locale.to_s)
     model = class_for(model_name).unscoped.find_by(id: id)
     return if model.nil?
 

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -28,7 +28,7 @@ class ScheduledPublishingWorker < WorkerBase
     queued_jobs.map { |job| job['args'][0] }
   end
 
-  def perform(edition_id)
+  def call(edition_id)
     edition = Edition.find(edition_id)
     return if edition.published?
 

--- a/app/workers/search_index_add_worker.rb
+++ b/app/workers/search_index_add_worker.rb
@@ -1,5 +1,4 @@
 class SearchIndexAddWorker < WorkerBase
-
   attr_reader :id, :class_name
 
   def call(class_name, id)

--- a/app/workers/search_index_add_worker.rb
+++ b/app/workers/search_index_add_worker.rb
@@ -2,7 +2,7 @@ class SearchIndexAddWorker < WorkerBase
 
   attr_reader :id, :class_name
 
-  def perform(class_name, id)
+  def call(class_name, id)
     @class_name = class_name
     @id = id
 

--- a/app/workers/search_index_delete_worker.rb
+++ b/app/workers/search_index_delete_worker.rb
@@ -1,5 +1,4 @@
 class SearchIndexDeleteWorker < WorkerBase
-
   attr_reader :link, :index
 
   def call(link, index)

--- a/app/workers/search_index_delete_worker.rb
+++ b/app/workers/search_index_delete_worker.rb
@@ -2,7 +2,7 @@ class SearchIndexDeleteWorker < WorkerBase
 
   attr_reader :link, :index
 
-  def perform(link, index)
+  def call(link, index)
     Whitehall::SearchIndex.for(index.to_sym).delete(link)
   end
 end

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -22,9 +22,11 @@ class WorkerBase
     if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
       args.pop
       request_id = last_arg["request_id"]
-      GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+    else
+      request_id = nil
     end
 
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
     call(*args)
   end
 end

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -1,7 +1,30 @@
 class WorkerBase
   include Sidekiq::Worker
 
+  def self.perform_async(*args)
+    args << request_id_argument
+    super(*args)
+  end
+
   def self.perform_async_in_queue(queue, *args)
+    args << request_id_argument
     client_push('class' => self, 'args' => args, 'queue' => queue || get_sidekiq_options["queue"])
+  end
+
+  def self.request_id_argument
+    {request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]}
+  end
+  private_class_method :request_id_argument
+
+  def perform(*args)
+    last_arg = args.last
+
+    if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+      args.pop
+      request_id = last_arg["request_id"]
+      GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+    end
+
+    call(*args)
   end
 end

--- a/lib/whitehall/gov_uk_delivery/worker.rb
+++ b/lib/whitehall/gov_uk_delivery/worker.rb
@@ -1,13 +1,11 @@
 module Whitehall
   module GovUkDelivery
-    class Worker
-      include Sidekiq::Worker
-
+    class Worker < WorkerBase
       def self.notify!(edition, notification_date, title = nil, summary = nil)
         self.perform_async(edition.id, notification_date.iso8601, title: title, summary: summary)
       end
 
-      def perform(edition_id, notification_date, options = {})
+      def call(edition_id, notification_date, options = {})
         options.symbolize_keys!
 
         edition = Edition.find(edition_id)

--- a/test/functional/admin/links_reports_controller_test.rb
+++ b/test/functional/admin/links_reports_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
       assert links_report = @publication.links_reports.last
       job = LinksReportWorker.jobs.last
-      assert_equal [links_report.id], job['args']
+      assert_equal links_report.id, job['args'].first
     end
   end
 
@@ -30,7 +30,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
       assert links_report = @publication.links_reports.last
       job = LinksReportWorker.jobs.last
-      assert_equal [links_report.id], job['args']
+      assert_equal links_report.id, job['args'].first
     end
   end
 

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -64,4 +64,28 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
       assert_requested(:patch, %r|publishing-api.*links/#{attachment_content_id}|, headers: onward_headers)
     end
   end
+
+  test "govuk_request_id is not passed downstream if the job pre-dates request tracing (e.g. scheduled publishing jobs)" do
+    Sidekiq::Testing.fake! do
+      PublishingApiWorker.perform_async(@draft_edition.class.name, @draft_edition.id)
+      PublishingApiWorker.jobs.first["args"].delete("request_id" => nil)
+
+      GdsApi::GovukHeaders.set_header(:govuk_request_id, @govuk_request_id)
+      PublishingApiWorker.perform_one
+    end
+
+    content_id = @draft_edition.content_id
+
+    assert_requested(:put, %r|publishing-api.*content/#{content_id}|) do |request|
+      assert !request.headers.key?("Govuk-Request-Id")
+    end
+
+    assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|) do |request|
+      assert !request.headers.key?("Govuk-Request-Id")
+    end
+
+    assert_requested(:patch, %r|publishing-api.*links/#{content_id}|) do |request|
+      assert !request.headers.key?("Govuk-Request-Id")
+    end
+  end
 end

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+require "sidekiq/testing"
+
+class RequestTracingTest < ActionDispatch::IntegrationTest
+  setup do
+    @govuk_request_id = "12345-67890"
+    @draft_edition = create(:draft_publication)
+    @presenter = PublishingApiPresenters.presenter_for(@draft_edition)
+    login_as(create(:gds_admin))
+
+    # Use the real GovUkDelivery client
+    Whitehall.govuk_delivery_client = GdsApi::GovUkDelivery.new(Plek.find('govuk-delivery'))
+
+    stub_request(:put, /panopticon/)
+    stub_request(:post, /govuk-delivery/)
+  end
+
+  def force_publish(edition, headers = {})
+    post_via_redirect("/government/admin/editions/#{edition.id}/force_publish", {
+      reason: "Test",
+      lock_version: 0,
+    }, headers)
+  end
+
+  test "govuk_request_id is passed downstream across the worker boundary on publish" do
+    inbound_headers = {
+      "HTTP_GOVUK_REQUEST_ID" => @govuk_request_id,
+    }
+
+    Sidekiq::Testing.fake! do
+      force_publish(@draft_edition, inbound_headers)
+
+      # Simulate each worker running in a separate thread
+      worker_classes = Sidekiq::Worker.jobs.map { |job| job["class"] }.uniq.map(&:constantize)
+      worker_classes.each do |worker_class|
+        while worker_class.jobs.any?
+          GdsApi::GovukHeaders.clear_headers
+          worker_class.perform_one
+          GdsApi::GovukHeaders.clear_headers
+        end
+      end
+    end
+
+    assert_equal 200, response.status, response.body
+
+    onward_headers = {
+      "GOVUK-Request-Id" => @govuk_request_id
+    }
+
+    assert_requested(:post, /govuk-delivery/, headers: onward_headers)
+    assert_requested(:put, /panopticon/, headers: onward_headers)
+
+    # Main document
+    content_id = @draft_edition.content_id
+    assert_requested(:put, %r|publishing-api.*content/#{content_id}|, headers: onward_headers)
+    assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
+    assert_requested(:patch, %r|publishing-api.*links/#{content_id}|, headers: onward_headers)
+
+    # HTML attachments
+    @draft_edition.html_attachments.each do |html_attachment|
+      attachment_content_id = html_attachment.content_id
+      assert_requested(:put, %r|publishing-api.*content/#{attachment_content_id}|, headers: onward_headers)
+      assert_requested(:post, %r|publishing-api.*content/#{attachment_content_id}/publish|, headers: onward_headers)
+      assert_requested(:patch, %r|publishing-api.*links/#{attachment_content_id}|, headers: onward_headers)
+    end
+  end
+end

--- a/test/unit/links_report_test.rb
+++ b/test/unit/links_report_test.rb
@@ -13,7 +13,7 @@ class LinksReportTest < ActiveSupport::TestCase
       assert_equal %w(http://example.com http://link.com), links_report.links
 
       job = LinksReportWorker.jobs.last
-      assert_equal [links_report.id], job['args']
+      assert_equal links_report.id, job['args'].first
     end
   end
 

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -301,11 +301,23 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       Whitehall::PublishingApi.schedule_async(edition)
 
-      assert_equal [english_path, timestamp], PublishingApiScheduleWorker.jobs[0]['args']
-      assert_equal [french_path, timestamp], PublishingApiScheduleWorker.jobs[1]['args']
+      first_job = PublishingApiScheduleWorker.jobs[0]['args']
+      second_job = PublishingApiScheduleWorker.jobs[1]['args']
 
-      assert_equal [edition.id, 'en'], PublishingApiComingSoonWorker.jobs[0]['args']
-      assert_equal [edition.id, 'fr'], PublishingApiComingSoonWorker.jobs[1]['args']
+      assert_equal english_path, first_job[0]
+      assert_equal timestamp, first_job[1]
+
+      assert_equal french_path, second_job[0]
+      assert_equal timestamp, second_job[1]
+
+      first_job = PublishingApiComingSoonWorker.jobs[0]['args']
+      second_job = PublishingApiComingSoonWorker.jobs[1]['args']
+
+      assert_equal edition.id, first_job[0]
+      assert_equal 'en', first_job[1]
+
+      assert_equal edition.id, second_job[0]
+      assert_equal 'fr', second_job[1]
     end
   end
 
@@ -325,8 +337,14 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       Whitehall::PublishingApi.schedule_async(updated_edition)
 
-      assert_equal [english_path, timestamp], PublishingApiScheduleWorker.jobs[0]['args']
-      assert_equal [spanish_path, timestamp], PublishingApiScheduleWorker.jobs[1]['args']
+      first_job = PublishingApiScheduleWorker.jobs[0]['args']
+      second_job = PublishingApiScheduleWorker.jobs[1]['args']
+
+      assert_equal english_path, first_job[0]
+      assert_equal timestamp, first_job[1]
+
+      assert_equal spanish_path, second_job[0]
+      assert_equal timestamp, second_job[1]
 
       assert_equal [], PublishingApiComingSoonWorker.jobs
     end
@@ -357,8 +375,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       Whitehall::PublishingApi.unschedule_async(edition)
 
-      assert_equal [german_path], PublishingApiUnscheduleWorker.jobs[0]['args']
-      assert_equal [english_path], PublishingApiUnscheduleWorker.jobs[1]['args']
+      assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
+      assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
 
       assert_equal german_path, PublishingApiGoneWorker.jobs[0]['args'].first
       assert_equal english_path, PublishingApiGoneWorker.jobs[1]['args'].first
@@ -380,8 +398,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       Whitehall::PublishingApi.unschedule_async(updated_edition)
 
-      assert_equal [german_path], PublishingApiUnscheduleWorker.jobs[0]['args']
-      assert_equal [english_path], PublishingApiUnscheduleWorker.jobs[1]['args']
+      assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
+      assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
 
       assert_equal [], PublishingApiGoneWorker.jobs
     end

--- a/test/unit/whitehall/search_index_test.rb
+++ b/test/unit/whitehall/search_index_test.rb
@@ -22,9 +22,10 @@ module Whitehall
 
       Sidekiq::Testing.fake! do
         SearchIndex.delete(searchable_thing)
-        job = SearchIndexDeleteWorker.jobs.last
+        args = SearchIndexDeleteWorker.jobs.last['args']
 
-        assert_equal ['full_slug', 'index_name'], job['args']
+        assert_equal 'full_slug', args[0]
+        assert_equal 'index_name', args[1]
       end
     end
   end

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -48,7 +48,8 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
   end
 
   test "fails gracefully if the model cannot be found" do
-    PublishingApiWorker.new.perform('Edition', non_existant_id = 12)
+    non_existent_id = 12
+    PublishingApiWorker.new.perform('Edition', non_existent_id)
   end
 
   test "passes the update_type option to the presenter" do

--- a/test/unit/workers/worker_base_test.rb
+++ b/test/unit/workers/worker_base_test.rb
@@ -6,7 +6,7 @@ class WorkerBaseTest < ActiveSupport::TestCase
 
   class MyWorker < WorkerBase
     sidekiq_options queue: "my-test-queue"
-    def perform
+    def perform(*_args)
       WorkerBaseTest.worker_has_run!
     end
   end
@@ -20,7 +20,7 @@ class WorkerBaseTest < ActiveSupport::TestCase
     example_arg = stub("example arg")
     WorkerBase.expects(:client_push).with(
       'class' => WorkerBaseTest::MyWorker,
-      'args' => [example_arg],
+      'args' => [example_arg, { request_id: nil }],
       'queue' => 'test_queue'
     )
     MyWorker.perform_async_in_queue('test_queue', example_arg)
@@ -30,7 +30,7 @@ class WorkerBaseTest < ActiveSupport::TestCase
     example_arg = stub("example arg")
     WorkerBase.expects(:client_push).with(
       'class' => WorkerBaseTest::MyWorker,
-      'args' => [example_arg],
+      'args' => [example_arg, { request_id: nil }],
       'queue' => 'my-test-queue'
     )
     MyWorker.perform_async_in_queue(nil, example_arg)


### PR DESCRIPTION
https://trello.com/c/Eddv2AiS/688-for-migrated-formats-update-for-request-tracing

This change makes it so that a `request_id` is passed into Sidekiq jobs so that we can send this as a header downstream, via `GdsApi::GovukHeaders`. Currently, this header is lost when the Sidekiq jobs run because they run in a separate process to the one in which the request was processed. 

This was the basis for these pull requests:
https://github.com/alphagov/publisher/pull/469
https://github.com/alphagov/collections-publisher/pull/194