### PR TITLE
Republish Detailed Guides

### DIFF
--- a/db/data_migration/20160426103809_republish_missing_detailed_guides.rb
+++ b/db/data_migration/20160426103809_republish_missing_detailed_guides.rb
@@ -1,0 +1,7 @@
+# Quite a few published DetailedGuides do not have items in the content store
+# (~1700 out of ~3800 at time of writing). This task republishes all
+# DetailedGuides to correctly create the corresponding content items.
+
+DetailedGuide.published.joins(:document).find_each do |dg|
+  Whitehall::PublishingApi.republish_document_async(dg.document)
+end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -47,7 +47,6 @@ module Whitehall
       PublishingApiDocumentRepublishingWorker.perform_async(published_edition_id, pre_publication_edition_id)
     end
 
-
     def self.schedule_async(edition)
       return unless served_from_content_store?(edition)
       publish_timestamp = edition.scheduled_publication.as_json


### PR DESCRIPTION
Whitehall currently has ~1700 published detailed guides that do not have
a corresponding content item in the content store.

We recently changed frontend behaviour for documents rendered by
Whitehall - specifically, parts of the header now rely on the content
item to pull in correct tagging information.

This data migration uses the existing #republish_document_async method
to send both the published edition and the pre-publication edition (if
present) to the V2 publishing API.

Trello: https://trello.com/c/uenXZFDX