### PR TITLE
Always send content_id to Rummager

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -164,7 +164,6 @@ class Organisation < ActiveRecord::Base
   mount_uploader :logo, LogoUploader
 
   searchable title: :title_for_search,
-             content_id: :content_id,
              acronym: :acronym,
              link: :search_link,
              content: :indexable_content,

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -47,6 +47,7 @@ module Searchable
 
       self.searchable_options = options.reverse_merge \
         format:         -> (o) { o.class.model_name.element },
+        content_id:     -> (o) { o.try(:content_id) },
         index_after:    :save,
         unindex_after:  :destroy,
         only:           :all,

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -317,43 +317,44 @@ class ConsultationTest < ActiveSupport::TestCase
   test "#search_index :has_official_document should be true if either the consultation or it's outcome has official document attachments" do
     Consultation.any_instance.stubs(:search_link)
 
-    assert_equal false, build(:consultation).search_index[:has_official_document]
+    refute create(:consultation).search_index[:has_official_document]
 
-    command_paper_consultation = build(:consultation)
+    command_paper_consultation = create(:consultation)
     command_paper_consultation.stubs(:has_official_document?).returns(true)
-    assert_equal true, command_paper_consultation.search_index[:has_official_document]
+    assert command_paper_consultation.search_index[:has_official_document]
 
-    consultation_with_command_paper_outcome = build(:consultation, outcome: build(:consultation_outcome))
+    consultation_with_command_paper_outcome = create(:consultation, outcome: create(:consultation_outcome))
     consultation_with_command_paper_outcome.outcome.stubs(:has_official_document?).returns(true)
-    assert_equal true, consultation_with_command_paper_outcome.search_index[:has_official_document]
+    assert consultation_with_command_paper_outcome.search_index[:has_official_document]
   end
 
   test "#search_index :has_command_paper should be true if either the consultation or it's outcome has command paper attachments" do
     Consultation.any_instance.stubs(:search_link)
 
-    assert_equal false, build(:consultation).search_index[:has_command_paper]
+    refute create(:consultation).search_index[:has_command_paper]
 
-    command_paper_consultation = build(:consultation)
+    command_paper_consultation = create(:consultation)
     command_paper_consultation.stubs(:has_command_paper?).returns(true)
-    assert_equal true, command_paper_consultation.search_index[:has_command_paper]
+    assert command_paper_consultation.search_index[:has_command_paper]
 
-    consultation_with_command_paper_outcome = build(:consultation, outcome: build(:consultation_outcome))
+    consultation_with_command_paper_outcome = create(:consultation, outcome: create(:consultation_outcome))
     consultation_with_command_paper_outcome.outcome.stubs(:has_command_paper?).returns(true)
-    assert_equal true, consultation_with_command_paper_outcome.search_index[:has_command_paper]
+    assert consultation_with_command_paper_outcome.search_index[:has_command_paper]
   end
 
   test "#search_index :has_act_paper should be true if either the consultation or it's outcome has act paper attachments" do
     Consultation.any_instance.stubs(:search_link)
 
-    assert_equal false, build(:consultation).search_index[:has_act_paper]
+    consultation = create(:consultation)
+    refute consultation.search_index[:has_act_paper]
 
-    command_paper_consultation = build(:consultation)
+    command_paper_consultation = create(:consultation)
     command_paper_consultation.stubs(:has_act_paper?).returns(true)
-    assert_equal true, command_paper_consultation.search_index[:has_act_paper]
+    assert command_paper_consultation.search_index[:has_act_paper]
 
-    consultation_with_command_paper_outcome = build(:consultation, outcome: build(:consultation_outcome))
+    consultation_with_command_paper_outcome = create(:consultation, outcome: create(:consultation_outcome))
     consultation_with_command_paper_outcome.outcome.stubs(:has_act_paper?).returns(true)
-    assert_equal true, consultation_with_command_paper_outcome.search_index[:has_act_paper]
+    assert consultation_with_command_paper_outcome.search_index[:has_act_paper]
   end
 
   test "#government returns the government active on the opening_at date" do

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -35,6 +35,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
       corporate_information_page_type: CorporateInformationPageType::TermsOfReference,
       organisation: organisation)
 
+    assert_equal corporate_information_page.content_id, corporate_information_page.search_index['content_id']
     assert_equal "#{organisation.name} \u2013 #{corporate_information_page.title}", corporate_information_page.search_index['title']
     assert_equal "/government/organisations/#{organisation.slug}/about/#{corporate_information_page.slug}", corporate_information_page.search_index['link']
   end

--- a/test/unit/ministerial_role_test.rb
+++ b/test/unit/ministerial_role_test.rb
@@ -132,21 +132,25 @@ class MinisterialRoleTest < ActiveSupport::TestCase
 
     assert_equal 4, results.length
     assert_equal({'title' => 'Deputy Prime Minister',
+                  'content_id' => deputy_prime_minister.content_id,
                   'link' => '/government/ministers/deputy-prime-minister',
                   'indexable_content' => 'Cleggy.',
                   'format' => 'minister',
                   'description' => 'Current role holder: Nick Clegg.'}, results[0])
     assert_equal({'title' => 'Secretary of State for Culture',
+                  'content_id' => culture_minister.content_id,
                   'link' => '/government/ministers/secretary-of-state-for-culture',
                   'indexable_content' => 'Hunty.',
                   'format' => 'minister',
                   'description' => 'Current role holder: Jeremy Hunt.'}, results[1])
     assert_equal({'title' => 'Solicitor General',
+                  'content_id' => solicitor_general.content_id,
                   'link' => '/government/ministers/solicitor-general',
                   'indexable_content' => 'Garnerian.',
                   'format' => 'minister',
                   'description' => 'Current role holder: Edward Garnier.'}, results[2])
     assert_equal({'title' => 'Prime Minister',
+                  'content_id' => prime_minister.content_id,
                   'link' => '/government/ministers/prime-minister',
                   'indexable_content' => 'Cameronian.',
                   'format' => 'minister',

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -11,9 +11,10 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test 'should return search index data suitable for Rummageable' do
-    person = create(:person, forename: 'David', surname: 'Cameron', biography: 'David Cameron became Prime Minister in May 2010.')
+    person = create(:person, content_id: 'f585949d-3796-4566-ab31-cb0d978aec00', forename: 'David', surname: 'Cameron', biography: 'David Cameron became Prime Minister in May 2010.')
 
     assert_equal({
+                  'content_id' => 'f585949d-3796-4566-ab31-cb0d978aec00',
                   'title' => 'David Cameron',
                   'link' => '/government/people/david-cameron',
                   'indexable_content' => 'David Cameron became Prime Minister in May 2010.',

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -58,6 +58,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   test 'is search indexable' do
     announcement = create_announcement_with_changes
     expected_indexed_content = {
+      'content_id' => announcement.content_id,
       'title' => announcement.title,
       'link' => announcement.public_path,
       'format' => 'statistics_announcement',

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -172,18 +172,20 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test 'returns search index data for all take part pages' do
-    create(:take_part_page, title: 'Build a new polling station', summary: 'Help people vote!', body: 'Everyone can build a building.')
-    create(:take_part_page, title: 'Stand for election', summary: 'Help govern this country!', body: 'Maybe you can change the system from within?')
+    create(:take_part_page, content_id: '845593d6-273d-4440-b44a-8c44ab530c9e', title: 'Build a new polling station', summary: 'Help people vote!', body: 'Everyone can build a building.')
+    create(:take_part_page, content_id: 'a7a3a7f3-f967-4723-8de3-1e2d8f9fb4cb', title: 'Stand for election', summary: 'Help govern this country!', body: 'Maybe you can change the system from within?')
 
     results = TakePartPage.search_index.to_a
 
     assert_equal 2, results.length
     assert_equal({'title' => 'Build a new polling station',
+                  'content_id' => "845593d6-273d-4440-b44a-8c44ab530c9e",
                   'link' => "/government/get-involved/take-part/build-a-new-polling-station",
                   'indexable_content' => 'Everyone can build a building.',
                   'format' => 'take_part',
                   'description' => 'Help people vote!'}, results[0])
     assert_equal({'title' => 'Stand for election',
+                  'content_id' => "a7a3a7f3-f967-4723-8de3-1e2d8f9fb4cb",
                   'link' => "/government/get-involved/take-part/stand-for-election",
                   'indexable_content' => 'Maybe you can change the system from within?',
                   'format' => 'take_part',

--- a/test/unit/topic_test.rb
+++ b/test/unit/topic_test.rb
@@ -77,8 +77,9 @@ class TopicTest < ActiveSupport::TestCase
   end
 
   test 'should return search index data suitable for Rummageable' do
-    topic = create(:topic, name: "topic name", description: "topic description")
+    topic = create(:topic, content_id: 'aa1f1646-6ae6-4a65-86e3-9803fa870c6a', name: "topic name", description: "topic description")
     assert_equal({
+                  'content_id' => 'aa1f1646-6ae6-4a65-86e3-9803fa870c6a',
                   'title' => 'topic name',
                   'link' => '/government/topics/topic-name',
                   'indexable_content' => 'topic description',

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -205,10 +205,11 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   test 'search index data for a worldwide organisation includes name, summary, the correct link and format' do
-    worldwide_organisation = create(:worldwide_organisation, name: 'British Embassy to Hat land', slug: 'british-embassy-to-hat-land')
+    worldwide_organisation = create(:worldwide_organisation, content_id: '7d58b5d8-6d91-4dbb-b3e1-c2a27f131046', name: 'British Embassy to Hat land', slug: 'british-embassy-to-hat-land')
     create(:published_corporate_information_page, corporate_information_page_type: CorporateInformationPageType.find('about'), worldwide_organisation: worldwide_organisation, organisation: nil, summary: 'Providing assistance to uk residents in hat land')
 
     assert_equal({'title' => worldwide_organisation.name,
+                  'content_id' => '7d58b5d8-6d91-4dbb-b3e1-c2a27f131046',
                   'link' => '/government/world/organisations/british-embassy-to-hat-land',
                   'indexable_content' => 'Providing assistance to uk residents in hat land',
                   'format' => 'worldwide_organisation',


### PR DESCRIPTION
This makes sure that we send the `content_id` to rummager for all content in Whitehall. This will be handy Rummager starts to read from the publishing-api (https://github.com/alphagov/rummager/pull/632).

It would allow us to skip the `lookup_content_id` in the [indexing task](https://github.com/alphagov/rummager/blob/48db9ed8fd858cfc0b481776c66c7d9591bef57e/lib/indexer/tag_lookup.rb#L22) for some content, potentially saving a lot of requests.

Related PR: https://github.com/alphagov/whitehall/pull/2560.