### PR TITLE
Add placeholder for Document Collections

### DIFF
--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -39,6 +39,8 @@ private
     case edition
     when ::CaseStudy
       PublishingApiPresenters::CaseStudy
+    when ::DocumentCollection
+      PublishingApiPresenters::DocumentCollectionPlaceholder
     else
       PublishingApiPresenters::Edition
     end

--- a/app/presenters/publishing_api_presenters/document_collection_placeholder.rb
+++ b/app/presenters/publishing_api_presenters/document_collection_placeholder.rb
@@ -1,0 +1,11 @@
+require_relative "../publishing_api_presenters"
+
+class PublishingApiPresenters::DocumentCollectionPlaceholder < PublishingApiPresenters::Edition
+  def links
+    super.merge(documents: item.documents.pluck(:content_id))
+  end
+
+  def document_format
+    'placeholder_document_collection'
+  end
+end

--- a/db/data_migration/20160428120220_republish_document_collection_placeholders.rb
+++ b/db/data_migration/20160428120220_republish_document_collection_placeholders.rb
@@ -1,0 +1,1 @@
+DataHygiene::PublishingApiDocumentRepublisher.new(DocumentCollection).perform

--- a/test/unit/presenters/publishing_api_presenters/document_collection_placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/document_collection_placeholder_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class PublishingApiPresenters::DocumentCollectionPlaceholderTest < ActiveSupport::TestCase
+  def present(model_instance, options = {})
+    PublishingApiPresenters::DocumentCollectionPlaceholder.new(model_instance, options)
+  end
+
+  test 'presents a placeholder_document_collection ready for adding to the publishing API' do
+    publications_in_collection = [
+      create(:published_policy_paper, title: 'Free bunnies for all citizens'),
+      create(:published_policy_paper, title: 'Photos of cats to be included in all HMRC letters')
+    ]
+
+    documents_in_collection = publications_in_collection.map(&:document)
+
+    create(:published_policy_paper, title: 'Something about tax')
+
+    document_collection = create(:published_document_collection,
+      title: 'Things that make you go aww',
+      summary: 'Things the government does that will make you happy',
+      groups: [
+        build(:document_collection_group, documents: documents_in_collection)
+      ])
+
+    public_path = Whitehall.url_maker.public_document_path(document_collection)
+
+    expected_hash = {
+      base_path: public_path,
+      title: 'Things that make you go aww',
+      description: 'Things the government does that will make you happy',
+      format: 'placeholder_document_collection',
+      locale: 'en',
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      public_updated_at: document_collection.public_timestamp,
+      routes: [{ path: public_path, type: 'exact' }],
+      redirects: [],
+      need_ids: [],
+      details: {
+        change_note: nil,
+        tags: {
+          browse_pages: [],
+          policies: [],
+          topics: []
+        }
+      }
+    }
+
+    presented_item = present(document_collection)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal documents_in_collection.map(&:content_id).sort, presented_item.links[:documents].sort
+    assert_equal 'major', presented_item.update_type
+    assert_equal document_collection.content_id, presented_item.content_id
+
+    assert_valid_against_schema(presented_item.content, 'placeholder')
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -81,4 +81,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(build(:html_attachment))
     assert_equal PublishingApiPresenters::HtmlAttachment, presenter.class
   end
+
+  test ".presenter_for returns a DocumentCollectionPlaceholder presenter for `DocumentCollection`" do
+    presenter = PublishingApiPresenters.presenter_for(build(:document_collection))
+    assert_equal PublishingApiPresenters::DocumentCollectionPlaceholder, presenter.class
+  end
 end


### PR DESCRIPTION
Add a specific placeholder for Document Collections that pushes the
content ids of its linked documents to the publishing api. This will be
used to determine which collections an edition is part of for migrated
formats.

Trello: https://trello.com/c/UcqLRRSu/387-add-document-collection-documents-to-placeholder