### PR TITLE
Add withdrawn_notice to DetailedGuide presenter.

### DIFF
--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -24,7 +24,9 @@ private
       related_mainstream_content: related_mainstream,
       political: item.political?,
       government: government
-    )
+    ).tap do |json|
+      json[:withdrawn_notice] = withdrawn_notice if item.withdrawn?
+    end
   end
 
   def body
@@ -67,5 +69,18 @@ private
       slug: gov.slug,
       current: gov.current?
     }
+  end
+
+  def withdrawn_notice
+    {
+      explanation: unpublishing_explanation,
+      withdrawn_at: item.updated_at
+    }
+  end
+
+  def unpublishing_explanation
+    if item.unpublishing.try(:explanation).present?
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.unpublishing.explanation)
+    end
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -201,4 +201,29 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
 
     assert_equal related_guides, expected_related_guides
   end
+
+  test 'DetailedGuide presents withdrawn_notice correctly' do
+    create(:government)
+    detailed_guide = create(
+      :published_detailed_guide,
+      :withdrawn,
+    )
+    detailed_guide.build_unpublishing(
+      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
+      explanation: 'No longer relevant'
+    )
+    detailed_guide.unpublishing.save!
+
+    presented_item = present(detailed_guide)
+    details = presented_item.content[:details]
+
+    expected_withdrawn_notice = {
+      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
+      withdrawn_at: detailed_guide.updated_at
+    }
+
+    assert_valid_against_schema(presented_item.content, 'detailed_guide')
+    assert_equal expected_withdrawn_notice[:withdrawn_at], details[:withdrawn_notice][:withdrawn_at]
+    assert_equivalent_html expected_withdrawn_notice[:explanation], details[:withdrawn_notice][:explanation]
+  end
 end


### PR DESCRIPTION
Implementation is mostly copied from CaseStudies.

These are necessary for the DetailedGuide migration.