### PR TITLE
Add data migration to republish detailed guides.

### DIFF
--- a/db/data_migration/20160504085342_republish_detailed_guides.rb
+++ b/db/data_migration/20160504085342_republish_detailed_guides.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(DetailedGuide)
+republisher.perform


### PR DESCRIPTION
DetailedGuides need to be republished using the updated presenter.