### PR TITLE
Remove WW priorities from publishing-api

### DIFF
--- a/db/data_migration/20160505110730_redirect_worldwide_priorities.rb
+++ b/db/data_migration/20160505110730_redirect_worldwide_priorities.rb
@@ -1,0 +1,32 @@
+OLD_PATH = "/government/priority"
+
+#as defined in https://docs.google.com/spreadsheets/d/1N3tvPceqG_7ASE9cET_lbQRdJevW_9h-UDtov_-uRlM/edit#gid=0
+SLUGS = [
+  ["supporting-uk-business-to-develop-opportunities-in-the-eastern-caribbean","/government/world/barbados"],
+  ["uk-and-caribbean-collaboration-on-security-issues","/government/world/barbados"],
+  ["promoting-human-rights-issues-in-the-eastern-caribbean","/government/world/barbados"]
+  ["supporting-british-nationals-in-barbados-and-the-eastern-caribbean","/government/world/organisations/british-high-commission-barbados"]
+  ["strengthening-peace-security-and-democracy-in-ethiopia-somaliland-and-djibouti","/government/world/ethiopia"]
+  ["protecting-the-uk-against-drug-trafficking-and-organised-crime-in-west-africa","/government/world/senegal"]
+  ["supporting-british-nationals-in-the-dominican-republic-and-haiti","/government/world/organisations/british-embassy-santo-domingo"]
+  ["increasing-business-with-the-dominican-republic-and-haiti","/government/world/dominican-republic"]
+  ["promoting-strong-relations-between-the-uk-and-the-republic-of-haiti","/government/world/haiti"]
+  ["improving-business-with-guyana-and-suriname","/government/world/guyana"]
+  ["uk-science-and-innovation-network-gulf","/government/world/qatar"]
+  ["chadian-presiden-at-londons-illegal-wildlife-trade-conference","/government/news/decisive-action-agreed-on-illegal-wildlife-trade"]
+  ["chadian-presiden-at-londons-illegal-wildlife-trade-conference--2","/government/news/decisive-action-agreed-on-illegal-wildlife-trade"]
+  ["supporting-british-nationals-in-the-usa","/government/world/usa"]
+  ["developing-good-governance-in-the-turks-and-caicos-islands","/government/world/turks-and-caicos-islands"]
+  ["supporting-development-in-pakistan--2","/government/world/organisations/dfid-pakistan"]
+  ["supporting-drc-development-with-the-department-for-international-development","/government/world/organisations/dfid-drc"]
+  ["supporting-conflict-resolution-in-guinea-bissau","/government/world/guinea-bissau"]
+  ["working-with-south-africa-to-promote-and-build-our-people-to-people-partnerships","/government/world/south-africa"]
+  ["supporting-development-in-belize","/government/world/belize"]
+]
+
+SLUGS.each do |slug|
+  old_base_path = OLD_PATH + "/" + slug[0]
+  new_base_path = slug[1]
+  redirects = [{ path: old_base_path, destination: new_base_path, type: "exact" }]
+  PublishingApiRedirectWorker.perform_async(old_base_path, redirects, I18n.default_locale.to_s)
+end

--- a/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
+++ b/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
@@ -1,0 +1,29 @@
+BASE_PATH_ROOT = "/government/priority"
+
+SLUGS = [
+  "supporting-uk-business-to-develop-opportunities-in-the-eastern-caribbean",
+  "uk-and-caribbean-collaboration-on-security-issues",
+  "promoting-human-rights-issues-in-the-eastern-caribbean",
+  "supporting-british-nationals-in-barbados-and-the-eastern-caribbean",
+  "strengthening-peace-security-and-democracy-in-ethiopia-somaliland-and-djibouti",
+  "protecting-the-uk-against-drug-trafficking-and-organised-crime-in-west-africa",
+  "supporting-british-nationals-in-the-dominican-republic-and-haiti",
+  "increasing-business-with-the-dominican-republic-and-haiti",
+  "promoting-strong-relations-between-the-uk-and-the-republic-of-haiti",
+  "improving-business-with-guyana-and-suriname",
+  "uk-science-and-innovation-network-gulf",
+  "chadian-presiden-at-londons-illegal-wildlife-trade-conference",
+  "chadian-presiden-at-londons-illegal-wildlife-trade-conference--2",
+  "supporting-british-nationals-in-the-usa",
+  "developing-good-governance-in-the-turks-and-caicos-islands",
+  "supporting-development-in-pakistan--2",
+  "supporting-drc-development-with-the-department-for-international-development",
+  "supporting-conflict-resolution-in-guinea-bissau",
+  "working-with-south-africa-to-promote-and-build-our-people-to-people-partnerships",
+  "supporting-development-in-belize",
+]
+
+SLUGS.each do |slug|
+  base_path = BASE_PATH_ROOT + "/" + slug
+  Whitehall.government_search_client.delete_content! base_path
+end


### PR DESCRIPTION
Trello: https://trello.com/c/AtYGioxe/321-worldwide-priorities-deleting-the-format-medium

Publish redirects to Publishing Api, in order to remove legacy worldwide priorities contents, as defined here: https://docs.google.com/spreadsheets/d/1N3tvPceqG_7ASE9cET_lbQRdJevW_9h-UDtov_-uRlM/edit#gid=0