### PR TITLE
Respect soft deletion for attachments

### DIFF
--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -113,6 +113,6 @@ class AttachmentVisibility
   end
 
   def edition_ids
-    @edition_ids ||= Attachment.where(attachment_data_id: id).where(attachable_type: 'Edition').pluck(:attachable_id)
+    @edition_ids ||= Attachment.not_deleted.where(attachment_data_id: id).where(attachable_type: 'Edition').pluck(:attachable_id)
   end
 end


### PR DESCRIPTION
This PR addresses an issue where when a `FileAttachment` is deleted from an `Edition` but is also attached to an earlier, superseded `Edition` the file continues to be served.

This was caused by the `AttachmentVisibility` class not filtering out `deleted? == true` `Attachment`s.

This fixes the issue but the `AttachmentVisibility` class would definitely benefit from further simplification which I will attempt in another PR.

[Trello](https://trello.com/c/ezstdA92/389-fix-attachment-visibility-for-unpublished-attachments-medium)