### PR TITLE
Send organisations and emphasised_organisations to pub-api

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -5,6 +5,7 @@ class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
     extract_links([
       :document_collections,
       :lead_organisations,
+      :organisations,
       :related_policies,
       :supporting_organisations,
       :topics,

--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -25,7 +25,8 @@ private
       body: body,
       format_display_type: item.display_type_key,
       first_public_at: first_public_at,
-      change_history: item.change_history.as_json
+      change_history: item.change_history.as_json,
+      emphasised_organisations: item.lead_organisations.map(&:content_id),
     }).tap do |json|
       json[:image] = image_details if image_available?
       json[:withdrawn_notice] = withdrawn_notice if item.withdrawn?

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -20,11 +20,12 @@ private
   def details
     super.merge(
       body: body,
-      first_public_at: first_public_at,
       change_history: item.change_history.as_json,
-      related_mainstream_content: related_mainstream,
-      political: item.political?,
+      emphasised_organisations: item.lead_organisations.map(&:content_id),
+      first_public_at: first_public_at,
       government: government,
+      political: item.political?,
+      related_mainstream_content: related_mainstream,
     ).tap do |json|
       json[:withdrawn_notice] = withdrawn_notice if item.withdrawn?
       json[:national_applicability] = national_applicability if item.nation_inapplicabilities.any?

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -3,7 +3,8 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::DetailedGuide < PublishingApiPresenters::Edition
   def links
     extract_links([
-      :lead_organisations
+      :lead_organisations,
+      :organisations,
     ]).merge(
       related_guides: related_guides,
       related_mainstream: related_mainstream

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -16,6 +16,16 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
   end
 
   def links
+    extract_links([:organisations]).merge(topic_and_parent_links_payload)
+  end
+
+  def base_path
+    Whitehall.url_maker.public_document_path(item)
+  end
+
+private
+
+  def topic_and_parent_links_payload
     topic_tags = item.specialist_sector_tags
     return {} unless topic_tags.present?
 
@@ -36,12 +46,6 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
       { topics: content_id_lookup.values }
     end
   end
-
-  def base_path
-    Whitehall.url_maker.public_document_path(item)
-  end
-
-private
 
   def topic_path_from(tag)
     "/topic/#{tag}"

--- a/app/presenters/publishing_api_presenters/placeholder.rb
+++ b/app/presenters/publishing_api_presenters/placeholder.rb
@@ -5,7 +5,10 @@ require_relative "../publishing_api_presenters"
 # out when read back out from the content store.
 class PublishingApiPresenters::Placeholder < PublishingApiPresenters::Item
   def links
-    extract_links([:topics])
+    extract_links([
+      :topics,
+      :organisations,
+    ])
   end
 
 private

--- a/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
+++ b/app/presenters/publishing_api_presenters/policy_area_placeholder.rb
@@ -1,7 +1,10 @@
 # Note that "Policy Area" is the new name for "Topic".
 class PublishingApiPresenters::PolicyAreaPlaceholder < PublishingApiPresenters::Placeholder
   def links
-    extract_links([:topics])
+    extract_links([
+      :topics,
+      :organisations,
+    ])
   end
 
   private

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -4,6 +4,7 @@ class PublishingApiPresenters::TakePart < PublishingApiPresenters::Item
   def links
     extract_links([
       :lead_organisations,
+      :organisations,
       :policy_areas,
       :topics,
     ])

--- a/app/presenters/publishing_api_presenters/take_part.rb
+++ b/app/presenters/publishing_api_presenters/take_part.rb
@@ -3,8 +3,6 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::TakePart < PublishingApiPresenters::Item
   def links
     extract_links([
-      :lead_organisations,
-      :organisations,
       :policy_areas,
       :topics,
     ])

--- a/app/presenters/publishing_api_presenters/topical_event.rb
+++ b/app/presenters/publishing_api_presenters/topical_event.rb
@@ -9,6 +9,9 @@ class PublishingApiPresenters::TopicalEvent < PublishingApiPresenters::Placehold
   end
 
   def links
-    extract_links([:topics])
+    extract_links([
+      :topics,
+      :organisations,
+    ])
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -45,6 +45,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     expected_links = {
       document_collections: [],
       lead_organisations: [case_study.lead_organisations.first.content_id],
+      organisations: [case_study.lead_organisations.first.content_id],
       related_policies: [],
       supporting_organisations: [],
       topics: [],
@@ -128,6 +129,7 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     expected_links_hash = {
       document_collections: [],
       lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
+      organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
       related_policies: [],
       supporting_organisations: [supporting_org.content_id],
       topics: [],

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -38,14 +38,15 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
           browse_pages: [],
           topics: [],
           policies: []
-        }
+        },
+        emphasised_organisations: case_study.lead_organisations.map(&:content_id),
       },
     }
 
     expected_links = {
       document_collections: [],
-      lead_organisations: [case_study.lead_organisations.first.content_id],
-      organisations: [case_study.lead_organisations.first.content_id],
+      lead_organisations: case_study.lead_organisations.map(&:content_id),
+      organisations: case_study.lead_organisations.map(&:content_id),
       related_policies: [],
       supporting_organisations: [],
       topics: [],

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -64,11 +64,12 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
           current: government.current?
         },
         related_mainstream_content: [],
+        emphasised_organisations: detailed_guide.lead_organisations.map(&:content_id),
       },
     }
     expected_links = {
-      lead_organisations: [detailed_guide.lead_organisations.first.content_id],
-      organisations: [detailed_guide.lead_organisations.first.content_id],
+      lead_organisations: detailed_guide.lead_organisations.map(&:content_id),
+      organisations: detailed_guide.organisations.map(&:content_id),
       related_guides: [],
       related_mainstream: [],
     }
@@ -83,8 +84,8 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
 
   test 'DetailedGuide presents related_mainstream and related_mainstream_content' do
     lookup_hash = {
-      "/guidance/lorem" => "deadbeef-cafe-babe-c0ffe1",
-      "/guidance/ipsum" => "deadbeef-cafe-babe-c0ffe2"
+      "/guidance/lorem" => "9dd9e077-ae45-45f6-ad9d-2a484e5ff312",
+      "/guidance/ipsum" => "9af50189-de1c-49af-a334-6b1d87b593a6"
     }
 
     publishing_api_has_lookups(lookup_hash)
@@ -104,8 +105,8 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     links = presented_item.links
     details = presented_item.content[:details]
     expected_ids = [
-      "deadbeef-cafe-babe-c0ffe1",
-      "deadbeef-cafe-babe-c0ffe2"
+      "9dd9e077-ae45-45f6-ad9d-2a484e5ff312",
+      "9af50189-de1c-49af-a334-6b1d87b593a6"
     ]
 
     # Links can come in any order, so we sort to make sure the set is the same.
@@ -117,7 +118,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
 
   test 'DetailedGuide presents related_mainstream with dodgy data' do
     lookup_hash = {
-      "/guidance/lorem" => "deadbeef-cafe-babe-c0ffe1"
+      "/guidance/lorem" => "cd7fde45-5f79-4982-8939-cedc4bed161c"
     }
     publishing_api_has_lookups(lookup_hash)
 
@@ -133,7 +134,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
 
     presented_item = present(detailed_guide)
     links = presented_item.links
-    expected_ids = ["deadbeef-cafe-babe-c0ffe1"]
+    expected_ids = ["cd7fde45-5f79-4982-8939-cedc4bed161c"]
 
     assert_equal expected_ids.sort, links[:related_mainstream].sort
   end

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -68,6 +68,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     }
     expected_links = {
       lead_organisations: [detailed_guide.lead_organisations.first.content_id],
+      organisations: [detailed_guide.lead_organisations.first.content_id],
       related_guides: [],
       related_mainstream: [],
     }

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -197,7 +197,10 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({ topics: %w(content_id_1) }, links)
+    assert_equal({
+      topics: %w(content_id_1),
+      organisations: [],
+    }, links)
   end
 
   test '#links treats the primary specialist sector of the item as the parent' do
@@ -211,7 +214,11 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({ topics: %w(content_id_1 content_id_2), parent: %w(content_id_1) }, links)
+    assert_equal({
+      topics: %w(content_id_1 content_id_2),
+      parent: %w(content_id_1),
+      organisations: [],
+    }, links)
   end
 
   test '#links.parent will not be set if the specialist sector is not found' do
@@ -224,6 +231,9 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({ topics: %w(content_id_1) }, links)
+    assert_equal({
+      topics: %w(content_id_1),
+      organisations: [],
+    }, links)
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/placeholder_test.rb
@@ -24,7 +24,10 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       need_ids: [],
       details: {},
     }
-    expected_links = { topics: [] }
+    expected_links = {
+      topics: [],
+      organisations: ministerial_role.organisations.map(&:content_id)
+    }
 
     presented_item = present(ministerial_role)
 
@@ -55,7 +58,10 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       need_ids: [],
       details: {},
     }
-    expected_links = { topics: [] }
+    expected_links = {
+      topics: [],
+      organisations: [],
+    }
 
     presented_item = present(person)
 
@@ -87,7 +93,10 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       details: {},
       analytics_identifier: "WO123",
     }
-    expected_links = { topics: [] }
+    expected_links = {
+      topics: [],
+      organisations: [],
+    }
 
     presented_item = present(worldwide_org)
 
@@ -119,7 +128,10 @@ class PublishingApiPresenters::PlaceholderTest < ActiveSupport::TestCase
       details: {},
       analytics_identifier: "WL123",
     }
-    expected_links = { topics: [] }
+    expected_links = {
+      topics: [],
+      organisations: [],
+    }
 
     presented_item = present(world_location)
 


### PR DESCRIPTION
Currently there are three types of organisations:
- lead organisations
- organisations
- supporting organisations

Where: organisations = lead organisations + supporting organisations

GOV.UK publishing apps do not send to the publishing-api the same organisation
types consistently.  We are going to modify all applications to send at least
the `organisations` content ids in the links hash and the `emphasised_organisations` content ids in the details hash. We will then:
- update frontend applications to use the organisations and the emphasised_organisations hashes and stop using the supporting organisations hash
- update publishing apps to stop sending the lead and supporting organisations hash
- drop the lead and supporting organisations data in the publishing apps and in the publishing api

ticket: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging