### PR TITLE
Lower publishing-api-sync-checks concurrency in dev.

### DIFF
--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -126,7 +126,10 @@ module DataHygiene
           success = false
         end
       else
-        failures << Failure.new(base_path: base_path, failed_expectations: ["item missing from #{content_store.titleize}"])
+        failures << Failure.new(
+          base_path: base_path,
+          failed_expectations: ["item unreachable in #{content_store.titleize}; response status: #{response.status_message}"]
+        )
         success = false
       end
       success

--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -47,7 +47,8 @@ module DataHygiene
     def initialize(scope)
       @scope = scope
       Ethon.logger = Logger.new(nil) # disable Typhoeus/Ethon debug logging
-      @hydra = Typhoeus::Hydra.new(max_concurrency: 20)
+      max_concurrency = Rails.env.development? ? 1 : 20
+      @hydra = Typhoeus::Hydra.new(max_concurrency: max_concurrency)
       @expectations = []
       @successes = []
       @failures = []

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -156,7 +156,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
       [
         check_failure(
           base_path: "/government/get-involved/take-part/take-part-slug",
-          failed_expectations: ["item missing from Content Store"],
+          failed_expectations: ["item unreachable in Content Store; response status: "],
         )
       ],
       check.failures
@@ -187,7 +187,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
       [
         check_failure(
           base_path: "/government/get-involved/take-part/take-part-slug",
-          failed_expectations: ["item missing from Draft Content Store"],
+          failed_expectations: ["item unreachable in Draft Content Store; response status: "],
         )
       ],
       check.failures


### PR DESCRIPTION
On my laptop (2013 i7 15" MacBook Pro FWIW), inside the vagrant VM, running a sync check will DOS the local `content-store`, causing all responses to return a "Bad Gateway" status.

This change lowers the concurrency during development to 1.

I don't think this is a great solution, so feel free to suggest alternatives/improvements.