### PR TITLE
[Do not merge] Add missing PublishedToPublishingApi to DetailedGuide model

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -9,6 +9,7 @@ class DetailedGuide < Edition
   include Edition::Organisations
   include Edition::RelatedPolicies
   include Edition::RelatedDocuments
+  include PublishesToPublishingApi
 
   validate :related_mainstream_content_valid?
   validate :additional_related_mainstream_content_valid?


### PR DESCRIPTION
This will make detailed guides automatically republish when they are modified.

I ought to have added this when I did the [republish PR](https://github.com/alphagov/whitehall/pull/2576) but I wasn't aware of its existence.

Perhaps we should wait on merging this, and bundle it with another republish data migration, to be safe on the side that nothing important has escaped republishing?