### PR TITLE
Fix translated publishing api base paths

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -2,7 +2,7 @@ module PublicDocumentRoutesHelper
   include ActionDispatch::Routing::PolymorphicRoutes
 
   def document_path(edition, options = {})
-    document_url(edition, options.merge(routing_type: :path))
+    document_url(edition, options.merge(only_path: true))
   end
 
   def public_document_path(edition, options = {})

--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -20,7 +20,7 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
   end
 
   def base_path
-    Whitehall.url_maker.public_document_path(item)
+    Whitehall.url_maker.public_document_path(item, locale: I18n.locale)
   end
 
 private

--- a/db/data_migration/20160512150912_republish_corporate_information_pages.rb
+++ b/db/data_migration/20160512150912_republish_corporate_information_pages.rb
@@ -1,0 +1,7 @@
+CorporateInformationPage
+  .published
+  .includes(:document)
+  .joins(:document, :translations)
+  .where("locale != 'en'").each do |cip|
+  Whitehall::PublishingApi.republish_document_async(cip.document)
+end

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -45,6 +45,45 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
     assert_valid_against_schema(presented_item.content, 'placeholder')
   end
 
+  test 'presents a translatable Edition, obeying the current locale' do
+    edition = create(:published_publication,
+                title: 'The title',
+                summary: 'The summary',
+                primary_specialist_sector_tag: 'oil-and-gas/taxation',
+                secondary_specialist_sector_tags: ['oil-and-gas/licensing'],
+                translated_into: [:cy])
+
+    public_path = Whitehall.url_maker.public_document_path(edition) + ".cy"
+
+    expected_hash = {
+      base_path: public_path,
+      title: 'cy-The title',
+      description: 'cy-The summary',
+      schema_name: 'placeholder_publication',
+      document_type: 'policy_paper',
+      locale: 'cy',
+      need_ids: [],
+      public_updated_at: edition.public_timestamp,
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend',
+      routes: [
+        { path: public_path, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        tags: {
+          browse_pages: [],
+          policies: [],
+          topics: ['oil-and-gas/taxation', 'oil-and-gas/licensing']
+        }
+      },
+    }
+
+    presented_content = I18n.with_locale(:cy) { present(edition).content }
+    assert_equal expected_hash, presented_content
+    assert_valid_against_schema(presented_content, 'placeholder')
+  end
+
   test 'can present a draft Edition for the publishing API' do
     edition = create(:publication,
                 title: 'The title',


### PR DESCRIPTION
For a while, Land Registry's translated corporate information pages in
have had redirects in publishing api instead of the placeholder. This means
those pages are inaccessible. In attempting to perform a one off fix to remove
the redirect, the root cause of the bug was discovered.

Whitehall’s publishing api workers use the I18n with_locale block to
tell presenters which locale to present for. This needs to be passed
through to the url helpers in order to append the locale on the
base_path.

This uncovered a bug in how we call url helpers which was ignoring the
requested locale if `routing_type: :path` was set. The correct
invocation is `only_path: true`.

This includes a data migration to republish the 250-odd Corp Info pages
with translations.