### PR TITLE
Dedupe related detailed guide content ids

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -33,7 +33,7 @@ class DetailedGuide < Edition
   end
 
   def related_detailed_guide_content_ids
-    related_to_editions.where(type: 'DetailedGuide').map(&:content_id)
+    related_to_editions.where(type: 'DetailedGuide').map(&:content_id).uniq
   end
 
   # Ensure that we set related detailed guides without stomping on other related documents


### PR DESCRIPTION
It's possible for a detailed guide to be related to a number of distinct editions which all map to the same `content_id`.

An example for this is https://www.gov.uk/guidance/military-end-use-control-guidance-notes.

It links to 140 different editions:

```ruby
> d = Document.find_by_slug("military-end-use-control-guidance-notes")
> dg = d.latest_edition
> dg.related_to_editions.map(&:id)
[3820, 17587, 221635, 315251, 497743, 3855, 7874, 8878, 17292, 581237,
3860, ...]
```

But the editions themselves are linked to only 12 distinct detailed guides, so they have lots of duplicated `content_ids`:

```ruby
> dg.related_to_editions.map(&:content_id)
["5c716f08-7631-11e4-a3cb-005056011aef", "5c716f08-7631-11e4-a3cb-005056011aef", ...]
```

This updates the method to dedupe them.