### PR TITLE
Add data migration to delete a detailed guide draft

### DIFF
--- a/db/data_migration/20160516075931_remove_draft_with_too_many_attachments.rb
+++ b/db/data_migration/20160516075931_remove_draft_with_too_many_attachments.rb
@@ -1,0 +1,5 @@
+detailed_guide = DetailedGuide.where(id: 621922).first
+
+if detailed_guide
+  Whitehall.edition_services.deleter(detailed_guide).perform!
+end


### PR DESCRIPTION
Why?

The DetailedGuide with id 621922 is a draft edition of the document 'Rights
of Way online order details'. It currently has 428 attachments in
production. Whitehall is currently unable to handle this many
attachments reliably - attempts by the publishing team to edit this draft or
discard it result in 504 Gateway timeouts. There are attachments missing
and these can't currently be added via the UI because of these timeouts.

This page is currently being split out by Content Team 2. While this
work is completing, the publishing team want to display a message to
users that they are aware of the issues and are investigating.

Removing the draft is intended to permit editing of a new one to add the
message. In the (likely) event that timeout issues continue to occur, a
followup migration (or editing of the content live via a console) will
add the warning message on behalf of the publishing team.