### PR TITLE
Publications Presenter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,6 +536,3 @@ DEPENDENCIES
   validates_email_format_of
   webmock (~> 1.22.3)
   whenever (= 0.9.4)
-
-BUNDLED WITH
-   1.11.2

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,4 +1,8 @@
 module AttachmentsHelper
+  def default_url_options
+    { host: Plek.new.website_root, protocol: 'https' }
+  end
+
   def previewable?(attachment)
     attachment.csv? && attachment.attachable.is_a?(Edition)
   end
@@ -7,5 +11,11 @@ module AttachmentsHelper
   # provides a convenient shorthand for generating a path for attachment preview.
   def preview_path_for_attachment(attachment)
     preview_attachment_path(id: attachment.attachment_data.id, file: attachment.filename_without_extension, extension: attachment.file_extension)
+  end
+
+  def block_attachments(attachments = [], alternative_format_contact_email = nil)
+    attachments.collect { |attachment|
+      render(partial: "documents/attachment", formats: :html, object: attachment, locals: {alternative_format_contact_email: alternative_format_contact_email})
+    }
   end
 end

--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -2,6 +2,7 @@ require 'delegate'
 
 module GovspeakHelper
   include ::Govspeak::ContactsExtractorHelpers
+  include Rails.application.routes.url_helpers
 
   BARCHART_REGEXP = /{barchart(.*?)}/
   SORTABLE_REGEXP = /{sortable}/

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -654,7 +654,9 @@ class Edition < ActiveRecord::Base
 private
 
   def date_for_government
-    first_public_at.try(:to_date)
+    published_edition_date = first_public_at.try(:to_date)
+    draft_edition_date = updated_at.try(:to_date)
+    published_edition_date || draft_edition_date
   end
 
   def enforcer(user)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -148,6 +148,12 @@ class Publication < Publicationesque
 
   private
 
+  def date_for_government
+    published_edition_date = first_public_at.try(:to_date)
+    draft_edition_date = updated_at.try(:to_date)
+    published_edition_date || draft_edition_date
+  end
+
   def attachment_required_before_moving_out_of_draft
     if %w(submitted scheduled published).include?(state) && !has_attachments?
       errors.add(:base, "Publications must have either a URL for off-site documents, an attachment or HTML version before being #{current_state}")

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -148,12 +148,6 @@ class Publication < Publicationesque
 
   private
 
-  def date_for_government
-    published_edition_date = first_public_at.try(:to_date)
-    draft_edition_date = updated_at.try(:to_date)
-    published_edition_date || draft_edition_date
-  end
-
   def attachment_required_before_moving_out_of_draft
     if %w(submitted scheduled published).include?(state) && !has_attachments?
       errors.add(:base, "Publications must have either a URL for off-site documents, an attachment or HTML version before being #{current_state}")

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -43,6 +43,8 @@ private
       PublishingApiPresenters::DocumentCollectionPlaceholder
     when ::DetailedGuide
       PublishingApiPresenters::DetailedGuide
+    when ::Publication
+      PublishingApiPresenters::Publication
     else
       PublishingApiPresenters::Edition
     end

--- a/app/presenters/publishing_api_presenters/political_helper.rb
+++ b/app/presenters/publishing_api_presenters/political_helper.rb
@@ -3,6 +3,7 @@ private
 
   def government
     gov = item.government
+    return nil unless gov
     {
       title: gov.name,
       slug: gov.slug,

--- a/app/presenters/publishing_api_presenters/publication.rb
+++ b/app/presenters/publishing_api_presenters/publication.rb
@@ -7,10 +7,8 @@ class PublishingApiPresenters::Publication < PublishingApiPresenters::Edition
 
   def links
     extract_links([
-      :lead_organisations,
       :organisations,
       :document_collections,
-      :supporting_organisations,
       :world_locations
     ]).merge(
       ministers: ministers,

--- a/app/presenters/publishing_api_presenters/publication.rb
+++ b/app/presenters/publishing_api_presenters/publication.rb
@@ -1,0 +1,58 @@
+require_relative "../publishing_api_presenters"
+
+class PublishingApiPresenters::Publication < PublishingApiPresenters::Edition
+  include PublishingApiPresenters::WithdrawingHelper
+  include PublishingApiPresenters::PoliticalHelper
+  include PublishingApiPresenters::ApplicabilityHelper
+
+  def links
+    extract_links([
+      :lead_organisations,
+      :organisations,
+      :document_collections,
+      :supporting_organisations,
+      :world_locations
+    ]).merge(
+      ministers: ministers,
+      related_statistical_data_sets: item.statistical_data_set_ids,
+      topical_events: topical_events
+    )
+  end
+
+private
+
+  def schema_name
+    "publication"
+  end
+
+  def details
+    super.merge({
+      body: body,
+      documents: documents,
+      first_public_at: first_public_at,
+      change_history: item.change_history.as_json,
+      emphasised_organisations: item.lead_organisations.map(&:content_id)
+    }).merge(political_details)
+      .tap do |json|
+        json[:withdrawn_notice] = withdrawn_notice if item.withdrawn?
+        json[:national_applicability] = national_applicability if item.nation_inapplicabilities.any?
+      end
+  end
+
+  def documents
+    return [] unless item.attachments.any?
+    Whitehall::GovspeakRenderer.new.block_attachments(item.attachments)
+  end
+
+  def ministers
+    item.role_appointments
+      .collect {|a| a.person.content_id}
+  end
+
+  def topical_events
+    TopicalEvent
+      .joins(:classification_memberships)
+      .where(classification_memberships: {edition_id: item.id})
+      .pluck(:content_id)
+  end
+end

--- a/db/data_migration/20160525093035_republish_publications_to_publishing_api.rb
+++ b/db/data_migration/20160525093035_republish_publications_to_publishing_api.rb
@@ -1,0 +1,3 @@
+Publication.includes(:document).find_each do |pub|
+  Whitehall::PublishingApi.republish_document_async(pub.document)
+end

--- a/lib/whitehall/govspeak_renderer.rb
+++ b/lib/whitehall/govspeak_renderer.rb
@@ -5,6 +5,7 @@ module Whitehall
       :govspeak_to_html,
       :govspeak_with_attachments_to_html,
       :html_attachment_govspeak_headers_html,
+      :block_attachments,
       to: :view_context
 
   private

--- a/script/publishing-api-sync-checks/publication_sync_check.rb
+++ b/script/publishing-api-sync-checks/publication_sync_check.rb
@@ -1,0 +1,21 @@
+publications = Publication.where(state: %w{published withdrawn})
+
+check = DataHygiene::PublishingApiSyncCheck.new(publications)
+
+check.add_expectation("schema_name") do |content_store_payload, _|
+  content_store_payload["schema_name"] == "publication"
+end
+
+check.add_expectation("document_type") do |content_store_payload, record|
+  content_store_payload["document_type"] == record.display_type_key
+end
+
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == record.search_link
+end
+
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.title
+end
+
+check.perform

--- a/test/unit/presenters/announcement_presenter_test.rb
+++ b/test/unit/presenters/announcement_presenter_test.rb
@@ -42,6 +42,8 @@ class AnnouncementPresenterTest < PresenterTestCase
     # TODO: perhaps rethink edition factory, so this apparent duplication
     # isn't neccessary
     fatality_notice.stubs(:organisations).returns([organisation])
+    government = Government.new
+    fatality_notice.stubs(:government).returns(government)
     hash = AnnouncementPresenter.new(fatality_notice, @view_context).as_hash
     assert hash[:field_of_operation]
   end

--- a/test/unit/presenters/document_filter_presenter_test.rb
+++ b/test/unit/presenters/document_filter_presenter_test.rb
@@ -19,6 +19,8 @@ class DocumentFilterPresenterTest < PresenterTestCase
         organisations: [organisation],
         public_timestamp: 3.days.ago.as_json
       )
+      government = Government.new
+      publication.stubs(:government).returns(government)
       # TODO: perhaps rethink edition factory, so this apparent duplication
       # isn't neccessary
       publication.stubs(:organisations).returns([organisation])

--- a/test/unit/presenters/publicationesque_presenter_test.rb
+++ b/test/unit/presenters/publicationesque_presenter_test.rb
@@ -37,6 +37,8 @@ class PublicationesquePresenterTest < PresenterTestCase
       public_timestamp: Time.zone.now,
       attachments: [],
       organisations: [organisation])
+    government = Government.new
+    publication.stubs(:government).returns(government)
     publication.stubs(:published_document_collections).returns([collection])
     publication.expects(:part_of_published_collection?).returns(true)
     # TODO: perhaps rethink edition factory, so this apparent duplication

--- a/test/unit/presenters/publishing_api_presenters/publication_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/publication_test.rb
@@ -1,0 +1,176 @@
+require 'test_helper'
+
+class PublishingApiPresenters::PublicationTest < ActiveSupport::TestCase
+  def present(edition)
+    PublishingApiPresenters::Publication.new(edition)
+  end
+
+  test "publication presentation includes the correct values" do
+    government = create(:government)
+    publication = create(:published_publication,
+                    title: 'Publication title',
+                    summary: 'The summary',
+                    body: 'Some content')
+
+    public_path = Whitehall.url_maker.public_document_path(publication)
+    expected_content = {
+      base_path: public_path,
+      title: 'Publication title',
+      description: 'The summary',
+      schema_name: 'publication',
+      document_type: 'policy_paper',
+      locale: 'en',
+      need_ids: [],
+      public_updated_at: publication.public_timestamp,
+      publishing_app: 'whitehall',
+      rendering_app: 'whitehall-frontend', #to be renamed into 'government-frontend'
+      routes: [
+        { path: public_path, type: 'exact' }
+      ],
+      redirects: [],
+      details: {
+        body: "<div class=\"govspeak\"><p>Some content</p></div>",
+        tags: {
+          browse_pages: [],
+          policies: [],
+          topics: []
+        },
+        documents: ["<section class=\"attachment embedded\" id=\"attachment_1\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/publications/publication-title/#{publication.attachments.first.title}\"><img alt=\"\" src=\"/government/assets/pub-cover-html.png\" /></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a href=\"/government/publications/publication-title/#{publication.attachments.first.title}\">#{publication.attachments.first.title}</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">HTML</span>\n    </p>\n\n\n  </div>\n</section>"],
+        first_public_at: publication.first_public_at,
+        change_history: [
+          { public_timestamp: publication.public_timestamp, note: 'change-note' }.as_json
+        ],
+        emphasised_organisations: publication.lead_organisations.map(&:content_id),
+        political: false,
+        government: {
+          title: government.name,
+          slug: government.slug,
+          current: government.current?
+        },
+      },
+    }
+
+    minister = create(:ministerial_role_appointment)
+    publication.role_appointments << minister
+    topical_event = create(:topical_event)
+    publication.classification_memberships.create(classification_id: topical_event.id)
+
+    expected_links = {
+      lead_organisations: publication.lead_organisations.map(&:content_id),
+      organisations: publication.lead_organisations.map(&:content_id),
+      document_collections: [],
+      supporting_organisations: [],
+      ministers: [minister.person.content_id],
+      related_statistical_data_sets: [],
+      world_locations: [],
+      topical_events: [topical_event.content_id],
+    }
+
+    presented_item = present(publication)
+
+    assert_valid_against_schema(presented_item.content, 'publication')
+    assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
+
+    assert_equal expected_content.except(:details),
+      presented_item.content.except(:details)
+
+    # We test for HTML equivlance rather than string equality to get around
+    # inconsistencies with line breaks between different XML libraries
+    assert_equivalent_html expected_content[:details].delete(:body),
+      presented_item.content[:details].delete(:body)
+    assert_equal expected_content[:details], presented_item.content[:details].except(:body)
+    assert_equal expected_links, presented_item.links
+    assert_equal publication.document.content_id, presented_item.content_id
+  end
+
+  test "links hash includes lead and supporting organisations in correct order" do
+    lead_org_1 = create(:organisation)
+    lead_org_2 = create(:organisation)
+    supporting_org = create(:organisation)
+    publication = create(:published_publication,
+                        lead_organisations: [lead_org_1, lead_org_2],
+                        supporting_organisations: [supporting_org])
+    presented_item = present(publication)
+    expected_links_hash = {
+      lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
+      organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
+      document_collections: [],
+      supporting_organisations: [supporting_org.content_id],
+      world_locations: [],
+      ministers: [],
+      related_statistical_data_sets: [],
+      topical_events: []
+    }
+
+    assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
+    assert_equal expected_links_hash, presented_item.links
+  end
+
+  test "details hash includes full document history" do
+    original_timestamp = 2.days.ago
+    original = create(:superseded_publication, first_published_at: original_timestamp)
+    new_timestamp = Time.zone.now
+    create(:government)
+    new_edition = create(:published_publication, document: original.document, published_major_version: 2, change_note: "More changes", major_change_published_at: new_timestamp)
+    presented_item = present(new_edition)
+    assert_valid_against_schema(presented_item.content, 'publication')
+    presented_history = presented_item.content[:details][:change_history]
+    expected_history = [
+      { public_timestamp: new_timestamp, note: "More changes" },
+      { public_timestamp: original_timestamp, note: "change-note" }
+    ].as_json
+    assert_equal expected_history, presented_history
+  end
+
+  test "links hash includes world locations" do
+    location = create(:world_location)
+    publication = create(:published_publication,
+                        world_locations: [location])
+    presented_item = present(publication)
+    assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
+    assert_equal [location.content_id], presented_item.links[:world_locations]
+  end
+
+  test "links hash includes document collections that the publication is part of" do
+    publication = create(:published_publication)
+    document_collections = [
+      create(:published_document_collection, groups: [build(:document_collection_group, documents: [publication.document])]),
+      create(:published_document_collection, groups: [build(:document_collection_group, documents: [publication.document])])
+    ]
+
+    publication.document_collections.reload
+    presented_item = present(publication)
+
+    assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
+    assert_same_elements document_collections.map(&:content_id), presented_item.links[:document_collections]
+  end
+
+  test "a withdrawn publication includes details of the archive notice" do
+    create(:government)
+    publication = create(:published_publication, :withdrawn)
+    publication.build_unpublishing(
+      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
+      explanation: 'No longer relevant')
+
+    publication.unpublishing.save!
+
+    archive_notice = {
+      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
+      archived_at: publication.updated_at
+    }
+
+    presented_item = present(publication)
+
+    assert_valid_against_schema(presented_item.content, 'publication')
+    assert_equal archive_notice[:archived_at], presented_item.content[:details][:withdrawn_notice][:withdrawn_at]
+    assert_equivalent_html archive_notice[:explanation],
+      presented_item.content[:details][:withdrawn_notice][:explanation]
+  end
+
+  test "an unpublished document has a first_public_at of the document creation time" do
+    create(:government)
+    publication = create(:draft_publication)
+    presented_item = present(publication)
+    assert_equal publication.document.created_at.iso8601, presented_item.content[:details][:first_public_at]
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters/publication_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/publication_test.rb
@@ -56,10 +56,8 @@ class PublishingApiPresenters::PublicationTest < ActiveSupport::TestCase
     publication.classification_memberships.create(classification_id: topical_event.id)
 
     expected_links = {
-      lead_organisations: publication.lead_organisations.map(&:content_id),
       organisations: publication.lead_organisations.map(&:content_id),
       document_collections: [],
-      supporting_organisations: [],
       ministers: [minister.person.content_id],
       related_statistical_data_sets: [],
       world_locations: [],
@@ -92,10 +90,8 @@ class PublishingApiPresenters::PublicationTest < ActiveSupport::TestCase
                         supporting_organisations: [supporting_org])
     presented_item = present(publication)
     expected_links_hash = {
-      lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
       document_collections: [],
-      supporting_organisations: [supporting_org.content_id],
       world_locations: [],
       ministers: [],
       related_statistical_data_sets: [],


### PR DESCRIPTION
Trello: https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api

 Back-end work for publishing of Publications format to the publishing API.

cc @binaryberry 