### PR TITLE
Fix PublishStaticPages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -48,6 +48,7 @@ class PublishStaticPages
     {
       content_id: page[:content_id],
       content: {
+        details: {},
         title: page[:title],
         description: page[:description],
         format: "placeholder", # This content will never be rendered by content store


### PR DESCRIPTION
A 'details' key is now required by content schemas.
This fixes the related unit test, failing on master.