### PR TITLE
Push HTML Attachments to Publishing API

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -16,7 +16,7 @@ class Admin::AttachmentsController < Admin::BaseController
   def new; end
 
   def create
-    if attachment.save
+    if save_attachment
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       render :new
@@ -24,7 +24,8 @@ class Admin::AttachmentsController < Admin::BaseController
   end
 
   def update
-    if attachment.update_attributes(attachment_params)
+    attachment.attributes = attachment_params
+    if save_attachment
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
@@ -170,6 +171,14 @@ private
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       raise
+    end
+  end
+
+  def save_attachment
+    if attachment.respond_to?(:save_and_update_publishing_api)
+      attachment.save_and_update_publishing_api
+    else
+      attachment.save
     end
   end
 end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -88,6 +88,10 @@ class HtmlAttachment < Attachment
     'HTML'
   end
 
+  def save_and_update_publishing_api
+    save && Whitehall.edition_services.draft_updater(attachable).perform!
+  end
+
   private
 
   def sluggable_locale?

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -118,4 +118,28 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment.update_attributes!(locale: "fr")
     assert attachment.slug.blank?
   end
+
+  test "#save_and_update_publishing_api saves the attachment" do
+    build(
+      :draft_publication,
+      html_attachments: [attachment = build(:html_attachment)]
+    )
+    attachment.save_and_update_publishing_api
+    assert attachment.persisted?, "Attachment has not been saved"
+  end
+
+  test "#save_and_udpate_publishing_api sends the attachable to draft_updater" do
+    edition = create(
+      :draft_publication,
+      html_attachments: [attachment = build(:html_attachment)]
+    )
+
+    Whitehall.edition_services
+      .expects(:draft_updater)
+      .with(edition)
+      .returns(draft_updater = stub)
+    draft_updater.expects(:perform!)
+
+    attachment.save_and_update_publishing_api
+  end
 end


### PR DESCRIPTION
When a document with HTML Attachments is pushed to the publishing API, it should also push its dependent HTML Attachments.