### PR TITLE
Try to run all relevant tests in schema test rake task

### DIFF
--- a/lib/tasks/test_publishing_schemas.rake
+++ b/lib/tasks/test_publishing_schemas.rake
@@ -1,7 +1,8 @@
 namespace :test do
   Rake::TestTask.new(:publishing_schemas => "test:prepare") do |t|
     t.libs << 'test'
-    t.test_files = FileList['test/unit/presenters/publishing_api_presenters/*_test.rb']
+    t.test_files = `grep -rlE "valid_against_(links_)?schema" test`.lines.map(&:chomp)
   end
+
   Rake::Task['test:publishing_schemas'].comment = "Test publishing API presenters against external schemas"
 end


### PR DESCRIPTION
We recently changed the content schemas to make `details` required (https://github.com/alphagov/govuk-content-schemas/pull/310). The tests for this PR passed for Whitehall, because for changes in govuk-content-schemas it only runs tests for the publishing-api presenters. 

This is done because we don’t want to run the entire whitehall test suite for schema tests as it would take a long time.

There are a couple of schema tests outside of this directory that use schema tests, and were not run previously:

```
test/unit/statistics_announcement_test.rb
test/unit/whitehall/publishing_api/redirect_test.rb
test/unit/whitehall/publishing_api_test.rb
```

Because the schema tests didn't test these files the test failure surfaced somewhere else (fixed in https://github.com/alphagov/whitehall/pull/2594).

With the grep-based file selection we pick up any new schema tests automatically.