### PR TITLE
Push HTML Pubs to Publishing API

### DIFF
--- a/db/data_migration/20160519081856_republish_html_attachments.rb
+++ b/db/data_migration/20160519081856_republish_html_attachments.rb
@@ -1,0 +1,19 @@
+published_edition_ids = Edition.where("state IN('published', 'withdrawn')")
+  .joins("INNER JOIN attachments ON attachable_id = editions.id
+          AND attachable_type = 'Edition'
+          AND attachments.type = 'HtmlAttachment'")
+  .pluck('editions.id')
+
+draft_edition_ids = Edition.where(state: 'draft')
+  .joins("INNER JOIN attachments ON attachable_id = editions.id
+          AND attachable_type = 'Edition'
+          AND attachments.type = 'HtmlAttachment'")
+  .pluck('editions.id')
+
+HtmlAttachment.where(attachable_type: 'Edition', attachable_id: published_edition_ids).find_each do |a|
+  Whitehall::PublishingApi.publish_async(a, 'republish', 'bulk_republishing')
+end
+
+HtmlAttachment.where(attachable_type: 'Edition', attachable_id: draft_edition_ids).find_each do |a|
+  Whitehall::PublishingApi.save_draft_async(a, 'republish', 'bulk_republishing')
+end


### PR DESCRIPTION
Pushes all current (published, withdrawn or draft) HTML Attachments
with the correct status.

Takes about 30 seconds to run on VM, then about an hour to process the
queue.

/cc @gpeng 