### PR TITLE
Touch `StatisticsAnnouncement` on `Publication#save`

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -18,6 +18,13 @@ class Publication < Publicationesque
   attr_accessor :statistics_announcement_id
   after_create :assign_statistics_announcement
 
+  after_save :touch_statistics_announcement
+  def touch_statistics_announcement
+    unless draft?
+      statistics_announcement.touch unless statistics_announcement.nil?
+    end
+  end
+
   def self.subtypes
     PublicationType.all
   end

--- a/db/data_migration/20160520082100_republish_statistics_announcements.rb
+++ b/db/data_migration/20160520082100_republish_statistics_announcements.rb
@@ -1,0 +1,11 @@
+publication_ids_published_since_april = Publication.where("first_published_at > ?", Time.new(2016,4,1)).pluck(:id)
+statistics_announcements_to_republish = StatisticsAnnouncement
+  .unscoped
+  .where(publication_id: publication_ids_published_since_april)
+
+republisher = DataHygiene::PublishingApiRepublisher.new(
+    statistics_announcements_to_republish
+  )
+
+republisher.perform
+

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -215,4 +215,18 @@ class PublicationsInTopicsTest < ActiveSupport::TestCase
 
     assert_equal publication, statistics_announcement.reload.publication
   end
+
+  test 'touches statistics_announcement on save' do
+    statistics_announcement = create(:statistics_announcement)
+    publication = build(:published_statistics, statistics_announcement: statistics_announcement)
+    statistics_announcement.expects(:touch)
+    publication.save!
+  end
+
+  test "it doesn't touch the statistics_announcement if it's in draft" do
+    statistics_announcement = create(:statistics_announcement)
+    publication = build(:draft_statistics, statistics_announcement: statistics_announcement)
+    statistics_announcement.expects(:touch).never
+    publication.save!
+  end
 end


### PR DESCRIPTION
When a `Publication` is saved in a state other than draft it should `touch` any associated `StatisticsAnnouncement` to ensure that it is sent to the publishing api.

This wasn't happening causing `StatisticsAnnouncement` objects associated with a published `Publication` not to be redirected.