### PR TITLE
Add helper copy to admin attachments interface

### DIFF
--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -1,11 +1,20 @@
 <% page_title "Attachments for #{attachment.attachable_model_name}" %>
 <% page_class "attachments index" %>
+<% is_publication = attachment.attachable_model_name == 'publication' %>
 
 <div class="row">
   <section class="col-md-8">
     <h1>Attachments for <%= attachment.attachable_model_name %></h1>
 
     <%= attachable_editing_tabs(attachable) do %>
+      <p class="qa-helper-copy">
+        <strong>Note:</strong>
+        <% if is_publication %>
+          Attachments added to a publication will appear automatically.
+        <% else %>
+          Attachments need to be referenced in the body markdown to appear in your document.
+        <% end %>
+      <p>
       <ul class="actions list-unstyled">
         <li>
           <%= link_to 'Upload new file attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment]) %>

--- a/test/integration/attachments_test.rb
+++ b/test/integration/attachments_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentsTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  test 'displays attachment helper copy for non-publications' do
+    edition = create(:edition)
+    visit "/government/admin/editions/#{edition.id}/attachments"
+
+    within ".qa-helper-copy" do
+      assert_text "need to be referenced"
+    end
+  end
+
+  test 'displays different helper copy for publications' do
+    publication = create(:publication)
+    visit "/government/admin/editions/#{publication.id}/attachments"
+
+    within ".qa-helper-copy" do
+      assert_text "will appear automatically"
+    end
+  end
+end


### PR DESCRIPTION
Attachments don't work consistently across all formats. While experienced publishers know this, we sometimes get support requests from users confused as to why their attachments are not displaying.

This commit aims to improve the situation ever so slightly with some copy.

Relevant Trello ticket (2ndline):
https://trello.com/c/XeE6aw32/156-improve-whitehall-publisher-attachment-copy

This isn't an ideal solution, as helper copy like this tends to be ignored.

I was thinking that in addition to this, the edit interface could actively scan the `body` field for input, and detect (using JavaScript) whether the user has or has not referenced all the attachments, and provide a yellow warning banner close to the submit button when not. Since this is a more involved solution, I'm curious if others think it's worth building.

Feel free to suggest copy improvements or testing improvements. Whitehall doesn't have Capybara integration tests similar to this one, so I'm not sure if it's in the right place or why it doesn't have any in the first place.

# Screenshots

![screen shot 2016-05-20 at 11 40 27](https://cloud.githubusercontent.com/assets/1650875/15425608/3e57768a-1e81-11e6-8048-8af49ec4fa99.png)
![screen shot 2016-05-20 at 11 40 32](https://cloud.githubusercontent.com/assets/1650875/15425609/3e57de0e-1e81-11e6-9aca-204390ac02e7.png)
