### PR TITLE
Add some extra documentation

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -113,6 +113,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
   end
 
   def schedule
+    # This will enqueue a `ScheduledPublishingWorker`
     edition_scheduler = Whitehall.edition_services.scheduler(@edition)
     if edition_scheduler.perform!
       redirect_to admin_editions_path(state: :scheduled), notice: "The document #{@edition.title} has been scheduled for publication"

--- a/app/controllers/statistics_announcements_controller.rb
+++ b/app/controllers/statistics_announcements_controller.rb
@@ -1,3 +1,4 @@
+# Note that announcement pages are rendered by the `government-frontend` application.
 class StatisticsAnnouncementsController < PublicFacingController
   include PublicDocumentRoutesHelper
 
@@ -13,6 +14,7 @@ class StatisticsAnnouncementsController < PublicFacingController
   end
 
 private
+
   def filter_params
     params.slice(:page, :keywords, :from_date, :to_date, :organisations, :topics)
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,4 +1,4 @@
-# The base class for all editoral content. It configures the searchable options and callbacks.
+# The base class for almost all editoral content.
 # @abstract Using STI should not create editions directly.
 class Edition < ActiveRecord::Base
   include Edition::Traits
@@ -8,17 +8,27 @@ class Edition < ActiveRecord::Base
 
   include Edition::Identifiable
   include Edition::LimitedAccess
+
+  # Adds a statemachine for the publishing workflow. States and methods like
+  # `publish` and `withdraw` are defined here.
   include Edition::Workflow
+
+  # Adds support for `unpublishing`, change notes and version numbers.
   include Edition::Publishing
+
+  # Sets up papertrail and versioning
   include Edition::AuditTrail
+
   include Edition::ActiveEditors
   include Edition::Translatable
+
+  # Add support for specialist sector tagging.
   include Edition::SpecialistSectors
+
   include Dependable
 
   serialize :need_ids, Array
 
-  # This mixin should go away when we switch to a search backend for admin documents
   extend Edition::FindableByOrganisation
 
   include Searchable

--- a/app/models/edition/findable_by_organisation.rb
+++ b/app/models/edition/findable_by_organisation.rb
@@ -1,4 +1,3 @@
-# This mixin should go away when we switch to a search backend for admin documents
 module Edition::FindableByOrganisation
   def in_organisation(organisation)
     organisation_ids = Array(organisation).map(&:id)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,3 +1,10 @@
+# Publications live at https://www.gov.uk/government/publications
+#
+# There are many types of publications - see `PublicationType`.
+#
+# Publication pages are rendered by Whitehall.
+#
+# Note that `Publicationesque` inherits from `Edition`
 class Publication < Publicationesque
   include Edition::Images
   include Edition::NationalApplicability

--- a/app/models/publicationesque.rb
+++ b/app/models/publicationesque.rb
@@ -1,3 +1,10 @@
+# Publicationesque is a common base class for things that look like
+# publications:
+#
+# - Consultations
+# - Publication
+# - StatisticalDataSet
+#
 # @abstract
 class Publicationesque < Edition
   include Edition::RelatedPolicies

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -1,3 +1,8 @@
+# Statistical data sets live at https://www.gov.uk/government/statistical-data-sets
+#
+# Example:
+#  https://www.gov.uk/government/statistical-data-sets/2011-skills-for-life-survey-small-area-estimation-data
+#
 class StatisticalDataSet < Publicationesque
   include Edition::AlternativeFormatProvider
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -1,3 +1,15 @@
+# Statistics Announcements can be found at https://www.gov.uk/government/statistics/announcements
+#
+# They are used to announce the publication of official statistics. Some info
+# can be found in the Wiki - https://gov-uk.atlassian.net/wiki/display/GOVUK/Statistics.
+#
+# Once the statistics are published, the statistics announcement will redirect and
+# dissapear from search.
+#
+# Statistics Announcements pages are rendered by the `government-frontend` app,
+# the index page is still rendered from Whitehall.
+#
+# Statistics announcements are not versioned/editioned.
 class StatisticsAnnouncement < ActiveRecord::Base
   extend FriendlyId
   friendly_id :title

--- a/app/services/scheduled_edition_publisher.rb
+++ b/app/services/scheduled_edition_publisher.rb
@@ -38,6 +38,7 @@ private
   end
 
   def fire_transition!
+    # The `publish` method is part of `Edition::Workflow`.
     edition.publish
     edition.save(validate: false)
     supersede_previous_editions!

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -1,5 +1,8 @@
 require 'sidekiq/api'
 
+# ScheduledPublishingWorker is a job that is scheduled by the `EditionScheduler`.
+# It is never executed immediately but uses the Sidekiq delay mechanism to
+# execute at the time the edition should be published.
 class ScheduledPublishingWorker < WorkerBase
   class ScheduledPublishingFailure < StandardError; end
 
@@ -32,6 +35,7 @@ class ScheduledPublishingWorker < WorkerBase
     edition = Edition.find(edition_id)
     return if edition.published?
 
+    # Call `ScheduledEditionPublisher` via the `EditionServiceCoordinator`.
     publisher = Whitehall.edition_services.scheduled_publisher(edition)
 
     Edition::AuditTrail.acting_as(publishing_robot) do


### PR DESCRIPTION
While debugging an issue with statistics announcements yesterday we learned a bunch of things about how Whitehall works. This commit is an attempt to put some of that back into the code as comments. The idea is that these comments would’ve helped us yesterday, so it might help someone the next time. It’s by no means complete but hopefully it’s a small improvement.