### PR TITLE
Sync check script for HTML Publications

### DIFF
--- a/script/publishing-api-sync-checks/html_publication_sync_check.rb
+++ b/script/publishing-api-sync-checks/html_publication_sync_check.rb
@@ -1,0 +1,44 @@
+html_attachments = HtmlAttachment.joins(<<-SQL).includes(attachable: [:document])
+  INNER JOIN editions ON attachable_id = editions.id
+    AND attachable_type = 'Edition'
+    AND attachments.type = 'HtmlAttachment'
+    AND editions.state IN ('published', 'withdrawn')
+  SQL
+
+check = DataHygiene::PublishingApiSyncCheck.new(html_attachments)
+
+check.override_base_path do |record|
+  Whitehall.url_maker.publication_html_attachment_path(publication_id: record.attachable.document.slug, id: record.to_param)
+end
+
+check.add_expectation("schema_name") do |content_store_payload, _|
+  content_store_payload["schema_name"] == "html_publication"
+  content_store_payload["document_type"] == "html_publication"
+end
+
+check.add_expectation("base_path") do |content_store_payload, record|
+  content_store_payload["base_path"] == Whitehall.url_maker.publication_html_attachment_path(publication_id: record.attachable.document.slug, id: record.to_param)
+end
+
+check.add_expectation("title") do |content_store_payload, record|
+  content_store_payload["title"] == record.title
+end
+
+check.add_expectation("locale") do |content_store_payload, record|
+  content_store_payload["locale"] == (record.locale || "en")
+end
+
+check.add_expectation("parent") do |content_store_payload, record|
+  content_store_payload["links"]["parent"][0]["content_id"] == record.attachable.content_id
+end
+
+check.add_expectation("content") do |content_store_payload, _|
+  content_store_payload["details"]["body"].present?
+  content_store_payload["details"]["headings"].present?
+end
+
+check.add_expectation("rendering_app") do |content_store_payload, _|
+  content_store_payload["rendering_app"] == "whitehall-frontend"
+end
+
+check.perform

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -115,7 +115,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     content_store_has_item("/government/get-involved/take-part/take-part-slug", payload, draft: true)
 
     check = check_take_part
-    expected_error_message = "Failed path: /government/get-involved/take-part/take-part-slug, failed expectations: format"
+    expected_error_message = "Failed path: /government/get-involved/take-part/take-part-slug in Content Store, failed expectations: format"
     assert_output(/Successes: 0\nFailures: 1\n#{expected_error_message}/m) do
       check.perform
     end
@@ -156,7 +156,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
       [
         check_failure(
           base_path: "/government/get-involved/take-part/take-part-slug",
-          failed_expectations: ["item unreachable in Content Store; response status: "],
+          failed_expectations: ["item unreachable, response status: "],
         )
       ],
       check.failures
@@ -187,7 +187,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
       [
         check_failure(
           base_path: "/government/get-involved/take-part/take-part-slug",
-          failed_expectations: ["item unreachable in Draft Content Store; response status: "],
+          failed_expectations: ["item unreachable, response status: "],
         )
       ],
       check.failures
@@ -256,7 +256,11 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
     check
   end
 
-  def check_failure(options)
-    DataHygiene::PublishingApiSyncCheck::Failure.new(options)
+  def check_failure(base_path:, failed_expectations:, content_store: "content-store")
+    DataHygiene::PublishingApiSyncCheck::Failure.new(
+      base_path: base_path,
+      failed_expectations: failed_expectations,
+      content_store: content_store
+    )
   end
 end


### PR DESCRIPTION
Also handle exceptions in sync check scripts. If a check raises an exception, report the error as normal but continue
the script.