### PR TITLE
Send locale for HTML Publications

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -92,6 +92,10 @@ class HtmlAttachment < Attachment
     save && Whitehall.edition_services.draft_updater(attachable).perform!
   end
 
+  def translated_locales
+    [locale || I18n.default_locale.to_s]
+  end
+
   private
 
   def sluggable_locale?

--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -30,7 +30,6 @@ private
     }
   end
 
-
   def base_path
     item.url
   end
@@ -65,5 +64,9 @@ private
 
   def govspeak_content
     item.govspeak_content
+  end
+
+  def locale
+    item.translated_locales.first
   end
 end

--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -18,7 +18,7 @@ class PublishingApiPresenters::Item
       description: description,
       schema_name: schema_name,
       document_type: document_type,
-      locale: I18n.locale.to_s,
+      locale: locale,
       need_ids: need_ids,
       public_updated_at: public_updated_at,
       publishing_app: "whitehall",
@@ -67,5 +67,9 @@ private
 
   def document_type
     schema_name
+  end
+
+  def locale
+    I18n.locale.to_s
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -142,4 +142,9 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
 
     attachment.save_and_update_publishing_api
   end
+
+  test "#translated_locales lists only the attachment's locale" do
+    assert_equal ["en"], HtmlAttachment.new.translated_locales
+    assert_equal ["cy"], HtmlAttachment.new(locale: "cy").translated_locales
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
@@ -51,4 +51,13 @@ class PublishingApiPresenters::HtmlAttachmentTest < ActiveSupport::TestCase
 
     assert_equal expected_hash, presented_content
   end
+
+  test "HtmlAttachment presentation includes the correct locale" do
+    create(:publication, :with_html_attachment, :published)
+
+    html_attachment = HtmlAttachment.last
+    html_attachment.locale = "cy"
+
+    assert_equal "cy", present(html_attachment).content[:locale]
+  end
 end


### PR DESCRIPTION
`HtmlAttachments` have their own locale. If the field is `nil` then
it’s the default locale (`en`).