### PR TITLE
Stop sending lead and supporting orgs to publishing-api

### DIFF
--- a/app/presenters/publishing_api_presenters/case_study.rb
+++ b/app/presenters/publishing_api_presenters/case_study.rb
@@ -6,10 +6,8 @@ class PublishingApiPresenters::CaseStudy < PublishingApiPresenters::Edition
   def links
     extract_links([
       :document_collections,
-      :lead_organisations,
       :organisations,
       :related_policies,
-      :supporting_organisations,
       :topics,
       :world_locations,
       :worldwide_organisations,
@@ -44,10 +42,10 @@ private
   end
 
   def image_available?
-    item.images.any? || lead_organisation_default_image_available?
+    item.images.any? || emphasised_organisation_default_image_available?
   end
 
-  def lead_organisation_default_image_available?
+  def emphasised_organisation_default_image_available?
     item.lead_organisations.first.default_news_image.present?
   end
 

--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -7,7 +7,6 @@ class PublishingApiPresenters::DetailedGuide < PublishingApiPresenters::Edition
 
   def links
     extract_links([
-      :lead_organisations,
       :organisations,
     ]).merge(
       related_guides: related_guides,

--- a/app/presenters/publishing_api_presenters/links_presenter.rb
+++ b/app/presenters/publishing_api_presenters/links_presenter.rb
@@ -2,12 +2,10 @@ module PublishingApiPresenters
   class LinksPresenter
     LINK_NAMES_TO_METHODS_MAP = {
       document_collections: :document_collection_ids,
-      lead_organisations: :lead_organisation_ids,
       organisations: :organisation_ids,
       policy_areas: :policy_area_ids,
       related_policies: :related_policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
-      supporting_organisations: :supporting_organisation_ids,
       topics: :topic_content_ids,
       world_locations: :world_location_ids,
       worldwide_organisations: :worldwide_organisation_ids,
@@ -33,10 +31,6 @@ module PublishingApiPresenters
       (item.try(:published_document_collections) || []).map(&:content_id)
     end
 
-    def lead_organisation_ids
-      (item.try(:lead_organisations) || []).map(&:content_id)
-    end
-
     def policy_area_ids
       (item.try(:topics) || []).map(&:content_id)
     end
@@ -47,10 +41,6 @@ module PublishingApiPresenters
 
     def statistical_data_set_ids
       (item.try(:statistical_data_sets) || []).map(&:content_id)
-    end
-
-    def supporting_organisation_ids
-      (item.try(:supporting_organisations) || []).map(&:content_id)
     end
 
     def organisation_ids

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -45,10 +45,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
     expected_links = {
       document_collections: [],
-      lead_organisations: case_study.lead_organisations.map(&:content_id),
       organisations: case_study.lead_organisations.map(&:content_id),
       related_policies: [],
-      supporting_organisations: [],
       topics: [],
       world_locations: [],
       worldwide_organisations: [],
@@ -129,10 +127,8 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
     presented_item = present(case_study)
     expected_links_hash = {
       document_collections: [],
-      lead_organisations: [lead_org_1.content_id, lead_org_2.content_id],
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
       related_policies: [],
-      supporting_organisations: [supporting_org.content_id],
       topics: [],
       world_locations: [],
       worldwide_organisations: [],

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -68,7 +68,6 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
       },
     }
     expected_links = {
-      lead_organisations: detailed_guide.lead_organisations.map(&:content_id),
       organisations: detailed_guide.organisations.map(&:content_id),
       related_guides: [],
       related_mainstream: [],

--- a/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/links_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApiPresenters::LinksPresenterTest < ActionView::TestCase
     document = create(:detailed_guide)
     links = links_for(document)
 
-    assert_equal document.lead_organisations.map(&:content_id), links[:lead_organisations]
+    assert_equal document.organisations.map(&:content_id), links[:organisations]
     # whitehall names and publishing api names don't necessarily match...
     assert_equal document.topics.map(&:content_id), links[:policy_areas]
   end


### PR DESCRIPTION
Frontend will use  and  to decide the order in which to display a document's organisations.

Part of: 
https://trello.com/c/us3MI1n9/602-fix-organisation-tagging