### PR TITLE
Add withdrawn_notice as a top level property...

### DIFF
--- a/app/presenters/publishing_api_presenters/item.rb
+++ b/app/presenters/publishing_api_presenters/item.rb
@@ -3,6 +3,8 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::Item
   extend Forwardable
 
+  include PublishingApiPresenters::WithdrawingHelper
+
   def_delegators :item, :base_path, :content_id, :title, :description, :need_ids, :public_updated_at
   attr_accessor :update_type
 
@@ -27,6 +29,9 @@ class PublishingApiPresenters::Item
       redirects: [],
       details: details,
     }.tap do |content_hash|
+      if item.try(:withdrawn?)
+        content_hash.merge!(withdrawn_notice: withdrawn_notice)
+      end
       if item.respond_to?(:analytics_identifier)
         content_hash.merge!(analytics_identifier: item.analytics_identifier)
       end

--- a/test/unit/presenters/publishing_api_presenters/case_study_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/case_study_test.rb
@@ -214,8 +214,11 @@ class PublishingApiPresenters::CaseStudyTest < ActiveSupport::TestCase
 
     assert_valid_against_schema(presented_item.content, 'case_study')
     assert_equal archive_notice[:archived_at], presented_item.content[:details][:withdrawn_notice][:withdrawn_at]
+    assert_equal archive_notice[:archived_at], presented_item.content[:withdrawn_notice][:withdrawn_at]
     assert_equivalent_html archive_notice[:explanation],
       presented_item.content[:details][:withdrawn_notice][:explanation]
+    assert_equivalent_html archive_notice[:explanation],
+      presented_item.content[:withdrawn_notice][:explanation]
   end
 
   test "an unpublished document has a first_public_at of the document creation time" do

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -227,7 +227,9 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
 
     assert_valid_against_schema(presented_item.content, 'detailed_guide')
     assert_equal expected_withdrawn_notice[:withdrawn_at], details[:withdrawn_notice][:withdrawn_at]
+    assert_equal expected_withdrawn_notice[:withdrawn_at], presented_item.content[:withdrawn_notice][:withdrawn_at]
     assert_equivalent_html expected_withdrawn_notice[:explanation], details[:withdrawn_notice][:explanation]
+    assert_equivalent_html expected_withdrawn_notice[:explanation], presented_item.content[:withdrawn_notice][:explanation]
   end
 
   test 'DetailedGuide presents national_applicability correctly when some are specified' do

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -275,4 +275,28 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
       organisations: [],
     }, links)
   end
+
+  test 'Edition presents withdrawn_notice correctly' do
+    create(:government)
+    edition = create(
+      :edition,
+      :withdrawn,
+    )
+    edition.build_unpublishing(
+      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
+      explanation: 'No longer relevant'
+    )
+    edition.unpublishing.save!
+
+    presented_item = present(edition)
+
+    expected_withdrawn_notice = {
+      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
+      withdrawn_at: edition.updated_at
+    }
+
+    assert_valid_against_schema(presented_item.content, "placeholder")
+    assert_equal expected_withdrawn_notice[:withdrawn_at], presented_item.content[:withdrawn_notice][:withdrawn_at]
+    assert_equivalent_html expected_withdrawn_notice[:explanation], presented_item.content[:withdrawn_notice][:explanation]
+  end
 end


### PR DESCRIPTION
Another part of https://trello.com/c/78Q9mrDe/708-make-whitehall-use-unpublishing-endpoint-medium

"Withdrawn notice" can be attributed to any format now, this means that it should move from the details hash and become a top level property. To ease the transition of this change for existing format expectations, the notice remains in the details hash until relevant front end applications can be updated.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/315 so do not merge yet please.