### PR TITLE
Remove schema validation in stats announcement test

### DIFF
--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -110,7 +110,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement = create(:statistics_announcement)
 
     Whitehall.publishing_api_v2_client.expects(:put_content).with do |content_id, payload|
-      content_id == test_uuid && assert_valid_against_schema(payload, "redirect")
+      content_id == test_uuid && payload[:format] == "redirect"
     end
     Whitehall.publishing_api_v2_client.expects(:patch_links)
     Whitehall.publishing_api_v2_client.expects(:publish)


### PR DESCRIPTION
This causes it to be run as part of the schema tests, which is unnecessary as the validation is tested in the presenter tests.