### PR TITLE
HTML Publications republishing updates

### DIFF
--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -8,10 +8,8 @@ class PublishingApiPresenters::HtmlAttachment < PublishingApiPresenters::Item
 
   def links
     {
-      parent: [
-        parent.content_id
-      ],
-      organisations: parent.organisations.map(&:content_id),
+      parent: parent_content_ids,
+      organisations: parent.organisations.pluck(:content_id),
     }
   end
 
@@ -60,6 +58,10 @@ private
 
   def parent
     item.attachable
+  end
+
+  def parent_content_ids
+    Edition.joins(:document).where(editions: {id: item.attachable_id}).pluck(:content_id)
   end
 
   def govspeak_content

--- a/app/presenters/publishing_api_presenters/html_attachment.rb
+++ b/app/presenters/publishing_api_presenters/html_attachment.rb
@@ -3,7 +3,7 @@ require_relative "../publishing_api_presenters"
 class PublishingApiPresenters::HtmlAttachment < PublishingApiPresenters::Item
   def initialize(item, update_type: nil)
     super
-    item.govspeak_content.render_govspeak!
+    item.govspeak_content.try(:render_govspeak!)
   end
 
   def links
@@ -41,11 +41,11 @@ private
   end
 
   def body
-    govspeak_content.computed_body_html
+    govspeak_content.try(:computed_body_html)
   end
 
   def headings
-    govspeak_content.computed_headers_html
+    govspeak_content.try(:computed_headers_html)
   end
 
   def first_published_version?

--- a/script/publishing-api-sync-checks/html_publication_sync_check.rb
+++ b/script/publishing-api-sync-checks/html_publication_sync_check.rb
@@ -1,4 +1,5 @@
-html_attachments = HtmlAttachment.joins(<<-SQL).includes(attachable: [:document])
+html_attachments = HtmlAttachment.includes(attachable: [:document])
+  .joins(<<-SQL)
   INNER JOIN editions ON attachable_id = editions.id
     AND attachable_type = 'Edition'
     AND attachments.type = 'HtmlAttachment'
@@ -9,6 +10,10 @@ check = DataHygiene::PublishingApiSyncCheck.new(html_attachments)
 
 check.override_base_path do |record|
   Whitehall.url_maker.publication_html_attachment_path(publication_id: record.attachable.document.slug, id: record.to_param)
+end
+
+check.add_expectation("content_id") do |content_store_payload, record|
+  content_store_payload["content_id"] == record.content_id
 end
 
 check.add_expectation("schema_name") do |content_store_payload, _|
@@ -28,8 +33,13 @@ check.add_expectation("locale") do |content_store_payload, record|
   content_store_payload["locale"] == (record.locale || "en")
 end
 
-check.add_expectation("parent") do |content_store_payload, record|
-  content_store_payload["links"]["parent"][0]["content_id"] == record.attachable.content_id
+check.add_expectation("has parent") do |content_store_payload, record|
+  content_store_payload["links"]["parent"].present?
+end
+
+check.add_expectation("correct parent") do |content_store_payload, record|
+  content_store_payload["links"]["parent"].present? &&
+    content_store_payload["links"]["parent"][0]["content_id"] == record.attachable.content_id
 end
 
 check.add_expectation("content") do |content_store_payload, _|

--- a/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/html_attachment_test.rb
@@ -60,4 +60,13 @@ class PublishingApiPresenters::HtmlAttachmentTest < ActiveSupport::TestCase
 
     assert_equal "cy", present(html_attachment).content[:locale]
   end
+
+  test "HtmlAttachment presentations sends an empty body if there's no govspeak" do
+    create(:publication, :with_html_attachment, :published)
+
+    GovspeakContent.delete_all
+    html_attachment = HtmlAttachment.last
+
+    assert_nil present(html_attachment).content[:body]
+  end
 end


### PR DESCRIPTION
- A performance improvement for presenting HTML Publications
- Handling edge cases where an HTML Publication has no govspeak content
- Check the parent exists and is correct in the sync check script
- Check the content_id is set correctly in the sync check script