### PR TITLE
Pass the authenticated user to sidekiq args...

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   before_filter :set_slimmer_application_name
   before_filter :set_audit_trail_whodunnit
+  before_filter :set_authenticated_user_header
 
   layout 'frontend'
   after_filter :set_slimmer_template
@@ -71,5 +72,11 @@ class ApplicationController < ActionController::Base
 
   def set_meta_description(description)
     @meta_description = Govspeak::Document.new(description).to_text
+  end
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
   end
 end

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -2,30 +2,36 @@ class WorkerBase
   include Sidekiq::Worker
 
   def self.perform_async(*args)
-    args << request_id_argument
+    args << request_header_arguments
     super(*args)
   end
 
   def self.perform_async_in_queue(queue, *args)
-    args << request_id_argument
+    args << request_header_arguments
     client_push('class' => self, 'args' => args, 'queue' => queue || get_sidekiq_options["queue"])
   end
 
-  def self.request_id_argument
-    {request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]}
+  def self.request_header_arguments
+    {
+      request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+    }
   end
-  private_class_method :request_id_argument
+  private_class_method :request_header_arguments
 
   def perform(*args)
     last_arg = args.last
 
-    if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+    if last_arg.is_a?(Hash) && last_arg.keys.include?("request_id")
       args.pop
+      authenticated_user = last_arg["authenticated_user"]
       request_id = last_arg["request_id"]
     else
+      authenticated_user = nil
       request_id = nil
     end
 
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, authenticated_user)
     GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
     call(*args)
   end

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -23,4 +23,12 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     get admin_people_path
     assert_select "a[href=?]", "/auth/gds/sign_out"
   end
+
+  test "should set the authenticated user header" do
+    login_as_admin
+    get admin_people_path
+    assert_match(
+      /uid-\d+/, GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]
+    )
+  end
 end

--- a/test/unit/workers/worker_base_test.rb
+++ b/test/unit/workers/worker_base_test.rb
@@ -20,7 +20,7 @@ class WorkerBaseTest < ActiveSupport::TestCase
     example_arg = stub("example arg")
     WorkerBase.expects(:client_push).with(
       'class' => WorkerBaseTest::MyWorker,
-      'args' => [example_arg, { request_id: nil }],
+      'args' => [example_arg, { authenticated_user: nil, request_id: nil }],
       'queue' => 'test_queue'
     )
     MyWorker.perform_async_in_queue('test_queue', example_arg)
@@ -30,10 +30,26 @@ class WorkerBaseTest < ActiveSupport::TestCase
     example_arg = stub("example arg")
     WorkerBase.expects(:client_push).with(
       'class' => WorkerBaseTest::MyWorker,
-      'args' => [example_arg, { request_id: nil }],
+      'args' => [example_arg, { authenticated_user: nil, request_id: nil }],
       'queue' => 'my-test-queue'
     )
     MyWorker.perform_async_in_queue(nil, example_arg)
+  end
+
+  test ".perform_async_in_queue populates header variables" do
+    GdsApi::GovukHeaders.expects(:headers).twice.returns({
+      govuk_request_id: "12345",
+      x_govuk_authenticated_user: "0a1b2c3d4e5f",
+    })
+    example_arg = stub("example arg")
+    WorkerBase.expects(:client_push).with(
+      'class' => WorkerBaseTest::MyWorker,
+      'args' => [example_arg, {
+        authenticated_user: "0a1b2c3d4e5f", request_id: "12345"
+      }],
+      'queue' => "test-queue"
+    )
+    MyWorker.perform_async_in_queue("test-queue", example_arg)
   end
 end
 


### PR DESCRIPTION
https://trello.com/c/6nDCqZXi/729-user-id-into-event-log

Events logged in the publishing API should contain the uid present in the `x_govuk_authenticated_user` header.