### PR TITLE
Adds a progress bar to sync check scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'rinku', require: 'rails_rinku'
 gem 'parallel', '1.4.1'
 gem 'responders', '~> 2.0'
 gem 'sidekiq-statsd', '0.1.5'
+gem 'ruby-progressbar', require: false
 
 gem 'deprecated_columns', '0.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,6 +511,7 @@ DEPENDENCIES
   responders (~> 2.0)
   rinku
   ruby-prof
+  ruby-progressbar
   rummageable (= 1.2.0)
   sass (= 3.4.9)
   sassc-rails


### PR DESCRIPTION
Rather than outputting “.” and “x”, report a progress bar to help
developers estimate their time. If you provide a filename as an
argument to a sync check script, it will log all checks to a CSV

Includes a small refactoring of the Sync Check Data Hygiene class 

<img width="1386" alt="screen shot 2016-06-02 at 19 04 25" src="https://cloud.githubusercontent.com/assets/18276/15755793/431e0d3a-28f6-11e6-9aab-c4794e6c2a2e.png">