### PR TITLE
More sidekiq workers in production

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 :verbose: true
-:concurrency: 2
+:concurrency: 8
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [bulk_republishing, 1]


### PR DESCRIPTION
We're now doing bulk republishing of documents from Whitehall, some of which take some time to process. The jobs are a mix of CPU and publishing-api bound. Adding more workers will improve throughput. There is enough space in CPU and RAM on the Whitehall backend boxes. This has been verified in integration.