### PR TITLE
Make sure that email is passed through to the govspeak render

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -18,8 +18,8 @@ module GovspeakHelper
     wrapped_in_govspeak_div(bare_govspeak_edition_to_html(edition))
   end
 
-  def govspeak_with_attachments_to_html(body, attachments = [])
-    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body, attachments))
+  def govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
+    wrapped_in_govspeak_div(bare_govspeak_with_attachments_to_html(body, attachments, alternative_format_contact_email))
   end
 
   def bare_govspeak_edition_to_html(edition)
@@ -28,8 +28,8 @@ module GovspeakHelper
     bare_govspeak_to_html(partially_processed_govspeak, images)
   end
 
-  def bare_govspeak_with_attachments_to_html(body, attachments = [])
-    partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(body, attachments)
+  def bare_govspeak_with_attachments_to_html(body, attachments = [], alternative_format_contact_email = nil)
+    partially_processed_govspeak = govspeak_with_attachments_and_alt_format_information(body, attachments, alternative_format_contact_email)
     bare_govspeak_to_html(partially_processed_govspeak, [])
   end
 

--- a/app/presenters/publishing_api_presenters/working_group.rb
+++ b/app/presenters/publishing_api_presenters/working_group.rb
@@ -26,7 +26,7 @@ private
 
   def body
     # It looks 'wrong' using the description as the body, but it isn't
-    Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.description, item.attachments)
+    Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.description, item.attachments, item.email)
   end
 
   def public_updated_at

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -433,4 +433,12 @@ class GovspeakHelperTest < ActionView::TestCase
     html = govspeak_to_html(input)
     assert_select_within_html html, "span.fraction > img[alt='1/x']"
   end
+
+  test 'govspeak_with_attachments_and_alt_format_information' do
+    body = "#Heading\n\n!@1\n\n##Subheading"
+    document = build(:published_detailed_guide, :with_file_attachment, body: body)
+    attachments = document.attachments
+    html = govspeak_with_attachments_to_html(body, attachments, 'batman@wayne.technology')
+    assert html.include? '>batman@wayne.technology</a>'
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters/working_group_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/working_group_test.rb
@@ -47,6 +47,7 @@ class PublishingApiPresenters::WorkingGroupTest < ActiveSupport::TestCase
 
     body = Nokogiri::HTML.parse(presenter.content[:details][:body])
     assert_not_nil body.at_css("section.attachment")
+    assert_match %r{#{presenter.content[:details][:email]}}, body.at_css("a[href^='mailto']"), "expect to see email in a mailto link"
     assert_match %r{#{group.attachments.first.title}}, body.at_css("section.attachment")
   end
 end


### PR DESCRIPTION
The email associated with the group was not being passed down to the helper that renders links out so we just ended up with links that had no text content.

This fix adds the params to pass the email down and tests the presenter and the individual helper in question.

### How to test manually
- Make sure you're running whitehall and sidekiq (after you pull the latest changes)
- Visit http://content-store.dev.gov.uk/content/government/groups/acumen-assessing-capturing-and-utilising-methane-from-expired-and-non-operational-landfills and confirm link does not have text content
- Visit http://whitehall-admin.dev.gov.uk/government/admin/groups/acumen-assessing-capturing-and-utilising-methane-from-expired-and-non-operational-landfills/edit and save a new version
- Visit http://content-store.dev.gov.uk/content/government/groups/acumen-assessing-capturing-and-utilising-methane-from-expired-and-non-operational-landfills and confirm link now has text content
- Visit http://government-frontend.dev.gov.uk/government/groups/acumen-assessing-capturing-and-utilising-methane-from-expired-and-non-operational-landfills#attachment-1311684-accessibility-request  and check link now renders (might require a reload of whitehall..)