### PR TITLE
Republish last 1000 publications

### DIFF
--- a/db/data_migration/20160525093035_republish_1000_publications_to_publishing_api.rb
+++ b/db/data_migration/20160525093035_republish_1000_publications_to_publishing_api.rb
@@ -1,3 +1,3 @@
-Publication.includes(:document).find_each do |pub|
+Publication.includes(:document).order('id desc').limit(1000).each do |pub|
   Whitehall::PublishingApi.republish_document_async(pub.document, bulk: true)
 end


### PR DESCRIPTION
Test the migration on the last 1000 publication, before trying to speed
up and migrate the full record set.