### PR TITLE
Update publication republish data migration

### DIFF
--- a/db/data_migration/20160525093035_republish_publications_to_publishing_api.rb
+++ b/db/data_migration/20160525093035_republish_publications_to_publishing_api.rb
@@ -1,3 +1,3 @@
-Publication.includes(:document).find_each do |pub|
+Publication.includes(:document).order("id DESC").limit(1000).each do |pub|
   Whitehall::PublishingApi.republish_document_async(pub.document, bulk: true)
 end


### PR DESCRIPTION
We are currently unable to republish all of the publications due to performance issues and the large number that require republication.

This commit just republishes the most recent 1000 to allow us to observe the republish in production.