### PR TITLE
Republish PolicyGroup

### DIFF
--- a/db/data_migration/20160613140318_republish_working_groups_for_accessibility_email.rb
+++ b/db/data_migration/20160613140318_republish_working_groups_for_accessibility_email.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(PolicyGroup.all)
+republisher.perform


### PR DESCRIPTION
This is required following an earlier update to fix a bug in the accessibility info where the alternative content email address was not exposed. (PR #2620) The Groups need to be republished for that change to take effect.