### PR TITLE
Fix "appeal your rateable value" document content_id

### DIFF
--- a/db/data_migration/20160616092031_fix_rateable_value_guide_content_id.rb
+++ b/db/data_migration/20160616092031_fix_rateable_value_guide_content_id.rb
@@ -1,0 +1,4 @@
+document = Document.find_by(slug: "how-to-appeal-your-rateable-value")
+correct_content_id = Whitehall.publishing_api_v2_client.lookup_content_id(base_path: "/guidance/how-to-appeal-your-rateable-value")
+document.content_id = correct_content_id # "e76c9e81-9fce-48e5-8ccb-100fe77ac14c"
+document.save!


### PR DESCRIPTION
This document currently points to `e47faa45-3a37-4061-a56f-ba88f1cfb37c`, which isn't a valid `content_id` recognised by either the `content-store` or `publishing-api`. This causes republishing of this document to fail.

Working the opposite way from the `publishing-api`, we do find a `content_item` that matches this document's `base_path`:

```
> ciid = Location.find_by(base_path: "/guidance/how-to-appeal-your-rateable-value").content_item_id
> ci = ContentItem.find(ciid).content_id
"e76c9e81-9fce-48e5-8ccb-100fe77ac14c"
```

Changing the document's `content_id` to the above appears to fix republishing without adverse effects.