### PR TITLE
Benchmark scripts for republishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :development do
   gem 'thin', '1.6.3'
   gem 'newrelic_rpm'
   gem 'quiet_assets'
+  gem 'stackprof', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    stackprof (0.2.9)
     statsd-ruby (1.2.1)
     subexec (0.2.3)
     test-queue (0.2.11)
@@ -524,6 +525,7 @@ DEPENDENCIES
   slimmer (= 9.0.1)
   sprockets (~> 3.0)
   sprockets-rails (= 2.3.3)
+  stackprof
   statsd-ruby (~> 1.2.1)
   test-queue (= 0.2.11)
   test_track (~> 0.1.0)!

--- a/app/presenters/publishing_api_presenters/publication.rb
+++ b/app/presenters/publishing_api_presenters/publication.rb
@@ -48,7 +48,7 @@ private
   end
 
   def topical_events
-    TopicalEvent
+    ::TopicalEvent
       .joins(:classification_memberships)
       .where(classification_memberships: {edition_id: item.id})
       .pluck(:content_id)

--- a/bench/publication_presenter.rb
+++ b/bench/publication_presenter.rb
@@ -1,0 +1,32 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+
+require 'stackprof'
+
+publications = Publication
+  .published
+  .order("id DESC")
+  .limit(100)
+  .to_a
+
+StackProf.run(mode: :wall, out: "tmp/publication_presenter_content.dump") do
+  puts Benchmark.measure {
+    publications.each do |publication|
+      PublishingApiPresenters::Publication.new(publication).content
+      print "."
+    end
+    puts
+  }
+end
+
+StackProf.run(mode: :wall, out: "tmp/publication_presenter_links.dump") do
+  puts Benchmark.measure {
+    publications.each do |publication|
+      PublishingApiPresenters::Publication.new(publication).links
+      print "."
+    end
+    puts
+  }
+end

--- a/bench/publishing_api.rb
+++ b/bench/publishing_api.rb
@@ -1,0 +1,24 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+
+require 'stackprof'
+
+publications = Publication
+  .published
+  .order("id DESC")
+  .limit(10)
+  .to_a
+
+StackProf.run(mode: :wall, out: "tmp/publishing_api_worker.dump") do
+  puts Benchmark.measure {
+    publications.each { |publication|
+      Whitehall::PublishingApi.locales_for(publication).each { |locale|
+        PublishingApiWorker.new.perform('Edition', publication.id, 'republish', locale.to_s)
+        print "."
+      }
+    }
+    puts
+  }
+end


### PR DESCRIPTION
Adds profiled benchmark scripts for the PublicationPresenter and also the PublishingApiWorker.

Uses [StackProf](https://github.com/tmm1/stackprof) to sample where the interpreter spends its time. It produces output like this:

```
$ bundle exec stackprof tmp/publishing_api_worker.dump --method PublishingApiWorker#call
PublishingApiWorker#call (/var/govuk/whitehall/app/workers/publishing_api_worker.rb:4)
  samples:     0 self (0.0%)  /   7099 total (97.7%)
  callers:
    7099  (  100.0%)  WorkerBase#perform
  callees (7099 total):
    7005  (   98.7%)  #<Module:0x007f3bb138d850>#with_locale
      80  (    1.1%)  #<Module:0x007f3bb8940250>.presenter_for
      13  (    0.2%)  ActiveRecord::FinderMethods#find_by
       1  (    0.0%)  ActiveSupport::Dependencies::ModuleConstMissing#const_missing
  code:
                                  |     4  |   def call(model_name, id, update_type = nil, locale = I18n.default_locale.to_s)
   13    (0.2%)                   |     5  |     model = class_for(model_name).unscoped.find_by(id: id)
                                  |     6  |     return if model.nil?
                                  |     7  |
   81    (1.1%)                   |     8  |     presenter = PublishingApiPresenters.presenter_for(model, update_type: update_type)
                                  |     9  |
 7005   (96.4%)                   |    10  |     I18n.with_locale(locale) do
                                  |    11  |       begin
block in PublishingApiWorker#call (/var/govuk/whitehall/app/workers/publishing_api_worker.rb:10)
  samples:     0 self (0.0%)  /   7005 total (96.4%)
  callers:
    7005  (  100.0%)  #<Module:0x007f3bb138d850>#with_locale
  callees (7005 total):
    6996  (   99.9%)  PublishingApiWorker#send_item
       9  (    0.1%)  ActiveSupport::Dependencies::ModuleConstMissing#const_missing
  code:
                                  |    10  |     I18n.with_locale(locale) do
                                  |    11  |       begin
 6996   (96.3%)                   |    12  |         send_item(presenter, locale)
                                  |    13  |       rescue GdsApi::HTTPClientError => e
                                  |    14  |         handle_client_error(e)
                                  |    15  |       end
                                  |    16  |
    9    (0.1%)                   |    17  |       if model.is_a?(::Unpublishing)
                                  |    18  |         # Unpublishings will be mirrored to the draft content-store, but we want
```