### PR TITLE
Use the bulk_republishing queue in PubApiDocRepublisher

### DIFF
--- a/lib/data_hygiene/publishing_api_document_republisher.rb
+++ b/lib/data_hygiene/publishing_api_document_republisher.rb
@@ -20,7 +20,7 @@ module DataHygiene
     def perform
       logger.info "Queuing #{documents.count} #{edition_class} instances for republishing to the Publishing API"
       documents.find_each do |document|
-        Whitehall::PublishingApi.republish_document_async(document)
+        Whitehall::PublishingApi.republish_document_async(document, bulk: true)
         logger << '.'
         @queued += 1
       end


### PR DESCRIPTION
This is a special republisher that is used for Editions, but it seems to be currently using the `default` queue. This means that when it's used it will flood the `default` queue and block all other republishing until it's done.

This commit switches it to use the `bulk_republishing` queue.