### PR TITLE
Revert "More sidekiq workers in production"

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 :verbose: true
-:concurrency: 8
+:concurrency: 2
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [bulk_republishing, 1]


### PR DESCRIPTION
Reverts alphagov/whitehall#2618

This was pointless as Sidekiq concurrency controls the number of threads. Due to the GIL, this doesn't help our throughput and can actually cause connection pool starvation.