### PR TITLE
Pass policy_areas to rummager instead of topics for statistics announcement filtering

### DIFF
--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -1,4 +1,3 @@
-
 class Frontend::StatisticsAnnouncementsFilter < FormObject
   named "StatisticsAnnouncementsFilter"
   attr_accessor :keywords,
@@ -60,8 +59,14 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
     Array(@topics)
   end
 
-  def topic_slugs
-    topics.map &:slug
+  # Policy areas used to be named topics.
+  # Elsewhere we use "topic" to refer to specialist sectors.
+  def policy_areas
+    topics
+  end
+
+  def policy_area_slugs
+    policy_areas.map(&:slug)
   end
 
   def valid_filter_params
@@ -70,7 +75,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
     params[:to_date]       = to_date            if to_date.present?
     params[:from_date]     = from_date          if from_date.present?
     params[:organisations] = organisation_slugs if organisations.present?
-    params[:topics]        = topic_slugs        if topics.present?
+    params[:policy_areas]  = policy_area_slugs  if policy_areas.present?
     params
   end
 

--- a/app/providers/frontend/statistics_announcement_provider.rb
+++ b/app/providers/frontend/statistics_announcement_provider.rb
@@ -22,7 +22,7 @@ module Frontend
         release_date_change_note: rummager_hash['metadata']['change_note'],
         previous_display_date: rummager_hash['metadata']['previous_display_date'],
         organisations: build_organisations(rummager_hash['organisations']),
-        topics: build_topics(rummager_hash['topics']),
+        topics: build_topics(rummager_hash['policy_areas']),
         state: rummager_hash['statistics_announcement_state'],
         cancellation_reason: rummager_hash['metadata']['cancellation_reason'],
         cancellation_date: rummager_hash['metadata']['cancelled_at'],

--- a/app/views/statistics_announcements/index.html.erb
+++ b/app/views/statistics_announcements/index.html.erb
@@ -29,7 +29,7 @@
           </div>
           <div class="filter">
             <%= label_tag "topics", "Policy Area" %>
-            <%= select_tag "topics[]", topic_options_for_statistics_announcement_filter(@filter.topic_slugs), id: "topics", class: "single-row-select" %>
+            <%= select_tag "topics[]", topic_options_for_statistics_announcement_filter(@filter.policy_area_slugs), id: "topics", class: "single-row-select" %>
           </div>
           <div class="filter">
             <%= label_tag "organisations", "Department" %>

--- a/lib/development_mode_stubs/fake_rummager_api_for_statistics_announcements.rb
+++ b/lib/development_mode_stubs/fake_rummager_api_for_statistics_announcements.rb
@@ -10,8 +10,8 @@ module DevelopmentModeStubs
         organisation_ids = Organisation.where(slug: params[:organisations]).pluck(:id)
         scope = scope.in_organisations(organisation_ids)
       end
-      if params[:topics].present?
-        topic_ids = Topic.where(slug: params[:topics]).pluck(:id)
+      if params[:policy_areas].present?
+        topic_ids = Topic.where(slug: params[:policy_areas]).pluck(:id)
         scope = scope.with_topics(topic_ids)
       end
       if params[:release_timestamp].present?
@@ -50,7 +50,7 @@ module DevelopmentModeStubs
         "slug" => announcement.slug,
         "release_timestamp" => announcement.current_release_date.release_date.iso8601,
         "organisations" => announcement.organisations_slugs,
-        "topics" => announcement.topic_slugs,
+        "policy_areas" => announcement.topic_slugs,
         "display_type" => announcement.publication_type.singular_name,
         "search_format_types" => ["statistics_announcement"],
         "format" => "statistics_announcement",

--- a/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
+++ b/test/unit/development_mode_stubs/fake_rummager_api_for_statistics_announcements_test.rb
@@ -45,7 +45,7 @@ class DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncementsTest < Acti
     assert_equal ["statistics_announcement"], returned_announcement_hash["search_format_types"]
     assert_equal "statistics_announcement", returned_announcement_hash["format"]
     assert_equal announcement.organisations_slugs, returned_announcement_hash["organisations"]
-    assert_equal announcement.topic_slugs, returned_announcement_hash["topics"]
+    assert_equal announcement.topic_slugs, returned_announcement_hash["policy_areas"]
     assert_equal "2050-01-01T09:30:00+00:00", returned_announcement_hash["release_timestamp"]
     assert_equal true, returned_announcement_hash["metadata"]["confirmed"]
     assert_equal "confirmed", returned_announcement_hash["statistics_announcement_state"]
@@ -99,7 +99,7 @@ class DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncementsTest < Acti
     announcement_1 = create :statistics_announcement, topics: [topic]
     announcement_2 = create :statistics_announcement
 
-    assert_equal [announcement_1.title], matched_titles(topics: [topic.slug])
+    assert_equal [announcement_1.title], matched_titles(policy_areas: [topic.slug])
   end
 
   test "#advanced_search returns results ordered by current_release_date's release_date" do

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -59,9 +59,9 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     assert_equal [], filter.topics
   end
 
-  test "topic_slugs returns slugs of topics" do
+  test "policy_area_slugs returns slugs of topics" do
     topic = create(:topic)
-    assert_equal [topic.slug], build(topics: [topic.slug]).topic_slugs
+    assert_equal [topic.slug], build(topics: [topic.slug]).policy_area_slugs
   end
 
   test "#valid_filter_params returns all attributes if all are present and valid excluding pagination parameters" do
@@ -79,7 +79,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
                    from_date: Date.new(2020, 1, 1),
                    to_date: Date.new(2020, 2, 1),
                    organisations: [organisation.slug],
-                   topics: [topic.slug],
+                   policy_areas: [topic.slug],
                  }, filter.valid_filter_params)
   end
 

--- a/test/unit/providers/frontend/statistics_announcement_provider_test.rb
+++ b/test/unit/providers/frontend/statistics_announcement_provider_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
   attr_accessor :rummager_api_stub
 
@@ -49,7 +51,7 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
       "slug" => "a-slug",
       "release_timestamp" => Time.zone.now,
       "organisations" => ["cabinet-office"],
-      "topics" => ["home-affairs"],
+      "policy_areas" => ["home-affairs"],
       "display_type" => "Statistics",
       "search_format_types" => ["statistics_announcement"],
       "format" => "statistics_announcement",


### PR DESCRIPTION
This is the same thing, but `topics` is deprecated.

| Old name     | New Name |
| ------------- | ------------- |
| Topics  | Policy Areas  |
| Specialist Sectors  | Topics  |

Note that whitehall still uses the old name throughout the code base, even though the UI uses the new name. We are deliberately not touching this right now.

https://trello.com/c/bDFlehc5/518-rename-topics-to-policy-areas-in-rummager-m