### PR TITLE
Pass policy_areas to rummager instead of topics for indexing

### DIFF
--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -33,7 +33,10 @@ module Searchable
     :speech_type,
     :statistics_announcement_state,
     :title,
+
+    # Topics display as policy areas in the frontend and map to policy areas in rummager
     :topics,
+
     :world_locations,
   ]
 
@@ -84,9 +87,11 @@ module Searchable
     extend ActiveSupport::Concern
 
     KEY_MAPPING = {
-      content: 'indexable_content'
+      content: 'indexable_content',
+      topics: 'policy_areas',
     }
 
+    # Build the payload to pass to the search index
     def search_index
       SEARCH_FIELDS.reduce({}) do |result, name|
         value = searchable_options[name].call(self)

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -64,7 +64,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       'format' => 'statistics_announcement',
       'description' => announcement.summary,
       'organisations' => announcement.organisations.map(&:slug),
-      'topics' => announcement.topics.map(&:slug),
+      'policy_areas' => announcement.topics.map(&:slug),
       'display_type' => announcement.display_type,
       'slug' => announcement.slug,
       'release_timestamp' => announcement.release_date,


### PR DESCRIPTION
This changes the indexing of documents in rummager to pass policy areas instead of topics.

Whitehall should already be using `policy_areas` for searching. (https://github.com/alphagov/whitehall/pull/2629 is an exception)

| Old name     | New Name |
| ------------- | ------------- |
| Topics  | Policy Areas  |
| Specialist Sectors  | Topics  |

https://trello.com/c/bDFlehc5/518-rename-topics-to-policy-areas-in-rummager-m