### PR TITLE
Output whitehall model id for sync check failures

### DIFF
--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -10,6 +10,9 @@ require 'gds_api/content_store'
 #   pasc.add_expectation { |json, model| json.fetch("format") == "statistics_announcement" }
 #   pasc.perform
 #
+# Pass in a file path as the first argument to output CSV data of any failures to
+# that file. For example: rails runner script/publishing-api-sync-checks/my-sync-checks.rb failures.csv
+#
 # The disadvantages of running against content-store are that you can't inspect
 # things like rendering_app.
 #
@@ -73,8 +76,10 @@ module DataHygiene
       @successes = []
       @failures = []
 
-      if ARGV[0].present? && !Rails.env.test?
-        csv_file = File.open(File.expand_path(ARGV[0]), "w")
+      csv_file_path = ARGV[0]
+
+      if csv_file_path.present? && !Rails.env.test?
+        csv_file = File.open(File.expand_path(csv_file_path), "w")
         @csv = CSV.new(csv_file)
       else
         @csv = NullCSV.new

--- a/test/unit/data_hygiene/publishing_api_sync_check_test.rb
+++ b/test/unit/data_hygiene/publishing_api_sync_check_test.rb
@@ -262,6 +262,7 @@ class DataHygiene::PublishingApiSyncCheckTest < ActiveSupport::TestCase
 
   def check_failure(base_path:, failed_expectations:, content_store: "content-store")
     DataHygiene::PublishingApiSyncCheck::Failure.new(
+      record_id: 1,
       base_path: base_path,
       failed_expectations: failed_expectations,
       content_store: content_store


### PR DESCRIPTION
Running the sync checks on a restricted set of documents that have previously failed would be simpler if you could have a list of all the `id`s of the offending documents.

Also a slight refactoring to make it even clearer at first glance what `ARGV[0]` is being used for.

cc @gpeng 