### PR TITLE
Set `bulk_publishing: true` for links republishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 30.5.0'
+  gem 'gds-api-adapters', '~> 31.1'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     ffi (1.9.6)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (30.5.0)
+    gds-api-adapters (31.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -468,7 +468,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 30.5.0)
+  gds-api-adapters (~> 31.1)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)
@@ -538,3 +538,6 @@ DEPENDENCIES
   validates_email_format_of
   webmock (~> 1.22.3)
   whenever (= 0.9.4)
+
+BUNDLED WITH
+   1.10.6

--- a/app/workers/publishing_api_links_worker.rb
+++ b/app/workers/publishing_api_links_worker.rb
@@ -7,7 +7,11 @@ class PublishingApiLinksWorker < WorkerBase
     content_id = item.content_id
     links = PublishingApiPresenters.presenter_for(item).links
     if links && !links.empty?
-      Whitehall.publishing_api_v2_client.patch_links(content_id, {links: links})
+      Whitehall.publishing_api_v2_client.patch_links(
+        content_id,
+        links: links,
+        bulk_publishing: true
+      )
     end
   end
 end


### PR DESCRIPTION
This will make sure that the publishing-api understands this is a republish. It can then de-prioritise handling these requests so that "human-initiated" publishing isn't slowed down.