### PR TITLE
Migrate detailed guides

### DIFF
--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -32,4 +32,8 @@ private
         json[:national_applicability] = item.national_applicability if item.nation_inapplicabilities.any?
       end
   end
+
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
 end

--- a/db/data_migration/20160628155533_republish_detailed_guides_3.rb
+++ b/db/data_migration/20160628155533_republish_detailed_guides_3.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(DetailedGuide)
+republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -43,7 +43,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
       locale: "en",
       need_ids: [],
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" }
       ],


### PR DESCRIPTION
Detailed guides are being migrated, and should therefore be rendered using `government-frontend`, not `whitehall`.

Relevant Trello: https://trello.com/c/CkHu0suq/317-6-detailed-guides-migration-final-tasks-deploy-1-medium