### PR TITLE
Send `topics` for detailed guide links

### DIFF
--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -7,6 +7,7 @@ class PublishingApiPresenters::DetailedGuide < PublishingApiPresenters::Edition
   def links
     extract_links([
       :organisations,
+      :topics,
     ]).merge(
       related_guides: item.related_detailed_guide_content_ids,
       related_mainstream: item.related_mainstream

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -69,6 +69,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
     }
     expected_links = {
       organisations: detailed_guide.organisations.map(&:content_id),
+      topics: [],
       related_guides: [],
       related_mainstream: [],
     }


### PR DESCRIPTION
A Detailed Guide can be tagged to `topics` (specialist sectors) but this data is currently not being sent to the publishing-api.

Fixes https://govuk.zendesk.com/agent/tickets/1364404

I plan to follow this up with a PR to make sure this kind of error can't be introduced again.
