### PR TITLE
Add unpublished field

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -28,6 +28,7 @@ class DocumentListExportPresenter
       'Specialist sectors',
       'Collections',
       'Affected by history-mode',
+      'Unpublished',
     ]
   end
 
@@ -50,6 +51,7 @@ class DocumentListExportPresenter
       specialist_sectors,
       collections,
       edition.political?,
+      unpublished?,
     ]
   end
 
@@ -102,6 +104,10 @@ class DocumentListExportPresenter
     else
       edition.state
     end
+  end
+
+  def unpublished?
+    edition.unpublishing ? 'yes' : 'no'
   end
 
   def policies

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -69,4 +69,18 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
     pub = DocumentListExportPresenter.new(publication)
     assert_equal "force published", pub.state
   end
+
+  test '#unpublished? returns `yes` when a document is unpublished' do
+    unpublished_edition = create(:edition, :unpublished)
+
+    presenter = DocumentListExportPresenter.new(unpublished_edition)
+    assert_equal "yes", presenter.unpublished?
+  end
+
+  test '#unpublished? returns `no` when a document is draft' do
+    draft_edition = create(:edition, :draft)
+
+    presenter = DocumentListExportPresenter.new(draft_edition)
+    assert_equal "no", presenter.unpublished?
+  end
 end


### PR DESCRIPTION
Add an unpublished field to easily distinguish unpublished documents by
draft documents.