### PR TITLE
Update `OffsiteLink` url validation

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -10,7 +10,7 @@ class OffsiteLink < ActiveRecord::Base
         host = uri.host
       end
 
-      unless url_is_gov_uk?(host) || url_is_gov_wales?(host)
+      unless url_is_gov_uk?(host) || url_is_gov_wales?(host) || url_is_whitelisted?(host)
         errors.add(:base, "Please enter a valid GOV.UK URL, such as https://www.gov.uk/jobsearch")
       end
     rescue URI::InvalidURIError
@@ -34,5 +34,14 @@ private
 
   def url_is_gov_uk?(host)
     !!(host =~ /gov\.uk$/)
+  end
+
+  def url_is_whitelisted?(host)
+    whitelisted_hosts = [
+      "flu-lab-net.eu",
+      "tse-lab-net.eu",
+    ]
+
+    whitelisted_hosts.any? { |whitelisted_host| host =~ /#{whitelisted_host}$/}
   end
 end

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -11,7 +11,7 @@ class OffsiteLink < ActiveRecord::Base
       end
 
       unless url_is_gov_uk?(host) || url_is_gov_wales?(host) || url_is_whitelisted?(host)
-        errors.add(:base, "Please enter a valid GOV.UK URL, such as https://www.gov.uk/jobsearch")
+        errors.add(:base, "Please enter a valid government URL, such as https://www.gov.uk/jobsearch")
       end
     rescue URI::InvalidURIError
       errors.add(:base, "Please enter a valid URL, such as https://www.gov.uk/jobsearch")

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,17 +1,16 @@
 class OffsiteLink < ActiveRecord::Base
   belongs_to :parent, polymorphic: true
   validates :title, :summary, :link_type, :url, presence: true, length: { maximum: 255 }
-  validate :url_is_govuk
+  validate :check_url_is_allowed
   validates :link_type, presence: true, inclusion: {in: %w{alert blog_post campaign careers service}}
 
-  def url_is_govuk
+  def check_url_is_allowed
     begin
       if (uri = Addressable::URI.parse(url))
         host = uri.host
       end
 
-      split_host = host.split(".") if host
-      if !host || split_host[split_host.length - 1] != "uk" || split_host[split_host.length - 2] != "gov"
+      unless url_is_gov_uk?(host) || url_is_gov_wales?(host)
         errors.add(:base, "Please enter a valid GOV.UK URL, such as https://www.gov.uk/jobsearch")
       end
     rescue URI::InvalidURIError
@@ -25,5 +24,15 @@ class OffsiteLink < ActiveRecord::Base
 
   def to_s
     title
+  end
+
+private
+
+  def url_is_gov_wales?(host)
+    !!(host =~ /gov\.wales$/)
+  end
+
+  def url_is_gov_uk?(host)
+    !!(host =~ /gov\.uk$/)
   end
 end

--- a/app/views/admin/classification_featurings/index.html.erb
+++ b/app/views/admin/classification_featurings/index.html.erb
@@ -36,13 +36,13 @@
     </div>
   </div>
 
-  <h2 class="feature-title">Feature new offsite link</h2>
+  <h2 class="feature-title">Feature new non-GOV.UK government link</h2>
   <% if @featurable_offsite_links.any? %>
     <%= render partial: 'admin/classification_featurings/featurable_offsite_links', locals: { classification_featurings: @classification_featurings, featurable_offsite_links: @featurable_offsite_links } %>
   <% else %>
-    <p class="no-content no-content-bordered">There are currently no offsite links.</p>
+    <p class="no-content no-content-bordered">There are currently no non-GOV.UK government links.</p>
   <% end %>
-  <%= link_to "Create an offsite link", polymorphic_path([:new, :admin, @classification, :offsite_link]), class: "btn btn-default" %>
+  <%= link_to "Create a non-GOV.UK government link", polymorphic_path([:new, :admin, @classification, :offsite_link]), class: "btn btn-default" %>
 <% end %>
 
 <%= render partial: "admin/classifications/tab_wrapper", locals: { model: @classification } %>

--- a/app/views/admin/feature_lists/_feature_list.html.erb
+++ b/app/views/admin/feature_lists/_feature_list.html.erb
@@ -20,19 +20,19 @@
   </div>
 
   <div class="col-md-6">
-    <h2 class="add-bottom-margin">Feature new offsite link</h2>
+    <h2 class="add-bottom-margin">Feature non-GOV.UK government link</h2>
     <% if @featurable_offsite_links.any? %>
       <%= render partial: 'admin/feature_lists/featurable_offsite_links', locals: { feature_list: feature_list, featurable_offsite_links: @featurable_offsite_links } %>
     <% else %>
-      <p class="no-content no-content-bordered">There are currently no offsite links.</p>
+      <p class="no-content no-content-bordered">There are currently no non-GOV.UK government links.</p>
     <% end %>
 
     <% if @organisation %>
-      <%= link_to "Create an offsite link", new_admin_organisation_offsite_link_path(@organisation), class: "btn btn-default" %>
+      <%= link_to "Create a non-GOV.UK government link", new_admin_organisation_offsite_link_path(@organisation), class: "btn btn-default" %>
     <% end %>
 
     <% if @world_location %>
-      <%= link_to "Create an offsite link", new_admin_world_location_offsite_link_path(@world_location), class: "btn btn-default" %>
+      <%= link_to "Create a non-GOV.UK government link", new_admin_world_location_offsite_link_path(@world_location), class: "btn btn-default" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/offsite_links/new.html.erb
+++ b/app/views/admin/offsite_links/new.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Create an offsite link" %>
 
 <h2>
-  Create an offsite link within ‘<%= @parent.name %>’
+  Create a non-GOV.UK government link within ‘<%= @parent.name %>’
 </h2>
 
 <%= render partial: "form", locals: {parent: @parent, offsite_link: @offsite_link} %>

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -191,7 +191,7 @@ end
 When(/^I add the offsite link "(.*?)" of type "(.*?)" to the organisation "(.*?)"$/) do |title, type, organisation_name|
   organisation = Organisation.find_by!(name: organisation_name)
   visit features_admin_organisation_path(organisation)
-  click_link "Create an offsite link"
+  click_link "Create a non-GOV.UK government link"
   fill_in :offsite_link_title, with: title
   select type, from: 'offsite_link_link_type'
   fill_in :offsite_link_summary, with: "summary"

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -183,7 +183,7 @@ end
 When(/^I add the offsite link "(.*?)" of type "(.*?)" to the topic "(.*?)"$/) do |title, type, topic_name|
   topic = Topic.find_by!(name: topic_name)
   visit admin_topic_classification_featurings_path(topic)
-  click_link "Create an offsite link"
+  click_link "Create a non-GOV.UK government link"
   fill_in :offsite_link_title, with: title
   select type, from: 'offsite_link_link_type'
   fill_in :offsite_link_summary, with: "summary"

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -73,7 +73,7 @@ end
 When(/^I add the offsite link "(.*?)" of type "(.*?)" to the topical event "(.*?)"$/) do |title, type, topical_event_name|
   topical_event = TopicalEvent.find_by!(name: topical_event_name)
   visit admin_topical_event_classification_featurings_path(topical_event)
-  click_link "Create an offsite link"
+  click_link "Create a non-GOV.UK government link"
   fill_in :offsite_link_title, with: title
   select type, from: 'offsite_link_link_type'
   fill_in :offsite_link_summary, with: "summary"

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -90,7 +90,7 @@ When(/^I add the offsite link "(.*?)" of type "(.*?)" to the world location "(.*
   world_location = WorldLocation.find_by!(name: location_name)
   visit admin_world_location_path(world_location)
   click_link "Features (English)"
-  click_link "Create an offsite link"
+  click_link "Create a non-GOV.UK government link"
   fill_in :offsite_link_title, with: title
   select type, from: 'offsite_link_link_type'
   fill_in :offsite_link_summary, with: "summary"

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -31,6 +31,11 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     assert offsite_link.valid?
   end
 
+  test 'should be valid with a gov.wales url' do
+    offsite_link = build(:offsite_link, url: 'http://gov.wales/page')
+    assert offsite_link.valid?
+  end
+
   test 'should be valid if the type is not supported' do
     offsite_link = build(:offsite_link, link_type: 'notarealtype')
     refute offsite_link.valid?

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -36,6 +36,16 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     assert offsite_link.valid?
   end
 
+  test 'should be valid with whitelisted urls' do
+    whitelisted_urls = [
+      'http://www.flu-lab-net.eu',
+      'http://www.tse-lab-net.eu'
+    ]
+    whitelisted_urls.each do |url|
+      assert build(:offsite_link, url: url).valid?, "#{url} not valid"
+    end
+  end
+
   test 'should be valid if the type is not supported' do
     offsite_link = build(:offsite_link, link_type: 'notarealtype')
     refute offsite_link.valid?


### PR DESCRIPTION
Currently the validation for `OffsiteLink#url` only allows `gov.uk` hosts. This PR also allows:

```
gov.wales
tse-lab-net.eu
flu-lab-net.eu
```

[Trello](https://trello.com/c/X5Ur3A5p/375-offsite-links-function-in-whitehall-not-allowing-offsite-links-small)

Also included in this PR are copy updates to more accurately describe the 'Offsite Link'.

Before:

<img width="597" alt="window_and_featured_items_on_global_summit_to_end_sexual_violence_in_conflict_-_admin_-_gov_uk" src="https://cloud.githubusercontent.com/assets/5216/16453127/a93cd458-3e03-11e6-8f67-0c554204b3d1.png">

<img width="571" alt="window_and_create_an_offsite_link_-_admin_-_gov_uk" src="https://cloud.githubusercontent.com/assets/5216/16453138/b2256026-3e03-11e6-819e-faacd3d2208c.png">

After: 

<img width="597" alt="window_and_featured_items_on_global_summit_to_end_sexual_violence_in_conflict_-_admin_-_gov_uk" src="https://cloud.githubusercontent.com/assets/5216/16453153/c23eb188-3e03-11e6-98f8-7dc65dea40a0.png">

<img width="280" alt="window_and_create_an_offsite_link_-_admin_-_gov_uk" src="https://cloud.githubusercontent.com/assets/5216/16453178/d4f0eb3e-3e03-11e6-8e2d-71ec223056df.png">

<img width="320" alt="window_and_create_an_offsite_link_-_admin_-_gov_uk" src="https://cloud.githubusercontent.com/assets/5216/16453168/c9cfda26-3e03-11e6-90cf-5490a5e75752.png">


