### PR TITLE
Correctly check for timezones in Notifier#edition_published!

### DIFF
--- a/lib/whitehall/gov_uk_delivery/notifier.rb
+++ b/lib/whitehall/gov_uk_delivery/notifier.rb
@@ -33,7 +33,7 @@ module Whitehall
       end
 
       def published_today?
-        Date.today == notification_date.to_date
+        Time.zone.today == notification_date.to_date
       end
 
       def outdated_speech?

--- a/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/notifier_test.rb
@@ -140,4 +140,17 @@ class Whitehall::GovUkDelivery::NotifierTest < ActiveSupport::TestCase
     notifier = notifier_for(publication)
     notifier.edition_published!
   end
+
+  test "#edition_published! takes into account timezones" do
+    time = Time.new(2011, 6, 11, 0, 30, 0, "+01:00")
+    Timecop.travel(time) {
+      edition = build(:draft_publication, public_timestamp: time, first_published_at: time)
+      force_publish(edition)
+
+      expect_govdelivery_worker_to_be_notified(edition)
+
+      notifier = notifier_for(edition)
+      notifier.edition_published!
+    }
+  end
 end


### PR DESCRIPTION
`Date.today` does not take into account timezones which was causing the notifier to fail during British Summer Time for publications going out just after midnight.