### PR TITLE
Use content_ids for stats data set links

### DIFF
--- a/app/presenters/publishing_api_presenters/publication.rb
+++ b/app/presenters/publishing_api_presenters/publication.rb
@@ -12,7 +12,7 @@ class PublishingApiPresenters::Publication < PublishingApiPresenters::Edition
       :world_locations
     ]).merge(
       ministers: ministers,
-      related_statistical_data_sets: item.statistical_data_set_ids,
+      related_statistical_data_sets: related_statistical_data_sets,
       topical_events: topical_events
     )
   end
@@ -52,5 +52,9 @@ private
       .joins(:classification_memberships)
       .where(classification_memberships: {edition_id: item.id})
       .pluck(:content_id)
+  end
+
+  def related_statistical_data_sets
+    item.statistical_data_sets.map(&:content_id)
   end
 end

--- a/test/unit/presenters/publishing_api_presenters/publication_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/publication_test.rb
@@ -7,10 +7,12 @@ class PublishingApiPresenters::PublicationTest < ActiveSupport::TestCase
 
   test "publication presentation includes the correct values" do
     government = create(:government)
+    statistical_data_set = create(:published_statistical_data_set)
     publication = create(:published_publication,
                     title: 'Publication title',
                     summary: 'The summary',
-                    body: 'Some content')
+                    body: 'Some content',
+                    statistical_data_sets: [statistical_data_set])
 
     public_path = Whitehall.url_maker.public_document_path(publication)
     expected_content = {
@@ -60,7 +62,7 @@ class PublishingApiPresenters::PublicationTest < ActiveSupport::TestCase
       organisations: publication.lead_organisations.map(&:content_id),
       document_collections: [],
       ministers: [minister.person.content_id],
-      related_statistical_data_sets: [],
+      related_statistical_data_sets: [statistical_data_set.content_id],
       world_locations: [],
       topical_events: [topical_event.content_id],
     }


### PR DESCRIPTION
This was using the numeric ids for the related stats data sets instead
of content ids, which was causing errors during publishing.

Errbit: https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/5772b2356578630ec1d50100

/cc @mgrassotti 