### PR TITLE
Fix topic links values when presenting edition for publishing API

### DIFF
--- a/app/presenters/publishing_api_presenters/edition.rb
+++ b/app/presenters/publishing_api_presenters/edition.rb
@@ -16,7 +16,9 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
   end
 
   def links
-    extract_links([:organisations]).merge(topic_and_parent_links_payload)
+    extract_links([:organisations])
+      .merge(topic_links)
+      .merge(parent_links)
   end
 
   def base_path
@@ -25,29 +27,34 @@ class PublishingApiPresenters::Edition < PublishingApiPresenters::Item
 
 private
 
-  def topic_and_parent_links_payload
-    topic_tags = item.specialist_sector_tags
-    return {} unless topic_tags.present?
-
-    parent_tag = item.primary_specialist_sector_tag
-    base_paths = topic_tags.map { |tag| topic_path_from(tag) }
-    content_id_lookup = Whitehall.publishing_api_v2_client.lookup_content_ids(base_paths: base_paths)
-
-    if parent_tag
-      parent_content_id = content_id_lookup[topic_path_from(parent_tag)]
-
-      if parent_content_id.nil?
-        Rails.logger.info "#{item.content_id} has non-existing primary_specialist_sector_tag: #{parent_tag}"
-        { topics: content_id_lookup.values }
-      else
-        { topics: content_id_lookup.values, parent: [parent_content_id] }
-      end
-    else
-      { topics: content_id_lookup.values }
-    end
+  def topic_base_paths
+    @topic_base_paths ||= item.specialist_sector_tags.map { |tag| full_topic_path_from(tag) }
   end
 
-  def topic_path_from(tag)
+  def content_id_lookup
+    @content_id_lookup ||= Whitehall.publishing_api_v2_client.lookup_content_ids(base_paths: topic_base_paths)
+  end
+
+  def topic_links
+    return { topics: [] } if topic_base_paths.blank?
+    { topics: content_id_lookup.values }
+  end
+
+  def parent_links
+    empty_parent = { parent: [] }
+    return empty_parent if topic_base_paths.blank?
+    parent_tag = item.primary_specialist_sector_tag
+    return empty_parent if parent_tag.blank?
+
+    parent_content_id = content_id_lookup[full_topic_path_from(parent_tag)]
+    return { parent: [parent_content_id] } if parent_content_id
+
+    Rails.logger.info "#{item.content_id} has non-existing primary_specialist_sector_tag: #{parent_tag}"
+    empty_parent
+  end
+
+
+  def full_topic_path_from(tag)
     "/topic/#{tag}"
   end
 

--- a/test/unit/presenters/publishing_api_presenters/edition_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/edition_test.rb
@@ -8,11 +8,13 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
   end
 
   test 'presents an Edition ready for adding to the publishing API' do
-    edition = create(:published_publication,
-                title: 'The title',
-                summary: 'The summary',
-                primary_specialist_sector_tag: 'oil-and-gas/taxation',
-                secondary_specialist_sector_tags: ['oil-and-gas/licensing'])
+    edition = create(
+      :published_publication,
+      title: 'The title',
+      summary: 'The summary',
+      primary_specialist_sector_tag: 'oil-and-gas/taxation',
+      secondary_specialist_sector_tags: ['oil-and-gas/licensing']
+    )
 
     public_path = Whitehall.url_maker.public_document_path(edition)
 
@@ -236,10 +238,7 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({
-      topics: %w(content_id_1),
-      organisations: [],
-    }, links)
+    assert_equal({ topics: %w(content_id_1), parent: [], organisations: [] }, links)
   end
 
   test '#links treats the primary specialist sector of the item as the parent' do
@@ -253,11 +252,14 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({
-      topics: %w(content_id_1 content_id_2),
-      parent: %w(content_id_1),
-      organisations: [],
-    }, links)
+    assert_equal(
+      {
+        topics: %w(content_id_1 content_id_2),
+        parent: %w(content_id_1),
+        organisations: [],
+      },
+      links
+    )
   end
 
   test '#links.parent will not be set if the specialist sector is not found' do
@@ -270,10 +272,21 @@ class PublishingApiPresenters::EditionTest < ActiveSupport::TestCase
 
     links = present(edition).links
 
-    assert_equal({
-      topics: %w(content_id_1),
-      organisations: [],
-    }, links)
+    assert_equal({ topics: %w(content_id_1), parent: [], organisations: [] }, links)
+  end
+
+  test "#links correctly sets blank topic and parent values if no specialist sectors are specified" do
+    edition = create(:edition)
+    links = present(edition).links
+
+    assert_equal(
+      {
+        topics: [],
+        parent: [],
+        organisations: [],
+      },
+      links
+    )
   end
 
   test 'Edition presents withdrawn_notice correctly' do


### PR DESCRIPTION
This wasn't setting empty arrays for the topics and parent link types
in the absence of any specialist sector taggings. The publishing API
expects these values to be set to clear any previously set links of
that type.