### PR TITLE
[Do not merge] Republish `Publication`s removed from publishing api

### DIFF
--- a/db/data_migration/20160705125732_republish_publications_removed_from_publishing_api.rb
+++ b/db/data_migration/20160705125732_republish_publications_removed_from_publishing_api.rb
@@ -1,0 +1,5 @@
+documents = Document.where(id: [313584, 321220])
+documents.each do |document|
+  Whitehall::PublishingApi.republish_document_async(document, bulk: true)
+end
+


### PR DESCRIPTION
This PR republishes two `Publication`s that had an incorrect `content_id` set in publishing api. `Publication` is not yet fully migrated but this discrepancy is causing sync check failures for `HtmlAttachment`

[Corresponding publishing API PR](https://github.com/alphagov/publishing-api/pull/399)