### PR TITLE
Add unpublished to csv export status

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -28,7 +28,6 @@ class DocumentListExportPresenter
       'Specialist sectors',
       'Collections',
       'Affected by history-mode',
-      'Unpublished',
     ]
   end
 
@@ -51,7 +50,6 @@ class DocumentListExportPresenter
       specialist_sectors,
       collections,
       edition.political?,
-      unpublished?,
     ]
   end
 
@@ -101,13 +99,11 @@ class DocumentListExportPresenter
   def state
     if edition.force_published?
       "force published"
+    elsif edition.unpublishing
+      "unpublished"
     else
       edition.state
     end
-  end
-
-  def unpublished?
-    edition.unpublishing ? 'yes' : 'no'
   end
 
   def policies

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -70,17 +70,10 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
     assert_equal "force published", pub.state
   end
 
-  test '#unpublished? returns `yes` when a document is unpublished' do
+  test '#state returns `unpublished` when a document is unpublished' do
     unpublished_edition = create(:edition, :unpublished)
 
     presenter = DocumentListExportPresenter.new(unpublished_edition)
-    assert_equal "yes", presenter.unpublished?
-  end
-
-  test '#unpublished? returns `no` when a document is draft' do
-    draft_edition = create(:edition, :draft)
-
-    presenter = DocumentListExportPresenter.new(draft_edition)
-    assert_equal "no", presenter.unpublished?
+    assert_equal "unpublished", presenter.state
   end
 end


### PR DESCRIPTION
Add the ‘unpublished’ status in the status column and not in a separate
column.