### PR TITLE
Present Contact title and type correctly.

### DIFF
--- a/app/presenters/publishing_api_presenters/contact.rb
+++ b/app/presenters/publishing_api_presenters/contact.rb
@@ -67,11 +67,11 @@ private
   end
 
   def contact_type
-    contact.contact_type.id
+    contact.contact_type.name
   end
 
   def details
-    details = { description: description, contact_type: contact_type }
+    details = { description: description, contact_type: contact_type, title: title }
     details[:post_addresses] = [post_address] if postal_code
     details[:email_addresses] = [email_address] if email
     details[:phone_numbers] = phone_numbers if contact_numbers.any?

--- a/test/unit/presenters/publishing_api_presenters/contact_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/contact_test.rb
@@ -38,7 +38,8 @@ class PublishingApiPresenters::ContactTest < ActiveSupport::TestCase
       publishing_app: "whitehall",
       details: {
         description: nil,
-        contact_type: 1,
+        title: "Government Digital Service",
+        contact_type: "General contact",
         post_addresses: [
           {
             title: "GDS mail room",


### PR DESCRIPTION
The schema expects contact_type to be a string, and title to be in the details hash.