### PR TITLE
Make Policies resilient to Publishing API issues

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -51,6 +51,8 @@ private
 
   def document_related_policies
     @document.policies
+  rescue GdsApi::TimedOutException, GdsApi::HTTPServerError
+    []
   end
 
   def find_unpublishing

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -38,6 +38,15 @@ private
     Rails.cache.fetch('policy.linkables', expires_in: 5.minutes) do
       publishing_api.get_linkables(document_type: "policy").to_a
     end
+  rescue GdsApi::TimedOutException, GdsApi::HTTPServerError
+    # This call normally takes ~20ms. If it takes longer than a second, fetch a stale value from
+    # cache. Rails adds 5 minutes to the `expires_in` value above to generate the TTL it sends to
+    # memcached, so we will have 5 minutes of staleness before the key is evicted.
+    # If there's no key in the cache, raise the original error. Frontend controllers can choose to
+    # display empty data, but admin controllers will prefer to error the page.
+    stale_data = Rails.cache.fetch('policy.linkables')
+    return stale_data if stale_data
+    raise
   end
 
   def self.find_policy(content_id)
@@ -45,6 +54,8 @@ private
   end
 
   def self.publishing_api
-    @publishing_api ||= Whitehall.publishing_api_v2_client
+    @publishing_api ||= Whitehall.publishing_api_v2_client.dup.tap do |client|
+      client.options[:timeout] = 1
+    end
   end
 end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -162,6 +162,13 @@ module DocumentControllerTestHelpers
         get :show, id: edition.document
         assert_select ".meta a", text: policy_1["title"]
       end
+
+      view_test "shows no policies if publishing api is unavailable" do
+        edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
+        publishing_api_isnt_available
+        get :show, id: edition.document
+        refute_select ".meta a", text: policy_1["title"]
+      end
     end
 
     def should_show_the_world_locations_associated_with(document_type)

--- a/test/unit/models/policy_test.rb
+++ b/test/unit/models/policy_test.rb
@@ -15,4 +15,10 @@ class PolicyTest < ActiveSupport::TestCase
     assert_equal policy_1["content_id"], policy.content_id
     assert_equal policy_1["title"], policy.title
   end
+
+  test "#all returns an empty array if publishing api errors" do
+    publishing_api_isnt_available
+
+    assert_raises(GdsApi::HTTPServerError) { Policy.all }
+  end
 end


### PR DESCRIPTION
If Publishing API is slow or unavailable, use stale policies from
memcached, or ultimately just return an empty array.

I *believe* this is the only code that would be called from the front end, everything else is publish time.

/cc @tijmenb @gpeng 

https://trello.com/c/mixR6T3C/442-investigate-removing-whitehall-frontend-s-connection-to-publishing-api