### PR TITLE
Revert "Revert "Revert "Migrate detailed guides"""

### DIFF
--- a/app/presenters/publishing_api_presenters/detailed_guide.rb
+++ b/app/presenters/publishing_api_presenters/detailed_guide.rb
@@ -34,8 +34,4 @@ private
         json[:national_applicability] = item.national_applicability if item.nation_inapplicabilities.any?
       end
   end
-
-  def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-  end
 end

--- a/db/data_migration/20160628155533_republish_detailed_guides_3.rb
+++ b/db/data_migration/20160628155533_republish_detailed_guides_3.rb
@@ -1,2 +1,0 @@
-republisher = DataHygiene::PublishingApiDocumentRepublisher.new(DetailedGuide)
-republisher.perform

--- a/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
+++ b/test/unit/presenters/publishing_api_presenters/detailed_guide_test.rb
@@ -43,7 +43,7 @@ class PublishingApiPresenters::DetailedGuideTest < ActiveSupport::TestCase
       locale: "en",
       need_ids: [],
       publishing_app: "whitehall",
-      rendering_app: "government-frontend",
+      rendering_app: "whitehall-frontend",
       routes: [
         { path: public_path, type: "exact" }
       ],


### PR DESCRIPTION
This reverts commit 61cf5483aefe4bfc8cadcf9764b7e1e69d01ecde.

There was a problem with links not being passed through from Whitehall. Rolled back again... 😫
