### PR TITLE
Exclude deleted `HtmlAttachments` from sync checks

### DIFF
--- a/script/publishing-api-sync-checks/html_publication_sync_check.rb
+++ b/script/publishing-api-sync-checks/html_publication_sync_check.rb
@@ -3,6 +3,7 @@ html_attachments = HtmlAttachment.includes(attachable: [:document])
   INNER JOIN editions ON attachable_id = editions.id
     AND attachable_type = 'Edition'
     AND attachments.type = 'HtmlAttachment'
+    AND attachments.deleted = 0
     AND editions.state IN ('published', 'withdrawn')
   SQL
 


### PR DESCRIPTION
Deleted attachments should either redirect to the alternative, the parent or 404 depending on the state of the related objects. We should exclude them from the sync check script.