### PR TITLE
Update links on "How government works"

### DIFF
--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -13,7 +13,7 @@
 
 <div class="block content-list">
   <div class="inner-block">
-    <%= image_tag 'history/buildings/number-10-300.jpg', alt: 'King Charles Street' %>
+    <%= image_tag 'history/buildings/number-10-300.jpg', alt: '10 Downing Street' %>
     <nav>
       <h1>Contents</h1>
       <ol>

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -237,7 +237,7 @@
             public sector organisation for all the recorded information it has
             on any subject. Anyone can make a request for information –
             known as a Freedom of Information (or FOI) request.  There are no
-            restrictions in your age, nationality or where you live.</p>
+            restrictions on your age, nationality or where you live.</p>
             <p><a href="/make-a-freedom-of-information-request">How to make a freedom of information request</a></p>
             <p><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases') %></p>
 

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -84,7 +84,7 @@
               <span class="feature-caption">Ministerial departments</span>
               <span class="feature-value"><a href="/government/organisations#non-ministerial-departments"><%= @non_ministerial_department_count %></a></span>
               <span class="feature-caption">Non-ministerial departments</span>
-              <span class="feature-value"><a href="/government/organisations#agencies-and-public-bodies">300+</a></span>
+              <span class="feature-value"><a href="/government/organisations#agencies-and-government-bodies">300+</a></span>
               <span class="feature-caption">Agencies &amp; other public bodies</span></p>
           </div>
         </div>
@@ -137,7 +137,7 @@
               <li>staffing prisons</li>
               <li>issuing driving licences</li>
             </ul>
-            <p><a href="http://www.civilservice.gov.uk/" rel="external">Civil Service website</a></p>
+            <p>The <a href="/government/organisations/civil-service">Civil Service</a> is on GOV.UK.</p>
           </div>
         </div>
 
@@ -148,7 +148,7 @@
         <div class="one-third">
           <div class="inner-block">
             <h4>Work for us</h4>
-            <p><a href="https://jobsstatic.civilservice.gov.uk/csjobs.html/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
+            <p><a href="https://civilservicejobs.service.gov.uk/">Find and apply</a> for vacancies in departments, executive agencies and non-departmental public bodies.</p>
           </div>
         </div>
         <div class="one-third">
@@ -170,21 +170,21 @@
 
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Read about ways to <a href="/government/get-involved/">get involved</a>.</p>
+            <p>Read about ways to <a href="/government/get-involved">get involved</a>.</p>
           </div>
         </div>
 
         <div class="one-third">
           <div class="inner-block">
             <h4>Engage with government</h4>
-            <p>Interact with government through <a href="/government/get-involved/#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
+            <p>Interact with government through <a href="/government/get-involved#engage-with-government">consultations and petitions</a> to inform and influence the decisions it makes.</p>
           </div>
         </div>
 
         <div class="one-third">
           <div class="inner-block">
             <h4>Take part</h4>
-            <p><a href="/government/get-involved/#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
+            <p><a href="/government/get-involved#take-part">Offer your skills and energy</a> to a project in your neighbourhood, around the UK or overseas.</p>
           </div>
         </div>
       </div>
@@ -238,7 +238,7 @@
             on any subject. Anyone can make a request for information –
             known as a Freedom of Information (or FOI) request.  There are no
             restrictions in your age, nationality or where you live.</p>
-            <p><a href="https://www.gov.uk/make-a-freedom-of-information-request">How to make a freedom of information request</a></p>
+            <p><a href="/make-a-freedom-of-information-request">How to make a freedom of information request</a></p>
             <p><%= link_to "See FOI releases on GOV.UK", publications_filter_path(:publication_filter_option => 'foi-releases') %></p>
 
             <h4 class="with-gutter">Statistics</h4>
@@ -246,10 +246,10 @@
             public life. Statistics are used by people inside and outside
             government to make informed decisions and to measure the success of
             government policies and services. <a
-              href="https://www.gov.uk/government/publications/how-national-and-official-statistics-are-assured">Find
+              href="/government/statistics/how-national-and-official-statistics-are-assured">Find
               out about the legislation</a> that governs the publication of UK
             national and Official Statistics.</p>
-            <p><%= link_to "See statistics publications on GOV.UK", publications_filter_path(:publication_filter_option => 'statistics') %></p>
+            <p><%= link_to "See statistics publications on GOV.UK", '/government/statistics' %></p>
 
           </div>
         </div>
@@ -263,9 +263,9 @@
               <li>the job titles of senior civil servants and how much they are paid</li>
               <li>how the government is doing against its objectives</li>
             </ul>
-            <p><a href="http://www.number10.gov.uk/transparency/" rel="external">Read more about transparency</a></p>
+            <p><%= link_to 'See transparency releases on GOV.UK', publications_filter_path(:publication_filter_option => 'transparency-data') %></p>
             <h4 class="with-gutter">Data</h4>
-            <p>Putting data in people’s hands can help them have more of a say in the reform of public services. On <a href="http://www.data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
+            <p>Putting data in people’s hands can help them have more of a say in the reform of public services. On <a href="https://data.gov.uk" rel="external">data.gov.uk</a> you can easily find, review and use information about our country and communities - for example, to develop web applications.</p>
           </div>
         </div>
       </div>
@@ -274,7 +274,7 @@
         <div class="one-third">
           <div class="inner-block">
             <h3>Devolved government</h3>
-            <p>In <a href="http://home.scotland.gov.uk/home" rel="external">Scotland</a>, <a href="http://www.wales.gov.uk/" rel="external">Wales</a> and <a href="http://www.northernireland.gov.uk/" rel="external">Northern
+            <p>In <a href="http://www.gov.scot/" rel="external">Scotland</a>, <a href="http://gov.wales/" rel="external">Wales</a> and <a href="https://www.northernireland.gov.uk/" rel="external">Northern
             Ireland</a>, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.</p>
             <p>Areas the Scottish Government, Welsh Government, and the Northern Ireland Executive are responsible for, include:</p>
             <ul>


### PR DESCRIPTION
Lots of these links have changed. Most concerning is the one for Civil Service Jobs, where apparently we've removed all DNS for the old domain.