### PR TITLE
Add missing content to search & publishing-api

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -20,16 +20,54 @@ class PublishStaticPages
         content_id: "f56cfe74-8e5c-432d-bfcf-fd2521c5919c",
         title: "How government works",
         description: "About the UK system of government. Understand who runs government, and how government is run.",
-        indexable_content: "government, parliament, coalition, civil service, civil servants, policies, policy, minister, ministers, MP, rt hon, right honourable, department, ndpb, agency, executive agency, agencies, organisation, public bodies, public body, FOI, freedom of information, transparency, democracy, westminster, whitehall, house of commons, house of lords",
+        indexable_content: TemplateContent.new("home/how_government_works").indexable_content,
         base_path: "/government/how-government-works",
       },
       {
         content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
         title: "Get involved",
         description: "Find out how you can engage with government directly, and take part locally, nationally or internationally.",
-        indexable_content: "changing government policies, consultations, government departments",
+        indexable_content: TemplateContent.new("home/get_involved").indexable_content,
         base_path: "/government/get-involved",
-      }
+      },
+      {
+        content_id: "db95a864-874f-4f50-a483-352a5bc7ba18",
+        title: "History of the UK government",
+        description: "In this section you can read short biographies of notable people and explore the history of government buildings. You can also search our online records and read articles and blog posts by historians.",
+        indexable_content: TemplateContent.new("histories/index").indexable_content,
+        base_path: "/government/history",
+      },
+      {
+        content_id: "14aa298f-03a8-4e76-96de-483efa3d001f",
+        title: "10 Downing Street",
+        description: "10 Downing Street, the locale of British prime ministers since 1735, vies with the White House as being the most important political building anywhere in the world in the modern era.",
+        indexable_content: TemplateContent.new("histories/10_downing_street").indexable_content,
+        base_path: "/government/history/10-downing-street",
+      },
+      {
+        content_id: "7be62825-1538-4ff5-aa29-cd09350349f2",
+        title: "1 Horse Guards Road",
+        indexable_content: TemplateContent.new("histories/1_horse_guards_road").indexable_content,
+        base_path: "/government/history/1-horse-guards-road",
+      },
+      {
+        content_id: "9bdb6017-48c9-4590-b795-3c19d5e59320",
+        title: "11 Downing Street",
+        indexable_content: TemplateContent.new("histories/11_downing_street").indexable_content,
+        base_path: "/government/history/11-downing-street",
+      },
+      {
+        content_id: "bd216990-c550-4d28-ac05-649329298601",
+        title: "King Charles Street (FCO)",
+        indexable_content: TemplateContent.new("histories/king_charles_street").indexable_content,
+        base_path: "/government/history/king-charles-street",
+      },
+      {
+        content_id: "60808448-769d-4915-981c-f34eb5f1b7bc",
+        title: "lancaster-house (FCO)",
+        indexable_content: TemplateContent.new("histories/lancaster_house").indexable_content,
+        base_path: "/government/history/lancaster-house",
+      },
     ]
   end
 
@@ -51,7 +89,8 @@ class PublishStaticPages
         details: {},
         title: page[:title],
         description: page[:description],
-        format: "placeholder", # This content will never be rendered by content store
+        document_type: "placeholder",
+        schema_name: "placeholder",
         locale: "en",
         base_path: page[:base_path],
         publishing_app: "whitehall",
@@ -71,5 +110,18 @@ private
 
   def publishing_api
     @publishing_api ||= Whitehall.publishing_api_v2_client
+  end
+
+  class TemplateContent
+    include ActionView::Helpers::SanitizeHelper
+
+    def initialize(template_path)
+      @template_path = template_path
+    end
+
+    def indexable_content
+      template = File.read("#{Rails.root}/app/views/#{@template_path}.html.erb")
+      strip_tags(template)
+    end
   end
 end

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -3,7 +3,7 @@ require "govuk-content-schema-test-helpers"
 
 class PublishStaticPagesTest < ActiveSupport::TestCase
   test 'sends static pages to rummager and publishing api' do
-    Whitehall::FakeRummageableIndex.any_instance.expects(:add).twice.with(kind_of(Hash))
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
     publisher = PublishStaticPages.new
     expect_publishing(publisher.pages)
 
@@ -20,16 +20,9 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
     base_paths = PublishStaticPages.new.pages.map { |page| page[:base_path] }
     assert_equal(
       base_paths,
-      ["/government/how-government-works", "/government/get-involved"],
+      ["/government/how-government-works", "/government/get-involved", "/government/history", "/government/history/10-downing-street", "/government/history/1-horse-guards-road", "/government/history/11-downing-street", "/government/history/king-charles-street", "/government/history/lancaster-house"],
       "Base paths for static content should not be changed without first setting up a redirect"
     )
-  end
-
-  def expect_patch_links(pages)
-    pages.each do |page|
-      Whitehall.publishing_api_v2_client.expects(:patch_links)
-        .with(page[:content_id], { links: page[:links] })
-    end
   end
 
   def expect_publishing(pages)
@@ -38,7 +31,8 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
         .with(
           page[:content_id],
           has_entries(
-            format: "placeholder",
+            document_type: "placeholder",
+            schema_name: "placeholder",
             base_path: page[:base_path],
             title: page[:title]
           )


### PR DESCRIPTION
This adds the following pages to search & publishing-api:

https://www.gov.uk/government/history
https://www.gov.uk/government/history/10-downing-street
https://www.gov.uk/government/history/11-downing-street
https://www.gov.uk/government/history/king-charles-street
https://www.gov.uk/government/history/lancaster-house
https://www.gov.uk/government/history/1-horse-guards-road