### PR TITLE
Make data for html_attachment valid by schema.

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -59,11 +59,11 @@ module PublishingApi
     end
 
     def body
-      govspeak_content.try(:computed_body_html)
+      govspeak_content.try(:computed_body_html) || ""
     end
 
     def headings
-      govspeak_content.try(:computed_headers_html)
+      govspeak_content.try(:computed_headers_html) || ""
     end
 
     def first_published_version?
@@ -71,7 +71,7 @@ module PublishingApi
     end
 
     def public_timestamp
-      parent.public_timestamp
+      parent.public_timestamp || parent.updated_at
     end
 
     def parent

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -67,6 +67,18 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     GovspeakContent.delete_all
     html_attachment = HtmlAttachment.last
 
-    assert_nil present(html_attachment).content[:body]
+    assert_equal "", present(html_attachment).content[:details][:body]
+    assert_equal "", present(html_attachment).content[:details][:headings]
+  end
+
+  test "HtmlAttachment presentations sends the parent updated_at if it has no public_timestamp" do
+    Timecop.freeze do
+      create(:publication, :with_html_attachment, :draft)
+
+      GovspeakContent.delete_all
+      html_attachment = HtmlAttachment.last
+
+      assert_equal Time.zone.now, present(html_attachment).content[:details][:public_timestamp]
+    end
   end
 end


### PR DESCRIPTION
Required strings need to default to empty, not nil, when not present,
and public_timestamp needs a fallback.