### PR TITLE
Fix - Delete WW priorities from rummager

### DIFF
--- a/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
+++ b/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
@@ -724,5 +724,9 @@ BASE_PATHS = [
 ]
 
 BASE_PATHS.each do |base_path|
-  Whitehall.unified_search_client.delete_content! base_path
+  begin
+    Whitehall.unified_search_client.delete_content! base_path
+  rescue GdsApi::HTTPNotFound => e 
+    puts "\n" + "="*25 + "\nURL not found error:\n#{e}"
+  end
 end

--- a/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
+++ b/db/data_migration/20160506093328_delete_ww_priorities_rummager.rb
@@ -724,5 +724,5 @@ BASE_PATHS = [
 ]
 
 BASE_PATHS.each do |base_path|
-  Whitehall.government_search_client.delete_content! base_path
+  Whitehall.unified_search_client.delete_content! base_path
 end


### PR DESCRIPTION
The migration was not working because the pages were not found using the government search client.

Using the unified search client the pages can be found with base paths
and deleted from rummager.

Referring to https://github.com/alphagov/whitehall/pull/2579
and https://trello.com/c/AtYGioxe/292-worldwide-priorities-deleting-the-format-medium