### PR TITLE
Comment inconsistent naming in models

### DIFF
--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -77,6 +77,13 @@ module Admin
       end
     end
 
+    # DID YOU MEAN: Policy Area?
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # "Topic" is the newer name for "specialist sector"
+    # (https://www.gov.uk/topic)
+    # You can help improve this code by renaming all usages of this field to use
+    # the new terminology.
     def unfiltered_scope
       # We are doing a "greatest n by group" query here, but on a joined model,
       # i.e. the StatisticsAnnouncementDate, or in this case the

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -5,6 +5,14 @@ class Announcement < Edition
   include Edition::RelatedPolicies
   include Edition::WorldLocations
   include Edition::TopicalEvents
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   include Edition::Topics
 
   def self.sti_names

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -4,6 +4,13 @@ class Classification < ActiveRecord::Base
   include SimpleWorkflow
   include PublishesToPublishingApi
 
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   searchable title: :name,
              link: :search_link,
              content: :description,

--- a/app/models/classification_membership.rb
+++ b/app/models/classification_membership.rb
@@ -2,6 +2,14 @@ class ClassificationMembership < ActiveRecord::Base
   belongs_to :edition
   belongs_to :classification, foreign_key: :classification_id, inverse_of: :classification_memberships
   belongs_to :topical_event, foreign_key: :classification_id
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   belongs_to :topic, foreign_key: :classification_id
 
   belongs_to :detailed_guide, foreign_key: :edition_id

--- a/app/models/classification_relation.rb
+++ b/app/models/classification_relation.rb
@@ -1,6 +1,14 @@
 class ClassificationRelation < ActiveRecord::Base
   belongs_to :classification, inverse_of: :classification_relations
   belongs_to :related_classification, foreign_key: :related_classification_id, class_name: "Classification"
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   belongs_to :topic, foreign_key: :classification_id, class_name: "Topic"
   belongs_to :related_topic, foreign_key: :related_classification_id, class_name: "Topic"
 

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,7 +1,16 @@
 class DetailedGuide < Edition
   include Edition::Images
   include Edition::NationalApplicability
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   include Edition::Topics
+
   include ::Attachable
   include Edition::AlternativeFormatProvider
   include Edition::FactCheckable

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,6 +39,13 @@ class Document < ActiveRecord::Base
 
   validates_presence_of :content_id
 
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   delegate :topics, to: :latest_edition
 
   after_create :ensure_document_has_a_slug

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,7 +1,16 @@
 class DocumentCollection < Edition
   include Edition::Organisations
   include Edition::RelatedPolicies
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   include Edition::Topics
+
   include Edition::TopicalEvents
 
   has_many :groups,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -258,7 +258,16 @@ class Edition < ActiveRecord::Base
     public_timestamp: :public_timestamp,
     relevant_to_local_government: :relevant_to_local_government?,
     world_locations: nil,
+
+    # DID YOU MEAN: Policy Area?
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # "Topic" is the newer name for "specialist sector"
+    # (https://www.gov.uk/topic)
+    # You can help improve this code by renaming all usages of this field to use
+    # the new terminology.
     topics: nil,
+
     only: :search_only,
     index_after: [],
     unindex_after: [],

--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -1,3 +1,8 @@
+# DID YOU MEAN: Topic?
+# "Policy area" is the newer name for "topic"
+# (https://www.gov.uk/government/topics)
+# "Topic" is the newer name for "specialist sector"
+# (https://www.gov.uk/topic)
 module Edition::SpecialistSectors
   extend ActiveSupport::Concern
 

--- a/app/models/edition/topical_events.rb
+++ b/app/models/edition/topical_events.rb
@@ -22,6 +22,13 @@ module Edition::TopicalEvents
   end
 
   def search_index
+    # DID YOU MEAN: Policy Area?
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # "Topic" is the newer name for "specialist sector"
+    # (https://www.gov.uk/topic)
+    # You can help improve this code by renaming all usages of this field to use
+    # the new terminology.
     super.merge("topics" => topical_events.map(&:slug)) {|k, ov, nv| ov + nv}
   end
 end

--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -1,4 +1,10 @@
-# NB: Topic is being renamed to "Policy Area" across GOV.UK.
+# DID YOU MEAN: Policy Area?
+# "Policy area" is the newer name for "topic"
+# (https://www.gov.uk/government/topics)
+# "Topic" is the newer name for "specialist sector"
+# (https://www.gov.uk/topic)
+# You can help improve this code by renaming all usages of this field to use
+# the new terminology.
 module Edition::Topics
   extend ActiveSupport::Concern
   include Edition::Classifications

--- a/app/models/frontend/statistics_announcement.rb
+++ b/app/models/frontend/statistics_announcement.rb
@@ -5,8 +5,17 @@ class Frontend::StatisticsAnnouncement
                 :publication, :document_type,
                 :release_date, :display_date, :release_date_confirmed,
                 :release_date_change_note, :previous_display_date,
-                :organisations, :topics,
-                :state, :cancellation_reason, :cancellation_date
+                :organisations, :state, :cancellation_reason,
+                :cancellation_date
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
+  attr_accessor :topics
 
   def initialize(attrs = {})
     attrs = Hash(attrs)

--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -2,8 +2,17 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   named "StatisticsAnnouncementsFilter"
   attr_accessor :keywords,
                 :from_date, :to_date,
-                :organisations, :topics,
+                :organisations,
                 :page
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
+  attr_accessor :topics
 
   RESULTS_PER_PAGE = 40
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -77,6 +77,14 @@ class Organisation < ActiveRecord::Base
   has_many :organisation_classifications,
            -> { order('organisation_classifications.ordering') },
            dependent: :destroy
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   has_many :topics,
            -> { order('organisation_classifications.ordering') },
            through: :organisation_classifications

--- a/app/models/organisation_classification.rb
+++ b/app/models/organisation_classification.rb
@@ -1,5 +1,13 @@
 class OrganisationClassification < ActiveRecord::Base
   belongs_to :organisation
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   belongs_to :topic, foreign_key: :classification_id
   belongs_to :classification
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -24,6 +24,13 @@ class Policy
     content_ids.map { |content_id| find(content_id) }.compact
   end
 
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   def topics
     []
   end

--- a/app/models/publicationesque.rb
+++ b/app/models/publicationesque.rb
@@ -10,7 +10,16 @@ class Publicationesque < Edition
   include Edition::RelatedPolicies
   include Edition::HasDocumentCollections
   include Edition::Organisations
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   include Edition::Topics
+
   include ::Attachable
 
   def self.sti_names

--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -62,6 +62,11 @@ class RegisterableEdition
     edition.need_ids
   end
 
+  # DID YOU MEAN: Topic?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
   def specialist_sectors
     [edition.primary_specialist_sector_tag].compact + edition.secondary_specialist_sector_tags
   end

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -29,13 +29,24 @@ module Searchable
     :release_timestamp,
     :search_format_types,
     :slug,
-    :specialist_sectors,
+
+
     :speech_type,
     :statistics_announcement_state,
     :title,
 
-    # Topics display as policy areas in the frontend and map to policy areas in rummager
+    # DID YOU MEAN: Policy Area?
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # "Topic" is the newer name for "specialist sector"
+    # (https://www.gov.uk/topic)
+    # You can help improve this code by renaming all usages of this field to use
+    # the new terminology.
     :topics,
+
+    # DID YOU MEAN: Topic?
+    # See above.
+    :specialist_sectors,
 
     :world_locations,
   ]

--- a/app/models/services_and_information_finder.rb
+++ b/app/models/services_and_information_finder.rb
@@ -20,6 +20,12 @@ private
     {
       count: "0",
       filter_organisations: [organisation.slug],
+
+      # DID YOU MEAN: Topic?
+      # "Policy area" is the newer name for "topic"
+      # (https://www.gov.uk/government/topics)
+      # "Topic" is the newer name for "specialist sector"
+      # (https://www.gov.uk/topic)
       facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
     }
   end

--- a/app/models/services_and_information_parser.rb
+++ b/app/models/services_and_information_parser.rb
@@ -23,6 +23,11 @@ private
   end
 
   def content_groups
+    # DID YOU MEAN: Topic?
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # "Topic" is the newer name for "specialist sector"
+    # (https://www.gov.uk/topic)
     content.facets.specialist_sectors.options
   end
 end

--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -1,3 +1,8 @@
+# DID YOU MEAN: Topic?
+# "Policy area" is the newer name for "topic"
+# (https://www.gov.uk/government/topics)
+# "Topic" is the newer name for "specialist sector"
+# (https://www.gov.uk/topic)
 class SpecialistSector < ActiveRecord::Base
   belongs_to :edition
 
@@ -27,6 +32,11 @@ private
     sectors.select(&:parent)
   end
 
+  # DID YOU MEAN: Topic?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
   def self.fetch_sectors
     Whitehall.content_api.tags('specialist_sector', draft: true)
   rescue

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -25,6 +25,13 @@ class StatisticsAnnouncement < ActiveRecord::Base
     inverse_of: :statistics_announcement
   has_many :statistics_announcement_dates, dependent: :destroy
 
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   has_many :statistics_announcement_topics, inverse_of: :statistics_announcement, dependent: :destroy
   has_many :topics, through: :statistics_announcement_topics
 

--- a/app/models/statistics_announcement_topic.rb
+++ b/app/models/statistics_announcement_topic.rb
@@ -1,5 +1,13 @@
 class StatisticsAnnouncementTopic < ActiveRecord::Base
   belongs_to :statistics_announcement, inverse_of: :statistics_announcement_topics
+
+  # DID YOU MEAN: Policy Area?
+  # "Policy area" is the newer name for "topic"
+  # (https://www.gov.uk/government/topics)
+  # "Topic" is the newer name for "specialist sector"
+  # (https://www.gov.uk/topic)
+  # You can help improve this code by renaming all usages of this field to use
+  # the new terminology.
   belongs_to :topic, inverse_of: :statistics_announcement_topics
 
   validates :statistics_announcement, :topic, presence: true

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,4 +1,10 @@
-# NB: Topic is being renamed to "Policy Area" across GOV.UK.
+# DID YOU MEAN: Policy Area?
+# "Policy area" is the newer name for "topic"
+# (https://www.gov.uk/government/topics)
+# "Topic" is the newer name for "specialist sector"
+# (https://www.gov.uk/topic)
+# You can help improve this code by renaming all usages of this field to use
+# the new terminology.
 class Topic < Classification
   has_many :featured_links, -> { order(:created_at) },  as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :featured_links, reject_if: -> attributes { attributes['url'].blank? }, allow_destroy: true


### PR DESCRIPTION
*Topics* is an overloaded word. The "correct" meaning of topics
should be these things: https://www.gov.uk/topic

Not these things: https://www.gov.uk/government/topics (policy areas).

- Whitehall/Government frontend refers to these things correctly.
- Whitehall backend should be doing the same.
- URLs in whitehall use the old naming in places.
- Publishing API and content store use the correct names.
- Rummager uses a mix of old/new names for its fields. We have [open tickets to rename them](https://trello.com/c/bDFlehc5/518-rename-topics-to-policy-areas-in-rummager-m).
- The whitehall code is all over the place.

I've investigated a complete rename of the models, views and controllers in whitehall and it proved difficult to do all at once. So for now here's an obnoxious message flagging the issue, so devs
can understand the data model better.

I'd like to chip away at this problem by renaming small parts of whitehall in separate PRs. To avoid even more confusion, we should rename Topics -> Policy Areas before renaming Specialist Sectors -> Topics.

Please help if you can. @alphagov/team-gov-uk-finding-things have the most context on how these links are used on GOV.UK and we are happy to answer questions. 🎓 

Earlier failed attempt at this: https://trello.com/c/RWbzf8zb/685-whitehall-topics-policy-areas-clean-up