### PR TITLE
Fix detailed guide metadata

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -34,6 +34,8 @@ module PublishingApi
         [
           :organisations,
           :parent,
+          :policy_areas,
+          :related_policies,
           :topics,
         ]
       ).merge(

--- a/test/factories/classifications.rb
+++ b/test/factories/classifications.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :classification do
     sequence(:name) { |index| "classification-#{index}" }
-    description 'Classifcation description'
+    description 'Classification description'
   end
 end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -31,6 +31,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       summary: "Some summary",
       body: "Some content"
     )
+    EditionPolicy.create(edition_id: detailed_guide.id, policy_content_id: "dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8")
 
     public_path = Whitehall.url_maker.public_document_path(detailed_guide)
     expected_content = {
@@ -71,6 +72,8 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       organisations: detailed_guide.organisations.map(&:content_id),
       topics: [],
       parent: [],
+      related_policies: ["dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8"],
+      policy_areas: detailed_guide.topics.map(&:content_id),
       related_guides: [],
       related_mainstream: [],
     }


### PR DESCRIPTION
Detailed Guides also have policies and policy areas, which needs to be reflected in their presenter, in order to migrate them. This PR depends on [this govuk-content-schemas PR](https://github.com/alphagov/govuk-content-schemas/pull/361) being merged first, hence the mention for now.

[Trello](https://trello.com/c/CkHu0suq/317-6-detailed-guides-migration-final-tasks-deploy-1-medium)