### PR TITLE
Order cabinet members by cabinet role seniority

### DIFF
--- a/app/models/minister_sorter.rb
+++ b/app/models/minister_sorter.rb
@@ -6,7 +6,7 @@ class MinisterSorter
   def cabinet_ministers
     ministers = roles_by_person.select { |_, roles| roles.any?(&:cabinet_member?) }
     ministers.sort_by { |person, roles|
-      [roles.map(&:seniority).min, person.sort_key]
+      [roles.select(&:cabinet_member?).map(&:seniority).min, person.sort_key]
     }.map { |person, roles| [person, roles.sort_by(&:seniority)] }
   end
 

--- a/test/unit/minister_sorter_test.rb
+++ b/test/unit/minister_sorter_test.rb
@@ -72,4 +72,20 @@ class MinisterSorterTest < ActiveSupport::TestCase
     set = MinisterSorter.new(roles)
     assert_equal expected, set.other_ministers
   end
+
+  def test_should_list_cabinet_ministers_in_order_of_cabinet_role_seniority
+    senior_person = person("0")
+    junior_person = person("1")
+    roles = [
+      role("Senior Non Cabinet Role", 100, false, [senior_person]),
+      role("Senior Cabinet Role", 16, true, [senior_person]),
+      role("Junior Non Cabinet Role", 14, false, [junior_person]),
+      role("Junior Cabinet Role", 17, true, [junior_person]),
+    ]
+
+    expected = [senior_person, junior_person]
+    set = MinisterSorter.new(roles)
+
+    assert_equal expected, set.cabinet_ministers.collect(&:first)
+  end
 end


### PR DESCRIPTION
Two cabinet ministers are appearing on the ministers page
(https://www.gov.uk/government/ministers) in the wrong order.

Cabinet ministers are appearing on the ministers page according to
their role seniority, regardless of whether the role is a cabinet role
or not.

This means that cabinet ministers that also have another role, might
not be presented in the frontend in the same order as the "cabinet
members ordering" list in Whitehall admin.

This ensures that only the seniority of cabinet roles are taken into
account.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1378654