### PR TITLE
Update SpecialistTagFinder to use request path for content store call

### DIFF
--- a/app/views/documents/_header.html.erb
+++ b/app/views/documents/_header.html.erb
@@ -5,7 +5,7 @@
 <%
   header_title ||= ""
   policies ||= nil
-  specialist_tag_finder = SpecialistTagFinder.new(@document)
+  specialist_tag_finder = SpecialistTagFinder.new(request.path)
 %>
 <%=
   render(

--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -13,8 +13,6 @@ Then /^I can tag it to some specialist sectors$/ do
 end
 
 Given(/^there is a document tagged to specialist sectors$/) do
-  unstub_tag_finder # we're testing topic tags, remove any existing stubs
-
   @document = create(:published_publication, :guidance)
   document_base_path = PublishingApiPresenters.presenter_for(@document).content[:base_path]
   parent_base_path = "/parent-topic"

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -2,18 +2,20 @@ require 'gds_api/test_helpers/content_api'
 require "gds_api/test_helpers/content_store"
 
 Before do
-  # Assume documents rendered in these features have no topic tags.
-  # Stub can be removed in individual features if required.
-  SpecialistTagFinder.stubs(:new).returns(SpecialistTagFinder::Null.new)
+  # FIXME: This stubs out calls to the content store, returning an empty
+  # response. Calls to this endpoint are only needed in SpecialistTagFinder,
+  # for rendering the header in Whitehall frontend. Ideally this should be
+  # replaced by explicit stubs in every feature that renders a frontend page.
+  # That's a fairly large reworking of the tests, however, and those pages are
+  # in the process of being migrated to government-frontend. For now then, this
+  # stub should be overriden in specific features where this behaviour needs to
+  # be tested.
+  stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
 end
 
 module SpecialistSectorHelper
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::ContentStore
-
-  def unstub_tag_finder
-    SpecialistTagFinder.unstub(:new)
-  end
 
   def stub_specialist_sectors
     oil_and_gas = { slug: 'oil-and-gas', title: 'Oil and Gas' }

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -9,8 +9,8 @@ class SpecialistTagFinder
     end
   end
 
-  def initialize(edition)
-    @edition = edition
+  def initialize(edition_path)
+    @edition_path = edition_path
   end
 
   def topics
@@ -46,9 +46,7 @@ private
 
   def edition_content_item
     @edition_content_item ||= begin
-      presented_edition = PublishingApiPresenters.presenter_for(@edition)
-      edition_path = presented_edition.content[:base_path]
-      Whitehall.content_store.content_item(edition_path)
+      Whitehall.content_store.content_item(@edition_path)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -184,9 +184,11 @@ class ActionController::TestCase
   setup do
     request.env['warden'] = stub(authenticate!: false, authenticated?: false, user: nil)
 
-    # In controller tests, assume by default that the resource being rendered
-    # does not have any topic tags.
-    SpecialistTagFinder.stubs(:new).returns(SpecialistTagFinder::Null.new)
+    # In controller tests, stub out all calls to the content store. This
+    # implies that by default we don't care about responses from this endpoint,
+    # which is currently only used to render specialist sector links in the
+    # header.
+    stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
   end
 
   def login_as(role_or_user)

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -6,7 +6,7 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
 
   test "#topics returns all linked topics" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
     content_item = content_item_for_base_path(edition_base_path).merge!({
       "links" => {
         "topics" => [
@@ -18,33 +18,33 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
 
     content_store_has_item(edition_base_path, content_item)
 
-    assert_equal ["topic-1", "topic-2"], SpecialistTagFinder.new(edition).topics.map { |topic| topic["title"] }
+    assert_equal ["topic-1", "topic-2"], SpecialistTagFinder.new(edition_base_path).topics.map { |topic| topic["title"] }
   end
 
   test "#topics returns empty array if no content item found" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
 
     content_store_does_not_have_item(edition_base_path)
 
-    assert_equal [], SpecialistTagFinder.new(edition).topics
+    assert_equal [], SpecialistTagFinder.new(edition_base_path).topics
   end
 
   test "#topics returns empty array if content item has no topics link" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
     content_item = content_item_for_base_path(edition_base_path).merge!(
       "links" => { "other" => [] }
     )
 
     content_store_has_item(edition_base_path, content_item)
 
-    assert_equal [], SpecialistTagFinder.new(edition).topics
+    assert_equal [], SpecialistTagFinder.new(edition_base_path).topics
   end
 
   test "#top_level_topic returns the parent of the edition's parent topic" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
     parent_base_path = "/parent-item"
     edition_content_item = content_item_for_base_path(edition_base_path).merge!({
       "links" => { "parent" => [{ "base_path" => parent_base_path }] }
@@ -56,27 +56,27 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     content_store_has_item(edition_base_path, edition_content_item)
     content_store_has_item(parent_base_path, parent_content_item)
 
-    assert_equal "/grandpa", SpecialistTagFinder.new(edition).top_level_topic.base_path
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
   end
 
   test "#top_level_topic returns nil if no parents" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
     edition_content_item = content_item_for_base_path(edition_base_path).merge!({
       "links" => { }
     })
 
     content_store_has_item(edition_base_path, edition_content_item)
 
-    assert_equal nil, SpecialistTagFinder.new(edition).top_level_topic
+    assert_equal nil, SpecialistTagFinder.new(edition_base_path).top_level_topic
   end
 
   test "#top_level_topic returns nil if not content item found" do
     edition = create(:edition_with_document)
-    edition_base_path = PublishingApiPresenters.presenter_for(edition).content[:base_path]
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
 
     content_store_does_not_have_item(edition_base_path)
 
-    assert_equal nil, SpecialistTagFinder.new(edition).top_level_topic
+    assert_equal nil, SpecialistTagFinder.new(edition_base_path).top_level_topic
   end
 end


### PR DESCRIPTION
SpecialistTagFinder needs to fetch the current document from the content
store in order to retrieve its links data. These links are used when
rendering the document header. Previously the base path of the current
document was derived via the PublishingApiPresenters. This has proven to
be fragile as the @document being rendered on the page may be an
instance of a given model, or an instance of the model's corresponding frontend
presenter.

Following a recent refactor, the PublishingApiPresenters
'.presenter_for' method no longer provides a convenient catchall for
anything that doesn't match one of the classes in its case statement.
This makes the model vs. publishing presenter relationship more
transparent, but has lead to errors when an instance of a frontend
presenter gets passed in.

By using the current request path instead, we decouple
SpecialistTagFinder from the PublishingApiPresenters and avoid this
issue.