### PR TITLE
Correct sending of policy areas to rummager

### DIFF
--- a/app/models/edition/topical_events.rb
+++ b/app/models/edition/topical_events.rb
@@ -26,6 +26,8 @@ module Edition::TopicalEvents
     # (https://www.gov.uk/government/topics)
     # Rummager's policy areas also include "topical events", which we model
     # separately in whitehall.
-    super.merge("policy_areas" => topical_events.map(&:slug)) {|_k, ov, nv| ov + nv}
+    new_slugs = topical_events.map(&:slug)
+    existing_slugs = super.fetch("policy_areas", [])
+    super.merge("policy_areas" => new_slugs + existing_slugs)
   end
 end

--- a/app/models/edition/topical_events.rb
+++ b/app/models/edition/topical_events.rb
@@ -22,13 +22,10 @@ module Edition::TopicalEvents
   end
 
   def search_index
-    # DID YOU MEAN: Policy Area?
     # "Policy area" is the newer name for "topic"
     # (https://www.gov.uk/government/topics)
-    # "Topic" is the newer name for "specialist sector"
-    # (https://www.gov.uk/topic)
-    # You can help improve this code by renaming all usages of this field to use
-    # the new terminology.
-    super.merge("topics" => topical_events.map(&:slug)) {|k, ov, nv| ov + nv}
+    # Rummager's policy areas also include "topical events", which we model
+    # separately in whitehall.
+    super.merge("policy_areas" => topical_events.map(&:slug)) {|_k, ov, nv| ov + nv}
   end
 end

--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -23,7 +23,9 @@ module Edition::Topics
     # (https://www.gov.uk/government/topics)
     # Rummager's policy areas also include "topical events", which we model
     # separately in whitehall.
-    super.merge("policy_areas" => topics.map(&:slug)) { |_, ov, nv| ov + nv }
+    new_slugs = topics.map(&:slug)
+    existing_slugs = super.fetch("policy_areas", [])
+    super.merge("policy_areas" => new_slugs + existing_slugs)
   end
 
   def title_with_topics

--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -19,7 +19,11 @@ module Edition::Topics
   end
 
   def search_index
-    super.merge("topics" => topics.map(&:slug)) { |_, ov, nv| ov + nv }
+    # "Policy area" is the newer name for "topic"
+    # (https://www.gov.uk/government/topics)
+    # Rummager's policy areas also include "topical events", which we model
+    # separately in whitehall.
+    super.merge("policy_areas" => topics.map(&:slug)) { |_, ov, nv| ov + nv }
   end
 
   def title_with_topics

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -30,22 +30,26 @@ module Searchable
     :search_format_types,
     :slug,
 
-
     :speech_type,
     :statistics_announcement_state,
     :title,
 
-    # DID YOU MEAN: Policy Area?
     # "Policy area" is the newer name for "topic"
     # (https://www.gov.uk/government/topics)
     # "Topic" is the newer name for "specialist sector"
     # (https://www.gov.uk/topic)
-    # You can help improve this code by renaming all usages of this field to use
-    # the new terminology.
-    :topics,
+    #
+    # There are two ways for policy areas to wind up in rummager:
+    # 1. Models directly ask for them in the class method call to `searchable`:
+    #    in this case it is the responsibility of the subclasses to handle
+    #    the naming clash if they are still using the older name
+    # 2. Through the Edition::Topics and Edition::TopicalEvents concerns.
+    #    These override #search_index and add to the policy_areas key.
+    :policy_areas,
 
     # DID YOU MEAN: Topic?
-    # See above.
+    # See above: this should be renamed once the naming for policy areas is
+    # consistent.
     :specialist_sectors,
 
     :world_locations,
@@ -99,7 +103,6 @@ module Searchable
 
     KEY_MAPPING = {
       content: 'indexable_content',
-      topics: 'policy_areas',
     }
 
     # Build the payload to pass to the search index

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -73,7 +73,7 @@ class StatisticsAnnouncement < ActiveRecord::Base
               display_type: :display_type,
               slug: :slug,
               organisations: :organisations_slugs,
-              topics: :topic_slugs,
+              policy_areas: :topic_slugs,
               release_timestamp: :release_date,
               statistics_announcement_state: :state,
               metadata: :search_metadata,

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -53,7 +53,7 @@ module Whitehall
             link
             organisations
             people
-            topics
+            policy_areas
             topical_events
             search_format_types
             world_locations
@@ -78,13 +78,8 @@ module Whitehall
         results = @store.index(@index_name).values
 
         results = filter_by_keywords(keywords, results) unless keywords.blank?
-        results = params.inject(results) do |new_results, (field_name, value)|
-          # This client is called with params from Whitehall::DocumentFilter::Rummager,
-          # which uses `policy_areas`, the new name for `topics`. To keep
-          # returning documents for this query, we need to translate it back
-          # here.
-          field_name = 'topics' if field_name == 'policy_areas'
 
+        results = params.inject(results) do |new_results, (field_name, value)|
           case field_type(field_name)
           when :date
             filter_by_date_field(field_name, value, new_results)

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -50,6 +50,15 @@ FactoryGirl.define do
       end
     end
 
+    trait(:with_topical_events) do
+      after :build do |edition, evaluator|
+        if evaluator.topical_events.empty?
+          edition.classification_memberships.build(edition: edition,
+                                                   classification: build(:topical_event))
+        end
+      end
+    end
+
     trait(:imported) do
       state "imported"
       first_published_at { 1.year.ago }

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -419,6 +419,24 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal government.name, publication.search_index["government_name"]
   end
 
+
+  test "should present policy_areas to rummageable" do
+    government = create(:current_government)
+    publication = create(:published_policy_paper, title: "publication-title", political: true, first_published_at: government.start_date)
+
+    assert_equal publication.topics.map(&:name), publication.search_index["policy_areas"]
+    assert_not publication.search_index.include?("topics")
+  end
+
+  test "rummager policy_areas include topical_events" do
+    government = create(:current_government)
+    publication = create(:published_policy_paper, :with_topical_events, title: "publication-title", political: true, first_published_at: government.start_date)
+
+    expected = publication.topics.map(&:name) + publication.topical_events.map(&:name)
+    assert_equal expected, publication.search_index["policy_areas"]
+    assert_not publication.search_index.include?("topics")
+  end
+
   test 'search_format_types tags the edtion as an edition' do
     edition = build(:edition)
     assert edition.search_format_types.include?('edition')

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -433,7 +433,7 @@ class EditionTest < ActiveSupport::TestCase
     publication = create(:published_policy_paper, :with_topical_events, title: "publication-title", political: true, first_published_at: government.start_date)
 
     expected = publication.topics.map(&:name) + publication.topical_events.map(&:name)
-    assert_equal expected, publication.search_index["policy_areas"]
+    assert_equal expected.sort, publication.search_index["policy_areas"].sort
     assert_not publication.search_index.include?("topics")
   end
 

--- a/test/unit/whitehall/not_quite_as_fake_search_test.rb
+++ b/test/unit/whitehall/not_quite_as_fake_search_test.rb
@@ -1,4 +1,4 @@
-require "fast_test_helper"
+require "test_helper"
 require "whitehall/not_quite_as_fake_search"
 
 module Whitehall
@@ -54,17 +54,17 @@ module Whitehall
 
       test "advanced search can select documents with a field matching a list of values" do
         @index.add_batch(build_documents(*%w{Foo Bar}))
-        assert_search_returns_documents %w{Bar}, topics: ["Bar-topic1"]
+        assert_search_returns_documents %w{Bar}, policy_areas: ["Bar-topic1"]
       end
 
       test "advanced search can select documents with a field matching any item from a list of values" do
         @index.add_batch(build_documents(*%w{Foo Bar FooBar}))
-        assert_search_returns_documents %w{Foo Bar}, topics: ["Foo-topic2", "Bar-topic1"]
+        assert_search_returns_documents %w{Foo Bar}, policy_areas: ["Foo-topic2", "Bar-topic1"]
       end
 
       test "advanced search can select documents with a field matching a single value" do
         @index.add_batch(build_documents(*%w{Foo Bar}))
-        assert_search_returns_documents %w{Bar}, topics: "Bar-topic1"
+        assert_search_returns_documents %w{Bar}, policy_areas: "Bar-topic1"
       end
 
       test "advanced search for a field which is not present in a document does not return the document" do
@@ -175,7 +175,7 @@ module Whitehall
             "title" => title,
             "description" => "#{title}-description",
             "indexable_content" => "#{title}-indexable_content",
-            topics: ["#{title}-topic1", "#{title}-topic2"],
+            "policy_areas" => ["#{title}-topic1", "#{title}-topic2"],
             "has_official_document" => false,
             "public_timestamp" => Time.zone.parse("2011-01-01 00:00:00")
           }


### PR DESCRIPTION
This fixes the previous PR: https://github.com/alphagov/whitehall/pull/2630

That PR only worked for one format: statistics announcements, which are
a special case: they have their own special association with policy areas.

All the other models that actually send policy areas to rummager do so
via the Edition::Topics and Edition::TopicalEvent traits.

These traits override the `#search_index` method we changed in the
previous PR, so those models still passed "topics" instead of "policy_areas".

Paired with @rubenarakelyan 
Trello: https://trello.com/c/bDFlehc5/518-rename-topics-to-policy-areas-in-rummager-m