### PR TITLE
Revert "Remove redis config file"

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,3 @@
+host: 127.0.0.1
+port: 6379
+namespace: whitehall


### PR DESCRIPTION
This reverts commit c9e938a703bf413f8bd4aa460683b7bdcf1afaef.

This file isn't used by Whitehall but is required to hookup the Sidekiq monitoring.