### PR TITLE
Add detailed guides sync checks

### DIFF
--- a/script/publishing-api-sync-checks/detailed_guide_sync_check.rb
+++ b/script/publishing-api-sync-checks/detailed_guide_sync_check.rb
@@ -77,4 +77,14 @@ check.add_expectation("national_applicability") do |content_store_payload, recor
   end
 end
 
+check.add_expectation("policy_areas") do |content_store_payload, record|
+  policy_areas_ids = (record.try(:topics) || []).map(&:content_id).to_set
+  policy_areas_ids == content_store_payload["links"]["policy_areas"].to_set
+end
+
+check.add_expectation("related_policies") do |content_store_payload, record|
+  related_policies_ids = (record.try(:policy_content_ids) || []).to_set
+  related_policies_ids == content_store_payload["links"]["related_policies"].to_set
+end
+
 check.perform


### PR DESCRIPTION
Add sync checks to ensure for the presence of Policies and Policy areas.

Trello https://trello.com/c/nLPfZw2d/459-add-policies-and-policy-areas-to-detailed-guides-sync-checks