### PR TITLE
Remove redis.yml

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,0 @@
-host: 127.0.0.1
-port: 6379
-namespace: whitehall


### PR DESCRIPTION
This file is no longer required. The govuk_sidekiq gem and sidekiq monitoring are both configured using the `REDIS_HOST` and `REDIS_PORT` environment variables.