### PR TITLE
Fix `DetailedGuide` sync check

### DIFF
--- a/script/publishing-api-sync-checks/detailed_guide_sync_check.rb
+++ b/script/publishing-api-sync-checks/detailed_guide_sync_check.rb
@@ -78,13 +78,21 @@ check.add_expectation("national_applicability") do |content_store_payload, recor
 end
 
 check.add_expectation("policy_areas") do |content_store_payload, record|
-  policy_areas_ids = (record.try(:topics) || []).map(&:content_id).to_set
-  policy_areas_ids == content_store_payload["links"]["policy_areas"].to_set
+  policy_area_ids = (record.try(:topics) || []).map(&:content_id).to_set
+  content_store_policy_area_ids = content_store_payload["links"]["policy_areas"]
+    .map{ |policy_area| policy_area["content_id"] }
+    .to_set
+
+  policy_area_ids == content_store_policy_area_ids
 end
 
 check.add_expectation("related_policies") do |content_store_payload, record|
-  related_policies_ids = (record.try(:policy_content_ids) || []).to_set
-  related_policies_ids == content_store_payload["links"]["related_policies"].to_set
+  related_policy_ids = (record.try(:policy_content_ids) || []).to_set
+  content_store_related_policy_ids = content_store_payload["links"]["related_policies"]
+    .map{ |related_policy| related_policy["content_id"] }
+    .to_set
+
+  related_policy_ids == content_store_related_policy_ids
 end
 
 check.perform


### PR DESCRIPTION
This commit updates the `DetailedGuide` sync check to check against the `policy_areas` and `related_policies` `content_id` field rather than the whole object.