### PR TITLE
Add comments for the breadcrumb component

### DIFF
--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -30,7 +30,11 @@ module PublishingApi
     end
 
     def links
-      LinksPresenter.new(item).extract([:organisations, :topics, :parent])
+      LinksPresenter.new(item).extract([
+        :organisations,
+        :topics,
+        :parent, # please use the breadcrumb component when migrating document_type to government-frontend
+      ])
     end
   end
 end

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
 
     def links
       {
-        parent: parent_content_ids,
+        parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
         organisations: parent.organisations.pluck(:content_id),
       }
     end


### PR DESCRIPTION
These document types haven't been migrated yet, because they have a parent, they can take advantage of the breadcrumb component.