### PR TITLE
Remove non existing policy relations

### DIFF
--- a/db/data_migration/20160726125204_remove_non_existent_policies.rb
+++ b/db/data_migration/20160726125204_remove_non_existent_policies.rb
@@ -1,0 +1,12 @@
+#These records are `Policy` associations for Detailed Guides where the policy
+#does no exist in publishing api. As there doesn't seem to be any other way of
+#identifying the policies that they relate to we may as well tidy them up
+#
+#433102,/guidance/being-inspected-as-a-childrens-centre-guidance-for-providers
+#  ["5d646277-7631-11e4-a3cb-005056011aef"] not in publishing api
+#441050,/guidance/fashion-and-textiles-technical-apprenticeships
+#  ["6053a0e7-7631-11e4-a3cb-005056011aef"] not in publishing api
+#480715,/guidance/being-inspected-as-a-boarding-andor-residential-school
+#  ["5d646277-7631-11e4-a3cb-005056011aef"] not in publishing api
+
+EditionPolicy.where(edition_id: [433102, 441050, 480715]).destroy


### PR DESCRIPTION
While migrating `DetailedGuide` the sync checks revealed these `EditionPolicy` records that have no matching `ContentItem` in Publishing API. I've not found anything other than a `content_id` to identify them (in Whitehall, Policy Publisher or Publishing API) so have no idea what content they actually link to.

433102 (/guidance/being-inspected-as-a-childrens-centre-guidance-for-providers) -> "5d646277-7631-11e4-a3cb-005056011aef"

441050 (/guidance/fashion-and-textiles-technical-apprenticeships) -> "6053a0e7-7631-11e4-a3cb-005056011aef"

480715 (/guidance/being-inspected-as-a-boarding-andor-residential-school) -> "5d646277-7631-11e4-a3cb-005056011aef"

So... This data migration removes them.

There are >500 other records in `edition_policies` that refer to these two items but I've left them for now as just removing all references from the table would leave us with no history should the missing items be identified.

