### PR TITLE
Switch detailed guides to government frontend

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -33,6 +33,10 @@ class DetailedGuide < Edition
 
   validates_with HeadingHierarchyValidator
 
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
   def rummager_index
     :detailed_guides
   end

--- a/db/data_migration/20160727123435_republish_detailed_guides_again.rb
+++ b/db/data_migration/20160727123435_republish_detailed_guides_again.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(DetailedGuide)
+republisher.perform

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -42,21 +42,13 @@ class UnpublishingTest < ActiveSupport::TestCase
                                       request_json_includes(schema_name: 'unpublishing'))
   end
 
-  test 'When a case study is unpublished, a job is queued to republish the draft to the draft stack' do
+  test 'When an edition is unpublished, a job is queued to republish the draft to the draft stack' do
     path = Whitehall.url_maker.public_document_path(@published_edition)
     stub_panopticon_registration(@published_edition)
 
     Whitehall::PublishingApi.expects(:save_draft_async).once
 
     unpublish(@published_edition, unpublishing_params)
-  end
-
-  test 'When an edition that is not a case study is unpublished, no "unpublishing" is sent to the Publishing API' do
-    detailed_guide = create(:published_detailed_guide)
-    path = Whitehall.url_maker.public_document_path(detailed_guide)
-    stub_panopticon_registration(detailed_guide)
-    unpublish(detailed_guide, unpublishing_params)
-    assert_not_requested(:put, %r{#{PUBLISHING_API_V2_ENDPOINT}/content.*})
   end
 
   test 'when a translated edition is unpublished, an "unpublishing" is published to the Publishing API for each translation' do

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -6,6 +6,11 @@ class DetailedGuideTest < ActiveSupport::TestCase
   should_allow_inline_attachments
   should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
+  test "is rendered by government_frontend" do
+    detailed_guide = build(:detailed_guide)
+    assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, detailed_guide.rendering_app
+  end
+
   test "should be able to relate to topics" do
     article = build(:detailed_guide)
     assert article.can_be_associated_with_topics?

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -44,7 +44,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       locale: "en",
       need_ids: [],
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "government-frontend",
       routes: [
         { path: public_path, type: "exact" }
       ],


### PR DESCRIPTION
This PR switches over rendering from Whitehall to government-frontend as the penultimate step to migrating this format to to Whitehall -> Publishing API -> Content Store -> Government Frontend

[Trello](https://trello.com/c/CkHu0suq/317-6-detailed-guides-migration-final-tasks-deploy-1-medium)


