### PR TITLE
Fixes `destroy` to `destroy_all`

### DIFF
--- a/db/data_migration/20160726125204_remove_non_existent_policies.rb
+++ b/db/data_migration/20160726125204_remove_non_existent_policies.rb
@@ -9,4 +9,4 @@
 #480715,/guidance/being-inspected-as-a-boarding-andor-residential-school
 #  ["5d646277-7631-11e4-a3cb-005056011aef"] not in publishing api
 
-EditionPolicy.where(edition_id: [433102, 441050, 480715]).destroy
+EditionPolicy.where(edition_id: [433102, 441050, 480715]).destroy_all


### PR DESCRIPTION
Original commit for this migration had an error. Migration not yet run so fixed in place.