### PR TITLE
Revert "Switch `DetailedGuide` rendering to `government-frontend`"

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -33,10 +33,6 @@ class DetailedGuide < Edition
 
   validates_with HeadingHierarchyValidator
 
-  def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-  end
-
   def rummager_index
     :detailed_guides
   end

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -6,11 +6,6 @@ class DetailedGuideTest < ActiveSupport::TestCase
   should_allow_inline_attachments
   should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
-  test "is rendered by government_frontend" do
-    detailed_guide = build(:detailed_guide)
-    assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, detailed_guide.rendering_app
-  end
-
   test "should be able to relate to topics" do
     article = build(:detailed_guide)
     assert article.can_be_associated_with_topics?

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -44,7 +44,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       locale: "en",
       need_ids: [],
       publishing_app: "whitehall",
-      rendering_app: "government-frontend",
+      rendering_app: "whitehall-frontend",
       routes: [
         { path: public_path, type: "exact" }
       ],


### PR DESCRIPTION
This reverts commit 63e97efe93d2de2ba39b03947e54cd9d9fdf4be4. 

Withdrawn notices are in the wrong place in the content store representation and are not being displayed.

Some users are reporting that unpublishing is not redirecting. https://govuk.zendesk.com/agent/tickets/1386102

Reverting while we investigate -> fix.

I'm going to rerun the previous data migration as I can't bear to add another one called 'republish detailed guides'