### PR TITLE
Add search parameter to display the finder as open

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   before_filter :set_slimmer_application_name
+  before_filter :set_slimmer_show_organisations_filter
   before_filter :set_audit_trail_whodunnit
   before_filter :set_authenticated_user_header
 
@@ -31,6 +32,12 @@ class ApplicationController < ActionController::Base
 
   def set_slimmer_application_name
     set_slimmer_headers(application_name: 'inside_government')
+  end
+
+  # Always open the finder (organisations filter box) on the search results page
+  # to make it more obvious to users that the results can be filtered
+  def set_slimmer_show_organisations_filter
+    set_slimmer_headers(search_parameters: {show_organisations_filter: true}.to_json)
   end
 
   def set_slimmer_organisations_header(organisations)

--- a/test/functional/application_controller_search_parameters_test.rb
+++ b/test/functional/application_controller_search_parameters_test.rb
@@ -19,7 +19,7 @@ class ApplicationControllerSearchParametersTest < ActionController::TestCase
 
   tests TestController
 
-  test "sets search parameter header for orgs with scoped search" do
+  test "sets filter_organisations search parameter header for orgs with scoped search" do
     with_routing do |map|
       map.draw do
         get '/test_scoped', to: 'application_controller_search_parameters_test/test#test_scoped'
@@ -29,13 +29,13 @@ class ApplicationControllerSearchParametersTest < ActionController::TestCase
     assert_equal %{{"filter_organisations":["org1"]}}, response.headers["X-Slimmer-Search-Parameters"]
   end
 
-  test "doesn't set search parameter header for orgs without scoped search" do
+  test "doesn't set filter_organisations search parameter header for orgs without scoped search" do
     with_routing do |map|
       map.draw do
         get '/test_unscoped', to: 'application_controller_search_parameters_test/test#test_unscoped'
       end
       get :test_unscoped
     end
-    assert_equal nil, response.headers["X-Slimmer-Search-Parameters"]
+    assert_equal %{{"show_organisations_filter":true}}, response.headers["X-Slimmer-Search-Parameters"]
   end
 end


### PR DESCRIPTION
The finder on the search results page is normally shown closed, unless at least one filter has been selected, in which case it is shown open. This adds a search parameter that forces the finder to be shown open even if no filters are selected, for all searches originating from Whitehall.

The substantive functionality is implemented in Frontend (see https://github.com/alphagov/frontend/pull/984 and https://github.com/alphagov/frontend/pull/985).

Trello: https://trello.com/c/t9R5QDCf/42-when-a-search-happens-from-whitehall-content-open-the-organisation-filter-by-default

![screen shot 2016-08-01 at 09 37 43](https://cloud.githubusercontent.com/assets/444232/17288209/bea7d3b0-57cb-11e6-8235-427fd9cef735.png)
