### PR TITLE
Reorder people in groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,6 +16,27 @@ class Group < ActiveRecord::Base
     end
   end
 
+  def update_memberships_and_attributes(group_params, person_ids)
+    # This methods is intended to allow us to preserve the ordering of
+    # associated members. By destroying all group_memberships and then
+    # rebuilding them we ensure that the ascending membership IDs reflect the
+    # order of members in the edit form.
+    begin
+      Group.transaction do
+        self.group_memberships.destroy_all
+
+        person_ids.each do |person_id|
+          self.group_memberships.build(person_id: person_id)
+        end
+
+        self.assign_attributes(group_params)
+        save!
+      end
+    rescue
+      false
+    end
+  end
+
   validates_with Validator
 
   extend FriendlyId

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 class Group < ActiveRecord::Base
   belongs_to :organisation
   has_many :group_memberships
-  has_many :members, through: :group_memberships, source: :person
+  has_many :members, -> { order 'group_memberships.id' }, through: :group_memberships, source: :person
 
   accepts_nested_attributes_for :group_memberships, allow_destroy: true, reject_if: :all_blank
 

--- a/test/functional/admin/groups_controller_test.rb
+++ b/test/functional/admin/groups_controller_test.rb
@@ -206,6 +206,38 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     assert_equal %{"group-name" updated.}, flash[:notice]
   end
 
+  test "update with existing members re-ordered should not display errors" do
+    bob = create(:person)
+    dave = create(:person)
+    group = create(:group, members: [bob, dave])
+
+    put :update, organisation_id: @organisation.id, id: group, group: {
+      name: 'test-group',
+      group_memberships_attributes: {
+        "0" => { person_id: dave.id },
+        "1" => { person_id: bob.id }
+      }
+    }
+
+    assert_equal %{"test-group" updated.}, flash[:notice]
+    assert_equal nil, flash[:alert]
+  end
+
+  test "update with existing members re-ordered should preserve new ordering" do
+    bob = create(:person)
+    dave = create(:person)
+    group = create(:group, members: [bob, dave])
+
+    put :update, organisation_id: @organisation.id, id: group, group: {
+      group_memberships_attributes: {
+        "0" => { person_id: dave.id },
+        "1" => { person_id: bob.id }
+      }
+    }
+
+    assert_equal [dave, bob], group.members(reload: true)
+  end
+
   view_test "update with invalid data should display errors" do
     group = create(:group)
 


### PR DESCRIPTION
## [Trello card](https://trello.com/c/igNpPR9D/7-ability-to-reorder-people-in-groups)

When an admin edits a group's members, the ordering is not reflected in the front end.

This PR fixes this so that members can be reordered without having to resort to deleting them and re-adding them as a workaround.