### PR TITLE
Remove `withdrawn-notice` from `DetailedGuidePresenter`

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -26,7 +26,6 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::WithdrawnNotice.for(item))
     end
 
     def links
@@ -61,7 +60,6 @@ module PublishingApi
       }
       details_hash = maybe_add_national_applicability(details_hash)
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
-      details_hash.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
     end
 

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -224,33 +224,6 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     assert_equal related_guides, expected_related_guides
   end
 
-  test 'DetailedGuide presents withdrawn_notice correctly' do
-    create(:government)
-    detailed_guide = create(
-      :published_detailed_guide,
-      :withdrawn,
-    )
-    detailed_guide.build_unpublishing(
-      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
-      explanation: 'No longer relevant'
-    )
-    detailed_guide.unpublishing.save!
-
-    presented_item = present(detailed_guide)
-    details = presented_item.content[:details]
-
-    expected_withdrawn_notice = {
-      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
-      withdrawn_at: detailed_guide.updated_at
-    }
-
-    assert_valid_against_schema(presented_item.content, 'detailed_guide')
-    assert_equal expected_withdrawn_notice[:withdrawn_at], details[:withdrawn_notice][:withdrawn_at]
-    assert_equal expected_withdrawn_notice[:withdrawn_at], presented_item.content[:withdrawn_notice][:withdrawn_at]
-    assert_equivalent_html expected_withdrawn_notice[:explanation], details[:withdrawn_notice][:explanation]
-    assert_equivalent_html expected_withdrawn_notice[:explanation], presented_item.content[:withdrawn_notice][:explanation]
-  end
-
   test 'DetailedGuide presents national_applicability correctly when some are specified' do
     scotland_nation_inapplicability = create(
       :nation_inapplicability,


### PR DESCRIPTION
This is handled via the `/unpublish` endpoint now and shouldn't be in the format's presenter. Further PRs on the way to implement unpublishing/withdrawal via the `/unpublish` endpoint for `Edition` based things.

This format is still being rendered by Whitehall so this change won't adversely affect currently rendered pages. 