### PR TITLE
Fix unpublishing factories

### DIFF
--- a/app/models/unpublishing_reason.rb
+++ b/app/models/unpublishing_reason.rb
@@ -3,6 +3,10 @@ class UnpublishingReason
 
   attr_accessor :id, :name, :as_sentence
 
+  PUBLISHED_IN_ERROR_ID = 1
+  CONSOLIDATED_ID = 4
+  WITHDRAWN_ID = 5
+
   PublishedInError  = create(id: 1, name: 'Published in error', as_sentence: 'it was published in error')
   Consolidated      = create(id: 4, name: 'Consolidated into another GOV.UK page', as_sentence: 'it has been consolidated into another GOV.UK page')
   Withdrawn         = create(id: 5, name: 'No longer current government policy/activity', as_sentence: 'it is no longer current government policy/activity')

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -95,6 +95,9 @@ FactoryGirl.define do
     }
     trait(:withdrawn) {
       state "withdrawn"
+      after(:create) do |edition|
+        edition.unpublishing = build(:withdrawn_unpublishing, edition: edition)
+      end
     }
     trait(:featured) { featured true }
     trait(:scheduled) {

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -63,7 +63,9 @@ FactoryGirl.define do
       state "imported"
       first_published_at { 1.year.ago }
     end
+
     trait(:draft) { state "draft" }
+
     trait(:submitted) do
       transient do
         submitter nil
@@ -75,7 +77,9 @@ FactoryGirl.define do
         edition.versions.create! event: 'update', whodunnit: submitter.id, state: 'submitted'
       end
     end
+
     trait(:rejected) { state "rejected" }
+
     trait(:published) do
       state "published"
       first_published_at { 2.days.ago }
@@ -87,23 +91,18 @@ FactoryGirl.define do
         edition.refresh_index_if_required
       end
     end
-    trait(:deleted) {
-      state "deleted"
-    }
-    trait(:superseded) {
-      state "superseded"
-    }
-    trait(:withdrawn) {
-      state "withdrawn"
-      after(:create) do |edition|
-        edition.unpublishing = build(:withdrawn_unpublishing, edition: edition)
-      end
-    }
+
+    trait(:deleted) { state "deleted" }
+
+    trait(:superseded) { state "superseded" }
+
     trait(:featured) { featured true }
-    trait(:scheduled) {
+
+    trait(:scheduled) do
       state "scheduled"
       scheduled_publication 7.days.from_now
-    }
+    end
+
     trait(:access_limited) { access_limited true }
 
     trait(:with_alternative_format_provider) do
@@ -153,6 +152,13 @@ FactoryGirl.define do
     trait(:consolidated_redirect) do
       after(:create) do |edition|
         edition.unpublishing = build(:consolidated_unpublishing, edition: edition)
+      end
+    end
+
+    trait(:withdrawn) do
+      state "withdrawn"
+      after(:create) do |edition|
+        edition.unpublishing = build(:withdrawn_unpublishing, edition: edition)
       end
     end
   end

--- a/test/factories/unpublishings.rb
+++ b/test/factories/unpublishings.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :unpublishing do
-    unpublishing_reason_id UnpublishingReason::PublishedInError.id
+    unpublishing_reason_id UnpublishingReason::PUBLISHED_IN_ERROR_ID
     edition { create(:published_case_study, state: 'draft', first_published_at: 2.days.ago) }
 
     after(:build) do |unpublishing|
@@ -21,7 +21,13 @@ FactoryGirl.define do
   end
 
   factory :consolidated_unpublishing, parent: :unpublishing do
-    unpublishing_reason_id UnpublishingReason::Consolidated.id
+    unpublishing_reason_id UnpublishingReason::CONSOLIDATED_ID
     alternative_url Whitehall.public_root + '/government/another/page'
+  end
+
+  factory :withdrawn_unpublishing, parent: :unpublishing do
+    unpublishing_reason_id UnpublishingReason::WITHDRAWN_ID
+    redirect false
+    explanation "content was withdrawn"
   end
 end

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -10,8 +10,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   end
 
   test "#edit loads the unpublishing and renders the unpublish edit template" do
-    unpublishing = create(:unpublishing, edition: @edition)
-
+    unpublishing = @edition.unpublishing
     get :edit, edition_id: @edition.id
 
     assert_response :success
@@ -20,24 +19,21 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   end
 
   test "#update updates the unpublishing and redirects to admin policy page" do
-    unpublishing = create(:unpublishing, edition: @edition, explanation: "Content is mislidding")
-
-    put :update, edition_id: @edition.id, unpublishing: { explanation: "Content is misleading" }
+    put :update, edition_id: @edition.id, unpublishing: { explanation: "this used to say withdrawn" }
 
     assert_redirected_to admin_edition_path(@edition)
     assert_equal "The public explanation was updated", flash[:notice]
-    assert_equal "Content is misleading", unpublishing.reload.explanation
+    assert_equal "this used to say withdrawn", @edition.unpublishing.reload.explanation
   end
 
   test "#update shows form with error if the update was not possible" do
-    unpublishing = create(:unpublishing, edition: @edition, explanation: "Content is mislidding",
-      unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
-
+    unpublishing = @edition.unpublishing
+    original_explanation = unpublishing.explanation
     put :update, edition_id: @edition, unpublishing: { explanation: nil }
 
     assert_template :edit
     assert_equal "The public explanation could not be updated", flash[:alert]
-    assert_equal "Content is mislidding", unpublishing.reload.explanation
+    assert_equal original_explanation, unpublishing.reload.explanation
   end
 
 end


### PR DESCRIPTION
`withdrawn` `Edition`s should have an associated `Unpublishing`. This wasn't reflected in the factories and is fixed here.

This is part of the work to handle `Edition` unpublishing via the Publishing API.

#42c21bc is best reviewed as a commit as the subsequent formatting fixes make the diff a bit noisy.