### PR TITLE
Fix data migration to handle missing unpublishings

### DIFF
--- a/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
+++ b/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
@@ -6300,13 +6300,18 @@ def unpublish(content_ids, draft)
   ).find_each do |document|
     edition = document.latest_edition
 
-    edition.translated_locales.each do |locale|
-      PublishingApiWithdrawalWorker.perform_async(
-        document.content_id,
-        edition.unpublishing.explanation,
-        locale,
-        draft,
-      )
+    if edition.unpublishing
+      edition.translated_locales.each do |locale|
+        PublishingApiWithdrawalWorker.perform_async(
+          document.content_id,
+          edition.unpublishing.explanation,
+          locale,
+          draft,
+        )
+      end
+    else
+      puts "Edition #{edition.id} (#{edition.search_link}) does not have an unpublishing."
+      puts "This edition will need to be unwithdrawn and then withdrawn with an explanation."
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/aoTVNMQz/741-withdrawn-content-items-should-be-labelled-as-such-in-the-publishing-api-medium

A couple of records exist where there's state disparity between
the a withdrawn edition and the withdrawn status in the publishing
pipeline and no unpublishing exists in Whitehall. We need to skip
these records and manually fix them so the migration will just log them
for this purpose.