### PR TITLE
Fix “invalid specialist sector” error in Whitehall admin

### DIFF
--- a/db/migrate/20160805115415_remove_unlinked_specialist_sectors.rb
+++ b/db/migrate/20160805115415_remove_unlinked_specialist_sectors.rb
@@ -1,0 +1,9 @@
+class RemoveUnlinkedSpecialistSectors < ActiveRecord::Migration
+  def up
+    SpecialistSector.delete_all edition_id: nil
+  end
+
+  def down
+    # We can't undo deleting data in the migration
+  end
+end

--- a/db/migrate/20160805122401_disallow_nulls_in_specialist_sectors.rb
+++ b/db/migrate/20160805122401_disallow_nulls_in_specialist_sectors.rb
@@ -1,0 +1,6 @@
+class DisallowNullsInSpecialistSectors < ActiveRecord::Migration
+  def change
+    change_column_null :specialist_sectors, :edition_id, false
+    change_column_null :specialist_sectors, :tag, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622080303) do
+ActiveRecord::Schema.define(version: 20160805122401) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1008,8 +1008,8 @@ ActiveRecord::Schema.define(version: 20160622080303) do
   end
 
   create_table "specialist_sectors", force: :cascade do |t|
-    t.integer  "edition_id", limit: 4
-    t.string   "tag",        limit: 255
+    t.integer  "edition_id", limit: 4,                   null: false
+    t.string   "tag",        limit: 255,                 null: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.boolean  "primary",                default: false


### PR DESCRIPTION
Currently, when creating a new document in Whitehall admin, if any combination of primary and/or secondary specialist sector tags are specified then a “specialist sectors are invalid” error message is displayed. Updating a document to add such tags works as expected.

This is due to model validation to ensure any specific tag is not specified more than once for the same document. Due to existing tags in the `specialist_sectors` table that have `edition_id` set to `null`, and the fact that `edition_id` is `null` for a new document which has not yet been saved, most tags are seen as already existing for a new document, hence the validation fails.

This commit does the following:

* Deletes all rows in the `specialist_sectors` table that have `edition_id` set to `null`. These rows are not tagging any particular document and are therefore not required.

* Makes the `edition_id` and `tag` columns in the `specialist_sectors` table not-nullable to ensure such records cannot be re-inserted later.

Trello: https://trello.com/c/yoQ5KuaL/36-bug-in-tagging-whitehall-workflow

![screen shot 2016-08-05 at 13 35 47](https://cloud.githubusercontent.com/assets/444232/17436962/b99e539a-5b12-11e6-9675-4d8f4e009830.png)
