### PR TITLE
Check for an unpublishing explanation

### DIFF
--- a/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
+++ b/db/data_migration/20160720092223_unpublish_withdrawn_editions_with_state_disparity.rb
@@ -6300,7 +6300,7 @@ def unpublish(content_ids, draft)
   ).find_each do |document|
     edition = document.latest_edition
 
-    if edition.unpublishing
+    if edition.unpublishing && edition.unpublishing.explanation
       edition.translated_locales.each do |locale|
         PublishingApiWithdrawalWorker.perform_async(
           document.content_id,


### PR DESCRIPTION
[gds-api-adapters will not forward an explanation parameter
if the value is nil](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/publishing_api_v2.rb#L129), this raises an exception because this key
is expected for withdrawals so an additional condition is needed to check for an explanation otherwise this data migration will create failing Sidekiq jobs, retries and errors.