### PR TITLE
Support govspeak in unpublishing explanation

### DIFF
--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -6,10 +6,15 @@ class PublishingApiGoneWorker < PublishingApiWorker
       alternative_path, explanation, locale = args
     end
 
+    if explanation.present?
+      rendered_explanation = Whitehall::GovspeakRenderer
+        .new.govspeak_to_html(explanation)
+    end
+
     Whitehall.publishing_api_v2_client.unpublish(
       content_id,
       alternative_path: alternative_path,
-      explanation: explanation,
+      explanation: rendered_explanation,
       type: "gone",
       locale: locale,
     )

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -4,7 +4,7 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
       content_id,
       type: "withdrawal",
       locale: locale,
-      explanation: explanation,
+      explanation: Whitehall::GovspeakRenderer.new.govspeak_to_html(explanation),
       allow_draft: allow_draft,
     )
   end

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -40,7 +40,7 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     assert_publishing_api_unpublish(
       @published_edition.document.content_id,
-      request_json_includes(type: "gone", explanation: "Published by mistake", locale: "en")
+      request_json_includes(type: "gone", explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>", locale: "en")
     )
   end
 
@@ -62,9 +62,9 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublish(@published_edition, unpublishing_params)
 
     assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                    { type: "gone", explanation: "Published by mistake", locale: "en"})
+                                    { type: "gone", explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>", locale: "en"})
     assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                    { type: "gone", explanation: "Published by mistake", locale: "fr"})
+                                    { type: "gone", explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>", locale: "fr"})
   end
 
   test "when a translated edition is unpublished with a redirect, redirects are sent to the Publishing API for each translation" do

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -14,7 +14,7 @@ class WithdrawingTest < ActiveSupport::TestCase
       body: {
         type: "withdrawal",
         locale: "en",
-        explanation: "Old information",
+        explanation: "<div class=\"govspeak\"><p>Old information</p>\n</div>",
       }
     )
 

--- a/test/unit/edition/searchable_test.rb
+++ b/test/unit/edition/searchable_test.rb
@@ -64,10 +64,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
     edition = create(:published_edition)
 
     stub_panopticon_registration(edition)
-    withdrawal_request = stub_publishing_api_unpublish(
-      edition.content_id,
-      body: { type: "withdrawal", explanation: "Old policy", locale: "en" }
-    )
+    Whitehall::PublishingApi.stubs(:publish_withdrawal_async)
 
     edition.build_unpublishing(explanation: 'Old policy', unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
 
@@ -75,8 +72,6 @@ class Edition::SearchableTest < ActiveSupport::TestCase
     Whitehall::SearchIndex.expects(:add).with(edition)
 
     Whitehall.edition_services.withdrawer(edition).perform!
-
-    assert_requested withdrawal_request
   end
 
   test "should add latest change note to search index" do

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -14,12 +14,12 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
       body: {
         type: "gone",
         alternative_path: "alternative_path",
-        explanation: "explanation",
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
         locale: "de",
       }
     )
 
-    PublishingApiGoneWorker.new.perform(@uuid, "alternative_path", "explanation", "de")
+    PublishingApiGoneWorker.new.perform(@uuid, "alternative_path", "*why?*", "de")
 
     assert_requested request
   end

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -11,12 +11,12 @@ class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
       body: {
         type: "withdrawal",
         locale: "en",
-        explanation: "This content is no longer valid",
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>"
       }
     )
 
     PublishingApiWithdrawalWorker.new.perform(
-      uuid, "This content is no longer valid", "en"
+      uuid, "*why?*", "en"
     )
 
     assert_requested request


### PR DESCRIPTION
Around ~30% of `Unpublishing` objects with an explanation in Whitehall have some Govspeak in the explanation. Support for this was implemented in the recently removed `UnpublishingPresenter`. This PR puts it back by adding it to the two 'unpublishing' related workers that can have an `explanation` (`PublishingApiGoneWorker` and `PublishingApiWithdrawalWorker`)