### PR TITLE
Support unpublishing in document republishing worker

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -14,7 +14,15 @@
 class PublishingApiDocumentRepublishingWorker < WorkerBase
   attr_reader :published_edition, :pre_publication_edition
 
-  def perform(document_id)
+  def perform(*args)
+    if args.length > 1
+      document_id = Edition.where(id: args).pluck(:document_id).last
+      PublishingApiDocumentRepublishingWorker.new.perform(document_id)
+      return
+    end
+
+    document_id = args[0]
+
     document = Document.find(document_id)
     #this the latest edition in a visible state ie: withdrawn, published
     @published_edition = document.published_edition

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -43,6 +43,8 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
       elsif there_is_a_newer_draft?
         send_published_edition
         send_draft_edition
+      else
+        raise "Document id: #{document.id} has an unrecognised state for republishing"
       end
     end
   end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,11 +1,5 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(content_id, *args)
-    if args.length == 1
-      locale = args[0]
-    else
-      alternative_path, explanation, locale = args
-    end
-
+  def perform(content_id, alternative_path, explanation, locale)
     if explanation.present?
       rendered_explanation = Whitehall::GovspeakRenderer
         .new.govspeak_to_html(explanation)

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -1,5 +1,5 @@
 class PublishingApiGoneWorker < PublishingApiWorker
-  def perform(content_id, alternative_path, explanation, locale)
+  def perform(content_id, alternative_path, explanation, locale, allow_draft = false)
     if explanation.present?
       rendered_explanation = Whitehall::GovspeakRenderer
         .new.govspeak_to_html(explanation)
@@ -11,6 +11,7 @@ class PublishingApiGoneWorker < PublishingApiWorker
       explanation: rendered_explanation,
       type: "gone",
       locale: locale,
+      allow_draft: allow_draft,
     )
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -1,10 +1,11 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
-  def perform(content_id, destination, locale)
+  def perform(content_id, destination, locale, allow_draft = false)
     Whitehall.publishing_api_v2_client.unpublish(
       content_id,
       type: "redirect",
       locale: locale,
       alternative_path: destination,
+      allow_draft: allow_draft
     )
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -42,13 +42,10 @@ module Whitehall
     # Synchronise the published and/or draft documents in publishing-api with
     # the contents of Whitehall's database.
     def self.republish_document_async(document, bulk: false)
-      published_edition_id = document.published_edition.try(:id)
-      pre_publication_edition_id = document.pre_publication_edition.try(:id)
       queue = bulk ? 'bulk_republishing' : 'default'
       PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
         queue,
-        published_edition_id,
-        pre_publication_edition_id
+        document.id
       )
     end
 

--- a/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
@@ -28,4 +28,15 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
       DataHygiene::PublishingApiDocumentRepublisher.new(Organisation)
     end
   end
+
+  test "unpublishes if the document is unpublished" do
+    document  = create(:document, content_id: SecureRandom.uuid)
+    edition = create(:unpublished_edition, title: "Unpublished edition", document: document)
+    unpublishing = edition.unpublishing
+
+    PublishingApiUnpublishingWorker.expects(:new).returns(worker = mock)
+    worker.expects(:perform).with(unpublishing.id, true)
+
+    DataHygiene::PublishingApiDocumentRepublisher.new(edition.class, NullLogger.instance).perform
+  end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -78,4 +78,18 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
+
+  test "it supports jobs with the old method signature" do
+    document  = create(:document, content_id: SecureRandom.uuid)
+    edition = create(:published_edition, title: "Published edition", document: document)
+
+    real_worker = PublishingApiDocumentRepublishingWorker.new
+
+    PublishingApiDocumentRepublishingWorker
+      .expects(:new).returns(worker = mock)
+    worker.expects(:perform)
+      .with(document.id)
+
+    real_worker.perform(edition.id, nil)
+  end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
 
-class PublishingApiWorkerTest < ActiveSupport::TestCase
+class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
   test "it pushes the published and then the draft editions of a document" do
@@ -17,7 +17,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     ]
     Whitehall::PublishingApi.expects(:save_draft_async).with(draft, 'republish')
 
-    PublishingApiDocumentRepublishingWorker.new.perform(published.id, draft.id)
+    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
 
     assert_all_requested(requests)
   end
@@ -40,7 +40,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     # links once and could put this back into the array.
     patch_links_request = stub_publishing_api_patch_links(document.content_id, links: presenter.links)
 
-    PublishingApiDocumentRepublishingWorker.new.perform(edition.id, nil)
+    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
 
     assert_all_requested(requests)
     assert_requested(patch_links_request, times: 2)

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -110,4 +110,17 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
     real_worker.perform(edition.id, nil)
   end
+
+  test "it raises if an unknown combination is encountered" do
+    document = stub(
+      published_edition: nil,
+      id: 1,
+      pre_publication_edition: nil,
+    )
+
+    Document.stubs(:find).returns(document)
+    assert_raise "Document id: 1 has an unrecognised state for republishing" do
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -4,22 +4,43 @@ require 'gds_api/test_helpers/publishing_api_v2'
 class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
-  test "it pushes the published and then the draft editions of a document" do
-    document  = create(:document, content_id: SecureRandom.uuid)
-    published = create(:published_publication, title: "Published edition", document: document)
-    draft     = create(:draft_edition,         title: "Draft edition",     document: document)
+  test "it pushes the published and the draft editions of a document if there is a later draft" do
+    document = stub(
+      published_edition: published_edition = build(:edition, id: 1),
+      id: 1,
+      pre_publication_edition: draft_edition = build(:edition, id: 2),
+    )
 
-    presenter = PublishingApiPresenters.presenter_for(published, update_type: 'republish')
-    requests = [
-      stub_publishing_api_put_content(document.content_id, presenter.content),
-      stub_publishing_api_patch_links(document.content_id, links: presenter.links),
-      stub_publishing_api_publish(document.content_id, locale: presenter.content[:locale], update_type: 'republish')
-    ]
-    Whitehall::PublishingApi.expects(:save_draft_async).with(draft, 'republish')
+    Document.stubs(:find).returns(document)
+
+    PublishingApiWorker.expects(:new).returns(api_worker = mock)
+    api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en")
+
+    PublishingApiDraftWorker.expects(:new).returns(draft_worker = mock)
+    draft_worker.expects(:perform).with(draft_edition.class.name, draft_edition.id, "republish", "en")
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  end
 
-    assert_all_requested(requests)
+  class PublishException < StandardError; end
+  class DraftException < StandardError; end
+  test "it pushes the published version first if there is a more recent draft" do
+    document = stub(
+      published_edition: build(:edition),
+      id: 1,
+      pre_publication_edition: build(:edition),
+    )
+
+    Document.stubs(:find).returns(document)
+
+    PublishingApiWorker.stubs(:new).returns(api_worker = mock)
+    api_worker.stubs(:perform).raises(PublishException)
+    PublishingApiDraftWorker.stubs(:new).returns(draft_worker = mock)
+    draft_worker.stubs(:perform).raises(DraftException)
+
+    assert_raises PublishException do
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
   end
 
   test "it pushes all locales for the published document" do
@@ -44,5 +65,17 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
     assert_all_requested(requests)
     assert_requested(patch_links_request, times: 2)
+  end
+
+  test "it runs the PublishingApiUnpublishingWorker if the latest edition
+    has an unpublishing" do
+    document  = create(:document, content_id: SecureRandom.uuid)
+    edition = create(:unpublished_edition, title: "Unpublished edition", document: document)
+    unpublishing = edition.unpublishing
+
+    PublishingApiUnpublishingWorker.expects(:new).returns(worker_instance = mock)
+    worker_instance.expects(:perform).with(unpublishing.id, true)
+
+    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
 end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -23,18 +23,4 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
-
-  test "supports previous method signature" do
-    request = stub_publishing_api_unpublish(
-      @uuid,
-      body: {
-        type: "gone",
-        locale: "de",
-      }
-    )
-
-    PublishingApiGoneWorker.new.perform(@uuid, "de")
-
-    assert_requested request
-  end
 end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -23,4 +23,21 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "passes allow_draft if supplied" do
+    request = stub_publishing_api_unpublish(
+      @uuid,
+      body: {
+        type: "gone",
+        alternative_path: "alternative_path",
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
+        locale: "de",
+        allow_draft: true,
+      }
+    )
+
+    PublishingApiGoneWorker.new.perform(@uuid, "alternative_path", "*why?*", "de", true)
+
+    assert_requested request
+  end
 end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -25,4 +25,20 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "passes allow_draft if it is supplied" do
+    request = stub_publishing_api_unpublish(
+      @uuid,
+      body: {
+        type: 'redirect',
+        locale: 'fr',
+        alternative_path: @destination,
+        allow_draft: true,
+      }
+    )
+
+    PublishingApiRedirectWorker.new.perform(@uuid, @destination, "fr", true)
+
+    assert_requested request
+  end
 end

--- a/test/unit/workers/publishing_api_unpublishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_unpublishing_worker_test.rb
@@ -18,7 +18,8 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
       unpublished_edition.document.content_id,
       unpublishing.alternative_path,
       unpublishing.explanation,
-      :en
+      :en,
+      false
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -37,7 +38,8 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
     redirect_worker.expects(:perform).with(
       unpublished_edition.document.content_id,
       unpublishing.alternative_path,
-      :en
+      :en,
+      false
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -56,7 +58,8 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
     redirect_worker.expects(:perform).with(
       unpublished_edition.document.content_id,
       unpublishing.alternative_path,
-      :en
+      :en,
+      false
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -74,7 +77,8 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
     withdrawal_worker.expects(:perform).with(
       unpublished_edition.document.content_id,
       unpublishing.explanation,
-      :en
+      :en,
+      false
     )
 
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
@@ -88,5 +92,23 @@ class PublishingApiUnpublishingWorkerTest < ActiveSupport::TestCase
 
     Whitehall::PublishingApi.expects(:save_draft_async).with(unpublished_edition)
     PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id)
+  end
+
+  test "passes allow_draft if supplied" do
+    unpublished_edition = create(
+      :withdrawn_edition
+    )
+
+    PublishingApiWithdrawalWorker.expects(:new).returns(withdrawal_worker = mock)
+    unpublishing = unpublished_edition.unpublishing
+
+    withdrawal_worker.expects(:perform).with(
+      unpublished_edition.document.content_id,
+      unpublishing.explanation,
+      :en,
+      true
+    )
+
+    PublishingApiUnpublishingWorker.new.perform(unpublished_edition.unpublishing.id, true)
   end
 end


### PR DESCRIPTION
This PR adds an unpublishing step to the `PublishingApiDocumentRepublishingWorker` so as this worker can handle withdrawing, redirecting etc of editions that have an `Unpublishing`.

This works on the assumption that if the `#latest_edition` of a `Document` has an `Unpublishing` then we should unpublish it.