### PR TITLE
Add data migration to clear change note on an Edition

### DIFF
--- a/db/data_migration/20160810101232_update_change_note_on_publication.rb
+++ b/db/data_migration/20160810101232_update_change_note_on_publication.rb
@@ -1,0 +1,11 @@
+edition = Edition.where(id: 644875).first
+
+if edition.present?
+  edition.minor_change = true
+
+  # Skip validation here, because normally editions in a superseded state cannot
+  # have their minor_change field modified.
+  edition.save(validate: false)
+else
+  "Edition #{644875} not found."
+end


### PR DESCRIPTION
BEIS have published a document with a change note they'd prefer not to
display. See https://govuk.zendesk.com/agent/tickets/1391330.

This data migration sets sets minor_change to true on the edition to stop it being displayed on the frontend.

This will display as follows. Is this a sensible way to address the ticket, or is there a preferred alternative?

![screen shot 2016-08-10 at 11 43 35](https://cloud.githubusercontent.com/assets/519250/17551020/c256f916-5eef-11e6-9e87-82a2eba6a317.png)
