### PR TITLE
Remove rendering_app from Contact presentation

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -19,7 +19,6 @@ module PublishingApi
         locale: locale,
         public_updated_at: public_updated_at,
         publishing_app: "whitehall",
-        rendering_app: rendering_app,
         details: details,
         phase: phase,
       }

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -17,7 +17,7 @@ module PublishingApiTestHelpers
     editions.each do |edition|
       Whitehall.publishing_api_v2_client.expects(:put_content)
         .with(edition.content_id,
-          has_entries({publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'}.merge(content_entries)))
+          has_entries({publishing_app: 'whitehall'}.merge(content_entries)))
       Whitehall.publishing_api_v2_client.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Whitehall.publishing_api_v2_client.expects(:publish)
@@ -29,7 +29,7 @@ module PublishingApiTestHelpers
     editions.each do |edition|
       Whitehall.publishing_api_v2_client.expects(:put_content)
         .with(edition.content_id,
-          has_entries({publishing_app: 'whitehall', rendering_app: 'whitehall-frontend'}.merge(content_entries)))
+          has_entries({publishing_app: 'whitehall'}.merge(content_entries)))
       Whitehall.publishing_api_v2_client.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Whitehall.publishing_api_v2_client.expects(:publish)

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -118,7 +118,7 @@ class ContactTest < ActiveSupport::TestCase
     EditionDependenciesPopulator.new(news_article).populate!
     EditionDependenciesPopulator.new(corp_info_page).populate!
 
-    expect_publishing(contact, content_entries: {rendering_app: 'government-frontend'})
+    expect_publishing(contact)
     expect_republishing(news_article, corp_info_page)
 
     contact.update_attributes(title: "Changed contact title")

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -34,7 +34,6 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
       locale: "en",
       phase: "live",
       public_updated_at: @updated_at,
-      rendering_app: "government-frontend",
       publishing_app: "whitehall",
       details: {
         description: nil,


### PR DESCRIPTION
Remove `rendering_app` from Whitehall contacts as they will be rendered by govspeak.