### PR TITLE
Remove some unused methods

### DIFF
--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -15,10 +15,6 @@ class SpecialistSector < ActiveRecord::Base
     end
   end
 
-  def self.live_subsectors
-    find_subsectors(fetch_live_sectors).map {|sector_tag| sector_topic_from_tag(sector_tag) }
-  end
-
   def edition
     Edition.unscoped { super }
   end
@@ -39,12 +35,6 @@ private
   # (https://www.gov.uk/topic)
   def self.fetch_sectors
     Whitehall.content_api.tags('specialist_sector', draft: true)
-  rescue
-    raise DataUnavailable.new
-  end
-
-  def self.fetch_live_sectors
-    Whitehall.content_api.tags('specialist_sector', draft: false, bust_cache: true)
   rescue
     raise DataUnavailable.new
   end

--- a/test/unit/specialist_sector_test.rb
+++ b/test/unit/specialist_sector_test.rb
@@ -77,16 +77,6 @@ class SpecialistSectorTest < ActiveSupport::TestCase
     end
   end
 
-  test '.live_subsectors should return only live subsectors' do
-    assert_equal [@income_tax, @fields], SpecialistSector.live_subsectors
-  end
-
-  test '.live_subsectors should cache bust the Content API request' do
-    SpecialistSector.live_subsectors
-
-    assert_requested :get, Regexp.new("#{Plek.find('content_api')}.*\\?(.*&)?cachebust=")
-  end
-
 private
   def use_real_content_api
     Whitehall.content_api = GdsApi::ContentApi.new(Plek.find('content_api'))


### PR DESCRIPTION
This removes some unused methods. Part of an effort to stop whitehall from talking to content api.