### PR TITLE
[Do Not Merge] Data migration to remove inconsistent `Unpublishing`

### DIFF
--- a/db/data_migration/20160816140514_remove_inconsistent_unpublishings.rb
+++ b/db/data_migration/20160816140514_remove_inconsistent_unpublishings.rb
@@ -1,0 +1,6 @@
+unpublishings = Unpublishing.joins(:edition).where("editions.state like 'published'")
+
+puts "Deleting #{unpublishings.count} unpublishings"
+
+unpublishings.destroy_all
+


### PR DESCRIPTION
There are currently 184 `Edition` models that are in `published` state but have an `Unpublishing` object associated with them. These `Editions` are live on the site as they are predominantly served from Whitehall.

Having checked some manually it would appear that the `Unpublishing` objects have been created as part of an import in 2012. They are going to cause issues in the migration republishing of their associated content items so this data migration removes them altogether.