### PR TITLE
Add data migration to clear unwanted collection link

### DIFF
--- a/db/data_migration/20160818152707_change_update_type_on_collection_page.rb
+++ b/db/data_migration/20160818152707_change_update_type_on_collection_page.rb
@@ -1,0 +1,11 @@
+document_collection = DocumentCollection.find_by(id: 640432)
+
+if document_collection.present?
+  document_collection.minor_change = true
+
+  # Skip validation here, because normally document collections (editions) in a
+  # superseded state cannot have their minor_change field modified.
+  document_collection.save(validate: false)
+else
+  "Document Collection#640432 not found."
+end


### PR DESCRIPTION
We were asked to remove one of the history entries in a collection page.

In order to do that, we need a data migration that changes `minor_change` to true
in order to make it go away from the front-end.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1399255