### PR TITLE
Delete unpublishing when published

### DIFF
--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -38,6 +38,7 @@ private
   def fire_transition!
     super
     supersede_previous_editions!
+    delete_unpublishing!
   end
 
   def supersede_previous_editions!
@@ -47,6 +48,10 @@ private
         e.save(validate: false)
       end
     end
+  end
+
+  def delete_unpublishing!
+    edition.unpublishing.destroy if edition.unpublishing.present?
   end
 
   def scheduled_for_publication?

--- a/db/data_migration/20160819135541_remove_inconsistent_unpublishings.rb
+++ b/db/data_migration/20160819135541_remove_inconsistent_unpublishings.rb
@@ -1,0 +1,5 @@
+unpublishings = Unpublishing.joins(:edition).where(editions: {state: 'published'})
+
+puts "Deleting #{unpublishings.count} unpublishings"
+
+unpublishings.delete_all

--- a/test/unit/services/edition_force_publisher_test.rb
+++ b/test/unit/services/edition_force_publisher_test.rb
@@ -14,6 +14,18 @@ class EditionForcePublisherTest < ActiveSupport::TestCase
     assert_equal '1.0', edition.published_version
   end
 
+  test '#perform! deletes any unpublishings for the edition' do
+    unpublishing = create(:unpublishing)
+    edition = unpublishing.edition
+
+    EditionForcePublisher.new(edition).perform!
+
+    edition.reload
+
+    assert edition.published?
+    refute edition.unpublishing.present?
+  end
+
   %w(published imported rejected superseded).each do |state|
     test "#{state} editions cannot be force published" do
       edition = create(:"#{state}_edition")

--- a/test/unit/services/edition_publisher_test.rb
+++ b/test/unit/services/edition_publisher_test.rb
@@ -75,6 +75,19 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert published_edition.reload.superseded?, "expected previous edition to be superseded but it's #{published_edition.state}"
   end
 
+  test '#perform! deletes any unpublishings for the edition' do
+    unpublishing = create(:unpublishing)
+    edition = unpublishing.edition
+    edition.submit!
+
+    EditionPublisher.new(edition).perform!
+
+    edition.reload
+
+    assert edition.published?
+    refute edition.unpublishing.present?
+  end
+
   test '#perform! does not choke if previous editions are invalid' do
     published_edition = create(:published_edition)
     edition = published_edition.create_draft(create(:writer))


### PR DESCRIPTION
When publishing an edition that has been reset to draft via the
“Published in error” unpublishing action, we should delete the
unpublishing record.  This enables us to easily check for editions with
unpublishings when determining if a document should be visible on the
site. Making this check easier is helpful when writing sync checks for
migration.

Adds a data migration to clean up unpublishings of published editions.

/cc @gpeng 