### PR TITLE
Only use allow_draft for drafts

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -104,7 +104,7 @@ private
   end
 
   def send_unpublish(edition)
-    PublishingApiUnpublishingWorker.new.perform(edition.unpublishing.id, true)
+    PublishingApiUnpublishingWorker.new.perform(edition.unpublishing.id, edition.draft?)
   end
 
   def locales_for(edition)

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -67,8 +67,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     assert_requested(patch_links_request, times: 2)
   end
 
-  test "it runs the PublishingApiUnpublishingWorker if the latest edition
-    has an unpublishing" do
+  test "it runs the PublishingApiUnpublishingWorker if the latest edition has an unpublishing" do
     document  = create(:document, content_id: SecureRandom.uuid)
     edition = create(:unpublished_edition, title: "Unpublished edition", document: document)
     unpublishing = edition.unpublishing
@@ -92,7 +91,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     api_worker.expects(:perform).with(published_edition.class.name, published_edition.id, "republish", "en")
 
     PublishingApiUnpublishingWorker.expects(:new).returns(unpublishing_worker = mock)
-    unpublishing_worker.expects(:perform).with(published_edition.unpublishing.id, true)
+    unpublishing_worker.expects(:perform).with(published_edition.unpublishing.id, false)
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end


### PR DESCRIPTION
The `allow_draft` flag for the unpublished endpoint actually means
“only allow drafts”, so we shouldn’t set it when we’re unpublishing
something that has been withdrawn as it isn’t a draft.

@gpeng maybe there's more cases that will require this than `draft?` but I can't think of them right now.