### PR TITLE
Trim alternative urls

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -12,6 +12,12 @@ class Unpublishing < ActiveRecord::Base
 
   after_initialize :ensure_presence_of_content_id
 
+  before_validation :strip_alternative_url
+
+  def strip_alternative_url
+    alternative_url.strip! if alternative_url.present?
+  end
+
   def self.from_slug(slug, type)
     where(slug: slug, document_type: type.to_s).last
   end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -4,7 +4,7 @@ class PublishingApiRedirectWorker < PublishingApiWorker
       content_id,
       type: "redirect",
       locale: locale,
-      alternative_path: destination,
+      alternative_path: destination.strip,
       allow_draft: allow_draft
     )
   end

--- a/db/data_migration/20160823132000_resave_unpublishings.rb
+++ b/db/data_migration/20160823132000_resave_unpublishings.rb
@@ -1,0 +1,3 @@
+#Unpublishing was allowing alternative_url with trailing whitespace. This will
+#clean the data by causing it to be stripped
+Unpublishing.all.map(&:save)

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -55,6 +55,13 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert unpublishing.valid?
   end
 
+  test 'alternative_url is stripped before validate' do
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://gov.uk/guidance ")
+    unpublishing.valid?
+
+    assert_equal "https://gov.uk/guidance", unpublishing.alternative_url
+  end
+
   test 'alternative_path returns the path of alternative_url' do
     unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.dev.gov.uk/guidance/document-path')
     assert_equal "/guidance/document-path", unpublishing.alternative_path

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -41,4 +41,21 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "trims the destination url" do
+    @destination = "/government/has-been-redirected.fr "
+    request = stub_publishing_api_unpublish(
+      @uuid,
+      body: {
+        type: 'redirect',
+        locale: 'fr',
+        alternative_path: "/government/has-been-redirected.fr",
+        allow_draft: true,
+      }
+    )
+
+    PublishingApiRedirectWorker.new.perform(@uuid, @destination, "fr", true)
+
+    assert_requested request
+  end
 end


### PR DESCRIPTION
Some `Unpublishing` records in the DB have trailing whitespace on their `alternative_url` values. This prevents a redirect route being created.

This PR -

* strips whitespace on URLs going through the `PublishingApiRedirectWorker`
* strips whitespace from `alternative_url` before the object is saved
* saves all existing `Unpublishing` to clean up the database