### PR TITLE
Handle exceptions in `Unpublishing` data migration

### DIFF
--- a/db/data_migration/20160823132000_resave_unpublishings.rb
+++ b/db/data_migration/20160823132000_resave_unpublishings.rb
@@ -1,3 +1,16 @@
+#this is an orphaned Unpublishing that used to belong to a WorldwidePriority
+#which is a format we have removed.
+Unpublishing.find(190).destroy
+
 #Unpublishing was allowing alternative_url with trailing whitespace. This will
 #clean the data by causing it to be stripped
-Unpublishing.all.map(&:save)
+
+current_unpublishing_id = nil
+begin
+  Unpublishing.all.each do |unpublishing|
+    current_unpublishing_id = unpublishing.id
+    unpublishing.save!
+  end
+rescue Exception => ex
+  puts "Could not save #{current_unpublishing_id}, #{ex.message}"
+end


### PR DESCRIPTION
It seems there are one or more invalid `Unpublishing` objects in the Whitehall DB. Who'd have thought it...

This also adds 

```
Unpublishing.find(190).destroy
```

which is a rogue orphan `Unpublishing` that we no longer need as it has no Edition (it was a Worldwide Priority) and is thus invalid.

(A version of this migration is already in master but it hasn't been run yet, hence the edit rather than doing a new one)