### PR TITLE
Guard against `Document` without editions

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -31,6 +31,8 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
     #an associated unpublishing
     @pre_publication_edition = document.pre_publication_edition
 
+    return unless the_document_has_an_edition_to_check?
+
     if the_document_has_been_unpublished?
       send_draft_and_unpublish
     elsif the_document_has_been_withdrawn?
@@ -50,6 +52,12 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
   end
 
 private
+
+  def the_document_has_an_edition_to_check?
+    #there are documents in the Whitehall DB with only superseded editions
+    #this is mostly legacy data
+    pre_publication_edition || published_edition
+  end
 
   def the_document_has_been_unpublished?
     pre_publication_edition && pre_publication_edition.unpublishing

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -112,13 +112,37 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
 
   test "it raises if an unknown combination is encountered" do
     document = stub(
-      published_edition: nil,
+      published_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),
       id: 1,
       pre_publication_edition: nil,
     )
 
     Document.stubs(:find).returns(document)
     assert_raise "Document id: 1 has an unrecognised state for republishing" do
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+
+  test "it completes silently if there are no published or pre_pub editions" do
+    #whitehall has a lot of old documents that only have superseded editions
+    #we want to ignore these and not have to try and avoid passing them in
+    #when doing bulk republishing
+    document = stub(
+      published_edition: nil,
+      id: 1,
+      pre_publication_edition: nil,
+    )
+
+    Document.stubs(:find).returns(document)
+
+    raising_worker = mock
+    raising_worker.stubs(:perform).raises
+
+    PublishingApiWorker.stubs(:new).returns(raising_worker)
+    PublishingApiDraftWorker.stubs(:new).returns(raising_worker)
+    PublishingApiUnpublishingWorker.stubs(:new).returns(raising_worker)
+
+    assert_nothing_raised do
       PublishingApiDocumentRepublishingWorker.new.perform(document.id)
     end
   end


### PR DESCRIPTION
Some `Document` instances only have `superseded` editions. We should ignore these for the purposes of republishing.