### PR TITLE
Consistently format `first_public_at`

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -64,8 +64,7 @@ module PublishingApi
     end
 
     def first_public_at
-      return item.first_public_at if item.document.published?
-      item.document.created_at.iso8601
+      (item.document.published? ? item.first_public_at : item.document.created_at).try(:iso8601)
     end
 
 


### PR DESCRIPTION
We shouldn't return two different date formats from the same method. This makes it easier to check when checking whitehall/content-store sync after republishing.