### PR TITLE
Data migration to fix submitted/rejected state

### DIFF
--- a/db/data_migration/20160826154205_set_unpublished_editions_to_draft.rb
+++ b/db/data_migration/20160826154205_set_unpublished_editions_to_draft.rb
@@ -1,0 +1,14 @@
+#all of these editions are DetailedGuides that have been Unpublished with a
+#redirect (consolidated) but then either submitted again or submitted then
+#rejected (all months ago). This is causing them to now 404 instead of redirecting
+#on the live site and not be correctly republished during migration.
+#Setting them to `draft` makes them behave correctly when they are republished
+#
+#There isn't a valid transition from submitted back to draft without publishing
+#so this 'seems' like the best approach
+
+edition_ids = [386611 ,538971 ,539167 ,539189 ,539205 ,580614 ,539257 ,580652 ,320368 ,276354 ,424191 ,231079 ,208346 ,586588 ,231045 ,231062 ,454878 ,438503]
+Edition.where(id: edition_ids).each do |edition|
+  edition.state = "draft"
+  edition.save!
+end


### PR DESCRIPTION
The `Edition`s in this data migration have all been unpublished and then submitted (and in some cases subsequently rejected). This results in them 404-ing instead of redirecting in production currently and in them not republishing correctly when being migrated.

There is no valid transition from these states to `draft` but setting them to draft will cause all of the correct behaviour with no side effects so... data migration.