### PR TITLE
Fix unpublishing explanation update

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -79,8 +79,8 @@ module Whitehall
       PublishingApiGoneWorker.perform_async(content_id, alternative_path, explanation, locale)
     end
 
-    def self.publish_withdrawal_async(content_id, explanation, locale = I18n.default_locale.to_s)
-      PublishingApiWithdrawalWorker.perform_async(content_id, explanation, locale)
+    def self.publish_withdrawal_async(document_content_id, explanation, locale = I18n.default_locale.to_s)
+      PublishingApiWithdrawalWorker.perform_async(document_content_id, explanation, locale)
     end
 
     def self.unpublish_async(unpublishing)

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -18,12 +18,25 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_equal unpublishing, assigns(:unpublishing)
   end
 
-  test "#update updates the unpublishing and redirects to admin policy page" do
+  test "#update updates the withdrawal and redirects to admin policy page" do
+    Whitehall::PublishingApi.expects(:publish_withdrawal_async)
+
     put :update, edition_id: @edition.id, unpublishing: { explanation: "this used to say withdrawn" }
 
     assert_redirected_to admin_edition_path(@edition)
     assert_equal "The public explanation was updated", flash[:notice]
     assert_equal "this used to say withdrawn", @edition.unpublishing.reload.explanation
+  end
+
+  test "#update updates the unpublishing and redirects to admin policy page" do
+    @unpublished_edition = create(:unpublished_edition)
+    Whitehall::PublishingApi.expects(:unpublish_async)
+
+    put :update, edition_id: @unpublished_edition.id, unpublishing: { explanation: "this used to say unpublished" }
+
+    assert_redirected_to admin_edition_path(@unpublished_edition)
+    assert_equal "The public explanation was updated", flash[:notice]
+    assert_equal "this used to say unpublished", @unpublished_edition.unpublishing.reload.explanation
   end
 
   test "#update shows form with error if the update was not possible" do


### PR DESCRIPTION
The unpublishing explanation update was broken after the format migration.

This fix sets new calls to the publishing api endpoints, in order to perform the update on the publishing api too.