### PR TITLE
Update document unpublishing

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -46,7 +46,19 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
         send_published_edition
         send_draft_edition
       else
-        raise "Document id: #{document.id} has an unrecognised state for republishing"
+        error_message = <<-ERROR
+          Document id: #{document.id} has an unrecognised state for republishing.
+          the_document_has_been_unpublished? = #{the_document_has_been_unpublished?}
+          the_document_has_been_withdrawn? = #{the_document_has_been_withdrawn?}
+          there_is_only_a_draft? = #{there_is_only_a_draft?}
+          there_is_only_a_published_edition? = #{there_is_only_a_published_edition?}
+          there_is_a_newer_draft? = #{there_is_a_newer_draft?}
+          published_edition.id = #{published_edition.try(:id)}
+          pre_publication_edition.id = #{pre_publication_edition.try(:id)}
+          published_edition.unpublishing = #{published_edition.try(:unpublishing)}
+          pre_publication_edition.unpublishing = #{pre_publication_edition.try(:unpublishing)}
+        ERROR
+        raise error_message
       end
     end
   end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -12,6 +12,7 @@ class PublishingApiGoneWorker < PublishingApiWorker
       type: "gone",
       locale: locale,
       allow_draft: allow_draft,
+      discard_drafts: !allow_draft
     )
   end
 end

--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -14,5 +14,8 @@ class PublishingApiGoneWorker < PublishingApiWorker
       allow_draft: allow_draft,
       discard_drafts: !allow_draft
     )
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+    # nothing to do here as we can't unpublish something that doesn't exist
+    nil
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -5,7 +5,8 @@ class PublishingApiRedirectWorker < PublishingApiWorker
       type: "redirect",
       locale: locale,
       alternative_path: destination.strip,
-      allow_draft: allow_draft
+      allow_draft: allow_draft,
+      discard_drafts: !allow_draft,
     )
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -8,5 +8,8 @@ class PublishingApiRedirectWorker < PublishingApiWorker
       allow_draft: allow_draft,
       discard_drafts: !allow_draft,
     )
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+    # nothing to do here as we can't unpublish something that doesn't exist
+    nil
   end
 end

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -7,5 +7,8 @@ class PublishingApiWithdrawalWorker < PublishingApiWorker
       explanation: Whitehall::GovspeakRenderer.new.govspeak_to_html(explanation),
       allow_draft: allow_draft,
     )
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+    # nothing to do here as we can't unpublish something that doesn't exist
+    nil
   end
 end

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -65,7 +65,11 @@ class SchedulingTest < ActiveSupport::TestCase
     destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
     gone_request = stub_publishing_api_unpublish(
       scheduled_edition.content_id,
-      body: { type: "gone", locale: "en" }
+      body: {
+        type: "gone",
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     unscheduler.perform!

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -56,7 +56,11 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     statistics_announcement = create(:statistics_announcement)
     gone_request = stub_publishing_api_unpublish(
       statistics_announcement.content_id,
-      body: { type: "gone", locale: "en" }
+      body: {
+        type: "gone",
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     statistics_announcement.destroy

--- a/test/integration/take_part_page_test.rb
+++ b/test/integration/take_part_page_test.rb
@@ -32,7 +32,11 @@ class TakePartPageTest < ActiveSupport::TestCase
 
     gone_request = stub_publishing_api_unpublish(
       @take_part_page.content_id,
-      body: { type: "gone", locale: "en" }
+      body: {
+        type: "gone",
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     @take_part_page.destroy

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -39,7 +39,11 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
 
     gone_request = stub_publishing_api_unpublish(
       @topical_event_about_page.content_id,
-      body: { type: "gone", locale: "en" }
+      body: {
+        type: "gone",
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     @topical_event_about_page.destroy

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -61,10 +61,17 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublish(@published_edition, unpublishing_params)
 
-    assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                    { type: "gone", explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>", locale: "en"})
-    assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                    { type: "gone", explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>", locale: "fr"})
+    %w(en fr).each do |locale|
+      assert_publishing_api_unpublish(
+        @published_edition.document.content_id,
+        {
+          type: "gone",
+          explanation: "<div class=\"govspeak\"><p>Published by mistake</p>\n</div>",
+          locale: locale,
+          discard_drafts: true,
+        }
+      )
+    end
   end
 
   test "when a translated edition is unpublished with a redirect, redirects are sent to the Publishing API for each translation" do
@@ -79,15 +86,22 @@ class UnpublishingTest < ActiveSupport::TestCase
 
     unpublishing_redirect_params = unpublishing_params.merge({
       redirect: true,
-      alternative_url: Whitehall.public_root + '/government/page'
+      alternative_url: Whitehall.public_root + '/government/page',
     })
 
     unpublish(@published_edition, unpublishing_redirect_params)
 
-    assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                  { type: "redirect", alternative_path: "/government/page", locale: "en"})
-    assert_publishing_api_unpublish(@published_edition.document.content_id,
-                                  { type: "redirect", alternative_path: "/government/page", locale: "fr"})
+    %w(en fr).each do |locale|
+      assert_publishing_api_unpublish(
+        @published_edition.document.content_id,
+        {
+          type: "redirect",
+          alternative_path: "/government/page",
+          locale: locale,
+          discard_drafts: true
+        }
+      )
+    end
   end
 
 private

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -361,7 +361,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     destination = "/government/people/milli-vanilli"
     redirect_request = stub_publishing_api_unpublish(
       redirect_uuid,
-      body: { type: "redirect", alternative_path: destination, locale: "en" }
+      body: {
+        type: "redirect",
+        alternative_path: destination,
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     Whitehall::PublishingApi.publish_redirect_async(redirect_uuid, destination)
@@ -374,7 +379,11 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     gone_request = stub_publishing_api_unpublish(
       gone_uuid,
-      body: { type: "gone", locale: "en" }
+      body: {
+        type: "gone",
+        locale: "en",
+        discard_drafts: true,
+      }
     )
 
     Whitehall::PublishingApi.publish_gone_async(gone_uuid, nil, nil)

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -16,6 +16,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
         alternative_path: "alternative_path",
         explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
         locale: "de",
+        discard_drafts: true
       }
     )
 
@@ -32,7 +33,7 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
         alternative_path: "alternative_path",
         explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
         locale: "de",
-        allow_draft: true,
+        allow_draft: true
       }
     )
 

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -18,6 +18,7 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
         type: 'redirect',
         locale: 'fr',
         alternative_path: @destination,
+        discard_drafts: true,
       }
     )
 


### PR DESCRIPTION
When unpublishing a published item we need to discard any drafts first as there are some that have a later draft which seems to be an invalid state.