### PR TITLE
Mark Whitehall as not threadsafe

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,7 +88,9 @@ Whitehall::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
-  # Enable threaded mode
+  # This is not enabled because parts of the publishing pipeline
+  # are not threadsafe. Once we've removed instances of `I18n.with_locale`
+  # from the codebase, we will be able to enable this if desired.
   # config.threadsafe!
 
   # Send deprecation notices to registered listeners

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,8 @@
 :verbose: true
-:concurrency: 2
+# We set concurrency to 1 because parts of the publishing pipeline
+# are not threadsafe. Once we've removed instances of `I18n.with_locale`
+# from the workers, we can increase this again.
+:concurrency: 1
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [bulk_republishing, 1]


### PR DESCRIPTION
Due to the heavy usage of `I18n.with_locale` throughout
the application, we can't use threads for concurrency
in Whitehall, either in Sidekiq or in Web.

We'll hopefully resolve this with https://trello.com/c/AkXJa3wl/685-investigate-making-publishing-thread-safe