### PR TITLE
Revert "Avoid duplicate corporate information pages"

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -22,7 +22,6 @@ class CorporateInformationPage < Edition
 
   validates :corporate_information_page_type_id, presence: true
   validate :only_one_organisation_or_worldwide_organisation
-  validate :unique_organisation_and_page_type, on: :create, if: :organisation
 
   def body_required?
     !about_page?
@@ -48,16 +47,6 @@ class CorporateInformationPage < Edition
   def only_one_organisation_or_worldwide_organisation
     if organisation && worldwide_organisation
       errors.add(:base, "Only one organisation or worldwide organisation allowed")
-    end
-  end
-
-  def unique_organisation_and_page_type
-    duplicate_scope = CorporateInformationPage
-      .joins(:edition_organisation)
-      .where("edition_organisations.organisation_id = ?", organisation.id)
-      .where(corporate_information_page_type_id: corporate_information_page_type_id)
-    if duplicate_scope.exists?
-      errors.add(:base, "Another '#{display_type_key.humanize}' page already exists for this organisation")
     end
   end
 

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -29,18 +29,6 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     refute corporate_information_page.valid?
   end
 
-  test 'should be invalid if has a duplicate organisation id and page type' do
-    organisation = create(:organisation)
-    corporate_information_page = build(:corporate_information_page,
-                                       organisation: organisation,
-                                       corporate_information_page_type: CorporateInformationPageType::AboutUs)
-    corporate_information_page.save!
-    corporate_information_page2 = build(:corporate_information_page,
-                                       organisation: organisation,
-                                       corporate_information_page_type: CorporateInformationPageType::AboutUs)
-    refute corporate_information_page2.valid?
-  end
-
   test 'should return search index data suitable for Rummageable' do
     organisation = create(:organisation)
     corporate_information_page = create(:corporate_information_page,


### PR DESCRIPTION
Reverts alphagov/whitehall#2719

This change has created permission errors and is preventing editors from editing any corporate information pages