### PR TITLE
Add `TopicsCheck`

### DIFF
--- a/lib/sync_checker/checks/topics_check.rb
+++ b/lib/sync_checker/checks/topics_check.rb
@@ -1,0 +1,86 @@
+module SyncChecker
+  module Checks
+    class TopicsCheck
+      attr_reader :topic_content_id_map, :edition, :content_item
+
+      def initialize(edition, topic_content_id_map = TopicContentIdMap.fetch)
+        @topic_content_id_map = topic_content_id_map
+        @edition = edition
+      end
+
+      def call(response)
+        failures = []
+        if response.response_code == 200
+          @content_item = JSON.parse(response.body)
+          if run_check?
+            failures << check_parent
+            failures << check_topics
+          end
+        end
+        failures.flatten.compact
+      end
+
+    private
+
+      def run_check?
+        %w(gone redirect).exclude?(content_item["schema_name"])
+      end
+
+      def check_parent
+        return if links_parent.nil? && parent_base_path.nil?
+        return "expected links#parent but it isn't present" if links_parent.nil? && parent_base_path.present?
+        return "links#parent is present but shouldn't be" if links_parent.present? && parent_base_path.blank?
+
+        parent_content_id = links_parent["content_id"]
+        expected_parent_content_id = topic_content_id_map["/topic/#{edition.primary_specialist_sector_tag}"]
+        if parent_content_id != expected_parent_content_id
+          "expected parent#content_id to be '#{expected_parent_content_id}' but got '#{parent_content_id}'"
+        end
+      end
+
+      def check_topics
+        return if topic_base_paths.empty? && links_topics.nil?
+        return "expected links#topics but it isn't present" if links_topics.nil? && topic_base_paths.any?
+        return "links#topics are present but shouldn't be" if links_topics.present? && topic_base_paths.empty?
+        check_for_missing_topics + check_for_unexpected_topics
+      end
+
+      def check_for_missing_topics
+        expected_content_ids
+          .reject { |content_id| links_topics_content_ids.include?(content_id)}
+          .map { |missing_content_id| "links#topics should contain '#{missing_content_id}' but doesn't" }
+      end
+
+      def check_for_unexpected_topics
+        links_topics_content_ids
+          .reject { |content_id| expected_content_ids.include?(content_id)}
+          .map { |unexpected_content_id| "links#topics contains '#{unexpected_content_id}' but shouldn't" }
+      end
+
+      def topic_base_paths
+        edition.specialist_sector_tags.map { |tag| "/topic/#{tag}" }
+      end
+
+      def expected_content_ids
+        topic_content_id_map.slice(*topic_base_paths).values
+      end
+
+      def links_parent
+        parent_element = content_item["links"]["parent"]
+        parent_element ? parent_element[0] : nil
+      end
+
+      def links_topics
+        content_item["links"]["topics"]
+      end
+
+      def links_topics_content_ids
+        links_topics.map { |topic_element| topic_element["content_id"] }
+      end
+
+      def parent_base_path
+        edition.primary_specialist_sector_tag
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -108,7 +108,8 @@ module SyncChecker
             end
           ),
           Checks::UnpublishedCheck.new(document),
-          Checks::TranslationsCheck.new(edition_expected_in_live.available_locales)
+          Checks::TranslationsCheck.new(edition_expected_in_live.available_locales),
+          Checks::TopicsCheck.new(edition_expected_in_live)
         ]
       end
 

--- a/lib/sync_checker/topic_content_id_map.rb
+++ b/lib/sync_checker/topic_content_id_map.rb
@@ -1,0 +1,10 @@
+module SyncChecker
+  class TopicContentIdMap
+    def self.fetch
+      @content_id_map ||= Whitehall.publishing_api_v2_client
+        .lookup_content_ids(
+          base_paths: SpecialistSector.pluck(:tag).uniq.map { |tag| "/topic/#{tag}" }
+        )
+    end
+  end
+end

--- a/test/unit/sync_checker/checks/topics_check_test.rb
+++ b/test/unit/sync_checker/checks/topics_check_test.rb
@@ -1,0 +1,333 @@
+require "maxitest/autorun"
+require "mocha/setup"
+require "active_support"
+require "active_support/json"
+require "active_support/core_ext"
+
+require_relative "../../../../lib/sync_checker/checks/topics_check"
+
+module SyncChecker
+  module Checks
+    class TopicsCheckTest < Minitest::Test
+      def test_it_returns_no_errors_if_response_not_200
+        edition = stub(specialist_sector_tags: [])
+        response = stub(
+          response_code: 404
+        )
+        assert_equal [], TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_no_errors_if_response_gone
+        edition = stub(specialist_sector_tags: ["/booyah"])
+        response = stub(
+          response_code: 200,
+          body: {
+            schema_name: "gone"
+          }.to_json
+        )
+        assert_equal [], TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_no_errors_if_response_redirect
+        edition = stub(specialist_sector_tags: ["/booyah"])
+        response = stub(
+          response_code: 200,
+          body: {
+            schema_name: "redirect"
+          }.to_json
+        )
+        assert_equal [], TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_an_error_if_parent_is_incorrect
+        tag = "health-protection/services"
+        edition = stub(
+          specialist_sector_tags: [tag],
+          primary_specialist_sector_tag: tag,
+        )
+
+        topic_content_id_map = {"/topic/#{tag}" => "ABC-CORRECT-CONTENT-ID"}
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              parent: [
+                {
+                  content_id: "XYZ-WRONG-CONTENT-ID"
+                }
+              ],
+              topics: [
+                {
+                  content_id: "ABC-CORRECT-CONTENT-ID"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = ["expected parent#content_id to be 'ABC-CORRECT-CONTENT-ID' but got 'XYZ-WRONG-CONTENT-ID'"]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, topic_content_id_map).call(response)
+      end
+
+      def test_it_returns_no_error_if_parent_is_correct
+        tag = "health-protection/services"
+        edition = stub(
+          specialist_sector_tags: [tag],
+          primary_specialist_sector_tag: tag,
+        )
+
+        topic_content_id_map = {
+          "/topic/other_random" => "MAKE-SURE-THESE-ARE-FILTERED",
+          "/topic/#{tag}" => "ABC-CORRECT-CONTENT-ID"
+        }
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              parent: [
+                {
+                  content_id: "ABC-CORRECT-CONTENT-ID"
+                }
+              ],
+              topics: [
+                {
+                  content_id: "ABC-CORRECT-CONTENT-ID"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = []
+
+        assert_equal expected_errors, TopicsCheck.new(edition, topic_content_id_map).call(response)
+      end
+
+      def test_it_returns_no_error_if_there_is_no_parent_and_no_primary_specialist_sector
+        edition = stub(
+          specialist_sector_tags: [],
+          primary_specialist_sector_tag: nil,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+            }
+          }.to_json
+        )
+
+        expected_errors = []
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_an_error_if_parent_isnt_present_but_should_be
+        tag = "health-protection/services"
+        edition = stub(
+          specialist_sector_tags: [],
+          primary_specialist_sector_tag: tag,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+            }
+          }.to_json
+        )
+
+        expected_errors = ["expected links#parent but it isn't present"]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_an_error_if_parent_is_present_but_shouldnt_be
+        edition = stub(
+          specialist_sector_tags: [],
+          primary_specialist_sector_tag: nil,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              parent: [
+                {
+                  content_id: "BOOYAH"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = ["links#parent is present but shouldn't be"]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_no_errors_if_topics_are_appropriately_absent
+        edition = stub(
+          specialist_sector_tags: [],
+          primary_specialist_sector_tag: nil,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+            }
+          }.to_json
+        )
+
+        expected_errors = []
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_an_error_if_topics_is_present_and_shouldnt_be
+        edition = stub(
+          specialist_sector_tags: [],
+          primary_specialist_sector_tag: nil,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              topics: [
+                {
+                  content_id: "TOPIC_CONTENT_ID"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = ["links#topics are present but shouldn't be"]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_an_error_if_there_are_no_topics_but_there_should_be
+        tag = "test/tag"
+        edition = stub(
+          specialist_sector_tags: [tag],
+          primary_specialist_sector_tag: nil,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+            }
+          }.to_json
+        )
+
+        expected_errors = ["expected links#topics but it isn't present"]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, stub).call(response)
+      end
+
+      def test_it_returns_no_errors_if_the_topics_are_correct
+        tags = ["test/tag_one", "test/tag_two"]
+        edition = stub(
+          specialist_sector_tags: tags,
+          primary_specialist_sector_tag: nil,
+        )
+
+        topic_content_id_map = {
+          "/topic/#{tags[0]}" => "CORRECT_TOPIC_ID_ONE",
+          "/topic/#{tags[1]}" => "CORRECT_TOPIC_ID_TWO",
+        }
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              topics: [
+                {
+                  content_id: "CORRECT_TOPIC_ID_ONE"
+                },
+                {
+                  content_id: "CORRECT_TOPIC_ID_TWO"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = []
+
+        assert_equal expected_errors, TopicsCheck.new(edition, topic_content_id_map).call(response)
+      end
+
+      def test_it_returns_an_error_if_there_are_missing_topics
+        tags = ["test/tag_one", "test/tag_two"]
+        edition = stub(
+          specialist_sector_tags: tags,
+          primary_specialist_sector_tag: nil,
+        )
+
+        topic_content_id_map = {
+            "/topic/#{tags[0]}" => "MISSING_TOPIC_ID_ONE",
+            "/topic/#{tags[1]}" => "MISSING_TOPIC_ID_TWO",
+        }
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              topics: [
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = [
+          "links#topics should contain 'MISSING_TOPIC_ID_ONE' but doesn't",
+          "links#topics should contain 'MISSING_TOPIC_ID_TWO' but doesn't"
+        ]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, topic_content_id_map).call(response)
+      end
+
+      def test_it_returns_an_error_if_there_are_unexpected_topics
+        tags = ["test/tag_one"]
+        edition = stub(
+          specialist_sector_tags: tags,
+          primary_specialist_sector_tag: nil,
+        )
+
+        topic_content_id_map = {
+          "/topic/#{tags[0]}" => "CORRECT_TOPIC_ID_ONE"
+        }
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              topics: [
+                {
+                  content_id: "CORRECT_TOPIC_ID_ONE"
+                },
+                {
+                  content_id: "UNEXPECTED_TOPIC_ID"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        expected_errors = [
+          "links#topics contains 'UNEXPECTED_TOPIC_ID' but shouldn't",
+        ]
+
+        assert_equal expected_errors, TopicsCheck.new(edition, topic_content_id_map).call(response)
+      end
+    end
+  end
+end

--- a/test/unit/sync_checker/topic_content_id_map_test.rb
+++ b/test/unit/sync_checker/topic_content_id_map_test.rb
@@ -1,0 +1,26 @@
+require 'maxitest/autorun'
+require 'mocha/setup'
+
+require_relative '../../../config/environment'
+require_relative "../../../lib/sync_checker/topic_content_id_map"
+
+module SyncChecker
+  class TestTopicContentIdMap < Minitest::Test
+    def test_it_requests_all_specialist_sector_base_paths
+      SpecialistSector.expects(:pluck).with(:tag).returns(%w(test_one test_two))
+      Whitehall.expects(:publishing_api_v2_client).returns(
+        mock("client").tap do |client|
+          client.expects(:lookup_content_ids).with(
+            base_paths: %w(
+              /topic/test_one
+              /topic/test_two
+            )
+          ).returns("booyah")
+        end
+      )
+      assert_equal "booyah", TopicContentIdMap.fetch
+      #call again tests that result is memoized
+      assert_equal "booyah", TopicContentIdMap.fetch
+    end
+  end
+end


### PR DESCRIPTION
Ongoing work as part of https://github.com/alphagov/whitehall/pull/2715

So... the `Topic` in question are actually `specialist_sector_tags` and getting a `content_id` for these requires a call out to PublishingApi. Implementing this check as a `LinksCheck` would have meant having all of that and the logic that goes with it in the format specific checks so I've implemented it as a separate type.

There is duplication with `LinksPresenter` but I think it is reasonable as this is 'test' code and we have been trying to avoid calling the presenters within the test as they are part of the stack we are
testing.

`TopicContentIdMap` is essentially a cache of all of the topic base paths -> content ids to prevent repeated api calls. There are < 400 of them in the form {"base_path" => "content_id"} so memory shouldn't be an issue. 