### PR TITLE
Ignore `withdrawn` when checking translations

### DIFF
--- a/lib/sync_checker/checks/translations_check.rb
+++ b/lib/sync_checker/checks/translations_check.rb
@@ -7,6 +7,10 @@ module SyncChecker
         failures = []
         if response.response_code == 200
           @content_item = JSON.parse(response.body)
+          #FIXME we're ignore withdrawn items for now due to a bug in
+          #publishing api causing them not to have an `available_translations`
+          #links element
+          return [] if withdrawn?
           available_translations = content_item["links"]["available_translations"]
           if run_check?
             if available_translations
@@ -26,6 +30,10 @@ module SyncChecker
 
       def run_check?
         %w(redirect gone).exclude?(content_item["schema_name"])
+      end
+
+      def withdrawn?
+        content_item["withdrawn_notice"].present?
       end
     end
   end

--- a/test/unit/sync_checker/checks/translations_check_test.rb
+++ b/test/unit/sync_checker/checks/translations_check_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require 'maxitest/autorun'
 require 'mocha/setup'
 require 'active_support'
 require 'active_support/json'
@@ -32,6 +32,23 @@ class TranslationsCheckTest < Minitest::Test
     response = stub(
       response_code: 404,
       body: {
+      }.to_json
+    )
+
+    expected = %w(en fr)
+    assert_equal [], SyncChecker::Checks::TranslationsCheck.new(expected).call(response)
+  end
+
+  #there is currently a Publishing API bug that prevents the `available_translations`
+  #links being populated on `withdrawn` items. This makes things noisy so we should
+  #skip them for now.
+  def test_returns_an_empty_array_if_the_item_is_withdrawn
+    response = stub(
+      response_code: 200,
+      body: {
+        withdrawn_notice: {
+          explanation: "blahdy blah"
+        }
       }.to_json
     )
 


### PR DESCRIPTION
Part of work started in #2715 

Due to a bug in the Publishing API, `withdrawn` content doesn't contain an `available_translations` links element.

While this is the case and as it doesn't have a massive impact (or any at the moment because there aren't any migrated formats with translated withdrawn content) we should ignore them when checking the translations.