### PR TITLE
Fix locale order failures

### DIFF
--- a/lib/sync_checker/checks/translations_check.rb
+++ b/lib/sync_checker/checks/translations_check.rb
@@ -11,7 +11,7 @@ module SyncChecker
           if run_check?
             if available_translations
               locales_present = available_translations.map { |translation| translation["locale"] }
-              if locales_present != stringified_locales
+              if locales_present.sort != stringified_locales.sort
                 failures << "expected #{stringified_locales} translations but got #{locales_present}"
               end
             else

--- a/test/unit/sync_checker/checks/translations_check_test.rb
+++ b/test/unit/sync_checker/checks/translations_check_test.rb
@@ -97,6 +97,29 @@ class TranslationsCheckTest < Minitest::Test
     assert_equal expected_errors, SyncChecker::Checks::TranslationsCheck.new(expected).call(response)
   end
 
+  def test_does_not_fail_erroneously_if_locales_are_in_a_different_order
+    response = stub(
+      response_code: 200,
+      body: {
+        links: {
+          available_translations: [
+            {
+              locale: "fr",
+            },
+            {
+              locale: "en",
+            }
+          ]
+        }
+      }.to_json
+    )
+
+    expected = [:en, :fr]
+    expected_errors = []
+
+    assert_equal expected_errors, SyncChecker::Checks::TranslationsCheck.new(expected).call(response)
+  end
+
   def test_returns_no_errors_if_gone
     response = stub(
       response_code: 200,


### PR DESCRIPTION
Part of ongoing work from #2715 

The `TranslationCheck` was failing when the expected and actual locales were correct but in a different order. We don't care about that so this fixes it.