### PR TITLE
Don't send taggings to panopticon

### DIFF
--- a/app/models/registerable_edition.rb
+++ b/app/models/registerable_edition.rb
@@ -1,3 +1,9 @@
+# RegisterableEdition is an object that `GdsApi::Panopticon::Registerer` uses
+# to generate a payload to send to panopticon.
+#
+# The reason we're still sending things to panopticon is to make them available
+# to link to as "related artefacts" and to make the need_ids available for
+# metadata-api via content-api.
 class RegisterableEdition
   attr_accessor :edition
 
@@ -60,27 +66,6 @@ class RegisterableEdition
 
   def need_ids
     edition.need_ids
-  end
-
-  # DID YOU MEAN: Topic?
-  # "Policy area" is the newer name for "topic"
-  # (https://www.gov.uk/government/topics)
-  # "Topic" is the newer name for "specialist sector"
-  # (https://www.gov.uk/topic)
-  def specialist_sectors
-    [edition.primary_specialist_sector_tag].compact + edition.secondary_specialist_sector_tags
-  end
-
-  def organisation_ids
-    registered_organisations.map(&:slug)
-  end
-
-  def registered_organisations
-    if edition.respond_to?(:organisations)
-      edition.organisations.reject {|organisation| organisation.is_a?(WorldwideOrganisation) }
-    else
-      []
-    end
   end
 
   def content_id

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -18,7 +18,6 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "detailed_guide", registerable_edition.kind
     assert_equal "Edition summary", registerable_edition.description
     assert_equal "live", registerable_edition.state
-    assert_equal [], registerable_edition.specialist_sectors
     assert_equal ["/guidance/#{slug}"], registerable_edition.paths
     assert_equal [], registerable_edition.prefixes
     assert_equal edition.content_id, registerable_edition.content_id
@@ -116,19 +115,6 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     assert_equal "draft", edition.state
   end
 
-  test "attaches specialist sector tags based on specialist sectors" do
-    expected_primary_tag = "oil-and-gas/taxation"
-    expected_secondary_tags = ["oil-and-gas/licensing", "oil-and-gas/fields-and-wells"]
-
-    detailed_guide = create(:published_detailed_guide,
-                            primary_specialist_sector_tag: expected_primary_tag,
-                            secondary_specialist_sector_tags: expected_secondary_tags)
-
-    registerable_edition = RegisterableEdition.new(detailed_guide)
-
-    assert_equal [expected_primary_tag] + expected_secondary_tags, registerable_edition.specialist_sectors
-  end
-
   test "sets the kind for a generic type" do
     edition = build(:draft_detailed_guide)
     registerable_edition = RegisterableEdition.new(edition)
@@ -168,39 +154,6 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     registerable_edition = RegisterableEdition.new(edition)
 
     assert_equal "statistical_data_set", registerable_edition.kind
-  end
-
-  test "attaches tagged organisations' slugs as `organisation_ids`" do
-    primary_org = create(:organisation)
-    secondary_org = create(:organisation)
-
-    edition = create(:publication, lead_organisations: [primary_org], supporting_organisations: [secondary_org])
-    registerable_edition = RegisterableEdition.new(edition)
-
-    assert_same_elements [primary_org, secondary_org].map(&:slug), registerable_edition.organisation_ids
-  end
-
-  test "organisation_ids works with class whose organisation method is not a scope" do
-    primary_org = create(:organisation)
-
-    edition = create(:corporate_information_page, organisation: primary_org)
-    registerable_edition = RegisterableEdition.new(edition)
-    assert_same_elements [primary_org.slug], registerable_edition.organisation_ids
-  end
-
-  test "does not tag worldwide organisations yet as they are not registered in Panopticon" do
-    worldwide_organisation = create(:worldwide_organisation)
-
-    edition = create(:corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation)
-    registerable_edition = RegisterableEdition.new(edition)
-    assert_equal [], registerable_edition.organisation_ids
-  end
-
-  class EditionWithoutOrgs < Edition; end
-  test "deals with editions which don't do organisation tagging" do
-    registerable_edition = RegisterableEdition.new(EditionWithoutOrgs.new)
-
-    assert_same_elements [], registerable_edition.organisation_ids
   end
 
   test "sets the need ids for detailed guides" do


### PR DESCRIPTION
It's no longer necessary to send specialist sector and organisation tagging to panopticon, because panopticon listens to the publishing-api message queue to sync these.