### PR TITLE
Opt-in to always-raising gds-api-adapters

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -41,10 +41,13 @@ module Edition::RelatedPolicies
     parent_ids = Set.new
 
     content_ids.each do |policy_content_id|
-      link_response = publishing_api.get_links(policy_content_id)
-      next unless link_response
+      begin
+        link_response = publishing_api.get_links(policy_content_id)
+      rescue GdsApi::HTTPNotFound
+        next
+      end
 
-      if (pa_links = publishing_api.get_links(policy_content_id)["links"]["policy_areas"])
+      if (pa_links = link_response["links"]["policy_areas"])
         parent_ids += pa_links
       end
     end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,4 @@
+GdsApi.configure do |config|
+  # Never return nil when a server responds with 404 or 410.
+  config.always_raise_for_not_found = true
+end

--- a/lib/data_hygiene/publishing_api_sync_check.rb
+++ b/lib/data_hygiene/publishing_api_sync_check.rb
@@ -160,9 +160,11 @@ module DataHygiene
       translation_locales_for(record).each do |locale|
         base_path_for_translation = base_path_for(record, locale: locale)
         content_item = content_store.content_item(base_path_for_translation)
-        return false if content_item.nil? || content_item["base_path"] != base_path_for_translation
+        return false if content_item["base_path"] != base_path_for_translation
       end
       true
+    rescue GdsApi::HTTPNotFound
+      false
     end
 
     def compare_content(response, whitehall_model, content_store)

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -48,5 +48,7 @@ private
     @edition_content_item ||= begin
       Whitehall.content_store.content_item(@edition_path)
     end
+  rescue GdsApi::HTTPNotFound
+    nil
   end
 end


### PR DESCRIPTION
Since https://github.com/alphagov/gds-api-adapters/pull/544 we can opt-in to new API client behaviour that will always raise an exception when an API returns 404 or 410. This decreases the chances of nil-errors and standardises the behaviour.

Solves a bunch of deprecation warnings.