### PR TITLE
Remove /government/site/sha endpoint

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,6 +1,0 @@
-class SiteController < PublicFacingController
-  def sha
-    skip_slimmer
-    render text: Whitehall::CURRENT_RELEASE_SHA
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,8 +375,6 @@ Whitehall::Application.routes.draw do
 
     get '/policy-topics' => redirect("/topics")
 
-    get 'site/sha' => 'site#sha'
-
     get '/placeholder' => 'placeholder#show', as: :placeholder
   end
 

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -23,13 +23,6 @@ module Whitehall
   mattr_accessor :statistics_announcement_search_client
   mattr_accessor :uploads_cache_max_age
 
-  revision_file = "#{Rails.root}/REVISION"
-  if File.exists?(revision_file)
-    CURRENT_RELEASE_SHA = File.read(revision_file).chomp
-  else
-    CURRENT_RELEASE_SHA = "development"
-  end
-
   asset_host_override = Rails.root.join("config/initializers/asset_host.rb")
   if File.exist?(asset_host_override)
     load asset_host_override


### PR DESCRIPTION
This endpoint exposes the currently deployed version of Whitehall. It was added back in the days as an experiment (https://github.com/alphagov/whitehall/commit/f3913d07dab0ecc61cea24774b2e2cb464715bfe) and isn't used by anything.

<img width="1172" alt="screen shot 2016-09-05 at 17 28 54" src="https://cloud.githubusercontent.com/assets/233676/18253633/44ec9e14-738e-11e6-9737-eeb6f6643a56.png">

(The blib is me testing)

https://kibana.publishing.service.gov.uk/kibana#dashboard/temp/AVb7LfrB77njsOZt7CWV