### PR TITLE
Republish `DetailedGuide`

### DIFF
--- a/db/data_migration/20160906140055_republish_detailed_guides_once_more_with_feeling.rb
+++ b/db/data_migration/20160906140055_republish_detailed_guides_once_more_with_feeling.rb
@@ -1,0 +1,9 @@
+document_ids = Document
+  .joins(:editions)
+  .where(editions: {type: 'DetailedGuide'})
+  .pluck(:id)
+  .uniq
+
+document_ids.each do |doc_id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", doc_id)
+end


### PR DESCRIPTION
This will republish all `DetailedGuide` documents through the updated worker. This has been done numerous times on integration and staging but we now need to run it on production to do the final sync checks before switching over the rendering app.

Whilst we're not switching over the rendering app yet, this republishing will appropriately create redirect routes for unpublished items in the router so some editions will at that point be migrated away from Whitehall.