### PR TITLE
Fix documents unwithdrawing

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -8,7 +8,7 @@ module ServiceListeners
 
     def push(event:, options: {})
       case event
-      when "force_publish", "publish"
+      when "force_publish", "publish", "unwithdraw"
         api.publish_async(edition)
       when "update_draft"
         api.save_draft_async(edition)

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -1,19 +1,19 @@
 Whitehall.edition_services.tap do |es|
-  es.subscribe(/^(force_publish|publish)$/)                   { |event, edition, options| ServiceListeners::AuthorNotifier.new(edition, options[:user]).notify! }
-  es.subscribe(/^(force_publish|publish|unpublish|withdraw)$/) { |event, edition, options| ServiceListeners::EditorialRemarker.new(edition, options[:user], options[:remark]).save_remark! }
-  es.subscribe(/^(force_publish|publish)$/)                   { |event, edition, options| Whitehall::GovUkDelivery::Notifier.new(edition).edition_published! }
-  es.subscribe(/^(force_publish|publish|unpublish|withdraw)$/) { |_, edition, _| ServiceListeners::PanopticonRegistrar.new(edition).register! }
-  es.subscribe(/^(force_publish|publish)$/)                   { |_, edition, _| ServiceListeners::AnnouncementClearer.new(edition).clear! }
+  es.subscribe(/^(force_publish|publish|unwithdraw)$/)                   { |event, edition, options| ServiceListeners::AuthorNotifier.new(edition, options[:user]).notify! }
+  es.subscribe(/^(force_publish|publish|unwithdraw|unpublish|withdraw)$/) { |event, edition, options| ServiceListeners::EditorialRemarker.new(edition, options[:user], options[:remark]).save_remark! }
+  es.subscribe(/^(force_publish|publish|unwithdraw)$/)                   { |event, edition, options| Whitehall::GovUkDelivery::Notifier.new(edition).edition_published! }
+  es.subscribe(/^(force_publish|publish|unwithdraw|unpublish|withdraw)$/) { |_, edition, _| ServiceListeners::PanopticonRegistrar.new(edition).register! }
+  es.subscribe(/^(force_publish|publish|unwithdraw)$/)                   { |_, edition, _| ServiceListeners::AnnouncementClearer.new(edition).clear! }
 
   # search
-  es.subscribe(/^(force_publish|publish|withdraw)$/) { |_, edition, _| ServiceListeners::SearchIndexer.new(edition).index! }
+  es.subscribe(/^(force_publish|publish|withdraw|unwithdraw)$/) { |_, edition, _| ServiceListeners::SearchIndexer.new(edition).index! }
   es.subscribe("unpublish")                 { |event, edition, options| ServiceListeners::SearchIndexer.new(edition).remove! }
 
   # publishing API
   es.subscribe { |event, edition, options| ServiceListeners::PublishingApiPusher.new(edition).push(event: event, options: options) }
 
   # handling edition's dependency on other content
-  es.subscribe(/^(force_publish|publish)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }
-  es.subscribe(/^(force_publish|publish)$/) { |_, edition, _| edition.republish_dependent_editions }
+  es.subscribe(/^(force_publish|publish|unwithdraw)$/) { |_, edition, _| EditionDependenciesPopulator.new(edition).populate! }
+  es.subscribe(/^(force_publish|publish|unwithdraw)$/) { |_, edition, _| edition.republish_dependent_editions }
   es.subscribe("unpublish")                 { |_, edition, _| edition.edition_dependencies.destroy_all }
 end

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -63,12 +63,6 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
     assert_equal "Unwithdrawn", unwithdrawn_edition.editorial_remarks.first.body
   end
 
-  test "unwithdraw handles re-registration with Panopticon" do
-    unwithdraw
-
-    assert_requested @panopticon_request
-  end
-
   def unwithdraw(edition = nil)
     edition ||= @edition
     @unwithdrawer = EditionUnwithdrawer.new(edition, user: @user)

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -25,7 +25,7 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
   end
 
   test "unwithdraw performs steps in a transaction" do
-    EditionForcePublisher.any_instance.stubs(:perform!).raises("Something bad happened here.")
+    Edition.any_instance.stubs(:create_draft).raises("Something bad happened here.")
 
     assert_raises RuntimeError do
       unwithdraw


### PR DESCRIPTION
Trello: https://trello.com/c/6AUwUK9X/473-re-publishing-unwithdrawing-content-not-reflecting-for-certain-whitehall-formats-medium

The ForcePublisher service, called during unwithdrawing, generated a new transaction, which was competing with the unwithdrawn edition saving. The unwanted consequence of that was that the content was not unwithdrawn and the withdrawn notice was still visible on the public page.

We are now performing the unwithdrawing as an additional event, listened by PublishingApiPusher, instead of using the ForcePublisher.

Now if an editor publishes content on the website, withdraw the content and then re-publishes (unwithdraws) the content again, the withdraw notice should not be displayed anymore. 

This was happening on some Whitehall migrated formats, such as Detailed Guides and Case Studies.