### PR TITLE
Set correct document type for detailed guides

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: item.display_type_key,
+        document_type: "detailed_guide",
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "detailed_guide",

--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -19,7 +19,7 @@ module SyncChecker
       end
 
       def document_type
-        "detailed_guidance"
+        "detailed_guide"
       end
     end
   end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -40,7 +40,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       description: "Some summary",
       public_updated_at: detailed_guide.updated_at,
       schema_name: "detailed_guide",
-      document_type: "detailed_guidance",
+      document_type: "detailed_guide",
       locale: "en",
       need_ids: [],
       publishing_app: "whitehall",


### PR DESCRIPTION
Detailed Guides should have the document_type “detailed_guide”. The
frontend uses this to translate the format name in the page title.