### PR TITLE
HTML Attachment Publishing workflow

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -9,100 +9,41 @@ module ServiceListeners
     def push(event:, options: {})
       case event
       when "force_publish", "publish"
-        perform_publishing_api_action_on_pushable_items(
-          action: :publish_async
-        )
+        api.publish_async(edition)
       when "update_draft"
-        perform_publishing_api_action_on_pushable_items(
-          action: :save_draft_async
-        )
+        api.save_draft_async(edition)
       when "update_draft_translation"
-        pushable_items.each do |record|
-          api.save_draft_translation_async(record, options.fetch(:locale))
-        end
+        api.save_draft_translation_async(edition, options.fetch(:locale))
       when "unpublish"
         api.unpublish_async(edition.unpublishing)
-        edition_html_attachments.each do |attachment|
-          redirect_if_required(attachment)
-        end
       when "withdraw"
         api.publish_withdrawal_async(
           edition.content_id,
           edition.unpublishing.explanation,
           edition.primary_locale
         )
-        edition_html_attachments.each do |attachment|
-          api.republish_async(attachment)
-        end
       when "force_schedule", "schedule"
         api.schedule_async(edition)
-        #ignore attachments
       when "unschedule"
         api.unschedule_async(edition)
-        #ignore attachments
       when "delete"
-        perform_publishing_api_action_on_pushable_items(
-          action: :discard_draft_async
-        )
+        api.discard_draft_async(edition)
       end
+
+      html_attachments_pusher(event).call
     end
 
   private
 
-    def perform_publishing_api_action_on_pushable_items(action:)
-      pushable_items.each do |record|
-        api.send(action, record)
-      end
-    end
-
-    def pushable_items
-      pushable_items = [@edition]
-      pushable_items + edition_html_attachments
-    end
-
-    def edition_html_attachments
-      @edition.respond_to?(:html_attachments) ? @edition.html_attachments : []
+    def html_attachments_pusher(event)
+      Whitehall::PublishingApi::HtmlAttachmentPusher.new(
+        edition: edition,
+        event: event
+      )
     end
 
     def api
       Whitehall::PublishingApi
-    end
-
-    def redirect_if_required(attachment)
-      if attachment.is_a?(HtmlAttachment)
-        if requires_redirect_to_alternative?(attachment)
-          redirect_to_unpublishing_alternative(attachment)
-        else
-          redirect_to_parent(attachment)
-        end
-      end
-    end
-
-    def requires_redirect_to_alternative?(attachment)
-      unpublishing = attachment.attachable.unpublishing
-      unpublishing.unpublishing_reason_id == UnpublishingReason::Consolidated.id ||
-        unpublishing.redirect
-    end
-
-    def redirect_to_parent(attachment)
-      publish_redirect(
-        attachment.content_id,
-        Whitehall.url_maker.public_document_path(edition)
-      )
-    end
-
-    def redirect_to_unpublishing_alternative(attachment)
-      edition = attachment.attachable
-      publish_redirect(
-        attachment.content_id,
-        Addressable::URI.parse(
-          edition.unpublishing.alternative_url
-        ).path
-      )
-    end
-
-    def publish_redirect(content_id, destination)
-      api.publish_redirect_async(content_id, destination)
     end
   end
 end

--- a/lib/whitehall/publishing_api/html_attachment_pusher.rb
+++ b/lib/whitehall/publishing_api/html_attachment_pusher.rb
@@ -23,6 +23,15 @@ module Whitehall
       end
       alias :force_publish :publish
 
+      def update_draft
+        current_html_attachments.each do |html_attachment|
+          api.save_draft_async(html_attachment)
+        end
+      end
+      # we don't care whether this is a translation or the main document, we just send the
+      # correct html attachments regardless.
+      alias :update_draft_translation :update_draft
+
     private
 
       def previous_edition

--- a/lib/whitehall/publishing_api/html_attachment_pusher.rb
+++ b/lib/whitehall/publishing_api/html_attachment_pusher.rb
@@ -10,7 +10,7 @@ module Whitehall
       end
 
       def call
-        send(event) if respond_to?(event)
+        send(event) if respond_to?(event) && edition.respond_to?(:html_attachments)
       end
 
       def publish
@@ -21,6 +21,7 @@ module Whitehall
           api.publish_redirect_async(content_id, edition.search_link)
         end
       end
+      alias :force_publish :publish
 
     private
 

--- a/lib/whitehall/publishing_api/html_attachment_pusher.rb
+++ b/lib/whitehall/publishing_api/html_attachment_pusher.rb
@@ -50,6 +50,16 @@ module Whitehall
         end
       end
 
+      def withdraw
+        current_html_attachments.each do |html_attachment|
+          api.publish_withdrawal_async(
+            html_attachment.content_id,
+            edition.unpublishing.explanation,
+            edition.primary_locale
+          )
+        end
+      end
+
     private
 
       def previous_edition

--- a/lib/whitehall/publishing_api/html_attachment_pusher.rb
+++ b/lib/whitehall/publishing_api/html_attachment_pusher.rb
@@ -1,0 +1,48 @@
+require 'whitehall/publishing_api'
+
+module Whitehall
+  class PublishingApi
+    class HtmlAttachmentPusher
+      attr_reader :edition, :event
+      def initialize(edition:, event:)
+        @edition = edition
+        @event = event
+      end
+
+      def call
+        send(event) if respond_to?(event)
+      end
+
+      def publish
+        current_html_attachments.each do |html_attachment|
+          api.publish_async(html_attachment)
+        end
+        content_ids_to_remove.each do |content_id|
+          api.publish_redirect_async(content_id, edition.search_link)
+        end
+      end
+
+    private
+
+      def previous_edition
+        @previous_edition ||= edition.previous_edition
+      end
+
+      def current_html_attachments
+        edition.html_attachments
+      end
+
+      def content_ids_to_remove
+        return Set[] unless previous_edition
+        old_content_ids = previous_edition.html_attachments.pluck(:content_id).to_set
+        new_content_ids = current_html_attachments.pluck(:content_id).to_set
+
+        old_content_ids - new_content_ids
+      end
+
+      def api
+        Whitehall::PublishingApi
+      end
+    end
+  end
+end

--- a/lib/whitehall/publishing_api/html_attachment_pusher.rb
+++ b/lib/whitehall/publishing_api/html_attachment_pusher.rb
@@ -60,6 +60,15 @@ module Whitehall
         end
       end
 
+      def delete
+        current_html_attachments.each do |html_attachment|
+          PublishingApiDiscardDraftWorker.perform_async(
+            html_attachment.content_id,
+            edition.primary_locale
+          )
+        end
+      end
+
     private
 
       def previous_edition

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -74,6 +74,7 @@ FactoryGirl.define do
     parent: :publication, traits: [:draft, :published_in_error_redirect]
   factory :unpublished_publication_consolidated,
     parent: :publication, traits: [:draft, :consolidated_redirect]
+  factory :withdrawn_publication, parent: :publication, traits: [:withdrawn]
 
   factory :draft_corporate_publication, parent: :publication, traits: [:draft, :corporate]
   factory :submitted_corporate_publication, parent: :publication, traits: [:submitted, :corporate]

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -2,9 +2,20 @@ require 'test_helper'
 
 module ServiceListeners
   class PublishingApiPusherTest < ActiveSupport::TestCase
+    def stub_html_attachment_pusher(edition, event)
+      pusher = mock
+      Whitehall::PublishingApi::HtmlAttachmentPusher
+        .expects(:new)
+        .with(edition: edition, event: event)
+        .returns(pusher)
+
+      pusher.expects(:call)
+    end
+
     test "saves draft async for update_draft" do
       edition = build(:draft_publication)
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
+      stub_html_attachment_pusher(edition, "update_draft")
       PublishingApiPusher.new(edition).push(event: "update_draft")
     end
 
@@ -14,55 +25,28 @@ module ServiceListeners
         html_attachments: [attachment = build(:html_attachment)]
       )
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
-      Whitehall::PublishingApi.expects(:save_draft_async).with(attachment)
+      stub_html_attachment_pusher(edition, "update_draft")
       PublishingApiPusher.new(edition).push(event: "update_draft")
     end
 
     test "publish publishes" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
-      PublishingApiPusher.new(edition).push(event: "publish")
-    end
-
-    test "publish publishes attachments" do
-      edition = build(
-        :publication,
-        html_attachments: [attachment = build(:html_attachment)]
-      )
-      Whitehall::PublishingApi.expects(:publish_async).with(edition)
-      Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+      stub_html_attachment_pusher(edition, "publish")
       PublishingApiPusher.new(edition).push(event: "publish")
     end
 
     test "force_publish publishes" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
-      PublishingApiPusher.new(edition).push(event: "force_publish")
-    end
-
-    test "force_publish publishes attachments" do
-      edition = build(
-        :publication,
-        html_attachments: [attachment = build(:html_attachment)]
-      )
-      Whitehall::PublishingApi.expects(:publish_async).with(edition)
-      Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+      stub_html_attachment_pusher(edition, "force_publish")
       PublishingApiPusher.new(edition).push(event: "force_publish")
     end
 
     test "update_draft_translation saves draft translation" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
-      PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
-    end
-
-    test "update_draft_translation updates the attachments" do
-      edition = build(
-        :publication,
-        html_attachments: [attachment = build(:html_attachment)]
-      )
-      Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
-      Whitehall::PublishingApi.expects(:save_draft_translation_async).with(attachment, 'en')
+      stub_html_attachment_pusher(edition, "update_draft_translation")
       PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
     end
 
@@ -74,24 +58,7 @@ module ServiceListeners
 
       Whitehall::PublishingApi.expects(:publish_withdrawal_async)
         .with(edition.document.content_id, edition.unpublishing.explanation, edition.primary_locale)
-
-      PublishingApiPusher.new(edition).push(event: "withdraw")
-    end
-
-    test "withdraw republishes the attachments" do
-      document = build(:document)
-      edition = build(
-        :publication,
-        html_attachments: [attachment = build(:html_attachment)],
-        document: document,
-      )
-      edition.build_unpublishing(explanation: 'Old information',
-        unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
-
-      Whitehall::PublishingApi.expects(:publish_withdrawal_async)
-        .with(edition.content_id, edition.unpublishing.explanation, edition.primary_locale)
-
-      Whitehall::PublishingApi.expects(:republish_async).with(attachment)
+      stub_html_attachment_pusher(edition, "withdraw")
 
       PublishingApiPusher.new(edition).push(event: "withdraw")
     end
@@ -99,87 +66,36 @@ module ServiceListeners
     test "unpublish publishes the unpublishing" do
       edition = create(:unpublished_publication)
       Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
-      PublishingApiPusher.new(edition).push(event: "unpublish")
-    end
-
-    test "unpublish redirects the attachments to the alternative_url if in
-      error with redirect" do
-      edition = create(
-        :unpublished_publication_in_error_redirect,
-      )
-      attachment = edition.attachments.first
-      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
-        attachment.content_id,
-        Addressable::URI.parse(edition.unpublishing.alternative_url).path
-      )
-      PublishingApiPusher.new(edition).push(event: "unpublish")
-    end
-
-    test "unpublish redirects the attachments to the parent if in error
-      and !redirect" do
-      edition = create(
-        :unpublished_publication_in_error_no_redirect
-      )
-      attachment = edition.attachments.first
-      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
-        attachment.content_id,
-        Whitehall.url_maker.public_document_path(edition),
-      )
-      PublishingApiPusher.new(edition).push(event: "unpublish")
-    end
-
-    test "unpublish redirects the attachments to the alternative_url if
-      unpublished consolidated" do
-      edition = create(
-        :unpublished_publication_consolidated,
-      )
-      attachment = edition.attachments.first
-      Whitehall::PublishingApi.expects(:publish_redirect_async).with(
-        attachment.content_id,
-        Addressable::URI.parse(
-          edition.unpublishing.alternative_url
-        ).path,
-      )
+      stub_html_attachment_pusher(edition, "unpublish")
       PublishingApiPusher.new(edition).push(event: "unpublish")
     end
 
     test "force_schedule schedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
+      stub_html_attachment_pusher(edition, "force_schedule")
       PublishingApiPusher.new(edition).push(event: "force_schedule")
     end
 
     test "schedule schedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
+      stub_html_attachment_pusher(edition, "schedule")
       PublishingApiPusher.new(edition).push(event: "schedule")
     end
 
     test "unschedule unschedules the edition" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
+      stub_html_attachment_pusher(edition, "unschedule")
       PublishingApiPusher.new(edition).push(event: "unschedule")
     end
 
     test "delete discards draft" do
       edition = build(:publication)
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
+      stub_html_attachment_pusher(edition, "delete")
       PublishingApiPusher.new(edition).push(event: "delete")
-    end
-
-    test "delete discards draft attachments" do
-      edition = build(
-        :publication,
-        html_attachments: [attachment = build(:html_attachment)]
-      )
-      Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
-      Whitehall::PublishingApi.expects(:discard_draft_async).with(attachment)
-      PublishingApiPusher.new(edition).push(event: "delete")
-    end
-
-    test "does not raise an error if the edition has no html_attachments association" do
-      edition = create(:published_document_collection)
-      PublishingApiPusher.new(edition).push(event: "publish")
     end
   end
 end

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -198,6 +198,30 @@ module Whitehall
           )
           call(publication)
         end
+
+        class Withdraw < HtmlAttachmentPusherTest
+          test "for something that can't have html attachments" do
+            Whitehall::PublishingApi.expects(:publish_withdrawal_async).never
+            call(build(:person))
+          end
+
+          test "for a publication with no html attachments" do
+            publication = create(:withdrawn_publication, :with_external_attachment)
+            Whitehall::PublishingApi.expects(:publish_withdrawal_async).never
+            call(publication)
+          end
+
+          test "for a publication that has been withdrawn" do
+            publication = create(:withdrawn_publication)
+            attachment = publication.html_attachments.first
+            Whitehall::PublishingApi.expects(:publish_withdrawal_async).with(
+              attachment.content_id,
+              "content was withdrawn",
+              "en"
+            )
+            call(publication)
+          end
+        end
       end
     end
   end

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -10,6 +10,11 @@ module Whitehall
       end
 
       class Publish < HtmlAttachmentPusherTest
+        test "for something that can't have html attachments" do
+          Whitehall::PublishingApi.expects(:publish_async).never
+          call(build(:person))
+        end
+
         test "with no html attachments" do
           publication = create(:published_publication, :with_external_attachment)
           Whitehall::PublishingApi.expects(:publish_async).never

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+require 'whitehall/publishing_api/html_attachment_pusher'
+
+module Whitehall
+  class PublishingApi
+    class HtmlAttachmentPusherTest < ActiveSupport::TestCase
+      def call(edition)
+        event = self.class.name.demodulize.underscore
+        HtmlAttachmentPusher.new(edition: edition, event: event).call
+      end
+
+      class Publish < HtmlAttachmentPusherTest
+        test "with no html attachments" do
+          publication = create(:published_publication, :with_external_attachment)
+          Whitehall::PublishingApi.expects(:publish_async).never
+          call(publication)
+        end
+
+        test "with an html attachment on a new document" do
+          publication = create(:published_publication)
+          attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+          call(publication)
+        end
+
+        test "with an html attachment on all versions of a document" do
+          publication = create(:published_publication)
+
+          new_edition = publication.create_draft(create(:writer))
+          new_edition.minor_change = true
+          new_edition.submit!
+          new_edition.publish!
+
+          attachment = new_edition.html_attachments.first
+
+          Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+          call(new_edition)
+        end
+
+        test "with an html attachment on the new version of a document" do
+          publication = create(:published_publication, :with_external_attachment)
+
+          new_edition = publication.create_draft(create(:writer))
+          new_edition.attachments = [build(:html_attachment)]
+          new_edition.minor_change = true
+          new_edition.submit!
+          new_edition.publish!
+
+          attachment = new_edition.html_attachments.first
+
+          Whitehall::PublishingApi.expects(:publish_async).with(attachment)
+          call(new_edition)
+        end
+
+        test "with an html attachment on the old version of a document" do
+          publication = create(:published_publication)
+
+          new_edition = publication.create_draft(create(:writer))
+          new_edition.attachments = [build(:external_attachment)]
+          new_edition.minor_change = true
+          new_edition.submit!
+          new_edition.publish!
+
+          Whitehall::PublishingApi.expects(:publish_async).never
+
+          old_attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+            old_attachment.content_id,
+            new_edition.search_link
+          )
+
+          call(new_edition)
+        end
+
+        test "with different html attachments on each version of a document" do
+          publication = create(:published_publication)
+
+          new_edition = publication.create_draft(create(:writer))
+          new_edition.attachments = [build(:html_attachment)]
+          new_edition.minor_change = true
+          new_edition.submit!
+          new_edition.publish!
+
+          new_attachment = new_edition.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_async).with(new_attachment)
+
+          old_attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+            old_attachment.content_id,
+            new_edition.search_link
+          )
+
+          call(new_edition)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -156,6 +156,49 @@ module Whitehall
           call(new_edition)
         end
       end
+
+      class Unpublish < HtmlAttachmentPusherTest
+        test "for something that can't have html attachments" do
+          Whitehall::PublishingApi.expects(:publish_redirect_async).never
+          call(build(:person))
+        end
+
+        test "for a publication with no html attachments" do
+          publication = create(:published_publication, :with_external_attachment)
+          Whitehall::PublishingApi.expects(:publish_redirect_async).never
+          call(publication)
+        end
+
+        test "for a publication that has been consolidated" do
+          publication = create(:unpublished_publication_consolidated)
+          attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+            attachment.content_id,
+            '/government/another/page'
+          )
+          call(publication)
+        end
+
+        test "for a publication that has been unpublished with a redirect" do
+          publication = create(:unpublished_publication_in_error_redirect)
+          attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+            attachment.content_id,
+            '/government/another/page'
+          )
+          call(publication)
+        end
+
+        test "for a publication that has been unpublished without a redirect" do
+          publication = create(:unpublished_publication_in_error_no_redirect)
+          attachment = publication.html_attachments.first
+          Whitehall::PublishingApi.expects(:publish_redirect_async).with(
+            attachment.content_id,
+            publication.search_link
+          )
+          call(publication)
+        end
+      end
     end
   end
 end

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -15,25 +15,25 @@ module Whitehall
       end
 
       class Publish < HtmlAttachmentPusherTest
-        test "for something that can't have html attachments" do
+        test "for something that can't have html attachments doesn't publish" do
           Whitehall::PublishingApi.expects(:publish_async).never
           call(build(:person))
         end
 
-        test "with no html attachments" do
+        test "with no html attachments doesn't publish" do
           publication = create(:published_publication, :with_external_attachment)
           Whitehall::PublishingApi.expects(:publish_async).never
           call(publication)
         end
 
-        test "with an html attachment on a new document" do
+        test "with an html attachment on a new document publishes the attachment" do
           publication = create(:published_publication)
           attachment = publication.html_attachments.first
           Whitehall::PublishingApi.expects(:publish_async).with(attachment)
           call(publication)
         end
 
-        test "with an html attachment on all versions of a document" do
+        test "with an html attachment on all versions of a document publishes the attachment" do
           publication = create(:published_publication)
 
           new_edition = publication.create_draft(create(:writer))
@@ -47,7 +47,7 @@ module Whitehall
           call(new_edition)
         end
 
-        test "with an html attachment on the new version of a document" do
+        test "with an html attachment on the new version of a document publishes the attachment" do
           publication = create(:published_publication, :with_external_attachment)
 
           new_edition = publication.create_draft(create(:writer))
@@ -62,7 +62,7 @@ module Whitehall
           call(new_edition)
         end
 
-        test "with an html attachment on the old version of a document" do
+        test "with an html attachment on the old version of a document redirects the attachment" do
           publication = create(:published_publication)
 
           new_edition = publication.create_draft(create(:writer))
@@ -82,7 +82,7 @@ module Whitehall
           call(new_edition)
         end
 
-        test "with different html attachments on each version of a document" do
+        test "with different html attachments on each version of a document publishes the new attachment and redirects the old" do
           publication = create(:published_publication)
 
           new_edition = publication.create_draft(create(:writer))
@@ -105,25 +105,25 @@ module Whitehall
       end
 
       class UpdateDraft < HtmlAttachmentPusherTest
-        test "for something that can't have html attachments" do
+        test "for something that can't have html attachments doesn't save draft" do
           Whitehall::PublishingApi.expects(:save_draft_async).never
           call(build(:person))
         end
 
-        test "with no html attachments" do
+        test "with no html attachments doesn't save draft" do
           publication = create(:published_publication, :with_external_attachment)
           Whitehall::PublishingApi.expects(:save_draft_async).never
           call(publication)
         end
 
-        test "with an html attachment on a new document" do
+        test "with an html attachment on a new document saves it as a draft" do
           publication = create(:draft_publication)
           attachment = publication.html_attachments.first
           Whitehall::PublishingApi.expects(:save_draft_async).with(attachment)
           call(publication)
         end
 
-        test "with an html attachment on all versions of a document" do
+        test "with an html attachment on all versions of a document saves it as a draft" do
           publication = create(:published_publication)
           new_edition = publication.create_draft(create(:writer))
 
@@ -133,7 +133,7 @@ module Whitehall
           call(new_edition)
         end
 
-        test "with an html attachment on the old version of a document" do
+        test "with an html attachment on the old version of a document leaves the attachment alone" do
           publication = create(:published_publication)
 
           new_edition = publication.create_draft(create(:writer))
@@ -144,7 +144,7 @@ module Whitehall
           call(new_edition)
         end
 
-        test "with different html attachments on each version of a document" do
+        test "with different html attachments on each version of a document saves the new attachment as a draft" do
           publication = create(:published_publication)
 
           new_edition = publication.create_draft(create(:writer))
@@ -158,18 +158,18 @@ module Whitehall
       end
 
       class Unpublish < HtmlAttachmentPusherTest
-        test "for something that can't have html attachments" do
+        test "for something that can't have html attachments doesn't publish a redirect" do
           Whitehall::PublishingApi.expects(:publish_redirect_async).never
           call(build(:person))
         end
 
-        test "for a publication with no html attachments" do
+        test "for a publication with no html attachments doesn't publish a redirect" do
           publication = create(:published_publication, :with_external_attachment)
           Whitehall::PublishingApi.expects(:publish_redirect_async).never
           call(publication)
         end
 
-        test "for a publication that has been consolidated" do
+        test "for a publication that has been consolidated publishes a redirect to the alternative url" do
           publication = create(:unpublished_publication_consolidated)
           attachment = publication.html_attachments.first
           Whitehall::PublishingApi.expects(:publish_redirect_async).with(
@@ -179,7 +179,7 @@ module Whitehall
           call(publication)
         end
 
-        test "for a publication that has been unpublished with a redirect" do
+        test "for a publication that has been unpublished with a redirect publishes a redirect to the alternative url" do
           publication = create(:unpublished_publication_in_error_redirect)
           attachment = publication.html_attachments.first
           Whitehall::PublishingApi.expects(:publish_redirect_async).with(
@@ -189,7 +189,7 @@ module Whitehall
           call(publication)
         end
 
-        test "for a publication that has been unpublished without a redirect" do
+        test "for a publication that has been unpublished without a redirect publishes a redirect to the parent document" do
           publication = create(:unpublished_publication_in_error_no_redirect)
           attachment = publication.html_attachments.first
           Whitehall::PublishingApi.expects(:publish_redirect_async).with(
@@ -200,18 +200,18 @@ module Whitehall
         end
 
         class Withdraw < HtmlAttachmentPusherTest
-          test "for something that can't have html attachments" do
+          test "for something that can't have html attachments doesn't publish a withdrawal" do
             Whitehall::PublishingApi.expects(:publish_withdrawal_async).never
             call(build(:person))
           end
 
-          test "for a publication with no html attachments" do
+          test "for a publication with no html attachments doesn't publish a withdrawal" do
             publication = create(:withdrawn_publication, :with_external_attachment)
             Whitehall::PublishingApi.expects(:publish_withdrawal_async).never
             call(publication)
           end
 
-          test "for a publication that has been withdrawn" do
+          test "for a publication that has been withdrawn publishes a withdrawal" do
             publication = create(:withdrawn_publication)
             attachment = publication.html_attachments.first
             Whitehall::PublishingApi.expects(:publish_withdrawal_async).with(
@@ -224,18 +224,18 @@ module Whitehall
         end
 
         class Delete < HtmlAttachmentPusherTest
-          test "for something that can't have html attachments" do
+          test "for something that can't have html attachments doesn't discard any drafts" do
             PublishingApiDiscardDraftWorker.expects(:perform_async).never
             call(build(:person))
           end
 
-          test "for a draft publication with no html attachments" do
+          test "for a draft publication with no html attachments doesn't discard any drafts" do
             publication = create(:draft_publication, :with_external_attachment)
             PublishingApiDiscardDraftWorker.expects(:perform_async).never
             call(publication)
           end
 
-          test "for a draft publication with html attachments" do
+          test "for a draft publication with html attachments discards the draft" do
             publication = create(:draft_publication)
             attachment = publication.html_attachments.first
             PublishingApiDiscardDraftWorker.expects(:perform_async).with(

--- a/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
+++ b/test/unit/whitehall/publishing_api/html_attachment_pusher_test.rb
@@ -222,6 +222,29 @@ module Whitehall
             call(publication)
           end
         end
+
+        class Delete < HtmlAttachmentPusherTest
+          test "for something that can't have html attachments" do
+            PublishingApiDiscardDraftWorker.expects(:perform_async).never
+            call(build(:person))
+          end
+
+          test "for a draft publication with no html attachments" do
+            publication = create(:draft_publication, :with_external_attachment)
+            PublishingApiDiscardDraftWorker.expects(:perform_async).never
+            call(publication)
+          end
+
+          test "for a draft publication with html attachments" do
+            publication = create(:draft_publication)
+            attachment = publication.html_attachments.first
+            PublishingApiDiscardDraftWorker.expects(:perform_async).with(
+              attachment.content_id,
+              "en"
+            )
+            call(publication)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR contains the logic that decides what to do with an HTML Attachment when something happens to its parent.

The potential events are well defined in the Edition Services parts of Whitehall. We have a PublishingApiPusher service listener that deals with relevant events for the parent document and then forwards the event to this HTML Attachment-specific pusher.

The bulk of the complexity here is in removing attachments that were present on the previous (superseded) edition when a new edition is published.

A future PR will likely use this class (or a variation of it) to accurately republish all HTML Attachments in Whitehall.

/cc @gpeng 