### PR TITLE
Destroy 'Open policy making toolkit' guidance

### DIFF
--- a/db/data_migration/20160912131542_destroy_open_policy_making_toolkit_detailed_guide.rb
+++ b/db/data_migration/20160912131542_destroy_open_policy_making_toolkit_detailed_guide.rb
@@ -1,0 +1,5 @@
+document_id = DetailedGuide.find(644534).document_id
+
+Edition.where(document_id: document_id).destroy_all
+
+Document.find(document_id).destroy


### PR DESCRIPTION
This guide has been superseeded by a Specialist Publisher manual.

See https://trello.com/c/EDM9LDaZ/469-opm-toolkit-make-sure-the-right-one-is-live-large