### PR TITLE
Correcting .current-appointee links in Firefox on focus

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_person.scss
+++ b/app/assets/stylesheets/frontend/helpers/_person.scss
@@ -85,6 +85,9 @@
     .current-appointee {
       padding-top: 0;
       a {
+        display: block;
+        overflow: hidden;
+
         &:hover,
         &:focus,
         &:active {


### PR DESCRIPTION
When the user focus on the ministers on
https://www.gov.uk/government/organisations/cabinet-office in firefox,
the box around it started looking a bit funky.

# Current production code
![image](https://cloud.githubusercontent.com/assets/325384/18472541/64f35254-79b8-11e6-8bea-a33e445cdf1b.png)

# With fix applied
![image](https://cloud.githubusercontent.com/assets/325384/18472550/7568254c-79b8-11e6-9e15-7e2fde76b921.png)

# Tested on
* Firefox 48  on Mac OS X
* Chrome 53 on Mac OS X

I only tested the change on https://www.gov.uk/government/organisations/cabinet-office which I think is the only instance of `.current-appointee`. 