### PR TITLE
Use expanded links to resolve the grandparent in SpecialistTagFinder

### DIFF
--- a/features/step_definitions/specialist_sector_steps.rb
+++ b/features/step_definitions/specialist_sector_steps.rb
@@ -19,21 +19,24 @@ Given(/^there is a document tagged to specialist sectors$/) do
 
   document_content_item = content_item_for_base_path(document_base_path).merge!({
     "links" => {
-      "parent" => [{ "base_path" => parent_base_path }],
+      "parent" => [
+        {
+          "base_path" => parent_base_path,
+          "links" => {
+            "parent" => [
+              {
+                "title" => "Top Level Topic",
+                "web_url" => "http://gov.uk/top-level-topic"
+              }
+            ]
+          }
+        }
+      ],
       "topics" => [{ "title" => "Topic 1" }, { "title" => "Topic 2"  }]
-    }
-  })
-  parent_content_item = content_item_for_base_path(parent_base_path).merge!({
-    "links" => {
-      "parent" => [{
-        "title" => "Top Level Topic",
-        "web_url" => "http://gov.uk/top-level-topic"
-      }]
     }
   })
 
   content_store_has_item(document_base_path, document_content_item)
-  content_store_has_item(parent_base_path, parent_content_item)
 end
 
 Then(/^I should see the specialist sub\-sector and its parent sector$/) do

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -26,19 +26,13 @@ class SpecialistTagFinder
     # tagged with a parent - this is always one of the 2nd level topics.  The
     # top level topic (i.e. - the parent of the edition's parent) is required
     # in the frontend when rendering an Edition's breadcrumb.
-
     @top_level_topic ||= begin
       return unless edition_content_item
-      parents = Array(edition_content_item.links["parent"])
-      return unless parents.any?
+      parent = Array(edition_content_item.links["parent"])
+      return unless parent.any?
 
-      # FIXME: We now need to fetch the parent topic from the content store to
-      # retrieve its parent. We should replace this implementation with the
-      # publishing API's links expansion / dependency resolution, which is
-      # currently WIP.
-      parent_path = parents.first["base_path"]
-      parent_content_item = Whitehall.content_store.content_item(parent_path)
-      Array(parent_content_item.links["parent"]).first
+      parent_links = parent.first["links"]
+      Array(parent_links["parent"]).first
     end
   end
 

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -46,15 +46,19 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     edition = create(:edition_with_document)
     edition_base_path = Whitehall.url_maker.public_document_path(edition)
     parent_base_path = "/parent-item"
-    edition_content_item = content_item_for_base_path(edition_base_path).merge!({
-      "links" => { "parent" => [{ "base_path" => parent_base_path }] }
-    })
-    parent_content_item = content_item_for_base_path(parent_base_path).merge!({
-      "links" => { "parent" => [{ "base_path" => "/grandpa" }] }
-    })
-
+    edition_content_item = content_item_for_base_path(edition_base_path).merge!(
+      "links" => {
+        "parent" => [
+          {
+            "base_path" => parent_base_path,
+            "links" => {
+              "parent" => [{ "base_path" => "/grandpa", links: {}}],
+            }
+          }
+        ]
+      }
+    )
     content_store_has_item(edition_base_path, edition_content_item)
-    content_store_has_item(parent_base_path, parent_content_item)
 
     assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
   end
@@ -71,7 +75,7 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     assert_equal nil, SpecialistTagFinder.new(edition_base_path).top_level_topic
   end
 
-  test "#top_level_topic returns nil if not content item found" do
+  test "#top_level_topic returns nil if no content item found" do
     edition = create(:edition_with_document)
     edition_base_path = Whitehall.url_maker.public_document_path(edition)
 


### PR DESCRIPTION
This was identified a while ago as something to fix once the Publishing
API's link expansion functionality was complete. We can now access an
edition's grandparent topic without making an additional network
request.

NOTE: not tested locally due to whitehall issues on my VM. Will be looking to test on integration shortly.