### PR TITLE
Remove attachments from 620632

### DIFF
--- a/db/data_migration/20160913142837_remove_attachments_from_620632.rb
+++ b/db/data_migration/20160913142837_remove_attachments_from_620632.rb
@@ -1,0 +1,2 @@
+edition = Edition.find(620632)
+edition.attachments.map(&:delete)


### PR DESCRIPTION
Detailed guide 620632 has 454 attachments, therefore the draft cannot be discarded as it results in a gateway timeout error. This migration removes all the attachments from the draft to allow it to be discarded.

Zendesk: https://govuk.zendesk.com/agent/tickets/1417917