### PR TITLE
Revert "Remove attachments from 620632"

### DIFF
--- a/db/data_migration/20160913142837_remove_attachments_from_620632.rb
+++ b/db/data_migration/20160913142837_remove_attachments_from_620632.rb
@@ -1,2 +1,0 @@
-edition = Edition.find(620632)
-edition.attachments.map(&:delete)


### PR DESCRIPTION
Reverts alphagov/whitehall#2753

This edition that these attachments were attached too has already been removed so the data migration now errors.