### PR TITLE
Revert "Support inflight jobs"

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -14,15 +14,7 @@
 class PublishingApiDocumentRepublishingWorker < WorkerBase
   attr_reader :published_edition, :pre_publication_edition
 
-  def perform(*args)
-    if args.length > 1
-      document_id = Edition.where(id: args).pluck(:document_id).last
-      PublishingApiDocumentRepublishingWorker.new.perform(document_id)
-      return
-    end
-
-    document_id = args[0]
-
+  def perform(document_id)
     document = Document.find(document_id)
     #this the latest edition in a visible state ie: withdrawn, published
     @published_edition = document.published_edition

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -96,20 +96,6 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
 
-  test "it supports jobs with the old method signature" do
-    document  = create(:document, content_id: SecureRandom.uuid)
-    edition = create(:published_edition, title: "Published edition", document: document)
-
-    real_worker = PublishingApiDocumentRepublishingWorker.new
-
-    PublishingApiDocumentRepublishingWorker
-      .expects(:new).returns(worker = mock)
-    worker.expects(:perform)
-      .with(document.id)
-
-    real_worker.perform(edition.id, nil)
-  end
-
   test "it raises if an unknown combination is encountered" do
     document = stub(
       published_edition: stub(id: 2, unpublishing: stub(id: 4, unpublishing_reason_id: 100)),


### PR DESCRIPTION
This reverts commit b114b2b09f9e094f0048e2a1ce1e3f7dc66d8f08.

There are no longer any jobs inflight with this signature

/cc @gpeng 