### PR TITLE
Change email notification sender name

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -58,7 +58,7 @@ class Notifications < ActionMailer::Base
   private
 
   def no_reply_email_address
-    name = "DO NOT REPLY"
+    name = "GOV.UK publishing"
     if GovukAdminTemplate.environment_label !~ /production/i
       name.prepend("[GOV.UK #{GovukAdminTemplate.environment_label}] ")
     end

--- a/app/views/notifications/edition_published.text.erb
+++ b/app/views/notifications/edition_published.text.erb
@@ -2,7 +2,7 @@ Hello,
 
 The <%= @edition.format_name %> '<%= @edition.title %>' is published. It's now available at the following url: <%= @public_url %>
 
-New content will be live immediately, changes to previously published content can take up to 15 minutes. A blog post that explains more is at the following url: https://insidegovuk.blog.gov.uk/2014/11/05/how-soon-do-users-see-content-after-youve-pressed-publish
+New content goes live immediately but changes to previously published content can take up to 15 minutes. The GOV.UK publishing manual has more detail: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/reviewing-and-approving-content#publishing-times
 
 All the best,
 

--- a/test/unit/services/listeners/author_notifier_test.rb
+++ b/test/unit/services/listeners/author_notifier_test.rb
@@ -44,6 +44,6 @@ class ServiceListeners::AuthorNotifierTest < ActiveSupport::TestCase
 
     first_notification = ActionMailer::Base.deliveries.first
     # GovukAdminTemplate.environment_label isn't set in tests, hence the space inside the brackets
-    assert_equal '"[GOV.UK ] DO NOT REPLY" <inside-government@digital.cabinet-office.gov.uk>', first_notification[:from].to_s
+    assert_equal '"[GOV.UK ] GOV.UK publishing" <inside-government@digital.cabinet-office.gov.uk>', first_notification[:from].to_s
   end
 end


### PR DESCRIPTION
The service manual says:

> You must create an email address which your users can reply to, and you must read their messages.

https://www.gov.uk/service-manual/technology/how-to-email-your-users