### PR TITLE
Check for expanded links if links are missing in SpecialistTagFinder

### DIFF
--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -31,7 +31,10 @@ class SpecialistTagFinder
       parent = Array(edition_content_item.links["parent"])
       return unless parent.any?
 
-      parent_links = parent.first["links"]
+      # FIXME: Some content items may still contain the 'expanded_links' field.
+      # Remove the following defensive check once this is fixed.
+      parent_links = parent.first["links"] || parent.first["expanded_links"]
+
       Array(parent_links["parent"]).first
     end
   end

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -63,6 +63,27 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
   end
 
+  test "#top_level_topic falls back to expanded_links on the parent if links aren't present" do
+    edition = create(:edition_with_document)
+    edition_base_path = Whitehall.url_maker.public_document_path(edition)
+    parent_base_path = "/parent-item"
+    edition_content_item = content_item_for_base_path(edition_base_path).merge!(
+      "links" => {
+        "parent" => [
+          {
+            "base_path" => parent_base_path,
+            "expanded_links" => {
+              "parent" => [{ "base_path" => "/grandpa", links: {}}],
+            }
+          }
+        ]
+      }
+    )
+    content_store_has_item(edition_base_path, edition_content_item)
+
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
+  end
+
   test "#top_level_topic returns nil if no parents" do
     edition = create(:edition_with_document)
     edition_base_path = Whitehall.url_maker.public_document_path(edition)


### PR DESCRIPTION
Some content items unexpectedly contain the former, deprecated name for
this field. Add a fallback to prevent nil errors.

Tested locally on some of the pages failing in production at the moment: https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/57dbe1866578633e39930d00