### PR TITLE
Fix slow query with descending sort of Editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -137,7 +137,15 @@ class Edition < ActiveRecord::Base
   end
 
   def self.in_reverse_chronological_order
-    order(arel_table[:public_timestamp].desc, arel_table[:document_id].desc, arel_table[:id].desc)
+    ids = pluck(:id)
+    Edition
+      .unscoped
+      .where(id: ids)
+      .order(
+        arel_table[:public_timestamp].desc,
+        arel_table[:document_id].desc,
+        arel_table[:id].desc
+      )
   end
 
   def self.without_editions_of_type(*edition_classes)


### PR DESCRIPTION
In the `in_reverse_chronological_order` Edition scope, we’re asking
MySQL to sort in descending order by two fields which have a compound
index across them. MySQL can’t use the index because of the descending
order, and it doesn’t support descending indexes. MySQL also performs
the ordering and limiting first before the filtering.

The result of this is that it has to filesort the entire Editions table
with over half a million rows before it can decide that no rows should
be returned. In the Dev VM this can take 1.5 seconds per query. In
production, this is causing crawls of people pages by bots to make
renders take over 15 seconds and cause timeouts for real users.

To address the problem, we split the query into two halves at the point
`in_reverse_chronological_order` is called. Instead of ordering at that
point, we make Rails run the query in MySQL and select the Edition IDs.
We then remove all scoping and create a new scope with just the IDs
we’ve filtered to so far, followed by the ordering statement. This
means MySQL only needs to filesort across the rows we’re interested in.

In the example of selecting David Cameron’s speeches (as he has the
most on Whitehall at present), the initial id selection query takes
23ms on the VM, then the selection of the Editions and ordering takes
30ms. For someone without speeches, the initial query takes 3ms.

This should maintain compatibility for callers of this scope, as we
eventually return an ActiveRecord Relation (scope), despite running a
query in the middle of it.

/cc @alexmuller @gpeng fixes #2759 