### PR TITLE
Fix schema validation failure for contacts.

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -105,7 +105,7 @@ module PublishingApi
     end
 
     def country_name
-      country.title if country
+      country.try(:title) || ""
     end
 
     def updated_at

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -74,4 +74,9 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
 
     assert_equal expected_links, @presented.links
   end
+
+  test "world_location rendered as empty string when not present" do
+    @contact.country = nil
+    assert_equal "", @presented.content[:details][:post_addresses].first[:world_location]
+  end
 end


### PR DESCRIPTION
Missing world_location should be an empty string, not nil.