### PR TITLE
Add meta descriptions

### DIFF
--- a/app/controllers/fatality_notices_controller.rb
+++ b/app/controllers/fatality_notices_controller.rb
@@ -2,6 +2,7 @@ class FatalityNoticesController < DocumentsController
   def show
     @related_policies = document_related_policies
     @document = FatalityNoticePresenter.new(@document, @view_context)
+    set_meta_description(@document.summary)
     set_slimmer_format_header("news")
   end
 

--- a/app/controllers/html_attachments_controller.rb
+++ b/app/controllers/html_attachments_controller.rb
@@ -8,6 +8,7 @@ class HtmlAttachmentsController < PublicFacingController
   around_filter :set_locale_from_attachment
 
   def show
+    set_meta_description(@edition.summary)
   end
 
 private

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -25,6 +25,10 @@ class StatisticsController < DocumentsController
     end
   end
 
+  def show
+    set_meta_description(@document.summary)
+  end
+
 private
 
   def inject_statistics_publication_filter_option_param


### PR DESCRIPTION
This commit adds meta description tags to HTML attachments, statistics and fatality notices, the contents of which are set to the description associated with the relevant document. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them