### PR TITLE
Add meta descriptions

### DIFF
--- a/app/controllers/ministerial_roles_controller.rb
+++ b/app/controllers/ministerial_roles_controller.rb
@@ -14,6 +14,7 @@ class MinisterialRolesController < PublicFacingController
     @also_attends_cabinet = decorated_people_and_their_roles(cabinet_roles)
     @ministers_by_organisation = ministers_by_organisation
     @whips_by_organisation = whips_by_organisation
+    set_meta_description("Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business.")
   end
 
   def show

--- a/app/controllers/operational_fields_controller.rb
+++ b/app/controllers/operational_fields_controller.rb
@@ -6,6 +6,7 @@ class OperationalFieldsController < PublicFacingController
   def show
     @operational_field = OperationalField.friendly.find(params[:id])
     @organisation = Organisation.where(handles_fatalities: true).first
+    set_meta_description("Details about British fatalities for operations in #{@operational_field.name}.")
     set_slimmer_organisations_header([@organisation])
     set_slimmer_page_owner_header(@organisation)
     @fatality_notices = @operational_field.published_fatality_notices.order('first_published_at desc').map do |fatality_notice|

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -15,6 +15,7 @@ class OrganisationsController < PublicFacingController
     else
       @organisations = OrganisationsIndexPresenter.new(
         Organisation.excluding_courts_and_tribunals.listable.ordered_by_name_ignoring_prefix)
+      set_meta_description("What's the latest from a department, agency or public body?")
       render :index
     end
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,6 +6,7 @@ class PeopleController < PublicFacingController
 
     respond_to do |format|
       format.html do
+        set_meta_description("Biography of #{@person.name}.")
         set_slimmer_organisations_header(@person.organisations)
         set_slimmer_page_owner_header(@person.organisations.first)
       end
@@ -15,5 +16,6 @@ class PeopleController < PublicFacingController
 
   def index
     @people = decorate_collection(Person.all, PersonPresenter)
+    set_meta_description("All ministers and senior officials on GOV.UK.")
   end
 end

--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -4,8 +4,13 @@ class WorldLocationsController < PublicFacingController
 
   def index
     respond_to do |format|
-      format.json { redirect_to api_world_locations_path(format: :json) }
-      format.any { @world_locations = WorldLocation.all_by_type }
+      format.json do
+        redirect_to api_world_locations_path(format: :json)
+      end
+      format.any do
+        @world_locations = WorldLocation.all_by_type
+        set_meta_description("What is the UK government doing in a country?")
+      end
     end
   end
 
@@ -20,6 +25,7 @@ class WorldLocationsController < PublicFacingController
         @announcements = latest_presenters(Announcement.published.in_world_location(@world_location), translated: true, count: 2)
         @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
         @worldwide_organisations = @world_location.worldwide_organisations
+        set_meta_description("What the UK government is doing in #{@world_location.name}.")
         set_slimmer_world_locations_header([@world_location])
         set_slimmer_organisations_header(@world_location.worldwide_organisations_with_sponsoring_organisations)
       end

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -7,6 +7,7 @@ class WorldwideOrganisationsController < PublicFacingController
 
   def index
     @worldwide_organisations = WorldwideOrganisation.ordered_by_name
+    set_meta_description("A list of British organisations worldwide.")
   end
 
   def show

--- a/app/helpers/histories_helper.rb
+++ b/app/helpers/histories_helper.rb
@@ -1,0 +1,5 @@
+module HistoriesHelper
+  def meta_description(description)
+    @meta_description = Govspeak::Document.new(description).to_text
+  end
+end

--- a/app/views/classifications/index.html.erb
+++ b/app/views/classifications/index.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Policy Areas" %>
 <% page_class "classifications-index index-list-page" %>
-
+<% meta_description "What is the government doing about a policy area?" %>
 
 <div class="block-1">
   <div class="inner-block">

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -1,5 +1,6 @@
 <% page_title "History of 10 Downing Street" %>
 <% page_class "histories-show" %>
+<% meta_description "The history of 10 Downing Street." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/histories/11_downing_street.html.erb
+++ b/app/views/histories/11_downing_street.html.erb
@@ -1,5 +1,6 @@
 <% page_title "History of 11 Downing Street" %>
 <% page_class "histories-show" %>
+<% meta_description "The history of 11 Downing Street." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/histories/1_horse_guards_road.html.erb
+++ b/app/views/histories/1_horse_guards_road.html.erb
@@ -1,5 +1,6 @@
 <% page_title "History of 1 Horse Guards Road" %>
 <% page_class "histories-show" %>
+<% meta_description "The history of 1 Horse Guards Road." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -1,6 +1,6 @@
 <% page_title "History of the UK government" %>
 <% page_class "home-history" %>
-
+<% meta_description "In this section you can read short biographies of notable people and explore the history of government buildings. You can also search our online records and read articles and blog posts by historians." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/histories/king_charles_street.html.erb
+++ b/app/views/histories/king_charles_street.html.erb
@@ -1,5 +1,6 @@
 <% page_title "History of King Charles Street" %>
 <% page_class "histories-show" %>
+<% meta_description "The history of King Charles Street." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -1,5 +1,6 @@
 <% page_title "History of Lancaster House" %>
 <% page_class "histories-show" %>
+<% meta_description "The history of Lancaster House." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/home/get_involved.html.erb
+++ b/app/views/home/get_involved.html.erb
@@ -1,6 +1,6 @@
 <% page_title "Get involved" %>
 <% page_class "get-involved" %>
-
+<% meta_description "Find out how you can engage with government directly, and take part locally, nationally or internationally." %>
 
 <header class="block headings-block">
   <div class="inner-block floated-children">

--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -1,5 +1,6 @@
 <% page_title "How government works" %>
 <% page_class "inside_gov_how-gov-works" %>
+<% meta_description "In the UK, the Prime Minister leads the government with the support of the Cabinet and ministers. You can find out who runs government and how government is run, as well as learning about the history of government." %>
 
 <div id="how-government-works">
   <header class="block headings-block">


### PR DESCRIPTION
This commit adds meta description tags to various pages and formats, the contents of which are set to the description associated with the relevant page/format. This adds descriptions to external search engine results when the pages are re-indexed.

The pages/formats affected are:

* `/government/get-involved`
* `/government/how-government-works`
* `/government/ministers`
* `/government/organisations`
* `/government/topics`
* `/government/world/organisations`
* Everything under `/government/fields-of-operation`
* Everything under `/government/history`
* Everything under `/government/people`
* Everything under `/government/world/locations`

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them

Follow up to https://github.com/alphagov/whitehall/pull/2762