### PR TITLE
Add operational field placeholder

### DIFF
--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -1,5 +1,5 @@
 class OperationalField < ActiveRecord::Base
-  include HasContentId
+  include PublishesToPublishingApi
   include Searchable
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -1,4 +1,5 @@
 class OperationalField < ActiveRecord::Base
+  include HasContentId
   include Searchable
 
   validates :name, presence: true, uniqueness: true

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -1,0 +1,35 @@
+module PublishingApi
+  class OperationalFieldPresenter
+    attr_reader :links, :update_type
+
+    def initialize(operational_field, update_type: nil)
+      @operational_field = operational_field
+      @links = {}
+      @update_type = update_type
+    end
+
+    def content_id
+      operational_field.content_id
+    end
+
+    def content
+      {}.tap { |content|
+        content.merge!(PayloadBuilder::PolymorphicPath.for(operational_field))
+        content.merge!(
+          description: operational_field.description,
+          details: {},
+          document_type: "field_of_operation",
+          locale: "en",
+          publishing_app: "whitehall",
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          schema_name: "placeholder",
+          title: operational_field.name,
+        )
+      }
+    end
+
+  private
+
+    attr_reader :operational_field
+  end
+end

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -2,10 +2,10 @@ module PublishingApi
   class OperationalFieldPresenter
     attr_reader :links, :update_type
 
-    def initialize(operational_field, update_type: nil)
+    def initialize(operational_field, **_)
       @operational_field = operational_field
       @links = {}
-      @update_type = update_type
+      @update_type = "major"
     end
 
     def content_id

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -37,6 +37,8 @@ private
       PublishingApi::WorldwideOrganisationPresenter
     when ::Contact
       PublishingApi::ContactPresenter
+    when OperationalField
+      PublishingApi::OperationalFieldPresenter
     else
       raise UndefinedPresenterError, "Could not find presenter class for: #{model.inspect}"
     end

--- a/db/data_migration/20160923135447_set_content_id_on_operational_fields.rb
+++ b/db/data_migration/20160923135447_set_content_id_on_operational_fields.rb
@@ -1,0 +1,1 @@
+OperationalField.all.each(&:save)

--- a/test/integration/operational_field_publishing_test.rb
+++ b/test/integration/operational_field_publishing_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+
+class OperationalFieldPublishingTest < ActiveSupport::TestCase
+  #api calls happen in after commit so we need to disable transactions
+  self.use_transactional_fixtures = false
+
+  setup do
+    DatabaseCleaner.clean_with :truncation
+    stub_any_publishing_api_call
+  end
+
+  test "OperationalField is published to the Publishing API on save" do
+    operational_field = build(:operational_field)
+    operational_field.save!
+
+    assert_publishing_api_put_content(
+      operational_field.content_id,
+      PublishingApiPresenters.presenter_for(operational_field).content
+    )
+
+    assert_publishing_api_publish(
+      operational_field.content_id,
+      { update_type: nil, locale: 'en' },
+      1
+    )
+  end
+end

--- a/test/integration/operational_field_publishing_test.rb
+++ b/test/integration/operational_field_publishing_test.rb
@@ -21,7 +21,7 @@ class OperationalFieldPublishingTest < ActiveSupport::TestCase
 
     assert_publishing_api_publish(
       operational_field.content_id,
-      { update_type: nil, locale: 'en' },
+      { update_type: 'major', locale: 'en' },
       1
     )
   end

--- a/test/unit/operational_field_test.rb
+++ b/test/unit/operational_field_test.rb
@@ -1,25 +1,25 @@
 require "test_helper"
 
 class OperationalFieldTest < ActiveSupport::TestCase
-  test "should be invalid without a name" do
-    operational_field = build(:operational_field, name: '')
+  test "is invalid without a name" do
+    operational_field = build(:operational_field, name: "")
     refute operational_field.valid?
   end
 
-  test "should be invalid without a unique name" do
+  test "is invalid without a unique name" do
     existing_operational_field = create(:operational_field)
     new_operational_field = build(:operational_field, name: existing_operational_field.name)
     refute new_operational_field.valid?
   end
 
-  test 'should set a slug from the field name' do
-    field = create(:operational_field, name: 'Field Name')
-    assert_equal 'field-name', field.slug
+  test "sets a slug from the field name" do
+    field = create(:operational_field, name: "Field Name")
+    assert_equal "field-name", field.slug
   end
 
-  test 'should not change the slug when the field name changes' do
-    field = create(:operational_field, name: 'Field Name')
-    field.update_attributes(name: 'New Field Name')
-    assert_equal 'field-name', field.slug
+  test "does not change the slug when the field name changes" do
+    field = create(:operational_field, name: "Field Name")
+    field.update_attributes(name: "New Field Name")
+    assert_equal "field-name", field.slug
   end
 end

--- a/test/unit/operational_field_test.rb
+++ b/test/unit/operational_field_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class OperationalFieldTest < ActiveSupport::TestCase
+  test "has a content_id when saved" do
+    operational_field = create(:operational_field)
+    assert operational_field.content_id
+  end
+
   test "is invalid without a name" do
     operational_field = build(:operational_field, name: "")
     refute operational_field.valid?

--- a/test/unit/operational_field_test.rb
+++ b/test/unit/operational_field_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class OperationalFieldTest < ActiveSupport::TestCase
+  test "publishes to PublishingApi" do
+    assert OperationalField.new.is_a?(PublishesToPublishingApi)
+  end
+
   test "has a content_id when saved" do
     operational_field = create(:operational_field)
     assert operational_field.content_id

--- a/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/operational_field_presenter_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
+  setup do
+    @operational_field = create(
+      :operational_field,
+      name: "Operational Field name",
+      description: "Operational Field description"
+    )
+
+    @presented_operational_field = PublishingApi::OperationalFieldPresenter.new(@operational_field)
+    @presented_content = @presented_operational_field.content
+  end
+
+  test "it presents a valid placeholder content item" do
+    assert_valid_against_schema @presented_content, "placeholder"
+  end
+
+  test "it delegates the content id" do
+    assert_equal @operational_field.content_id, @presented_operational_field.content_id
+  end
+
+  test "it presents the name as title" do
+    assert_equal "Operational Field name", @presented_content[:title]
+  end
+
+  test "it presents the description" do
+    assert_equal "Operational Field description", @presented_content[:description]
+  end
+
+  test "it presents the base_path" do
+    assert_equal "/government/fields-of-operation/operational-field-name", @presented_content[:base_path]
+  end
+
+  test "it presents the publishing_app as whitehall" do
+    assert_equal 'whitehall', @presented_content[:publishing_app]
+  end
+
+  test "it presents the rendering_app as whitehall-frontend" do
+    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  end
+
+  test "it presents the schema_name as placeholder" do
+    assert_equal "placeholder", @presented_content[:schema_name]
+  end
+
+  test "it presents the document type as field_of_operation" do
+    assert_equal "field_of_operation", @presented_content[:document_type]
+  end
+
+  test "it presents the global process wide locale as the locale of the operational_field" do
+    assert_equal "en", @presented_content[:locale]
+  end
+
+  test "it presents empty details" do
+    assert_empty @presented_content[:details]
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -113,4 +113,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(build(:document_collection))
     assert_equal PublishingApi::DocumentCollectionPlaceholderPresenter, presenter.class
   end
+
+  test ".presenter_for returns an OperationalFieldPresenter for an OperationalField" do
+    presenter = PublishingApiPresenters.presenter_for(build(:operational_field))
+    assert_equal PublishingApi::OperationalFieldPresenter, presenter.class
+  end
 end


### PR DESCRIPTION
Migrates Fields of Operation as placeholders so that they can be linked to from Fatality Notices.

**Depends on #2766 being deployed.**

Mobbed on by @andrewgarner @bevanloon @binaryberry @gpeng @mgrassotti @nickcolley  

[See Trello](https://trello.com/c/0UAMj5gj/407-8-fatality-notice-migration-implement-publishing-of-format-to-publishing-api-large)