### PR TITLE
Add content_id migration for OperationalField

### DIFF
--- a/db/migrate/20160923134615_add_content_id_to_operational_field.rb
+++ b/db/migrate/20160923134615_add_content_id_to_operational_field.rb
@@ -1,0 +1,5 @@
+class AddContentIdToOperationalField < ActiveRecord::Migration
+  def change
+    add_column :operational_fields, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160805122401) do
+ActiveRecord::Schema.define(version: 20160923134615) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -743,6 +743,7 @@ ActiveRecord::Schema.define(version: 20160805122401) do
     t.datetime "updated_at"
     t.text     "description", limit: 65535
     t.string   "slug",        limit: 255
+    t.string   "content_id",  limit: 255
   end
 
   add_index "operational_fields", ["slug"], name: "index_operational_fields_on_slug", using: :btree


### PR DESCRIPTION
This is required to allow us to generate placeholders in the Content Store for Operational Fields.

Trello: https://trello.com/c/0UAMj5gj
Mob: @andrewgarner @bevanloon @gpeng @mgrassotti