### PR TITLE
Send complete Fatality Notice to Publishing API

### DIFF
--- a/app/presenters/fatality_notice_presenter.rb
+++ b/app/presenters/fatality_notice_presenter.rb
@@ -2,5 +2,4 @@ class FatalityNoticePresenter < Whitehall::Decorators::Decorator
   include EditionPresenterHelper
 
   delegate_instance_methods_of FatalityNotice
-
 end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -39,7 +39,8 @@ module PublishingApi
 
     def links
       {
-        organisations: item.organisations.map(&:content_id)
+        organisations: item.organisations.map(&:content_id),
+        policy_areas: item.topics.map(&:content_id)
       }
     end
   end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -18,6 +18,7 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: "fatality_notice",
+          details: details
         )
       }
     end
@@ -25,5 +26,9 @@ module PublishingApi
   private
 
     attr_reader :item
+
+    def details
+      { body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item) }
+    end
   end
 end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -18,7 +18,8 @@ module PublishingApi
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: "fatality_notice",
-          details: details
+          details: details,
+          links: links
         )
       }
     end
@@ -33,6 +34,12 @@ module PublishingApi
         first_public_at: item.first_public_at,
         change_history: item.change_history.as_json,
         emphasised_organisations: item.lead_organisations.map(&:content_id)
+      }
+    end
+
+    def links
+      {
+        organisations: item.organisations.map(&:content_id)
       }
     end
   end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -14,6 +14,7 @@ module PublishingApi
       content[:public_updated_at] = item.public_timestamp || item.updated_at
       content.merge!(BaseItemPresenter.new(item).base_attributes)
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+      content[:rendering_app] = Whitehall::RenderingApp::WHITEHALL_FRONTEND
       content
     end
 

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -10,8 +10,9 @@ module PublishingApi
 
     def content
       content = {}
-      content.merge!(BaseItemPresenter.new(item).base_attributes)
       content[:description] = item.summary
+      content.merge!(BaseItemPresenter.new(item).base_attributes)
+      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content
     end
 

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -40,7 +40,8 @@ module PublishingApi
     def links
       {
         organisations: item.organisations.map(&:content_id),
-        policy_areas: item.topics.map(&:content_id)
+        policy_areas: item.topics.map(&:content_id),
+        field_of_operation: [item.operational_field.content_id]
       }
     end
   end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -28,7 +28,10 @@ module PublishingApi
     attr_reader :item
 
     def details
-      { body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item) }
+      {
+        body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
+        first_public_at: item.first_public_at
+      }
     end
   end
 end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -15,6 +15,7 @@ module PublishingApi
       content.merge!(BaseItemPresenter.new(item).base_attributes)
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content[:rendering_app] = Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      content[:schema_name] = "fatality_notice"
       content
     end
 

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -1,0 +1,22 @@
+module PublishingApi
+  class FatalityNoticePresenter
+    def initialize(item)
+      @item = item
+    end
+
+    def content_id
+      item.content_id
+    end
+
+    def content
+      content = {}
+      content.merge!(BaseItemPresenter.new(item).base_attributes)
+      content[:description] = item.summary
+      content
+    end
+
+  private
+
+    attr_reader :item
+  end
+end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -30,7 +30,8 @@ module PublishingApi
     def details
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
-        first_public_at: item.first_public_at
+        first_public_at: item.first_public_at,
+        change_history: item.change_history.as_json
       }
     end
   end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -16,6 +16,7 @@ module PublishingApi
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content[:rendering_app] = Whitehall::RenderingApp::WHITEHALL_FRONTEND
       content[:schema_name] = "fatality_notice"
+      content[:document_type] = "fatality_notice"
       content
     end
 

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -11,6 +11,7 @@ module PublishingApi
     def content
       content = {}
       content[:description] = item.summary
+      content[:public_updated_at] = item.public_timestamp || item.updated_at
       content.merge!(BaseItemPresenter.new(item).base_attributes)
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -31,7 +31,8 @@ module PublishingApi
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
         first_public_at: item.first_public_at,
-        change_history: item.change_history.as_json
+        change_history: item.change_history.as_json,
+        emphasised_organisations: item.lead_organisations.map(&:content_id)
       }
     end
   end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -9,15 +9,17 @@ module PublishingApi
     end
 
     def content
-      content = {}
-      content[:description] = item.summary
-      content[:public_updated_at] = item.public_timestamp || item.updated_at
-      content.merge!(BaseItemPresenter.new(item).base_attributes)
-      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content[:rendering_app] = Whitehall::RenderingApp::WHITEHALL_FRONTEND
-      content[:schema_name] = "fatality_notice"
-      content[:document_type] = "fatality_notice"
-      content
+      {}.tap { |content|
+        content.merge!(BaseItemPresenter.new(item).base_attributes)
+        content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+        content.merge!(
+          description: item.summary,
+          document_type: "fatality_notice",
+          public_updated_at: item.public_timestamp || item.updated_at,
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          schema_name: "fatality_notice",
+        )
+      }
     end
 
   private

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -52,6 +52,8 @@ private
       PublishingApi::DocumentCollectionPlaceholderPresenter
     when ::DetailedGuide
       PublishingApi::DetailedGuidePresenter
+    when ::FatalityNotice
+      PublishingApi::FatalityNoticePresenter
     when ::Publication
       PublishingApi::PublicationPresenter
     else

--- a/db/data_migration/20160928102653_republish_fatality_notices.rb
+++ b/db/data_migration/20160928102653_republish_fatality_notices.rb
@@ -1,0 +1,2 @@
+publisher = DataHygiene::PublishingApiDocumentRepublisher.new(FatalityNotice)
+publisher.perform

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -58,7 +58,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     assert_valid_against_schema(presented_item.content, 'case_study')
     assert_valid_against_links_schema({ links: presented_item.links }, 'case_study')
     assert_equal expected_content.except(:details), presented_item.content.except(:details)
-    # We test for HTML equivlance rather than string equality to get around
+    # We test for HTML equivalance rather than string equality to get around
     # inconsistencies with line breaks between different XML libraries
     assert_equivalent_html(
       expected_content[:details].delete(:body),

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -69,3 +69,21 @@ class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupp
     assert_equal @expected_time, @presented_fatality_notice.content[:public_updated_at]
   end
 end
+
+class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCase
+  setup do
+    @fatality_notice = create(
+      :fatality_notice,
+      body: "*Test string*"
+    )
+
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+  end
+
+  test "it presents the Govspeak body as details rendered as HTML" do
+    assert_equal(
+      "<div class=\"govspeak\"><p><em>Test string</em></p>\n</div>",
+      @presented_fatality_notice.content[:details][:body]
+    )
+  end
+end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -6,7 +6,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
       :fatality_notice,
       title: "Fatality Notice title",
       summary: "Fatality Notice summary",
-      first_published_at: Time.now
+      first_published_at: Time.zone.now
     )
 
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
@@ -60,7 +60,7 @@ end
 
 class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupport::TestCase
   setup do
-    @expected_time = Time.parse("10/01/2016")
+    @expected_time = Time.zone.parse("10/01/2016")
     @fatality_notice = create(
       :fatality_notice
     )

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -1,30 +1,29 @@
 require 'test_helper'
 
 class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
-  def present(edition)
-    PublishingApi::FatalityNoticePresenter.new(edition)
+  setup do
+    fatality_notice = build(
+      :fatality_notice,
+      title: "Fatality Notice title",
+      summary: "Fatality Notice summary"
+    )
+
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(fatality_notice)
   end
 
-  def build_fatality_notice(arguments)
-    build(:fatality_notice, arguments)
-  end
+  test "it delegates the content id" do
+    presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
+      stub(content_id: "c07da942-7e01-4809-adda-cc31df098e5b")
+    )
 
-  def build_presenter(arguments)
-    present(build_fatality_notice(arguments))
-  end
-
-  test "it presents the content id" do
-    presented_fatality_notice = present(stub(content_id: "c07da942-7e01-4809-adda-cc31df098e5b"))
     assert_equal "c07da942-7e01-4809-adda-cc31df098e5b", presented_fatality_notice.content_id
   end
 
   test "it presents the title" do
-    presented_fatality_notice = build_presenter(title: "Fatality Notice title")
-    assert_equal "Fatality Notice title", presented_fatality_notice.content[:title]
+    assert_equal "Fatality Notice title", @presented_fatality_notice.content[:title]
   end
 
   test "it presents the summary as the description" do
-    presented_fatality_notice = build_presenter(summary: "Fatality Notice summary")
-    assert_equal "Fatality Notice summary", presented_fatality_notice.content[:description]
+    assert_equal "Fatality Notice summary", @presented_fatality_notice.content[:description]
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -5,11 +5,16 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
     @fatality_notice = create(
       :fatality_notice,
       title: "Fatality Notice title",
-      summary: "Fatality Notice summary"
+      summary: "Fatality Notice summary",
+      first_published_at: Time.now
     )
 
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
     @presented_content = I18n.with_locale("de") { @presented_fatality_notice.content }
+  end
+
+  test "it presents a valid fatality_notice content item" do
+    assert_valid_against_schema @presented_content, "fatality_notice"
   end
 
   test "it delegates the content id" do
@@ -130,7 +135,7 @@ class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::
   setup do
     @fatality_notice = create(:fatality_notice)
     presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
-    @presented_links = presented_fatality_notice.content[:links]
+    @presented_links = presented_fatality_notice.links
   end
 
   test "it presents the organisation content_ids as links, organisations" do
@@ -152,5 +157,42 @@ class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::
       [@fatality_notice.operational_field.content_id],
       @presented_links[:field_of_operation]
     )
+  end
+end
+
+class PublishingApi::FatalityNoticePresenterUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
+      create(:fatality_notice, minor_change: false)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "major", @presented_fatality_notice.update_type
+  end
+end
+
+class PublishingApi::FatalityNoticePresenterMinorUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
+      create(:fatality_notice, minor_change: true)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "minor", @presented_fatality_notice.update_type
+  end
+end
+
+class PublishingApi::FatalityNoticePresenterUpdateTypeArgumentTest < ActiveSupport::TestCase
+  setup do
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
+      create(:fatality_notice, minor_change: true),
+      update_type: "major"
+    )
+  end
+
+  test "presents based on the supplied update type argument" do
+    assert_equal "major", @presented_fatality_notice.update_type
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -108,4 +108,15 @@ class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport
   test "it presents first_public_at as details, first_public_at" do
     assert_equal @expected_time, @presented_fatality_notice.content[:details][:first_public_at]
   end
+
+  test "it presents change_history" do
+    change_history = [
+      {
+        "public_timestamp" => @expected_time,
+        "note" => "change-note"
+      }
+    ]
+
+    assert_equal change_history, @presented_fatality_notice.content[:details][:change_history]
+  end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
+  def present(edition)
+    PublishingApi::FatalityNoticePresenter.new(edition)
+  end
+
+  def build_fatality_notice(arguments)
+    build(:fatality_notice, arguments)
+  end
+
+  def build_presenter(arguments)
+    present(build_fatality_notice(arguments))
+  end
+
+  test "it presents the content id" do
+    presented_fatality_notice = present(stub(content_id: "c07da942-7e01-4809-adda-cc31df098e5b"))
+    assert_equal "c07da942-7e01-4809-adda-cc31df098e5b", presented_fatality_notice.content_id
+  end
+
+  test "it presents the title" do
+    presented_fatality_notice = build_presenter(title: "Fatality Notice title")
+    assert_equal "Fatality Notice title", presented_fatality_notice.content[:title]
+  end
+
+  test "it presents the summary as the description" do
+    presented_fatality_notice = build_presenter(summary: "Fatality Notice summary")
+    assert_equal "Fatality Notice summary", presented_fatality_notice.content[:description]
+  end
+end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -86,4 +86,26 @@ class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCas
       @presented_fatality_notice.content[:details][:body]
     )
   end
+
+  test "it presents first_public_at as nil for draft" do
+    assert_nil @presented_fatality_notice.content[:details][:first_published_at]
+  end
+end
+
+class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport::TestCase
+  setup do
+    @expected_time = Time.new(2015, 12, 25)
+    @fatality_notice = create(
+      :fatality_notice,
+      :published,
+      body: "*Test string*",
+      first_published_at: @expected_time
+    )
+
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+  end
+
+  test "it presents first_public_at as details, first_public_at" do
+    assert_equal @expected_time, @presented_fatality_notice.content[:details][:first_public_at]
+  end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -37,7 +37,11 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
 
   test "it presents the rendering_app as whitehall-frontend" do
     assert_equal 'whitehall-frontend', @presented_fatality_notice.content[:rendering_app]
-  end  
+  end
+
+  test "it presents the schema_name as fatality_notice" do
+    assert_equal "fatality_notice", @presented_fatality_notice.content[:schema_name]
+  end
 end
 
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -42,6 +42,10 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents the schema_name as fatality_notice" do
     assert_equal "fatality_notice", @presented_fatality_notice.content[:schema_name]
   end
+
+  test "it presents the document type as fatality_notice" do
+    assert_equal "fatality_notice", @presented_fatality_notice.content[:document_type]
+  end
 end
 
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -125,3 +125,18 @@ class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport
     )
   end
 end
+
+class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::TestCase
+  setup do
+    @fatality_notice = create(:fatality_notice)
+    presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+    @presented_links = presented_fatality_notice.content[:links]
+  end
+
+  test "it presents the organisation content_ids as links, organisations" do
+    assert_equal(
+      @fatality_notice.organisations.map(&:content_id),
+      @presented_links[:organisations]
+    )
+  end
+end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -24,6 +24,26 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the base_path" do
-    assert_equal  "/government/fatalities/fatality-notice-title", @presented_fatality_notice.content[:base_path]
+    assert_equal "/government/fatalities/fatality-notice-title", @presented_fatality_notice.content[:base_path]
+  end
+
+  test "it presents updated_at if public_timestamp is nil" do
+    assert_equal @fatality_notice.updated_at, @presented_fatality_notice.content[:public_updated_at]
+  end
+end
+
+
+class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupport::TestCase
+  setup do
+    @expected_time = Time.parse("10/01/2016")
+    @fatality_notice = create(
+      :fatality_notice
+    )
+    @fatality_notice.public_timestamp = @expected_time
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+  end
+
+  test "it presents public_timestamp if it exists" do
+    assert_equal @expected_time, @presented_fatality_notice.content[:public_updated_at]
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -146,4 +146,11 @@ class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::
       @presented_links[:policy_areas]
     )
   end
+
+  test "it presents the field of operation as links, field_of_operation" do
+    assert_equal(
+      [@fatality_notice.operational_field.content_id],
+      @presented_links[:field_of_operation]
+    )
+  end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -46,6 +46,12 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents the document type as fatality_notice" do
     assert_equal "fatality_notice", @presented_fatality_notice.content[:document_type]
   end
+
+  test "it presents the global process wide locale as the locale of the fatality_notice" do
+    I18n.with_locale "de" do
+      assert_equal "de", @presented_fatality_notice.content[:locale]
+    end
+  end
 end
 
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -30,6 +30,14 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents updated_at if public_timestamp is nil" do
     assert_equal @fatality_notice.updated_at, @presented_fatality_notice.content[:public_updated_at]
   end
+
+  test "it presents the publishing_app as whitehall" do
+    assert_equal 'whitehall', @presented_fatality_notice.content[:publishing_app]
+  end
+
+  test "it presents the rendering_app as whitehall-frontend" do
+    assert_equal 'whitehall-frontend', @presented_fatality_notice.content[:rendering_app]
+  end  
 end
 
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -119,4 +119,11 @@ class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport
 
     assert_equal change_history, @presented_fatality_notice.content[:details][:change_history]
   end
+
+  test "it presents the lead organisation content_ids as details, emphasised_organisations" do
+    assert_equal(
+      @fatality_notice.lead_organisations.map(&:content_id),
+      @presented_fatality_notice.content[:details][:emphasised_organisations]
+    )
+  end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -2,21 +2,17 @@ require 'test_helper'
 
 class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   setup do
-    fatality_notice = build(
+    @fatality_notice = create(
       :fatality_notice,
       title: "Fatality Notice title",
       summary: "Fatality Notice summary"
     )
 
-    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(fatality_notice)
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
   end
 
   test "it delegates the content id" do
-    presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
-      stub(content_id: "c07da942-7e01-4809-adda-cc31df098e5b")
-    )
-
-    assert_equal "c07da942-7e01-4809-adda-cc31df098e5b", presented_fatality_notice.content_id
+    assert_equal @fatality_notice.content_id, @presented_fatality_notice.content_id
   end
 
   test "it presents the title" do
@@ -25,5 +21,9 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
 
   test "it presents the summary as the description" do
     assert_equal "Fatality Notice summary", @presented_fatality_notice.content[:description]
+  end
+
+  test "it presents the base_path" do
+    assert_equal  "/government/fatalities/fatality-notice-title", @presented_fatality_notice.content[:base_path]
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -9,6 +9,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
     )
 
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+    @presented_content = I18n.with_locale("de") { @presented_fatality_notice.content }
   end
 
   test "it delegates the content id" do
@@ -16,44 +17,41 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the title" do
-    assert_equal "Fatality Notice title", @presented_fatality_notice.content[:title]
+    assert_equal "Fatality Notice title", @presented_content[:title]
   end
 
   test "it presents the summary as the description" do
-    assert_equal "Fatality Notice summary", @presented_fatality_notice.content[:description]
+    assert_equal "Fatality Notice summary", @presented_content[:description]
   end
 
   test "it presents the base_path" do
-    assert_equal "/government/fatalities/fatality-notice-title", @presented_fatality_notice.content[:base_path]
+    assert_equal "/government/fatalities/fatality-notice-title", @presented_content[:base_path]
   end
 
   test "it presents updated_at if public_timestamp is nil" do
-    assert_equal @fatality_notice.updated_at, @presented_fatality_notice.content[:public_updated_at]
+    assert_equal @fatality_notice.updated_at, @presented_content[:public_updated_at]
   end
 
   test "it presents the publishing_app as whitehall" do
-    assert_equal 'whitehall', @presented_fatality_notice.content[:publishing_app]
+    assert_equal 'whitehall', @presented_content[:publishing_app]
   end
 
   test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal 'whitehall-frontend', @presented_fatality_notice.content[:rendering_app]
+    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as fatality_notice" do
-    assert_equal "fatality_notice", @presented_fatality_notice.content[:schema_name]
+    assert_equal "fatality_notice", @presented_content[:schema_name]
   end
 
   test "it presents the document type as fatality_notice" do
-    assert_equal "fatality_notice", @presented_fatality_notice.content[:document_type]
+    assert_equal "fatality_notice", @presented_content[:document_type]
   end
 
   test "it presents the global process wide locale as the locale of the fatality_notice" do
-    I18n.with_locale "de" do
-      assert_equal "de", @presented_fatality_notice.content[:locale]
-    end
+    assert_equal "de", @presented_content[:locale]
   end
 end
-
 
 class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupport::TestCase
   setup do
@@ -77,18 +75,18 @@ class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCas
       body: "*Test string*"
     )
 
-    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+    @presented_details = PublishingApi::FatalityNoticePresenter.new(@fatality_notice).content[:details]
   end
 
   test "it presents the Govspeak body as details rendered as HTML" do
     assert_equal(
       "<div class=\"govspeak\"><p><em>Test string</em></p>\n</div>",
-      @presented_fatality_notice.content[:details][:body]
+      @presented_details[:body]
     )
   end
 
   test "it presents first_public_at as nil for draft" do
-    assert_nil @presented_fatality_notice.content[:details][:first_published_at]
+    assert_nil @presented_details[:first_published_at]
   end
 end
 
@@ -102,11 +100,11 @@ class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport
       first_published_at: @expected_time
     )
 
-    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+    @presented_details = PublishingApi::FatalityNoticePresenter.new(@fatality_notice).content[:details]
   end
 
   test "it presents first_public_at as details, first_public_at" do
-    assert_equal @expected_time, @presented_fatality_notice.content[:details][:first_public_at]
+    assert_equal @expected_time, @presented_details[:first_public_at]
   end
 
   test "it presents change_history" do
@@ -117,13 +115,13 @@ class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport
       }
     ]
 
-    assert_equal change_history, @presented_fatality_notice.content[:details][:change_history]
+    assert_equal change_history, @presented_details[:change_history]
   end
 
   test "it presents the lead organisation content_ids as details, emphasised_organisations" do
     assert_equal(
       @fatality_notice.lead_organisations.map(&:content_id),
-      @presented_fatality_notice.content[:details][:emphasised_organisations]
+      @presented_details[:emphasised_organisations]
     )
   end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -139,4 +139,11 @@ class PublishingApi::PublishedFatalityNoticePresenterLinksTest < ActiveSupport::
       @presented_links[:organisations]
     )
   end
+
+  test "it presents the topics content_ids as links, policy_areas" do
+    assert_equal(
+      @fatality_notice.topics.map(&:content_id),
+      @presented_links[:policy_areas]
+    )
+  end
 end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -118,4 +118,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(build(:operational_field))
     assert_equal PublishingApi::OperationalFieldPresenter, presenter.class
   end
+
+  test ".presenter_for returns a FatalityNoticePresenter for a FatalityNotice" do
+    presenter = PublishingApiPresenters.presenter_for(build(:fatality_notice))
+    assert_equal PublishingApi::FatalityNoticePresenter, presenter.class
+  end
 end


### PR DESCRIPTION
- Add functionality to present the Fatality Notice document format for the Publishing API
- Adds data migration to republish all Fatality Notices

[See Trello](https://trello.com/c/0UAMj5gj)

Mobbed on by @mgrassotti @gpeng @andrewgarner @bevanloon @nickcolley @binaryberry 🎉 👯  👍

