### PR TITLE
Add related mainstream sync check

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -64,7 +64,7 @@ module PublishingApi
     end
 
     def first_public_at
-      (item.document.published? ? item.first_public_at : item.document.created_at).try(:iso8601)
+      item.document.published? ? item.first_public_at : item.document.created_at
     end
 
 

--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -27,9 +27,14 @@ module SyncChecker
       end
 
       def expected_details_hash(edition)
-        super.merge(
-          related_mainstream_content: related_mainstream_content_ids(edition)
-        )
+        super.tap do |expected_details_hash|
+          expected_details_hash.merge(
+            national_applicability: edition.national_applicability
+          ) if edition.nation_inapplicabilities.any?
+          expected_details_hash.merge(
+            related_mainstream_content: related_mainstream_content_ids(edition)
+          )
+        end
       end
 
     private

--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -14,12 +14,28 @@ module SyncChecker
               .reject(&:unpublishing)
               .map(&:content_id)
               .uniq
+          ),
+          Checks::LinksCheck.new(
+            "related_mainstream_content",
+            related_mainstream_content_ids(edition_expected_in_live)
           )
         ]
       end
 
       def document_type
         "detailed_guide"
+      end
+
+      def expected_details_hash(edition)
+        super.merge(
+          related_mainstream_content: related_mainstream_content_ids(edition)
+        )
+      end
+
+    private
+
+      def related_mainstream_content_ids(edition)
+        edition.related_mainstreams.pluck(:content_id)
       end
     end
   end

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -134,9 +134,7 @@ module SyncChecker
           body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(edition),
           change_history: edition.change_history.as_json,
           emphasised_organisations: edition.lead_organisations.map(&:content_id),
-          first_public_at: first_public_at(edition),
-          political: edition.political?,
-          government: expected_government_value(edition)
+          first_public_at: first_public_at(edition)
         }
       end
 
@@ -165,7 +163,13 @@ module SyncChecker
       end
 
       def first_public_at(edition)
-        (document.published? ? edition.first_public_at : document.created_at).try(:iso8601)
+        first_public_at = if document.published?
+                            edition.first_public_at
+                          else
+                            document.created_at
+                          end
+
+        first_public_at.to_datetime.rfc3339(3)
       end
 
       def expected_government_value(edition)

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -138,13 +138,6 @@ module SyncChecker
           political: edition.political?,
           government: expected_government_value(edition)
         }
-        expected_details.tap do |details_hash|
-          details_hash.merge(
-            {
-              national_applicability: edition.national_applicability
-            }
-          ) if edition.nation_inapplicabilities.any?
-        end
       end
 
     private

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -51,7 +51,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       redirects: [],
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
-        first_public_at: detailed_guide.created_at.iso8601,
+        first_public_at: detailed_guide.created_at,
         change_history: [],
         tags: {
           browse_pages: [],


### PR DESCRIPTION
Adds a check for the `related_mainstream_content` in both links and details to the `DetailedGuide` sync checks.

Also fixes date format inconsistencies and moves `national_applicabilities` out of `EditionBase` as it isn't common to all `Edition` formats.

[Trello](https://trello.com/c/CkHu0suq/317-6-detailed-guides-migration-final-tasks-deploy-1-medium)