### PR TITLE
Fatality notice sync checks

### DIFF
--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -43,10 +43,15 @@ module PublishingApi
     def details
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
-        first_public_at: item.first_public_at,
+        first_public_at: first_public_at,
         change_history: item.change_history.as_json,
         emphasised_organisations: item.lead_organisations.map(&:content_id)
       }
+    end
+
+    def first_public_at
+      document = item.document
+      document.published? ? item.first_public_at : document.created_at
     end
   end
 end

--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -31,6 +31,7 @@ module SyncChecker
           expected_details_hash.merge(
             national_applicability: edition.national_applicability
           ) if edition.nation_inapplicabilities.any?
+
           expected_details_hash.merge(
             related_mainstream_content: related_mainstream_content_ids(edition)
           )

--- a/lib/sync_checker/formats/fatality_notice_check.rb
+++ b/lib/sync_checker/formats/fatality_notice_check.rb
@@ -1,0 +1,20 @@
+module SyncChecker
+  module Formats
+    class FatalityNoticeCheck < EditionBase
+      def root_path
+        "/government/fatalities/"
+      end
+
+      def rendering_app
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+
+      def checks_for_live(locale)
+        super << Checks::LinksCheck.new(
+          "field_of_operation",
+          [edition_expected_in_live.operational_field.content_id]
+        )
+      end
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -73,6 +73,37 @@ class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupp
   end
 end
 
+class PublishingApi::DraftFatalityNoticePresenter < ActiveSupport::TestCase
+  test "it presents the Fatality Notice's parent document created_at as first_public_at" do
+    presented_notice = PublishingApi::FatalityNoticePresenter.new(
+      create(:draft_fatality_notice) do |fatality_notice|
+        fatality_notice.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      Date.new(2015, 4, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+class PublishingApi::DraftFatalityBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
+  test "it presents the Fatality Notice's first_public_at" do
+    presented_notice = PublishingApi::FatalityNoticePresenter.new(
+      create(:published_fatality_notice) do |fatality_notice|
+        fatality_notice.stubs(:first_public_at).returns(Date.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      Date.new(2015, 04, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+
 class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCase
   setup do
     @fatality_notice = create(


### PR DESCRIPTION
Adds sync checks for the Fatality Notice format as part of ongoing migration work.

[Trello](https://trello.com/c/0UAMj5gj/407-8-fatality-notice-migration-implement-publishing-of-format-to-publishing-api-large)

Also fixes `first_public_at` behaviour in `FatalityNoticePresenter` to be consistent with previously migrated edition formats.

Mobbed on by: @andrewgarner, @bevanloon, @binaryberry, @gpeng, @mgrassotti, @nickcolley
