### PR TITLE
Switch rendering app for fatality notice

### DIFF
--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -35,4 +35,8 @@ class FatalityNotice < Announcement
   def search_format_types
     super + [FatalityNotice.search_format_type]
   end
+
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
 end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
           description: item.summary,
           document_type: "fatality_notice",
           public_updated_at: item.public_timestamp || item.updated_at,
-          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          rendering_app: item.rendering_app,
           schema_name: "fatality_notice",
           details: details
         )

--- a/db/data_migration/20160930145614_republish_fatality_notices_to_switch_rendering_app.rb
+++ b/db/data_migration/20160930145614_republish_fatality_notices_to_switch_rendering_app.rb
@@ -1,0 +1,2 @@
+publisher = DataHygiene::PublishingApiDocumentRepublisher.new(FatalityNotice)
+publisher.perform

--- a/lib/sync_checker/formats/fatality_notice_check.rb
+++ b/lib/sync_checker/formats/fatality_notice_check.rb
@@ -6,7 +6,7 @@ module SyncChecker
       end
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
       def checks_for_live(locale)

--- a/test/unit/fatality_notice_test.rb
+++ b/test/unit/fatality_notice_test.rb
@@ -41,4 +41,8 @@ class FatalityNoticeTest < ActiveSupport::TestCase
     fatality_notice = create(:published_fatality_notice, operational_field: operational_field)
     assert_equal operational_field.slug, fatality_notice.search_index["operational_field"]
   end
+
+  test "is rendered by government-frontend" do
+    assert FatalityNotice.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
 end

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -41,8 +41,8 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
     assert_equal 'whitehall', @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  test "it presents the rendering_app as government-frontend" do
+    assert_equal 'government-frontend', @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as fatality_notice" do


### PR DESCRIPTION
Switches rendering app from whitehall to government-frontend as part of the ongoing migration of Fatality Notices.

[Trello](https://trello.com/c/0UAMj5gj/407-8-fatality-notice-migration-implement-publishing-of-format-to-publishing-api-large)

Paired with @gpeng, @bevanloon 