### PR TITLE
Update `DetailedGuide` sync check

### DIFF
--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -18,6 +18,13 @@ module SyncChecker
           Checks::LinksCheck.new(
             "related_mainstream_content",
             related_mainstream_content_ids(edition_expected_in_live)
+          ),
+          Checks::LinksCheck.new(
+            "document_collections",
+            edition_expected_in_live
+              .document_collections
+              .published
+              .map(&:content_id)
           )
         ]
       end


### PR DESCRIPTION
`document_collections` were missing from the links check for the live content store sync check. They aren't any more...