### PR TITLE
Fix removing specialist sector tags

### DIFF
--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -11,11 +11,13 @@ module Edition::SpecialistSectors
     has_many :primary_specialist_sectors,
              -> { where(primary: true) },
              class_name: 'SpecialistSector',
-             foreign_key: :edition_id
+             foreign_key: :edition_id,
+             dependent: :destroy
     has_many :secondary_specialist_sectors,
              -> { where(primary: false) },
              class_name: 'SpecialistSector',
-             foreign_key: :edition_id
+             foreign_key: :edition_id,
+             dependent: :destroy
 
     add_trait do
       def process_associations_before_save(edition)

--- a/test/unit/edition/specialist_sectors_test.rb
+++ b/test/unit/edition/specialist_sectors_test.rb
@@ -54,4 +54,18 @@ class Edition::SpecialistSectorsTest < ActiveSupport::TestCase
     assert_equal tag, publication.primary_specialist_sector_tag
     assert_equal [], publication.secondary_specialist_sector_tags
   end
+
+  test "users can remove a tag" do
+    publication = create(:published_edition)
+
+    publication.update_attributes!({
+      primary_specialist_sector_tag: "environmental-management/waste"
+    })
+
+    publication.update_attributes!({
+      primary_specialist_sector_tag: nil
+    })
+
+    assert_equal nil, publication.primary_specialist_sector_tag
+  end
 end


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/2692 changed the specialist sector tags table in the database to disallow `edition_id` to be set to `null`, in order to fix an issue where tags could not be added to new editions. This inadvertently created a new issue where editions with tags could not have these tags removed, since ActiveRecord was trying to set `edition_id` to `null` when a tag was removed from an edition.

This commit changes the behaviour of ActiveRecord in this case to delete removed tags from the database table.

Trello: https://trello.com/c/IjjV13t3/169-trying-to-remove-a-specialist-tag-in-whitehall-publisher-results-in-an-error