### PR TITLE
Remove thin dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'thin', '1.6.3'
   gem 'newrelic_rpm'
   gem 'quiet_assets'
   gem 'stackprof', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,6 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
-    daemons (1.1.9)
     dalli (2.7.2)
     database_cleaner (1.4.0)
     debug_inspector (0.0.2)
@@ -126,7 +125,6 @@ GEM
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
-    eventmachine (1.0.4)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -422,10 +420,6 @@ GEM
     statsd-ruby (1.2.1)
     subexec (0.2.3)
     test-queue (0.2.11)
-    thin (1.6.3)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
-      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -544,7 +538,6 @@ DEPENDENCIES
   statsd-ruby (~> 1.2.1)
   test-queue (= 0.2.11)
   test_track (~> 0.1.0)!
-  thin (= 1.6.3)
   timecop
   transitions
   typhoeus (~> 1.1)

--- a/startup.sh
+++ b/startup.sh
@@ -14,4 +14,4 @@ fi
 export STATIC_DEV
 echo
 bundle install
-bundle exec rails s thin -p 3020
+bundle exec rails s -p 3020


### PR DESCRIPTION
We don’t use thin apart from in development, and we don’t need to do
that either. Having thin as a dependency means we have eventmachine as
a dependency as well, which doesn’t build cleanly on macOS Sierra