### PR TITLE
Remove redundant code from Person

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,12 +1,5 @@
 class Person < ActiveRecord::Base
   include PublishesToPublishingApi
-
-  def self.columns
-    # This is here to enable us to gracefully remove the biography column
-    # in a future commit, *after* this change has been deployed
-    super.reject { |column| ['biography'].include?(column.name) }
-  end
-
   include Searchable
 
   mount_uploader :image, ImageUploader, mount_on: :carrierwave_image

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -3,13 +3,6 @@ require 'test_helper'
 class PersonTest < ActiveSupport::TestCase
   should_protect_against_xss_and_content_attacks_on :biography
 
-  test "#columns excludes biography so that we can safely it from editions in a future migration" do
-    # This test ensure that we're excluding the biography column from Person.columns.
-    # You can safely remove this, and Person.columns, once it's been deployed and we've subsequently removed
-    # this column for real.
-    refute Person.columns.map(&:name).include?('biography')
-  end
-
   test 'should return search index data suitable for Rummageable' do
     person = create(:person, content_id: 'f585949d-3796-4566-ab31-cb0d978aec00', forename: 'David', surname: 'Cameron', biography: 'David Cameron became Prime Minister in May 2010.')
 


### PR DESCRIPTION
Fun fact: this TODO has been around since March, 2013. It's no longer needed.

https://github.com/alphagov/whitehall/commit/227edc1c4eedc3a92f9c397eef60a894aae54279