### PR TITLE
Update slug for British Consulate Sylhet

### DIFF
--- a/db/data_migration/20161010105438_update_worldwide_organisation_british_consulate_sylhet_slug.rb
+++ b/db/data_migration/20161010105438_update_worldwide_organisation_british_consulate_sylhet_slug.rb
@@ -1,0 +1,3 @@
+world_org = WorldwideOrganisation.find_by(slug: 'british-high-commission-office-sylhet')
+world_org.slug = 'british-consulate-sylhet'
+world_org.save!


### PR DESCRIPTION
Part of https://trello.com/c/4p0ojDbC/494-september-redirects-medium

`WorldwideOrganisation` implements `PublishesToPublishingApi` which will automatically republish and create the appropriate redirects, so this should be sufficient.

Expected before:

```
- 200 `curl -I "https://www.gov.uk/government/world/organisations/british-high-commission-office-sylhet"`
- 404 `curl -I "https://www.gov.uk/government/world/organisations/british-consulate-sylhet"`
- 200 `curl -I "https://www.gov.uk/api/content/government/world/organisations/british-high-commission-office-sylhet"`
- 404 `curl -I "https://www.gov.uk/api/content/government/world/organisations/british-consulate-sylhet"`
```

Expected after:

```
- 301 `curl -I "https://www.gov.uk/government/world/organisations/british-high-commission-office-sylhet"`
- 200 `curl -I "https://www.gov.uk/government/world/organisations/british-consulate-sylhet"`
- 200 (with document_type redirect) `curl -I "www.gov.uk/api/content/government/world/organisations/british-high-commission-office-sylhet"`
- 200 `curl -I "https://www.gov.uk/api/content/government/world/organisations/british-consulate-sylhet"`
```
