### PR TITLE
Preview Detailed Guides in Whitehall

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -37,7 +37,7 @@ class DetailedGuide < Edition
   validates_with HeadingHierarchyValidator
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 
   def rummager_index

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         details: details,
         document_type: "detailed_guide",
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "detailed_guide",
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))

--- a/test/unit/detailed_guide_test.rb
+++ b/test/unit/detailed_guide_test.rb
@@ -246,6 +246,6 @@ class DetailedGuideTest < ActiveSupport::TestCase
   end
 
   test "is rendered by government-frontend" do
-    assert DetailedGuide.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    assert DetailedGuide.new.rendering_app == Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 end


### PR DESCRIPTION
Revert admin preview of Detailed Guides to happen in Whitehall Admin.
Draft stack doesn’t currently support serving attached PDFs, so we need
to fall back to serving previews of Detailed Guides using Whitehall
Admin.

/cc @gpeng 