### PR TITLE
Redirect deleted translations when republishing an edition

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -7,6 +7,11 @@ module ServiceListeners
     end
 
     def push(event:, options: {})
+      # This is done synchronously before the rest of the publishing,
+      # because it creates redirects and currently (02/11/2016) publishing-api links
+      # will are not recalculated on parent documents when their translations are unpublished.
+      handle_translations
+
       case event
       when "force_publish", "publish", "unwithdraw"
         api.publish_async(edition)
@@ -37,6 +42,21 @@ module ServiceListeners
 
     def handle_html_attachments(event)
       PublishingApiHtmlAttachmentsWorker.perform_async(edition.id, event)
+    end
+
+    # If the previous edition had extra translations, redirect them to the :en locale.
+    def handle_translations
+      previous_edition = edition.previous_edition
+      if previous_edition
+        removed_locales = previous_edition.translations.map(&:locale) - edition.translations.map(&:locale)
+        removed_locales.each do |locale|
+          PublishingApiRedirectWorker.new.perform(
+            edition.content_id,
+            edition.search_link,
+            locale
+          )
+        end
+      end
     end
 
     def api

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -10,7 +10,7 @@ module ServiceListeners
     end
 
     test "saves draft async for update_draft" do
-      edition = build(:draft_publication)
+      edition = build(:draft_publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
       PublishingApiPusher.new(edition).push(event: "update_draft")
@@ -19,7 +19,8 @@ module ServiceListeners
     test "saves attachments draft" do
       edition = build(
         :draft_publication,
-        html_attachments: [attachment = build(:html_attachment)]
+        html_attachments: [build(:html_attachment)],
+        document: build(:document)
       )
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
@@ -27,21 +28,21 @@ module ServiceListeners
     end
 
     test "publish publishes" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "publish")
       PublishingApiPusher.new(edition).push(event: "publish")
     end
 
     test "force_publish publishes" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "force_publish")
       PublishingApiPusher.new(edition).push(event: "force_publish")
     end
 
     test "update_draft_translation saves draft translation" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
       stub_html_attachment_pusher(edition, "update_draft_translation")
       PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
@@ -68,31 +69,61 @@ module ServiceListeners
     end
 
     test "force_schedule schedules the edition" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "force_schedule")
       PublishingApiPusher.new(edition).push(event: "force_schedule")
     end
 
     test "schedule schedules the edition" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "schedule")
       PublishingApiPusher.new(edition).push(event: "schedule")
     end
 
     test "unschedule unschedules the edition" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
       stub_html_attachment_pusher(edition, "unschedule")
       PublishingApiPusher.new(edition).push(event: "unschedule")
     end
 
     test "delete discards draft" do
-      edition = build(:publication)
+      edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "delete")
       PublishingApiPusher.new(edition).push(event: "delete")
+    end
+
+    test "redirects deleted translations" do
+      published_edition = create(:published_edition, document: build(:document), translated_into: [:es, :fr])
+
+      old_translations = published_edition.translations
+      en = old_translations[0]
+      es = old_translations[1]
+      fr = old_translations[2]
+
+      new_edition = published_edition.create_draft(create(:writer))
+      new_edition.translations = [en, es]
+      new_edition.minor_change = true
+      new_edition.submit!
+
+      Whitehall::PublishingApi.expects(:publish_async).with(new_edition)
+      stub_html_attachment_pusher(new_edition, "publish")
+
+      pusher = mock
+      PublishingApiRedirectWorker
+        .expects(:new)
+        .returns(pusher)
+
+      pusher.expects(:perform).with(
+        new_edition.document.content_id,
+        new_edition.search_link,
+        fr.locale
+      )
+
+      PublishingApiPusher.new(new_edition).push(event: "publish")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/ieIgR5mN/488-deleted-translations-not-unpublished-medium

When publishing an edition, compare the list of currently attached translations to the list from the previous edition. For each translation that has been removed, unpublish it with a redirect to the english version of the edition.

Not very confident the code I wrote is idiomatic or that I'm using the mocking assertions correctly, so please point out any problems.

Tested on integration and seems to work correctly.

Updates the tests to instantiate a `document` before passing into `publishing_api_pusher` since we'd never expect otherwise (it's unrealistic data) and you can't test if something has a previous edition without a document.
