### PR TITLE
Send logo url for Detailed Guides if defined

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -59,6 +59,7 @@ module PublishingApi
         related_mainstream_content: related_mainstream_content_ids,
       }
       details_hash = maybe_add_national_applicability(details_hash)
+      details_hash.merge!(image: {url: item.logo_url}) if item.logo_url.present?
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
     end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -232,4 +232,17 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     assert_valid_against_schema(presented_item.content, 'detailed_guide')
     assert_equal expected_national_applicability, details[:national_applicability]
   end
+
+  test 'DetailedGuide presents an image correctly' do
+    detailed_guide = create(
+      :published_detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content",
+      logo_url: "http://www.example.com/foo.jpg"
+    )
+
+    presented_item = present(detailed_guide)
+    assert_equal "http://www.example.com/foo.jpg", presented_item.content[:details][:image][:url]
+  end
 end


### PR DESCRIPTION
One detailed guide has a `logo_url` configured for regulatory reasons.
This should be sent to the publishing api so that government frontend
can render it.
It isn’t possible for Detailed guides to have a main image in any other
way, so we reuse the `image` field in the details hash for this purpose.