### PR TITLE
Present `access_limited` for Fatality Notices

### DIFF
--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
           schema_name: "fatality_notice",
           details: details
         )
+        content.merge!(PayloadBuilder::AccessLimitation.for(item))
       }
     end
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -227,3 +227,17 @@ class PublishingApi::FatalityNoticePresenterUpdateTypeArgumentTest < ActiveSuppo
     assert_equal "major", @presented_fatality_notice.update_type
   end
 end
+
+class PublishingApi::AccessLimitedFatalityNoticeTest < ActiveSupport::TestCase
+  setup do
+    @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
+      @fatality_notice = create(:fatality_notice, :access_limited)
+    )
+    @user = create(:user, organisation: @fatality_notice.organisations.first, uid: "booyah")
+    @presented_content = @presented_fatality_notice.content
+  end
+
+  test "presents allowed users" do
+    assert_equal ["booyah"], @presented_content[:access_limited][:users]
+  end
+end


### PR DESCRIPTION
The Fatality Notice format supports access limiting but this was not being sent to the Publishing API.