### PR TITLE
Use https for `test_track` from github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :test do
   gem 'webmock', '~> 2.1', require: false
   gem 'ci_reporter_minitest'
   gem 'database_cleaner', '1.4.0'
-  gem 'test_track', '~> 0.1.0', github: 'alphagov/test_track', branch: 'master'
+  gem 'test_track', '~> 0.1.0', git: 'https://github.com/alphagov/test_track'
   gem 'govuk-content-schema-test-helpers', '1.4.0'
   gem 'minitest-fail-fast'
   gem 'maxitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: git://github.com/alphagov/test_track.git
+  remote: https://github.com/alphagov/test_track
   revision: 1f997082e2f1be94274d294c2f8d34ab0b21bb7f
-  branch: master
   specs:
     test_track (0.1.0)
       rails (>= 3.1.0)


### PR DESCRIPTION
Was using the `git` protocol which bundler has started complaining about as being insecure.