### PR TITLE
Publish new people page so it renders on finder frontend

### DIFF
--- a/app/services/publish_finder.rb
+++ b/app/services/publish_finder.rb
@@ -1,0 +1,31 @@
+class PublishFinder
+  attr_reader :finder_content_item
+
+  def initialize(finder_content_item)
+    @finder_content_item = finder_content_item
+  end
+
+  def self.call(finder_content_item)
+    new(finder_content_item).call
+  end
+
+  def call
+    Whitehall.publishing_api_v2_client.put_content(
+      content_id,
+      finder_content_item
+    )
+    Whitehall.publishing_api_v2_client.publish(content_id, "major")
+  end
+
+private
+
+  def content_id
+    @content_id ||= existing_content_id || SecureRandom.uuid
+  end
+
+  def existing_content_id
+    Whitehall
+      .publishing_api_v2_client
+      .lookup_content_id(base_path: finder_content_item['base_path'])
+  end
+end

--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -1,0 +1,30 @@
+{
+  "base_path": "/government/people",
+  "title": "All ministers and senior officials on GOV.UK",
+  "description": "",
+  "locale": "en",
+  "document_type": "finder",
+  "schema_name": "finder",
+  "publishing_app": "whitehall",
+  "rendering_app": "finder-frontend",
+  "details": {
+    "document_noun": "person",
+    "default_order": "title",
+    "facets": [],
+    "filter": {
+      "format": "person"
+    },
+    "format_name": "All ministers and senior officials on GOV.UK",
+    "show_summaries": true
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/people"
+    },
+    {
+      "type": "exact",
+      "path": "/government/people.json"
+    }
+  ]
+}

--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -1,0 +1,11 @@
+namespace :finders do
+  desc 'Publish finder pages to the publishing API'
+  task publish: :environment do
+    Dir[Rails.root + "lib/finders/*.json"].each do |file_path|
+      puts "Publishing #{file_path}"
+
+      content_item = JSON.parse(File.read(file_path))
+      PublishFinder.call(content_item)
+    end
+  end
+end

--- a/test/unit/finder_schema_validation_test.rb
+++ b/test/unit/finder_schema_validation_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class FinderSchemaValidationTest < ActiveSupport::TestCase
+  test "the people finder is a valid finder" do
+    people_finder = JSON.parse(File.read("lib/finders/people.json"))
+
+    assert_valid_against_schema(people_finder, 'finder')
+  end
+end

--- a/test/unit/services/publish_finder_test.rb
+++ b/test/unit/services/publish_finder_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class PublishFinderTest < ActiveSupport::TestCase
+  test "it assigns a valid content id the first time it publishes the finder" do
+    people_finder = JSON.parse(File.read("lib/finders/people.json"))
+
+    publishing_api_has_lookups({})
+    SecureRandom.stubs(:uuid).returns('a-content-id')
+
+    PublishFinder.call(people_finder)
+
+    assert_publishing_api_put_content('a-content-id', people_finder)
+    assert_publishing_api_publish('a-content-id', update_type: 'major')
+  end
+
+  test 'it uses the existing content id when publishing' do
+    people_finder = JSON.parse(File.read("lib/finders/people.json"))
+
+    publishing_api_has_lookups('/government/people' => 'existing-content-id')
+
+    PublishFinder.call(people_finder)
+
+    assert_publishing_api_put_content('existing-content-id', people_finder)
+    assert_publishing_api_publish('existing-content-id', update_type: 'major')
+  end
+end


### PR DESCRIPTION
We are migrating the rendering app of the people page to `finder-frontend`. This PR adds a rake task to publish the new finder.

Trello: https://trello.com/c/reCVyzpg/259-migrate-the-people-page-to-a-finder

This PR depends on:
- [x] https://github.com/alphagov/govuk-content-schemas/pull/424 because without these schemas, the tests will fail;
- [x] https://github.com/alphagov/finder-frontend/pull/256, otherwise `finder-frontend` won't display any people on that new page.

Both PRs have been merged. The new page looks like this:

<img width="1272" alt="screen shot 2016-10-21 at 15 32 20" src="https://cloud.githubusercontent.com/assets/416701/19602056/a1075084-97a3-11e6-84cd-636f99008b6b.png">
