### PR TITLE
Add a rake task to publish links for withdrawn items

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -33,11 +33,26 @@ namespace :publishing_api do
     end
   end
 
-  desc "Send publishable item links to Publishing API."
-  task publishing_api_patch_links: :environment do
+  desc "Send published item links to Publishing API."
+  task patch_published_item_links: :environment do
     editions = Edition.published
     count = editions.count
     puts "# Sending #{count} published editions to Publishing API"
+
+    editions.pluck(:id).each_with_index do |item_id, i|
+      PublishingApiLinksWorker.perform_async(item_id)
+
+      puts "Queuing #{i}-#{i + 99} of #{count} items" if i % 100 == 0
+    end
+
+    puts "Finished queuing items for Publishing API"
+  end
+
+  desc "Send withdrawn item links to Publishing API."
+  task patch_withdrawn_item_links: :environment do
+    editions = Edition.withdrawn
+    count = editions.count
+    puts "# Sending #{count} withdrawn editions to Publishing API"
 
     editions.pluck(:id).each_with_index do |item_id, i|
       PublishingApiLinksWorker.perform_async(item_id)


### PR DESCRIPTION
A data hygiene task to ensure that the publishing api has the correct
links present for withdrawn content items, bringing it line with the
content-store and whitehall. We've detected multiple instances in
production where this is not the case.

https://trello.com/c/jVPQzU1S/232-republish-the-links-of-withdrawn-whitehall-content

Note: needs testing against a sensible data setup, which my VM is currently lacking in a big way. Will get round to that shortly but this can be reviewed in the meantime, particularly as the code is nearly identical to the existing published items task in the same file.