### PR TITLE
Make sync checks quicker to start

### DIFF
--- a/lib/sync_checker/request_queue.rb
+++ b/lib/sync_checker/request_queue.rb
@@ -1,21 +1,18 @@
-
 module SyncChecker
   DRAFT_CONTENT_STORE = 'draft-content-store'
   LIVE_CONTENT_STORE = 'content-store'
 
   class RequestQueue
     attr_reader :request_type, :requests
-    def initialize(document_check, failure_result_set, mutex)
+    def initialize(document_check, failure_result_set)
       @requests = []
       document_check.base_paths[:draft].each do |locale, path|
         requests << draft_request = Typhoeus::Request.new(
           request_url(path, DRAFT_CONTENT_STORE)
         )
         draft_request.on_complete do |response|
-          mutex.synchronize do
-            result = document_check.check_draft(response, locale)
-            failure_result_set << result
-          end
+          result = document_check.check_draft(response, locale)
+          failure_result_set << result
         end
       end
 
@@ -24,10 +21,8 @@ module SyncChecker
           request_url(path, LIVE_CONTENT_STORE)
         )
         live_request.on_complete do |response|
-          mutex.synchronize do
-            result = document_check.check_live(response, locale)
-            failure_result_set << result
-          end
+          result = document_check.check_live(response, locale)
+          failure_result_set << result
         end
       end
     end

--- a/script/run_sync_checks
+++ b/script/run_sync_checks
@@ -32,12 +32,12 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-document_format = "SyncChecker::Formats::#{ARGV[0]}Check".constantize
-documents = (
+checker = "SyncChecker::Formats::#{ARGV[0]}Check".constantize
+scope = (
   if options[:ids]
-    document_format.scope_with_ids(options[:ids])
+    checker.scope_with_ids(options[:ids])
   else
-    document_format.scope
+    checker.scope
   end
 )
 
@@ -47,9 +47,9 @@ if options[:republish]
     total: documents.count,
     format: "%e [%b>%i] [%c/%C]"
   )
-  documents.pluck(:id).each do |id|
+  scope.pluck(:id).each do |id|
     begin
-      document_format.republish(id)
+      checker.republish(id)
     rescue GdsApi::TimedOutException, GdsApi::HTTPServerError
       progress.log "Timeout..."
       retry
@@ -60,6 +60,5 @@ if options[:republish]
   exit 0
 end
 
-checks = documents.map { |doc| document_format.new(doc) }
-checker = SyncChecker::SyncCheck.new(checks, csv_file_path: options[:output])
-checker.run
+sync_check = SyncChecker::SyncCheck.new(checker, scope, csv_file_path: options[:output])
+sync_check.run

--- a/test/unit/sync_checker/request_queue_test.rb
+++ b/test/unit/sync_checker/request_queue_test.rb
@@ -22,8 +22,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     }
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
-    mutex = Mutex.new
-    queued_request = SyncChecker::RequestQueue.new(document_check, result_set, mutex)
+    queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
     Typhoeus.stub("https://draft-content-store.test.alphagov.co.uk/content/one").and_return(response)
 
@@ -38,8 +37,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     }
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
-    mutex = Mutex.new
-    queued_request = SyncChecker::RequestQueue.new(document_check, result_set, mutex)
+    queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
     Typhoeus.stub("https://content-store.test.alphagov.co.uk/content/one").and_return(response)
 
@@ -54,8 +52,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     }
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
-    mutex = Mutex.new
-    queued_request = SyncChecker::RequestQueue.new(document_check, result_set, mutex)
+    queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
     Typhoeus.stub("https://content-store.test.alphagov.co.uk/content/one").and_return(response)
 
@@ -72,8 +69,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     }
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
-    mutex = Mutex.new
-    queued_request = SyncChecker::RequestQueue.new(document_check, result_set, mutex)
+    queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
     Typhoeus.stub("https://draft-content-store.test.alphagov.co.uk/content/one").and_return(response)
 
@@ -90,7 +86,6 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     }
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
-    mutex = Mutex.new
     Typhoeus::Request.expects(:new).with(
       "https://draft-content-store.test.alphagov.co.uk/content/one",
     ).returns(draft_request = stub(:on_complete))
@@ -98,7 +93,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
       "https://content-store.test.alphagov.co.uk/content/two",
     ).returns(live_request = stub(:on_complete))
 
-    queued_request = SyncChecker::RequestQueue.new(document_check, result_set, mutex)
+    queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
 
     assert queued_request.requests.include?(draft_request)
     assert queued_request.requests.include?(live_request)

--- a/test/unit/sync_checker/sync_check_test.rb
+++ b/test/unit/sync_checker/sync_check_test.rb
@@ -8,63 +8,70 @@ require_relative '../../../lib/sync_checker/sync_check'
 
 module SyncChecker
   class SyncCheckTest < Minitest::Test
+    class FakeRelation < Array
+      def initialize(*args)
+        super(*args)
+        replace(self.map { |v| OpenStruct.new(v) })
+      end
+
+      alias find_each each
+    end
+
+    Check = Struct.new(:id) do
+      def base_paths
+        {draft: [[:en, "/#{id}"]], live: [[:en, "/#{id}"]]}
+      end
+    end
+
     def setup
       ProgressBar.stubs(:create).returns(stub_everything)
     end
 
     def test_it_creates_a_queued_request_for_each_check
-      document_checks = [
-        stub,
-        stub
-      ]
-
       options = {
-        mutex: Mutex.new,
         failures: stub(:<< => true, results: []),
         hydra: stub(run: nil, queue: nil, queued_requests: [])
       }
 
-      checker = SyncCheck.new(document_checks, options)
+      scope = FakeRelation.new([{id: 1}, {id: 2}])
 
-      document_checks.each do |document_check|
+      sync_check = SyncCheck.new(Check, scope, options)
+
+      scope.each do |document|
         RequestQueue.expects(:new).with(
-          document_check,
-          options[:failures],
-          options[:mutex]
+          Check.new(document),
+          options[:failures]
         ).returns(stub(requests: []))
       end
 
-      checker.run
+      sync_check.run
     end
 
     def test_queues_the_requests
-      document_checks = [
-        stub(id: 1, base_path: "/one"),
-        stub(id: 2, base_path: "/one"),
-      ]
+      scope = FakeRelation.new([{id: 1}, {id: 2}])
 
-      checker = SyncCheck.new(document_checks, hydra: hydra = stub(queue: nil, run: nil, queued_requests: []))
+      sync_check = SyncCheck.new(Check, scope, hydra: hydra = stub(queue: nil, run: nil, queued_requests: []))
 
       RequestQueue.stubs(:new).returns(stub(requests: [1, 2]))
       hydra.expects(:queue).with(1)
       hydra.expects(:queue).with(2)
 
-      checker.run
+      sync_check.run
     end
 
     def test_it_creates_a_hydra
       Typhoeus::Hydra.expects(:new).with(max_concurrency: 20).returns(hydra = stub)
-      checker = SyncCheck.new([])
-      checker.hydra == hydra
+      sync_check = SyncCheck.new(Check, FakeRelation.new)
+      sync_check.hydra == hydra
     end
 
     def test_runs_the_hydra
       Typhoeus::Hydra.expects(:new)
         .with(max_concurrency: 20)
-        .returns(hydra = stub(queued_requests: []))
+        .returns(hydra = stub(queued_requests: [], queue: nil))
       hydra.expects(:run)
-      checker = SyncCheck.new([])
-      checker.run
+      sync_check = SyncCheck.new(Check, FakeRelation.new([{id: 1}]))
+      sync_check.run
     end
   end
 end


### PR DESCRIPTION
Pass an ActiveRecord scope and a separate Check class into the
SyncCheck. This allows the SyncCheck itself to find the objects in
batches, which matters for Publications where we need to check over
100k documents and load all the related ActiveRecord objects.

Also removes the Mutex as this isn’t needed in Typhoeus.

/cc @gpeng 