### PR TITLE
Publication sync check fixes

### DIFF
--- a/lib/sync_checker/checks/unpublished_check.rb
+++ b/lib/sync_checker/checks/unpublished_check.rb
@@ -16,6 +16,7 @@ module SyncChecker
             #withdraw
             unpublishing = document.published_edition.unpublishing
             failures << check_for_withdrawn_notice(unpublishing)
+            failures << check_withdrawn_at(unpublishing)
           elsif pre_publication_has_unpublishing?
             unpublishing = document.pre_publication_edition.unpublishing
             if unpublishing.unpublishing_reason_id == 1
@@ -96,6 +97,16 @@ module SyncChecker
 
         if !EquivalentXml.equivalent?(withdrawn_explanation, item_withdrawn_explanation)
           "expected withdrawn notice: '#{withdrawn_explanation}' but got '#{item_withdrawn_explanation}'"
+        end
+      end
+
+      def check_withdrawn_at(unpublishing)
+        item_withdrawn_at = content_item["withdrawn_notice"]["withdrawn_at"]
+        return "expected withdrawn at but was missing" if item_withdrawn_at.blank?
+
+        edition_withdrawn_at = unpublishing.edition.updated_at.to_datetime.utc.rfc3339(3)
+        if item_withdrawn_at != edition_withdrawn_at
+          "expected withdrawn at '#{edition_withdrawn_at}' but got '#{item_withdrawn_at}'"
         end
       end
     end

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -44,7 +44,7 @@ module SyncChecker
       end
 
       def document_type
-        edition_expected_in_live.publication_type.key
+        (edition_expected_in_live || edition_expected_in_draft).publication_type.key
       end
 
       def expected_details_hash(edition)


### PR DESCRIPTION
This firstly fixes the publication check to fetch the publication type correctly. Previously the checks would crash completely as it was checking a draft publication, and would try to get the type of a nil Edition.

Also adds a check for the withdrawn_at field. This will fail on most withdrawn publications as currently Whitehall is unable to send this field to the Publishing API.
