### PR TITLE
HtmlAttachments sync check

### DIFF
--- a/lib/sync_checker/checks/html_attachment_unpublished_check.rb
+++ b/lib/sync_checker/checks/html_attachment_unpublished_check.rb
@@ -1,0 +1,78 @@
+module SyncChecker
+  module Checks
+    HtmlAttachmentUnpublishedCheck = Struct.new(:attachment) do
+      attr_reader :attachable, :content_item, :unpublishing, :response
+
+      def call(response)
+        @attachable = attachment.attachable
+        @unpublishing = attachable.unpublishing
+        @response = response
+
+        failures = []
+        return failures unless attachable.unpublishing.present?
+
+        if there_is_an_item_in_the_content_store?
+          @content_item = JSON.parse(response.body)
+          if attachable_has_been_withdrawn?
+            failures << check_for_withdrawn_notice
+          elsif attachable_has_been_unpublished?
+            failures << check_redirected
+          end
+        else
+          failures << "attachable has been unpublished but the attachment has nothing in the content store"
+        end
+        failures.compact
+      end
+
+      private
+
+      def there_is_an_item_in_the_content_store?
+        response.body != ""
+      end
+
+      def attachable_has_been_withdrawn?
+        attachable.withdrawn?
+      end
+
+      def check_for_withdrawn_notice
+        item_withdrawn_explanation = content_item["withdrawn_notice"]["explanation"]
+        return if unpublishing.explanation.blank? && item_withdrawn_explanation.blank?
+
+        withdrawn_explanation = Whitehall::GovspeakRenderer.new.govspeak_to_html(unpublishing.explanation)
+
+        if !EquivalentXml.equivalent?(withdrawn_explanation, item_withdrawn_explanation)
+          "expected withdrawn notice: '#{withdrawn_explanation}' but got '#{item_withdrawn_explanation}'"
+        end
+      end
+
+      def attachable_has_been_unpublished?
+        attachable.draft? && unpublishing.present?
+      end
+
+      def check_redirected
+        if attachable_should_be_redirected_to_parent?
+          check_for_redirect_to_parent
+        else
+          check_for_redirect_to_alternative_url
+        end
+      end
+
+      def attachable_should_be_redirected_to_parent?
+        unpublishing.unpublishing_reason_id == UnpublishingReason::PUBLISHED_IN_ERROR_ID &&
+          !unpublishing.redirect?
+      end
+
+      def check_for_redirect_to_parent
+        "attachment should redirect to parent" unless content_item["schema_name"] == "redirect"
+      end
+
+      def check_for_redirect_to_alternative_url
+        "attachment should redirect to the 'https://gov.uk/alt'" unless content_item["schema_name"] == "redirect"
+      end
+
+      def unpublishing
+        attachable.unpublishing
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/html_attachment_check.rb
+++ b/lib/sync_checker/formats/html_attachment_check.rb
@@ -1,0 +1,107 @@
+module SyncChecker
+  module Formats
+    class HtmlAttachmentCheck
+      def initialize(attachment)
+        @attachment = attachment
+        @locale = (attachment.locale || "en").to_str
+      end
+
+      def checks_for_draft
+        [
+          Checks::TopLevelCheck.new(
+            top_level_fields_hash
+          ),
+          Checks::DetailsCheck.new(
+            expected_details_hash
+          )
+        ]
+      end
+
+      def check_draft(response, locale)
+        run_checks(response, locale, checks_for_draft, DRAFT_CONTENT_STORE)
+      end
+
+      def checks_for_live(locale)
+        [
+          Checks::TopLevelCheck.new(
+            top_level_fields_hash
+          ),
+          Checks::LinksCheck.new(
+            "organisations",
+            (attachable.try(:organisations) || []).map(&:content_id)
+          ),
+          Checks::LinksCheck.new(
+            "parent",
+            [attachable.content_id]
+          ),
+          Checks::DetailsCheck.new(
+            expected_details_hash
+          )
+        ]
+      end
+
+      def check_live(response, locale)
+        run_checks(response, locale, checks_for_live, LIVE_CONTENT_STORE)
+      end
+
+      def base_paths
+        {
+          draft: { locale => attachment.url },
+          live: { locale => attachment.url }
+        }
+      end
+
+    private
+
+      attr_reader :attachment, :locale
+
+      def attachable
+        attachment.attachable
+      end
+
+      def expected_details_hash
+        {
+          body: attachment.govspeak_content_body_html
+        }
+      end
+
+      def top_level_fields_hash(translation_for_locale)
+        {
+          base_path: attachment.url,
+          content_id: attachment.content_id,
+          document_type: "html_publication",
+          locale: locale,
+          publishing_app: "whitehall",
+          schema_name: "html_publication",
+          title: attachment.title,
+          description: nil,
+          rendering_app: rendering_app
+        }
+      end
+
+      def attachment_should_exist_in_draft_content_store?
+        attachable.draft? && attachable.unpublishing.blank?
+      end
+
+      def rendering_app
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+
+      def run_checks(response, locale, checks, content_store)
+        errors = checks.flat_map { |check| check.call(response) }
+
+        if errors.any?
+          return Failure.new(
+            response.request.base_url,
+            response.response_code,
+            attachable.id,
+            attachment.id,
+            locale,
+            content_store,
+            errors
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/html_attachment_check.rb
+++ b/lib/sync_checker/formats/html_attachment_check.rb
@@ -36,6 +36,9 @@ module SyncChecker
           ),
           Checks::DetailsCheck.new(
             expected_details_hash
+          ),
+          Checks::HtmlAttachmentUnpublishedCheck.new(
+            attachment
           )
         ]
       end

--- a/test/unit/sync_checker/checks/html_attachment_unpublished_check_test.rb
+++ b/test/unit/sync_checker/checks/html_attachment_unpublished_check_test.rb
@@ -1,0 +1,265 @@
+require 'equivalent-xml'
+
+require "minitest/autorun"
+require "mocha/setup"
+require "active_support/json"
+require "active_model"
+
+require_relative "../../../../lib/whitehall/govspeak_renderer"
+require_relative "../../../../lib/active_record_like_interface"
+require_relative "../../../../app/models/unpublishing_reason"
+require_relative "../../../../lib/sync_checker/checks/html_attachment_unpublished_check.rb"
+
+module SyncChecker
+  module Checks
+    class HtmlUnpublishedCheckTest < Minitest::Test
+      def setup
+        Whitehall::GovspeakRenderer.stubs(:new).returns(@stub_renderer = stub)
+      end
+
+      def test_returns_no_errors_if_the_attachable_has_no_unpublishing
+        attachment = stub(
+          attachable: stub(
+            unpublishing: nil,
+            "withdrawn?" => false,
+            "draft?" => false
+          )
+        )
+
+        assert_equal [], HtmlAttachmentUnpublishedCheck.new(attachment).call(stub)
+      end
+
+      def test_returns_no_errors_if_the_attachable_is_withdrawn_and_the_attachment_has_a_withdrawn_notice
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::WITHDRAWN_ID,
+              explanation: "Withdrawnificated"
+            ),
+            "withdrawn?" => true,
+            "draft?" => false
+          )
+        )
+
+        response = stub(
+          body: {
+            withdrawn_notice: {
+              explanation: "<p>Withdrawnificated</p>"
+            }
+          }.to_json
+        )
+
+        @stub_renderer.stubs(:govspeak_to_html).returns("<p>Withdrawnificated</p>")
+
+        assert_equal [], HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_an_error_if_the_document_should_be_withdrawn_but_has_no_notice
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::WITHDRAWN_ID,
+              explanation: "Withdrawnificated"
+            ),
+            "withdrawn?" => true,
+            "draft?" => false
+          )
+        )
+
+        response = stub(
+          body: {
+            withdrawn_notice: { }
+          }.to_json
+        )
+
+        @stub_renderer.stubs(:govspeak_to_html).returns("<p>Withdrawnificated</p>")
+
+        expected_error = "expected withdrawn notice: '<p>Withdrawnificated</p>' but got ''"
+
+        assert_equal [expected_error],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_no_error_if_the_attachable_is_unpublished_in_error_and_the_attachment_returns_a_redirect_to_the_parent
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::PUBLISHED_IN_ERROR_ID,
+              explanation: "Unpublished Error",
+              alternative_url: "https://gov.uk/alt",
+              "redirect?" => false
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          #we can't currently test the destination of a content-store redirect item
+          #as it isn't in the JSON
+          body: {
+            schema_name: "redirect",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        assert_equal [],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_an_error_if_the_attachable_is_unpublished_in_error_and_there_is_no_redirect_to_the_parent
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::PUBLISHED_IN_ERROR_ID,
+              explanation: "Unpublished Error",
+              alternative_url: "https://gov.uk/alt",
+              "redirect?" => false
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          body: {
+            schema_name: "gone",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        expected_error = "attachment should redirect to parent"
+
+        assert_equal [expected_error],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_no_error_if_the_attachable_is_unpublished_in_error_and_the_attachment_returns_a_redirect_to_the_alternative_url
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::PUBLISHED_IN_ERROR_ID,
+              explanation: "Unpublished Error",
+              alternative_url: "https://gov.uk/alt",
+              "redirect?" => true
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          body: {
+            schema_name: "redirect",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        assert_equal [],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_an_error_if_the_attachable_is_unpublished_in_error_and_the_attachment_does_not_redirect
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::PUBLISHED_IN_ERROR_ID,
+              explanation: "Unpublished Error",
+              alternative_url: "https://gov.uk/alt",
+              "redirect?" => true
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          body: {
+            schema_name: "gone",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        expected_error = "attachment should redirect to the 'https://gov.uk/alt'"
+
+        assert_equal [expected_error],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_no_error_if_attachable_consolidated_and_attachment_redirects
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::CONSOLIDATED_ID,
+              alternative_url: "https://gov.uk/alt"
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          body: {
+            schema_name: "redirect",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        assert_equal [],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+
+      def test_returns_an_error_if_attachable_consolidated_and_attachment_does_not_redirect
+        attachment = stub(
+          attachable: stub(
+            unpublishing: stub(
+              unpublishing_reason_id: UnpublishingReason::CONSOLIDATED_ID,
+              alternative_url: "https://gov.uk/alt"
+            ),
+            "withdrawn?" => false,
+            "draft?" => true
+          )
+        )
+
+        response = stub(
+          body: {
+            schema_name: "gone",
+            withdrawn_notice: {},
+            details: {}
+          }.to_json
+        )
+
+        expected_error = "attachment should redirect to the 'https://gov.uk/alt'"
+
+        assert_equal [expected_error],
+          HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+      end
+    end
+
+    def test_returns_an_error_if_there_is_no_item_in_the_content_store
+      attachment = stub(
+        attachable: stub(
+          unpublishing: stub(
+            unpublishing_reason_id: UnpublishingReason::CONSOLIDATED_ID,
+            alternative_url: "https://gov.uk/alt"
+          ),
+          "withdrawn?" => false,
+          "draft?" => true
+        )
+      )
+      response = stub(
+        body: ""
+      )
+
+      expected_error = "attachable has been unpublished but the attachment has nothing in the content store"
+
+      assert_equal [expected_error],
+        HtmlAttachmentUnpublishedCheck.new(attachment).call(response)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the `HtmlAttachment` -> `HtmlPublication` format to the sync checks as part of its migration.

[Trello](https://trello.com/c/uwsLR1xU/285-html-publications-migration-implement-publishing-of-format-to-publishing-api-large)
