### PR TITLE
Send unpublished_at to Publishing API on withdrawal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 34.1.0'
+  gem 'gds-api-adapters', '~> 37.5.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       rails (>= 4.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
@@ -132,7 +132,7 @@ GEM
     ffi (1.9.14)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (34.1.0)
+    gds-api-adapters (37.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -186,7 +186,7 @@ GEM
     hashery (2.1.1)
     hashie (3.4.3)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     invalid_utf8_rejector (0.0.1)
@@ -477,7 +477,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 34.1.0)
+  gds-api-adapters (~> 37.5.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)
@@ -547,4 +547,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.10.6
+   1.13.2

--- a/app/workers/publishing_api_withdrawal_worker.rb
+++ b/app/workers/publishing_api_withdrawal_worker.rb
@@ -1,11 +1,19 @@
 class PublishingApiWithdrawalWorker < PublishingApiWorker
   def perform(content_id, explanation, locale, allow_draft = false)
+    unpublished_at = Edition
+      .joins(:document)
+      .where(documents: {content_id: content_id})
+      .where(state: "withdrawn")
+      .pluck(:updated_at)
+      .first
+
     Whitehall.publishing_api_v2_client.unpublish(
       content_id,
       type: "withdrawal",
       locale: locale,
       explanation: Whitehall::GovspeakRenderer.new.govspeak_to_html(explanation),
       allow_draft: allow_draft,
+      unpublished_at: unpublished_at
     )
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
     # nothing to do here as we can't unpublish something that doesn't exist

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,4 +1,4 @@
 GdsApi.configure do |config|
-  # Never return nil when a server responds with 404 or 410.
-  config.always_raise_for_not_found = true
+  # Opt out of always returning hashes for `GdsApi::Response`s
+  config.hash_response_for_requests = false
 end

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -15,6 +15,7 @@ class WithdrawingTest < ActiveSupport::TestCase
         type: "withdrawal",
         locale: "en",
         explanation: "<div class=\"govspeak\"><p>Old information</p>\n</div>",
+        unpublished_at: edition.updated_at.utc.iso8601,
       }
     )
 

--- a/test/unit/workers/publishing_api_withdrawal_worker_test.rb
+++ b/test/unit/workers/publishing_api_withdrawal_worker_test.rb
@@ -4,19 +4,21 @@ require "gds_api/test_helpers/publishing_api_v2"
 class PublishingApiWithdrawalWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
 
-  test "publishes a 'gone' item for the supplied content id" do
-    uuid = SecureRandom.uuid
+  test "publishes a 'withdrawal' item for the supplied content id" do
+    publication = create(:withdrawn_publication)
+
     request = stub_publishing_api_unpublish(
-      uuid,
+      publication.document.content_id,
       body: {
         type: "withdrawal",
         locale: "en",
-        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>"
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
+        unpublished_at: publication.updated_at.utc.iso8601
       }
     )
 
     PublishingApiWithdrawalWorker.new.perform(
-      uuid, "*why?*", "en"
+      publication.document.content_id, "*why?*", "en"
     )
 
     assert_requested request


### PR DESCRIPTION
https://trello.com/c/Bnj1Z6K4/504-fix-withdrawn-date-for-rendered-formats

Whitehall displays the last updated time of a withdrawn edition as the
date it was withdrawn. This wasn’t being passed through to Publishing
API and therefore Government Frontend wasn’t able to display it.

This uses new functionality in Publishing API and passes what Whitehall
considers to be the withdrawn date when unpublishing or republishing.
