### PR TITLE
Increment progress bar per document

### DIFF
--- a/lib/sync_checker/result_set.rb
+++ b/lib/sync_checker/result_set.rb
@@ -26,8 +26,6 @@ module SyncChecker
         csv << result.to_row
         progress_bar.log result.to_s
       end
-
-      progress_bar.increment
     end
 
     attr_reader :results, :progress_bar, :csv

--- a/lib/sync_checker/sync_check.rb
+++ b/lib/sync_checker/sync_check.rb
@@ -21,6 +21,7 @@ module SyncChecker
         request = RequestQueue.new(document_check, failures)
         request.requests.each { |req| hydra.queue(req) }
         hydra.run
+        progress_bar.increment
       end
 
       progress_bar.finish

--- a/test/unit/sync_checker/result_set_test.rb
+++ b/test/unit/sync_checker/result_set_test.rb
@@ -5,15 +5,8 @@ require_relative '../../../config/environment'
 
 module SyncChecker
   class ResultSetTest < Minitest::Test
-    def test_adding_result_increments_the_progress_bar
-      result_set = ResultSet.new(progress_bar = stub(increment: true, log: nil))
-      progress_bar.expects(:increment)
-      result_set << stub(document_id: 1, to_row: true)
-    end
-
-    def test_adding_nil_result_increments_the_progress_bar_but_is_excluded_from_results
-      result_set = ResultSet.new(progress_bar = stub(increment: true))
-      progress_bar.expects(:increment)
+    def test_adding_nil_result_is_excluded_from_results
+      result_set = ResultSet.new(stub)
       result_set << nil
       assert_equal 0, result_set.results.length
     end


### PR DESCRIPTION
The progress bar was still incrementing per request/test but the total was being set per document. This was causing the checks to start to error once the number of documents had been exceeded. Each document might have numerous tests (editions, translations etc) so number of tests is always > number of documents.

This does change the behaviour of the progress bar to show total documents to test. Previously it showed total tests to run.