### PR TITLE
Fix edition based sync check for first public at

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -164,12 +164,7 @@ module SyncChecker
       end
 
       def first_public_at(edition)
-        first_public_at = if document.published?
-                            edition.first_public_at
-                          else
-                            document.created_at
-                          end
-
+        first_public_at = edition.first_public_at || edition.document.created_at
         first_public_at.to_datetime.rfc3339(3)
       end
 


### PR DESCRIPTION
Documents that were unpublished previously sent `created_at` even though they have a `first_published_at` value.

`first_published_at` might not contain seconds, as they are stripped out by the HTML form in Whitehall admin. When compared against `created_at` this causes sync check errors due to missing seconds.

Mobbed on by @andrewgarner @bevanloon @gpeng 