### PR TITLE
Fix sync check republishing failure

### DIFF
--- a/script/run_sync_checks
+++ b/script/run_sync_checks
@@ -44,7 +44,7 @@ scope = (
 if options[:republish]
   progress = ProgressBar.create(
     title: "Republishing",
-    total: documents.count,
+    total: scope.count,
     format: "%e [%b>%i] [%c/%C]"
   )
   scope.pluck(:id).each do |id|


### PR DESCRIPTION
Republishing failed because the `documents` variable was renamed to `scope` in 9e2d4b8109827d222adf95a3fe17e1fac6cd84ba

Fixed the subsequent call to `documents` so that it is now also `scope`

Mobbed with @andrewgarner @bevanloon @gpeng 