### PR TITLE
Fix financial table footer styling relying on order

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -326,7 +326,8 @@
 
         // ideally this should be just a top margin on the tfoot
         // but as that is very tricky, this is more complex
-        tbody:last-of-type tr:last-child > * {
+        tbody:last-of-type tr:last-child > *,
+        tfoot ~ tbody:last-of-type tr:last-child > * {
           padding-bottom: $gutter;
         }
         tbody:last-child tr:last-child > * {


### PR DESCRIPTION
The original styling of footers in financial tables assumed that tfoot will always be the last block. But it's also valid to have it before any tbody.
This fixes that the spacing before a tfoot always applies, independently of the order in which it appears. This is important because the tool we will recommend to build these tables will add the tfoot before any tbody.

This does not affect anything, because such tables (`table.financial-data` within HTML publications) don't exist yet.
It's a follow-up to #2796.