### PR TITLE
Add log output to SyncChecker

### DIFF
--- a/lib/sync_checker/sync_check.rb
+++ b/lib/sync_checker/sync_check.rb
@@ -17,6 +17,7 @@ module SyncChecker
       progress_bar.start
 
       scope.find_each do |document|
+        progress_bar.log "running check for document_id #{document.id}"
         document_check = checker.new(document)
         request = RequestQueue.new(document_check, failures)
         request.requests.each { |req| hydra.queue(req) }


### PR DESCRIPTION
This adds a line to the log output that displays the `document_id` of the document that is about to be checked. This will allow easier debugging when the checks fall over during a run.