### PR TITLE
Remove `document_collection` links from LinksPresenter

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -32,7 +32,6 @@ module PublishingApi
     def links
       LinksPresenter.new(item).extract(
         [
-          :document_collections,
           :organisations,
           :parent,
           :related_policies,

--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -1,7 +1,6 @@
 module PublishingApi
   class LinksPresenter
     LINK_NAMES_TO_METHODS_MAP = {
-      document_collections: :document_collection_ids,
       organisations: :organisation_ids,
       policy_areas: :policy_area_ids,
       related_policies: :related_policy_ids,
@@ -27,10 +26,6 @@ module PublishingApi
   private
 
     attr_reader :item
-
-    def document_collection_ids
-      (item.try(:published_document_collections) || []).map(&:content_id)
-    end
 
     def policy_area_ids
       (item.try(:topics) || []).map(&:content_id)

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -35,7 +35,6 @@ module PublishingApi
           :topics,
           :parent,
           :organisations,
-          :document_collections,
           :world_locations,
           :policy_areas,
           :related_policies,

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -44,7 +44,6 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       },
     }
     expected_links = {
-      document_collections: [],
       organisations: case_study.lead_organisations.map(&:content_id),
       related_policies: [],
       topics: [],
@@ -136,7 +135,6 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
                         supporting_organisations: [supporting_org])
     presented_item = present(case_study)
     expected_links_hash = {
-      document_collections: [],
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
       related_policies: [],
       topics: [],
@@ -188,20 +186,6 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'case_study')
     assert_equal [policy_area_1["content_id"], policy_1["content_id"]], presented_item.links[:related_policies]
-  end
-
-  test "links hash includes document collections that the case study is part of" do
-    case_study = create(:published_case_study)
-    document_collections = [
-      create(:published_document_collection, groups: [build(:document_collection_group, documents: [case_study.document])]),
-      create(:published_document_collection, groups: [build(:document_collection_group, documents: [case_study.document])])
-    ]
-
-    case_study.document_collections.reload
-    presented_item = present(case_study)
-
-    assert_valid_against_links_schema({ links: presented_item.links }, 'case_study')
-    assert_same_elements document_collections.map(&:content_id), presented_item.links[:document_collections]
   end
 
   test "a withdrawn case study includes details of the archive notice" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -62,7 +62,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       topics: [],
       parent: [],
       organisations: publication.lead_organisations.map(&:content_id),
-      document_collections: [],
       ministers: [minister.person.content_id],
       related_statistical_data_sets: [statistical_data_set.content_id],
       world_locations: [],
@@ -111,7 +110,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       topics: [],
       parent: [],
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
-      document_collections: [],
       world_locations: [],
       ministers: [],
       related_statistical_data_sets: [],
@@ -147,20 +145,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     presented_item = present(publication)
     assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
     assert_equal [location.content_id], presented_item.links[:world_locations]
-  end
-
-  test "links hash includes document collections that the publication is part of" do
-    publication = create(:published_publication)
-    document_collections = [
-      create(:published_document_collection, groups: [build(:document_collection_group, documents: [publication.document])]),
-      create(:published_document_collection, groups: [build(:document_collection_group, documents: [publication.document])])
-    ]
-
-    publication.document_collections.reload
-    presented_item = present(publication)
-
-    assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
-    assert_same_elements document_collections.map(&:content_id), presented_item.links[:document_collections]
   end
 
   test "a withdrawn publication includes details of the archive notice" do


### PR DESCRIPTION
`DocumentCollection` will create `document` links when it is published so having this reciprocal link is uneccessary and will become invalid with forthcoming schema changes.