### PR TITLE
Only present valid specialist sectors to Publishing API

### DIFF
--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -57,7 +57,7 @@ module PublishingApi
     end
 
     def topic_content_ids
-      item.specialist_sectors.map(&:topic_content_id)
+      item.specialist_sectors.reject(&:invalid?).map(&:topic_content_id)
     end
 
     def parent_content_ids

--- a/test/factories/specialist_sector.rb
+++ b/test/factories/specialist_sector.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
   factory :specialist_sector do
+    trait :invalid do
+      # Turn off validation so we can create specialist sector with nil
+      # content id
+      to_create { |specialist_sector| specialist_sector.save(validate: false) }
+      topic_content_id nil
+    end
   end
 end

--- a/test/unit/presenters/publishing_api/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/links_presenter_test.rb
@@ -24,6 +24,19 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
     assert_equal({ topics: %w(content_id_1), parent: [], organisations: [] }, links)
   end
 
+  test 'rejects invalid specialist sectors' do
+    edition = create(:edition)
+
+    create(:specialist_sector, topic_content_id: "content_id_1", edition: edition, primary: true)
+    create(:specialist_sector, :invalid, edition: edition, primary: false)
+    create(:specialist_sector, topic_content_id: "content_id_3", edition: edition, primary: false)
+
+    assert_equal(
+      { topics: %w(content_id_1 content_id_3) },
+      links_for(edition, %i(topics))
+    )
+  end
+
   test 'it treats the primary specialist sector of the item as the parent' do
     edition = create(:edition)
     create(:specialist_sector, topic_content_id: "content_id_1", edition: edition, primary: true)


### PR DESCRIPTION
It is possible for the relationship between a specialist sector and an edition to remain persisted despite the specialist sector being invalid. This extra check ensures we only present valid sepcialist sectors to the Publishing API.

This change was identified when publishing a document collection that had a specialist sector that was missing a `content_id`. The specialist sector in question appears to have been withdrawn as it is not visible on GOV.UK.

The Publishing API rejected the JSON as the links hash contained the `nil``content_id` of the specialist sector.