### PR TITLE
Ignore access limited drafts

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -21,6 +21,7 @@ module SyncChecker
       end
 
       def edition_expected_in_draft
+        return nil if draft_is_access_limited?(document)
         document.pre_publication_edition || document.published_edition
       end
 
@@ -176,6 +177,11 @@ module SyncChecker
           slug: government.slug,
           current: government.current?
         }.stringify_keys
+      end
+
+      def draft_is_access_limited?(document)
+        draft = document.pre_publication_edition
+        !!(draft && draft.access_limited?)
       end
     end
   end


### PR DESCRIPTION
The sync checks can't retrieve access limited draft items from the draft content store which causes failures. As we can't retrieve the we need to ignore them in the checks.

Part of migration work in [Trello](https://trello.com/c/DoIbAkZB)