### PR TITLE
Guard against nil topic content_ids

### DIFF
--- a/lib/sync_checker/checks/topics_check.rb
+++ b/lib/sync_checker/checks/topics_check.rb
@@ -38,7 +38,7 @@ module SyncChecker
 
       def check_topics
         return if expected_content_ids.empty? && links_topics.nil?
-        return "expected links#topics but it isn't present" if links_topics.nil? && expected_content_ids.any?
+        return "expected links#topics but it isn't present" if links_topics.nil? && !expected_content_ids.empty?
         return "links#topics are present but shouldn't be" if links_topics.present? && expected_content_ids.empty?
         check_for_missing_topics + check_for_unexpected_topics
       end


### PR DESCRIPTION
At the moment, there are topics with a `nil` `content_id` in the Whitehall DB. This will be fixed but currently using `.any?` in the sync checks when testing them returns `false` when there is only a `nil` so the sync checks currently fall over when they encounter that.

Part of [Trello](https://trello.com/c/DoIbAkZB/)