### PR TITLE
Run Sync Checks using Sidekiq

### DIFF
--- a/app/models/sync_check_result.rb
+++ b/app/models/sync_check_result.rb
@@ -1,0 +1,17 @@
+class SyncCheckResult < ActiveRecord::Base
+  # Used to store results of Sync Checks when running migrations. The check_class
+  # will be one from the `SyncChecker::Formats` namespace. This is a developer-only
+  # model, and will be used to drive a dashboard that measures the progress of
+  # migration.
+
+  validates :check_class, presence: true
+  validates :item_id, uniqueness: {scope: :check_class}
+
+  serialize :failures
+
+  def self.record(check_class, item_id, failures)
+    record = find_or_initialize_by(check_class: check_class, item_id: item_id)
+    record.failures = failures
+    record.save!
+  end
+end

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -14,6 +14,8 @@ class PublishingApiWorker < WorkerBase
         handle_client_error(e)
       end
     end
+
+    SyncCheckWorker.enqueue(model)
   end
 
   private

--- a/app/workers/sync_check_worker.rb
+++ b/app/workers/sync_check_worker.rb
@@ -1,0 +1,23 @@
+class SyncCheckWorker < WorkerBase
+  sidekiq_options queue: :sync_checks
+
+  def perform(check_class, id)
+    check_class = check_class.constantize if check_class.is_a? String
+
+    item = check_class.scope_with_ids(id).first
+    return if item.nil?
+
+    results = []
+
+    document_check = check_class.new(item)
+    request = SyncChecker::RequestQueue.new(document_check, results)
+    hydra = Typhoeus::Hydra.new
+    request.requests.each { |req| hydra.queue(req) }
+    hydra.run
+
+    results.compact!
+    results = nil if results.empty?
+
+    SyncCheckResult.record(check_class, item.id, results)
+  end
+end

--- a/app/workers/sync_check_worker.rb
+++ b/app/workers/sync_check_worker.rb
@@ -20,4 +20,29 @@ class SyncCheckWorker < WorkerBase
 
     SyncCheckResult.record(check_class, item.id, results)
   end
+
+  def self.enqueue(item)
+    check_class = check_class_for(item)
+    return if check_class.nil?
+
+    item_id = item_id_for(item)
+    perform_in(5.minutes, check_class, item_id)
+  end
+
+  def self.check_class_for(item)
+    name = "SyncChecker::Formats::#{item.class.name}Check"
+    begin
+      name.constantize
+    rescue NameError
+      nil
+    end
+  end
+
+  def self.item_id_for(item)
+    if item.is_a? Edition
+      item.document_id
+    else
+      item.id
+    end
+  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,3 +12,4 @@
   - [publishing_api, 4]
   - [default, 5]
   - [scheduled_publishing, 10]
+  - [sync_checks, 1]

--- a/db/migrate/20161106133205_create_sync_check_results.rb
+++ b/db/migrate/20161106133205_create_sync_check_results.rb
@@ -1,0 +1,13 @@
+class CreateSyncCheckResults < ActiveRecord::Migration
+  def change
+    create_table :sync_check_results do |t|
+      t.string :check_class
+      t.integer :item_id
+      t.text :failures
+
+      t.timestamps null: false
+
+      t.index [:check_class, :item_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161010135926) do
+ActiveRecord::Schema.define(version: 20161106133205) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1098,6 +1098,16 @@ ActiveRecord::Schema.define(version: 20161010135926) do
   add_index "statistics_announcements", ["slug"], name: "index_statistics_announcements_on_slug", using: :btree
   add_index "statistics_announcements", ["title"], name: "index_statistics_announcements_on_title", using: :btree
   add_index "statistics_announcements", ["topic_id"], name: "index_statistics_announcements_on_topic_id", using: :btree
+
+  create_table "sync_check_results", force: :cascade do |t|
+    t.string   "check_class", limit: 255
+    t.integer  "item_id",     limit: 4
+    t.text     "failures",    limit: 65535
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "sync_check_results", ["check_class", "item_id"], name: "index_sync_check_results_on_check_class_and_item_id", unique: true, using: :btree
 
   create_table "take_part_pages", force: :cascade do |t|
     t.string   "title",             limit: 255,      null: false

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -14,10 +14,9 @@ module SyncChecker
         PublishingApiDocumentRepublishingWorker.new.perform(id)
       end
 
-      attr_reader :document, :results
+      attr_reader :document
       def initialize(document)
         @document = document
-        @results = []
       end
 
       def edition_expected_in_draft

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,7 @@ class ActiveSupport::TestCase
     Edition::AuditTrail.whodunnit = fake_whodunnit
     stub_any_publishing_api_call
     stub_publishing_api_policies
+    SyncCheckWorker.stubs(:enqueue)
   end
 
   teardown do

--- a/test/unit/models/sync_check_result_test.rb
+++ b/test/unit/models/sync_check_result_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class SyncCheckResultTest < ActiveSupport::TestCase
+  test ".record performs an upsert" do
+    SyncCheckResult.record("Foo", 1234, ["bar"])
+    result = SyncCheckResult.first
+    assert_equal "Foo", result.check_class
+    assert_equal 1234, result.item_id
+    assert_equal ["bar"], result.failures
+
+    SyncCheckResult.record("Foo", 1234, ["baz"])
+    result = SyncCheckResult.first
+    assert_equal "Foo", result.check_class
+    assert_equal 1234, result.item_id
+    assert_equal ["baz"], result.failures
+
+    SyncCheckResult.record("Qux", 1234, ["baz"])
+    result = SyncCheckResult.first
+    assert_equal "Foo", result.check_class
+    assert_equal 1234, result.item_id
+    assert_equal ["baz"], result.failures
+
+    result = SyncCheckResult.last
+    assert_equal "Qux", result.check_class
+    assert_equal 1234, result.item_id
+    assert_equal ["baz"], result.failures
+  end
+end

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -14,6 +14,8 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
 
+    SyncCheckWorker.expects(:enqueue).with(edition)
+
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
 
     assert_all_requested(requests)
@@ -27,6 +29,8 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
+
+    SyncCheckWorker.expects(:enqueue).with(edition)
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
 
@@ -64,6 +68,8 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: update_type, locale: "en")
     ]
+
+    SyncCheckWorker.expects(:enqueue).with(edition)
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id, update_type)
 

--- a/test/unit/workers/sync_check_worker_test.rb
+++ b/test/unit/workers/sync_check_worker_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require 'gds_api/test_helpers/content_store.rb'
+
+class SyncCheckWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  def dummy_content_item(item)
+    presenter = PublishingApiPresenters.presenter_for(item)
+
+    content = presenter.content
+    content[:content_id] = presenter.content_id
+    content[:links] = {
+      available_translations: [
+        {content_id: presenter.content_id, locale: "en"}
+      ]
+    }
+    presenter.links.each do |type, ids|
+      content[:links][type] = ids.map { |id| {content_id: id} }
+    end
+
+    content
+  end
+
+  test "it tests a content item without errors and records the result" do
+    case_study = create(:published_case_study)
+
+    content_item = dummy_content_item(case_study)
+
+    content_store_has_item(case_study.search_link, content_item)
+    content_store_has_item(case_study.search_link, content_item, draft: true)
+
+    SyncCheckWorker.new.perform(SyncChecker::Formats::CaseStudyCheck, case_study.document_id)
+
+    assert_equal 1, SyncCheckResult.where(
+      failures: nil,
+      check_class: SyncChecker::Formats::CaseStudyCheck,
+      item_id: case_study.document_id
+    ).count
+  end
+
+  test "it tests a content item with errors and records the result" do
+    case_study = create(:published_case_study)
+
+    content_item = dummy_content_item(case_study)
+    content_item[:content_id] = "foobar"
+
+    content_store_has_item(case_study.search_link, content_item)
+    content_store_has_item(case_study.search_link, content_item, draft: true)
+
+    SyncCheckWorker.new.perform(SyncChecker::Formats::CaseStudyCheck, case_study.document_id)
+
+    result = SyncCheckResult.first
+
+    assert_equal "SyncChecker::Formats::CaseStudyCheck", result.check_class
+    assert_equal case_study.document_id, result.item_id
+    assert_equal 2, result.failures.size
+    assert_match %r{expected content_id}, result.failures.first.errors.first
+    assert_match %r{expected content_id}, result.failures.last.errors.first
+  end
+end


### PR DESCRIPTION
Runs automatically 5 minutes after all publishing api actions, and results are stored in a new database table. We'll later add a hidden dashboard in Whitehall admin to report the current progress of the sync checks per format.

/cc @gpeng 