### PR TITLE
Ignore rejected editions

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -26,6 +26,7 @@ module SyncChecker
       end
 
       def edition_expected_in_live
+        return nil if latest_edition_is_rejected?(document)
         case
         when document.published_edition
           document.published_edition
@@ -182,6 +183,12 @@ module SyncChecker
       def draft_is_access_limited?(document)
         draft = document.pre_publication_edition
         !!(draft && draft.access_limited?)
+      end
+
+      def latest_edition_is_rejected?(document)
+        document.published_edition.nil? &&
+          document.pre_publication_edition &&
+          document.pre_publication_edition.rejected?
       end
     end
   end


### PR DESCRIPTION
If there is no current `published|withdrawn` edition and the latest edition is in `rejected` state then we shouldn't expect anything in the content store when running sync checks. Returning a 404 in the scenario is in keeping with current Whitehall behaviour.

e.g. Document id: 199790, https://www.gov.uk/government/collections/notice-of-rights-and-entitlements-for-detainees-translations

Part of [Trello](https://trello.com/c/DoIbAkZB)