### PR TITLE
Fix sync check withdrawn date comparison

### DIFF
--- a/lib/sync_checker/checks/unpublished_check.rb
+++ b/lib/sync_checker/checks/unpublished_check.rb
@@ -100,11 +100,15 @@ module SyncChecker
         end
       end
 
+      def format_date(date)
+        Time.parse(date.to_s).utc
+      end
+
       def check_withdrawn_at(unpublishing)
-        item_withdrawn_at = content_item["withdrawn_notice"]["withdrawn_at"]
+        item_withdrawn_at = format_date(content_item["withdrawn_notice"]["withdrawn_at"])
         return "expected withdrawn at but was missing" if item_withdrawn_at.blank?
 
-        edition_withdrawn_at = unpublishing.edition.updated_at.to_datetime.utc.rfc3339(3)
+        edition_withdrawn_at = format_date(unpublishing.edition.updated_at)
         if item_withdrawn_at != edition_withdrawn_at
           "expected withdrawn at '#{edition_withdrawn_at}' but got '#{item_withdrawn_at}'"
         end

--- a/lib/sync_checker/checks/unpublished_check.rb
+++ b/lib/sync_checker/checks/unpublished_check.rb
@@ -101,7 +101,7 @@ module SyncChecker
       end
 
       def format_date(date)
-        Time.parse(date.to_s).utc
+        Time.zone.parse(date.to_s).utc
       end
 
       def check_withdrawn_at(unpublishing)

--- a/test/unit/sync_checker/checks/unpublished_check_test.rb
+++ b/test/unit/sync_checker/checks/unpublished_check_test.rb
@@ -1,7 +1,9 @@
+ENV["RAILS_ENV"] = "test"
+
+require File.expand_path('../../../../../config/environment', __FILE__)
 require 'minitest/autorun'
 require 'mocha/setup'
-require 'active_support/json'
-
+require 'rails/test_help'
 require_relative '../../../../lib/sync_checker/checks/unpublished_check'
 require_relative '../../../../lib/whitehall/govspeak_renderer'
 


### PR DESCRIPTION
This fixes DocumentCollection sync check failures where withdrawn dates in the Content Store are reportedly different to those in Whitehall. This is caused by dates being in different formats. Dates being returned from Content Store as iso8601 (so we get something like `2016-04-27T14:04:31Z`). Whitehall, on the other hand is using `updated_at` field from the `unpublishing.edition` which is stored and retrieved with an offset (something like `2016-04-27T14:04:31.000+00:00`).

The solution here is to parse both dates as utc. However, Whitehall has, as part of its test suite, a test to ensure that no files are using the plain Ruby Time object. Instead using `ActiveSupport::TimeWithZone` is encouraged. To this end some Rails goodness is now included in `unpublished_check_test` to ensure proper set up of `TimeWithZone` object during the tests.