### PR TITLE
Fix configuration of listening queues for Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,11 +5,9 @@
 :concurrency: 1
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - [bulk_republishing, 1]
-  - [imports, 2]
-  - [router, 4]
-  - [panopticon, 4]
-  - [publishing_api, 4]
-  - [default, 5]
-  - [scheduled_publishing, 10]
-  - [sync_checks, 1]
+  - scheduled_publishing
+  - default
+  - publishing_api
+  - panopticon
+  - bulk_republishing
+  - sync_checks


### PR DESCRIPTION
This is currently configured using weighted queues. In newer versions
of Sidekiq, queues can have absolute priorities. So from this change,
scheduled publishing would always be processed first, followed by the
`default` queue (currently things like link reports, govspeak
rendering, document lists and should probably be tidied up elsewhere)
etc. `snyc_checks` should come after `bulk_republishing` as the sync
checks are entirely for developer use and should thus be the lowest
priority.

Both router and imports queues are no longer used.