### PR TITLE
Fix Edition topic sync checks

### DIFF
--- a/db/data_migration/20161107092104_fix_detached_specialist_sector.rb
+++ b/db/data_migration/20161107092104_fix_detached_specialist_sector.rb
@@ -1,0 +1,23 @@
+linkable_topics = LinkableTopics.new
+
+linkable_topic_items = linkable_topics.send(:fetch_topics_from_publishing_api)
+linkable_topic_items = linkable_topics.send(:change_separator, linkable_topic_items)
+linkable_topic_items = linkable_topics.send(:select_only_subtopics, linkable_topic_items)
+
+specialist_sectors = SpecialistSector.where(topic_content_id: nil)
+
+puts 'Found %{count} Specialist Sectors with a missing `topic_content_id`' %
+       { count: specialist_sectors.count }
+
+specialist_sectors.each do |specialist_sector|
+  puts '- Processing %{specialist_sector}' % { specialist_sector: specialist_sector.inspect }
+
+  if (topic = linkable_topic_items.find { |item| item['base_path'] == "/topic/#{specialist_sector['tag']}" })
+    puts '  Found topic %{topic}' % { topic: topic.inspect }
+    puts '  %{status} `content_id` %{content_id}' %
+           { content_id: specialist_sector.topic_content_id = topic['content_id'],
+             status: specialist_sector.save ? 'Assigned' : 'Failed to assign' }
+  else
+    puts '  No topic found'
+  end
+end

--- a/lib/sync_checker/checks/topics_check.rb
+++ b/lib/sync_checker/checks/topics_check.rb
@@ -3,8 +3,9 @@ module SyncChecker
     class TopicsCheck
       attr_reader :edition, :content_item
 
-      def initialize(edition)
+      def initialize(edition, topic_blacklist: nil)
         @edition = edition
+        @topic_blacklist = topic_blacklist
       end
 
       def call(response)
@@ -56,7 +57,11 @@ module SyncChecker
       end
 
       def expected_content_ids
-        edition.specialist_sector_tags
+        if @topic_blacklist
+          edition.specialist_sector_tags - @topic_blacklist
+        else
+          edition.specialist_sector_tags
+        end
       end
 
       def links_parent

--- a/lib/sync_checker/draft_topic_content_ids.rb
+++ b/lib/sync_checker/draft_topic_content_ids.rb
@@ -1,0 +1,15 @@
+require_relative '../../lib/whitehall'
+
+module SyncChecker
+  class DraftTopicContentIds
+    def self.fetch
+      @draft_content_ids ||= begin
+        Whitehall.publishing_api_v2_client
+          .get_linkables(document_type: 'topic')
+          .map(&:with_indifferent_access)
+          .select { |linkable| linkable[:publication_state] == 'draft' }
+          .map { |linkable| linkable[:content_id] }
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -110,7 +110,8 @@ module SyncChecker
           ),
           Checks::UnpublishedCheck.new(document),
           Checks::TranslationsCheck.new(edition_expected_in_live.available_locales),
-          Checks::TopicsCheck.new(edition_expected_in_live)
+          Checks::TopicsCheck.new(edition_expected_in_live,
+                                  topic_blacklist: DraftTopicContentIds.fetch)
         ]
       end
 

--- a/test/unit/sync_checker/checks/topics_check_test.rb
+++ b/test/unit/sync_checker/checks/topics_check_test.rb
@@ -307,6 +307,38 @@ module SyncChecker
 
         assert_equal expected_errors, TopicsCheck.new(edition).call(response)
       end
+
+      def test_it_returns_no_errors_when_draft_topics_are_not_present_in_the_response
+        tag = 'ABC-CORRECT-CONTENT-ID'
+        draft_tag = 'XYZ-CORRECT-CONTENT-ID'
+
+        edition = stub(
+          specialist_sector_tags: [tag, draft_tag],
+          primary_specialist_sector_tag: tag,
+        )
+
+        response = stub(
+          response_code: 200,
+          body: {
+            links: {
+              parent: [
+                {
+                  content_id: 'ABC-CORRECT-CONTENT-ID'
+                }
+              ],
+              topics: [
+                {
+                  content_id: 'ABC-CORRECT-CONTENT-ID'
+                }
+              ]
+            }
+          }.to_json
+        )
+
+        topics_check = TopicsCheck.new(edition, topic_blacklist: ['XYZ-CORRECT-CONTENT-ID'])
+
+        assert_empty topics_check.call(response)
+      end
     end
   end
 end

--- a/test/unit/sync_checker/draft_topic_content_ids_test.rb
+++ b/test/unit/sync_checker/draft_topic_content_ids_test.rb
@@ -1,0 +1,40 @@
+require 'maxitest/autorun'
+require 'mocha/setup'
+
+require_relative '../../../config/environment'
+require_relative '../../../lib/sync_checker/draft_topic_content_ids'
+
+module SyncChecker
+  class TestDraftTopicContentIds < Minitest::Test
+    def test_it_returns_an_array_of_published_content_ids
+      Whitehall.expects(:publishing_api_v2_client).returns(
+        mock('client').tap do |client|
+          client.expects(:get_linkables)
+            .with(document_type: 'topic')
+            .returns(
+              [
+                {
+                  title: 'Draft 1',
+                  content_id: 'e284845c-19f0-4130-8920-3888105b4433',
+                  publication_state: 'draft',
+                  base_path: '/topic/draft-1',
+                  internal_name: 'Draft 1'
+                },
+                {
+                  title: 'Published 1',
+                  content_id: 'e3968207-2557-4f18-9f35-7d2ea328d2c6',
+                  publication_state: 'published',
+                  base_path: '/topic/published-1',
+                  internal_name: 'Published 1'
+                }
+              ]
+            )
+        end
+      )
+
+      assert_equal ['e284845c-19f0-4130-8920-3888105b4433'], DraftTopicContentIds.fetch
+      # call again tests that result is memoized
+      assert_equal ['e284845c-19f0-4130-8920-3888105b4433'], DraftTopicContentIds.fetch
+    end
+  end
+end

--- a/test/unit/workers/sync_check_worker_test.rb
+++ b/test/unit/workers/sync_check_worker_test.rb
@@ -5,6 +5,7 @@ class SyncCheckWorkerTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
 
   setup do
+    SyncChecker::DraftTopicContentIds.stubs(:fetch)
     SyncCheckWorker.unstub(:enqueue)
   end
 


### PR DESCRIPTION
Fixes two issues causing a sync check failure:

**1. Editions failing to publish**

An Edition with a Specialist Sector missing a `content_id` fails to publish. The Publishing API returns a [422 response](https://httpstatuses.com/422) because the presented Edition contains the `nil` `content_id` of the Specialist Sector.

This adds a data migration to ensure that all Specialist Sectors associated with existing Editions have a reference to the `content_id` of the associated Topic. These associations should already exists but somehow have become out sync.

**2. Sync checks for draft topics**

Draft Topics can be associated with an Edition. This association should be presented to the Publishing API so it can maintain that association and perform any operations on linked content items should the draft Topic be modified in the future.

However, we are unable to assert that association exists through a sync check as draft Topics are excluded from the Content Item we assert against. The content items represent the public state of an Edition on GOV.UK and not the state of the Edition private to the Publishing Platform.

_Supersedes #2808_