### PR TITLE
Fix related documents for two document collections

### DIFF
--- a/db/data_migration/20161109144547_fix_major_projects_data_and_employers_illegal_working_penalties_documents.rb
+++ b/db/data_migration/20161109144547_fix_major_projects_data_and_employers_illegal_working_penalties_documents.rb
@@ -1,0 +1,31 @@
+# This is a document that is being linked from /government/collections/major-projects-data.
+d = Document.find(168857)
+
+# Here's the issue:
+# > d.editions.map(&:state)
+# ["superseded", "draft", "published"]
+#                ^^^^^^^ - This is wrong and shouldn't happen today, let's fix it.
+corrupted_edition = d.editions[1]
+corrupted_edition.state = 'superseded'
+corrupted_edition.unpublishing.destroy!
+
+# The validate: false is necessary to get around the lack of a policy area on this document.
+corrupted_edition.save(validate: false)
+
+PublishingApiDocumentRepublishingWorker.new.perform(d.id)
+
+# This is a document that is being linked from /government/collections/employers-illegal-working-penalties
+d = Document.find(216539)
+
+# Here's the issue:
+# > d.editions.map(&:state)
+# ["superseded", "superseded", "draft", "published"]
+#                              ^^^^^^^ - As above, this is wrong.
+corrupted_edition = d.editions[2]
+corrupted_edition.state = 'superseded'
+corrupted_edition.unpublishing.destroy!
+
+# This one doesn't need validate: false.
+corrupted_edition.save!
+
+PublishingApiDocumentRepublishingWorker.new.perform(d.id)


### PR DESCRIPTION
Two of the document collections we are migrating are linking to documents which are in an odd state in Whitehall; their latest edition is published, but the one before that is draft:

```
> d = Document.find(168857)
> d.editions.map(&:state)
["superseded", "draft", "published"]
```

This causes `PublishingApiDocumentRepublishingWorker` to pick up the draft as a `pre_publication_edition`, and since it has an unpublishing, that will lead to a redirect being published to the content-store. This will fail the sync check.

This data migration finds the culprits and sets them to superseded, while deleting their unpublishings.

Investigated with @gpeng and @mgrassotti (I'm just writing the data migration, really)

Relates to https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-33-4-363-partial-check.