### PR TITLE
Publish content items for “services and information” pages

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -15,6 +15,7 @@ class Admin::OrganisationsController < Admin::BaseController
   def create
     @organisation = Organisation.new(organisation_params)
     if @organisation.save
+      publish_services_and_information_page
       redirect_to admin_organisations_path
     else
       render :new
@@ -63,6 +64,7 @@ class Admin::OrganisationsController < Admin::BaseController
   def update
     delete_absent_organisation_classifications
     if @organisation.update_attributes(organisation_params)
+      publish_services_and_information_page
       redirect_to admin_organisation_path(@organisation)
     else
       render :edit
@@ -131,5 +133,9 @@ class Admin::OrganisationsController < Admin::BaseController
 
   def load_organisation
     @organisation = Organisation.friendly.find(params[:id])
+  end
+
+  def publish_services_and_information_page
+    Whitehall::PublishingApi.publish_services_and_information_async(@organisation.id)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -482,8 +482,6 @@ class Organisation < ActiveRecord::Base
     featured_links.limit(visible_featured_links_count)
   end
 
-  private
-
   def organisations_with_services_and_information_link
     %w{
       charity-commission
@@ -492,6 +490,7 @@ class Organisation < ActiveRecord::Base
       driver-and-vehicle-standards-agency
       environment-agency
       high-speed-two-limited
+      highways-england
       hm-revenue-customs
       marine-management-organisation
       maritime-and-coastguard-agency
@@ -500,6 +499,8 @@ class Organisation < ActiveRecord::Base
       planning-inspectorate
     }
   end
+
+private
 
   def organisations_with_scoped_search
     [

--- a/app/presenters/publishing_api/services_and_information_presenter.rb
+++ b/app/presenters/publishing_api/services_and_information_presenter.rb
@@ -1,0 +1,59 @@
+module PublishingApi
+  class ServicesAndInformationPresenter
+    include ApplicationHelper
+
+    attr_accessor :organisation
+
+    def initialize(organisation)
+      self.organisation = organisation
+    end
+
+    # Updates are always classed as "minor" because we don't actually
+    # have any content in the content item, only metadata.
+    def update_type
+      "minor"
+    end
+
+    def content_id
+      Whitehall.publishing_api_v2_client.lookup_content_id(
+        base_path: base_path
+      ) || SecureRandom.uuid
+    end
+
+    def content
+      # We're not using the BaseItemPresenter here since it's a special_route
+      # and the BaseItemPresenter adds extra fields that are not allowed by
+      # that schema.
+      {
+        base_path: base_path,
+        title: "Services and information - #{organisation.name}",
+        description: "",
+        document_type: "special_route",
+        public_updated_at: organisation.updated_at,
+        publishing_app: "whitehall",
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "special_route",
+        routes: [
+          {
+            type: "exact",
+            path: "/government/organisations/#{organisation.slug}/services-information"
+          },
+        ]
+      }
+    end
+
+    def links
+      {
+        parent: [
+          organisation.content_id
+        ]
+      }
+    end
+
+  private
+
+    def base_path
+      "/government/organisations/#{organisation.slug}/services-information"
+    end
+  end
+end

--- a/app/workers/publishing_api_services_and_information_worker.rb
+++ b/app/workers/publishing_api_services_and_information_worker.rb
@@ -1,0 +1,9 @@
+class PublishingApiServicesAndInformationWorker < PublishingApiWorker
+  def perform(organisation_id)
+    organisation = Organisation.find(organisation_id)
+    if organisation.has_services_and_information_link?
+      payload = PublishingApi::ServicesAndInformationPresenter.new(organisation)
+      send_item(payload, "en")
+    end
+  end
+end

--- a/lib/tasks/publish_services_and_information_pages.rake
+++ b/lib/tasks/publish_services_and_information_pages.rake
@@ -1,0 +1,11 @@
+namespace :services_information do
+  desc 'Publish all services and information pages to the publishing API'
+  task publish: :environment do
+    organisations = Organisation.new.organisations_with_services_and_information_link
+    Organisation.where(slug: organisations).each do |organisation|
+      puts "Publishing services and information page for #{organisation.name}"
+
+      Whitehall::PublishingApi.publish_services_and_information_async(organisation.id)
+    end
+  end
+end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -110,6 +110,10 @@ module Whitehall
       PublishingApiDiscardDraftWorker.perform_async(edition.content_id, locale)
     end
 
+    def self.publish_services_and_information_async(organisation_id)
+      PublishingApiServicesAndInformationWorker.perform_async(organisation_id)
+    end
+
     def self.locales_for(model_instance)
       if model_instance.respond_to?(:translated_locales) && (locales = model_instance.translated_locales).any?
         locales

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
+  def present(model_instance)
+    PublishingApi::ServicesAndInformationPresenter.new(model_instance)
+  end
+
+  test 'presents a Services and Information page ready for adding to the publishing API' do
+    organisation = create(:organisation, name: "Organisation of Things")
+    public_path = Whitehall.url_maker.organisation_path(organisation) + "/services-information"
+
+    expected_hash = {
+      base_path: public_path,
+      title: "Services and information - Organisation of Things",
+      description: "",
+      schema_name: "special_route",
+      document_type: "special_route",
+      publishing_app: "whitehall",
+      rendering_app: "whitehall-frontend",
+      public_updated_at: organisation.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+    }
+    expected_links = {
+      parent: [
+        organisation.content_id
+      ]
+    }
+    expected_update_type = "minor"
+
+    presented_item = present(organisation)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal expected_links, presented_item.links
+    assert_equal expected_update_type, presented_item.update_type
+
+    assert_valid_against_schema(presented_item.content, "special_route")
+  end
+end

--- a/test/unit/workers/publishing_api_services_and_information_worker_test.rb
+++ b/test/unit/workers/publishing_api_services_and_information_worker_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+
+class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  setup do
+    @organisation = create(:organisation, name: "Organisation of Things", slug: "things")
+    SecureRandom.stubs(uuid: "a-content-id")
+    @payload = PublishingApi::ServicesAndInformationPresenter.new(@organisation)
+  end
+
+  test "publishes a services and information page for an eligible organisation" do
+    stub_request(:post, "#{Plek.new.find('publishing-api')}/lookup-by-base-path")
+      .to_return(body: {}.to_json)
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
+
+    put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
+    publish_request = stub_publishing_api_publish("a-content-id", {
+      update_type: "minor",
+      locale: "en"
+    })
+    patch_links_request = stub_publishing_api_patch_links("a-content-id", {
+      links: @payload.links
+    })
+
+    PublishingApiServicesAndInformationWorker.new.perform(@organisation.id)
+
+    assert_requested put_content_request
+    assert_requested publish_request
+    assert_requested patch_links_request
+  end
+
+  test "does not publish a services and information page for an ineligible organisation" do
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(false)
+
+    put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
+    publish_request = stub_publishing_api_publish("a-content-id", {
+      update_type: "minor",
+      locale: "en"
+    })
+    patch_links_request = stub_publishing_api_patch_links("a-content-id", {
+      links: @payload.links
+    })
+
+    PublishingApiServicesAndInformationWorker.new.perform(@organisation.id)
+
+    assert_not_requested put_content_request
+    assert_not_requested publish_request
+    assert_not_requested patch_links_request
+  end
+
+  test "correctly re-publishes a services and information page" do
+    stub_request(:post, "#{Plek.new.find('publishing-api')}/lookup-by-base-path")
+      .to_return(body: {
+        "/government/organisations/things/services-information": "another-content-id"
+      }.to_json)
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
+
+    put_content_request = stub_publishing_api_put_content("another-content-id", @payload.content)
+    publish_request = stub_publishing_api_publish("another-content-id", {
+      update_type: "minor",
+      locale: "en"
+    })
+    patch_links_request = stub_publishing_api_patch_links("another-content-id", {
+      links: @payload.links
+    })
+
+    PublishingApiServicesAndInformationWorker.new.perform(@organisation.id)
+
+    assert_requested put_content_request
+    assert_requested publish_request
+    assert_requested patch_links_request
+  end
+end


### PR DESCRIPTION
This commit adds a service and corresponding rake task to publish content items for “services and information” pages. These pages are enabled for certain organisations and are currently rendered by whitehall using data from rummager without any content item. Adding a content item will enable migrating these pages to the collections app.

The “services and information” page for an organisation is re-published each time the parent organisation is edited.

Trello: https://trello.com/c/5kK0YosJ/276-move-services-and-information-pages-to-collections

A follow-up PR will change the name of the schema for all services and information content items based on https://github.com/alphagov/govuk-content-schemas/pull/437.

Deployment checklist:

- [ ] Deploy whitehall
- [ ] Remove extra "More Highways England services and information" link on https://www.gov.uk/government/organisations/highways-england
- [ ] Run the rake task `services_information:publish` to publish all services and information pages to the content-store