### PR TITLE
Remove extraneous draft from Publishing API

### DIFF
--- a/db/data_migration/20161110105158_discard_draft_document_collection.rb
+++ b/db/data_migration/20161110105158_discard_draft_document_collection.rb
@@ -1,0 +1,2 @@
+doc = Document.find(229878)
+PublishingApiDiscardDraftWorker.new.perform(doc.content_id, :en)


### PR DESCRIPTION
https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check
The Publishing API contains a draft item for this particular document, the publishing app and path of the draft are the same so it appears to be a valid draft of the same piece of content. The draft is missing from Whitehall data so this content item is blocking the republication of the document collection, so discard this in order to prevent a lock version conflict and allow it to be republished.