### PR TITLE
Remove related policies that do not exist within the publishing api

### DIFF
--- a/db/data_migration/20161110141524_remove_orphaned_related_policies.rb
+++ b/db/data_migration/20161110141524_remove_orphaned_related_policies.rb
@@ -1,0 +1,5 @@
+#This removes related policies that do not exist within the publishing api
+EditionPolicy.where(edition_id: 438411, policy_content_id: '5d5e9d5a-7631-11e4-a3cb-005056011aef').first.destroy
+EditionPolicy.where(edition_id: 441853, policy_content_id: '5d5ea079-7631-11e4-a3cb-005056011aef').first.destroy
+EditionPolicy.where(edition_id: 324040, policy_content_id: '5d3bf7fb-7631-11e4-a3cb-005056011aef').first.destroy
+EditionPolicy.where(edition_id: 456453, policy_content_id: '5f52615a-7631-11e4-a3cb-005056011aef').first.destroy


### PR DESCRIPTION
Paired with @bevanloon 

[Trello](https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check)

- In response to Sync Check error: "the links key 'related_policies' is not present"

- The `EditionPolicy` table has some records that do not exist when calling `get_linkables(document_type: "policy")` 

@alphagov/team-gov-uk-finding-things Are you able to advise as to how `linkables` was originally populated? We are not overly sure why these ids are not there.