### PR TITLE
Present `parent` with DocumentCollection

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -28,7 +28,7 @@ module PublishingApi
 
     def links
       links = LinksPresenter.new(item).extract(
-        %i(organisations policy_areas topics related_policies)
+        %i(organisations policy_areas topics related_policies parent)
       )
       links.merge!(documents: item.documents.map(&:content_id))
       links.merge!(PayloadBuilder::TopicalEvents.for(item))

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -242,6 +242,13 @@ class PublishingApi::PublishedDocumentCollectionPresenterLinksTest < ActiveSuppo
       @presented_links[:topics]
     )
   end
+
+  test "it presents the primary_specialist_sector content_id as links, parent" do
+    assert_equal(
+      @document_collection.primary_specialist_sectors.map(&:content_id),
+      @presented_links[:parent]
+    )
+  end
 end
 
 class PublishingApi::PublishedDocumentCollectionPresenterRelatedPolicyLinksTest < ActiveSupport::TestCase


### PR DESCRIPTION
This adds `parent` to the JSON presented to Publishing API the Document Collection format.

Paired with @gpeng 

[Trello](https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check)