### PR TITLE
Unpublish draft document collection

### DIFF
--- a/db/data_migration/20161111104626_unpublish_official_documents.rb
+++ b/db/data_migration/20161111104626_unpublish_official_documents.rb
@@ -1,0 +1,6 @@
+doc = Document.find(200300)
+# This document was unpublished in Whitehall
+# 3 years ago, yet it only has one edition in draft state.
+# This is also true in the Publishing API so clean up this
+# draft with an unpublishing of type "gone".
+PublishingApiGoneWorker.new.perform(doc.content_id, "", "", :en, true)


### PR DESCRIPTION
https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check
This particular document collection was unpublished in Whitehall
3 years ago, it's in a draft state in the Publishing API and needs
to be recorded as unpublished as a gone. So do that.