### PR TITLE
Fix invalid `change_note`

### DIFF
--- a/db/data_migration/20161114151014_fix_invalid_change_history.rb
+++ b/db/data_migration/20161114151014_fix_invalid_change_history.rb
@@ -1,0 +1,3 @@
+edition = Edition.find(394423)
+edition.change_note = "Document updated"
+edition.save(validate: false)


### PR DESCRIPTION
The document collection edition (id: 394423) is a major change but has a `nil` change note. This makes it invalid against the document schema and prevents it from being published via the publishing API.

This commit adds a data migration to add a 'Document updated' change note. (NB `validate: false` is required as Whitehall does not allow the addition of a change note to `superseded` `Edition`s.)

Part of: [Trello](https://trello.com/c/DoIbAkZB)

Paired with @bevanloon 