### PR TITLE
Present access_limited in metadata

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -23,6 +23,7 @@ module PublishingApi
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: "document_collection",
       )
+      content.merge!(PayloadBuilder::AccessLimitation.for(item))
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
     end
 
@@ -47,7 +48,6 @@ module PublishingApi
         emphasised_organisations: item.lead_organisations.map(&:content_id),
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
-        details_hash.merge!(PayloadBuilder::AccessLimitation.for(item))
       end
     end
 


### PR DESCRIPTION
Discovered as part of https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check
The `access_limited` property isn't valid in the details hash, [it
should be presented in the metadata](https://github.com/alphagov/govuk-content-schemas/blob/c19c6a641265991d83d1b5ec176657e1a67a4ded/formats/metadata.json#L66).