### PR TITLE
Redraft and redirect unpublished-fishing-focus

### DIFF
--- a/db/data_migration/20161114170750_update_content_id_and_redirect_unpublished_fishing_focus.rb
+++ b/db/data_migration/20161114170750_update_content_id_and_redirect_unpublished_fishing_focus.rb
@@ -1,0 +1,8 @@
+doc = Document.find(199968)
+new_content_id = SecureRandom.uuid
+
+doc.content_id = new_content_id
+doc.save(validate: false)
+
+PublishingApiDraftWorker.new.perform("DocumentCollection", doc.latest_edition.id)
+PublishingApiRedirectWorker.new.perform(doc.content_id, "/government/publications/fishing-focus", :en, true)


### PR DESCRIPTION
https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check

This collection has been renamed as a means to freeing up the base path
for a new piece of content, however this doesn't get reflected in the
Publishing API so the renamed item needs a new content id and
redrafting then unpublished as a redirect to the newer content item.
It's that simple.
Relies on https://github.com/alphagov/whitehall/pull/2827 as this item is access limited.