### PR TITLE
Send topical event start and end dates to rummager

### DIFF
--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -10,6 +10,7 @@ module Searchable
     :description,
     :display_type,
     :detailed_format,
+    :end_date,
     :format,
     :government_name,
     :id,
@@ -29,9 +30,9 @@ module Searchable
     :release_timestamp,
     :search_format_types,
     :slug,
-
     :speech_type,
     :statistics_announcement_state,
+    :start_date,
     :title,
 
     # "Policy area" is the newer name for "topic"

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -4,7 +4,9 @@ class TopicalEvent < Classification
              content: :description,
              format: 'topical_event',
              description: :description_without_markup,
-             slug: :slug
+             slug: :slug,
+             start_date: :start_date,
+             end_date: :end_date
 
   has_one :about_page
 

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -49,4 +49,14 @@ class TopicalEventTest < ActiveSupport::TestCase
     topical_event.save!
     assert_equal [topical_event], TopicalEvent.for_edition(publication.id)
   end
+
+  test "start and end dates are considered indexable for search" do
+    start_date = Date.new(2016, 1, 1)
+    end_date = Date.new(2017, 1, 1)
+    topical_event = create(:topical_event, start_date: start_date, end_date: end_date)
+    rummager_payload = topical_event.search_index
+
+    assert_equal start_date, rummager_payload["start_date"]
+    assert_equal end_date, rummager_payload["end_date"]
+  end
 end


### PR DESCRIPTION
These fields were added to rummager here:
https://github.com/alphagov/rummager/pull/715

This allows us to build a finder for topical events that knows about
active/inactive topical events.

In whitehall, an active topical event is one with an end date that is in the
future. All others are considered inactive and are not listed at the moment.
We order topical events by the start date.

We display topical events and policy areas at /government/topics.
Replacing with finders is the simplest way to render this page from the
new publishing platform and means we can delete the action from whitehall.

https://trello.com/c/oVfSAO9W/311-migrate-policy-areas-index-to-a-finder

Before deploying:
- [x] Deploy https://github.com/alphagov/rummager/pull/715
- [x] Wait a day for the elasticsearch index to be rebuilt