### PR TITLE
Rake task to send content to search by model

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -45,6 +45,25 @@ namespace :rummager do
       end
       puts "Complete."
     end
+
+    desc "indexes all content belonging to a model"
+    task :model, [:model_name] => :environment do |_, args|
+      model_name = args[:model_name]
+
+      begin
+        model = model_name.constantize
+      rescue NameError
+        raise "You need to specify a valid model name, not \"#{model_name}\""
+      end
+
+      raise "#{model_name} doesn't seem to be searchable" unless model.respond_to? :search_index
+
+      model.all.each do |ed|
+        puts "Indexing: #{ed.content_id}"
+        Whitehall::SearchIndex.add(ed)
+      end
+      puts "Complete."
+    end
   end
 
   desc "removes and re-indexes all searchable whitehall content"


### PR DESCRIPTION
At the moment we don't periodically rebuild search indexes,
so we need to reindex content when adding new fields to
rummager.

This will let us reindex just the TopicalEvents after adding
start and end dates: https://github.com/alphagov/whitehall/pull/2829

Trello:
https://trello.com/c/oVfSAO9W/311-migrate-policy-areas-index-to-a-finder