### PR TITLE
Migrate Groups index page to a finder

### DIFF
--- a/lib/finders/groups.json
+++ b/lib/finders/groups.json
@@ -1,0 +1,29 @@
+{
+  "base_path": "/government/groups",
+  "title": "Groups",
+  "description": "",
+  "locale": "en",
+  "document_type": "finder",
+  "schema_name": "finder",
+  "publishing_app": "whitehall",
+  "rendering_app": "finder-frontend",
+  "details": {
+    "document_noun": "policy_group",
+    "default_order": "title",
+    "facets": [],
+    "filter": {
+      "format": "policy_group"
+    },
+    "show_summaries": true
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/groups"
+    },
+    {
+      "type": "exact",
+      "path": "/government/groups.json"
+    }
+  ]
+}


### PR DESCRIPTION
Trello: https://trello.com/c/up6PH1Fe/319-finder-for-government-groups

When merged/deployed it `finders:publish` rake task needs to be ran in order for this change to happen.

- [ ] run `finders:publish`

## Before

![screen shot 2016-11-15 at 11 56 14](https://cloud.githubusercontent.com/assets/136777/20304935/cce44230-ab2a-11e6-98d8-59a08cd229d8.png)

## After

![screen shot 2016-11-15 at 11 56 01](https://cloud.githubusercontent.com/assets/136777/20304947/dd5b0680-ab2a-11e6-87db-c0ebdcbcdd11.png)
![screen shot 2016-11-15 at 11 56 24](https://cloud.githubusercontent.com/assets/136777/20304948/dd5b429e-ab2a-11e6-8e59-1e9393ae4ce7.png)

