### PR TITLE
Basic finder for policy areas

### DIFF
--- a/lib/finders/policy_areas.json
+++ b/lib/finders/policy_areas.json
@@ -1,0 +1,30 @@
+{
+   "base_path":"/government/topics",
+   "title":"Policy Areas",
+   "description":"Government policy and what it is doing about different issues.",
+   "locale":"en",
+   "document_type":"finder",
+   "schema_name":"finder",
+   "publishing_app":"whitehall",
+   "rendering_app":"finder-frontend",
+   "details": {
+      "document_noun": "policy area",
+      "facets":[
+      ],
+      "default_order": "title",
+      "filter": {
+        "format": "topic"
+      },
+      "show_summaries": true
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/topics"
+    },
+    {
+      "type": "exact",
+      "path": "/government/topics.json"
+    }
+  ]
+}


### PR DESCRIPTION
This can replace https://www.gov.uk/government/topics once we have
another finder for topical events. This allows us to render this
information without custom code in whitehall, and the publishing
api becomes the single source of the truth for policy areas.

Once both are deployed the classification#index action can be removed.

Can merge when:
- [x] the topical event finder is deployed.
- [x] product review