### PR TITLE
Switch rendering app for document collection

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -60,6 +60,10 @@ class DocumentCollection < Edition
     editions.scheduled
   end
 
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
   private
 
   def create_default_group

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
         details: details,
         document_type: "document_collection",
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: item.rendering_app,
         schema_name: "document_collection",
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/db/data_migration/20161115140926_republish_document_collection_to_switch_rendering_apps.rb
+++ b/db/data_migration/20161115140926_republish_document_collection_to_switch_rendering_apps.rb
@@ -1,0 +1,2 @@
++publisher = DataHygiene::PublishingApiDocumentRepublisher.new(DocumentCollection)
++publisher.perform

--- a/lib/sync_checker/formats/document_collection_check.rb
+++ b/lib/sync_checker/formats/document_collection_check.rb
@@ -6,7 +6,7 @@ module SyncChecker
       end
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
       def checks_for_live(locale)

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -141,4 +141,9 @@ class DocumentCollectionTest < ActiveSupport::TestCase
 
     assert_equal [scheduled_publication], collection.scheduled_editions
   end
+
+  test 'specifies the rendering app as government frontend' do
+    document_collection = DocumentCollection.new
+    assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
+  end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -42,8 +42,8 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
     assert_equal 'whitehall', @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  test "it presents the rendering_app as government-frontend" do
+    assert_equal 'government-frontend', @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as document_collection" do


### PR DESCRIPTION
Do not merge until Wraith tests have been run.

Document Collection Deploy 1 task - this switches over the rendering app to be `government-frontend` by doing the following:

* Expose a method/property on the Document Collection model that sets the `rendering_app`. 
* Use this method to set the `rendering_app` in the `content` when presenting the Document Collection to the Publishing Api
* Run a data migration to republish Document Collections so that the new `renedering_app` is pushed through the pipes.
* Update the sync checks to expect `government-frontend` as the `rendering_app` for the sync check task after the republish above.

[Trello ticket](https://trello.com/c/hKtIXIS1)