### PR TITLE
Fix the rendering app for static pages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -122,7 +122,7 @@ class PublishStaticPages
         locale: "en",
         base_path: page[:base_path],
         publishing_app: "whitehall",
-        rendering_app: "whitehall",
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         routes: [
           {
             path: page[:base_path],


### PR DESCRIPTION
The rendering app for these pages is "whitehall", which doesn't exist (it's "whitehall-frontend").

This hasn't caused trouble yet because we don't register routes for placeholders. If we did, these pages would have shown 404 to users.

Found during spelunking through https://alphagov.github.io/govuk-developers/apps.html.

cc @carvil.