### PR TITLE
Change services and information content item

### DIFF
--- a/app/presenters/publishing_api/services_and_information_presenter.rb
+++ b/app/presenters/publishing_api/services_and_information_presenter.rb
@@ -21,25 +21,27 @@ module PublishingApi
     end
 
     def content
-      # We're not using the BaseItemPresenter here since it's a special_route
-      # and the BaseItemPresenter adds extra fields that are not allowed by
-      # that schema.
-      {
-        base_path: base_path,
+      content = BaseItemPresenter.new(
+        organisation,
         title: "Services and information - #{organisation.name}",
-        description: "",
-        document_type: "special_route",
+        need_ids: [],
+      ).base_attributes
+
+      content.merge!(
+        base_path: base_path,
+        description: nil,
+        details: {},
+        document_type: "services_and_information",
         public_updated_at: organisation.updated_at,
-        publishing_app: "whitehall",
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "special_route",
+        rendering_app: "collections",
+        schema_name: "generic",
         routes: [
           {
             type: "exact",
             path: "/government/organisations/#{organisation.slug}/services-information"
           },
         ]
-      }
+      )
     end
 
     def links

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -12,13 +12,17 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
     expected_hash = {
       base_path: public_path,
       title: "Services and information - Organisation of Things",
-      description: "",
-      schema_name: "special_route",
-      document_type: "special_route",
+      description: nil,
+      schema_name: "generic",
+      document_type: "services_and_information",
+      locale: "en",
       publishing_app: "whitehall",
-      rendering_app: "whitehall-frontend",
+      rendering_app: "collections",
       public_updated_at: organisation.updated_at,
       routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      need_ids: [],
+      details: {},
     }
     expected_links = {
       parent: [
@@ -33,6 +37,6 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
     assert_equal expected_links, presented_item.links
     assert_equal expected_update_type, presented_item.update_type
 
-    assert_valid_against_schema(presented_item.content, "special_route")
+    assert_valid_against_schema(presented_item.content, "generic")
   end
 end


### PR DESCRIPTION
This commit changes the “services and information” content item that is published to the content-store, in order to be rendered by `collections` rather than `whitehall-frontend`. It also uses the new `generic` schema and a unique `services_and_infomation` document type, replacing `special_route`.

Trello: https://trello.com/c/5kK0YosJ/276-move-services-and-information-pages-to-collections

To be merged after https://github.com/alphagov/govuk-content-schemas/pull/437, https://github.com/alphagov/whitehall/pull/2818 and https://github.com/alphagov/collections/pull/197 are deployed.

Deployment checklist:

- [ ] Deploy whitehall
- [ ] Run the rake task `services_information:publish` to re-publish all services and information pages to the content-store