### PR TITLE
Publish content item for case studies finder

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -1,0 +1,30 @@
+{
+  "base_path": "/government/case-studies",
+  "title": "Case studies: Real-life examples of government activity",
+  "description": "Real examples of how government programmes are helping businesses and people in the UK.",
+  "locale": "en",
+  "document_type": "finder",
+  "schema_name": "finder",
+  "publishing_app": "whitehall",
+  "rendering_app": "finder-frontend",
+  "details": {
+    "document_noun": "case study",
+    "default_order": "-public_timestamp",
+    "facets": [],
+    "filter": {
+      "format": "case_study"
+    },
+    "format_name": "Case studies: Real-life examples of government activity",
+    "show_summaries": true
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/case-studies"
+    },
+    {
+      "type": "exact",
+      "path": "/government/case-studies.json"
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a content item that represents the “case studies” index page (https://www.gov.uk/government/case-studies). Once this content item is published using the existing `finders:publish` rake task, finder-frontend will render that page as a finder, rather than being rendered by whitehall-frontend.

Trello: https://trello.com/c/RerTRcJ4/325-migrate-case-studies-to-a-finder

A follow-up PR will remove the code that renders the case studies index page from whitehall.

Deployment checklist:

- [ ] Deploy whitehall
- [ ] Run the rake task `finders:publish` to publish the content item to the content-store

Before:

![screen shot 2016-11-21 at 11 31 34](https://cloud.githubusercontent.com/assets/444232/20481246/1efcc74c-afde-11e6-8124-4d0966c5b2eb.png)

After:

![screen shot 2016-11-21 at 11 31 40](https://cloud.githubusercontent.com/assets/444232/20481256/23fec22c-afde-11e6-8124-cb0075eb1861.png)
