### PR TITLE
Change text for Taiwan on embassy finder page

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -99,7 +99,7 @@ private
     },
     "Taiwan" => {
       building: "British Office Taipei",
-      location: "Taipei",
+      location: "Taiwan",
       base_path: "/government/world/organisations/british-office-taipei",
     },
     "Timor Leste" => {


### PR DESCRIPTION
[Trello](https://trello.com/c/kKQBJE3A/203-simple-text-updates-to-the-embassy-finder)

Location of British Office Taipei changed from Taipei to Taiwan.