### PR TITLE
Remove Highways England services and information link

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -482,7 +482,12 @@ class Organisation < ActiveRecord::Base
     featured_links.limit(visible_featured_links_count)
   end
 
-  def organisations_with_services_and_information_link
+  # This is the same as organisations_with_services_and_information_link
+  # but also includes Highways England. This is because they have a manual
+  # link to their "services and information" page which we don't want to
+  # duplicate, but we still want to publish the page. This can be removed
+  # once they have removed their manual link.
+  def organisations_with_services_and_information_page
     %w{
       charity-commission
       department-for-education
@@ -501,6 +506,23 @@ class Organisation < ActiveRecord::Base
   end
 
 private
+
+  def organisations_with_services_and_information_link
+    %w{
+      charity-commission
+      department-for-education
+      department-for-environment-food-rural-affairs
+      driver-and-vehicle-standards-agency
+      environment-agency
+      high-speed-two-limited
+      hm-revenue-customs
+      marine-management-organisation
+      maritime-and-coastguard-agency
+      medicines-and-healthcare-products-regulatory-agency
+      natural-england
+      planning-inspectorate
+    }
+  end
 
   def organisations_with_scoped_search
     [

--- a/lib/tasks/publish_services_and_information_pages.rake
+++ b/lib/tasks/publish_services_and_information_pages.rake
@@ -1,7 +1,7 @@
 namespace :services_information do
   desc 'Publish all services and information pages to the publishing API'
   task publish: :environment do
-    organisations = Organisation.new.organisations_with_services_and_information_link
+    organisations = Organisation.new.organisations_with_services_and_information_page
     Organisation.where(slug: organisations).each do |organisation|
       puts "Publishing services and information page for #{organisation.name}"
 


### PR DESCRIPTION
This commit removes Highways England from the list of organisations with an automatic link to their “services and information” from their organisation home page. This was added in https://github.com/alphagov/whitehall/pull/2818 but is being temporarily removed until Highways England can remove their manual link to the page, in order to prevent duplication.