### PR TITLE
Render DocumentCollection preview with Whitehall

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -61,7 +61,10 @@ class DocumentCollection < Edition
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    #this is overridden in the presenter for published content
+    #but maintained here to force preview to use Whitehall
+    #until a draft linkset is implemented in Publishing API
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 
   private

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
         details: details,
         document_type: "document_collection",
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "document_collection",
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -144,6 +144,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
 
   test 'specifies the rendering app as government frontend' do
     document_collection = DocumentCollection.new
-    assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
+    assert_equal Whitehall::RenderingApp::WHITEHALL_FRONTEND, document_collection.rendering_app
   end
 end


### PR DESCRIPTION
DocumentCollection preview has been prematurely switched to `draft-origin` which can't fully support the format as draft content store does not get updated with draft links. This is a known issue that will be addressed shortly but in the meantime this commit switches rendering of previews back to Whitehall.

Fixes [Zendesk](https://govuk.zendesk.com/agent/tickets/1466446)