### PR TITLE
The name to be shown should be "group" instead of "policy_group"

### DIFF
--- a/lib/finders/groups.json
+++ b/lib/finders/groups.json
@@ -8,7 +8,7 @@
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
   "details": {
-    "document_noun": "policy_group",
+    "document_noun": "group",
     "default_order": "title",
     "facets": [],
     "filter": {


### PR DESCRIPTION
Trello: https://trello.com/c/up6PH1Fe/319-finder-for-government-groups

It should be saying "groups" instead of `policy_group`
![screen shot 2016-11-21 at 16 01 29](https://cloud.githubusercontent.com/assets/136777/20489877/fbcc0474-b003-11e6-8a05-da2ce53d692b.png)
