### PR TITLE
Fix Admin bookmarklet for migrated formats

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,0 +1,12 @@
+class Admin::DocumentsController < Admin::BaseController
+  def by_content_id
+    document = Document.find_by(content_id: params[:content_id])
+    url_maker = Whitehall::UrlMaker.new(host: Plek.find('whitehall'))
+    if document
+      redirect_to url_maker.admin_edition_path(document.latest_edition)
+    else
+      flash[:error] = "The requested content was not found"
+      redirect_to url_maker.admin_editions_path
+    end
+  end
+end

--- a/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
+++ b/app/views/admin/find_in_admin_bookmarklet/_bookmarklet.erb
@@ -9,10 +9,16 @@ function id_from_url() {
   return window.location.toString().split('/').pop();
 };
 function id_from_doc_page() {
-  return $('.document-page, [id^=detailed_guide_]').attr('id').split('_').pop();
+  document_page_id = $('.document-page, [id^=detailed_guide_]');
+  if (document_page_id.length > 0) {
+    return document_page_id.attr('id').split('_').pop();
+  }
 };
 function id_from_doc_collection() {
   return $('.document_collection, .documentcollection').attr('id').split('_').pop();
+};
+function content_id_from_meta_tag() {
+  return $("meta[name='govuk:content-id']").attr('content');
 };
 
 function path_builder(path_fragment) {
@@ -60,7 +66,14 @@ function get_mapping() {
 
 function nav_to_backend() {
   var mapping = get_mapping();
-  if (mapping) window.location = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin/" + mapping.path_builder(mapping.id_finder());
+  if (mapping){ 
+    admin_path = "<%= Whitehall.admin_root + Whitehall.router_prefix %>/admin";
+    if(mapping.id_finder()){
+      window.location = admin_path + "/" + mapping.path_builder(mapping.id_finder());
+    }else{
+      window.location = admin_path + "/by-content-id/" + content_id_from_meta_tag();
+    };
+  }
 }
 
 nav_to_backend();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Whitehall::Application.routes.draw do
 
         get 'find-in-admin-bookmarklet' => 'find_in_admin_bookmarklet#index', as: :find_in_admin_bookmarklet_instructions_index
         get 'find-in-admin-bookmarklet/:browser' => 'find_in_admin_bookmarklet#show', as: :find_in_admin_bookmarklet_instructions
+        get 'by-content-id/:content_id' => 'documents#by_content_id'
 
         resources :users, only: [:index, :show, :edit, :update]
 

--- a/test/functional/admin/documents_controller_test.rb
+++ b/test/functional/admin/documents_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Admin::DocumentsControllerTest < ActionController::TestCase
+  def setup
+    login_as :user
+    @document = create(:edition, :with_document).document
+    @url_maker = Whitehall::UrlMaker.new(host: Plek.find('whitehall'))
+  end
+
+  view_test 'GET by-content-id redirects to content by content_id' do
+    get :by_content_id, content_id: @document.content_id
+    assert_redirected_to @url_maker.admin_edition_path(@document.latest_edition)
+  end
+
+  view_test 'GET by-content-id redirects to a search if content_id is not found' do
+    get :by_content_id, content_id: @document.content_id + "wrong-id"
+    assert_redirected_to @url_maker.admin_editions_path
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/nYKudXNT/512-fix-whitehall-admin-bookmarklet-for-migrated-formats-medium

1. Provide a new route which finds content by `content_id`.
2. Amend the bookmarklet javascript to fall back to using the `content_id` if no db ID is found.
3.  Where no db ID is present and no `content_id` present, forward the user to the search page.