### PR TITLE
Update HtmlAttachment content ids

### DIFF
--- a/db/data_migration/20161121164046_update_html_attachment_content_ids.rb
+++ b/db/data_migration/20161121164046_update_html_attachment_content_ids.rb
@@ -1,0 +1,10 @@
+# previous content ids (not in publishing api)
+# 1638037 => "643dd053-5f82-451f-bcc4-b8b676a80433"
+# 1683924 => "e52eaeda-abe6-4b53-aaf9-ef4049ad215c"
+
+{
+  163803 => "1daa93ab-a5f0-4043-9177-f6aad84e0d4d",
+  1683924 => "22443bfa-c8d2-45b0-9827-a3ae42b759b5"
+}.each do |id, new_content_id|
+  HtmlAttachment.find(id).update_attributes(content_id: new_content_id)
+end


### PR DESCRIPTION
This commit changes the content id for two `HtmlAttachment` that have a `ContentItem` with the correct base path in publishing API but with a different `content_id` which is preventing the Whitehall publishing from succeeding. These will be republished in a subsequent commit.