### PR TITLE
Add email for ordering attachment files in an alternative format

### DIFF
--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -79,7 +79,7 @@ module PublishingApi
 
     def documents
       return [] unless item.attachments.any?
-      Whitehall::GovspeakRenderer.new.block_attachments(item.attachments)
+      Whitehall::GovspeakRenderer.new.block_attachments(item.attachments, alternative_format_email)
     end
 
     def ministers
@@ -88,6 +88,10 @@ module PublishingApi
 
     def related_statistical_data_sets
       item.statistical_data_sets.map(&:content_id)
+    end
+
+    def alternative_format_email
+      item.alternative_format_provider.try(:alternative_format_contact_email)
     end
   end
 end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -175,4 +175,12 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     presented_item = present(publication)
     assert_equal publication.document.created_at.iso8601, presented_item.content[:details][:first_public_at]
   end
+
+  test "documents include the alternative format contact email" do
+    publication = create(:publication, :with_command_paper)
+    presented_item = present(publication)
+    document = presented_item.content[:details][:documents].first
+    assert document.include?("This file may not be suitable for users of assistive technology.")
+    assert document.include?("mailto:#{publication.alternative_format_provider.alternative_format_contact_email}")
+  end
 end


### PR DESCRIPTION
Add the email address for ordering attachment files in an alternative
format.