### PR TITLE
Fix services and information content item publishing

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -450,6 +450,10 @@ class Organisation < ActiveRecord::Base
     organisations_with_services_and_information_link.include?(slug)
   end
 
+  def has_services_and_information_page?
+    organisations_with_services_and_information_page.include?(slug)
+  end
+
   def has_scoped_search?
     organisations_with_scoped_search.include?(slug)
   end

--- a/app/presenters/publishing_api/services_and_information_presenter.rb
+++ b/app/presenters/publishing_api/services_and_information_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content_id
-      Whitehall.publishing_api_v2_client.lookup_content_id(
+      @content_id ||= Whitehall.publishing_api_v2_client.lookup_content_id(
         base_path: base_path
       ) || SecureRandom.uuid
     end

--- a/app/workers/publishing_api_services_and_information_worker.rb
+++ b/app/workers/publishing_api_services_and_information_worker.rb
@@ -1,7 +1,7 @@
 class PublishingApiServicesAndInformationWorker < PublishingApiWorker
   def perform(organisation_id)
     organisation = Organisation.find(organisation_id)
-    if organisation.has_services_and_information_link?
+    if organisation.has_services_and_information_page?
       payload = PublishingApi::ServicesAndInformationPresenter.new(organisation)
       send_item(payload, "en")
     end

--- a/test/unit/workers/publishing_api_services_and_information_worker_test.rb
+++ b/test/unit/workers/publishing_api_services_and_information_worker_test.rb
@@ -13,7 +13,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
   test "publishes a services and information page for an eligible organisation" do
     stub_request(:post, "#{Plek.new.find('publishing-api')}/lookup-by-base-path")
       .to_return(body: {}.to_json)
-    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
+    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(true)
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id", {
@@ -32,7 +32,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
   end
 
   test "does not publish a services and information page for an ineligible organisation" do
-    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(false)
+    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(false)
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id", {
@@ -55,7 +55,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
       .to_return(body: {
         "/government/organisations/things/services-information": "another-content-id"
       }.to_json)
-    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
+    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(true)
 
     put_content_request = stub_publishing_api_put_content("another-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("another-content-id", {


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/2818 added content item publishing for services and information pages. Due to a bug in the worker, content items could not be successfully published. This commit fixes the bug by persisting the same generated content ID across a session if the base path does not exist. It also fixes the check made before updating a content item to reflect the changes made by https://github.com/alphagov/whitehall/pull/2844.

Trello: https://trello.com/c/5kK0YosJ/276-move-services-and-information-pages-to-collections