### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -43,7 +43,7 @@ mkdir -p ./attachment-cache
 
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Whitehall app that don't work
with the currently deployed govuk-content-schemas (this changes comes
from GOV.UK RFC 59).