### PR TITLE
Paginate the case studies finder

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -15,7 +15,8 @@
       "format": "case_study"
     },
     "format_name": "Case studies: Real-life examples of government activity",
-    "show_summaries": true
+    "show_summaries": true,
+    "default_documents_per_page": 100
   },
   "routes": [
     {


### PR DESCRIPTION
This commit changes the content item for the case studies finder to paginate results, and show up to 100 per page.

Trello: https://trello.com/c/RerTRcJ4/325-migrate-case-studies-to-a-finder