### PR TITLE
Finder for topical events

### DIFF
--- a/lib/finders/topical_events.json
+++ b/lib/finders/topical_events.json
@@ -1,0 +1,57 @@
+{
+   "base_path":"/government/topics",
+   "title":"Topical Events",
+   "description":"Government news and information about major events: including the budget, commemorative events, responses to global incidents and more",
+   "document_type":"finder",
+   "schema_name":"finder",
+   "locale":"en",
+   "publishing_app":"whitehall",
+   "rendering_app":"finder-frontend",
+   "details": {
+     "document_noun": "topical event",
+     "default_documents_per_page": 20,
+     "default_order": "-start_date",
+     "filter": {
+       "format": "topical_event"
+     },
+     "show_summaries": true,
+     "facets": [
+       {
+         "key": "end_date",
+         "name": "Status",
+         "type": "topical",
+         "open_value": {
+           "label": "Current",
+           "value": "current"
+         },
+         "closed_value": {
+           "label": "Archived",
+           "value": "archived"
+         },
+         "preposition": "with status",
+         "display_as_result_metadata": false,
+         "filterable": true
+       },
+       {
+         "key": "start_date",
+         "name": "Created",
+         "type": "date",
+         "preposition": "created",
+         "display_as_result_metadata": false,
+         "filterable": true
+       }
+     ]
+   },
+   "routes": [
+     {
+       "type": "exact",
+       "path": "/government/topical-events"
+     },
+     {
+       "type": "exact",
+       "path": "/government/topical-events.json"
+     }
+   ]
+}
+
+


### PR DESCRIPTION
This splits the list of topical events from the list of policy areas, which are
currently combined on the /government/topics index page.

We're creating finders for both of these, which adds search/filtering
functionality and removes the need for additional templates and controllers in
whitehall.

The finder can be filtered by status (open or closed) and the date (`open_date`).

https://trello.com/b/GBkshanv/taxonomy-tea://trello.com/c/oVfSAO9W/311-migrate-policy-areas-index-to-a-finder

Before merge:

- [x] Deploy https://github.com/alphagov/govuk-content-schemas/pull/441 for the active/inactive facet
- [x] Product review
- [x] Decide what to put in the meta description

Screenshot:
<img width="990" alt="screen shot 2016-11-24 at 15 05 14" src="https://cloud.githubusercontent.com/assets/87579/20628627/00d2ea0a-b31f-11e6-93a8-7a4d5fbc3e9b.png">

