### PR TITLE
Html attachments migration fixes

### DIFF
--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -86,10 +86,7 @@ private
   def send_draft_and_unpublish
     send_draft_edition
     send_unpublish(pre_publication_edition)
-    PublishingApiHtmlAttachmentsWorker.new.perform(
-      pre_publication_edition.id,
-      "unpublish"
-    )
+    handle_attachments_for(pre_publication_edition)
   end
 
   def send_draft_edition
@@ -101,20 +98,13 @@ private
         locale
       )
     end
-
-    PublishingApiHtmlAttachmentsWorker.new.perform(
-      pre_publication_edition.id,
-      "update_draft"
-    )
+    handle_attachments_for(pre_publication_edition)
   end
 
   def send_published_and_withdraw
     send_published_edition
     send_unpublish(published_edition)
-    PublishingApiHtmlAttachmentsWorker.new.perform(
-      published_edition.id,
-      "withdraw"
-    )
+    handle_attachments_for(published_edition)
   end
 
   def send_published_edition
@@ -126,11 +116,7 @@ private
         locale
       )
     end
-
-    PublishingApiHtmlAttachmentsWorker.new.perform(
-      published_edition.id,
-      "republish"
-    )
+    handle_attachments_for(published_edition)
   end
 
   def send_unpublish(edition)
@@ -141,5 +127,12 @@ private
     Whitehall::PublishingApi.locales_for(edition).each do |locale|
       yield locale.to_s
     end
+  end
+
+  def handle_attachments_for(edition)
+    PublishingApiHtmlAttachmentsWorker.new.perform(
+      edition.id,
+      "republish"
+    )
   end
 end

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -28,7 +28,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiHtmlAttachmentsWorker
       .any_instance
       .expects(:perform)
-      .with(draft_edition.id, "update_draft")
+      .with(draft_edition.id, "republish")
       .in_sequence(invocation_order)
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
@@ -114,7 +114,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiHtmlAttachmentsWorker
       .any_instance
       .expects(:perform)
-      .with(published_edition.id, "withdraw")
+      .with(published_edition.id, "republish")
       .in_sequence(invocation_order)
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)


### PR DESCRIPTION
When we 'unpublish' an HtmlAttachment as a result of a republishing action we need to send the `allow_draft: true` argument to the 'next' worker and also set `update_type: "republish"`.
`allow_draft` is required as there are a number (~300) of corresponding `ContentItem` records in publishing-api that are in draft state that can't be unpublished otherwise.

This PR makes `republish` also handle `unpublishing`. This action is called from the `PublishingApiDocumentRepublishingWorker` when the parent attachable `Edition` is republished.

/cc @boffbowsh 