### PR TITLE
Add Highways England services and information links

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -450,10 +450,6 @@ class Organisation < ActiveRecord::Base
     organisations_with_services_and_information_link.include?(slug)
   end
 
-  def has_services_and_information_page?
-    organisations_with_services_and_information_page.include?(slug)
-  end
-
   def has_scoped_search?
     organisations_with_scoped_search.include?(slug)
   end
@@ -486,12 +482,7 @@ class Organisation < ActiveRecord::Base
     featured_links.limit(visible_featured_links_count)
   end
 
-  # This is the same as organisations_with_services_and_information_link
-  # but also includes Highways England. This is because they have a manual
-  # link to their "services and information" page which we don't want to
-  # duplicate, but we still want to publish the page. This can be removed
-  # once they have removed their manual link.
-  def organisations_with_services_and_information_page
+  def organisations_with_services_and_information_link
     %w{
       charity-commission
       department-for-education
@@ -510,23 +501,6 @@ class Organisation < ActiveRecord::Base
   end
 
 private
-
-  def organisations_with_services_and_information_link
-    %w{
-      charity-commission
-      department-for-education
-      department-for-environment-food-rural-affairs
-      driver-and-vehicle-standards-agency
-      environment-agency
-      high-speed-two-limited
-      hm-revenue-customs
-      marine-management-organisation
-      maritime-and-coastguard-agency
-      medicines-and-healthcare-products-regulatory-agency
-      natural-england
-      planning-inspectorate
-    }
-  end
 
   def organisations_with_scoped_search
     [

--- a/app/workers/publishing_api_services_and_information_worker.rb
+++ b/app/workers/publishing_api_services_and_information_worker.rb
@@ -1,7 +1,7 @@
 class PublishingApiServicesAndInformationWorker < PublishingApiWorker
   def perform(organisation_id)
     organisation = Organisation.find(organisation_id)
-    if organisation.has_services_and_information_page?
+    if organisation.has_services_and_information_link?
       payload = PublishingApi::ServicesAndInformationPresenter.new(organisation)
       send_item(payload, "en")
     end

--- a/lib/tasks/publish_services_and_information_pages.rake
+++ b/lib/tasks/publish_services_and_information_pages.rake
@@ -1,7 +1,7 @@
 namespace :services_information do
   desc 'Publish all services and information pages to the publishing API'
   task publish: :environment do
-    organisations = Organisation.new.organisations_with_services_and_information_page
+    organisations = Organisation.new.organisations_with_services_and_information_link
     Organisation.where(slug: organisations).each do |organisation|
       puts "Publishing services and information page for #{organisation.name}"
 

--- a/test/unit/workers/publishing_api_services_and_information_worker_test.rb
+++ b/test/unit/workers/publishing_api_services_and_information_worker_test.rb
@@ -13,7 +13,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
   test "publishes a services and information page for an eligible organisation" do
     stub_request(:post, "#{Plek.new.find('publishing-api')}/lookup-by-base-path")
       .to_return(body: {}.to_json)
-    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(true)
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id", {
@@ -32,7 +32,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
   end
 
   test "does not publish a services and information page for an ineligible organisation" do
-    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(false)
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(false)
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id", {
@@ -55,7 +55,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
       .to_return(body: {
         "/government/organisations/things/services-information": "another-content-id"
       }.to_json)
-    Organisation.any_instance.stubs(:has_services_and_information_page?).returns(true)
+    Organisation.any_instance.stubs(:has_services_and_information_link?).returns(true)
 
     put_content_request = stub_publishing_api_put_content("another-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("another-content-id", {


### PR DESCRIPTION
Following on fromm https://github.com/alphagov/whitehall/pull/2844, Highways England has now removed the manual link to their “services and information” page, so this commit rationalises the logic around showing such links automatically and adds Highways England to the list of organisartion that have such a link.