### PR TITLE
Remove unused field from Consultation response forms

### DIFF
--- a/app/models/consultation_response_form.rb
+++ b/app/models/consultation_response_form.rb
@@ -4,8 +4,6 @@ class ConsultationResponseForm < ActiveRecord::Base
 
   delegate :url, :file, to: :consultation_response_form_data
 
-  validates :title, presence: true
-
   accepts_nested_attributes_for :consultation_response_form_data
 
   after_destroy :destroy_consultation_response_form_data_if_required

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -20,7 +20,6 @@
           <%= participation_fields.text_field :email %>
           <%= participation_fields.text_area :postal_address, rows: "4", style: "width: auto" %>
           <%= participation_fields.fields_for :consultation_response_form, participation_fields.object.consultation_response_form || participation_fields.object.build_consultation_response_form do |response_form_fields| %>
-            <%= response_form_fields.text_field :title, label_text: "Downloadable response form title", required: false %>
             <% if response_form_fields.object.persisted? %>
               <div class="attachment">
                 <p>Current data: <%= link_to File.basename(response_form_fields.object.consultation_response_form_data.file.path), response_form_fields.object.consultation_response_form_data.file.url %></p>

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -28,7 +28,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       assert_select "select[name*='edition[closing_at']", count: 5
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_url]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
-      assert_select "input[type='text'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][title]']"
       assert_select "input[type='file'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]']"
     end
   end
@@ -39,7 +38,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
         link_url: "http://participation.com",
         email: "countmein@participation.com",
         consultation_response_form_attributes: {
-          title: "the title of the response form",
           consultation_response_form_data_attributes: {
             file: fixture_file_upload('two-pages.pdf')
           }
@@ -56,7 +54,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     assert_equal attributes[:closing_at], consultation.closing_at
     assert_equal "http://participation.com", consultation.consultation_participation.link_url
     assert_equal "countmein@participation.com", consultation.consultation_participation.email
-    assert_equal "the title of the response form", response_form.title
 
     VirusScanHelpers.simulate_virus_scan(response_form.consultation_response_form_data.file)
     assert response_form.consultation_response_form_data.file.present?
@@ -68,7 +65,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
         link_url: nil,
         email: nil,
         consultation_response_form_attributes: {
-          title: nil,
           consultation_response_form_data_attributes: {
             file: nil
           }
@@ -88,7 +84,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
         link_url: nil,
         email: nil,
         consultation_response_form_attributes: {
-          title: nil,
           consultation_response_form_data_attributes: {
             file: fixture_file_upload('two-pages.pdf')
           }
@@ -125,7 +120,6 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
       assert_select "textarea[name='edition[consultation_participation_attributes][postal_address]']"
       assert_select "input[type='hidden'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][id]'][value='#{response_form.id}']"
-      assert_select "input[type='text'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][title]']"
       assert_select "input[type='hidden'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][id]'][value='#{response_form.consultation_response_form_data.id}']"
       assert_select "input[type='file'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]']"
     end

--- a/test/unit/consultation_participation_test.rb
+++ b/test/unit/consultation_participation_test.rb
@@ -43,13 +43,6 @@ class ConsultationParticipationTest < ActiveSupport::TestCase
     assert participation.valid?
   end
 
-  test "should be invalid if the response form has no title" do
-    data_attributes = attributes_for(:consultation_response_form_data)
-    form_attributes = attributes_for(:consultation_response_form, title: nil, consultation_response_form_data_attributes: data_attributes)
-    participation = build(:consultation_participation, consultation_response_form_attributes: form_attributes)
-    refute participation.valid?
-  end
-
   test "should be invalid if the response form's data has no file" do
     participation = build(:consultation_participation, consultation_response_form: build(:consultation_response_form, file: nil))
     refute participation.valid?

--- a/test/unit/consultation_response_form_test.rb
+++ b/test/unit/consultation_response_form_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class ConsultationResponseFormTest < ActiveSupport::TestCase
-  test 'should be invalid without a title' do
-    form = build(:consultation_response_form, title: nil)
-    refute form.valid?
-  end
 
   test "does not destroy response form data when other response forms are associated with it" do
     consultation_response_form = create(:consultation_response_form)


### PR DESCRIPTION
Editors are being asked for a title when filling a consultation participation form, but it's not being used. This change removes the field from the admin view and the title validation from the model. 

I've chosen not to do a migration to remove the title column from the Consultation Response Form table as I believe it would be quite slow, and during the final phase of migration that table will be dropped. But happy to be proven wrong.

cc @fofr 

[Trello](https://trello.com/c/QseqtCaJ/509-consultations-migration-basic-content-schema-examples-and-front-end-work-large)