### PR TITLE
Sort and group world locations to respect accented characters

### DIFF
--- a/app/helpers/world_location_helper.rb
+++ b/app/helpers/world_location_helper.rb
@@ -1,7 +1,17 @@
 module WorldLocationHelper
 
   def group_and_sort(locations)
-    locations.sort_by(&:name_without_prefix).group_by {|location| location.name_without_prefix.first.upcase }.sort
+    locations.
+      # transliterate name for sorting once, we're going to use it twice:
+      map { |location| [ActiveSupport::Inflector.transliterate(location.name_without_prefix), location] }.
+      # ... 1. to sort (to avoid Côt coming after Cow) ...
+      sort_by { |transliterated_name, _location| transliterated_name }.
+      # ... 2. to group by the first letter (to avoid Éire not being in E)...
+      group_by { |transliterated_name, _location| transliterated_name.first.upcase }.
+      # then we sort the structure by the first letters
+      sort.
+      # finally we remove the sorted name from the structure
+      map { |(letter, names_and_locations)| [letter, names_and_locations.map { |_transliterated_name, location| location }] }
   end
 
   def world_location_survey_url(location)

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -262,3 +262,9 @@ Then(/^there should be nothing featured on the home page of world location "(.*?
   rows = find(featured_documents_selector).all('.feature')
   assert rows.empty?
 end
+
+Then(/^I should see the following world locations grouped under "(.*?)" in order:$/) do |letter, ordered_locations|
+  within :xpath, ".//*#{xpath_class_selector('world-locations')}//*#{xpath_class_selector('js-filter-block')}[./h2[text()='#{letter}']]" do
+    assert_equal ordered_locations.raw.map(&:first), page.all('.world_location').map(&:text)
+  end
+end

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -34,6 +34,10 @@ module HtmlSelectorsHelpers
         "Now, go and add a mapping in #{__FILE__}"
     end
   end
+
+  def xpath_class_selector(class_name)
+    "[contains(concat(' ', normalize-space(@class), ' '), ' #{class_name} ')]"
+  end
 end
 
 World(HtmlSelectorsHelpers)

--- a/features/world-locations.feature
+++ b/features/world-locations.feature
@@ -82,3 +82,20 @@ Feature: Administering world location information
       | name              | Afrolandie                                                  |
       | title             | UK en Afrolandie                                            |
       | mission_statement | Enseigner aux gens comment infuser le thé                   |
+
+  Scenario: Viewing the list presents world locations in name order, ignoring "The" accents, grouped by first letter
+    Given a world location "Special Republic" exists
+    And a world location "Spëcial Kingdom" exists
+    And a world location "The Excellent Free States" exists
+    And a world location "Egg Island" exists
+    And a world location "Échouéland" exists
+    And a world location "Special Isles" exists
+    When I visit the world locations page
+    Then I should see the following world locations grouped under "E" in order:
+      | Échouéland |
+      | Egg Island |
+      | The Excellent Free States |
+    And I should see the following world locations grouped under "S" in order:
+      | Special Isles |
+      | Spëcial Kingdom |
+      | Special Republic |


### PR DESCRIPTION
For: https://trello.com/c/E92zVUmf/67-world-location-index-in-wrong-alphabetical-order

In 3c0eb7e2a9f4ef791a9403c6d3f2fda8bad0590b we changed the sort order of
world locations on the public index page to ignore "The" prefixes, so that
places like "The Occupied Palestinian Territories" appear under "O" not
"T".  Unfortunately this meant sorting in ruby and this didn't respect
accented characters, meaning places like "São Tomé and Principe" appeared
at the end of "S" rather than inbetween "San Marino" and "Saudi Arabia".

The order before we account for "The" prefixes is correct for accented
characters, because it comes from the DB which has the correct collation
settings.  The version of the name without the prefix does not live in the
DB so we have to do the sort in memory, and this breaks the ordering for
accented characters.

The solution, much like that used in Frontend (https://github.com/alphagov/frontend/pull/1053)
is to use `ActiveSupport::Inflector.transliterate` to convert accented
characters to their de-accented variants and sort using that version of
the name.  This makes the grouping marginally more complex as we also
use the first char of the prefix-less name to group by, and we don't want
to create a group for the accented characters, and we don't want to
transliterate the name twice either.