### PR TITLE
Create embassy exception text for Central African Republic

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -42,6 +42,11 @@ private
   end
 
   SPECIAL_CASES = {
+    "Central African Republic" => {
+      building: "Foreign and Commonwealth Office",
+      location: "the UK",
+      base_path: "/government/organisations/foreign-commonwealth-office",
+    },
     "French Polynesia" => {
       building: "British High Commission Wellington",
       location: "New Zealand",


### PR DESCRIPTION
Trello: https://trello.com/c/hK6IUWma/338-create-exception-text-for-central-african-republic-on-the-find-an-embassy-page

Reason:

Because of the political situation in Central African Republic, the standard fallback message of "There are no consular services available in [Country]. British nationals should contact the local authorities." is not appropriate.

## Before

![screen shot 2016-11-23 at 16 06 30](https://cloud.githubusercontent.com/assets/136777/20569177/1872e05e-b197-11e6-97db-82b3aa5d0c0f.png)


## After

![screen shot 2016-11-23 at 16 05 59](https://cloud.githubusercontent.com/assets/136777/20569186/1d12eb9a-b197-11e6-863d-72c2362d5402.png)
