### PR TITLE
Improve statistical data set finder

### DIFF
--- a/lib/finders/statistical_data_sets.json
+++ b/lib/finders/statistical_data_sets.json
@@ -14,7 +14,8 @@
     "filter": {
       "format": "statistical_data_set"
     },
-    "show_summaries": true
+    "show_summaries": true,
+    "default_documents_per_page": 20
   },
   "routes": [
     {

--- a/lib/finders/statistical_data_sets.json
+++ b/lib/finders/statistical_data_sets.json
@@ -14,7 +14,7 @@
     "filter": {
       "format": "statistical_data_set"
     },
-    "show_summaries": false
+    "show_summaries": true
   },
   "routes": [
     {


### PR DESCRIPTION
Adds summaries and limits the number of results shown by default.

## Before

<img width="963" alt="screen shot 2016-11-24 at 10 14 38" src="https://cloud.githubusercontent.com/assets/233676/20594625/d77fb8e0-b22e-11e6-965f-28cba502179a.png">

## After

<img width="966" alt="screen shot 2016-11-24 at 10 14 16" src="https://cloud.githubusercontent.com/assets/233676/20594624/d77e4140-b22e-11e6-8bd4-a326f30e8ff2.png">
