### PR TITLE
Make case studies pagination the same as search

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -16,7 +16,7 @@
     },
     "format_name": "Case studies: Real-life examples of government activity",
     "show_summaries": true,
-    "default_documents_per_page": 100
+    "default_documents_per_page": 20
   },
   "routes": [
     {


### PR DESCRIPTION
Our site search currently displays 20 results (https://www.gov.uk/search?q=tax). This changes the number of case studies on https://www.gov.uk/government/case-studies to be the same for consistency.