### PR TITLE
More html attachments migration fixes

### DIFF
--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -75,7 +75,7 @@ class PublishingApiHtmlAttachmentsWorker
 private
 
   def update_publishing_api_content
-    if edition.draft?
+    if Edition::PRE_PUBLICATION_STATES.include?(edition.state)
       update_draft(update_type: "republish")
     else
       do_publish("republish")


### PR DESCRIPTION
This PR contains two fixes:

The first commit ensures that we send all attachments attached to 'non-live' `Editions` to the draft content store. (ie `submitted`,  `rejected` etc not just `draft`).

The second adds logic to the sync check to ensure we only check either content store for the attachment when it should be in there. The logic is based on the state of the attachable `Edition` and its parent `Document`.

* If the `Edition` is the first `draft` then the attachment should only be in the draft content store
* If the `Edition` is `published` and there is no newer `draft` then the attachment should be in both content stores
* If the `Edition` is `published` but there is a newer `draft` (or one of the other 'pre-publication' states) the the attachment should only be in the live content store.

