### PR TITLE
Add organisation to services and information content item

### DIFF
--- a/app/presenters/publishing_api/services_and_information_presenter.rb
+++ b/app/presenters/publishing_api/services_and_information_presenter.rb
@@ -48,7 +48,10 @@ module PublishingApi
       {
         parent: [
           organisation.content_id
-        ]
+        ],
+        organisations: [
+          organisation.content_id
+        ],
       }
     end
 

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -27,7 +27,10 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
     expected_links = {
       parent: [
         organisation.content_id
-      ]
+      ],
+      organisations: [
+        organisation.content_id
+      ],
     }
     expected_update_type = "minor"
 


### PR DESCRIPTION
This commit adds the organisation to the “services and information” content item, which allows collections to use the `govuk_navigation_helpers` to render analytics meta tags.

Trello: https://trello.com/c/gZQn6ss2/336-upgrade-collections-frontend