### PR TITLE
Send `organisation_type` to search index

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -179,7 +179,8 @@ class Organisation < ActiveRecord::Base
              organisations: :search_organisations,
              boost_phrases: :acronym,
              slug: :slug,
-             organisation_state: :searchable_govuk_status
+             organisation_state: :searchable_govuk_status,
+             organisation_type: :organisation_type_key
 
   extend FriendlyId
   friendly_id


### PR DESCRIPTION
We will need this field to experiment with an organisations finder (in finder-frontend) that could replace the current bespoke organisations page (https://www.gov.uk/government/organisations).

The field is added to the schema in https://github.com/alphagov/rummager/pull/718.

This PR can be merged & deployed independently from that PR. To make it work we will have to republish all organisations once rummager has been deployed and its indexes have been migrated.

Trello: https://trello.com/c/FRYiVa3U