### PR TITLE
Rename Wales Office

### DIFF
--- a/db/data_migration/20161128100423_rename_wales_office.rb
+++ b/db/data_migration/20161128100423_rename_wales_office.rb
@@ -1,0 +1,9 @@
+wales_office = Organisation.find_by(slug: "wales-office")
+
+# Rename the organisation
+new_name = "Office of the Secretary of State for Wales"
+wales_office.update_attributes!(name: new_name)
+
+# Modify the address accordingly
+new_slug = "office-of-the-secretary-of-state-for-wales"
+DataHygiene::OrganisationReslugger.new(wales_office, new_slug).run!


### PR DESCRIPTION
Trello: https://trello.com/c/6My4HUMH/515-name-changes-to-wales-office-medium

Rename the organisation and its slug, accordingly with the new name
"Office of the Secretary of State for Wales”.