### PR TITLE
Correct typo in finder json

### DIFF
--- a/lib/finders/topical_events.json
+++ b/lib/finders/topical_events.json
@@ -1,5 +1,5 @@
 {
-   "base_path":"/government/topics",
+   "base_path":"/government/topical-events",
    "title":"Topical Events",
    "description":"Government news and information about major events: including the budget, commemorative events, responses to global incidents and more",
    "document_type":"finder",


### PR DESCRIPTION
Added in
https://github.com/alphagov/whitehall/commit/94ae9a79a2e176072fc8d503f6b7e25fb9586a79

This can't be published at the moment because the base path does not
match the routes. It should be /topical-events throughout.