### PR TITLE
Stop with_translations from returning duplicate records

### DIFF
--- a/lib/patches/globalize_with_translations.rb
+++ b/lib/patches/globalize_with_translations.rb
@@ -1,0 +1,16 @@
+# Backport https://github.com/globalize/globalize/pull/489
+require 'globalize/active_record/class_methods'
+require 'globalize/version'
+
+raise "Check if #{__FILE__} is still needed, we expect it to be redundant with Globalize 5.1.0+. (We are now using #{Globalize::Version})" if Globalize::Version != '5.0.1'
+
+module Globalize
+  module ActiveRecord
+    module ClassMethods
+      def with_translations(*locales)
+        locales = translated_locales if locales.empty?
+        preload(:translations).joins(:translations).readonly(false).with_locales(locales).uniq
+      end
+    end
+  end
+end

--- a/test/unit/with_translations_test.rb
+++ b/test/unit/with_translations_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class WithTranslationsTest < ActiveSupport::TestCase
+  setup do
+    role = build(:ministerial_role)
+    with_locale(:en) do
+      role.name = 'Minister of fun'
+    end
+    with_locale(:fr) do
+      role.name = "Ministre de l'amusement"
+    end
+    role.save!
+  end
+
+  test "with_translations with no arguments returns each item once only" do
+    assert_equal 1, Role.with_translations.count
+  end
+
+  test "with_translations with no arguments preloads all the translations on each item" do
+    loaded_role = Role.with_translations.first
+
+    query_count = count_queries { loaded_role.name }
+    assert_equal 0, query_count
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/GKIrSeAN/72-investigate-duplication-of-role-titles-when-there-is-a-translation

The intention of the globalize `with_translations` scope when called without any arguments is that it will preload all translations for the records it returns. However, ever since [#329](https://github.com/globalize/globalize/issues/329) (released in v4.0.1 of globalize) it has done so by duplicating in the results any records that have multiple translations.  This is fixed in [#489](https://github.com/globalize/globalize/pull/489) (unreleased at time of writing).

This commit backports the fix from globalize 5.1.0 as a patch with a timebomb that will explode when we change the version of globalize.  We also add a test to make sure that things still behave as we expect if we do remove the patch.

We have been susceptible to this since we [upgraded to rails 4.0.13](https://github.com/alphagov/whitehall/commit/d215782886cfee49d41364d9f06855aed6ffb59b) in Jan 2015 as this is when we moved to globalize 4.0.3 (from globalize3 0.3.0). However, we've not encountered the problem as there aren't many places where we use `with_translations` without specifying a locale in many places, or without some other part of the query making the result set unique.  The other reason for not seeing the bug much is that in the places we are using the API this way we don't have much data that would cause the bug (most things only have one english translation).  One place that did exhibit the bug is in displaying ministers on the org show pages (plain orgs, not worldwide orgs).  If a role has translations and there is a person assigned to that role then they would have the role listed as many times as there are translations, instead of just the once.