### PR TITLE
Update publication presenter first_public_at

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
     def links
@@ -55,19 +56,14 @@ module PublishingApi
         body: body,
         change_history: item.change_history.as_json,
         emphasised_organisations: item.lead_organisations.map(&:content_id),
-        first_public_at: first_public_at,
         related_mainstream_content: related_mainstream_content_ids,
       }
       details_hash = maybe_add_national_applicability(details_hash)
       details_hash.merge!(image: {url: item.logo_url}) if item.logo_url.present?
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
+      details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end
-
-    def first_public_at
-      item.document.published? ? item.first_public_at : item.document.created_at
-    end
-
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
     def links
@@ -41,18 +42,14 @@ module PublishingApi
 
     def details
       {
-        first_public_at: first_public_at,
         change_history: item.change_history.as_json,
         collection_groups: collection_groups,
         body: govspeak_renderer.govspeak_edition_to_html(item),
         emphasised_organisations: item.lead_organisations.map(&:content_id),
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
+        details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
       end
-    end
-
-    def first_public_at
-      item.first_published_at || item.document.created_at
     end
 
     def collection_groups

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -24,9 +24,9 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: "fatality_notice",
           details: details,
-          first_published_at: first_public_at.utc
         )
         content.merge!(PayloadBuilder::AccessLimitation.for(item))
+        content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
       }
     end
 
@@ -43,17 +43,12 @@ module PublishingApi
     attr_reader :item
 
     def details
-      {
+      details_hash = {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item),
-        first_public_at: first_public_at,
         change_history: item.change_history.as_json,
         emphasised_organisations: item.lead_organisations.map(&:content_id)
       }
-    end
-
-    def first_public_at
-      document = item.document
-      document.published? ? item.first_public_at : document.created_at
+      details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end
   end
 end

--- a/app/presenters/publishing_api/payload_builder/first_public_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_public_at.rb
@@ -1,0 +1,9 @@
+module PublishingApi
+  module PayloadBuilder
+    class FirstPublicAt
+      def self.for(item)
+        { first_public_at: FirstPublishedAt.for(item)[:first_published_at] }
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/payload_builder/first_published_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_published_at.rb
@@ -1,0 +1,9 @@
+module PublishingApi
+  module PayloadBuilder
+    class FirstPublishedAt
+      def self.for(item)
+        { first_published_at: item.first_published_at || item.document.created_at }
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -27,6 +27,7 @@ module PublishingApi
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
       content.merge!(PayloadBuilder::WithdrawnNotice.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
     def links
@@ -60,17 +61,12 @@ module PublishingApi
         change_history: item.change_history.as_json,
         documents: documents,
         emphasised_organisations: item.lead_organisations.map(&:content_id),
-        first_public_at: first_public_at,
       }
       details_hash = maybe_add_national_applicability(details_hash)
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details_hash.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
-    end
-
-    def first_public_at
-      return item.first_public_at if item.document.published?
-      item.document.created_at.iso8601
+      details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end
 
     def body

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -49,6 +49,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" }
       ],
       redirects: [],
+      first_published_at: detailed_guide.created_at,
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         first_public_at: detailed_guide.created_at,

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -96,7 +96,7 @@ class PublishingApi::DraftFatalityBelongingToPublishedDocumentNoticePresenter < 
   test "it presents the Fatality Notice's first_public_at" do
     presented_notice = PublishingApi::FatalityNoticePresenter.new(
       create(:published_fatality_notice) do |fatality_notice|
-        fatality_notice.stubs(:first_public_at).returns(DateTime.new(2015, 4, 10))
+        fatality_notice.stubs(:first_published_at).returns(DateTime.new(2015, 4, 10))
       end
     )
 

--- a/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module PublishingApi
+  module PayloadBuilder
+    class PayloadBuilderFirstPublicAtTest < ActiveSupport::TestCase
+      def test_uses_first_published_at
+        first_published_at = Object.new
+        item = stub
+        FirstPublishedAt.stubs(:for).with(item).returns({ first_published_at: first_published_at })
+
+        assert_equal(
+          { first_public_at: first_published_at },
+          FirstPublicAt.for(item)
+        )
+      end
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module PublishingApi
+  module PayloadBuilder
+    class PayloadBuilderFirstPublishedAtTest < ActiveSupport::TestCase
+      def test_returns_first_published_at_if_present
+        first_published_at = Object.new
+        item = stub(first_published_at: first_published_at)
+
+        assert_equal(
+          { first_published_at: first_published_at },
+          FirstPublishedAt.for(item)
+        )
+      end
+
+      def test_returns_document_created_at_for_nil_first_published_at
+        created_at = Object.new
+        item = stub(first_published_at: nil, document: stub(created_at: created_at))
+
+        assert_equal(
+          { first_published_at: created_at },
+          FirstPublishedAt.for(item)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes it consistent with previously migrated formats.

Prior art: https://github.com/alphagov/whitehall/pull/2772