### PR TITLE
[DO NOT MERGE] Handle deleted html attachments

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -10,6 +10,11 @@ module Attachable
              -> { not_deleted.order('attachments.ordering, attachments.id') },
              as: :attachable
 
+    has_many :deleted_html_attachments,
+             -> { deleted },
+             class_name: "HtmlAttachment",
+             as: :attachable
+
     if respond_to?(:add_trait)
       add_trait do
         def process_associations_after_save(edition)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -39,6 +39,7 @@ class Attachment < ActiveRecord::Base
   scope :for_current_locale, -> { where(locale: [nil, I18n.locale]) }
 
   scope :not_deleted, -> { where(deleted: false) }
+  scope :deleted, -> { where(deleted: true) }
 
   def self.parliamentary_sessions
     (1951..Time.zone.now.year).to_a.reverse.map do |year|

--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -85,6 +85,7 @@ private
       update_draft(update_type: "republish")
     else
       do_publish("republish")
+      discard_drafts(deleted_html_attachments)
     end
   end
 

--- a/test/unit/attachable_test.rb
+++ b/test/unit/attachable_test.rb
@@ -272,4 +272,24 @@ class AttachableTest < ActiveSupport::TestCase
     assert Attachment.find(attachment_1.id).deleted?
     assert Attachment.find(attachment_2.id).deleted?
   end
+
+  test "#deleted_html_attachments returns associated HTML attachments that have been deleted" do
+    publication = create(:draft_publication, attachments: [
+      attachment_1 = build(:html_attachment, title: "First"),
+      attachment_2 = build(:html_attachment, title: "Second"),
+    ])
+
+    attachment_1.destroy
+    attachment_2.destroy
+
+    assert_equal [attachment_1, attachment_2], publication.deleted_html_attachments
+  end
+
+  test "#deleted_html_attachments doesn't return undeleted attachments" do
+    publication = create(:draft_publication, attachments: [
+      build(:html_attachment, title: "First"),
+    ])
+
+    assert_empty publication.deleted_html_attachments
+  end
 end

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -181,6 +181,19 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
 
       call(new_edition)
     end
+
+    test "with a deleted html attachment removes the draft" do
+      publication = create(:draft_publication)
+      attachment = publication.html_attachments.first
+      attachment.destroy
+
+      PublishingApiDiscardDraftWorker.any_instance.expects(:perform).with(
+        attachment.content_id,
+        "en"
+      )
+
+      call(publication)
+    end
   end
 
   class Unpublish < PublishingApiHtmlAttachmentsWorkerTest

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -311,6 +311,17 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
       call(publication)
     end
 
+    test "for a published publication with a deleted attachment discards the attachment draft" do
+      publication = create(:published_publication)
+      attachment = publication.html_attachments.first
+      attachment.destroy
+      PublishingApiDiscardDraftWorker.any_instance.expects(:perform).with(
+        attachment.content_id,
+        "en"
+      )
+      call(publication)
+    end
+
     test "for a withdrawn publicaton with an attachment withdraws the attachment" do
       publication = create(:withdrawn_publication)
       attachment = publication.html_attachments.first


### PR DESCRIPTION
When an `Edition` is saved after one or more attached `HtmlAttachment` have been deleted we should discard the draft of the attachment during the `update` event.

We also need to consider this when republishing a document particularly as in some cases there are published `Edition`s with deleted attachments in the content store that shouldn't be there.

This PR supports updating and republishing and will also correct the content store when a document is republished. The 'correction' part may be better served by a data migration but the correct course of action is complex to work through in a query so I've addressed it here.