### PR TITLE
Fix the Corporate Info Page translation

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -19,7 +19,7 @@
     <% end %>
     <div class="main-body">
       <div class="content">
-        <h1 class="main"><%= @corporate_information_page.title %></h1>
+        <h1 class="main"><%= @corporate_information_page.title(I18n.locale) %></h1>
         <p class="description">
           <%= @corporate_information_page.summary %>
         </p>

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -269,7 +269,7 @@ es-419:
       about:
       about_our_services:
       access_and_opening:
-      complaints_procedure:
+      complaints_procedure: Procedimiento de quejas
       equality_and_diversity:
       media_enquiries:
       membership:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -279,7 +279,7 @@ fr:
       petitions_and_campaigns:
       procurement:
       publication_scheme: Régime de publication
-      recruitment:
+      recruitment: Travail pour %{organisation_name}
       research:
       social_media_use: 'Utilisation réseaux sociaux '
       staff_update:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -271,7 +271,7 @@ it:
       access_and_opening:
       complaints_procedure:
       equality_and_diversity:
-      media_enquiries:
+      media_enquiries: Ufficio stampa
       membership:
       our_energy_use:
       our_governance:


### PR DESCRIPTION
Trello: https://trello.com/c/8UpiQt9K/522-translation-of-titles-of-worldwide-pages

The title is now fully translated using the i18n translation. The "page type" bit (e.g. "Media Enquiries" or "Working for") translation is not provided in the page. Since it was not loading the current locale, it was always translated in English.

This is a possible solution for the pages highlighted in the ticket, but it doesn’t provide a global solution. For a wider solution, a translation for all available languages and page types should be provided.