### PR TITLE
Revert "Simplify language around welsh language scheme"

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -473,7 +473,7 @@ cy:
       staff_update: Gwybodaeth a newyddion staff
       statistics: Ystadegau yn %{organisation_name}
       terms_of_reference: Cylch gorchwyl
-      welsh_language_scheme: gyhoeddi yn y Gymraeg
+      welsh_language_scheme: Cynllun iaith Gymraeg
   date:
     formats:
       default: "%d %B %Y"
@@ -625,7 +625,7 @@ cy:
       publication_scheme_html: Darllenwch am y mathau o wybodaeth rydym yn eu cyhoeddi'n
         rheolaidd yn ein %{link}.
       social_media_use_html: Darllenwch ein polisi ar %{link}
-      welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.
+      welsh_language_scheme_html: Dysgwch am ein hymrwymiad i gyhoeddi yn y %{link}.
     find_out_more: Gweld proffil llawn a'r holl fanylion cyswllt
     headings:
       about_us: Gwybodaeth amdanom ni

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,7 +292,7 @@ en:
     corporate_information:
       publication_scheme_html: Read about the types of information we routinely publish in our %{link}.
       personal_information_charter_html: Our %{link} explains how we treat your personal information.
-      welsh_language_scheme_html: Find out about our commitment to %{link}.
+      welsh_language_scheme_html: Find out about our commitment to publishing in the %{link}.
       social_media_use_html: Read our policy on %{link}.
       about_our_services_html: Find out %{link}.
   corporate_information_page:
@@ -307,7 +307,7 @@ en:
       recruitment: Working for %{organisation_name}
       our_energy_use: Our energy use
       membership: Membership
-      welsh_language_scheme: publishing in Welsh
+      welsh_language_scheme: Welsh language scheme
       equality_and_diversity: Equality and diversity
       petitions_and_campaigns: Petitions and campaigns
       research: Research at %{organisation_name}

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -88,9 +88,9 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
 
   test "should translate title" do
     welsh_language_scheme_page = build(:corporate_information_page, corporate_information_page_type: CorporateInformationPageType::WelshLanguageScheme)
-    assert_equal "publishing in Welsh", welsh_language_scheme_page.title
+    assert_equal "Welsh language scheme", welsh_language_scheme_page.title
     I18n.with_locale(:cy) do
-      assert_equal "gyhoeddi yn y Gymraeg", welsh_language_scheme_page.title
+      assert_equal "Cynllun iaith Gymraeg", welsh_language_scheme_page.title
     end
   end
 


### PR DESCRIPTION
Reverts alphagov/whitehall#2876

This also changes the page title to "publishing in Welsh" which isn't what we want at all.  Reverting this to unblock another deploy.  We'll come up with something better later.