### PR TITLE
Use Whitehall::UrlMaker to infer path to content

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -51,7 +51,7 @@ module SyncChecker
       end
 
       def get_path(locale)
-        path = "#{root_path}#{document.slug}"
+        path = Whitehall::UrlMaker.new.public_document_path(edition_expected_in_draft)
         path += ".#{locale}" unless locale.to_s == "en"
         path
       end

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -1,10 +1,6 @@
 module SyncChecker
   module Formats
     class PublicationCheck < EditionBase
-      def root_path
-        "/government/publications/"
-      end
-
       def checks_for_live(locale)
         super + [
           Checks::LinksCheck.new(


### PR DESCRIPTION
Part of https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api

Different publication types may have different routing in Whitehall,
for example `OfficialStatistics` which live under `/goverment/statistics`.
Return the correct root_path based on `PublicationType` so that we can
correctly query the content store for a matching piece of content.