### PR TITLE
Default to the user organisation in filters

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -43,8 +43,11 @@ class Admin::OrganisationsController < Admin::BaseController
   def features
     @feature_list = @organisation.load_or_create_feature_list(params[:locale])
 
-    filter_params = params.slice(:page, :type, :author, :organisation, :title).
-      merge(state: 'published')
+    filtering_organisation = params[:organisation] || @organisation.id
+
+    filter_params = params.slice(:page, :type, :author, :title).
+      merge(state: 'published', organisation: filtering_organisation)
+
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)
     @featurable_topical_events = TopicalEvent.active
     @featurable_offsite_links = @organisation.offsite_links

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -606,8 +606,8 @@ Then(/^I can filter instantaneously the list of documents by title, author, orga
   click_link "Reset all fields"
   within "#search_results" do
     assert page.has_css?(record_css_selector(@documents[0]))
-    assert page.has_css?(record_css_selector(@documents[1]))
-    assert page.has_css?(record_css_selector(@documents[2]))
+    assert page.has_no_css?(record_css_selector(@documents[1]))
+    assert page.has_no_css?(record_css_selector(@documents[2]))
   end
   select @organisation2.name, from: "organisation"
   within "#search_results" do

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -413,6 +413,16 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  view_test "GET :features without an organisation defaults to the user organisation" do
+    organisation = create(:organisation)
+
+    get :features, id: organisation, locale: 'en'
+    assert_response :success
+
+    selected_organisation = css_select('#organisation option[selected="selected"]')
+    assert_equal selected_organisation.text, organisation.name
+  end
+
   view_test "GDS Editors can set political status" do
     organisation = create(:organisation)
     writer = create(:writer, organisation: organisation)


### PR DESCRIPTION
In the organisation features, the default organisation wasn't set,
meaning we would be showing editions for all organisations.

That query is quite slow and is causing issues in mysql in production.

In order to mitigate that, we are filtering the editions by the users'
organisation by default, which makes the database queries faster on the
first page hit.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1472963

Errbit that shows the slow queries:
https://errbit.publishing.service.gov.uk/apps/53020d6c0da11585f10000e7/problems/583d970965786364a5f10400

Note: this isn't actually solving the slow query for all organisations. It's making sure that's not the default behaviour and that we reduce some loads on those pages which were causing issues earlier today in 2nd line.