### PR TITLE
Limit publication-style finders to 50 results per page

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -16,7 +16,7 @@
     },
     "format_name": "Case studies: Real-life examples of government activity",
     "show_summaries": true,
-    "default_documents_per_page": 20
+    "default_documents_per_page": 50
   },
   "routes": [
     {

--- a/lib/finders/statistical_data_sets.json
+++ b/lib/finders/statistical_data_sets.json
@@ -32,7 +32,7 @@
       "format": "statistical_data_set"
     },
     "show_summaries": true,
-    "default_documents_per_page": 20
+    "default_documents_per_page": 50
   },
   "routes": [
     {

--- a/lib/finders/topical_events.json
+++ b/lib/finders/topical_events.json
@@ -9,7 +9,7 @@
    "rendering_app":"finder-frontend",
    "details": {
      "document_noun": "topical event",
-     "default_documents_per_page": 20,
+     "default_documents_per_page": 50,
      "default_order": "-start_date",
      "filter": {
        "format": "topical_event"
@@ -53,5 +53,3 @@
      }
    ]
 }
-
-


### PR DESCRIPTION
This commit change the number of results per page to 50 for all publication-style finders (as in, finders for ever-growing publications rather than people, organisations etc). This standardises pagination with finders published by specialist-publisher (https://github.com/alphagov/specialist-publisher/pull/957).

Trello: https://trello.com/c/VKqW8wEV/347-add-pagination-for-specialist-document-finders

Deployment checklist:

- [ ] Deploy whitehall
- [ ] Run the `finders:publish` rake task to republish the finders