### PR TITLE
Add lang attribute to page translation links

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -199,7 +199,7 @@ Please tell us:
   end
 
   def link_to_translation(locale)
-    link_to native_language_name_for(locale), locale: locale
+    link_to native_language_name_for(locale), { locale: locale }, lang: locale
   end
 
   def part_of_metadata(document, policies = [], sector_tag_finder = SpecialistTagFinder::Null.new)

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -130,7 +130,7 @@ class DocumentHelperTest < ActionView::TestCase
       locale: "it",
       id: "a-world-location"
     })
-    assert_dom_equal %Q(<a href="#{world_location_path("a-world-location", :de)}">Deutsch</a>),
+    assert_dom_equal %(<a lang="de" href="#{world_location_path('a-world-location', :de)}">Deutsch</a>),
       link_to_translation(:de)
   end
 


### PR DESCRIPTION
This commit adds the HTML `lang` attribute to links to translated content. This ensures that the language name is understood correctly by screen readers and browsers, and therefore read correctly. Fixes https://github.com/alphagov/whitehall/issues/2873.