### PR TITLE
Create a common presenter for WorldLocationPresenter and WorldwideOrganisationPresenter

### DIFF
--- a/app/presenters/publishing_api/common_presenter.rb
+++ b/app/presenters/publishing_api/common_presenter.rb
@@ -1,0 +1,38 @@
+module PublishingApi
+  class CommonPresenter
+    attr_accessor :item
+    attr_accessor :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      item.content_id
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        title: item.name,
+        need_ids: [],
+      ).base_attributes
+
+      content.merge!(
+        description: nil,
+        details: {},
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "placeholder",
+      )
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
+    end
+
+    def links
+      {}
+    end
+  end
+end

--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -1,38 +1,4 @@
 module PublishingApi
-  class WorldLocationPresenter
-    attr_accessor :item
-    attr_accessor :update_type
-
-    def initialize(item, update_type: nil)
-      self.item = item
-      self.update_type = update_type || "major"
-    end
-
-    def content_id
-      item.content_id
-    end
-
-    def content
-      content = BaseItemPresenter.new(
-        item,
-        title: item.name,
-        need_ids: [],
-      ).base_attributes
-
-      content.merge!(
-        description: nil,
-        details: {},
-        document_type: item.class.name.underscore,
-        public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
-      )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
-      content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
-    end
-
-    def links
-      {}
-    end
+  class WorldLocationPresenter < PublishingApi::CommonPresenter
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -1,38 +1,4 @@
 module PublishingApi
-  class WorldwideOrganisationPresenter
-    attr_accessor :item
-    attr_accessor :update_type
-
-    def initialize(item, update_type: nil)
-      self.item = item
-      self.update_type = update_type || "major"
-    end
-
-    def content_id
-      item.content_id
-    end
-
-    def content
-      content = BaseItemPresenter.new(
-        item,
-        title: item.name,
-        need_ids: [],
-      ).base_attributes
-
-      content.merge!(
-        description: nil,
-        details: {},
-        document_type: item.class.name.underscore,
-        public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
-      )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
-      content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
-    end
-
-    def links
-      {}
-    end
+  class WorldwideOrganisationPresenter < PublishingApi::CommonPresenter
   end
 end


### PR DESCRIPTION
This commit is a suggestion to merge the functionality of both WorldLocationPresenter and WorldwideOrganisationPresenter to inherit from a common object since they have been using the exact same code. I believe this still gives freedom for both objects to part ways if needed in
the future.