### PR TITLE
Remove re-editioned edition

### DIFF
--- a/db/data_migration/20161202093716_remove_re_editioned_draft.rb
+++ b/db/data_migration/20161202093716_remove_re_editioned_draft.rb
@@ -1,0 +1,6 @@
+# This edition was archived then re-editioned around the time of the 2015 election.
+# It's not a workflow we support any more, it may have been manually resurrected so
+# delete the draft edition to allow the sync check to compare live to live versions.
+edition = Edition.find(483007)
+edition.delete_all_attachments
+edition.destroy


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api

This piece of content was archived and then re-editioned around the
time of the 2015 election. The two editions differ in that the live
withdrawn edition mentions the English Heritage organisation and the
draft we're going to remove mentions the Historic England org.
Historic England replaced English Heritage around March 2015 but the
draft content updates were never published, we're unsure why.
To allow sync checks to proceed we need to remove this draft as it's
a workflow anomaly.