### PR TITLE
Don't check deleted HtmlAttachments

### DIFF
--- a/lib/sync_checker/formats/html_attachment_check.rb
+++ b/lib/sync_checker/formats/html_attachment_check.rb
@@ -107,12 +107,16 @@ module SyncChecker
       end
 
       def attachment_should_exist_in_live_content_store?
-        Edition::PUBLICLY_VISIBLE_STATES.include?(attachable.state) ||
-          attachable_is_unpublished?
+        !attachment.deleted? && (
+          Edition::PUBLICLY_VISIBLE_STATES.include?(attachable.state) ||
+            attachable_is_unpublished?
+        )
       end
 
       def attachment_should_exist_in_draft_content_store?
-        attachable_is_the_latest_draft? || attachable_is_published_and_there_is_no_newer_draft?
+        !attachment.deleted? && (
+          attachable_is_the_latest_draft? || attachable_is_published_and_there_is_no_newer_draft?
+        )
       end
 
       def attachable_is_the_latest_draft?


### PR DESCRIPTION
This commit excludes deleted HtmlAttachment's from the sync check. Working out what state each content store should be in is complex as it requires knowledge of the state of the `attachable` and the state of the previous and subsequent editions, if there are any, in addition to knowledge of the presence of an attachment with the same base path existing previously or subsequently.

The publish and republish actions now delete draft content store representations for deleted attachments and 'residual' attachments that were lingering in the live content store have been removed in a separate [PR on
content-store](https://github.com/alphagov/content-store/pull/253/commits/6f60c96ceb07413f27d56c7edda7e335a8415173)