### PR TITLE
Fix unopened consultations

### DIFF
--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -40,7 +40,7 @@
   .consultation-block {
     @extend %contain-floats;
     @include white-links;
-    background: $inside-gov-brand;
+    background: $govuk-blue;
     color: $white;
     padding: $gutter-half;
     margin-bottom: $gutter * 1.5;
@@ -130,5 +130,5 @@
 .consultation-closed {
   .original-consultation {
     border-top: 0;
-  }  
+  }
 }

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -36,7 +36,6 @@
           <%= render partial: "document_summary", locals: { document: @document } %>
         </div>
       <% else %>
-
         <% if @document.outcome_published? %>
           <%= content_tag_for(:div, @document.outcome, class: 'consultation-response') do %>
             <% if @document.outcome.attachments.any? %>
@@ -85,14 +84,27 @@
           <% end %>
         <% end %>
 
-        <h2 class="original-consultation">Original consultation</h2>
-        <div class="consultation-block <%= consultation_css_class(@document) %>">
-          <div class="consultation-dates">
-            <p>This consultation ran from <span><%= absolute_time(@document.opening_at, class: 'opening-at') %> to<br><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+        <% if @document.closed? %>
+          <h2 class="original-consultation">Original consultation</h2>
+          <div class="consultation-block <%= consultation_css_class(@document) %>">
+            <div class="consultation-dates">
+              <p>This consultation ran from <span><%= absolute_time(@document.opening_at, class: 'opening-at') %> to<br><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+            </div>
+            <%= render partial: "document_summary", locals: { document: @document } %>
           </div>
+        <% elsif @document.not_yet_open? && @document.opening_at.present? %>
+          <div class="status-block">
+            <h2>This consultation opens on <%= absolute_time(@document.opening_at, class: 'opening-at') %></h2>
+          </div>
+          <div class="consultation-block <%= consultation_css_class(@document) %>">
+            <div class="consultation-dates">
+              <p>This consultation opens on<br><span><%= absolute_time(@document.opening_at, class: 'opening-at') %></span></p>
+              <p>It closes on<br><span><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+            </div>
 
-          <%= render partial: "document_summary", locals: { document: @document } %>
-        </div>
+            <%= render partial: "document_summary", locals: { document: @document } %>
+          </div>
+        <% end %>
       <% end %>
 
       <% if @document.attachments.any? %>

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -19,6 +19,12 @@ Scenario: Publishing a submitted consultation
   Then I should see the consultation "Beard Length Review" in the list of published documents
   And the consultation "Beard Length Review" should be visible to the public
 
+Scenario: Viewing an unopened consultation
+  Given I am an editor
+  And an unopened consultation exists
+  When I visit the consultation
+  Then the date the consultation opens should be viewable
+
 Scenario: Adding an outcome to a closed consultation
   Given I am an editor
   And a closed consultation exists

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -2,6 +2,15 @@ Given(/^a closed consultation exists$/) do
   create(:closed_consultation)
 end
 
+Given(/^an unopened consultation exists$/) do
+  create(:unopened_consultation)
+end
+
+When /^I visit the consultation$/ do
+  consultation = Consultation.find_by!(title: 'consultation-title')
+  visit consultation_path(consultation.document)
+end
+
 When /^I draft a new consultation "([^"]*)"$/ do |title|
   publishing_api_has_policies([title])
 
@@ -63,6 +72,12 @@ Then /^the consultation outcome should be viewable$/ do
     assert has_content?('Outcome summary')
     assert has_content?('Outcome attachment title')
   end
+end
+
+Then /^the date the consultation opens should be viewable$/ do
+  assert has_content?('This consultation opens on')
+  assert has_content?('It closes on')
+  refute has_content?('Original consultation')
 end
 
 Then(/^the public feedback should be viewable$/) do

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -28,6 +28,11 @@ FactoryGirl.define do
     closing_at { 1.day.ago }
   end
 
+  factory :unopened_consultation, parent: :published_consultation do
+    opening_at { 2.days.from_now }
+    closing_at { 3.days.from_now }
+  end
+
   factory :consultation_with_outcome, parent: :closed_consultation do
     outcome { create(:consultation_outcome) }
   end


### PR DESCRIPTION
Consultations can be published with an open date in the future.

This back-ports one of the unopened consultation fixes that was applied to government-frontend: https://github.com/alphagov/government-frontend/pull/201. This was the most grievous of the bugs fixed and shouldn't wait for migration as it misleads users.

Fixes: https://trello.com/c/GEyT6hzk/518-make-it-obvious-when-a-consultation-starts-small

Other bugs which were fixed in government-frontend, eg date formatting and the ways to respond block sometimes being empty were not trivial to fix. If migration takes a long time we should fix these in Whitehall too:
https://trello.com/c/IZp3Oo8l/526-formatting-when-consultation-ends-medium
https://trello.com/c/pEccXKHV/517-issue-with-ways-to-respond-section-in-consultations-medium

The consultation view doesn't have much existing test coverage.

## Before
![screen shot 2016-12-02 at 15 00 52](https://cloud.githubusercontent.com/assets/319055/20840198/4feaa744-b8a7-11e6-9b16-4319a464bea1.png)

## After
![screen shot 2016-12-02 at 15 01 00](https://cloud.githubusercontent.com/assets/319055/20840199/4fed9e36-b8a7-11e6-83d6-544867c2bff3.png)

