### PR TITLE
Redirect unpublished publication

### DIFF
--- a/db/data_migration/20161202164222_unpublish_publication_as_redirect.rb
+++ b/db/data_migration/20161202164222_unpublish_publication_as_redirect.rb
@@ -1,0 +1,2 @@
+doc = Document.find(8463)
+PublishingApiRedirectWorker.new.perform(doc.content_id, "/homelessness-data-notes-and-definitions", :en, true)


### PR DESCRIPTION
Part of https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api

This publication was withdrawn prior to the current unpublishing workflow,
there isn't a corresponding redirect in the content store so add one via
the publishing pipeline.