### PR TITLE
Fix the SyncCheck missing class error

### DIFF
--- a/app/workers/sync_check_worker.rb
+++ b/app/workers/sync_check_worker.rb
@@ -1,3 +1,5 @@
+require 'sync_checker'
+
 class SyncCheckWorker < WorkerBase
   sidekiq_options queue: :sync_checks
 

--- a/lib/sync_checker.rb
+++ b/lib/sync_checker.rb
@@ -1,0 +1,9 @@
+require 'sync_checker/draft_topic_content_ids'
+require 'sync_checker/failure'
+require 'sync_checker/request_queue'
+require 'sync_checker/result_set'
+require 'sync_checker/sync_check'
+require 'sync_checker/topic_content_id_map'
+
+module SyncChecker
+end


### PR DESCRIPTION
Trello: https://trello.com/c/TQat6bvZ/523-fix-auto-synccheck-error

Sync checks were raising an error due to a missing SyncChecker::Failure class. That is probably caused to a wrong file loading order.
Including the class in the file who requires it.