### PR TITLE
Redirect British High Commission Maldives

### DIFF
--- a/db/data_migration/20161205120945_rename_british_high_commission_maldives_to_british_embassy_maldives.rb
+++ b/db/data_migration/20161205120945_rename_british_high_commission_maldives_to_british_embassy_maldives.rb
@@ -1,0 +1,4 @@
+british_embassy_maldives = WorldwideOrganisation.find_by(slug: "british-high-commission-maldives")
+
+new_slug = "british-embassy-maldives"
+DataHygiene::OrganisationReslugger.new(british_embassy_maldives, new_slug).run!


### PR DESCRIPTION
Trello ticket: https://trello.com/c/kz4bqBA7/532-november-redirects-slug-changes

The name and all the other related name changes have already been done
using the publisher.

I'll follow up with a separate PR to router-data to redirect `/government/world/organisations/british-high-commission-maldives/about/complaints-procedure`
to `/government/world/organisations/british-embassy-maldives/about/complaints-procedure`