### PR TITLE
Filter unpublished statistical data sets when checking Publications

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -21,6 +21,7 @@ module SyncChecker
             "related_statistical_data_sets",
             edition_expected_in_live
               .statistical_data_sets
+              .select { |ds| ds.unpublishing.nil? }
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
Part of https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-sync-checks-10-300-sample-failing-107-321-total

There are several cases where sync checks fail because the expected
statistical data sets include unpublished items so exclude these from
the list of content ids we wish to verify.