### PR TITLE
Use document_type & schema_name for redirects

### DIFF
--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -14,7 +14,8 @@ module Whitehall
         {
           content_id: SecureRandom.uuid,
           base_path: base_path,
-          format: "redirect",
+          document_type: "redirect",
+          schema_name: "redirect",
           publishing_app: "whitehall",
           update_type: "major",
           redirects: redirects,


### PR DESCRIPTION
`format` is deprecated and will soon be removed from the schemas.

https://trello.com/c/C8A9bnuO/344-work-on-making-the-document-type-concept-clearer