### PR TITLE
Add migration to republish `Attachable`

### DIFF
--- a/db/data_migration/20161205141503_republish_html_attachments_via_attachables.rb
+++ b/db/data_migration/20161205141503_republish_html_attachments_via_attachables.rb
@@ -1,0 +1,13 @@
+document_ids = Edition
+  .where(id: HtmlAttachment.pluck(:attachable_id))
+  .where(state: %w(published draft withdrawn submitted scheduled))
+  .pluck(:document_id)
+  .uniq
+
+document_ids.each do |document_id|
+  print "."
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+    "bulk_republishing",
+    document_id
+  )
+end


### PR DESCRIPTION
This migration republishes all documents that are `Attachable` and have an `HtmlAttachment`.

This will cause the `HtmlAttachment`s to be republished too allowing us to get an up to date view of any remaining issues with the migration to Publishing API before switching them over completely.

Republishing via the `Attachable` `Edition`'s `Document` allows us to exercise the full republishing worker setup and avoids having to navigate the complicated state of `HtmlAttachment` within the migration.