### PR TITLE
Remove relationship to stats data set

### DIFF
--- a/db/data_migration/20161206120331_remove_stats_dataset_relationship.rb
+++ b/db/data_migration/20161206120331_remove_stats_dataset_relationship.rb
@@ -1,0 +1,6 @@
+# This DfT publication 'ict-spend' has one statistical data set
+# which is superseded and has the slug 'average-house-prices'
+# so assume this is a bad relationship and disconnect the two.
+pub = Publication.find(392444)
+pub.statistical_data_sets.select! { |ds| ds.id != 14779 }
+pub.save!


### PR DESCRIPTION
Part of https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-sync-checks-10-300-sample-failing-107-321-total

This DfT publication has an association to a statistical data set
from DCLG on a completely irrelevant subject. We're assuming this
is not intended. The data set is also superseded so remove the
relationship.