### PR TITLE
Use "on" not "at" for consultation close date

### DIFF
--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -30,7 +30,7 @@
       <% if @document.open? %>
         <div class="consultation-block <%= consultation_css_class(@document) %>">
           <div class="consultation-dates">
-            <p>This consultation closes at <span><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+            <p>This consultation closes on <span><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
           </div>
 
           <%= render partial: "document_summary", locals: { document: @document } %>


### PR DESCRIPTION
“This consultation closes on 21 January 2017 12:00am”
reads a little better than:
“This consultation closes at 21 January 2017 12:00am”

More complete date fixes already exist in government-frontend, users
will benefit from those after migration of the format.

## Before
![screen shot 2016-12-06 at 13 51 25](https://cloud.githubusercontent.com/assets/319055/20927836/1fef26de-bbbb-11e6-8e0d-0c2ae5ae2c8b.png)
