### PR TITLE
Remove relationship to stats data set

### DIFF
--- a/db/data_migration/20161206120331_remove_stats_dataset_relationship.rb
+++ b/db/data_migration/20161206120331_remove_stats_dataset_relationship.rb
@@ -2,5 +2,6 @@
 # which is superseded and has the slug 'average-house-prices'
 # so assume this is a bad relationship and disconnect the two.
 pub = Publication.find(392444)
+data_set = StatisticalDataSet.find(14779)
 pub.statistical_data_sets = (pub.statistical_data_sets - [data_set])
 pub.save!


### PR DESCRIPTION
Fix for broken https://github.com/alphagov/whitehall/pull/2912
This DfT publication has an association to a statistical data set
from DCLG on a completely irrelevant subject. We're assuming this
is not intended. The data set is also superseded so remove the
relationship.