### PR TITLE
Clear document_collections links for publication

### DIFF
--- a/db/data_migration/20161208112001_patch_empty_document_collections_links_for_publication.rb
+++ b/db/data_migration/20161208112001_patch_empty_document_collections_links_for_publication.rb
@@ -1,0 +1,14 @@
+pub = Publication.find(124751)
+
+links = PublishingApiPresenters.presenter_for(pub).links
+
+if links
+  # Explicitly set the document_collections links to an empty set
+  # these links are resolved by the Publishing API
+  links[:document_collections] = []
+  Whitehall.publishing_api_v2_client.patch_links(
+    pub.document.content_id,
+    links: links,
+    bulk_publishing: true
+  )
+end


### PR DESCRIPTION
Part of https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-sync-checks-4000-sample-failing-107-321-total

The Publishing API will resolve these links for us so clear
any `document_collections` links data previously added prior
to dependency resolution.