### PR TITLE
Statistical data set migration

### DIFF
--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -21,4 +21,8 @@ class StatisticalDataSet < Publicationesque
   def search_format_types
     super + ['publicationesque-statistics', StatisticalDataSet.search_format_type]
   end
+
+  def rendering_app
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+  end
 end

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -1,0 +1,56 @@
+module PublishingApi
+  class StatisticalDataSetPresenter
+    include UpdateTypeHelper
+
+    attr_reader :update_type
+
+    def initialize(item, update_type: nil)
+      @item = item
+      @update_type = update_type || default_update_type(item)
+    end
+
+    def content_id
+      item.content_id
+    end
+
+    def content
+      content = BaseItemPresenter.new(item).base_attributes
+      content.merge!(
+        description: item.summary,
+        details: details,
+        document_type: "statistical_data_set",
+        public_updated_at: item.public_timestamp || item.updated_at,
+        rendering_app: item.rendering_app,
+        schema_name: "statistical_data_set",
+      )
+      content.merge!(PayloadBuilder::AccessLimitation.for(item))
+      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
+    end
+
+    def links
+      LinksPresenter.new(item).extract(
+        %i(organisations policy_areas topics)
+      )
+    end
+
+  private
+
+    attr_reader :item
+
+    def details
+      {
+        body: govspeak_renderer.govspeak_edition_to_html(item),
+        change_history: item.change_history.as_json,
+        emphasised_organisations: item.lead_organisations.map(&:content_id),
+      }.tap do |details_hash|
+        details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
+        details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+      end
+    end
+
+    def govspeak_renderer
+      @govspeak_renderer ||= Whitehall::GovspeakRenderer.new
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -56,10 +56,12 @@ private
       PublishingApi::FatalityNoticePresenter
     when ::Publication
       PublishingApi::PublicationPresenter
+    when StatisticalDataSet
+      PublishingApi::StatisticalDataSetPresenter
     else
       # This is a catch-all clause for the following classes:
       # NewsArticle, WorldLocationNewsArticle, Speech, CorporateInformationPage,
-      # Consultations, StatisticalDataSet
+      # Consultations
       # The presenter implementation for all of these models is identical and
       # the structure of the presented payload is the same.
       PublishingApi::GenericEditionPresenter

--- a/db/data_migration/20161201100339_republish_statistical_data_sets.rb
+++ b/db/data_migration/20161201100339_republish_statistical_data_sets.rb
@@ -1,0 +1,2 @@
+publisher = DataHygiene::PublishingApiDocumentRepublisher.new(StatisticalDataSet)
+publisher.perform

--- a/lib/sync_checker/formats/statistical_data_set_check.rb
+++ b/lib/sync_checker/formats/statistical_data_set_check.rb
@@ -1,0 +1,13 @@
+module SyncChecker
+  module Formats
+    class StatisticalDataSetCheck < EditionBase
+      def root_path
+        "/government/statistical-data-sets/"
+      end
+
+      def rendering_app
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -1,0 +1,302 @@
+require 'test_helper'
+
+class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+
+    @statistical_data_set = create(
+      :statistical_data_set,
+      title: "Statistical Data Set title",
+      summary: "Statistical Data Set summary"
+    )
+
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
+    @presented_content = I18n.with_locale("de") { @presented_statistical_data_set.content }
+  end
+
+  test "it presents a valid statistical_data_set content item" do
+    assert_valid_against_schema @presented_content, "statistical_data_set"
+  end
+
+  test "it delegates the content id" do
+    assert_equal @statistical_data_set.content_id, @presented_statistical_data_set.content_id
+  end
+
+  test "it presents the title" do
+    assert_equal "Statistical Data Set title", @presented_content[:title]
+  end
+
+  test "it presents the summary as the description" do
+    assert_equal "Statistical Data Set summary", @presented_content[:description]
+  end
+
+  test "it presents the base_path" do
+    assert_equal "/government/statistical-data-sets/statistical-data-set-title", @presented_content[:base_path]
+  end
+
+  test "it presents updated_at if public_timestamp is nil" do
+    assert_equal @statistical_data_set.updated_at, @presented_content[:public_updated_at]
+  end
+
+  test "it presents the publishing_app as whitehall" do
+    assert_equal 'whitehall', @presented_content[:publishing_app]
+  end
+
+  test "it presents the rendering_app as whitehall-frontend" do
+    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  end
+
+  test "it presents the schema_name as statistical_data_set" do
+    assert_equal "statistical_data_set", @presented_content[:schema_name]
+  end
+
+  test "it presents the document type as statistical_data_set" do
+    assert_equal "statistical_data_set", @presented_content[:document_type]
+  end
+
+  test "it presents the global process wide locale as the locale of the statistical_data_set" do
+    assert_equal "de", @presented_content[:locale]
+  end
+end
+
+class PublishingApi::StatisticalDataSetWithPublicTimestampTest < ActiveSupport::TestCase
+  setup do
+    @expected_time = Time.zone.parse("10/01/2016")
+    @statistical_data_set = create(
+      :statistical_data_set
+    )
+    @statistical_data_set.public_timestamp = @expected_time
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
+  end
+
+  test "it presents public_timestamp if it exists" do
+    assert_equal @expected_time, @presented_statistical_data_set.content[:public_updated_at]
+  end
+end
+
+class PublishingApi::DraftStatisticalDataSetPresenter < ActiveSupport::TestCase
+  test "it presents the statistical data set's parent document created_at as first_public_at" do
+    presented_notice = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:draft_statistical_data_set) do |statistical_data_set|
+        statistical_data_set.document.stubs(:created_at).returns(DateTime.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      DateTime.new(2015, 4, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+class PublishingApi::StatisticalDataSetBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
+  test "it presents the Statistical Data Set's first_published_at as first_public_at" do
+    presented_notice = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:published_statistical_data_set) do |statistical_data_set|
+        statistical_data_set.stubs(:first_published_at).returns(DateTime.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      DateTime.new(2015, 04, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+class PublishingApi::PublishedStatisticalDataSetPresenterDetailsTest < ActiveSupport::TestCase
+  setup do
+    @expected_first_published_at = DateTime.new(2015, 12, 25)
+    @statistical_data_set = create(
+      :statistical_data_set,
+      :published,
+      body: "*Test string*",
+      first_published_at: @expected_first_published_at
+    )
+
+    @presented_content = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set).content
+    @presented_details = @presented_content[:details]
+  end
+
+  test "it presents first_public_at as details, first_public_at" do
+    assert_equal @expected_first_published_at, @presented_details[:first_public_at]
+  end
+
+  test "it presents change_history" do
+    change_history = [
+      {
+        "public_timestamp" => @expected_first_published_at,
+        "note" => "change-note"
+      }
+    ]
+
+    assert_equal change_history, @presented_details[:change_history]
+  end
+
+  test "it presents the lead organisation content_ids as details, emphasised_organisations" do
+    assert_equal(
+      @statistical_data_set.lead_organisations.map(&:content_id),
+      @presented_details[:emphasised_organisations]
+    )
+  end
+end
+
+class PublishingApi::PublishedStatisticalDataSetPresenterLinksTest < ActiveSupport::TestCase
+  setup do
+    @statistical_data_set = create(:statistical_data_set)
+    presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
+    @presented_links = presented_statistical_data_set.links
+  end
+
+  test "it presents the organisation content_ids as links, organisations" do
+    assert_equal(
+      @statistical_data_set.organisations.map(&:content_id),
+      @presented_links[:organisations]
+    )
+  end
+
+  test "it presents the policy area content_ids as links, policy_areas" do
+    assert_equal(
+      @statistical_data_set.topics.map(&:content_id),
+      @presented_links[:policy_areas]
+    )
+  end
+
+  test "it presents the topic content_ids as links, topics" do
+    assert_equal(
+      @statistical_data_set.specialist_sectors.map(&:content_id),
+      @presented_links[:topics]
+    )
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:statistical_data_set, minor_change: false)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "major", @presented_statistical_data_set.update_type
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterMinorUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:statistical_data_set, minor_change: true)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "minor", @presented_statistical_data_set.update_type
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterUpdateTypeArgumentTest < ActiveSupport::TestCase
+  setup do
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:statistical_data_set, minor_change: true),
+      update_type: "major"
+    )
+  end
+
+  test "presents based on the supplied update type argument" do
+    assert_equal "major", @presented_statistical_data_set.update_type
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterCurrentGovernmentTest < ActiveSupport::TestCase
+  setup do
+    # Goverments are not explicitly associated with an Edition.
+    # The Government is determined based on date of publication.
+    create(
+      :current_government,
+      name: "The Current Government",
+      slug: "the-current-government",
+    )
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      create(:statistical_data_set)
+    )
+  end
+
+  test "presents a current government" do
+    assert_equal(
+      {
+        "title": "The Current Government",
+        "slug": "the-current-government",
+        "current": true
+      },
+      @presented_statistical_data_set.content[:details][:government]
+    )
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveSupport::TestCase
+  setup do
+    # Goverments are not explicitly associated with an Edition.
+    # The Government is determined based on date of publication.
+    create(:current_government)
+    previous_government = create(
+      :previous_government,
+      name: "A Previous Government",
+      slug: "a-previous-government",
+    )
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      create(
+        :statistical_data_set,
+        first_published_at: previous_government.start_date + 1.day
+      )
+    )
+  end
+
+  test "presents a previous government" do
+    assert_equal(
+      {
+        "title": "A Previous Government",
+        "slug": "a-previous-government",
+        "current": false
+      },
+      @presented_statistical_data_set.content[:details][:government]
+    )
+  end
+end
+
+class PublishingApi::StatisticalDataSetPresenterPoliticalTest < ActiveSupport::TestCase
+  setup do
+    statistical_data_set = create(:statistical_data_set)
+    statistical_data_set.stubs(:political?).returns(true)
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      statistical_data_set
+    )
+  end
+
+  test "presents political" do
+    assert @presented_statistical_data_set.content[:details][:political]
+  end
+end
+
+class PublishingApi::StatisticalDataSetAccessLimitedTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+    statistical_data_set = create(:statistical_data_set)
+
+    PublishingApi::PayloadBuilder::AccessLimitation.expects(:for)
+      .with(statistical_data_set)
+      .returns(
+        { access_limited: { users: %w(abcdef12345) } }
+      )
+    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
+      statistical_data_set
+    )
+  end
+
+  test "include access limiting" do
+    assert_equal %w(abcdef12345), @presented_statistical_data_set.content[:access_limited][:users]
+  end
+
+  test "is valid against content schemas" do
+    assert_valid_against_schema @presented_statistical_data_set.content, "statistical_data_set"
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -47,9 +47,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
 
     assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(Consultation.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(StatisticalDataSet.new).class
   end
 
   test ".presenter_for returns a Placeholder presenter for an organisation" do
@@ -122,5 +119,10 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a FatalityNoticePresenter for a FatalityNotice" do
     presenter = PublishingApiPresenters.presenter_for(build(:fatality_notice))
     assert_equal PublishingApi::FatalityNoticePresenter, presenter.class
+  end
+
+  test ".presenter_for returns a StatisticalDataSetPresenter for a StatisticalDataSet" do
+    presenter = PublishingApiPresenters.presenter_for(build(:statistical_data_set))
+    assert_equal PublishingApi::StatisticalDataSetPresenter, presenter.class
   end
 end

--- a/test/unit/statistical_data_set_test.rb
+++ b/test/unit/statistical_data_set_test.rb
@@ -27,4 +27,9 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
     assert statistical_data_set.search_format_types.include?('statistical-data-set')
     assert statistical_data_set.search_format_types.include?('publicationesque-statistics')
   end
+
+  test 'specifies rendering app to be whitehall frontend' do
+    statistical_data_set = StatisticalDataSet.new
+    assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::WHITEHALL_FRONTEND)
+  end
 end


### PR DESCRIPTION
Statistical Dataset Migration: implement publishing of format to publishing API

[Trello](https://trello.com/c/a5btPA88)

* Remove the Placeholder Presenter
* Add a Presenter for the PublishingApi
* Add Sync Checks

Note - sometime the `equivalent-xml` gem that we are using to compare the `body` during sync checks reports a false failure. This is (we think) because the HTML we render is not strict XML (for example we are not closing `img` tags) and this in turn causes `equivalent-xml` to render the representation of these two items differently. We have manually re-run individual sync checks for documents that failed on integration and they have passed. Additionally, during testing, we manually checked failing sync checks and found no diffs between the item in whitehall and the item in the content store. We have created a card in [trello](https://trello.com/c/DwhzGiHh/776-fix-false-failures-in-sync-checks-details-body-doesn-t-match) to address the issue

Paired with @Rosa-Fox 