### PR TITLE
Present Consultation to the Publishing API

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -32,6 +32,7 @@ module PublishingApi
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(consultation),
         closing_date: consultation.closing_at,
+        emphasised_organisations: consultation.lead_organisations.map(&:content_id),
         opening_date: consultation.opening_at,
       }
     end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -12,6 +12,7 @@ module PublishingApi
       BaseItemPresenter
         .new(consultation)
         .base_attributes
+        .merge(PayloadBuilder::AccessLimitation.for(consultation))
         .merge(PayloadBuilder::PublicDocumentPath.for(consultation))
         .merge(
           description: consultation.summary,

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -31,6 +31,7 @@ module PublishingApi
     def base_details
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(consultation),
+        closing_date: consultation.closing_at,
         opening_date: consultation.opening_at,
       }
     end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -1,13 +1,16 @@
 module PublishingApi
   class ConsultationPresenter
     extend Forwardable
+    include UpdateTypeHelper
 
     SCHEMA_NAME = 'consultation'
 
+    attr_reader :update_type
     def_delegator :consultation, :content_id
 
-    def initialize(consultation)
+    def initialize(consultation, update_type: nil)
       self.consultation = consultation
+      self.update_type = update_type || default_update_type(consultation)
     end
 
     def content
@@ -35,6 +38,7 @@ module PublishingApi
   private
 
     attr_accessor :consultation
+    attr_writer :update_type
     def_delegator :consultation, :display_type_key, :document_type
 
     def base_details

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -52,6 +52,7 @@ module PublishingApi
         .merge(Documents.for(consultation))
         .merge(ExternalURL.for(consultation))
         .merge(FinalOutcome.for(consultation))
+        .merge(NationalApplicability.for(consultation))
         .merge(WaysToRespond.for(consultation))
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
@@ -142,7 +143,7 @@ module PublishingApi
         }.compact
       end
 
-      private
+    private
 
       attr_accessor :consultation, :renderer
       def_delegator :consultation, :outcome
@@ -162,6 +163,26 @@ module PublishingApi
 
         renderer.block_attachments(outcome.attachments, alternative_format_email)
       end
+    end
+
+    class NationalApplicability
+      def self.for(consultation)
+        new(consultation).call
+      end
+
+      def initialize(consultation)
+        self.consultation = consultation
+      end
+
+      def call
+        return {} unless consultation.nation_inapplicabilities.present?
+
+        { national_applicability: consultation.national_applicability }
+      end
+
+    private
+
+      attr_accessor :consultation
     end
 
     class WaysToRespond

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
           description: consultation.summary,
           details: details,
           document_type: document_type,
+          public_updated_at: public_updated_at,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: SCHEMA_NAME,
         )
@@ -36,6 +37,15 @@ module PublishingApi
     def details
       base_details
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
+    end
+
+    def public_updated_at
+      public_updated_at = (consultation.public_timestamp || consultation.updated_at)
+      public_updated_at = if public_updated_at.respond_to?(:to_datetime)
+                            public_updated_at.to_datetime
+                          end
+
+      public_updated_at.rfc3339
     end
   end
 end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -4,6 +4,8 @@ module PublishingApi
 
     SCHEMA_NAME = 'consultation'
 
+    def_delegator :consultation, :content_id
+
     def initialize(consultation)
       self.consultation = consultation
     end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -23,6 +23,12 @@ module PublishingApi
         )
     end
 
+    def links
+      LinksPresenter
+        .new(consultation)
+        .extract(%i(organisations policy_areas topics))
+    end
+
   private
 
     attr_accessor :consultation

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -1,0 +1,37 @@
+module PublishingApi
+  class ConsultationPresenter
+    SCHEMA_NAME = 'consultation'
+
+    def initialize(consultation)
+      self.consultation = consultation
+    end
+
+    def content
+      BaseItemPresenter
+        .new(consultation)
+        .base_attributes
+        .merge(PayloadBuilder::PublicDocumentPath.for(consultation))
+        .merge(
+          details: details,
+          document_type: 'consultation',
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+          schema_name: SCHEMA_NAME,
+        )
+    end
+
+  private
+
+    attr_accessor :consultation
+
+    def base_details
+      {
+        body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(consultation),
+      }
+    end
+
+    def details
+      base_details
+        .merge(PayloadBuilder::PoliticalDetails.for(consultation))
+    end
+  end
+end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -14,6 +14,7 @@ module PublishingApi
         .base_attributes
         .merge(PayloadBuilder::PublicDocumentPath.for(consultation))
         .merge(
+          description: consultation.summary,
           details: details,
           document_type: document_type,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -41,6 +41,7 @@ module PublishingApi
         .merge(ExternalURL.for(consultation))
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
+        .merge(PayloadBuilder::TagDetails.for(consultation))
     end
 
     def public_updated_at

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -38,6 +38,7 @@ module PublishingApi
 
     def details
       base_details
+        .merge(ExternalURL.for(consultation))
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
     end
@@ -49,6 +50,26 @@ module PublishingApi
                           end
 
       public_updated_at.rfc3339
+    end
+
+    class ExternalURL
+      def self.for(consultation)
+        new(consultation).call
+      end
+
+      def initialize(consultation)
+        self.consultation = consultation
+      end
+
+      def call
+        return {} unless consultation.external?
+
+        { held_on_another_website_url: consultation.external_url }
+      end
+
+    private
+
+      attr_accessor :consultation
     end
   end
 end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -36,6 +36,7 @@ module PublishingApi
 
     def details
       base_details
+        .merge(PayloadBuilder::FirstPublicAt.for(consultation))
         .merge(PayloadBuilder::PoliticalDetails.for(consultation))
     end
 

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -31,6 +31,7 @@ module PublishingApi
     def base_details
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(consultation),
+        opening_date: consultation.opening_at,
       }
     end
 

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class ConsultationPresenter
+    extend Forwardable
+
     SCHEMA_NAME = 'consultation'
 
     def initialize(consultation)
@@ -13,7 +15,7 @@ module PublishingApi
         .merge(PayloadBuilder::PublicDocumentPath.for(consultation))
         .merge(
           details: details,
-          document_type: 'consultation',
+          document_type: document_type,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: SCHEMA_NAME,
         )
@@ -22,6 +24,7 @@ module PublishingApi
   private
 
     attr_accessor :consultation
+    def_delegator :consultation, :display_type_key, :document_type
 
     def base_details
       {

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -49,6 +49,7 @@ module PublishingApi
 
     def details
       base_details
+        .merge(ChangeHistory.for(consultation))
         .merge(Documents.for(consultation))
         .merge(ExternalURL.for(consultation))
         .merge(FinalOutcome.for(consultation))
@@ -66,6 +67,26 @@ module PublishingApi
                           end
 
       public_updated_at.rfc3339
+    end
+
+    class ChangeHistory
+      def self.for(consultation)
+        new(consultation).call
+      end
+
+      def initialize(consultation)
+        self.consultation = consultation
+      end
+
+      def call
+        return {} unless consultation.change_history.present?
+
+        { change_history: consultation.change_history.as_json }
+      end
+
+    private
+
+      attr_accessor :consultation
     end
 
     class Documents

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -48,6 +48,8 @@ private
     case edition
     when ::CaseStudy
       PublishingApi::CaseStudyPresenter
+    when Consultation
+      PublishingApi::ConsultationPresenter
     when ::DocumentCollection
       PublishingApi::DocumentCollectionPresenter
     when ::DetailedGuide

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -388,7 +388,7 @@ Whitehall::Application.routes.draw do
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "attachments#preview", as: :preview_attachment
-  get '/government/uploads/*path.:extension' => "public_uploads#show"
+  get '/government/uploads/*path.:extension' => "public_uploads#show", as: :public_upload
 
   mount TestTrack::Engine => "test" if Rails.env.test?
 end

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -36,4 +36,8 @@ FactoryGirl.define do
   factory :consultation_with_outcome, parent: :closed_consultation do
     outcome { create(:consultation_outcome) }
   end
+
+  factory :consultation_with_outcome_attachment, parent: :closed_consultation do
+    outcome { create(:consultation_outcome, :with_file_attachment) }
+  end
 end

--- a/test/factories/responses.rb
+++ b/test/factories/responses.rb
@@ -24,5 +24,15 @@ FactoryGirl.define do
     sequence :summary do |n|
       "public feedback summary #{n}"
     end
+
+    trait(:with_file_attachment) do
+      attachments { FactoryGirl.build_list :file_attachment, 1 }
+
+      after :create do |consultation_outcome, _|
+        VirusScanHelpers.simulate_virus_scan(
+          consultation_outcome.attachments.first.attachment_data.file
+        )
+      end
+    end
   end
 end

--- a/test/factories/responses.rb
+++ b/test/factories/responses.rb
@@ -8,6 +8,16 @@ FactoryGirl.define do
     sequence :summary do |n|
       "outcome summary #{n}"
     end
+
+    trait(:with_file_attachment) do
+      attachments { FactoryGirl.build_list :file_attachment, 1 }
+
+      after :create do |consultation_outcome, _|
+        VirusScanHelpers.simulate_virus_scan(
+          consultation_outcome.attachments.first.attachment_data.file
+        )
+      end
+    end
   end
 
   factory :consultation_public_feedback, traits: [:response] do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -2,18 +2,25 @@ require 'test_helper'
 
 module PublishingApi::ConsultationPresenterTest
   class TestCase < ActiveSupport::TestCase
-    attr_accessor :consultation
+    attr_accessor :consultation, :update_type
 
     setup do
       create(:current_government)
     end
 
+    def presented_consultation
+      PublishingApi::ConsultationPresenter.new(
+        consultation,
+        update_type: update_type,
+      )
+    end
+
     def presented_content
-      PublishingApi::ConsultationPresenter.new(consultation).content
+      presented_consultation.content
     end
 
     def presented_links
-      PublishingApi::ConsultationPresenter.new(consultation).links
+      presented_consultation.links
     end
 
     def assert_attribute(attribute, value)
@@ -540,6 +547,37 @@ module PublishingApi::ConsultationPresenterTest
 
     test 'validity' do
       assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class ConsultationWithMajorChange < TestCase
+    setup do
+      self.consultation = create(:consultation, minor_change: false)
+      self.update_type = 'major'
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_consultation.update_type
+    end
+  end
+
+  class ConsultationWithMinorChange < TestCase
+    setup do
+      self.consultation = create(:consultation, minor_change: true)
+    end
+
+    test 'update type' do
+      assert_equal 'minor', presented_consultation.update_type
+    end
+  end
+
+  class ConsultationWithoutMinorChange < TestCase
+    setup do
+      self.consultation = create(:consultation, minor_change: false,)
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_consultation.update_type
     end
   end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -127,8 +127,13 @@ module PublishingApi::ConsultationPresenterTest
     setup do
       self.consultation = create(
         :open_consultation,
+        closing_at: 1.day.from_now,
         opening_at: 1.day.ago,
       )
+    end
+
+    test 'closing date' do
+      assert_details_attribute :closing_date, 1.day.from_now
     end
 
     test 'document type' do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -407,4 +407,46 @@ module PublishingApi::ConsultationPresenterTest
       assert_valid_against_schema presented_content, 'consultation'
     end
   end
+
+  class ConsultationWithNationalApplicability < TestCase
+    setup do
+      scotland_nation_inapplicability = create(
+        :nation_inapplicability,
+        nation: Nation.scotland,
+        alternative_url: 'http://scotland.com'
+      )
+
+      self.consultation = create(
+        :consultation,
+        nation_inapplicabilities: [scotland_nation_inapplicability]
+      )
+    end
+
+    test 'national applicability' do
+      assert_details_attribute :national_applicability,
+                               {
+                                 england: {
+                                   label: 'England',
+                                   applicable: true,
+                                 },
+                                 northern_ireland: {
+                                   label: 'Northern Ireland',
+                                   applicable: true,
+                                 },
+                                 scotland: {
+                                   label: 'Scotland',
+                                   applicable: false,
+                                   alternative_url: 'http://scotland.com'
+                                 },
+                                 wales: {
+                                   label: 'Wales',
+                                   applicable: true,
+                                 }
+                               }
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -4,6 +4,10 @@ module PublishingApi::ConsultationPresenterTest
   class TestCase < ActiveSupport::TestCase
     attr_accessor :consultation
 
+    setup do
+      create(:current_government)
+    end
+
     def presented_content
       PublishingApi::ConsultationPresenter.new(consultation).content
     end
@@ -40,12 +44,6 @@ module PublishingApi::ConsultationPresenterTest
 
   class BasicConsultationTest < TestCase
     setup do
-      create(
-        :current_government,
-        name: 'The Current Government',
-        slug: 'the-current-government',
-      )
-
       self.consultation = create(:consultation)
     end
 
@@ -83,7 +81,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test 'document type' do
-      assert_attribute :document_type, 'consultation'
+      assert_attribute :document_type, 'open_consultation'
     end
 
     test 'political details' do
@@ -100,6 +98,94 @@ module PublishingApi::ConsultationPresenterTest
 
     test 'schema name' do
       assert_attribute :schema_name, 'consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class UnopenedConsultationTest < TestCase
+    setup do
+      self.consultation = create(:unopened_consultation)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'consultation'
+    end
+  end
+
+  class OpenConsultationTest < TestCase
+    setup do
+      self.consultation = create(:open_consultation)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'open_consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class OpenConsultationWithParticipationTest < TestCase
+    setup do
+      participation = create(:consultation_participation,
+                             link_url: 'http://www.example.com')
+
+      self.consultation = create(:open_consultation,
+                                 consultation_participation: participation)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'open_consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class ClosedConsultationTest < TestCase
+    setup do
+      self.consultation = create('closed_consultation')
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'closed_consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class ClosedConsultationWithFeedbackTest < TestCase
+    setup do
+      self.consultation = create(:closed_consultation)
+
+      create(:consultation_public_feedback,
+             consultation: consultation,
+             summary: 'Public feedback summary')
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'closed_consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class ClosedConsultationWithOutcomeTest < TestCase
+    setup do
+      self.consultation = create(:consultation_with_outcome)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'consultation_outcome'
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -108,6 +108,10 @@ module PublishingApi::ConsultationPresenterTest
       assert_attribute :schema_name, 'consultation'
     end
 
+    test 'tags' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::TagDetails'
+    end
+
     test 'validity' do
       assert_valid_against_schema presented_content, 'consultation'
     end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -88,6 +88,10 @@ module PublishingApi::ConsultationPresenterTest
       assert_attribute :document_type, 'open_consultation'
     end
 
+    test 'first public at details' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::FirstPublicAt'
+    end
+
     test 'political details' do
       assert_details_payload 'PublishingApi::PayloadBuilder::PoliticalDetails'
     end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -125,11 +125,18 @@ module PublishingApi::ConsultationPresenterTest
 
   class OpenConsultationTest < TestCase
     setup do
-      self.consultation = create(:open_consultation)
+      self.consultation = create(
+        :open_consultation,
+        opening_at: 1.day.ago,
+      )
     end
 
     test 'document type' do
       assert_attribute :document_type, 'open_consultation'
+    end
+
+    test 'opening date' do
+      assert_details_attribute :opening_date, 1.day.ago
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -248,4 +248,23 @@ module PublishingApi::ConsultationPresenterTest
       assert_valid_against_schema presented_content, 'consultation'
     end
   end
+
+  class ConsultationHeldOnAnotherWebsite < TestCase
+    setup do
+      self.consultation = create(
+        :open_consultation,
+        external: true,
+        external_url: 'https://example.com/link/to/consultation'
+      )
+    end
+
+    test 'held on another website URL' do
+      assert_details_attribute :held_on_another_website_url,
+                               'https://example.com/link/to/consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -196,4 +196,40 @@ module PublishingApi::ConsultationPresenterTest
       assert_valid_against_schema presented_content, 'consultation'
     end
   end
+
+  class ConsultationWithPublicTimestamp < TestCase
+    setup do
+      self.consultation = create(:consultation_with_outcome)
+
+      consultation.stubs(public_timestamp: Date.new(1999),
+                         updated_at: Date.new(2012))
+    end
+
+    test 'public updated at' do
+      assert_attribute :public_updated_at,
+                       '1999-01-01T00:00:00+00:00'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+
+  class ConsultationWithoutPublicTimestamp < TestCase
+    setup do
+      self.consultation = create(:consultation_with_outcome)
+
+      consultation.stubs(public_timestamp: nil,
+                         updated_at: Date.new(2012))
+    end
+
+    test 'public updated at' do
+      assert_attribute :public_updated_at,
+                       '2012-01-01T00:00:00+00:00'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -114,6 +114,10 @@ module PublishingApi::ConsultationPresenterTest
       assert_details_attribute :body, body_double
     end
 
+    test 'content id' do
+      assert_equal consultation.content_id, presented_consultation.content_id
+    end
+
     test 'description' do
       assert_attribute :description, consultation.summary
     end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -80,6 +80,10 @@ module PublishingApi::ConsultationPresenterTest
       assert_details_attribute :body, body_double
     end
 
+    test 'description' do
+      assert_attribute :description, consultation.summary
+    end
+
     test 'document type' do
       assert_attribute :document_type, 'open_consultation'
     end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -78,11 +78,11 @@ module PublishingApi::ConsultationPresenterTest
         link_three: 'link_three',
       }
 
-      LinksPresenter
+      PublishingApi::LinksPresenter
         .expects(:new)
         .with(consultation)
         .returns(
-          mock('LinksPresenter') {
+          mock('PublishingApi::LinksPresenter') {
             expects(:extract)
               .with(expected_link_keys)
               .returns(links_double)
@@ -190,8 +190,28 @@ module PublishingApi::ConsultationPresenterTest
 
   class OpenConsultationWithParticipationTest < TestCase
     setup do
-      participation = create(:consultation_participation,
-                             link_url: 'http://www.example.com')
+      response_form_data_attributes = attributes_for(
+        :consultation_response_form_data
+      )
+
+      response_form_attributes = attributes_for(
+        :consultation_response_form,
+        consultation_response_form_data_attributes: response_form_data_attributes
+      )
+
+      participation = create(
+        :consultation_participation,
+        consultation_response_form_attributes: response_form_attributes,
+        email: 'postmaster@example.com',
+        link_url: 'http://www.example.com',
+        postal_address: <<-ADDRESS.strip_heredoc.chop
+                        2 Home Farm Ln
+                        Kirklington
+                        Newark
+                        NG22 8PE
+                        UK
+      ADDRESS
+      )
 
       self.consultation = create(:open_consultation,
                                  consultation_participation: participation)
@@ -199,6 +219,23 @@ module PublishingApi::ConsultationPresenterTest
 
     test 'document type' do
       assert_attribute :document_type, 'open_consultation'
+    end
+
+    test 'ways to respond' do
+      expected_ways_to_respond = {
+        attachment_url: 'https://www.test.alphagov.co.uk/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
+        email: 'postmaster@example.com',
+        link_url: 'http://www.example.com',
+        postal_address: <<-ADDRESS.strip_heredoc.chop
+                        2 Home Farm Ln
+                        Kirklington
+                        Newark
+                        NG22 8PE
+                        UK
+                        ADDRESS
+      }
+
+      assert_details_attribute :ways_to_respond, expected_ways_to_respond
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -1,0 +1,109 @@
+require 'test_helper'
+
+module PublishingApi::ConsultationPresenterTest
+  class TestCase < ActiveSupport::TestCase
+    attr_accessor :consultation
+
+    def presented_content
+      PublishingApi::ConsultationPresenter.new(consultation).content
+    end
+
+    def assert_attribute(attribute, value)
+      assert_equal value, presented_content[attribute]
+    end
+
+    def assert_details_attribute(attribute, value)
+      assert_equal value, presented_content[:details][attribute]
+    end
+
+    def assert_payload(builder, data: -> { presented_content })
+      builder_double = builder.demodulize.underscore
+      payload_double = { :"#{builder_double}_key" => "#{builder_double}_value" }
+
+      builder
+        .constantize
+        .expects(:for)
+        .at_least_once
+        .with(consultation)
+        .returns(payload_double)
+
+      actual_data = data.call
+      expected_data = actual_data.merge(payload_double)
+
+      assert_equal expected_data, actual_data
+    end
+
+    def assert_details_payload(builder)
+      assert_payload builder, data: -> { presented_content[:details] }
+    end
+  end
+
+  class BasicConsultationTest < TestCase
+    setup do
+      create(
+        :current_government,
+        name: 'The Current Government',
+        slug: 'the-current-government',
+      )
+
+      self.consultation = create(:consultation)
+    end
+
+    test 'base' do
+      attributes_double = {
+        base_attribute_one: 'base_attribute_one',
+        base_attribute_two: 'base_attribute_two',
+        base_attribute_three: 'base_attribute_three',
+      }
+
+      PublishingApi::BaseItemPresenter
+        .expects(:new)
+        .with(consultation)
+        .returns(stub(base_attributes: attributes_double))
+
+      actual_content = presented_content
+      expected_content = actual_content.merge(attributes_double)
+
+      assert_equal actual_content, expected_content
+    end
+
+    test 'body details' do
+      body_double = Object.new
+
+      govspeak_renderer = mock('Whitehall::GovspeakRenderer')
+
+      govspeak_renderer
+        .expects(:govspeak_edition_to_html)
+        .with(consultation)
+        .returns(body_double)
+
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+
+      assert_details_attribute :body, body_double
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'consultation'
+    end
+
+    test 'political details' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::PoliticalDetails'
+    end
+
+    test 'public document path' do
+      assert_payload 'PublishingApi::PayloadBuilder::PublicDocumentPath'
+    end
+
+    test 'rendering app' do
+      assert_attribute :rendering_app, 'whitehall-frontend'
+    end
+
+    test 'schema name' do
+      assert_attribute :schema_name, 'consultation'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -449,4 +449,25 @@ module PublishingApi::ConsultationPresenterTest
       assert_valid_against_schema presented_content, 'consultation'
     end
   end
+
+  class ConsultationWithChangeHistory < TestCase
+    setup do
+      self.consultation = create(:open_consultation)
+    end
+
+    test 'change history' do
+      expected_change_history = [
+        {
+          'public_timestamp' => '2011-11-10T11:11:11.000+00:00',
+          'note' => 'change-note',
+        }
+      ]
+
+      assert_details_attribute :change_history, expected_change_history
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'consultation'
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -12,6 +12,10 @@ module PublishingApi::ConsultationPresenterTest
       PublishingApi::ConsultationPresenter.new(consultation).content
     end
 
+    def presented_links
+      PublishingApi::ConsultationPresenter.new(consultation).links
+    end
+
     def assert_attribute(attribute, value)
       assert_equal value, presented_content[attribute]
     end
@@ -63,6 +67,32 @@ module PublishingApi::ConsultationPresenterTest
       expected_content = actual_content.merge(attributes_double)
 
       assert_equal actual_content, expected_content
+    end
+
+    test 'base links' do
+      expected_link_keys = %i(organisations policy_areas topics)
+
+      links_double = {
+        link_one: 'link_one',
+        link_two: 'link_two',
+        link_three: 'link_three',
+      }
+
+      LinksPresenter
+        .expects(:new)
+        .with(consultation)
+        .returns(
+          mock('LinksPresenter') {
+            expects(:extract)
+              .with(expected_link_keys)
+              .returns(links_double)
+          }
+        )
+
+      actual_links = presented_links
+      expected_links = actual_links.merge(links_double)
+
+      assert_equal actual_links, expected_links
     end
 
     test 'body details' do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -88,6 +88,11 @@ module PublishingApi::ConsultationPresenterTest
       assert_attribute :document_type, 'open_consultation'
     end
 
+    test 'emphasised organisations' do
+      assert_details_attribute :emphasised_organisations,
+                               consultation.lead_organisations.map(&:content_id)
+    end
+
     test 'first public at details' do
       assert_details_payload 'PublishingApi::PayloadBuilder::FirstPublicAt'
     end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -320,6 +320,16 @@ module PublishingApi::ConsultationPresenterTest
     end
   end
 
+  class ConsultationWithAccessLimitation < TestCase
+    setup do
+      self.consultation = create(:consultation)
+    end
+
+    test 'access limited' do
+      assert_payload 'PublishingApi::PayloadBuilder::AccessLimitation'
+    end
+  end
+
   class ConsultationWithFileAttachments < TestCase
     setup do
       self.consultation = create(:consultation, :with_html_attachment)

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -44,9 +44,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
 
     assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(CorporateInformationPage.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(Consultation.new).class
   end
 
   test ".presenter_for returns a Placeholder presenter for an organisation" do
@@ -124,5 +121,10 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a StatisticalDataSetPresenter for a StatisticalDataSet" do
     presenter = PublishingApiPresenters.presenter_for(build(:statistical_data_set))
     assert_equal PublishingApi::StatisticalDataSetPresenter, presenter.class
+  end
+
+  test ".presenter_for returns a ConsultationPresenter for a Consultation" do
+    presenter = PublishingApiPresenters.presenter_for(build(:consultation))
+    assert_equal PublishingApi::ConsultationPresenter, presenter.class
   end
 end


### PR DESCRIPTION
Add logic to present consultations to the Publishing API.

[See Trello](https://trello.com/c/J1ZnHJIh)