### PR TITLE
Provide translation for blog_post document type

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -27,6 +27,13 @@ ar:
         few:
         many:
         other: "مقالات مرخصة"
+      blog_post:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       case_study:
         zero:
         one: "دراسة حالة"

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -136,6 +136,9 @@ az:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one: "Öyrənilib"
         other: "Öyrənilib"

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -16,6 +16,11 @@ be:
         few:
         many:
         other: "Аб'явы"
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       authored_article:
         one: "Аўтарскі артыкул"
         few:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -15,6 +15,9 @@ bg:
       authored_article:
         one: "Авторска статия"
         other: "Авторски статии"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "Казус"
         other: "Казуси"

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -15,6 +15,9 @@ bn:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one:
         other:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -18,6 +18,10 @@ cs:
         one: Autorský článek
         few:
         other: Autorské články
+      blog_post:
+        one:
+        few:
+        other:
       case_study:
         one: Případová studie
         few:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -27,6 +27,13 @@ cy:
         few:
         many:
         other:
+      blog_post:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       case_study:
         zero:
         one: Astudiaeth achos

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -15,6 +15,9 @@ de:
       authored_article:
         one: Namensartikel
         other: Namensartikel
+      blog_post:
+        one:
+        other:
       case_study:
         one: Fallstudie
         other: Fallstudien

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -15,6 +15,9 @@ dr:
       authored_article:
         one: "مقاله نوشته شده"
         other: "مقاله های نوشته شده"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "بررسی  موردی"
         other: "بررسی های موردی"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -15,6 +15,9 @@ el:
       authored_article:
         one: "Κείμενο συντάκτη"
         other: "Κείμενα συντακτών"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "Παράδειγμα"
         other: "Παραδείγματα"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,9 @@ en:
       announcement:
         one: Announcement
         other: Announcements
+      blog_post:
+        one: Blog post
+        other: Blog posts
       case_study:
         one: Case study
         other: Case studies

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -15,6 +15,9 @@ es-419:
       authored_article:
         one: Artículo con autor
         other: Artículos con autor
+      blog_post:
+        one:
+        other:
       case_study:
         one: Caso de estudio
         other: Casos de estudio

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -15,6 +15,9 @@ es:
       authored_article:
         one: Artículo de autor
         other: Artículos de autor
+      blog_post:
+        one:
+        other:
       case_study:
         one: Caso de estudio práctico
         other: Casos de estudio práctico

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -15,6 +15,9 @@ et:
       authored_article:
         one: Avaldatud artikkel
         other: 'Avaldatud artiklid '
+      blog_post:
+        one:
+        other:
       case_study:
         one: Juhtumiuuring
         other: Juhtumiuuringud

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -138,6 +138,9 @@ fa:
       authored_article:
         one: "مقاله"
         other: "مقالات"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "مطالعه ی موردی"
         other: "مطالعه های موردی"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -15,6 +15,9 @@ fr:
       authored_article:
         one: Article signé
         other: Articles signés
+      blog_post:
+        one:
+        other:
       case_study:
         one: Etude de cas
         other: Etudes de cas

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -21,6 +21,11 @@ he:
         two:
         many:
         other: "מאמרים מאושרים"
+      blog_post:
+        one:
+        two:
+        many:
+        other:
       case_study:
         one: "מקרה בוחן"
         two:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -15,6 +15,9 @@ hi:
       authored_article:
         one: "मूल आलेख"
         other: "मूल आलेख"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "विषय अध्ययन"
         other: "विषय अध्ययन"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -139,6 +139,9 @@ hu:
       authored_article:
         one: Publicisztika
         other: Publicisztikák
+      blog_post:
+        one:
+        other:
       case_study:
         one: Esettanulmány
         other: Esettanulmányok

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -15,6 +15,9 @@ hy:
       authored_article:
         one: "Հեղինակային հոդված"
         other: "Հեղինակային հոդվածներ"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "Թեմատիկ ուսումնասիրություն"
         other: "Թեմատիկ ուսումնասիրություններ"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -138,6 +138,9 @@ id:
       authored_article:
         one: Artikel yang ditulis
         other: Artikel-artikel yang ditulis
+      blog_post:
+        one:
+        other:
       case_study:
         one: Studi kasus
         other: Studi-studi kasus

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -15,6 +15,9 @@ it:
       authored_article:
         one: Articolo autorizzato
         other: Articoli autorizzati
+      blog_post:
+        one:
+        other:
       case_study:
         one: Caso studio
         other: Casi studio

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -137,6 +137,9 @@ ja:
       authored_article:
         one: Authored article
         other: Authored articles
+      blog_post:
+        one:
+        other:
       case_study:
         one: "ケーススタディ"
         other: "ケーススタディ"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -136,6 +136,9 @@ ka:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one:
         other:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -137,6 +137,9 @@ ko:
       authored_article:
         one: "기사"
         other: "기사"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "케이스 스터디"
         other: "케이스 스터디"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -18,6 +18,10 @@ lt:
         one: Autoriaus straipsnis
         few:
         other: Autorių straipsniai
+      blog_post:
+        one:
+        few:
+        other:
       case_study:
         one: Atvejo analizė
         few:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -15,6 +15,9 @@ lv:
       authored_article:
         one: Autora raksts
         other: Autora raksti
+      blog_post:
+        one:
+        other:
       case_study:
         one: Piemērs
         other: Piemēri

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -136,6 +136,9 @@ ms:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one:
         other:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -21,6 +21,11 @@ pl:
         few:
         many:
         other: Dokumenty utworzone przez
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       case_study:
         one: Studium przypadku
         few:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -15,6 +15,9 @@ ps:
       authored_article:
         one: "تالیف شوی مضمون"
         other: "تالیف شوي مضامین"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "موردی څیړنه"
         other: "مودری څیړنی"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -15,6 +15,9 @@ pt:
       authored_article:
         one: Artigo
         other: Artigos
+      blog_post:
+        one:
+        other:
       case_study:
         one: Estudo de caso
         other: Estudos de caso

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -18,6 +18,10 @@ ro:
         one: 'Articol '
         few:
         other: 'Articol '
+      blog_post:
+        one:
+        few:
+        other:
       case_study:
         one: Studiu de caz
         few:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -21,6 +21,11 @@ ru:
         few:
         many:
         other: "Авторские статьи"
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       case_study:
         one: "Ситуационный анализ"
         few:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -15,6 +15,9 @@ si:
       authored_article:
         one: "රචිත ලිපිය  "
         other: "රචිත ලිපි"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "සිද්ධි අධ්යනයනය"
         other: "සිද්ධීන්  අධ්යයයනය"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -18,6 +18,10 @@ sk:
         one:
         few:
         other:
+      blog_post:
+        one:
+        few:
+        other:
       case_study:
         one:
         few:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -15,6 +15,9 @@ so:
       authored_article:
         one: Maqaal la qorey
         other: Maqaallo la qorey
+      blog_post:
+        one:
+        other:
       case_study:
         one: Daraasad xaalad gaar ah
         other: Daraasado xaalado gaar ah

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -15,6 +15,9 @@ sq:
       authored_article:
         one: Artikull autori
         other: Artikuj autoresh
+      blog_post:
+        one:
+        other:
       case_study:
         one: Rast studimi
         other: Raste studimi

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -21,6 +21,11 @@ sr:
         few:
         many:
         other: Autorski članci
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       case_study:
         one: Studija slučaja
         few:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -15,6 +15,9 @@ sw:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one:
         other:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -15,6 +15,9 @@ ta:
       authored_article:
         one: " எழுதப்பட்ட   கட்டுரை"
         other: "எழுதப்பட்ட கட்டுரைகள்"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "சம்பவ ஆய்வுக் கற்கை"
         other: "சம்பவ ஆய்வுக் கற்கைகள்"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -137,6 +137,9 @@ th:
       authored_article:
         one: "บทความที่เขียน"
         other: "บทความที่เขียน"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "กรณีศึกษา"
         other: "กรณีศึกษา"

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -15,6 +15,9 @@ tk:
       authored_article:
         one:
         other:
+      blog_post:
+        one:
+        other:
       case_study:
         one:
         other:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -138,6 +138,9 @@ tr:
       authored_article:
         one: Yazılan makale
         other: Yazılan makaleler
+      blog_post:
+        one:
+        other:
       case_study:
         one: "Örnek Olay"
         other: "Örnek Olaylar"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -21,6 +21,11 @@ uk:
         few:
         many:
         other: "Статті"
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       case_study:
         one: "Тематичне дослідження"
         few:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -15,6 +15,9 @@ ur:
       authored_article:
         one: "تحریر کردہ مضمون"
         other: "تحریر کردہ مضامین"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "کیس اسٹڈی"
         other: "کیس اسٹڈیز"

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -15,6 +15,9 @@ uz:
       authored_article:
         one: Muallif maqolasi
         other: Muallif maqolalari
+      blog_post:
+        one:
+        other:
       case_study:
         one: Holat o'rganilishi
         other: Holat o'rganilishlari

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -138,6 +138,9 @@ vi:
       authored_article:
         one: bài viết do tác giả
         other: Các bài viết do tác giả
+      blog_post:
+        one:
+        other:
       case_study:
         one: Trường hợp cụ thể
         other: Các Trường hợp cụ thể

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -136,6 +136,9 @@ zh-hk:
       authored_article:
         one: "撰寫文章"
         other: "其他撰寫文章"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "案例研究"
         other: "其他案例研究"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -136,6 +136,9 @@ zh-tw:
       authored_article:
         one: "撰寫文章"
         other: "撰寫其他文章"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "案例研究"
         other: "其他案例研究"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -136,6 +136,9 @@ zh:
       authored_article:
         one: "撰写的文章"
         other: "撰写的文章"
+      blog_post:
+        one:
+        other:
       case_study:
         one: "实例研究"
         other: "实例研究"


### PR DESCRIPTION
For: https://trello.com/c/f2ueZJ74/78-correct-blog-post-to-blog-post

Without a translation we humanize and titleize the document type so we
get "Blog Post" but this would contravene the GOV.UK style guide so we
provide this translation to give us "Blog post" instead.  We only have
the English translation so the others will fall back to this, although
we do add the empty translations to avoid causing the i18n_key_test to
fail.