### PR TITLE
Treat key space limit env var value as an Integer

### DIFF
--- a/config/initializers/rack_initializer.rb
+++ b/config/initializers/rack_initializer.rb
@@ -3,6 +3,6 @@
 if ENV.has_key?("KEY_SPACE_LIMIT")
   # http://stackoverflow.com/a/9123664/61435
   if Rack::Utils.respond_to?("key_space_limit=")
-    Rack::Utils.key_space_limit = ENV.fetch("KEY_SPACE_LIMIT")
+    Rack::Utils.key_space_limit = Integer(ENV["KEY_SPACE_LIMIT"])
   end
 end


### PR DESCRIPTION
This value is used in a numerical comparison by Rack middleware so make sure it's treated as an Integer.