### PR TITLE
Statistical data set deploy one

### DIFF
--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -23,6 +23,6 @@ class StatisticalDataSet < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 end

--- a/db/data_migration/20161212145620_republish_statistical_data_set.rb
+++ b/db/data_migration/20161212145620_republish_statistical_data_set.rb
@@ -1,0 +1,2 @@
+publisher = DataHygiene::PublishingApiDocumentRepublisher.new(StatisticalDataSet)
+publisher.perform

--- a/lib/sync_checker/formats/statistical_data_set_check.rb
+++ b/lib/sync_checker/formats/statistical_data_set_check.rb
@@ -6,7 +6,7 @@ module SyncChecker
       end
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
     end
   end

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -42,8 +42,8 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
     assert_equal 'whitehall', @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  test "it presents the rendering_app as government-frontend" do
+    assert_equal 'government-frontend', @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as statistical_data_set" do

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -44,6 +44,9 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
 
     assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(CorporateInformationPage.new).class
+
+    assert_equal PublishingApi::GenericEditionPresenter,
+      PublishingApiPresenters.presenter_for(Consultation.new).class
   end
 
   test ".presenter_for returns a Placeholder presenter for an organisation" do

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -44,9 +44,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
 
     assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(CorporateInformationPage.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(Consultation.new).class
   end
 
   test ".presenter_for returns a Placeholder presenter for an organisation" do

--- a/test/unit/statistical_data_set_test.rb
+++ b/test/unit/statistical_data_set_test.rb
@@ -28,8 +28,8 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
     assert statistical_data_set.search_format_types.include?('publicationesque-statistics')
   end
 
-  test 'specifies rendering app to be whitehall frontend' do
+  test 'specifies rendering app to be government frontend' do
     statistical_data_set = StatisticalDataSet.new
-    assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::WHITEHALL_FRONTEND)
+    assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::GOVERNMENT_FRONTEND)
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/UB9SDxIo/536-statistical-dataset-migration-final-tasks-deploy-1-small)

- Render `Statistical Data Sets` using `government-frontend`.

- Do not merge this until [Statistical Data Set Migration](https://github.com/alphagov/whitehall/pull/2918) has been merged and we have rebased.

- Paired with @bevanloon.
