### PR TITLE
Use Nokogiri::HTML in sync_check details body

### DIFF
--- a/lib/sync_checker/checks/details_check.rb
+++ b/lib/sync_checker/checks/details_check.rb
@@ -40,11 +40,14 @@ module SyncChecker
         content_body = content_item["details"]["body"]
         content_body.gsub!(/<td>\s*<\/td>/, "<td>&nbsp;</td>") if content_body
         expected_body = expected_details[:body]
-
         EquivalentXml.equivalent?(
-          content_body,
-          expected_body
+          string_to_xml(content_body),
+          string_to_xml(expected_body)
         )
+      end
+
+      def string_to_xml(string)
+        Nokogiri::HTML(string)
       end
     end
   end


### PR DESCRIPTION
There are occasional (and random) false failures running sync checks of the type "details body doesn't match". When investigating the failures, a visual comparison of the `details body` between whitehall and content-store/draft-content-store representations show them to be the equivalent. This is annoying and wastes developer time.

Current speculation as to the cause is that `equivalent-xml` sometimes does not parse a string into html correctly, dropping tags randomly. The solution is to pass Nokogiri::HTML representations of the strings into `equivalent-xml`.

[Trello](https://trello.com/c/DwhzGiHh/538-fix-false-failures-in-sync-checks-details-body-doesn-t-match-1)