### PR TITLE
Configure GDS API Adapters to always return hashes

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -218,7 +218,7 @@ Please tell us:
     end
 
     links_to_topics = sector_tag_finder.topics.map do |topic|
-      link_to topic.title, topic.web_url, class: 'sector-link'
+      link_to topic['title'], topic['web_url'], class: 'sector-link'
     end
     part_of += links_to_topics
 

--- a/app/helpers/specialist_sector_helper.rb
+++ b/app/helpers/specialist_sector_helper.rb
@@ -2,7 +2,7 @@ module SpecialistSectorHelper
 
   def add_sector_name(title, top_level_topic)
     if top_level_topic
-      "#{link_to(top_level_topic.title, top_level_topic.web_url)} &ndash; #{title.downcase}".html_safe
+      "#{link_to(top_level_topic['title'], top_level_topic['web_url'])} &ndash; #{title.downcase}".html_safe
     else
       title
     end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -52,7 +52,7 @@ class Person < ActiveRecord::Base
       filter_people: [slug],
       filter_format: "policy",
       order: "-public_timestamp"
-    ).results
+    )["results"]
   end
 
   def search_link

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -14,7 +14,7 @@ class PolicyGroup < ActiveRecord::Base
       filter_policy_groups: [slug],
       filter_format: "policy",
       order: "-public_timestamp"
-    ).results
+    )["results"]
   end
 
   def has_summary?

--- a/app/presenters/detailed_guide_presenter.rb
+++ b/app/presenters/detailed_guide_presenter.rb
@@ -6,7 +6,7 @@ class DetailedGuidePresenter < Whitehall::Decorators::Decorator
   def related_mainstream_content_title
     @related_mainstream_content_title ||= begin
       item = Whitehall.content_store.content_item(related_mainstream_base_path)
-      item.title
+      item["title"]
     rescue GdsApi::TimedOutException
       ""
     end
@@ -15,7 +15,7 @@ class DetailedGuidePresenter < Whitehall::Decorators::Decorator
   def additional_related_mainstream_content_title
     @additional_related_mainstream_content_title ||= begin
       item = Whitehall.content_store.content_item(additional_related_mainstream_base_path)
-      item.title
+      item["title"]
     rescue GdsApi::TimedOutException
       ""
     end

--- a/app/views/admin/editions/_need.html.erb
+++ b/app/views/admin/editions/_need.html.erb
@@ -1,10 +1,10 @@
-<tr id="user-need-id-<%= need.id %>">
+<tr id="user-need-id-<%= need["id"] %>">
   <td class="description">
-    As a <%= need.role %>,<br>
-    I need to <%= need.goal %>,<br>
-    So that <%= need.benefit %>
+    As a <%= need["role"] %>,<br>
+    I need to <%= need["goal"] %>,<br>
+    So that <%= need["benefit"] %>
   </td>
   <td>
-    <%= link_to "View need in Maslow", Whitehall.maslow.need_page_url(need.id), class: "maslow-url" %>
+    <%= link_to "View need in Maslow", Whitehall.maslow.need_page_url(need["id"]), class: "maslow-url" %>
   </td>
 </tr>

--- a/app/views/policies/_document_list.html.erb
+++ b/app/views/policies/_document_list.html.erb
@@ -1,7 +1,11 @@
 <ol class="policies document-list">
   <% policies.each do |policy| %>
     <%= content_tag(:li, class: "document-row") do %>
-      <%= link_to policy.title, policy.link, class: 'title' %>
+      <% if policy.kind_of? Hash %>
+        <%= link_to policy["title"], policy["link"], class: 'title' %>
+      <% else %>
+        <%= link_to policy.title, policy.link, class: 'title' %>
+      <% end %>
     <% end %>
   <% end %>
 </ol>

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,4 +1,0 @@
-GdsApi.configure do |config|
-  # Opt out of always returning hashes for `GdsApi::Response`s
-  config.hash_response_for_requests = false
-end

--- a/lib/specialist_tag_finder.rb
+++ b/lib/specialist_tag_finder.rb
@@ -16,7 +16,7 @@ class SpecialistTagFinder
   def topics
     @topics ||= begin
       return [] unless edition_content_item
-      Array(edition_content_item.links["topics"])
+      Array(edition_content_item["links"]["topics"])
     end
   end
 
@@ -28,7 +28,7 @@ class SpecialistTagFinder
     # in the frontend when rendering an Edition's breadcrumb.
     @top_level_topic ||= begin
       return unless edition_content_item
-      parent = Array(edition_content_item.links["parent"])
+      parent = Array(edition_content_item["links"]["parent"])
       return unless parent.any?
 
       # FIXME: Some content items may still contain the 'expanded_links' field.

--- a/test/support/policy_tagging_helpers.rb
+++ b/test/support/policy_tagging_helpers.rb
@@ -21,7 +21,7 @@ module PolicyTaggingHelpers
       "Child maintenance reform",
     ]
 
-    assert_equal all_policy_titles, object.published_policies.map(&:title)
+    assert_equal all_policy_titles, object.published_policies.collect {|p| p["title"]}
   end
 
   def stub_publishing_api_policies

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -814,8 +814,8 @@ class EditionTest < ActiveSupport::TestCase
     edition = create(:edition, need_ids: ["000123", "000456"])
 
     assert edition.has_associated_needs?
-    assert_equal "000123", edition.associated_needs.first.id
-    assert_equal "000456", edition.associated_needs.last.id
+    assert_equal "000123", edition.associated_needs.first["id"]
+    assert_equal "000456", edition.associated_needs.last["id"]
   end
 
   test 'previously_published returns nil for new edition' do

--- a/test/unit/specialist_tag_finder_test.rb
+++ b/test/unit/specialist_tag_finder_test.rb
@@ -60,7 +60,7 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     )
     content_store_has_item(edition_base_path, edition_content_item)
 
-    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic["base_path"]
   end
 
   test "#top_level_topic falls back to expanded_links on the parent if links aren't present" do
@@ -81,7 +81,7 @@ class SpecialistTagFinderTest < ActiveSupport::TestCase
     )
     content_store_has_item(edition_base_path, edition_content_item)
 
-    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic.base_path
+    assert_equal "/grandpa", SpecialistTagFinder.new(edition_base_path).top_level_topic["base_path"]
   end
 
   test "#top_level_topic returns nil if no parents" do


### PR DESCRIPTION
Trello: https://trello.com/c/pWDuxs87/516-use-hashes-for-api-responses-in-whitehall-medium

Migrate Whitehall's API response handling to use hashes so that the deprecation warning from GDS API Adapters is not shown any more and we can use newer versions of GDS API Adapters with Whitehall.