### PR TITLE
Update accessibility attachment content, change `eg`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,7 +427,7 @@ en:
       heading: This file may not be suitable for users of assistive technology.
       request_a_different_format: Request an accessible format.
       full_help_html: |
-        If you use assistive technology (eg a screen reader) and need a
+        If you use assistive technology (such as a screen reader) and need a
         version of this document in a more accessible format, please email %{email}.
         Please tell us what format you need. It will help us if you say what assistive technology you use.
     opendocument:


### PR DESCRIPTION
Our content guidelines have been updated this year. They now discourage using "eg":
https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/