### PR TITLE
Reslug News Frequently Asked Questions

### DIFF
--- a/db/data_migration/20161222102639_reslug_news_faq.rb
+++ b/db/data_migration/20161222102639_reslug_news_faq.rb
@@ -1,0 +1,4 @@
+article = NewsArticle.find(688810)
+document = article.document
+
+document.update_attributes(slug: "information-about-the-uk-leaving-the-eu")


### PR DESCRIPTION
Trello: https://trello.com/c/YYaiCU7Y/548-slug-change-required

Modify the slug of the document into
"Information-about-the-UK-leaving-the-EU"