### PR TITLE
Fix All Organisations filter

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_filter_options.js
+++ b/app/assets/javascripts/admin/views/editions/_filter_options.js
@@ -32,15 +32,36 @@
   };
 
   FilterOptions.prototype.updateResults = function updateResults(skipAntiRepeat) {
-    this.$searchResults.fadeTo(0.4, 0.6);
+    // ### HACK ###
+    // This section is a temporary solution to avoid querying for "All organisations" 
+    // without a title or a slug. This query leads to a server timeout.
+    // https://trello.com/c/NE2xfVo8/539-bad-gateway-error-for-featured-documents-in-whitehall-admin-1-day
 
-    if ( this.activeRequest ) this.activeRequest.abort();
-    this.activeRequest = $.ajax({
-      method: 'get',
-      url: this.getPath,
-      data: this.$filterForm.serialize(),
-      success: this.renderResults
-    });
+    var formData = this.$filterForm.serializeArray();
+
+    if(typeof(formData[2]) !== 'undefined'){
+      var title = formData[0]['value'];
+      var organisation = formData[2]['value'];
+
+      var allOrganisationsSelected = !organisation
+      var noTitleSpecified = !title
+    }
+
+    if (noTitleSpecified && allOrganisationsSelected) {
+      $('#title_filter').append("<p class=\'warning\'>You need to specify a title or a slug when searching in All Organisations</p>");
+    } else {
+      $('#title_filter .warning').remove();
+      // ### END HACK ###
+      this.$searchResults.fadeTo(0.4, 0.6);
+      if ( this.activeRequest ) this.activeRequest.abort();
+      this.activeRequest = $.ajax({
+        method: 'get',
+        url: this.getPath,
+        data: this.$filterForm.serialize(),
+        success: this.renderResults
+      });
+    };
+
   };
 
   FilterOptions.prototype.renderResults = function renderResults(resultHtml) {


### PR DESCRIPTION
Trello:
https://trello.com/c/NE2xfVo8/539-bad-gateway-error-for-featured-documen
ts-in-whitehall-admin-1-day

Selecting All Organizations was leading to a server timeout and a
subsequent Bad Gateway error. This is probably due to the query which
is taking too long.

As a temporary solution we are inviting the user to insert a title or a
slug if “All organisations” is selected, to reduce the target scope.