### PR TITLE
Stop queuing sync checks

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -14,8 +14,6 @@ class PublishingApiWorker < WorkerBase
         handle_client_error(e)
       end
     end
-
-    SyncCheckWorker.enqueue(model)
   end
 
   private

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -14,8 +14,6 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
 
-    SyncCheckWorker.expects(:enqueue).with(edition)
-
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
 
     assert_all_requested(requests)
@@ -29,8 +27,6 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
     ]
-
-    SyncCheckWorker.expects(:enqueue).with(edition)
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
 
@@ -68,8 +64,6 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, update_type: update_type, locale: "en")
     ]
-
-    SyncCheckWorker.expects(:enqueue).with(edition)
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id, update_type)
 


### PR DESCRIPTION
Currently the sync checks are too flakey to provide useful automated reporting due to problems with checking HTML equality. Additionally, when doing large republishing jobs as we are during migration the sync checks add considerable load in Sidekiq.

This commit stops enqueing sync check jobs with each publishing api action.

The worker code has been left in place as we will reenable this once the bulk republishing has been done and the checks are more robust.

[Trello to revert](https://trello.com/c/ExEtzxoh/811-re-enable-auto-sync-checks)