### PR TITLE
Refactor presented Consultation alternative format contact email

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -117,16 +117,11 @@ module PublishingApi
 
       attr_accessor :consultation, :renderer
 
-      def alternative_format_email
-        consultation
-          .alternative_format_provider
-          .try(:alternative_format_contact_email)
-      end
 
       def documents
         renderer.block_attachments(
           consultation.attachments,
-          alternative_format_email,
+          consultation.alternative_format_contact_email,
         )
       end
     end
@@ -177,12 +172,6 @@ module PublishingApi
       attr_accessor :consultation, :renderer
       def_delegator :consultation, :outcome
 
-      def alternative_format_email
-        consultation
-          .alternative_format_provider
-          .try(:alternative_format_contact_email)
-      end
-
       def final_outcome_detail
         outcome.summary
       end
@@ -190,7 +179,10 @@ module PublishingApi
       def final_outcome_documents
         return unless outcome.attachments.present?
 
-        renderer.block_attachments(outcome.attachments, alternative_format_email)
+        renderer.block_attachments(
+          outcome.attachments,
+          outcome.alternative_format_contact_email,
+        )
       end
     end
 
@@ -253,7 +245,7 @@ module PublishingApi
 
         renderer.block_attachments(
           public_feedback.attachments,
-          consultation.alternative_format_provider.try(:alternative_format_contact_email),
+          public_feedback.alternative_format_contact_email,
         )
       end
 

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -311,18 +311,16 @@ module PublishingApi::ConsultationPresenterTest
     test 'public feedback documents' do
       attachments_double = Object.new
 
-      alternative_format_email =
-        consultation
-          .alternative_format_provider
-          .try(:alternative_format_contact_email)
-
       govspeak_renderer = mock('Whitehall::GovspeakRenderer')
 
       govspeak_renderer.stubs(:govspeak_to_html)
 
       govspeak_renderer
         .expects(:block_attachments)
-        .with(consultation.public_feedback.attachments, alternative_format_email)
+        .with(
+          consultation.public_feedback.attachments,
+          consultation.public_feedback.alternative_format_contact_email
+        )
         .returns(attachments_double)
 
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
@@ -362,16 +360,14 @@ module PublishingApi::ConsultationPresenterTest
     test 'final outcome documents' do
       attachments_double = Object.new
 
-      alternative_format_email =
-        consultation
-          .alternative_format_provider
-          .try(:alternative_format_contact_email)
-
       govspeak_renderer = mock('Whitehall::GovspeakRenderer')
 
       govspeak_renderer
         .expects(:block_attachments)
-        .with(consultation.outcome.attachments, alternative_format_email)
+        .with(
+          consultation.outcome.attachments,
+          consultation.outcome.alternative_format_contact_email,
+        )
         .returns(attachments_double)
 
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
@@ -406,16 +402,14 @@ module PublishingApi::ConsultationPresenterTest
     test 'documents' do
       attachments_double = Object.new
 
-      alternative_format_email =
-        consultation
-          .alternative_format_provider
-          .alternative_format_contact_email
-
       govspeak_renderer = mock('Whitehall::GovspeakRenderer')
 
       govspeak_renderer
         .expects(:block_attachments)
-        .with(consultation.attachments, alternative_format_email)
+        .with(
+          consultation.attachments,
+          consultation.alternative_format_contact_email,
+        )
         .returns(attachments_double)
 
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)


### PR DESCRIPTION
Now makes use of the model helper methods.