### PR TITLE
HtmlAttachments retain content_id of previous version

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -97,7 +97,11 @@ class HtmlAttachment < Attachment
     [locale || I18n.default_locale.to_s]
   end
 
-  private
+  def generate_content_id
+    previously_deleted_content_id || super
+  end
+
+private
 
   def sluggable_locale?
     locale.blank? or locale == "en"
@@ -111,5 +115,18 @@ class HtmlAttachment < Attachment
     if locale_changed? and !sluggable_locale?
       self.slug = nil
     end
+  end
+
+  def previously_deleted_content_id
+    @previously_deleted_content_id ||= fetch_previously_published_content_ids.last
+  end
+
+  def fetch_previously_published_content_ids
+    document_id = attachable.document_id
+    edition_ids = Edition.unscoped.where(document_id: document_id).pluck(:id)
+    HtmlAttachment.where(
+      attachable_id: edition_ids,
+      title: title
+    ).pluck(:content_id)
   end
 end

--- a/lib/has_content_id.rb
+++ b/lib/has_content_id.rb
@@ -3,8 +3,12 @@ module HasContentId
 
   included do
     before_validation do
-      self.content_id ||= SecureRandom.uuid
+      self.content_id ||= generate_content_id
     end
     validates :content_id, presence: true, format: { with: /[\w\d]{8}-[\w\d]{4}-[\w\d]{4}-[\w\d]{4}-[\w\d]{12}/ }
+  end
+
+  def generate_content_id
+    SecureRandom.uuid
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -148,4 +148,43 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal ["en"], HtmlAttachment.new.translated_locales
     assert_equal ["cy"], HtmlAttachment.new(locale: "cy").translated_locales
   end
+
+  test "attachment with the same base path as a previously deleted attachment
+    retains the content_id" do
+    content_id = "2f142514-15bf-4779-b651-5a9aaf6df93c"
+    deleted_attachment = create(
+      :html_attachment,
+      content_id: content_id,
+      title: "booyah",
+      attachable: build(:published_publication)
+    )
+    first_edition = deleted_attachment.attachable
+    deleted_attachment.destroy
+
+    new_draft = first_edition.create_draft(first_edition.creator)
+    new_attachment = create(
+      :html_attachment,
+      title: "booyah",
+      attachable: new_draft
+    )
+
+    assert_equal content_id, new_attachment.content_id
+  end
+
+  test "attachment with an unused base path gets a new content_id" do
+    first_attachment = create(
+      :html_attachment,
+      title: "booyah",
+      attachable: build(:published_publication)
+    )
+    published_edition = first_attachment.attachable
+    new_draft = published_edition.create_draft(published_edition.creator)
+    second_attachment = create(
+      :html_attachment,
+      title: "kasha",
+      attachable: new_draft
+    )
+
+    assert_not_equal first_attachment.content_id, second_attachment.content_id
+  end
 end


### PR DESCRIPTION
When a published HtmlAttachment is deleted the base path is redirected to the parent document's base path. If another attachment is created that has the same base path it is currently assigned a new `content_id`. This causes it to be rejected by PublishingApi as there is already a redirect content item occupying that base path with a different `content_id`.

This PR checks for a previously published `HtmlAttachment` at the same base path when creating a new one and persists that previous `content_id` if one is found.

Part of [Trello](https://trello.com/c/uwsLR1xU)