### PR TITLE
Switch rendering of `HtmlAttachment` to government frontend

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -13,6 +13,10 @@ class HtmlAttachment < Attachment
   delegate :body, :body_html, :headers_html,
             to: :govspeak_content, allow_nil: true, prefix: true
 
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
   def manually_numbered_headings?
     govspeak_content.manually_numbered_headings?
   end

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -26,7 +26,7 @@ module PublishingApi
         details: details,
         document_type: schema_name,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: item.rendering_app,
         schema_name: schema_name,
       )
       content.merge!(PayloadBuilder::Routes.for(base_path))

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -187,4 +187,8 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
 
     assert_not_equal first_attachment.content_id, second_attachment.content_id
   end
+
+  test "#rendering_app returns government_frontend" do
+    assert_equal "government-frontend", HtmlAttachment.new.rendering_app
+  end
 end

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       locale: 'en',
       public_updated_at: html_attachment.updated_at,
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'government-frontend',
       routes: [
         { path: html_attachment.url, type: 'exact' }
       ],


### PR DESCRIPTION
Switches rendering from whitehall to government-frontend. This only switches rendering and does not contain a data migration to republish previous content as that will be done in a separate step.