### PR TITLE
Consultation sync checks

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
     def links
       LinksPresenter
         .new(consultation)
-        .extract(%i(organisations policy_areas topics))
+        .extract(%i(organisations policy_areas related_policies topics))
     end
 
   private

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
     def links
       LinksPresenter
         .new(consultation)
-        .extract(%i(organisations policy_areas related_policies topics))
+        .extract(%i(organisations parent policy_areas related_policies topics))
     end
 
   private

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -16,6 +16,14 @@ module SyncChecker::Formats
 
   private
 
+    LENGTH_OF_FRACTIONAL_SECONDS = 3
+
+    def first_public_at(consultation)
+      (consultation.first_published_at || consultation.document.created_at)
+        .to_datetime
+        .rfc3339(LENGTH_OF_FRACTIONAL_SECONDS)
+    end
+
     def top_level_fields_hash(consultation, _)
       super.tap do |fields|
         fields[:document_type] = consultation.display_type_key

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -3,6 +3,7 @@ module SyncChecker::Formats
     def expected_details_hash(consultation)
       super.tap do |details|
         details.except!(:change_history) unless consultation.change_history.present?
+        details.merge!(expected_documents(consultation))
       end
     end
 
@@ -17,6 +18,17 @@ module SyncChecker::Formats
   private
 
     LENGTH_OF_FRACTIONAL_SECONDS = 3
+
+    def expected_documents(consultation)
+      return {} unless consultation.attachments.present?
+
+      {
+        documents: Whitehall::GovspeakRenderer.new.block_attachments(
+          consultation.attachments,
+          consultation.alternative_format_contact_email
+        )
+      }
+    end
 
     def first_public_at(consultation)
       (consultation.first_published_at || consultation.document.created_at)

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -13,5 +13,13 @@ module SyncChecker::Formats
     def root_path
       '/government/consultations/'
     end
+
+  private
+
+    def top_level_fields_hash(consultation, _)
+      super.tap do |fields|
+        fields[:document_type] = consultation.display_type_key
+      end
+    end
   end
 end

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -6,6 +6,7 @@ module SyncChecker::Formats
         details.merge!(expected_documents(consultation))
         details.merge!(expected_external_url(consultation))
         details.merge!(expected_final_outcome(consultation))
+        details.merge!(expected_national_applicability(consultation))
       end
     end
 
@@ -54,6 +55,14 @@ module SyncChecker::Formats
                                      )
                                  end,
       }.compact
+    end
+
+    def expected_national_applicability(consultation)
+      return {} unless consultation.nation_inapplicabilities.present?
+
+      {
+        national_applicability: consultation.national_applicability.deep_stringify_keys
+      }
     end
 
     def first_public_at(consultation)

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -8,6 +8,7 @@ module SyncChecker::Formats
         details.merge!(expected_final_outcome(consultation))
         details.merge!(expected_government(consultation))
         details.merge!(expected_national_applicability(consultation))
+        details.merge!(expected_political(consultation))
         details.merge!(expected_public_feedback(consultation))
         details.merge!(expected_ways_to_respond(consultation))
       end
@@ -77,6 +78,10 @@ module SyncChecker::Formats
       {
         national_applicability: consultation.national_applicability.deep_stringify_keys
       }
+    end
+
+    def expected_political(consultation)
+      { political: consultation.political? }
     end
 
     def expected_public_feedback(consultation)

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -4,6 +4,7 @@ module SyncChecker::Formats
       super.tap do |details|
         details.except!(:change_history) unless consultation.change_history.present?
         details.merge!(expected_documents(consultation))
+        details.merge!(expected_external_url(consultation))
       end
     end
 
@@ -28,6 +29,12 @@ module SyncChecker::Formats
           consultation.alternative_format_contact_email
         )
       }
+    end
+
+    def expected_external_url(consultation)
+      return {} unless consultation.external?
+
+      { held_on_another_website_url: consultation.external_url }
     end
 
     def first_public_at(consultation)

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -1,0 +1,11 @@
+module SyncChecker::Formats
+  class ConsultationCheck < EditionBase
+    def rendering_app
+      Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    end
+
+    def root_path
+      '/government/consultations/'
+    end
+  end
+end

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -6,6 +6,7 @@ module SyncChecker::Formats
         details.merge!(expected_documents(consultation))
         details.merge!(expected_external_url(consultation))
         details.merge!(expected_final_outcome(consultation))
+        details.merge!(expected_government(consultation))
         details.merge!(expected_national_applicability(consultation))
         details.merge!(expected_public_feedback(consultation))
         details.merge!(expected_ways_to_respond(consultation))
@@ -56,6 +57,18 @@ module SyncChecker::Formats
                                      )
                                  end,
       }.compact
+    end
+
+    def expected_government(consultation)
+      return {} unless consultation.government
+
+      {
+        'government' => {
+          'title' => consultation.government.name,
+          'slug' => consultation.government.slug,
+          'current' => consultation.government.current?
+        }
+      }
     end
 
     def expected_national_applicability(consultation)

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -1,5 +1,11 @@
 module SyncChecker::Formats
   class ConsultationCheck < EditionBase
+    def expected_details_hash(consultation)
+      super.tap do |details|
+        details.except!(:change_history) unless consultation.change_history.present?
+      end
+    end
+
     def rendering_app
       Whitehall::RenderingApp::WHITEHALL_FRONTEND
     end

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -10,6 +10,7 @@ module SyncChecker::Formats
         details.merge!(expected_national_applicability(consultation))
         details.merge!(expected_political(consultation))
         details.merge!(expected_public_feedback(consultation))
+        details.merge!(expected_tags(consultation))
         details.merge!(expected_ways_to_respond(consultation))
       end
     end
@@ -108,6 +109,23 @@ module SyncChecker::Formats
         public_feedback_documents: documents,
         public_feedback_publication_date: publication_date,
       }.compact
+    end
+
+    def expected_tags(consultation)
+      policies = if consultation.can_be_related_to_policies?
+                   consultation.policies.map(&:slug)
+                 end
+
+      topics = Array(consultation.primary_specialist_sector_tag) +
+        consultation.secondary_specialist_sector_tags
+
+      {
+        'tags' => {
+          'browse_pages' => [],
+          'policies' => policies.compact,
+          'topics' => topics.compact,
+        }
+      }
     end
 
     def expected_ways_to_respond(consultation)

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -77,7 +77,12 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test 'base links' do
-      expected_link_keys = %i(organisations policy_areas topics)
+      expected_link_keys = %i(
+        organisations
+        policy_areas
+        related_policies
+        topics
+      )
 
       links_double = {
         link_one: 'link_one',

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -79,6 +79,7 @@ module PublishingApi::ConsultationPresenterTest
     test 'base links' do
       expected_link_keys = %i(
         organisations
+        parent
         policy_areas
         related_policies
         topics


### PR DESCRIPTION
This is a first pass at sync checks for Consultations. I've run them successfully against ~60 of the most frequently visited consultations in development.

I think I've covered everything off but as these are the first I've written there may be accidental omissions!

Trello: https://trello.com/c/aLeUBH7W