### PR TITLE
Republish HtmlAttachments

### DIFF
--- a/db/data_migration/20170105110027_republish_html_attachments_again.rb
+++ b/db/data_migration/20170105110027_republish_html_attachments_again.rb
@@ -1,0 +1,14 @@
+# HtmlAttachments are now republished when their parent document is republished.
+# This encapsulates all the logic of decided what states need to go where etc.
+
+document_ids = Edition.joins(
+  "INNER JOIN attachments ON attachable_id = editions.id
+   AND attachments.type = 'HtmlAttachment'"
+).pluck(:document_id).uniq
+
+puts "Republishing #{document_ids.count} documents"
+
+document_ids.each do |document_id|
+  print "."
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id)
+end


### PR DESCRIPTION
Republishes all HtmlAttachments via their parent document. This will be used to switch the rendering app of all HtmlAttachments as part of the  format migration.