### PR TITLE
Pass the edition to the document_type method...

### DIFF
--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -29,7 +29,7 @@ module SyncChecker
         ]
       end
 
-      def document_type
+      def document_type(_edition)
         "detailed_guide"
       end
 

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -147,7 +147,7 @@ module SyncChecker
         {
           base_path: get_path(edition, locale),
           content_id: document.content_id,
-          document_type: document_type,
+          document_type: document_type(edition),
           locale: locale.to_s,
           publishing_app: "whitehall",
           schema_name: document.document_type.underscore,
@@ -161,7 +161,7 @@ module SyncChecker
         Whitehall::RenderingApp::WHITEHALL_FRONTEND
       end
 
-      def document_type
+      def document_type(_edition)
         document.document_type.underscore
       end
 

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -40,8 +40,8 @@ module SyncChecker
         ]
       end
 
-      def document_type
-        (edition_expected_in_live || edition_expected_in_draft).publication_type.key
+      def document_type(edition)
+        edition.publication_type.key
       end
 
       def expected_details_hash(edition)


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-571-107-321

There's an edge case where a draft can exist with a different `document_type`
to its published counterpart, in this case the draft check needs to use the
draft edition's `document_type` rather than assume it to be the same as the
published one.