### PR TITLE
Remove redundant edition policies

### DIFF
--- a/db/data_migration/20170109120231_remove_redundant_edition_policies.rb
+++ b/db/data_migration/20170109120231_remove_redundant_edition_policies.rb
@@ -1,0 +1,7 @@
+policy_content_ids = [
+  "5d3bf7fb-7631-11e4-a3cb-005056011aef",
+  "5d5e9d5a-7631-11e4-a3cb-005056011aef",
+  "5d3bf786-7631-11e4-a3cb-005056011aef",
+  "5d5ea079-7631-11e4-a3cb-005056011aef"
+]
+EditionPolicy.delete_all(policy_content_id: policy_content_ids)


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-571-107-321

These policies don't exist in the Publishing API but are related to
Publications, remove them so that after republishing the expected
links are correct