### PR TITLE
Add unwithdraw support to HtmlAttachment worker

### DIFF
--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -13,6 +13,7 @@ class PublishingApiHtmlAttachmentsWorker
     do_publish(edition.minor_change? ? "minor" : "major")
   end
   alias :force_publish :publish
+  alias :unwithdraw :publish
 
   def republish
     update_publishing_api_content

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -393,4 +393,18 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
       call(publication)
     end
   end
+
+  class Unwithdraw < PublishingApiHtmlAttachmentsWorkerTest
+    test "with an html attachment on a new document publishes the attachment" do
+      publication = create(:withdrawn_publication)
+      attachment = publication.html_attachments.first
+      PublishingApiWorker.any_instance.expects(:perform).with(
+        "HtmlAttachment",
+        attachment.id,
+        "major",
+        "en"
+      )
+      call(publication)
+    end
+  end
 end


### PR DESCRIPTION
When a document is unwithdrawn it should unwithdraw its `HtmlAttachment`s but support for this event was missing from `PublishingApiHtmlAttachmentsWorker`. 

This commit adds it.

Part of [Trello](https://trello.com/c/Pmv4JhR7/561-htmlattachments-not-being-unwithdrawn)