### PR TITLE
Filter expected policies for sync checks

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -101,7 +101,7 @@ module SyncChecker
           ),
           Checks::LinksCheck.new(
             "related_policies",
-            (edition_expected_in_live.try(:policy_content_ids) || [])
+            (edition_expected_in_live.try(:policies) || []).map(&:content_id)
           ),
           Checks::DetailsCheck.new(
             I18n.with_locale(locale) do


### PR DESCRIPTION
The [policies interface](https://github.com/alphagov/whitehall/blob/master/app/models/edition/related_policies.rb#L62-L64) internally filters out any policy content ids that are no longer known to the Publishing API. By using this interface we avoid sync check failures.