### PR TITLE
Rename Scotland Office

### DIFF
--- a/db/data_migration/20170110103253_rename_scotland_office.rb
+++ b/db/data_migration/20170110103253_rename_scotland_office.rb
@@ -1,0 +1,9 @@
+scotland_office = Organisation.find_by(slug: "scotland-office")
+
+# Rename the organisation
+new_name = "UK Government Scotland"
+scotland_office.update_attributes!(name: new_name)
+
+# Modify the address accordingly
+new_slug = "uk-government-scotland"
+DataHygiene::OrganisationReslugger.new(scotland_office, new_slug).run!


### PR DESCRIPTION
Trello: https://trello.com/c/1NZCWSNV/752-name-changes-to-scotland-office

Rename the organisation and its slug, accordingly with the new name
"UK Government Scotland”.