### PR TITLE
Fix statistics announcements redirect on unpublish

### DIFF
--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::PublishingApi
+
   setup do
     @user = login_as(:gds_editor)
     @announcement = create(:statistics_announcement)
@@ -31,6 +33,9 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
 
   test "POST :create with valid params unpublishes the announcement" do
     redirect_url = 'https://www.test.alphagov.co.uk/example'
+
+    stub_publishing_api_destroy_intent(@announcement.base_path)
+
     post :create, statistics_announcement_id: @announcement, statistics_announcement: {
       redirect_url: redirect_url
     }

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -179,4 +179,16 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
 
     Whitehall.edition_services.force_publisher(statistics).perform!
   end
+
+  test "it is redirected to an alternate URL when unpublished" do
+    statistics_announcement = create(:statistics_announcement)
+
+    Whitehall::PublishingApi.expects(:publish_redirect_async)
+      .with(statistics_announcement.content_id, "https://www.test.alphagov.co.uk/government/something-else")
+
+    statistics_announcement.update_attributes!(
+      publishing_state: "unpublished",
+      redirect_url: "https://www.test.alphagov.co.uk/government/something-else"
+    )
+  end
 end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class StatisticsAnnouncementTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::PublishingApi
 
   test 'can set publication type using an ID' do
     announcement = StatisticsAnnouncement.new(publication_type_id: PublicationType::OfficialStatistics.id)
@@ -84,33 +83,6 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
 
     assert announcement.can_index_in_search?
     assert_equal expected_indexed_content, announcement.search_index
-  end
-
-  test 'is indexed for search after being saved' do
-    Whitehall::SearchIndex.stubs(:add)
-    Whitehall::SearchIndex.expects(:add).with { |instance| instance.is_a?(StatisticsAnnouncement) && instance.title = 'indexed announcement' }
-
-    Whitehall.publishing_api_v2_client.expects(:put_content)
-    Whitehall.publishing_api_v2_client.expects(:patch_links)
-    Whitehall.publishing_api_v2_client.expects(:publish)
-
-    stub_default_publishing_api_put_intent
-
-    announcement = create(:statistics_announcement, title: 'indexed announcement', slug: "example")
-    announcement.run_callbacks(:commit)
-  end
-
-  test 'is removed from search after being unpublished' do
-    announcement = create(:statistics_announcement)
-    redirect_url = "https://www.test.alphagov.co.uk/foo"
-
-    stub_publishing_api_destroy_intent(announcement.base_path)
-
-    Whitehall::SearchIndex.expects(:add).never
-    Whitehall::SearchIndex.expects(:delete).with(announcement)
-
-    announcement.update!(publishing_state: "unpublished", redirect_url: redirect_url)
-    announcement.run_callbacks(:commit)
   end
 
   test 'only valid when associated publication is of a matching type' do


### PR DESCRIPTION
When a statistics announcement without an associated publication
is unpublished, it should publish a redirect to the publishing api
so that government frontend can perform the redirect.

A redirect url is already required to unpublish.