### PR TITLE
Expect withdrawn document_collections...

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -7,7 +7,7 @@ module SyncChecker
             "document_collections",
             edition_expected_in_live
               .document_collections
-              .published
+              .where(state: %w(published withdrawn))
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-571-107-321

Withdrawn collections will appear in the content store for a publication,
they do not get rendered on the withdrawn item but are present in the JSON
response. The sync checker expected only published collections to appear
in the links hash but withdrawn is also a valid state to expect.