### PR TITLE
Remove non-existent stats datasets

### DIFF
--- a/db/data_migration/20170109152833_remove_non_existent_stats_datasets.rb
+++ b/db/data_migration/20170109152833_remove_non_existent_stats_datasets.rb
@@ -1,0 +1,10 @@
+# Documents with non existent statistical_data_sets
+doc_ids = [53956,64993,65089,72821]
+non_existent_data_sets = Document.where(id: [71831, 71833])
+
+doc_ids.each do |doc_id|
+  d = Document.find(doc_id)
+  e = d.published_edition
+  e.statistical_data_sets = (e.statistical_data_sets - non_existent_data_sets)
+  e.save!
+end


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-571-107-321

These datasets don't exist in the Publishing API and are superseded in Whitehall so remove associations with them.