### PR TITLE
Expect superseded document collections...

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -7,7 +7,7 @@ module SyncChecker
             "document_collections",
             edition_expected_in_live
               .document_collections
-              .where(state: %w(published withdrawn))
+              .where(state: %w(published superseded withdrawn))
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-571-107-321

The content store will show superseded document collections for a Publication
though this relationship doesn't get rendered anywhere so adjust the sync check
to expect superseded collections to be present.