### PR TITLE
Disable config.assets.debug by default

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Whitehall::Application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = !ENV['DEBUG_ASSETS'].nil?
   config.assets.cache_store = :null_store
   config.sass.cache = false
 


### PR DESCRIPTION
Pass the DEBUG_ASSETS environment to switch it back on.

This can slow down page render times considerably, because there are
over 100 different javascript files that get requested individually.  In
some cases the page can take around 20 seconds just to finish rendering.
This really slows down development if you're not working on the
frontend.

> When debug mode is off, Sprockets concatenates and runs the necessary
> preprocessors on all files.
http://guides.rubyonrails.org/asset_pipeline.html#turning-debugging-off