### PR TITLE
Merge rummageable into whitehall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'slimmer', '9.0.1'
 gem 'plek', '~> 1.12'
 gem 'isbn_validation'
 gem 'gds-sso', '~> 11.0'
-gem 'rummageable', '1.2.0'
 gem 'addressable', ">= 2.3.7"
 gem 'unicorn', '5.0.0'
 gem 'kaminari', '0.15.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,10 +355,6 @@ GEM
     ruby-prof (0.15.2)
     ruby-progressbar (1.7.5)
     ruby-rc4 (0.1.5)
-    rummageable (1.2.0)
-      multi_json
-      null_logger
-      rest-client
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
@@ -524,7 +520,6 @@ DEPENDENCIES
   rinku
   ruby-prof
   ruby-progressbar
-  rummageable (= 1.2.0)
   sass (= 3.4.9)
   sassc-rails
   shared_mustache (~> 0.2.1)

--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -1,0 +1,102 @@
+require 'benchmark'
+require 'json'
+require 'multi_json'
+require 'null_logger'
+require 'rest_client'
+
+module Whitehall
+  module Rummageable
+    class Index
+      def initialize(base_url, index_name, options = {})
+        @index_url = [base_url, index_name.sub(%r{^/}, '')].join('/')
+        @logger = options[:logger] || NullLogger.instance
+        @batch_size = options.fetch(:batch_size, 20)
+        @retry_delay = options.fetch(:retry_delay, 2)
+        @attempts = options.fetch(:attempts, 3)
+      end
+
+      def add(entry)
+        repeatedly do
+          make_request(:post, documents_url, MultiJson.encode([entry]))
+        end
+      end
+
+      def add_batch(entries)
+        entries.each_slice(@batch_size) do |batch|
+          repeatedly do
+            make_request(:post, documents_url, MultiJson.encode(batch))
+          end
+        end
+      end
+
+      def amend(link, changes)
+        repeatedly do
+          make_request(:post, documents_url(link: link), changes)
+        end
+      end
+
+      def delete(id, options = {})
+        type = options[:type] || 'edition'
+        repeatedly do
+          make_request(:delete, documents_url(id: id, type: type))
+        end
+      end
+
+      def delete_all
+        repeatedly do
+          make_request(:delete, documents_url + '?delete_all=1')
+        end
+      end
+
+      def commit
+        repeatedly do
+          make_request(:post, [@index_url, 'commit'].join('/'), MultiJson.encode({}))
+        end
+      end
+
+    private
+
+      def repeatedly
+        @attempts.times do |i|
+          begin
+            return yield
+          rescue RestClient::RequestFailed, RestClient::RequestTimeout, RestClient::ServerBrokeConnection => e
+            @logger.warn e.message
+            raise if @attempts == i + 1
+            @logger.info 'Retrying...'
+            sleep(@retry_delay) if @retry_delay
+          end
+        end
+      end
+
+      def log_request(method, url, _payload = nil)
+        @logger.info("Rummageable request: #{method.upcase} #{url}")
+      end
+
+      def log_response(method, url, call_time, response)
+        time = sprintf('%.03f', call_time)
+        result = response.length > 0 ? JSON.parse(response).fetch('result', 'UNKNOWN') : "UNKNOWN"
+        @logger.info("Rummageable response: #{method.upcase} #{url} - time: #{time}s, result: #{result}")
+      end
+
+      def make_request(method, *args)
+        response = nil
+        log_request(method, *args)
+        call_time = Benchmark.realtime do
+          response = RestClient.send(method, *args, content_type: :json, accept: :json)
+        end
+        log_response(method, args.first, call_time, response)
+        response
+      end
+
+      def documents_url(options = {})
+        options[:id] ||= options[:link]
+
+        parts = [@index_url, 'documents']
+        parts << CGI.escape(options[:type]) if options[:type]
+        parts << CGI.escape(options[:id]) if options[:id]
+        parts.join('/')
+      end
+    end
+  end
+end

--- a/test/unit/whitehall/rummageable_test.rb
+++ b/test/unit/whitehall/rummageable_test.rb
@@ -1,0 +1,230 @@
+require 'test_helper'
+
+class RummageableTest < ActiveSupport::TestCase
+  def rummager_url
+    'http://search.dev.gov.uk'
+  end
+
+  def index_name
+    'index-name'
+  end
+
+  def documents_url(options = {})
+    options[:id] ||= options[:link]
+
+    parts = rummager_url, options.fetch(:index, index_name), 'documents'
+    parts << CGI.escape(options[:type]) if options[:type]
+    parts << CGI.escape(options[:id]) if options[:id]
+    parts.join('/')
+  end
+
+  def link_url
+    documents_url(link: link)
+  end
+
+  def status(http_code)
+    {
+      200 => { status: 200, body: '{"result":"OK"}' },
+      502 => { status: 502, body: 'Bad gateway' }
+    }.fetch(http_code)
+  end
+
+  def build_document(index)
+    {
+      'title' => "TITLE #{index}",
+      'link' => "/link#{index}"
+    }
+  end
+
+  def one_document
+    build_document(1)
+  end
+
+  def two_documents
+    [one_document] << build_document(2)
+  end
+
+  def link
+    '/path'
+  end
+
+  def commit_url
+    [rummager_url, index_name, 'commit'].join('/')
+  end
+
+  def document_url
+    'http://example.com/foo'
+  end
+
+  def stub_successful_request
+    stub_request(:post, documents_url).to_return(status(200))
+  end
+
+  def stub_one_failed_request
+    stub_request(:post, documents_url).
+      to_return(status(502)).times(1).then.to_return(status(200))
+  end
+
+  def stub_repeatedly_failing_requests(failures)
+    stub_request(:post, documents_url).to_return(status(502)).times(failures)
+  end
+
+  def stub_successful_delete_request
+    stub_request(:delete, documents_url(id: document_url, type: 'edition')).to_return(status(200))
+  end
+
+  def stub_one_failed_delete_request
+    stub_request(:delete, documents_url(id: document_url, type: 'edition')).
+      to_return(status(502)).times(1).then.to_return(status(200))
+  end
+
+  test "add should index a single document by posting it as json" do
+    stub_successful_request
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.add(one_document)
+    assert_requested :post, documents_url, times: 1 do |request|
+      request.body == [one_document].to_json &&
+        request.headers['Content-Type'] == 'application/json' &&
+        request.headers['Accept'] == 'application/json'
+    end
+  end
+
+  test "add batch should index multiple documents in one request" do
+    stub_successful_request
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.add_batch(two_documents)
+    assert_requested :post, documents_url, body: two_documents.to_json
+  end
+
+  test "add batch should split large batches into multiple requests" do
+    stub_successful_request
+    documents = (1..3).map { |i| build_document(i) }
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, batch_size: 2)
+    index.add_batch(documents)
+    assert_requested :post, documents_url, body: documents[0, 2].to_json
+    assert_requested :post, documents_url, body: documents[2, 1].to_json
+  end
+
+  test "add should return true when successful" do
+    stub_successful_request
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    assert index.add(one_document), 'should return true on success'
+  end
+
+  test "add should sleep and retry on bad gateway errors" do
+    stub_one_failed_request
+    Whitehall::Rummageable::Index.any_instance.expects(:sleep).with(1)
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, retry_delay: 1)
+    assert index.add(one_document), 'should return true on success'
+    assert_requested :post, documents_url, times: 2
+  end
+
+  test "add should not sleep between attempts if retry delay is nil" do
+    stub_one_failed_request
+    Whitehall::Rummageable::Index.any_instance.expects(:sleep).never
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, retry_delay: nil)
+    index.add(one_document)
+    assert_requested :post, documents_url, times: 2
+  end
+
+  test "add should propagate exceptions after too many failed attempts" do
+    failures = attempts = 2
+    stub_repeatedly_failing_requests(failures)
+    Whitehall::Rummageable::Index.any_instance.stubs(:sleep)
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, attempts: attempts)
+    assert_raises RestClient::BadGateway do
+      index.add(one_document)
+    end
+  end
+
+  test "add should log attempts to post to rummager" do
+    stub_successful_request
+    logger = stub('logger', debug: true)
+    logger.expects(:info).twice
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, logger: logger)
+    index.add(one_document)
+  end
+
+  test "add should log failures" do
+    stub_one_failed_request
+    Whitehall::Rummageable::Index.any_instance.stubs(:sleep)
+    logger = stub('logger', debug: true, info: true)
+    logger.expects(:warn).once
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, logger: logger)
+    index.add(one_document)
+  end
+
+  test "add should return unknown status for blank response" do
+    RestClient.expects(:send).returns("")
+    Whitehall::Rummageable::Index.any_instance.stubs(:sleep)
+
+    logger = stub('logger', debug: true, info: true)
+    logger.expects(:info).once.with(regexp_matches(/result: UNKNOWN/))
+
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, logger: logger)
+    index.add(one_document)
+  end
+
+  test "amend should post amendments to a document by its link" do
+    new_document = { 'title' => 'Cheese', 'indexable_content' => 'Blah' }
+    stub_request(:post, link_url).with(body: new_document).to_return(status(200))
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.amend(link, { 'title' => 'Cheese', 'indexable_content' => 'Blah' })
+    assert_requested :post, link_url, body: new_document
+  end
+
+  test "commit should post to rummager" do
+    stub_request(:post, commit_url).to_return(status(200))
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.commit
+    assert_requested :post, commit_url, body: {}.to_json
+  end
+
+  test "delete should delete a document by its url" do
+    stub_successful_delete_request
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.delete(document_url)
+    assert_requested :delete, documents_url(id: document_url, type: 'edition') do |request|
+      request.headers['Content-Type'] == 'application/json' &&
+        request.headers['Accept'] == 'application/json'
+    end
+  end
+
+  test "delete should delete a document by its type and id" do
+    stub_request(:delete, documents_url(id: 'jobs-exact', type: 'best_bet')).to_return(status(200))
+
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.delete('jobs-exact', type: 'best_bet')
+
+    assert_requested :delete, documents_url(id: 'jobs-exact', type: 'best_bet') do |request|
+      request.headers['Content-Type'] == 'application/json' &&
+        request.headers['Accept'] == 'application/json'
+    end
+  end
+
+  test "delete should be able to delete all documents" do
+    stub_request(:delete, /#{documents_url}/).to_return(status(200))
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.delete_all
+    assert_requested :delete, documents_url, query: { delete_all: 1 } do |request|
+      request.headers['Content-Type'] == 'application/json' &&
+        request.headers['Accept'] == 'application/json'
+    end
+  end
+
+  test "delete should handle connection errors" do
+    stub_one_failed_delete_request
+    Whitehall::Rummageable::Index.any_instance.expects(:sleep).once
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name)
+    index.delete(document_url)
+    assert_requested :delete, documents_url(id: document_url, type: 'edition'), times: 2
+  end
+
+  test "delete should log attempts to delete documents from rummager" do
+    stub_successful_delete_request
+    logger = stub('logger')
+    logger.expects(:info).twice
+    index = Whitehall::Rummageable::Index.new(rummager_url, index_name, logger: logger)
+    index.delete(document_url)
+  end
+end


### PR DESCRIPTION
whitehall is the only remaining app that uses the rummageable gem. Due to the complexity of re-writing the search code to use gds-api-adapters and the current nature of flux in the codebase, this commit merges the rummageable gem into the whitehall codebase. This allows the gem to be fully deprecated while also allowing whitehall to continue to utilise the code in a self-contained manner.

Trello: https://trello.com/c/g9OGDm4q/257-remove-rummageable-from-a-number-of-repositories-so-it-can-be-archived