### PR TITLE
Switch rendering app in HtmlAttachment sync check

### DIFF
--- a/lib/sync_checker/formats/html_attachment_check.rb
+++ b/lib/sync_checker/formats/html_attachment_check.rb
@@ -137,7 +137,7 @@ module SyncChecker
       end
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
       def run_checks(response, locale, checks, content_store)


### PR DESCRIPTION
Now that the rendering app has been switched in production we need to check against `government-frontend` and not `whitehall-frontend` in the sync checks.