### PR TITLE
Env var to disable config.assets.debug in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Whitehall::Application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = ENV['DISABLE_ASSETS_DEBUG'].nil?
   config.assets.cache_store = :null_store
   config.sass.cache = false
 


### PR DESCRIPTION
(This replaces https://github.com/alphagov/whitehall/pull/2958 and inverts the flag. 
See https://github.com/alphagov/whitehall/pull/2958#issuecomment-272151447 by @fofr)

This setting can slow down page render times considerably, because there
are over 100 different javascript files that get requested individually.
In some cases the page can take around 20 seconds just to finish
rendering.  This really slows down development if you're not working on
the frontend.

Without this flag:
<img width="1085" alt="screen shot 2017-01-12 at 16 25 50" src="https://cloud.githubusercontent.com/assets/87579/21898405/ad71fe00-d8e4-11e6-9793-a74b2454cc17.png">

With this flag:
<img width="1363" alt="screen shot 2017-01-12 at 16 24 31" src="https://cloud.githubusercontent.com/assets/87579/21898415/b409188e-d8e4-11e6-8ceb-3bfdd3a18da3.png">



> When debug mode is off, Sprockets concatenates and runs the necessary
> preprocessors on all files.
http://guides.rubyonrails.org/asset_pipeline.html#turning-debugging-off

Debug mode is on by default because with it off, compiled assets are
cached, which interferes with auto reloading.