### PR TITLE
Only check published and withdrawn datasets..

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -21,7 +21,7 @@ module SyncChecker
             "related_statistical_data_sets",
             edition_expected_in_live
               .statistical_data_sets
-              .select { |ds| ds.unpublishing.nil? }
+              .where(state: %w(published withdrawn))
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

For live sync checks we're only interested in links for
stats datasets which relate to published or withdrawn items.