### PR TITLE
Fix state of collision-at-shalesmoor-tram-stop

### DIFF
--- a/db/data_migration/20170117153659_fix_state_of_withdrawn_shalesmoor_document.rb
+++ b/db/data_migration/20170117153659_fix_state_of_withdrawn_shalesmoor_document.rb
@@ -1,0 +1,3 @@
+edition = Document.where(slug: 'collision-at-shalesmoor-tram-stop').first.editions.first
+edition.state = 'published'
+edition.save


### PR DESCRIPTION
The Document with the slug "collision-at-shalesmoor-tram-stop" is
causing errors on production. The Document contains one Edition which
has a state of "withdrawn", however there are no Unpublishings for this
Edition. This causes an error when the `_withdrawn_notice.html.erb`
partial is rendered since it expects an `unpublishing` to be present.

This migration sets the state of the Edition to "published" which will
stop this error.

Related Trello card: https://trello.com/c/aCCABqhW/821-check-the-state-of-government-news-collision-at-shalesmoor-tram-stop
