### PR TITLE
Rename UK Government Scotland back to Scotland Office

### DIFF
--- a/db/data_migration/20170118111510_revert_scotland_office_rename.rb
+++ b/db/data_migration/20170118111510_revert_scotland_office_rename.rb
@@ -1,0 +1,9 @@
+scotland_office = Organisation.find_by(slug: "uk-government-scotland")
+
+# Rename the organisation
+new_name = "Scotland Office"
+scotland_office.update_attributes!(name: new_name)
+
+# Modify the address accordingly
+new_slug = "scotland-office"
+DataHygiene::OrganisationReslugger.new(scotland_office, new_slug).run!


### PR DESCRIPTION
Scotland Office was the original name that was changed in
https://github.com/alphagov/whitehall/pull/2953 but this was done
prematurely.

This PR changes it back.

