### PR TITLE
[DO NOT MERGE] Revert "Fix Consultation first public at"

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -74,6 +74,13 @@ class Consultation < Publicationesque
     outcome.published_on
   end
 
+  def first_public_at
+    opening_at.to_datetime unless opening_at.nil?
+  end
+
+  def make_public_at(date)
+  end
+
   def allows_attachment_references?
     true
   end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -430,9 +430,9 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   test "should display 2 consultations in reverse chronological order" do
     organisation = create(:organisation)
-    consultation_2 = create(:published_consultation, organisations: [organisation], first_published_at: 2.days.ago)
-    _consultation_3 = create(:published_consultation, organisations: [organisation], first_published_at: 3.days.ago)
-    consultation_1 = create(:published_consultation, organisations: [organisation], first_published_at: 1.day.ago)
+    consultation_2 = create(:published_consultation, organisations: [organisation], opening_at: 2.days.ago)
+    consultation_3 = create(:published_consultation, organisations: [organisation], opening_at: 3.days.ago)
+    consultation_1 = create(:published_consultation, organisations: [organisation], opening_at: 1.day.ago)
 
     get :show, id: organisation
 
@@ -441,9 +441,9 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should display 2 consultations with details and a link to publications filter if there are many consultations" do
     organisation = create(:organisation)
-    consultation_3 = create(:published_consultation, organisations: [organisation], first_published_at: 5.days.ago, opening_at: 5.days.ago, closing_at: 1.days.ago)
-    consultation_2 = create(:published_consultation, organisations: [organisation], first_published_at: 4.days.ago, opening_at: 4.days.ago, closing_at: 1.days.ago)
-    consultation_1 = create(:published_consultation, organisations: [organisation], first_published_at: 3.days.ago, opening_at: 3.days.ago)
+    consultation_3 = create(:published_consultation, organisations: [organisation], opening_at: 5.days.ago, closing_at: 1.days.ago)
+    consultation_2 = create(:published_consultation, organisations: [organisation], opening_at: 4.days.ago, closing_at: 1.days.ago)
+    consultation_1 = create(:published_consultation, organisations: [organisation], opening_at: 3.days.ago)
     response = create(:consultation_outcome, consultation: consultation_3, attachments: [
       build(:file_attachment)
     ])

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -217,7 +217,7 @@ class PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "#index orders consultations by first_published_at date by default" do
-    consultations = 5.times.map {|i| create(:published_consultation, first_published_at: (10 - i).days.ago) }
+    consultations = 5.times.map {|i| create(:published_consultation, opening_at: (10 - i).days.ago) }
 
     get :index
 
@@ -227,7 +227,7 @@ class PublicationsControllerTest < ActionController::TestCase
 
   view_test "#index orders documents by appropriate timestamp by default" do
     documents = [
-      consultation = create(:published_consultation, first_published_at: 5.days.ago),
+      consultation = create(:published_consultation, opening_at: 5.days.ago),
       publication = create(:published_publication, first_published_at: 4.days.ago)
     ]
 
@@ -347,8 +347,7 @@ class PublicationsControllerTest < ActionController::TestCase
     consultation = create(:published_consultation, title: "consultation-title",
                          organisations: [org, org2],
                          opening_at: Time.zone.parse("2012-03-14"),
-                         closing_at: Time.zone.parse("2012-03-15"),
-                         first_published_at: Time.zone.parse("2012-03-10"))
+                         closing_at: Time.zone.parse("2012-03-15"))
 
     get :index, format: :json
 
@@ -360,7 +359,7 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_equal consultation.id, json["id"]
     assert_equal consultation_path(consultation.document), json["url"]
     assert_equal "org-name and other-org", json["organisations"]
-    assert_equal %{<time class="public_timestamp" datetime="2012-03-10T00:00:00+00:00">10 March 2012</time>}, json["display_date_microformat"]
+    assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
     assert_equal "Consultation", json["display_type"]
   end
 
@@ -501,10 +500,10 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_publication_order [newest, middle, oldest]
   end
 
-  test '#index atom feed orders consultations according to first_published_at (newest first)' do
-    oldest = create(:published_consultation, first_published_at: 5.days.ago, title: "oldest")
-    newest = create(:published_consultation, first_published_at: 1.days.ago, title: "newest")
-    middle = create(:published_consultation, first_published_at: 3.days.ago, title: "middle")
+  test '#index atom feed orders consultations according to opening_at (newest first)' do
+    oldest = create(:published_consultation, opening_at: 5.days.ago, title: "oldest")
+    newest = create(:published_consultation, opening_at: 1.days.ago, title: "newest")
+    middle = create(:published_consultation, opening_at: 3.days.ago, title: "middle")
 
     get :index, format: :atom
 

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -50,7 +50,7 @@ class TopicsControllerTest < ActionController::TestCase
     published = []
     4.times do |i|
       published << create(:published_consultation, {
-        title: "title-#{i}", topics: [topic], first_published_at: i.days.ago
+        title: "title-#{i}", topics: [topic], opening_at: i.days.ago
       })
     end
 

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -252,10 +252,10 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal today, consultation.outcome_published_on
   end
 
-  test "make_public_at should set first_published_at" do
+  test "make_public_at should not set first_published_at" do
     consultation = build(:consultation, first_published_at: nil)
     consultation.make_public_at(2.days.ago)
-    assert consultation.first_published_at
+    refute consultation.first_published_at
   end
 
   test "display_type when not yet open" do
@@ -353,10 +353,10 @@ class ConsultationTest < ActiveSupport::TestCase
     assert consultation_with_command_paper_outcome.search_index[:has_act_paper]
   end
 
-  test "#government returns the government active on the first_public_at date" do
+  test "#government returns the government active on the opening_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    consultation = create(:consultation, first_published_at: 4.years.ago)
+    consultation = create(:consultation, opening_at: 4.years.ago)
 
     assert_equal previous_government, consultation.government
   end

--- a/test/unit/document_history_test.rb
+++ b/test/unit/document_history_test.rb
@@ -22,14 +22,14 @@ class DocumentHistoryTest < ActiveSupport::TestCase
     assert_history_equal [[4.days.ago, edition.change_note]], history
   end
 
-  test "#changes on a consultation derives the timestamp from the consultation first published time" do
-    first_published_at = 1.day.ago
-    edition = create(:draft_consultation, first_published_at: first_published_at, opening_at: 1.day.from_now, closing_at: 2.days.from_now)
+  test "#changes on a consultation derives the timestamp from the consultation opening time" do
+    opening_at = 1.day.from_now
+    edition  = create(:draft_consultation, opening_at: opening_at, closing_at: 2.days.from_now)
     EditionForcePublisher.new(edition).perform!
     edition.reload
     history  = DocumentHistory.new(edition.document)
 
-    assert_equal first_published_at, history.first.public_timestamp
+    assert_equal opening_at, history.first.public_timestamp
   end
 
   test "#changes returns change history for all historic editions, excluding those with minor changes" do

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -64,7 +64,7 @@ class OrganisationFilterTest < ActiveSupport::TestCase
     expected = [
       document(:detailed_guide, first_published_at: 1.days.ago),
       document(:policy_paper, first_published_at: 2.days.ago),
-      document(:consultation, first_published_at: 4.days.ago),
+      document(:consultation, opening_at: 4.days.ago),
       document(:statistics, first_published_at: 5.days.ago),
     ]
 
@@ -96,7 +96,7 @@ class WorldLocationFilterTest < ActiveSupport::TestCase
     expected = [
       document(:detailed_guide, first_published_at: 1.days.ago),
       document(:policy_paper, first_published_at: 2.days.ago),
-      document(:consultation, first_published_at: 4.days.ago),
+      document(:consultation, opening_at: 4.days.ago),
       document(:statistics, first_published_at: 5.days.ago),
     ]
 
@@ -121,7 +121,7 @@ class ClassificationFilterTest < ActiveSupport::TestCase
     expected = [
       document(:detailed_guide, first_published_at: 1.days.ago),
       document(:policy_paper, first_published_at: 2.days.ago),
-      document(:consultation, first_published_at: 4.days.ago),
+      document(:consultation, opening_at: 4.days.ago),
       document(:statistics, first_published_at: 5.days.ago),
     ]
 

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -537,7 +537,7 @@ module PublishingApi::ConsultationPresenterTest
     test 'change history' do
       expected_change_history = [
         {
-          'public_timestamp' => '2011-11-09T11:11:11.000+00:00',
+          'public_timestamp' => '2011-11-10T11:11:11.000+00:00',
           'note' => 'change-note',
         }
       ]


### PR DESCRIPTION
Reverts alphagov/whitehall#2959 This has caused issues as the historic data needs to be backfilled to set `first_published_at`. There is no record in the DB of that date so we need to discuss the options for that before implementing this functionality.