### PR TITLE
Fix published Consultation first_published_at

### DIFF
--- a/db/data_migration/20170118133214_populate_consultation_first_published_at.rb
+++ b/db/data_migration/20170118133214_populate_consultation_first_published_at.rb
@@ -1,0 +1,21 @@
+Consultation.where(first_published_at: nil).each do |consultation|
+  next unless consultation.document.ever_published_editions.any?
+  next unless consultation.opening_at.present?
+
+  public_at = consultation.make_public_at(consultation.opening_at.to_datetime)
+  result = consultation.save(touch: false, validate: false)
+
+  puts "Setting %s first_published_at to %s \n=> %s" %
+         [consultation.inspect, public_at, result]
+end
+
+Consultation.where("date(first_published_at) > date(opening_at)").each do |consultation|
+  next unless consultation.document.ever_published_editions.any?
+  next unless consultation.opening_at.present?
+
+  public_at = consultation.first_published_at = consultation.opening_at.to_datetime
+  result = consultation.save(touch: false, validate: false)
+
+  puts "Setting %s first_published_at to %s \n=> %s" %
+         [consultation.inspect, public_at, result]
+end


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/2959 introduced changes to fix the `first_public_at` value to be when the Consultation was published not when it opened. It however failed to backfill the existing Consultation data so that the correct values are in place so that the inherited code from Edition behaves as expected.

Consultation previously set `make_public_at(date)` as a NOOP causing all existing Consultations to have a nil `first_published_at` value when they were published. This migration backfills the Consultations to have the value that would have been returned had the code not been
removed.

We have to skip validations as they expect the date to be in the present.