### PR TITLE
Fix 'Published before' placeholder date

### DIFF
--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -68,7 +68,7 @@
             <%= label_tag "from_date", "Published after" %>
             <%= text_field_tag :from_date, @filter.date_from, placeholder: "e.g. 01/01/2013" %>
             <%= label_tag "to_date", "Published before" %>
-            <%= text_field_tag :to_date, @filter.date_to, placeholder: "e.g. 30/02/2013" %>
+            <%= text_field_tag :to_date, @filter.date_to, placeholder: "e.g. 28/02/2013" %>
           </div>
         <% end %>
 

--- a/app/views/statistics_announcements/index.html.erb
+++ b/app/views/statistics_announcements/index.html.erb
@@ -40,7 +40,7 @@
             <%= text_field_tag :from_date, params[:from_date], placeholder: "e.g. 01/01/2013" %>
 
             <%= label_tag :to_date, "Published before" %>
-            <%= text_field_tag :to_date, params[:to_date], placeholder: "e.g. 30/02/2013" %>
+            <%= text_field_tag :to_date, params[:to_date], placeholder: "e.g. 28/02/2013" %>
           </div>
           <%= f.submit "Refresh results", class: "button" %>
         </fieldset>

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -267,7 +267,7 @@ class PublicationsControllerTest < ActionController::TestCase
     get :index
 
     assert_select "input[name='from_date'][placeholder=?]", "e.g. 01/01/2013"
-    assert_select "input[name='to_date'][placeholder=?]", "e.g. 30/02/2013"
+    assert_select "input[name='to_date'][placeholder=?]", "e.g. 28/02/2013"
   end
 
   view_test "#index should show a helpful message if there are no matching publications" do


### PR DESCRIPTION
The placeholder date in the 'before' field was '30/02/2013', which is not a valid date. If you try to copy this date into the form field[1], nothing breaks but the data is not filtered.

This commit changes the placeholder to '28/02/2013'.

[1] Guess how I found this bug. 🙂 