### PR TITLE
Whitelist custom offsite link domain

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -40,6 +40,7 @@ private
     whitelisted_hosts = [
       "flu-lab-net.eu",
       "tse-lab-net.eu",
+      "beisgovuk.citizenspace.com"
     ]
 
     whitelisted_hosts.any? { |whitelisted_host| host =~ /#{whitelisted_host}$/}


### PR DESCRIPTION
[Story](https://trello.com/c/dwGesi34/96-whitelist-https-beisgovuk-citizenspace-com)

This PR adds a domain used by the BEIS department to the offsite link whitelist. They want to link to this from their homepage.