### PR TITLE
Fix withdrawn message edit

### DIFF
--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -3,12 +3,12 @@ class Admin::EditionUnpublishingController < Admin::BaseController
   before_filter :enforce_permissions!
 
   def update
+    services = Whitehall.edition_services
     if @unpublishing.update_attributes(explanation: params[:unpublishing][:explanation])
       if withdrawing?
-        content_id = @unpublishing.edition.content_id
-        Whitehall::PublishingApi.publish_withdrawal_async(content_id, @unpublishing.explanation)
+        services.withdrawer(@unpublishing.edition).perform!
       else
-        Whitehall::PublishingApi.unpublish_async(@unpublishing)
+        services.unpublisher(@unpublishing.edition).perform!
       end
       redirect_to admin_edition_path(@unpublishing.edition), notice: "The public explanation was updated"
     else

--- a/app/models/edition/workflow.rb
+++ b/app/models/edition/workflow.rb
@@ -76,7 +76,7 @@ module Edition::Workflow
       end
 
       event :unpublish do
-        transitions from: :published, to: :draft
+        transitions from: [:published, :draft], to: :draft
       end
 
       event :supersede, success: :destroy_associations_with_edition_dependencies_and_dependants do
@@ -84,7 +84,7 @@ module Edition::Workflow
       end
 
       event :withdraw do
-        transitions from: :published, to: :withdrawn
+        transitions from: [:published, :withdrawn], to: :withdrawn
       end
 
       event :unwithdraw do

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -36,7 +36,7 @@
       <%= # TODO: remove condition based on unpublishing once we have a separate state for unpublished editions
         delete_edition_button(@edition) if @edition.can_delete? && @edition.unpublishing.nil? %>
       <% if can?(:unpublish, @edition) %>
-        <% if @edition.can_unpublish? %>
+        <% if @edition.published? %>
           <%= link_to 'Withdraw or unpublish', confirm_unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version), class: "btn btn-danger" %>
         <% elsif @edition.unpublishing.present? && @edition.unpublishing.explanation.present? %>
           <%= link_to "Edit #{withdrawal_or_unpublishing(@edition)} explanation", edit_admin_edition_unpublishing_path(@edition), class: "btn btn-primary" %>

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -19,7 +19,13 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   end
 
   test "#update updates the withdrawal and redirects to admin policy page" do
-    Whitehall::PublishingApi.expects(:publish_withdrawal_async)
+    Whitehall.edition_services
+      .expects(:withdrawer)
+      .with(@edition)
+      .returns(withdrawer = stub)
+
+    withdrawer.expects(:perform!)
+
 
     put :update, edition_id: @edition.id, unpublishing: { explanation: "this used to say withdrawn" }
 
@@ -30,7 +36,13 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
 
   test "#update updates the unpublishing and redirects to admin policy page" do
     @unpublished_edition = create(:unpublished_edition)
-    Whitehall::PublishingApi.expects(:unpublish_async)
+
+    Whitehall.edition_services
+      .expects(:unpublisher)
+      .with(@unpublished_edition)
+      .returns(unpublisher = stub)
+
+    unpublisher.expects(:perform!)
 
     put :update, edition_id: @unpublished_edition.id, unpublishing: { explanation: "this used to say unpublished" }
 

--- a/test/unit/services/edition_unpublisher_test.rb
+++ b/test/unit/services/edition_unpublisher_test.rb
@@ -31,8 +31,22 @@ class EditionUnpublisherTest < ActiveSupport::TestCase
     assert_equal Time.zone.now, feature.reload.ended_at
   end
 
-  test 'only "published" editions can be unpublished' do
-    (Edition.available_states - [:published]).each do |state|
+  test '"published" editions can be unpublished' do
+    edition = create(:published_edition)
+    unpublisher = EditionUnpublisher.new(edition, unpublishing: unpublishing_params)
+
+    assert unpublisher.perform!
+  end
+
+  test '"draft" editions can be unpublished' do
+    edition = create(:draft_edition)
+    unpublisher = EditionUnpublisher.new(edition, unpublishing: unpublishing_params)
+
+    assert unpublisher.perform!
+  end
+
+  test 'other edition states cannot be unpublished' do
+    (Edition.available_states - [:published, :draft]).each do |state|
       edition = create(:edition, state: state)
       unpublisher = EditionUnpublisher.new(edition, unpublishing: unpublishing_params)
 

--- a/test/unit/services/edition_withdrawer_test.rb
+++ b/test/unit/services/edition_withdrawer_test.rb
@@ -14,8 +14,25 @@ class EditionWithdrawerTest < ActiveSupport::TestCase
     assert_equal '1.0', edition.published_version
   end
 
-  test 'only "published" editions can be withdrawn' do
-    (Edition.available_states - [:published]).each do |state|
+
+  test '"published" editions can be withdrawn' do
+    edition = create(:published_edition)
+    edition.build_unpublishing(unpublishing_params)
+    unpublisher = EditionWithdrawer.new(edition)
+
+    assert unpublisher.perform!
+  end
+
+  test '"withdrawn" editions can be withdrawn' do
+    edition = create(:withdrawn_edition)
+    edition.build_unpublishing(unpublishing_params)
+    unpublisher = EditionWithdrawer.new(edition)
+
+    assert unpublisher.perform!
+  end
+
+  test 'other states cannot be withdrawn' do
+    (Edition.available_states - [:published, :withdrawn]).each do |state|
       edition = create(:edition, state: state)
       edition.build_unpublishing(unpublishing_params)
       unpublisher = EditionWithdrawer.new(edition)

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -396,7 +396,7 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
 
   class Unwithdraw < PublishingApiHtmlAttachmentsWorkerTest
     test "with an html attachment on a new document publishes the attachment" do
-      publication = create(:withdrawn_publication)
+      publication = create(:published_publication)
       attachment = publication.html_attachments.first
       PublishingApiWorker.any_instance.expects(:perform).with(
         "HtmlAttachment",


### PR DESCRIPTION
Partly to do with https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321
This aims to amend state machine to allow repeated unpublishing transitions which may occur due to legacy data or incomplete updates to the Publishing API.

This will also allow the `unpublish` and `withdraw` events more than once which ensures that the full publishing api interactions are carried out when updating unpublishing/withdrawal explanations.