### PR TITLE
Register Document Type with Rummager for Editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -286,7 +286,8 @@ class Edition < ActiveRecord::Base
     is_political: :political?,
     is_historic: :historic?,
     is_withdrawn: :withdrawn?,
-    government_name: :search_government_name
+    government_name: :search_government_name,
+    content_store_document_type: :display_type_key,
   )
 
   def search_title

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -7,6 +7,7 @@ module Searchable
     :boost_phrases,
     :content,
     :content_id,
+    :content_store_document_type,
     :description,
     :display_type,
     :detailed_format,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -22,7 +22,7 @@ namespace :rummager do
       index.commit
     end
 
-    desc "indexes all published detailed guiudes"
+    desc "indexes all published detailed guides"
     task detailed: :environment do
       index = Whitehall::SearchIndex.for(:detailed_guides)
       index.add_batch(RummagerPresenters.present_all_detailed_content)

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -416,8 +416,8 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal publication.political?, publication.search_index["is_political"]
     assert_equal publication.historic?, publication.search_index["is_historic"]
     assert_equal government.name, publication.search_index["government_name"]
+    assert_equal "policy_paper", publication.search_index["content_store_document_type"]
   end
-
 
   test "should present policy_areas to rummageable" do
     government = create(:current_government)


### PR DESCRIPTION
We need to be able to filter Rummager on `document_type` for Guidance content, so this change updates `Searchable` to present the document type for all "Editions".

This has been tested locally by running the Rake task for Detailed Guidance, and also for Government, but each time just re-publishing a single document. I verified the presence of the `content_store_document_type` field in `search-admin`.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager 