### PR TITLE
Show current locale attachments only

### DIFF
--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -75,7 +75,20 @@ module PublishingApi
 
     def documents
       return [] unless item.attachments.any?
-      Whitehall::GovspeakRenderer.new.block_attachments(item.attachments, alternative_format_email)
+      Whitehall::GovspeakRenderer.new.block_attachments(
+        attachments_for_current_locale,
+        alternative_format_email
+      )
+    end
+
+    def attachments_for_current_locale
+      attachments = item.attachments
+      locales_that_match = Array(I18n.locale.to_s)
+      locales_that_match << "" if I18n.locale == I18n.default_locale
+      attachments.to_a.select do |attachment|
+        attachment.is_a?(FileAttachment) ||
+          locales_that_match.include?(attachment.locale.to_s)
+      end
     end
 
     def ministers

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -33,9 +33,10 @@ module SyncChecker
           ),
           Checks::LinksCheck.new(
             "children",
-            edition_expected_in_live
-              .html_attachments
-              .pluck(:content_id)
+            filter_documents_for_locale(
+              edition_expected_in_live,
+              locale
+            )
           )
         ]
       end
@@ -56,6 +57,16 @@ module SyncChecker
 
       def rendering_app
         Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+
+      def filter_documents_for_locale(edition, locale)
+        all_attachments = edition.attachments
+        locales_to_filter = Array(locale.to_s)
+        locales_to_filter << "" if locale.to_s == I18n.default_locale.to_s
+        all_attachments.select do |attachment|
+          attachment.is_a?(FileAttachment) ||
+            locales_to_filter.include?(attachment.locale.to_s)
+        end
       end
     end
   end


### PR DESCRIPTION
This will make Publication documents present only the attachments that match the current locale of the document.

This is required to ensure that the content store version of the document is equivalent to its Whitehall rendered version.

Part of [Trello](https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321)