### PR TITLE
Switch publication rendering app

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -52,6 +52,10 @@ class Publication < Publicationesque
     where(publication_type_id: PublicationType.statistical.map(&:id))
   end
 
+  def rendering_app
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  end
+
   def allows_inline_attachments?
     false
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -53,7 +53,13 @@ class Publication < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    #TODO: This format is being rendered by government-frontend
+    #but this has been switched in the presenter
+    #as preview needs to be done by Whitehall until
+    #draft links are available in publishing api.
+    #Preview is switched dependent on the return value of this method
+    #in app/helpers/public_document_routes_helper.rb:49
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 
   def allows_inline_attachments?

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -21,7 +21,9 @@ module PublishingApi
         details: details,
         document_type: item.display_type_key,
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
+        #TODO: rendering app is hard coded until
+        #item.rendering_app is switched when preview is ready
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "publication",
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -31,8 +31,7 @@ end
 Then /^I should see a link to the preview version of the publication "([^"]*)"$/ do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  preview_path_regexp = Regexp.new(Regexp.escape(preview_document_path(publication)).gsub(/cachebust=[0-9]+/, 'cachebust=[0-9]+'))
-  assert_match preview_path_regexp, find("a.preview_version")[:href]
+  assert_equal preview_document_url(publication), find("a.preview_version")[:href]
 end
 
 Then /^I should see that it was rejected by "([^"]*)"$/ do |rejected_by|

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -56,7 +56,7 @@ module SyncChecker
     private
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
       def filter_documents_for_locale(edition, locale)

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -120,9 +120,9 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
   end
 
   test "Creates a preview URL with cachebust and edition parameters" do
-    edition = create(:draft_publication)
+    edition = create(:draft_speech)
     preview_url = preview_document_url(edition)
-    assert_equal "http://test.host/government/publications/#{edition.slug}?cachebust=#{Time.zone.now.getutc.to_i}&preview=#{edition.id}", preview_url
+    assert_equal "http://test.host/government/speeches/#{edition.slug}?cachebust=#{Time.zone.now.getutc.to_i}&preview=#{edition.id}", preview_url
   end
 
   test "Creates a preview URL without parameters for edition formats that have migrated" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -25,7 +25,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       need_ids: [],
       public_updated_at: publication.public_timestamp,
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend', #to be renamed into 'government-frontend'
+      rendering_app: 'government-frontend',
       routes: [
         { path: public_path, type: 'exact' }
       ],


### PR DESCRIPTION
This PR switches the rendering of the `Publication` document type from whitehall to government-frontend as part of the migration of the format.

It doesn't republish existing documents as that will be done in stages due to the large number of documents of this type.

The rendering app cannot be switched at the model level currently as preview is not working correctly for attachments until we have draft links in the publishing API. 