### PR TITLE
Present rendered markdown for Consultation outcomes

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -173,7 +173,7 @@ module PublishingApi
       def_delegator :consultation, :outcome
 
       def final_outcome_detail
-        outcome.summary
+        renderer.govspeak_to_html(outcome.summary)
       end
 
       def final_outcome_documents

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -49,8 +49,12 @@ module SyncChecker::Formats
 
       outcome = consultation.outcome
 
+      detail = if outcome.summary.present?
+                 govspeak_renderer.govspeak_to_html(outcome.summary)
+               end
+
       {
-        final_outcome_detail: outcome.summary,
+        final_outcome_detail: detail,
         final_outcome_documents: if outcome.attachments.present?
                                    govspeak_renderer
                                      .block_attachments(

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -359,14 +359,33 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test 'final outcome detail' do
+      final_outcome_detail_double = Object.new
+
+      govspeak_renderer = mock('Whitehall::GovspeakRenderer')
+
+      govspeak_renderer.stubs(:block_attachments)
+
+      govspeak_renderer
+        .expects(:govspeak_to_html)
+        .with(consultation.outcome.summary)
+        .returns(final_outcome_detail_double)
+
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+
+      PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
+      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
+
       assert_details_attribute :final_outcome_detail,
-                               consultation.outcome.summary
+                               final_outcome_detail_double
     end
 
     test 'final outcome documents' do
       attachments_double = Object.new
 
       govspeak_renderer = mock('Whitehall::GovspeakRenderer')
+
+      govspeak_renderer.stubs(:govspeak_to_html)
 
       govspeak_renderer
         .expects(:block_attachments)


### PR DESCRIPTION
Fixes an omission highlighted by running the Wraith comparison tests.