### PR TITLE
Register same type as Publishing API with Rummager

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -287,7 +287,7 @@ class Edition < ActiveRecord::Base
     is_historic: :historic?,
     is_withdrawn: :withdrawn?,
     government_name: :search_government_name,
-    content_store_document_type: :display_type_key,
+    content_store_document_type: :content_store_document_type,
   )
 
   def search_title
@@ -669,6 +669,10 @@ class Edition < ActiveRecord::Base
 
   def detailed_format
     display_type.parameterize
+  end
+
+  def content_store_document_type
+    PublishingApiPresenters.presenter_for(self).content.fetch(:document_type)
   end
 
 private


### PR DESCRIPTION
Explicitly fetch the Content Store document type for storage in Rummager.

Follow up from https://github.com/alphagov/whitehall/pull/2981