### PR TITLE
Remove old unpublishing code

### DIFF
--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -44,15 +44,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_all_requested(requests)
   end
 
-  test ".publish_async skips sending unpublishings for formats other than case study" do
-    edition = create(:draft_publication)
-    unpublishing = create(:unpublishing, edition: edition)
-
-    Whitehall::PublishingApi.publish_async(unpublishing)
-
-    assert_not_requested :put, %r{/content/}
-  end
-
   test ".publish_async sends case studies to the content store" do
     edition = create(:published_case_study)
 


### PR DESCRIPTION
We no longer send `Unpublishing` objects to the publishing api for any content. This has been replaced by the `/unpublish` endpoint and the associated workers (`PublishingApiRedirectWorker`,
`PublishingApiWithdrawalWorker` etc)