### PR TITLE
World location news article migration

### DIFF
--- a/app/models/world_location_news_article.rb
+++ b/app/models/world_location_news_article.rb
@@ -34,4 +34,8 @@ class WorldLocationNewsArticle < Newsesque
   def display_type_key
     'news_article'
   end
+
+  def rendering_app
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+  end
 end

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
       )
     end
 
-    private
+  private
 
     def details
       {

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "news_article",
+        document_type: "world_location_news_article",
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "world_location_news_article",

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -1,0 +1,70 @@
+module PublishingApi
+  class WorldLocationNewsArticlePresenter
+    include UpdateTypeHelper
+    attr_reader :item
+    attr_reader :update_type
+
+    def initialize(item, update_type: nil)
+      @item = item
+      @update_type = update_type || default_update_type(item)
+    end
+
+    def content_id
+      item.content_id
+    end
+
+    def content
+      content = BaseItemPresenter.new(item).base_attributes
+      content.merge!(
+        description: item.summary,
+        details: details,
+        document_type: "news_article",
+        public_updated_at: item.public_timestamp || item.updated_at,
+        rendering_app: item.rendering_app,
+        schema_name: "world_location_news_article",
+      )
+      content.merge!(PayloadBuilder::AccessLimitation.for(item))
+      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
+    end
+
+    def links
+      LinksPresenter.new(item).extract(
+        %i(worldwide_organisations parent policy_areas topics world_locations)
+      )
+    end
+
+    private
+
+    def details
+      {
+        body: govspeak_renderer.govspeak_edition_to_html(item),
+        change_history: item.change_history.as_json,
+      }.tap do |details_hash|
+        details_hash[:image] = image_details if image_available?
+        details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
+        details_hash.merge!(PayloadBuilder::TagDetails.for(item))
+        details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+      end
+    end
+
+    def image_details
+      {
+        url: Whitehall.public_asset_host + presented_world_location_news_article.lead_image_path,
+        alt_text: presented_world_location_news_article.lead_image_alt_text
+      }
+    end
+
+    def image_available?
+      item.images.any?
+    end
+
+    def govspeak_renderer
+      @govspeak_renderer ||= Whitehall::GovspeakRenderer.new
+    end
+
+    def presented_world_location_news_article
+      ::WorldLocationNewsArticlePresenter.new(item)
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -60,9 +60,11 @@ private
       PublishingApi::PublicationPresenter
     when StatisticalDataSet
       PublishingApi::StatisticalDataSetPresenter
+    when WorldLocationNewsArticle
+      PublishingApi::WorldLocationNewsArticlePresenter
     else
       # This is a catch-all clause for the following classes:
-      # NewsArticle, WorldLocationNewsArticle, Speech, CorporateInformationPage,
+      # NewsArticle, Speech, CorporateInformationPage,
       # Consultations
       # The presenter implementation for all of these models is identical and
       # the structure of the presented payload is the same.

--- a/lib/sync_checker/checks/unpublished_check.rb
+++ b/lib/sync_checker/checks/unpublished_check.rb
@@ -81,7 +81,7 @@ module SyncChecker
 
       def check_alternative_path(unpublishing)
         alternative_url = unpublishing.alternative_url
-        alternative_path = URI(alternative_url).path
+        alternative_path = URI(alternative_url.strip).path
 
         item_alternative_path = content_item["details"]["alternative_path"]
         if alternative_path != item_alternative_path

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -1,0 +1,34 @@
+module SyncChecker
+  module Formats
+    class WorldLocationNewsArticleCheck < EditionBase
+      def root_path
+        "/government/world-location-news/"
+      end
+
+      def rendering_app
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+
+      def expected_details_hash(edition)
+        super.reject{ |k, _| k == :emphasised_organisations }
+      end
+
+      def document_type(_edition)
+        "news_article"
+      end
+
+      def checks_for_live(locale)
+        super + [
+          Checks::LinksCheck.new(
+            "worldwide_organisations",
+            edition_expected_in_live.worldwide_organisations.map(&:content_id)
+          ),
+          Checks::LinksCheck.new(
+            "world_locations",
+            edition_expected_in_live.world_locations.map(&:content_id)
+          )
+        ]
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -10,7 +10,7 @@ module SyncChecker
       end
 
       def expected_details_hash(edition)
-        super.reject{ |k, _| k == :emphasised_organisations }
+        super.reject { |k, _| k == :emphasised_organisations }
       end
 
       def document_type(_edition)

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -14,7 +14,7 @@ module SyncChecker
       end
 
       def document_type(_edition)
-        "news_article"
+        "world_location_news_article"
       end
 
       def checks_for_live(locale)

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -1,0 +1,320 @@
+require 'test_helper'
+class PublishingApi::WorldLocationNewsArticlePresenterTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+
+    @world_location_news_article = create(
+      :world_location_news_article,
+      title: "World Location News Article title",
+      summary: "World Location News Article summary"
+    )
+
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article)
+    @presented_content = I18n.with_locale("de") { @presented_world_location_news_article.content }
+  end
+
+  test "it presents a valid world_location_news_article content item" do
+    assert_valid_against_schema @presented_content, "world_location_news_article"
+  end
+
+  test "it delegates the content id" do
+    assert_equal @world_location_news_article.content_id, @presented_world_location_news_article.content_id
+  end
+
+  test "it presents the title" do
+    assert_equal "World Location News Article title", @presented_content[:title]
+  end
+
+  test "it presents the summary as the description" do
+    assert_equal "World Location News Article summary", @presented_content[:description]
+  end
+
+  test "it presents the base_path" do
+    assert_equal "/government/world-location-news/world-location-news-article-title.de", @presented_content[:base_path]
+  end
+
+  test "it presents updated_at if public_timestamp is nil" do
+    assert_equal @world_location_news_article.updated_at, @presented_content[:public_updated_at]
+  end
+
+  test "it presents the publishing_app as whitehall" do
+    assert_equal 'whitehall', @presented_content[:publishing_app]
+  end
+
+  test "it presents the rendering_app as whitehall-frontend" do
+    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  end
+
+  test "it presents the schema_name as world_location_news_article" do
+    assert_equal "world_location_news_article", @presented_content[:schema_name]
+  end
+
+  test "it presents the document type as news_article" do
+    assert_equal "news_article", @presented_content[:document_type]
+  end
+
+  test "it presents the global process wide locale as the locale of the world_location_news_article" do
+    assert_equal "de", @presented_content[:locale]
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticleWithPublicTimestampTest < ActiveSupport::TestCase
+  setup do
+    @expected_time = Time.zone.parse("10/01/2016")
+    @world_location_news_article = create(
+      :world_location_news_article
+    )
+    @world_location_news_article.public_timestamp = @expected_time
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article)
+  end
+
+  test "it presents public_timestamp if it exists" do
+    assert_equal @expected_time, @presented_world_location_news_article.content[:public_updated_at]
+  end
+end
+
+class PublishingApi::DraftWorldLocationNewsArticlePresenter < ActiveSupport::TestCase
+  test "it presents the world location news article's parent document created_at as first_public_at" do
+    presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:draft_world_location_news_article) do |world_location_news_article|
+        world_location_news_article.document.stubs(:created_at).returns(DateTime.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      DateTime.new(2015, 4, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticleBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
+  test "it presents the World Location News Article's first_published_at as first_public_at" do
+    presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:published_world_location_news_article) do |world_location_news_article|
+        world_location_news_article.stubs(:first_published_at).returns(DateTime.new(2015, 4, 10))
+      end
+    )
+
+    assert_equal(
+      DateTime.new(2015, 04, 10),
+      presented_notice.content[:details][:first_public_at]
+    )
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterDetailsTest < ActiveSupport::TestCase
+  setup do
+    @expected_first_published_at = DateTime.new(2015, 12, 25)
+    @world_location_news_article = create(
+      :world_location_news_article,
+      :published,
+      body: "*Test string*",
+      first_published_at: @expected_first_published_at
+    )
+
+    @presented_content = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article).content
+    @presented_details = @presented_content[:details]
+  end
+
+  test "it presents first_public_at as details, first_public_at" do
+    assert_equal @expected_first_published_at, @presented_details[:first_public_at]
+  end
+
+  test "it presents change_history" do
+    change_history = [
+      {
+        "public_timestamp" => @expected_first_published_at,
+        "note" => "change-note"
+      }
+    ]
+
+    assert_equal change_history, @presented_details[:change_history]
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterLinksTest < ActiveSupport::TestCase
+  setup do
+    @world_location_news_article = create(:world_location_news_article)
+    presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article)
+    @presented_links = presented_world_location_news_article.links
+  end
+
+  test "it presents the worldwide organisation content_ids as links, worldwide_organisations" do
+    assert_equal(
+      @world_location_news_article.worldwide_organisations.map(&:content_id),
+      @presented_links[:worldwide_organisations]
+    )
+  end
+
+  test "it presents the world location content_ids as links, world_locations" do
+    assert_equal(
+      @world_location_news_article.world_locations.map(&:content_id),
+      @presented_links[:world_locations]
+    )
+  end
+
+  test "it presents the topics(or specialist sectors as they used to be) content_ids as links, topics" do
+    assert_equal(
+      @world_location_news_article.specialist_sectors.map(&:content_id),
+      @presented_links[:topics]
+    )
+  end
+
+  test "it presents the primary_specialist_sector content_ids as links, parent" do
+    assert_equal(
+      @world_location_news_article.primary_specialist_sectors.map(&:content_id),
+      @presented_links[:parent]
+    )
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:world_location_news_article, minor_change: false)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "major", @presented_world_location_news_article.update_type
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterMinorUpdateTypeTest < ActiveSupport::TestCase
+  setup do
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:world_location_news_article, minor_change: true)
+    )
+  end
+
+  test "if the update type is not supplied it presents based on the item" do
+    assert_equal "minor", @presented_world_location_news_article.update_type
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterUpdateTypeArgumentTest < ActiveSupport::TestCase
+  setup do
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:world_location_news_article, minor_change: true),
+      update_type: "major"
+    )
+  end
+
+  test "presents based on the supplied update type argument" do
+    assert_equal "major", @presented_world_location_news_article.update_type
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterCurrentGovernmentTest < ActiveSupport::TestCase
+  setup do
+    # Goverments are not explicitly associated with an Edition.
+    # The Government is determined based on date of publication.
+    create(
+      :current_government,
+      name: "The Current Government",
+      slug: "the-current-government",
+    )
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(:world_location_news_article)
+    )
+  end
+
+  test "presents a current government" do
+    assert_equal(
+      {
+        "title": "The Current Government",
+        "slug": "the-current-government",
+        "current": true
+      },
+      @presented_world_location_news_article.content[:details][:government]
+    )
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterPreviousGovernmentTest < ActiveSupport::TestCase
+  setup do
+    # Goverments are not explicitly associated with an Edition.
+    # The Government is determined based on date of publication.
+    create(:current_government)
+    previous_government = create(
+      :previous_government,
+      name: "A Previous Government",
+      slug: "a-previous-government",
+    )
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      create(
+        :world_location_news_article,
+        first_published_at: previous_government.start_date + 1.day
+      )
+    )
+  end
+
+  test "presents a previous government" do
+    assert_equal(
+      {
+        "title": "A Previous Government",
+        "slug": "a-previous-government",
+        "current": false
+      },
+      @presented_world_location_news_article.content[:details][:government]
+    )
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticlePresenterPoliticalTest < ActiveSupport::TestCase
+  setup do
+    world_location_news_article = create(:world_location_news_article)
+    world_location_news_article.stubs(:political?).returns(true)
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      world_location_news_article
+    )
+  end
+
+  test "presents political" do
+    assert @presented_world_location_news_article.content[:details][:political]
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticleAccessLimitedTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+    world_location_news_article = create(:world_location_news_article)
+
+    PublishingApi::PayloadBuilder::AccessLimitation.expects(:for)
+      .with(world_location_news_article)
+      .returns(
+        { access_limited: { users: %w(abcdef12345) } }
+      )
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(
+      world_location_news_article
+    )
+  end
+
+  test "include access limiting" do
+    assert_equal %w(abcdef12345), @presented_world_location_news_article.content[:access_limited][:users]
+  end
+
+  test "is valid against content schemas" do
+    assert_valid_against_schema @presented_world_location_news_article.content, "world_location_news_article"
+  end
+end
+
+class PublishingApi::WorldLocationNewsArticleImageDetailsTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+    @image = build(:image, alt_text: 'Image alt text')
+    @world_location_news_article = create(:world_location_news_article, images: [@image])
+    @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article)
+   end
+
+  test "includes details of the world location news article image if present" do
+    expected_hash = {
+      url: (Whitehall.public_asset_host + @image.url(:s300)),
+      alt_text: @image.alt_text
+    }
+
+    assert_valid_against_schema(@presented_world_location_news_article.content, 'world_location_news_article')
+    assert_equal expected_hash, @presented_world_location_news_article.content[:details][:image]
+  end
+end

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -306,7 +306,7 @@ class PublishingApi::WorldLocationNewsArticleImageDetailsTest < ActiveSupport::T
     @image = build(:image, alt_text: 'Image alt text')
     @world_location_news_article = create(:world_location_news_article, images: [@image])
     @presented_world_location_news_article = PublishingApi::WorldLocationNewsArticlePresenter.new(@world_location_news_article)
-   end
+  end
 
   test "includes details of the world location news article image if present" do
     expected_hash = {

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -49,8 +49,8 @@ class PublishingApi::WorldLocationNewsArticlePresenterTest < ActiveSupport::Test
     assert_equal "world_location_news_article", @presented_content[:schema_name]
   end
 
-  test "it presents the document type as news_article" do
-    assert_equal "news_article", @presented_content[:document_type]
+  test "it presents the document type as world_location_news_article" do
+    assert_equal "world_location_news_article", @presented_content[:document_type]
   end
 
   test "it presents the global process wide locale as the locale of the world_location_news_article" do

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -37,9 +37,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
       PublishingApiPresenters.presenter_for(NewsArticle.new).class
 
     assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(WorldLocationNewsArticle.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(Speech.new).class
 
     assert_equal PublishingApi::GenericEditionPresenter,
@@ -126,5 +123,10 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a ConsultationPresenter for a Consultation" do
     presenter = PublishingApiPresenters.presenter_for(build(:consultation))
     assert_equal PublishingApi::ConsultationPresenter, presenter.class
+  end
+
+  test ".preseter_for returns a WorldLocationNewsArticle for a WorldLocationNewsArticle" do
+    presenter = PublishingApiPresenters.presenter_for(build(:world_location_news_article))
+    assert_equal PublishingApi::WorldLocationNewsArticlePresenter, presenter.class
   end
 end

--- a/test/unit/world_location_news_article_test.rb
+++ b/test/unit/world_location_news_article_test.rb
@@ -43,4 +43,9 @@ class WorldLocationNewsArticleTest < ActiveSupport::TestCase
     world_article.worldwide_organisations = []
     refute world_article.valid?
   end
+
+  test 'specifies rendering app to be whitehall frontend' do
+    world_location_news_article = WorldLocationNewsArticle.new
+    assert world_location_news_article .rendering_app.include?(Whitehall::RenderingApp::WHITEHALL_FRONTEND)
+  end
 end


### PR DESCRIPTION
World Location News Article Migration: implement publishing of format to publishing API.

[Trello Card #550](https://trello.com/c/QNIWUbzl/550-wlna-migration-implement-publishing-of-format-to-publishing-api-2-1423-11-000)

* Remove the Placeholder Presenter
* Add a Presenter for the PublishingApi
* Add Sync Checks