### PR TITLE
Resolve content id conflicts...

### DIFF
--- a/db/data_migration/20170126153516_resolve_content_id_conflict.rb
+++ b/db/data_migration/20170126153516_resolve_content_id_conflict.rb
@@ -1,0 +1,12 @@
+# There are two documents sharing the same slug but with different
+# content ids. One of them has no editions and is blocking the other
+# from being republished in the publishing api.
+# Removes the blocking document and uses its content id to avoid
+# base path conflicts downstream.
+[[312378, 308033], [326641, 313515]].each do |blocked_document_id, blocking_document_id|
+  blocked_document = Document.find(blocked_document_id)
+  blocking_document = Document.find(blocking_document_id)
+  blocked_document.content_id = blocking_document.content_id
+  blocked_document.save!
+  blocking_document.destroy
+end


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

Some manual workflow to retire content and succeed it with new content
has caused a base_path conflict in the publishing API for a couple
of publications. In both cases one of the publications is redundant
and the publishing API has a record of it, so any attempts to republish
the useful content fails with a conflict. So re-purpose the blocking content
id and remove the redundant document in Whitehall so that republishing works.