### PR TITLE
Filter FileAttachment types from expected content ids...

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -64,7 +64,7 @@ module SyncChecker
         locales_to_filter = Array(locale.to_s)
         locales_to_filter << "" if locale.to_s == I18n.default_locale.to_s
         locale_attachments = all_attachments.select do |attachment|
-          attachment.is_a?(FileAttachment) ||
+          attachment.is_a?(HtmlAttachment) &&
             locales_to_filter.include?(attachment.locale.to_s)
         end
         locale_attachments.map(&:content_id)


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

We're only interested in html attachments in this check so ensure
we don't expect the content ids of file attachments in the sync
check.