### PR TITLE
Republish a document collection

### DIFF
--- a/db/data_migration/20170130134111_publish_out_of_sync_document_collections.rb
+++ b/db/data_migration/20170130134111_publish_out_of_sync_document_collections.rb
@@ -1,0 +1,3 @@
+# This document collection is published in Whitehall
+# but draft in the Publishing API
+PublishingApiDocumentRepublishingWorker.new.perform(344972)


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

This document collection is out of sync between Whitehall and the Publishing API so republish it.