### PR TITLE
Prefix `EXECUTOR_NUMBER` to the test database name

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@ development:
 test: &test
   encoding: utf8
   adapter: mysql2
-  database: whitehall_test<%= ENV['TEST_ENV_NUMBER'] %>
+  database: whitehall_test<%= "_executor_#{ENV['EXECUTOR_NUMBER']}_" if ENV['EXECUTOR_NUMBER']%><%= ENV['TEST_ENV_NUMBER'] %>
   username: whitehall
   password: whitehall
 


### PR DESCRIPTION
We currently have Whitehall pinned to one agent in CI and this is causing issues when two or more builds run concurrently. Each time a build starts it drops the test dastabases and as these aren't currently namespaced the already running build then fails.

This commit prefixes the DB names with the EXECUTOR_NUMBER environment variable which should prevent this condition occurring.

NB This currently won't pass CI as the newly named DBs require the addition of new permissions on the CI box for `'whitehall'@'localhost'`.

/cc @djsd123 