### PR TITLE
Send finders to rummager

### DIFF
--- a/app/services/publish_finder.rb
+++ b/app/services/publish_finder.rb
@@ -10,6 +10,13 @@ class PublishFinder
   end
 
   def call
+    send_to_publishing_api
+    send_to_rummager
+  end
+
+private
+
+  def send_to_publishing_api
     Whitehall.publishing_api_v2_client.put_content(
       content_id,
       finder_content_item
@@ -17,7 +24,24 @@ class PublishFinder
     Whitehall.publishing_api_v2_client.publish(content_id, "major")
   end
 
-private
+  def send_to_rummager
+    index = Whitehall::SearchIndex.for(:government)
+    index.add(present_for_rummager)
+  end
+
+  def present_for_rummager
+    {
+      _id: finder_content_item.fetch("base_path"),
+      link: finder_content_item.fetch("base_path"),
+      format: "finder",
+      title: finder_content_item.fetch("title"),
+      description: finder_content_item.fetch("description", ""),
+      content_store_document_type: finder_content_item.fetch("document_type"),
+      content_id: content_id,
+      publishing_app: finder_content_item.fetch("publishing_app"),
+      rendering_app: finder_content_item.fetch("rendering_app"),
+    }
+  end
 
   def content_id
     @content_id ||= existing_content_id || SecureRandom.uuid

--- a/test/unit/services/publish_finder_test.rb
+++ b/test/unit/services/publish_finder_test.rb
@@ -6,6 +6,7 @@ class PublishFinderTest < ActiveSupport::TestCase
 
     publishing_api_has_lookups({})
     SecureRandom.stubs(:uuid).returns('a-content-id')
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
 
     PublishFinder.call(people_finder)
 
@@ -17,6 +18,7 @@ class PublishFinderTest < ActiveSupport::TestCase
     people_finder = JSON.parse(File.read("lib/finders/people.json"))
 
     publishing_api_has_lookups('/government/people' => 'existing-content-id')
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
 
     PublishFinder.call(people_finder)
 


### PR DESCRIPTION
This commit changes the `PublishFinder` service to also send finders to rummager for indexing so that they show up in search results.

Trello: https://trello.com/c/Rdi7VDkE/450-add-new-finders-to-search