### PR TITLE
Withdraw deleted publications translations

### DIFF
--- a/db/data_migration/20170131090838_withdraw_deleted_publications_translations.rb
+++ b/db/data_migration/20170131090838_withdraw_deleted_publications_translations.rb
@@ -1,0 +1,34 @@
+edition_translation_data = {
+  526403 => ["en", "zh", "zh-tw"],
+  654995  => ["cy", "en"],
+  679612  => ["cy", "en"],
+  505871  => ["cy", "en"],
+  474060  => ["cy", "en"],
+  698000  => ["cy", "en"],
+  610495  => ["cy", "en"],
+  630871  => ["cy", "en"],
+  665884  => ["cy", "en"],
+  599695  => ["cy", "en"],
+  626791  => ["cy", "en"],
+  440210  => ["cy", "en"],
+  571531  => ["cy", "en"],
+  537197  => ["cy", "en"],
+  533156  => ["cy", "en"],
+  545235  => ["cy", "en"],
+  641072  => ["cy", "en"],
+  647249  => ["en", "ja", "ko", "zh"],
+}
+
+edition_translation_data.each do |edition_id, locales|
+  edition = Edition.find_by(id: edition_id)
+  if edition
+    edition_translation_locales = edition.translations.map(&:locale).map(&:to_s)
+    locales.each do |locale|
+      unless edition_translation_locales.include?(locale)
+        alternative_url = Whitehall::UrlMaker.new.public_document_url(edition)
+        explanation = "This translation is no longer available. You can find the original version of this content at [#{alternative_url}](#{alternative_url})"
+        PublishingApiGoneWorker(edition.content_id, nil, explanation, locale, true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

~20 editions have deleted translations still lurking in the content store. 