### PR TITLE
Present Consultation feedback attachments with published date

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -13,9 +13,19 @@ module AttachmentsHelper
     preview_attachment_path(id: attachment.attachment_data.id, file: attachment.filename_without_extension, extension: attachment.file_extension)
   end
 
-  def block_attachments(attachments = [], alternative_format_contact_email = nil)
-    attachments.collect { |attachment|
-      render(partial: "documents/attachment", formats: :html, object: attachment, locals: {alternative_format_contact_email: alternative_format_contact_email})
-    }
+  def block_attachments(attachments = [],
+                        alternative_format_contact_email = nil,
+                        published_on = nil)
+    attachments.collect do |attachment|
+      render(
+        partial: 'documents/attachment',
+        formats: :html,
+        object: attachment,
+        locals: {
+          alternative_format_contact_email: alternative_format_contact_email,
+          published_on: published_on,
+        }
+      )
+    end
   end
 end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -246,6 +246,7 @@ module PublishingApi
         renderer.block_attachments(
           public_feedback.attachments,
           public_feedback.alternative_format_contact_email,
+          public_feedback.published_on,
         )
       end
 

--- a/db/data_migration/20170202085121_republish_consultations_to_fix_feedback_attachments.rb
+++ b/db/data_migration/20170202085121_republish_consultations_to_fix_feedback_attachments.rb
@@ -1,0 +1,3 @@
+DataHygiene::PublishingApiDocumentRepublisher
+  .new(Consultation)
+  .perform

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -103,6 +103,7 @@ module SyncChecker::Formats
                       .block_attachments(
                         public_feedback.attachments,
                         public_feedback.alternative_format_contact_email,
+                        public_feedback.published_on,
                       )
                   end
 

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -325,7 +325,8 @@ module PublishingApi::ConsultationPresenterTest
         .expects(:block_attachments)
         .with(
           consultation.public_feedback.attachments,
-          consultation.public_feedback.alternative_format_contact_email
+          consultation.public_feedback.alternative_format_contact_email,
+          consultation.public_feedback.published_on,
         )
         .returns(attachments_double)
 


### PR DESCRIPTION
When publishing the public feedback documents the attachment template which is rendered and sent to content store [must be rendered](https://github.com/alphagov/whitehall/blame/master/app/views/consultations/show.html.erb#L71) with a `published` field.

[Trello](https://trello.com/c/FQYfhHtf)