### PR TITLE
Don't present Withdrawn notice

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -26,7 +26,6 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::WithdrawnNotice.for(item))
     end
 
     def links
@@ -53,7 +52,6 @@ module PublishingApi
         format_display_type: item.display_type_key,
       }
       details_hash[:image] = image_details if image_available?
-      details_hash.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
     end
 

--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -25,7 +25,6 @@ module PublishingApi
         schema_name: "placeholder_#{item.class.name.underscore}",
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
-      content.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
     end
 

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -26,7 +26,6 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
-      content.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
     end
 
@@ -64,7 +63,6 @@ module PublishingApi
       }
       details_hash = maybe_add_national_applicability(details_hash)
       details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
-      details_hash.merge!(PayloadBuilder::WithdrawnNotice.for(item))
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -65,7 +65,6 @@ private
     else
       # This is a catch-all clause for the following classes:
       # NewsArticle, Speech, CorporateInformationPage,
-      # Consultations
       # The presenter implementation for all of these models is identical and
       # the structure of the presented payload is the same.
       PublishingApi::GenericEditionPresenter

--- a/db/data_migration/20170206103928_republish_case_studies_to_remove_withdrawn_from_details.rb
+++ b/db/data_migration/20170206103928_republish_case_studies_to_remove_withdrawn_from_details.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(CaseStudy)
+republisher.perform

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -188,30 +188,6 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     assert_equal [policy_area_1["content_id"], policy_1["content_id"]], presented_item.links[:related_policies]
   end
 
-  test "a withdrawn case study includes details of the archive notice" do
-    case_study = create(:published_case_study, :withdrawn)
-    case_study.build_unpublishing(
-      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
-      explanation: 'No longer relevant')
-
-    case_study.unpublishing.save!
-
-    archive_notice = {
-      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
-      archived_at: case_study.updated_at
-    }
-
-    presented_item = present(case_study)
-
-    assert_valid_against_schema(presented_item.content, 'case_study')
-    assert_equal archive_notice[:archived_at], presented_item.content[:details][:withdrawn_notice][:withdrawn_at]
-    assert_equal archive_notice[:archived_at], presented_item.content[:withdrawn_notice][:withdrawn_at]
-    assert_equivalent_html archive_notice[:explanation],
-      presented_item.content[:details][:withdrawn_notice][:explanation]
-    assert_equivalent_html archive_notice[:explanation],
-      presented_item.content[:withdrawn_notice][:explanation]
-  end
-
   test "an unpublished document has a first_public_at of the document creation time" do
     case_study = create(:draft_case_study)
     presented_item = present(case_study)

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -148,28 +148,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     assert_equal [location.content_id], presented_item.links[:world_locations]
   end
 
-  test "a withdrawn publication includes details of the archive notice" do
-    create(:government)
-    publication = create(:published_publication, :withdrawn)
-    publication.build_unpublishing(
-      unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
-      explanation: 'No longer relevant')
-
-    publication.unpublishing.save!
-
-    archive_notice = {
-      explanation: "<div class=\"govspeak\"><p>No longer relevant</p></div>",
-      archived_at: publication.updated_at
-    }
-
-    presented_item = present(publication)
-
-    assert_valid_against_schema(presented_item.content, 'publication')
-    assert_equal archive_notice[:archived_at], presented_item.content[:details][:withdrawn_notice][:withdrawn_at]
-    assert_equivalent_html archive_notice[:explanation],
-      presented_item.content[:details][:withdrawn_notice][:explanation]
-  end
-
   test "documents include the alternative format contact email" do
     publication = create(:publication, :with_command_paper)
     presented_item = present(publication)


### PR DESCRIPTION
The withdrawn notice is set as a result of a call to the `/unpublish` endpoint so it is no longer necessary to present it with the content item.

Unblocks https://github.com/alphagov/govuk-content-schemas/pull/511