### PR TITLE
Add parent to Statistical Data Set presenter

### DIFF
--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -30,7 +30,7 @@ module PublishingApi
 
     def links
       LinksPresenter.new(item).extract(
-        %i(organisations policy_areas topics)
+        %i(organisations policy_areas topics parent)
       )
     end
 

--- a/db/data_migration/20170125155058_republish_statistical_data_sets_to_include_parent.rb
+++ b/db/data_migration/20170125155058_republish_statistical_data_sets_to_include_parent.rb
@@ -1,0 +1,2 @@
+publisher = DataHygiene::PublishingApiDocumentRepublisher.new(StatisticalDataSet)
+publisher.perform

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -168,6 +168,13 @@ class PublishingApi::PublishedStatisticalDataSetPresenterLinksTest < ActiveSuppo
       @presented_links[:topics]
     )
   end
+
+  test "it presents the primary_specialist_sector content_ids as links, parent" do
+    assert_equal(
+      @statistical_data_set.primary_specialist_sectors.map(&:content_id),
+      @presented_links[:parent]
+    )
+  end
 end
 
 class PublishingApi::StatisticalDataSetPresenterUpdateTypeTest < ActiveSupport::TestCase


### PR DESCRIPTION
When presenting a Statistical Data Set to the publishing api, we need to include `parent` in the `links` hash. This was missed out when we initially migrated the format (https://github.com/alphagov/whitehall/pull/2918).