### PR TITLE
Change slug of main office of BCG in Madrid

### DIFF
--- a/db/data_migration/20170206132149_change_url_of_british_consulate_general_madrid_main_office.rb
+++ b/db/data_migration/20170206132149_change_url_of_british_consulate_general_madrid_main_office.rb
@@ -1,0 +1,11 @@
+madrid_office = WorldwideOffice.find_by(
+  slug: 'british-consulate-general-madrid--2'
+)
+organisation = madrid_office.worldwide_organisation
+
+if organisation.slug != 'british-consulate-general-madrid'
+  raise "Unexpected organisation #{organisation.name} for Madrid Office"
+end
+
+new_slug = 'british-consulate-general-madrid'
+madrid_office.update_attributes!(slug: new_slug)


### PR DESCRIPTION
This commit updates the slug of the main office of the British Consulate
General in Madrid. It does so with a data migration.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1763388