### PR TITLE
Connect type dropdown in UI and model validations for OffsiteLinks

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,8 +1,26 @@
 class OffsiteLink < ActiveRecord::Base
+  module LinkTypes
+    def self.all
+      @types ||= %w(alert blog_post campaign careers nhs_content service)
+    end
+
+    def self.humanize(link_type)
+      if link_type == 'nhs_content'
+        'NHS content'
+      else
+        link_type.humanize
+      end
+    end
+
+    def self.as_select_options
+      all.map { |type| [humanize(type), type] }
+    end
+  end
+
   belongs_to :parent, polymorphic: true
   validates :title, :summary, :link_type, :url, presence: true, length: { maximum: 255 }
   validate :check_url_is_allowed
-  validates :link_type, presence: true, inclusion: {in: %w{alert blog_post campaign careers service nhs_content}}
+  validates :link_type, presence: true, inclusion: {in: LinkTypes.all}
 
   def check_url_is_allowed
     begin
@@ -19,11 +37,7 @@ class OffsiteLink < ActiveRecord::Base
   end
 
   def humanized_link_type
-    if link_type == 'nhs_content'
-      'NHS content'
-    else
-      link_type.humanize
-    end
+    LinkTypes.humanize(link_type)
   end
 
   def to_s

--- a/app/views/admin/offsite_links/_form.html.erb
+++ b/app/views/admin/offsite_links/_form.html.erb
@@ -8,7 +8,7 @@
         <%= form.label :link_type, "Type", required: true %>
 
         <div class="form-group">
-          <%= form.select :link_type, [["Alert", "alert"], ["Blog Post", "blog_post"], ["Campaign", "campaign"], ["Careers", "careers"], ["Service", "service"]], {}, {class: 'form-control input-md-2'} %>
+          <%= form.select :link_type, OffsiteLink::LinkTypes.as_select_options, {}, {class: 'form-control input-md-2'} %>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
In the UI the dropdown for allowable types was a hand-coded list that
needs to be kept manually in sync with the list of allowable values for
the link_type attribute.  By extracting the types to a separate concern
we can connect the source for the validation and the source for the
values in the dropdown.

This acts as a follow up to #3010.