### PR TITLE
Fix nil organisations for HtmlPublicationPresenter

### DIFF
--- a/db/data_migration/20170207113434_fix_html_attachments_nil_organisations.rb
+++ b/db/data_migration/20170207113434_fix_html_attachments_nil_organisations.rb
@@ -1,0 +1,10 @@
+#Fix the interested editions and add MOD to them
+edition_ids = [421608, 421659, 421662, 421675, 421676, 421679, 423612, 464978]
+
+mod_organisation_id = 17
+mod = Organisation.find(mod_organisation_id)
+
+editions = Edition.find(edition_ids).each{|e| e.organisations << mod}
+editions.map(&:document_id).each do |document_id|
+  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+end


### PR DESCRIPTION
Trello: https://trello.com/c/dMbLwfHJ/585-fix-bug-with-html-pub-having-no-organisation-2

Some HtmlPublication were provoking an error on government frontend due to nil organisations for the attachment attachable.

We are fixing this adding an organisation to the attachable which
has no one, selecting it from the previous editions.