### PR TITLE
Present News Articles to the Publishing API

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -48,6 +48,10 @@ class NewsArticle < Newsesque
     false
   end
 
+  def rendering_app
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+  end
+
   private
 
   def only_news_article_allowed_invalid_data_can_be_awaiting_type

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -1,0 +1,173 @@
+module PublishingApi
+  class NewsArticlePresenter
+    extend Forwardable
+    include UpdateTypeHelper
+
+    SCHEMA_NAME = 'news_article'
+
+    attr_reader :update_type
+
+    def initialize(news_article, update_type: nil)
+      self.news_article = news_article
+      self.update_type = update_type || default_update_type(news_article)
+    end
+
+    def_delegator :news_article, :content_id
+
+    def content
+      BaseItemPresenter
+        .new(news_article)
+        .base_attributes
+        .merge(PayloadBuilder::AccessLimitation.for(news_article))
+        .merge(PayloadBuilder::FirstPublishedAt.for(news_article))
+        .merge(PayloadBuilder::PublicDocumentPath.for(news_article))
+        .merge(
+          description: news_article.summary,
+          details: details,
+          document_type: display_type_key,
+          public_updated_at: public_updated_at,
+          rendering_app: news_article.rendering_app,
+          schema_name: SCHEMA_NAME,
+        )
+    end
+
+    def links
+      LinksPresenter
+        .new(news_article)
+        .extract(%i(parent policy_areas related_policies topics world_locations))
+        .merge(Ministers.for(news_article))
+        .merge(PayloadBuilder::TopicalEvents.for(news_article))
+    end
+
+  private
+
+    attr_accessor :news_article
+    attr_writer :update_type
+
+    def_delegator :news_article, :display_type_key
+
+    def base_details
+      {
+        body: body,
+        emphasised_organisations: emphasised_organisations,
+      }
+    end
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(news_article)
+    end
+
+    def details
+      base_details
+        .merge(ChangeHistory.for(news_article))
+        .merge(Image.for(news_article))
+        .merge(PayloadBuilder::FirstPublicAt.for(news_article))
+        .merge(PayloadBuilder::PoliticalDetails.for(news_article))
+        .merge(PayloadBuilder::TagDetails.for(news_article))
+    end
+
+    def emphasised_organisations
+      news_article.lead_organisations.map(&:content_id)
+    end
+
+    def public_updated_at
+      public_updated_at = (news_article.public_timestamp || news_article.updated_at)
+      public_updated_at = if public_updated_at.respond_to?(:to_datetime)
+                            public_updated_at.to_datetime
+                          end
+
+      public_updated_at.rfc3339
+    end
+
+    class ChangeHistory
+      extend Forwardable
+
+      def self.for(news_article)
+        new(news_article).call
+      end
+
+      def initialize(news_article)
+        self.news_article = news_article
+      end
+
+      def call
+        return {} unless change_history.present?
+
+        { change_history: change_history.as_json }
+      end
+
+    private
+
+      attr_accessor :news_article
+      def_delegator :news_article, :change_history
+    end
+
+    class Image
+      extend Forwardable
+
+      def self.for(news_article)
+        new(news_article).call
+      end
+
+      def initialize(news_article)
+        self.news_article = ::NewsArticlePresenter.new(news_article)
+      end
+
+      def call
+        {
+          image: {
+            url: image_uri.to_s,
+            caption: image_caption,
+            alt_text: image_alt_text,
+          },
+        }
+      end
+
+    private
+
+      attr_accessor :news_article
+      def_delegator :news_article, :lead_image_caption, :image_caption
+
+      def image_alt_text
+        news_article.lead_image_alt_text.squish
+      end
+
+      def image_path
+        image_path = news_article.lead_image_path
+
+        image_path.starts_with?('/') ? image_path : image_path.prepend('/')
+      end
+
+      def image_uri
+        URI(Whitehall.public_asset_host).tap { |uri| uri.path = image_path }
+      end
+    end
+
+    class Ministers
+      extend Forwardable
+
+      def self.for(news_article)
+        new(news_article).call
+      end
+
+      def initialize(news_article)
+        self.news_article = news_article
+      end
+
+      def call
+        return {} unless ministers.present?
+
+        { ministers: ministers.collect(&:content_id) }
+      end
+
+    private
+
+      attr_accessor :news_article
+      def_delegator :news_article, :role_appointments
+
+      def ministers
+        role_appointments.try(:collect, &:person)
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -56,6 +56,8 @@ private
       PublishingApi::DetailedGuidePresenter
     when ::FatalityNotice
       PublishingApi::FatalityNoticePresenter
+    when ::NewsArticle
+      PublishingApi::NewsArticlePresenter
     when ::Publication
       PublishingApi::PublicationPresenter
     when StatisticalDataSet
@@ -64,7 +66,8 @@ private
       PublishingApi::WorldLocationNewsArticlePresenter
     else
       # This is a catch-all clause for the following classes:
-      # NewsArticle, Speech, CorporateInformationPage,
+      # - CorporateInformationPage
+      # - Speech
       # The presenter implementation for all of these models is identical and
       # the structure of the presented payload is the same.
       PublishingApi::GenericEditionPresenter

--- a/db/data_migration/20170207151039_republish_news_articles.rb
+++ b/db/data_migration/20170207151039_republish_news_articles.rb
@@ -1,0 +1,3 @@
+DataHygiene::PublishingApiDocumentRepublisher
+  .new(NewsArticle)
+  .perform

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -30,4 +30,15 @@ FactoryGirl.define do
     news_article_type_id { NewsArticleType::NewsStory.id }
   end
 
+  factory :news_article_news_story, parent: :news_article do
+    news_article_type_id { NewsArticleType::NewsStory.id }
+  end
+
+  factory :news_article_press_release, parent: :news_article do
+    news_article_type_id { NewsArticleType::PressRelease.id }
+  end
+
+  factory :news_article_government_response, parent: :news_article do
+    news_article_type_id { NewsArticleType::GovernmentResponse.id }
+  end
 end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -1,0 +1,362 @@
+require 'test_helper'
+
+module PublishingApi::NewsArticlePresenterTest
+  class TestCase < ActiveSupport::TestCase
+    attr_accessor :news_article, :update_type
+
+    setup do
+      create(:current_government)
+    end
+
+    def presented_news_article
+      PublishingApi::NewsArticlePresenter.new(
+        news_article,
+        update_type: update_type,
+      )
+    end
+
+    def presented_content
+      presented_news_article.content
+    end
+
+    def presented_links
+      presented_news_article.links
+    end
+
+    def assert_attribute(attribute, value)
+      assert_equal value, presented_content[attribute]
+    end
+
+    def assert_details_attribute(attribute, value)
+      assert_equal value, presented_content[:details][attribute]
+    end
+
+    def assert_payload(builder, data: -> { presented_content })
+      builder_double = builder.demodulize.underscore
+      payload_double = { :"#{builder_double}_key" => "#{builder_double}_value" }
+
+      builder
+        .constantize
+        .expects(:for)
+        .at_least_once
+        .with(news_article)
+        .returns(payload_double)
+
+      actual_data = data.call
+      expected_data = actual_data.merge(payload_double)
+
+      assert_equal expected_data, actual_data
+    end
+
+    def assert_details_payload(builder)
+      assert_payload builder, data: -> { presented_content[:details] }
+    end
+
+    def assert_links_payload(builder)
+      assert_payload builder, data: -> { presented_links }
+    end
+  end
+
+  class BasicNewsArticleTest < TestCase
+    setup do
+      self.news_article = create(:news_article)
+    end
+
+    test 'base' do
+      attributes_double = {
+        base_attribute_one: 'base_attribute_one',
+        base_attribute_two: 'base_attribute_two',
+        base_attribute_three: 'base_attribute_three',
+      }
+
+      PublishingApi::BaseItemPresenter
+        .expects(:new)
+        .with(news_article)
+        .returns(stub(base_attributes: attributes_double))
+
+      actual_content = presented_content
+      expected_content = actual_content.merge(attributes_double)
+
+      assert_equal actual_content, expected_content
+    end
+
+    test 'base links' do
+      expected_link_keys = %i(
+        parent
+        policy_areas
+        related_policies
+        topics
+        world_locations
+      )
+
+      links_double = {
+        link_one: 'link_one',
+        link_two: 'link_two',
+        link_three: 'link_three',
+      }
+
+      PublishingApi::LinksPresenter
+        .expects(:new)
+        .with(news_article)
+        .returns(
+          mock('PublishingApi::LinksPresenter') {
+            expects(:extract)
+              .with(expected_link_keys)
+              .returns(links_double)
+          }
+        )
+
+      actual_links = presented_links
+      expected_links = actual_links.merge(links_double)
+
+      assert_equal actual_links, expected_links
+    end
+
+    test 'body details' do
+      body_double = Object.new
+
+      govspeak_renderer = mock('Whitehall::GovspeakRenderer')
+
+      govspeak_renderer
+        .expects(:govspeak_edition_to_html)
+        .with(news_article)
+        .returns(body_double)
+
+      Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+
+      assert_details_attribute :body, body_double
+    end
+
+    test 'access limitation' do
+      assert_payload 'PublishingApi::PayloadBuilder::AccessLimitation'
+    end
+
+    test 'content id' do
+      assert_equal news_article.content_id, presented_news_article.content_id
+    end
+
+    test 'description' do
+      assert_attribute :description, news_article.summary
+    end
+
+    test 'emphasised organisations' do
+      assert_details_attribute :emphasised_organisations,
+                               news_article.lead_organisations.map(&:content_id)
+    end
+
+    test 'first public at details' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::FirstPublicAt'
+    end
+
+    test 'first published at details' do
+      assert_payload 'PublishingApi::PayloadBuilder::FirstPublishedAt'
+    end
+
+    test 'political details' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::PoliticalDetails'
+    end
+
+    test 'public document path' do
+      assert_payload 'PublishingApi::PayloadBuilder::PublicDocumentPath'
+    end
+
+    test 'rendering app' do
+      assert_attribute :rendering_app, news_article.rendering_app
+    end
+
+    test 'schema name' do
+      assert_attribute :schema_name, 'news_article'
+    end
+
+    test 'topical events' do
+      assert_links_payload 'PublishingApi::PayloadBuilder::TopicalEvents'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class GovernmentResponseTest < TestCase
+    def setup
+      self.news_article = create(:news_article_government_response)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'government_response'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsStoryTest < TestCase
+    def setup
+      self.news_article = create(:news_article_news_story)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'news_story'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class PressReleaseTest < TestCase
+    def setup
+      self.news_article = create(:news_article_press_release)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'press_release'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsArticleWithImage < TestCase
+    setup do
+      self.news_article = create(:published_news_article)
+    end
+
+    test 'image' do
+      ::NewsArticlePresenter
+        .expects(:new)
+        .with(news_article)
+        .returns(
+          stub(
+            lead_image_path: '/foo',
+            lead_image_alt_text: 'Bar',
+            lead_image_caption: 'Baz',
+          )
+        )
+
+      expected_image_url = Whitehall.public_asset_host + '/foo'
+      expected_image_caption = 'Baz'
+      expected_image_alt_text = 'Bar'
+
+      expected_image = {
+        url: expected_image_url,
+        caption: expected_image_caption,
+        alt_text: expected_image_alt_text,
+      }
+
+      assert_details_attribute :image, expected_image
+    end
+  end
+
+  class NewsArticleWithMinisterialRoleAppointments < TestCase
+    setup do
+      self.news_article = create(
+        :news_article,
+        role_appointments: create_list(:ministerial_role_appointment, 2)
+      )
+    end
+
+    test 'ministers' do
+      expected_content_ids = news_article
+        .role_appointments
+        .map(&:person)
+        .map(&:content_id)
+
+      assert_equal presented_links[:ministers], expected_content_ids
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsArticleWithPublicTimestamp < TestCase
+    setup do
+      self.news_article = create(:published_news_article)
+
+      news_article.stubs(public_timestamp: Date.new(1999),
+                         updated_at: Date.new(2012))
+    end
+
+    test 'public updated at' do
+      assert_attribute :public_updated_at,
+                       '1999-01-01T00:00:00+00:00'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsArticleWithoutPublicTimestamp < TestCase
+    setup do
+      self.news_article = create(:published_news_article)
+
+      news_article.stubs(public_timestamp: nil,
+                         updated_at: Date.new(2012))
+    end
+
+    test 'public updated at' do
+      assert_attribute :public_updated_at,
+                       '2012-01-01T00:00:00+00:00'
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsArticleWithChangeHistory < TestCase
+    setup do
+      self.news_article = create(:published_news_article)
+    end
+
+    test 'change history' do
+      expected_change_history = [
+        {
+          'public_timestamp' => '2011-11-09T11:11:11.000+00:00',
+          'note' => 'change-note',
+        }
+      ]
+
+      assert_details_attribute :change_history, expected_change_history
+    end
+
+    test 'validity' do
+      assert_valid_against_schema presented_content, 'news_article'
+    end
+  end
+
+  class NewsArticleWithMajorChange < TestCase
+    setup do
+      self.news_article = create(:news_article, minor_change: false)
+      self.update_type = 'major'
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_news_article.update_type
+    end
+  end
+
+  class NewsArticleWithMinorChange < TestCase
+    setup do
+      self.news_article = create(:news_article, minor_change: true)
+    end
+
+    test 'update type' do
+      assert_equal 'minor', presented_news_article.update_type
+    end
+  end
+
+  class NewsArticleWithoutMinorChange < TestCase
+    setup do
+      self.news_article = create(:news_article, minor_change: false)
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_news_article.update_type
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -34,9 +34,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
       PublishingApiPresenters.presenter_for(GenericEdition.new).class
 
     assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(NewsArticle.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(Speech.new).class
 
     assert_equal PublishingApi::GenericEditionPresenter,
@@ -125,8 +122,13 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     assert_equal PublishingApi::ConsultationPresenter, presenter.class
   end
 
-  test ".preseter_for returns a WorldLocationNewsArticle for a WorldLocationNewsArticle" do
+  test ".presenter_for returns a WorldLocationNewsArticlePresenter for a WorldLocationNewsArticle" do
     presenter = PublishingApiPresenters.presenter_for(build(:world_location_news_article))
     assert_equal PublishingApi::WorldLocationNewsArticlePresenter, presenter.class
+  end
+
+  test ".presenter_for returns a NewsArticlePresenter for a NewsArticle" do
+    presenter = PublishingApiPresenters.presenter_for(build(:news_article))
+    assert_equal PublishingApi::NewsArticlePresenter, presenter.class
   end
 end


### PR DESCRIPTION
Add logic to present News Articles to the Publishing API.

[See Trello](https://trello.com/c/yQPIPkAu/592-news-article-migration-2-implement-publishing-of-format-to-publishing-api)