### PR TITLE
Add topics section to document review page

### DIFF
--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -35,6 +35,7 @@
 @import "sidebar";
 @import "lists";
 @import "get_involved";
+@import "topics_section";
 
 // GLOBAL
 // Styles that apply to all of admin.

--- a/app/assets/stylesheets/admin/topics_section.scss
+++ b/app/assets/stylesheets/admin/topics_section.scss
@@ -1,0 +1,24 @@
+@import "design-patterns/breadcrumbs";
+
+.taxon-breadcrumb {
+  // reset the default browser styles
+  ol {
+    padding: 0;
+    margin: 0;
+  }
+
+  li:last-child {
+    font-weight: bold;
+  }
+
+  color: $black;
+
+  @include breadcrumbs;
+}
+
+.content-bordered{
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+}

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -72,7 +72,10 @@ class Admin::EditionsController < Admin::BaseController
 
   def show
     fetch_version_and_remark_trails
-    fetch_expanded_links
+
+    if @edition.can_be_tagged_to_taxonomy? && tagging_taxonomy_enabled?
+      fetch_expanded_links
+    end
   end
 
   def new

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -72,6 +72,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def show
     fetch_version_and_remark_trails
+    fetch_expanded_links
   end
 
   def new
@@ -158,6 +159,10 @@ class Admin::EditionsController < Admin::BaseController
   def fetch_version_and_remark_trails
     @edition_remarks = @edition.document_remarks_trail.reverse
     @edition_history = Kaminari.paginate_array(@edition.document_version_trail.reverse).page(params[:page]).per(30)
+  end
+
+  def fetch_expanded_links
+    @expanded_links = ExpandedLinksFetcher.new(@edition.content_id).fetch
   end
 
   def edition_class

--- a/app/services/expanded_links_fetcher.rb
+++ b/app/services/expanded_links_fetcher.rb
@@ -1,0 +1,45 @@
+class ExpandedLinksFetcher
+  attr_accessor :content_id
+
+  def initialize(content_id)
+    @content_id = content_id
+  end
+
+  def fetch
+    ExpandedLinks.new(
+      Whitehall.publishing_api_v2_client.get_expanded_links(content_id)
+    )
+  end
+
+  class ExpandedLinks
+    def initialize(publishing_api_response)
+      @response = publishing_api_response
+    end
+
+    def selected_taxon_paths
+      response["expanded_links"].fetch("taxons", []).map { |taxon_hash| taxon_path(taxon_hash) }
+    end
+
+  private
+
+    attr_reader :response
+
+    def taxon_path(taxon_hash)
+      parents = [{ title: taxon_hash["title"] }]
+
+
+      direct_parents = taxon_hash["links"]["parent_taxons"]
+      while direct_parents
+        # There should not be more than one parent for a taxon. If there is,
+        # make an arbitrary choice.
+        direct_parent = direct_parents.first
+
+        parents << { title: direct_parent["title"] }
+
+        direct_parents = direct_parent["links"]["parent_taxons"]
+      end
+
+      parents.reverse
+    end
+  end
+end

--- a/app/views/admin/editions/_edition_view_edit_buttons.html.erb
+++ b/app/views/admin/editions/_edition_view_edit_buttons.html.erb
@@ -14,9 +14,4 @@
   <% elsif @edition.is_latest_edition? and @edition.published? %>
     <%= redraft_edition_button(@edition) %>
   <% end %>
-
-  <% if @edition.can_be_tagged_to_taxonomy? && tagging_taxonomy_enabled? %>
-    <%= link_to "Tag to new taxonomy", edit_admin_edition_tags_path(@edition.id),
-        class: "btn btn-lg btn-default tag-taxonomy" %>
-  <% end %>
 </section>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -45,6 +45,33 @@
 
 <%= render_partial_if_exists 'extra_metadata' %>
 
+<% if @edition.can_be_tagged_to_taxonomy? && tagging_taxonomy_enabled? %>
+  <section class="taxonomy-topics" id="topic-new-taxonomy">
+    <h2>Topics (new taxonomy)
+      <%= link_to edit_admin_edition_tags_path(@edition.id), class:"btn btn-default pull-right" do %>
+        <% if @expanded_links.selected_taxon_paths.any? %>
+          <span class="glyphicon glyphicon-edit"></span> Change topics
+        <% else %>
+          <span class="glyphicon glyphicon-plus-sign"></span> Add topic
+        <% end %>
+      <% end %>
+    </h2>
+    <% if @expanded_links.selected_taxon_paths.any? %>
+      <div class="content content-bordered">
+        <% @expanded_links.selected_taxon_paths.each do |path| %>
+          <%= render partial: 'taxon_breadcrumb', locals: {
+            breadcrumbs: path
+          } %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="no-content no-content-bordered">
+        No topics - please add a topic before publishing
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
 <% if @edition.translatable? %>
   <section class="translations" id="translations">
     <h2>

--- a/app/views/admin/editions/_taxon_breadcrumb.html.erb
+++ b/app/views/admin/editions/_taxon_breadcrumb.html.erb
@@ -1,0 +1,9 @@
+<div class="taxon-breadcrumb">
+  <ol>
+  <% breadcrumbs.each_with_index do |crumb, index| %>
+    <li>
+        <%= crumb[:title] %>
+    </li>
+  <% end %>
+  </ol>
+</div>

--- a/test/unit/services/expanded_links_fetcher_test.rb
+++ b/test/unit/services/expanded_links_fetcher_test.rb
@@ -1,0 +1,171 @@
+require 'test_helper'
+
+class ExpandedLinksFetcherTest < ActiveSupport::TestCase
+  test "it returns '[]' if there are no taxons" do
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {}
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal links_fetcher.fetch.selected_taxon_paths, []
+  end
+
+  test "it returns a single taxon for the path if the taxon has no parents" do
+    title = "Education, training and skills"
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => title,
+            "links" => {}
+          }
+        ]
+      }
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: title }]]
+  end
+
+  test "it returns both taxons for the path if the taxon has a parent but no grandparents" do
+    parent_title = "Education, training and skills"
+    title = "Further Education"
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => title,
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => parent_title,
+                  "links" => {}
+                }
+              ]
+            }
+          }
+        ]
+      }
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_title }, { title: title }]]
+  end
+
+  test "it returns all taxons for the path if the taxon has a parent, grandparent, but no great-grandparents" do
+    grandparent_title = "Education, training and skills"
+    parent_title = "Further Education"
+    title = "Student Finance"
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => title,
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => parent_title,
+                  "links" => {
+                    "parent_taxons" => [
+                      "title" => grandparent_title,
+                      "links" => {}
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: grandparent_title }, { title: parent_title }, { title: title }]]
+  end
+
+  test "it returns paths for multiple taxons" do
+    parent_title_1 = "Education, training and skills"
+    title_1 = "Further Education"
+
+    parent_title_2 = "Money"
+    title_2 = "Paying taxes"
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => title_1,
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => parent_title_1,
+                  "links" => {}
+                }
+              ]
+            }
+          },
+          {
+            "title" => title_2,
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => parent_title_2,
+                  "links" => {}
+                }
+              ]
+            }
+          }
+        ]
+      }
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal(
+      links_fetcher.fetch.selected_taxon_paths,
+      [
+        [{ title: parent_title_1 }, { title: title_1 }],
+        [{ title: parent_title_2 }, { title: title_2 }],
+      ]
+    )
+  end
+
+  test "it uses the first taxon if there are multiple parents" do
+    parent_title_1 = "Education, training and skills"
+    parent_title_2 = "Work and pensions"
+    title = "Further Education"
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => title,
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => parent_title_1,
+                  "links" => {}
+                },
+                {
+                  "title" => parent_title_2,
+                  "links" => {}
+                },
+              ]
+            }
+          }
+        ]
+      }
+    )
+
+    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_title_1 }, { title: title }]]
+  end
+end


### PR DESCRIPTION
# Background
We're going to be showing a tagging interface for the new education taxonomy to publishers in selected organisations, ahead of deploying a new navigation beta.

Tagging will eventually be mandatory to publish, but it is currently optional.

This functionality is behind a feature flag as the tagging interface itself is going to be iterated.

# This change
When reviewing a document, you should be able to see all the topics the document is currently tagged to. These get rendered breadcrumb style so publishers can understand the browse paths that will lead to the document.

## Screenshots
![transport to education and training for people aged 16 to 18 publication admin gov uk](https://cloud.githubusercontent.com/assets/87579/22697204/b3ac9686-ed48-11e6-9b4b-e0fab6bd6750.png)
![transport to education and training for people aged 16 to 18 publication admin gov uk_2](https://cloud.githubusercontent.com/assets/87579/22697212/b7f4a300-ed48-11e6-8ec4-798cf87ea5f1.png)

Trello: https://trello.com/c/sKsbTkKk/464-add-topics-section-to-whitehall-document-overview-page
Prototype: https://govuk-tagging.herokuapp.com/publication-review?
Paired with @klssmith 