### PR TITLE
[Do not merge] Don't expect links to withdrawn datasets

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -21,7 +21,7 @@ module SyncChecker
             "related_statistical_data_sets",
             edition_expected_in_live
               .statistical_data_sets
-              .where(state: %w(published withdrawn))
+              .where(state: %w(published))
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

Only specific link types will show withdrawn items in the Publishing API.
We only show published related stats data sets.