### PR TITLE
Gone-ify deleted translations

### DIFF
--- a/db/data_migration/20170207165538_withdraw_deleted_publications_translations.rb
+++ b/db/data_migration/20170207165538_withdraw_deleted_publications_translations.rb
@@ -1,0 +1,20 @@
+edition_translation_data = {
+  698000  => ["cy", "en"],
+  665884  => ["cy", "en"],
+  641072  => ["cy", "en"],
+  647249  => ["en", "ja", "ko", "zh"],
+}
+
+edition_translation_data.each do |edition_id, locales|
+  edition = Edition.find_by(id: edition_id)
+  if edition
+    edition_translation_locales = edition.translations.map(&:locale).map(&:to_s)
+    locales.each do |locale|
+      unless edition_translation_locales.include?(locale)
+        alternative_url = Whitehall::UrlMaker.new.public_document_url(edition)
+        explanation = "This translation is no longer available. You can find the original version of this content at [#{alternative_url}](#{alternative_url})"
+        PublishingApiGoneWorker.perform_async(edition.content_id, nil, explanation, locale)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

[A previous data migration](https://github.com/alphagov/whitehall/blob/master/db/data_migration/20170131090838_withdraw_deleted_publications_translations.rb) didn't remove these as expected, probably due to the inclusion of the `draft` flag.