### PR TITLE
Fix sync checker edition base `get_path`

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -52,7 +52,7 @@ module SyncChecker
 
       def get_path(edition, locale)
         path = Whitehall::UrlMaker.new.public_document_path(edition)
-        path += ".#{locale}" unless locale.to_s == "en"
+        path += ".#{locale}" unless locale.to_s == edition.primary_locale || locale.to_s == "en"
         path
       end
 

--- a/test/unit/sync_checker/checks/edition_base_test.rb
+++ b/test/unit/sync_checker/checks/edition_base_test.rb
@@ -1,0 +1,58 @@
+require 'minitest/autorun'
+require 'mocha/setup'
+require 'active_support'
+require 'active_support/json'
+require 'active_support/core_ext'
+require 'test_helper'
+
+require_relative '../../../../lib/sync_checker/formats/edition_base'
+
+module SyncChecker::Checks
+  class EditionBaseCheckTest < ActiveSupport::TestCase
+    def sync_check
+      SyncChecker::Formats::EditionBase.new("")
+    end
+
+    def test_base_path_with_non_english_primary_locale
+      edition = build(:world_location_news_article)
+      edition.primary_locale = "fr"
+      edition.save!
+
+      expected_path = Whitehall::UrlMaker.new.public_document_path(edition)
+
+      sync_check_path = sync_check.get_path(edition, "fr")
+
+      assert_equal expected_path, sync_check_path
+    end
+
+    def test_base_path_with_english_primary_locale_and_a_translated_edition
+      edition = build(:world_location_news_article)
+      with_locale(:fr) { edition.title = "en-francais" }
+      edition.primary_locale = "fr"
+      edition.save!
+
+      edition.translated_locales.each do |locale|
+        expected_path = I18n.with_locale(locale) do
+          Whitehall::UrlMaker.new.public_document_path(edition)
+        end
+
+        sync_check_path = sync_check.get_path(edition, locale)
+
+        assert_equal expected_path, sync_check_path
+      end
+    end
+
+    def test_base_path_cannot_end_with_dot_en
+      edition = build(:world_location_news_article)
+      with_locale(:fr) { edition.title = "en-francais" }
+      edition.primary_locale = "fr"
+      edition.save!
+
+      edition.translated_locales.each do |locale|
+        sync_check_path = sync_check.get_path(edition, locale)
+
+        refute sync_check_path.ends_with?(".en")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The SyncChecker::Formats::EditionBase creates base paths which it uses
to query the content store. When an edition with a primary_locale not
equal to english is being checked, however, curious base paths are
being created which contain the appended locale twice. For example the
base path returned is
government/world-location-news/172185.fr.fr instead of
government/world-location-news/172185.fr

This is caused by the `get_path` method which uses Whitehall::UrlMaker
to construct the base path and then appends the locale if the locale
being sync checked is not "en".

Unfortunately, UrlMaker automatically appends the locale to a path if
the edition is a `non_english_edition?`. This occurs in editions such
as World Location News Articles where an edition can be designated as
being foreign language only. In the database, this is reflected by the
edition having a `primary_locale` not equal to english.