### PR TITLE
Fix publication attachment locale

### DIFF
--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -81,8 +81,8 @@ module PublishingApi
 
     def attachments_for_current_locale
       attachments = item.attachments
-      locales_that_match = Array(I18n.locale.to_s)
-      locales_that_match << "" if I18n.locale == I18n.default_locale
+      #nil/"" locale should always be returned
+      locales_that_match = [I18n.locale.to_s, ""]
       attachments.to_a.select do |attachment|
         attachment.is_a?(FileAttachment) ||
           locales_that_match.include?(attachment.locale.to_s)

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -62,7 +62,7 @@ module SyncChecker
       def filter_documents_for_locale(edition, locale)
         all_attachments = edition.attachments
         #pub-api always expands the default locale so we need
-        #en and '' (some default locale attachments have nil locales)
+        #en and '' (nil locale attachments should always be present)
         locales_to_filter = ["en", "", locale.to_s]
         locale_attachments = all_attachments.select do |attachment|
           attachment.is_a?(HtmlAttachment) &&


### PR DESCRIPTION
`Publication`s can be created in multiple languages. Associated `HtmlAttachment`s can also be created in multiple languages and Whitehall allows the publisher to choose which language version of a `Publication` to attach to, either a specific version or 'all languages'.

This commit updates the `PublishingApi::PublicationPresenter` to support that. Previously we were treating an attachment with `nil` locale as being 'default' ie `:en`.
