### PR TITLE
Guard against unpublished deleted Documents

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -56,7 +56,9 @@ private
   end
 
   def find_unpublishing
-    Unpublishing.from_slug(params[:id], document_class)
+    unpublishing = Unpublishing.from_slug(params[:id], document_class)
+
+    unpublishing if unpublishing && !unpublishing.edition.deleted?
   end
 
   def find_document_or_edition

--- a/db/data_migration/20170213082122_delete_orphaned_unpublishings.rb
+++ b/db/data_migration/20170213082122_delete_orphaned_unpublishings.rb
@@ -1,0 +1,9 @@
+orphaned_unpublishings = Unpublishing.find_by_sql <<-SQL
+                            SELECT *
+                            FROM unpublishings
+                            WHERE edition_id NOT IN (
+                              SELECT id FROM editions
+                            )
+SQL
+
+Unpublishing.delete(orphaned_unpublishings.map(&:id))

--- a/test/functional/documents_controller_test.rb
+++ b/test/functional/documents_controller_test.rb
@@ -15,6 +15,18 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_cache_control("max-age=#{5.minutes}")
   end
 
+  test "show responds with 'not found' and default cache control 'max-age' if document has been unpublished and then deleted" do
+    login_as(:departmental_editor)
+    edition = create(:unpublished_publication)
+
+    Whitehall.edition_services.deleter(edition).perform!
+
+    get :show, id: edition.unpublishing.slug
+
+    assert_response :not_found
+    assert_cache_control("max-age=#{5.minutes}")
+  end
+
   test "show responds with 'unpublished' and default cache control 'max-age' if document has been unpublished" do
     login_as(:departmental_editor)
     edition = create(:unpublished_publication)


### PR DESCRIPTION
An Unpublishing will exist for a Document that has subsequently been deleted. Adding an extra guard ensures we don't render the unpublishing and instead correctly convey that the Document has been deleted.