### PR TITLE
Ensure placeholder image is presented

### DIFF
--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -41,7 +41,7 @@ module PublishingApi
         body: govspeak_renderer.govspeak_edition_to_html(item),
         change_history: item.change_history.as_json,
       }.tap do |details_hash|
-        details_hash[:image] = image_details if image_available?
+        details_hash[:image] = image_details
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::TagDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))


### PR DESCRIPTION
Even if there are no images for a WLNA, we still want to present a placeholder image to the publishing api.

[Trello: https://trello.com/c/DgBRDuIK/](https://trello.com/c/DgBRDuIK/)