### PR TITLE
Fix flakey feature

### DIFF
--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -31,7 +31,13 @@ end
 Then /^I should see a link to the preview version of the publication "([^"]*)"$/ do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  assert_equal preview_document_url(publication), find("a.preview_version")[:href]
+  preview_url_regexp = Regexp.new(
+    Regexp.escape(
+      preview_document_path(publication)
+    ).gsub(/cachebust=[0-9]+/, 'cachebust=[0-9]+')
+  )
+
+  assert_match preview_url_regexp, find("a.preview_version")[:href]
 end
 
 Then /^I should see that it was rejected by "([^"]*)"$/ do |rejected_by|


### PR DESCRIPTION
The `cachebust` querystring parameter of the `Publication` preview url is a timestamp. This was causing intermittent failures.

This commit matches with a numeric regex rather than an explicit value.