### PR TITLE
Rescope expected stats data sets...

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -19,10 +19,7 @@ module SyncChecker
           ),
           Checks::LinksCheck.new(
             "related_statistical_data_sets",
-            edition_expected_in_live
-              .statistical_data_sets
-              .where(state: %w(published withdrawn))
-              .map(&:content_id)
+            expected_statistical_data_sets(edition_expected_in_live)
           ),
           Checks::LinksCheck.new(
             "topical_events",
@@ -69,6 +66,12 @@ module SyncChecker
             locales_to_filter.include?(attachment.locale.to_s)
         end
         locale_attachments.map(&:content_id)
+      end
+
+      def expected_statistical_data_sets(edition)
+        published_content_ids = edition.published_statistical_data_sets.pluck(:content_id)
+        withdrawn_content_ids = edition.statistical_data_sets.withdrawn.pluck(:content_id)
+        published_content_ids + withdrawn_content_ids
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

We previously scoped Publication#statistical_data_sets down to published and withdrawn items,
this would ultimately join on the `latest_edition` for a document which would be incorrect for live
editions. So compose the expected data sets from `Publication#published_statistical_data_sets` +
withdrawn items from `Publication#statistical_data_sets`.