### PR TITLE
Reset the content id for an HtmlAttachment...

### DIFF
--- a/db/data_migration/20170213120430_reset_content_id_for_html_attachment.rb
+++ b/db/data_migration/20170213120430_reset_content_id_for_html_attachment.rb
@@ -1,0 +1,1 @@
+HtmlAttachment.update(1935679, content_id: "7154da1b-8cc2-4ccc-a375-a314e2ef4e8c")


### PR DESCRIPTION
This HtmlAttachment has a different `content_id` in the Publishing API
there's only one Edition of the attachable relation so it's safe enough
to correct the `content_id` without polluting the document history.