### PR TITLE
Republish the latest 10,000 Publication documents

### DIFF
--- a/db/data_migration/20170213113416_republish_publications_migration_one.rb
+++ b/db/data_migration/20170213113416_republish_publications_migration_one.rb
@@ -1,0 +1,17 @@
+latest_publication_document_ids = Document.where(
+  id: Publication.where(state: %w(draft published withdrawn)).pluck(:id)
+)
+  .order(id: :desc)
+  .limit(10000)
+  .pluck(:id)
+
+latest_publication_document_ids.each do |document_id|
+  print "."
+  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+end
+
+puts "\n" * 10
+puts "*" * 50
+puts "Last document republished #{latest_publication_document_ids.last}"
+puts "*" * 50
+puts "\n" * 10


### PR DESCRIPTION
The `Publication` format has had its rendering app switched to
government-frontend. Due to the large number of documents involved we
are back filling these in batches. This is the first batch of 10,000
from most recent backwards. All newly created/published publications
will already be being rendered with government-frontend so we can work
backwards from this migration.

The data migration will output the oldest document `id` that has been
republished. This should be recorded and form the starting point for the
next migration.