### PR TITLE
Prepend forward slash to image path

### DIFF
--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -50,14 +50,14 @@ module PublishingApi
 
     def image_details
       {
-        url: Whitehall.public_asset_host + presented_world_location_news_article.lead_image_path,
+        url: image_url,
         alt_text: presented_world_location_news_article.lead_image_alt_text,
         caption: presented_world_location_news_article.lead_image_caption
       }
     end
 
-    def image_available?
-      item.images.any?
+    def image_url
+      URI.join(Whitehall.public_asset_host, presented_world_location_news_article.lead_image_path).to_s
     end
 
     def govspeak_renderer

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -319,3 +319,21 @@ class PublishingApi::WorldLocationNewsArticleImageDetailsTest < ActiveSupport::T
     assert_equal expected_hash, @presented_world_location_news_article.content[:details][:image]
   end
 end
+
+class PublishingApi::WorldLocationNewsArticlePlaceholderImageTest < ActiveSupport::TestCase
+  setup do
+    create(:current_government)
+    @wlna = create(:world_location_news_article)
+    @presented_wlna = PublishingApi::WorldLocationNewsArticlePresenter.new(@wlna)
+  end
+
+  test "includes a placeholder image when no image is presented" do
+    expected_placeholder_image = {
+      alt_text: "placeholder",
+      caption: nil,
+      url: Whitehall.public_asset_host + "/placeholder.jpg"
+    }
+
+    assert_equal expected_placeholder_image, @presented_wlna.content[:details][:image]
+  end
+end


### PR DESCRIPTION
When creating placeholder images, the forward slash is not automatically added (https://github.com/alphagov/whitehall/blob/master/app/presenters/lead_image_presenter_helper.rb#L12).

By creating a properly formed URI, we ensure that the forward slash is prepended if needed and a valid image path is sent as part of the image hash.

Part of the WLNA migration sync checks - [Trello](https://trello.com/c/DgBRDuIK)
