### PR TITLE
Refactor presented News Article image URLs

### DIFF
--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -116,7 +116,7 @@ module PublishingApi
       def call
         {
           image: {
-            url: image_uri.to_s,
+            url: image_url,
             caption: image_caption,
             alt_text: image_alt_text,
           },
@@ -132,14 +132,8 @@ module PublishingApi
         news_article.lead_image_alt_text.squish
       end
 
-      def image_path
-        image_path = news_article.lead_image_path
-
-        image_path.starts_with?('/') ? image_path : image_path.prepend('/')
-      end
-
-      def image_uri
-        URI(Whitehall.public_asset_host).tap { |uri| uri.path = image_path }
+      def image_url
+        URI.join(Whitehall.public_asset_host, news_article.lead_image_path).to_s
       end
     end
 


### PR DESCRIPTION
Use [URI.join](http://ruby-doc.org/stdlib-2.4.0/libdoc/uri/rdoc/URI.html#method-c-join) instead of our own implementation.