### PR TITLE
Unpin CI agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 REPOSITORY = 'whitehall'
 DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
-node ('ci-agent-3') {
+node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([


### PR DESCRIPTION
Whitehall was pinned to ci-agent-3 but the performance fixes have been
deployed to all agents now so we can remove this restriction.