### PR TITLE
Update data migration to correctly republish Publications

### DIFF
--- a/db/data_migration/20170213113416_republish_publications_migration_one.rb
+++ b/db/data_migration/20170213113416_republish_publications_migration_one.rb
@@ -1,8 +1,8 @@
 document_scope = Document.where(
-  id: Publication.where(state: %w(draft published withdrawn)).pluck(:id)
+  id: Publication.where(state: %w(draft published withdrawn)).pluck(:document_id)
 )
 
-lowest_document_id_for_this_republish = 290000
+lowest_document_id_for_this_republish = 330000
 document_scope = document_scope.where(
   "id > ?", lowest_document_id_for_this_republish
 ).order(id: :desc)


### PR DESCRIPTION
Need to use `document_id` not `id`