### PR TITLE
Add sync check failure for 4xx and 5xx errors

### DIFF
--- a/lib/sync_checker/checks/http_status_check.rb
+++ b/lib/sync_checker/checks/http_status_check.rb
@@ -1,0 +1,15 @@
+module SyncChecker
+  module Checks
+    HttpStatusCheck = Struct.new(:disallowed_response_codes) do
+      def call(response)
+        failures = []
+
+        if Array(disallowed_response_codes).include?(response.response_code)
+          failures << "http response code #{response.response_code} returned for #{response.request.base_url}"
+        end
+
+        failures
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -1,6 +1,8 @@
 module SyncChecker
   module Formats
     class EditionBase
+      HTTP_400_AND_500_ERRORS = 400..599
+
       def self.scope
         klass = self.name.demodulize.sub(/Check$/, '')
         Document.where(id: klass.constantize.all.pluck(:document_id).uniq)
@@ -70,7 +72,8 @@ module SyncChecker
               expected_details_hash(edition_expected_in_draft, locale)
             end
           ),
-          Checks::TranslationsCheck.new(edition_expected_in_draft.available_locales)
+          Checks::TranslationsCheck.new(edition_expected_in_draft.available_locales),
+          Checks::HttpStatusCheck.new(HTTP_400_AND_500_ERRORS)
         ]
       end
 
@@ -115,7 +118,8 @@ module SyncChecker
           Checks::UnpublishedCheck.new(document),
           Checks::TranslationsCheck.new(edition_expected_in_live.available_locales),
           Checks::TopicsCheck.new(edition_expected_in_live,
-                                  topic_blacklist: DraftTopicContentIds.fetch)
+                                  topic_blacklist: DraftTopicContentIds.fetch),
+          Checks::HttpStatusCheck.new(HTTP_400_AND_500_ERRORS)
         ]
       end
 

--- a/test/unit/sync_checker/checks/http_status_check_test.rb
+++ b/test/unit/sync_checker/checks/http_status_check_test.rb
@@ -1,0 +1,43 @@
+require 'minitest/autorun'
+require 'mocha/setup'
+require 'active_support/json'
+require_relative '../../../../lib/sync_checker/checks/http_status_check'
+
+module SyncChecker::Checks
+  class HttpStatusCheckTest < Minitest::Test
+    def response(response_code)
+      response_request = stub(base_url: "/government/base/url")
+
+      stub(
+        response_code: response_code,
+        request: response_request
+      )
+    end
+
+    def test_returns_failure_results_with_single_disallowed_response_code_and_the_same_actual_response_code
+      results = HttpStatusCheck.new(404).call(response(404))
+
+      refute_empty results
+    end
+
+    def test_returns_failure_results_with_range_of_disallowed_response_codes_and_actual_response_code_inside_range
+      (400..499).each do |http_response|
+        results = HttpStatusCheck.new(400..499).call(response(http_response))
+
+        refute_empty results
+      end
+    end
+
+    def test_returns_no_failure_results_with_single_disallowed_response_code_and_different_actual_response_code
+      results = HttpStatusCheck.new(404).call(response(200))
+
+      assert_empty results
+    end
+
+    def test_returns_no_failure_results_with_range_of_disallowed_response_codes_and_actual_response_code_outside_range
+      results = HttpStatusCheck.new(400..499).call(response(200))
+
+      assert_empty results
+    end
+  end
+end


### PR DESCRIPTION
Sync checks are reporting no failures when a base path returns a 4xx or 5xx against the content stores.

Note there was already a test named `test_returns_empty_array_if_response_not_200`. I've renamed this test to reflect the 301 nature that it actually tests - I'm assuming there was some reason we wanted not to report failures on "moved permanently".

I think it's sensible to flag up where we don't find items in the content store so we don't get a bunch of false positives in the sync checks, but given the previous test noted above, happy to have a discussion around it.