### PR TITLE
Fix attachment locales

### DIFF
--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -86,8 +86,7 @@ module PublishingApi
       #nil/"" locale should always be returned
       locales_that_match = [I18n.locale.to_s, ""]
       attachments.to_a.select do |attachment|
-        attachment.is_a?(FileAttachment) ||
-          locales_that_match.include?(attachment.locale.to_s)
+        locales_that_match.include?(attachment.locale.to_s)
       end
     end
 

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -62,8 +62,7 @@ module SyncChecker
         #en and '' (nil locale attachments should always be present)
         locales_to_filter = ["en", "", locale.to_s]
         locale_attachments = all_attachments.select do |attachment|
-          attachment.is_a?(HtmlAttachment) &&
-            locales_to_filter.include?(attachment.locale.to_s)
+          locales_to_filter.include?(attachment.locale.to_s)
         end
         locale_attachments.map(&:content_id)
       end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -219,4 +219,31 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       assert_match(/nil one/, document_elements.first)
     end
   end
+
+  test "file attachments are correctly filtered for locale" do
+    publication = create(:published_publication)
+    publication.stubs(:attachments).returns(
+      [
+        build(:csv_attachment, id: 1, title: "en one", locale: "en"),
+        build(:csv_attachment, id: 2, title: "cy one", locale: "cy"),
+        build(:csv_attachment, id: 3, title: "nil one", locale: nil)
+      ]
+    )
+
+    presented_publication = PublishingApi::PublicationPresenter.new(publication)
+
+    I18n.with_locale(:cy) do
+      document_elements = presented_publication.content[:details][:documents]
+      assert_equal 2, document_elements.length
+      assert_match(/cy one/, document_elements.first)
+      assert_match(/nil one/, document_elements.last)
+    end
+
+    I18n.with_locale(:en) do
+      document_elements = presented_publication.content[:details][:documents]
+      assert_equal 2, document_elements.length
+      assert_match(/en one/, document_elements.first)
+      assert_match(/nil one/, document_elements.last)
+    end
+  end
 end


### PR DESCRIPTION
We are correctly filtering `HtmlAttachment`s based on locale on `Publication` documents but this filtering needs to also be applied to `FileAttachment`s.