### PR TITLE
Add range argument for Edition sync checks

### DIFF
--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -10,6 +10,10 @@ module SyncChecker
         Document.where(id: ids)
       end
 
+      def self.scope_with_range(range)
+        self.scope.where(id: range)
+      end
+
       def self.republish(id)
         PublishingApiDocumentRepublishingWorker.new.perform(id)
       end

--- a/script/run_sync_checks
+++ b/script/run_sync_checks
@@ -30,12 +30,19 @@ OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  opts.on("-b", "--between RANGE", "set the scope to document ids between") do |b|
+    range_arr = b.split(',').map(&:to_i)
+    options[:range] = Range.new(*range_arr)
+  end
 end.parse!
 
 checker = "SyncChecker::Formats::#{ARGV[0]}Check".constantize
 scope = (
   if options[:ids]
     checker.scope_with_ids(options[:ids])
+  elsif options[:range]
+    checker.scope_with_range(options[:range])
   else
     checker.scope
   end


### PR DESCRIPTION
Adds a -b option when running the sync checks.

Usage: `script/run_sync_checks -b 1000,2000`

Checks any documents that match the format and have an `id` between 1000
and 2000.

This is required to run checks when we are republishing in batches.