### PR TITLE
Find the missing children

### DIFF
--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -1,6 +1,6 @@
 module SyncChecker::Formats
   class ConsultationCheck < EditionBase
-    def expected_details_hash(consultation)
+    def expected_details_hash(consultation, _)
       super.tap do |details|
         details.except!(:change_history) unless consultation.change_history.present?
         details.merge!(expected_documents(consultation))

--- a/lib/sync_checker/formats/detailed_guide_check.rb
+++ b/lib/sync_checker/formats/detailed_guide_check.rb
@@ -33,7 +33,7 @@ module SyncChecker
         "detailed_guide"
       end
 
-      def expected_details_hash(edition)
+      def expected_details_hash(edition, _)
         super.tap do |expected_details_hash|
           expected_details_hash.merge(
             national_applicability: edition.national_applicability

--- a/lib/sync_checker/formats/document_collection_check.rb
+++ b/lib/sync_checker/formats/document_collection_check.rb
@@ -24,7 +24,7 @@ module SyncChecker
         ]
       end
 
-      def expected_details_hash(edition)
+      def expected_details_hash(edition, _)
         super.merge(
           collection_groups: collection_groups(edition)
         )

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -67,7 +67,7 @@ module SyncChecker
           ),
           Checks::DetailsCheck.new(
             I18n.with_locale(locale) do
-              expected_details_hash(edition_expected_in_draft)
+              expected_details_hash(edition_expected_in_draft, locale)
             end
           ),
           Checks::TranslationsCheck.new(edition_expected_in_draft.available_locales)
@@ -109,7 +109,7 @@ module SyncChecker
           ),
           Checks::DetailsCheck.new(
             I18n.with_locale(locale) do
-              expected_details_hash(edition_expected_in_live)
+              expected_details_hash(edition_expected_in_live, locale)
             end
           ),
           Checks::UnpublishedCheck.new(document),
@@ -135,7 +135,7 @@ module SyncChecker
         end
       end
 
-      def expected_details_hash(edition)
+      def expected_details_hash(edition, _locale)
         {
           body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(edition),
           change_history: edition.change_history.as_json,

--- a/lib/sync_checker/formats/news_article_check.rb
+++ b/lib/sync_checker/formats/news_article_check.rb
@@ -1,7 +1,7 @@
 module SyncChecker
   module Formats
     class NewsArticleCheck < EditionBase
-      def expected_details_hash(news_article)
+      def expected_details_hash(news_article, _)
         super.tap do |details|
           details.except!(:change_history) unless news_article.change_history.present?
           details.merge!(expected_government(news_article))

--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -30,10 +30,12 @@ module SyncChecker
           ),
           Checks::LinksCheck.new(
             "children",
+            #file attachments won't appear in children
+            #as they're not in publishing api
             filter_documents_for_locale(
               edition_expected_in_live,
               locale
-            )
+            ).reject{ |attachment| attachment.is_a?(FileAttachment) }
           )
         ]
       end

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -14,7 +14,7 @@ module SyncChecker
         end
       end
 
-      def expected_details_hash(world_location_news_article)
+      def expected_details_hash(world_location_news_article, _)
         super.tap do |details|
           details.merge!(expected_government(world_location_news_article))
           details.merge!(expected_image(world_location_news_article))


### PR DESCRIPTION
Changes introduced in #3045 have caused some (err... loads) of unexpected failures in the `Publication` sync checks. We need to filter the `FileAttachment`s by locale when presenting but we don't want to include them in the sync check of the `children` links as publishing-API is unaware of them and won't create a link.

So... the first commit excludes them from the check.

The second commit filters the documents passed to the details check for `Publication`s by locale. This worryingly doesn't seem to have been causing failures but they are [filtered by locale in the presenter](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/publication_presenter.rb#L76-L91) so we should filter them in the check too. 