### PR TITLE
Remove a News Article

### DIFF
--- a/db/data_migration/20170217141821_remove_test_news_article.rb
+++ b/db/data_migration/20170217141821_remove_test_news_article.rb
@@ -1,0 +1,3 @@
+doc = Document.find(333532)
+edition = doc.editions.first
+Whitehall.edition_services.deleter(edition).perform!


### PR DESCRIPTION
- News Article with base-path `/government/news/test--19` failed sync checks
- It was a draft and never published
- It looks as though it was created to try out some of the application's functionality by a member of the content team
- Does not serve any use so have added a data migration to delete it