### PR TITLE
Data migration to republish some Publications

### DIFF
--- a/db/data_migration/20170217153845_republish_publications_migration_two.rb
+++ b/db/data_migration/20170217153845_republish_publications_migration_two.rb
@@ -1,0 +1,18 @@
+document_scope = Document.where(
+  id: Publication.where(state: %w(draft published withdrawn)).pluck(:document_id)
+)
+
+lowest_id_for_this_republish = 260000
+highest_id_for_this_republish = 330000
+document_scope = document_scope.where(
+  id:  lowest_id_for_this_republish..highest_id_for_this_republish
+).order(id: :desc)
+
+
+puts "Republishing #{document_scope.count} documents"
+
+document_scope.pluck(:id).each do |document_id|
+  print "."
+  PublishingApiDocumentRepublishingWorker
+    .perform_async_in_queue("bulk_republishing", document_id)
+end


### PR DESCRIPTION
As part of the migration of the `Publication` format, we need to republish them to update the rendering app. We are doing this in stages. This is the second batch which will republish ~37000 documents.