### PR TITLE
Add live breadcrumbs preview

### DIFF
--- a/app/assets/javascripts/admin/modules/breadcrumb_preview.js
+++ b/app/assets/javascripts/admin/modules/breadcrumb_preview.js
@@ -1,0 +1,67 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.BreadcrumbPreview = function() {
+    var that = this;
+
+    that.fetchCheckedCheckboxes = function() {
+      return $('.topic-tree :checked');
+    };
+
+    that.buildBreadcrumbsStructure = function(checkboxes) {
+      var structure = $.map(checkboxes, function(checkbox) {
+        var $checkbox = $(checkbox);
+        var ancestors = $checkbox.data('ancestors').split('|');
+
+        return [ancestors];
+      });
+
+      return structure;
+    };
+
+    that.filterBreadcrumbs = function(breadcrumbs) {
+      var longestFirst = breadcrumbs.sort(function (a, b) {
+        return b.length - a.length;
+      });
+
+      var breadcrumbsToDisplay = [];
+
+      $.each(longestFirst, function(index, breadcrumb) {
+        var visited = false;
+
+        $.each(breadcrumbsToDisplay, function(index, visitedBreadcrumb) {
+          var breadcrumbString = JSON.stringify(breadcrumb);
+          var visitedBreadcrumbString = JSON.stringify(visitedBreadcrumb.slice(0, breadcrumb.length));
+
+          if (breadcrumbString === visitedBreadcrumbString) {
+            visited = true;
+          }
+        });
+
+        if (!visited) {
+          breadcrumbsToDisplay.push(breadcrumb);
+        }
+      });
+
+      return breadcrumbsToDisplay;
+    }
+
+    that.start = function(element) {
+      var $topicTree = $('.topic-tree');
+      $(element).removeClass('hidden');
+
+      $topicTree.on('change', function() {
+        var checkboxes = that.fetchCheckedCheckboxes();
+        var breadcrumbsArray = that.buildBreadcrumbsStructure(checkboxes);
+        var breadcrumbsToDisplay = that.filterBreadcrumbs(breadcrumbsArray);
+
+        $(element).mustache(
+          'admin/edition_tags/_breadcrumb_list',
+          { breadcrumbs: breadcrumbsToDisplay }
+        );
+      });
+
+      $topicTree.trigger('change');
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/admin/modules/breadcrumb_preview.js
+++ b/app/assets/javascripts/admin/modules/breadcrumb_preview.js
@@ -2,13 +2,13 @@
   "use strict";
 
   Modules.BreadcrumbPreview = function() {
-    var that = this;
+    var preview = this;
 
-    that.fetchCheckedCheckboxes = function() {
+    preview.fetchCheckedCheckboxes = function() {
       return $('.topic-tree :checked');
     };
 
-    that.buildBreadcrumbsStructure = function(checkboxes) {
+    preview.buildBreadcrumbsStructure = function(checkboxes) {
       var structure = $.map(checkboxes, function(checkbox) {
         var $checkbox = $(checkbox);
         var ancestors = $checkbox.data('ancestors').split('|');
@@ -19,7 +19,18 @@
       return structure;
     };
 
-    that.filterBreadcrumbs = function(breadcrumbs) {
+    preview.renderUpdatedBreadcrumbs = function(element) {
+      var checkboxes = preview.fetchCheckedCheckboxes();
+      var breadcrumbsArray = preview.buildBreadcrumbsStructure(checkboxes);
+      var breadcrumbsToDisplay = preview.filterBreadcrumbs(breadcrumbsArray);
+
+      $(element).mustache(
+        'admin/edition_tags/_breadcrumb_list',
+        { breadcrumbs: breadcrumbsToDisplay }
+      );
+    };
+
+    preview.filterBreadcrumbs = function(breadcrumbs) {
       var longestFirst = breadcrumbs.sort(function (a, b) {
         return b.length - a.length;
       });
@@ -31,7 +42,9 @@
 
         $.each(breadcrumbsToDisplay, function(index, visitedBreadcrumb) {
           var breadcrumbString = JSON.stringify(breadcrumb);
-          var visitedBreadcrumbString = JSON.stringify(visitedBreadcrumb.slice(0, breadcrumb.length));
+          var visitedBreadcrumbString = JSON.stringify(
+            visitedBreadcrumb.slice(0, breadcrumb.length)
+          );
 
           if (breadcrumbString === visitedBreadcrumbString) {
             visited = true;
@@ -44,24 +57,18 @@
       });
 
       return breadcrumbsToDisplay;
-    }
+    };
 
-    that.start = function(element) {
-      var $topicTree = $('.topic-tree');
+    preview.start = function(element) {
       $(element).removeClass('hidden');
 
-      $topicTree.on('change', function() {
-        var checkboxes = that.fetchCheckedCheckboxes();
-        var breadcrumbsArray = that.buildBreadcrumbsStructure(checkboxes);
-        var breadcrumbsToDisplay = that.filterBreadcrumbs(breadcrumbsArray);
+      var $topicTree = $('.topic-tree');
 
-        $(element).mustache(
-          'admin/edition_tags/_breadcrumb_list',
-          { breadcrumbs: breadcrumbsToDisplay }
-        );
+      $topicTree.on('change', function() {
+        preview.renderUpdatedBreadcrumbs(element);
       });
 
       $topicTree.trigger('change');
-    }
+    };
   };
 })(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/admin/modules/breadcrumb_preview.js
+++ b/app/assets/javascripts/admin/modules/breadcrumb_preview.js
@@ -24,10 +24,19 @@
       var breadcrumbsArray = preview.buildBreadcrumbsStructure(checkboxes);
       var breadcrumbsToDisplay = preview.filterBreadcrumbs(breadcrumbsArray);
 
-      $(element).mustache(
-        'admin/edition_tags/_breadcrumb_list',
-        { breadcrumbs: breadcrumbsToDisplay }
-      );
+      if (breadcrumbsToDisplay.length === 0) {
+        $(element).removeClass("content").removeClass("content-bordered");
+        $(element).addClass("no-content").addClass("no-content-bordered");
+        $(element).text("No topics - please add a topic before publishing");
+      } else {
+        $(element).addClass("content").addClass("content-bordered");
+        $(element).removeClass("no-content").removeClass("no-content-bordered");
+
+        $(element).mustache(
+          'admin/edition_tags/_breadcrumb_list',
+          { breadcrumbs: breadcrumbsToDisplay }
+        );
+      }
     };
 
     preview.filterBreadcrumbs = function(breadcrumbs) {

--- a/app/helpers/admin/edition_tags_helper.rb
+++ b/app/helpers/admin/edition_tags_helper.rb
@@ -8,7 +8,8 @@ module Admin::EditionTagsHelper
       "edition_taxonomy_tag_form[taxons][]",
       taxon.content_id,
       checked,
-      id: taxon.content_id
+      id: taxon.content_id,
+      "data-ancestors": taxon.breadcrumb_trail.map(&:name).join('|')
     )
   end
 end

--- a/app/views/admin/edition_tags/_breadcrumb_list.mustache
+++ b/app/views/admin/edition_tags/_breadcrumb_list.mustache
@@ -1,0 +1,9 @@
+{{#breadcrumbs}}
+<div class="taxon-breadcrumb">
+  <ol>
+    {{#.}}
+      <li>{{.}}</li>
+    {{/.}}
+  </ol>
+</div>
+{{/breadcrumbs}}

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -1,49 +1,46 @@
 <% page_title "Tagging: " + @edition.title %>
 
 <div class="row">
-  <div class="col-md-12">
-    <h1><%= @edition.title %></h1>
-    <h2>Edit topics</h2>
-    <p class="lead add-top-margin add-bottom-margin">
-      Edit topics for the new education taxonomy. Changes do not go through the review process.
+  <h1><%= @edition.title %></h1>
+  <h2>Edit topics</h2>
+  <p class="lead add-top-margin add-bottom-margin">
+    Edit topics for the new education taxonomy. Changes do not go through the review process.
+  </p>
+  <p class="lead add-top-margin add-bottom-margin">
+    Adding topics will include this content in the navigation beta.
+  </p>
+
+  <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
+    <%= form.hidden_field :previous_version %>
+
+    <div class="publishing-controls well">
+      <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
+    </div>
+
+    <p class="warning">
+      Warning: topic changes to published content appear instantly on the live site.
     </p>
-    <p class="lead add-top-margin add-bottom-margin">
-      Adding topics will include this content in the navigation beta.
+
+    <div class="form-group" data-module="taxonomy-tree-checkboxes">
+      <div class="topic-tree">
+
+        <p class="bold-taxon-name">
+          <%= @edition_tag_form.education_taxons.name %>
+        </p>
+
+        <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
+      </div>
+    </div>
+
+    <div class="content content-bordered hidden" data-module="breadcrumb-preview">
+    </div>
+
+    <p class="warning">
+      Warning: topic changes to published content appear instantly on the live site.
     </p>
 
-    <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
-      <%= form.hidden_field :previous_version %>
-
-      <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
-      </div>
-
-      <p class="warning">
-        Warning: topic changes to published content appear instantly on the live site.
-      </p>
-
-      <div class="form-group" data-module="taxonomy-tree-checkboxes">
-        <div class="topic-tree">
-
-          <p class="bold-taxon-name">
-            <%= @edition_tag_form.education_taxons.name %>
-          </p>
-
-          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
-        </div>
-      </div>
-
-      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
-      </div>
-
-      <p class="warning">
-        Warning: topic changes to published content appear instantly on the live site.
-      </p>
-
-      <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
-      </div>
-    <% end %>
-
-  </div>
+    <div class="publishing-controls well">
+      <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -1,7 +1,7 @@
 <% page_title "Tagging: " + @edition.title %>
 
 <div class="row">
-  <div class="col-md-8">
+  <div class="col-md-12">
     <h1><%= @edition.title %></h1>
     <h2>Edit topics</h2>
     <p class="lead add-top-margin add-bottom-margin">
@@ -31,6 +31,9 @@
 
           <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
         </div>
+      </div>
+
+      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
       </div>
 
       <p class="warning">

--- a/lib/taxonomy.rb
+++ b/lib/taxonomy.rb
@@ -42,6 +42,24 @@ module Taxonomy
       tree.tap(&:shift)
     end
 
+    # Get ancestors of a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to the parent taxon
+    def ancestors
+      if parent_node.nil?
+        []
+      else
+        parent_node.ancestors + [parent_node]
+      end
+    end
+
+    # Get a breadcrumb trail for a taxon
+    #
+    # @return [Array] all taxons in the path from the root of the taxonomy to this taxon
+    def breadcrumb_trail
+      ancestors + [self]
+    end
+
     def count
       tree.count
     end

--- a/test/javascripts/unit/admin/modules/breadcrumb_preview_test.js
+++ b/test/javascripts/unit/admin/modules/breadcrumb_preview_test.js
@@ -1,0 +1,23 @@
+module("BreadcrumbPreview", function(){
+  var subject = new GOVUKAdmin.Modules.BreadcrumbPreview();
+
+  test(".filterBreadcrumbs returns an empty array", function() {
+    deepEqual(
+      this.subject.filterBreadcrumbs([]),
+      []
+    )
+  });
+
+  test(".filterBreadcrumbs filters out breadcrumbs that are prefixes of other breadcrumbs", function() {
+    deepEqual(
+      this.subject.filterBreadcrumbs([
+        ["foo", "bar"],
+        ["foo"],
+        ["foo", "bar", "baz"]
+      ]),
+      [
+        ["foo", "bar", "baz"]
+      ]
+    )
+  });
+});


### PR DESCRIPTION
The goal of this commit is to show the uses how their choice of the taxons affects
the document in the taxon and also in the breadcrumbs.

Trello: https://trello.com/c/REchyOAj/463-add-live-breadcrumb-preview-to-whitehall-tagging-interface

Paired with @MatMoore 

### Screenshot

![screen shot 2017-02-17 at 15 52 57](https://cloud.githubusercontent.com/assets/136777/23074509/d0508640-f530-11e6-9596-ca74bf1b8779.png)
