### PR TITLE
Handle nil role_appointment for Speeches...

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -64,6 +64,7 @@ module PublishingApi
     end
 
     def links_for_speaker
+      return {} unless speaker
       { speaker: [speaker.content_id] }
     end
 

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -87,5 +87,15 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       assert_includes(presented.links[:speaker], person.content_id)
       assert_includes(presented.links[:topical_events], topical_event.content_id)
     end
+
+    context "no role appointment (no speaker)" do
+      before do
+        speech.role_appointment = nil
+      end
+
+      it "doesn't present a speaker link" do
+        refute(presented.links.has_key?(:speaker))
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/JNmI4cqs/612-speech-migration-3-write-sync-checks-and-run-it-for-speech

A Speech can have a nil `role_appointment` which effectively means it has no speaker.
So don't attempt to present the `speaker` link in this case.