### PR TITLE
Add migration to permanently remove News Article translations

### DIFF
--- a/db/data_migration/20170214074738_cleanup_news_article_translations.rb
+++ b/db/data_migration/20170214074738_cleanup_news_article_translations.rb
@@ -1,0 +1,21 @@
+gone_worker = PublishingApiGoneWorker.new
+url_maker = Whitehall::UrlMaker.new
+
+edition_locales_no_longer_available = {
+  462010 => :ur,
+  469420 => :es,
+  511083 => :sq,
+  522054 => :cy,
+  681937 => :es,
+}
+
+edition_locales_no_longer_available.each do |edition_id, locale|
+  edition = Edition.find(edition_id)
+
+  alternative_url = url_maker.public_document_url(edition)
+  explanation = 'This translation is no longer available. You can find ' +
+    'the original version of this content at ' +
+    "[#{alternative_url}](#{alternative_url})"
+
+  gone_worker.perform(edition.content_id, nil, explanation, locale)
+end


### PR DESCRIPTION
Cleans up News Articles translations that should have been deleted when the translation was removed.

[Trello](https://trello.com/c/sI8JxvNs)