### PR TITLE
Send speech body as html

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
 
     def details
       details = {
-        body: item.body,
+        body: body,
         political: item.political,
         delivered_on: item.delivered_on.iso8601,
         change_history: item.change_history.as_json,
@@ -51,6 +51,10 @@ module PublishingApi
     end
 
   private
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+    end
 
     def image_payload
       {

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -4,8 +4,7 @@ module SyncChecker
       def checks_for_live(_locale)
         checks = super + [
           Checks::LinksCheck.new(
-            "policies",
-            (edition_expected_in_live.try(:related_policies) || []).map(&:content_id)
+            "policies", edition_expected_in_live.policy_content_ids
           ),
           Checks::LinksCheck.new(
             "topical_events",

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -43,8 +43,17 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       create(:speech,
              title: "Speech title",
              summary: "The description",
-             body: "Some content",
+             body: "# Woo!\nSome content",
              role_appointment: role_appointment)
+    end
+
+    let(:expected_body) do
+      expected_body = <<-HTML.strip_heredoc
+      <div class="govspeak"><h1 id="woo">Woo!</h1>
+      <p>Some content</p>
+      </div>
+      HTML
+      expected_body.chomp
     end
 
     it "contains the expected values" do
@@ -55,7 +64,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
       details = presented.content[:details]
       refute(details[:political])
-      assert_equal("Some content",    details[:body])
+      assert_equal(expected_body,     details[:body])
       assert_match(iso8601_regex,     details[:delivered_on])
 
       assert_equal("The Government",  details[:government][:title])


### PR DESCRIPTION
https://trello.com/c/JNmI4cqs/612-speech-migration-3-write-sync-checks-and-run-it-for-speech

Another small change to the presenter to present body content similar to other formats.