### PR TITLE
Improve copy and design of new edit topics page

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -16,7 +16,7 @@ class Admin::EditionTagsController < Admin::BaseController
     )
 
     @edition_tag_form.publish!
-    redirect_to edit_admin_edition_tags_path(@edition),
+    redirect_to admin_edition_path(@edition),
       notice: "The tags have been updated."
   rescue GdsApi::HTTPConflict
     redirect_to edit_admin_edition_tags_path(@edition),

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -1,46 +1,40 @@
-<% page_title "Tagging: " + @edition.title %>
+<% page_title "Edit topics: " + @edition.title %>
 
 <div class="row">
-  <h1><%= @edition.title %></h1>
-  <h2>Edit topics</h2>
-  <p class="lead add-top-margin add-bottom-margin">
-    Edit topics for the new education taxonomy. Changes do not go through the review process.
-  </p>
-  <p class="lead add-top-margin add-bottom-margin">
-    Adding topics will include this content in the navigation beta.
-  </p>
-
-  <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
-    <%= form.hidden_field :previous_version %>
-
-    <div class="publishing-controls well">
-      <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
-    </div>
-
-    <p class="warning">
-      Warning: topic changes to published content appear instantly on the live site.
+  <div class="col-md-9">
+    <h1>Edit topics</h1>
+    <p class="lead add-top-margin add-bottom-margin">
+      <strong><%= @edition.title %></strong>
     </p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
+      <%= form.hidden_field :previous_version %>
 
-    <div class="form-group" data-module="taxonomy-tree-checkboxes">
-      <div class="topic-tree">
+      <div class="form-group" data-module="taxonomy-tree-checkboxes">
+        <div class="topic-tree">
 
-        <p class="bold-taxon-name">
-          <%= @edition_tag_form.education_taxons.name %>
-        </p>
+          <p class="bold-taxon-name">
+            <%= @edition_tag_form.education_taxons.name %>
+          </p>
 
-        <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
+          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
+        </div>
       </div>
-    </div>
 
-    <div class="content content-bordered hidden" data-module="breadcrumb-preview">
-    </div>
+      <h2>Selected topics</h2>
+      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
+      </div>
 
-    <p class="warning">
-      Warning: topic changes to published content appear instantly on the live site.
-    </p>
+      <p class="warning">
+        Warning: topic changes to published content appear instantly on the live site.
+      </p>
 
-    <div class="publishing-controls well">
-      <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
-    </div>
-  <% end %>
+      <div class="publishing-controls well">
+        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Various improvements following product review:

- Redirect back to the document overview after tagging
- Remove extra copy at the top of the page, we don't think it's necessary
- Remove additional buttons and warnings at the top of the page, so that there is a linear flow
  to the page
- Make "Edit topics" the title, rather than the page we're editing topics for
- Make the title element consistent with the actual title of the page
- Add "Selected topics" title to the topics preview box

This is branched off of https://github.com/alphagov/whitehall/pull/3053 - that should be merged  first. I've raised this separately because I don't want to clutter up that PR.

https://trello.com/c/h7TGge8t/465-change-the-tree-tagging-interface-in-whitehall-to-have-symmetric-checkbox-interactions

![edit_topics_product_review](https://cloud.githubusercontent.com/assets/87579/23172078/883aa8bc-f84c-11e6-8e60-0029342a0724.png)
