### PR TITLE
Add event tracking to checkboxes on topic tagging page

### DIFF
--- a/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
+++ b/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
@@ -43,11 +43,36 @@
       return $checkedSiblings.length > 0;
     };
 
+    var checkboxTrackClick = function(action, options) {
+      var root = window;
+      root.ga('send', 'event', {
+        eventCategory: options.eventCategory,
+        eventAction: action,
+        eventLabel: options.eventLabel,
+        eventValue: 1,
+        cd1: options.cd1,
+        cd2: options.cd2,
+        cd4: options.cd4
+      });
+    };
+
     this.start = function(element) {
-      $(element).on('click', 'input:checkbox', function() {
+      var $element = $(element);
+      var publicPath = $element.data("content-public-path");
+      var contentFormat = $element.data("content-format");
+      var contentId = $element.data("content-id");
 
-        var checked = $(this).is(":checked");
-
+      $element.on('click', 'input:checkbox', function() {
+        var $checkbox = $(this);
+        var checked = $checkbox.is(":checked");
+        var taxonName = $checkbox.data("taxon-name");
+        var options = {
+          eventCategory: "pageElementInteraction",
+          eventLabel: taxonName,
+          cd1: publicPath,
+          cd2: contentFormat,
+          cd4: contentId
+        }
         /*
         Checking a checkbox also checks all of the ancestor taxons.
         Unchecking a checkbox also unchecks all of the ancestor taxons,
@@ -56,8 +81,10 @@
         and the content could be shown to users seeking any of them.
         */
         if (checked) {
+          checkboxTrackClick("checkboxClickedOn", options);
           checkAncestors(this);
         } else {
+          checkboxTrackClick("checkboxClickedOff", options);
           uncheckDescendants(this);
 
           if (!hasCheckedSiblings(this)) {

--- a/app/helpers/admin/edition_tags_helper.rb
+++ b/app/helpers/admin/edition_tags_helper.rb
@@ -9,6 +9,7 @@ module Admin::EditionTagsHelper
       taxon.content_id,
       checked,
       id: taxon.content_id,
+      "data-taxon-name" => taxon.name,
       "data-ancestors": taxon.breadcrumb_trail.map(&:name).join('|')
     )
   end

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -13,7 +13,12 @@
     <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
       <%= form.hidden_field :previous_version %>
 
-      <div class="form-group" data-module="taxonomy-tree-checkboxes">
+      <div class="form-group"
+        data-module="taxonomy-tree-checkboxes"
+        data-content-id="<%= @edition.content_id %>"
+        data-content-format="<%= @edition.display_type %>"
+        data-content-public-path="<%= public_document_path(@edition) %>">
+
         <div class="topic-tree">
 
           <p class="bold-taxon-name">


### PR DESCRIPTION
This sends data to Google Analytics when taxon checkboxes are checked or
unchecked. The data sent includes:

- whether the checkbox is checked or unchecked
- the taxon name of the checkbox
- the public path of the document
- the content format of the document
- the content id of the document

Trello card: https://trello.com/c/pbtbMZer/469-add-event-tracking-to-checkboxes-on-topic-tagging-page

Paired with @Davidslv 