### PR TITLE
Use `links#policies` 

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
         [
           :organisations,
           :parent,
-          :related_policies,
+          :policies,
           :topics,
           :world_locations,
           :worldwide_organisations,

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
     def links
       LinksPresenter
         .new(consultation)
-        .extract(%i(organisations parent policy_areas related_policies topics))
+        .extract(%i(organisations parent policy_areas policies topics))
     end
 
   private

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -35,7 +35,7 @@ module PublishingApi
           :organisations,
           :parent,
           :policy_areas,
-          :related_policies,
+          :policies,
           :topics,
         ]
       ).merge(

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -30,7 +30,7 @@ module PublishingApi
 
     def links
       links = LinksPresenter.new(item).extract(
-        %i(organisations policy_areas topics related_policies parent)
+        %i(organisations policy_areas topics policies parent)
       )
       links.merge!(documents: item.documents.map(&:content_id))
       links.merge!(PayloadBuilder::TopicalEvents.for(item))

--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -4,6 +4,7 @@ module PublishingApi
       organisations: :organisation_ids,
       policy_areas: :policy_area_ids,
       related_policies: :related_policy_ids,
+      policies: :policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
       topics: :topic_content_ids,
       parent: :parent_content_ids,
@@ -34,6 +35,7 @@ module PublishingApi
     def related_policy_ids
       item.try(:policy_content_ids) || []
     end
+    alias :policy_ids :related_policy_ids
 
     def statistical_data_set_ids
       (item.try(:statistical_data_sets) || []).map(&:content_id)

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -36,7 +36,7 @@ module PublishingApi
         organisations
         parent
         policy_areas
-        related_policies
+        policies
         topics
         world_locations
       )

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -39,7 +39,7 @@ module PublishingApi
           :organisations,
           :world_locations,
           :policy_areas,
-          :related_policies,
+          :policies,
         ]
       ).merge(
         PayloadBuilder::TopicalEvents.for(item)

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -44,8 +44,7 @@ module PublishingApi
     end
 
     def links
-      links = LinksPresenter.new(item).extract([:organisations, :policy_areas])
-      links.merge!(links_for_policies)
+      links = LinksPresenter.new(item).extract([:organisations, :policy_areas, :policies])
       links.merge!(links_for_speaker)
       links.merge!(links_for_topical_events)
     end
@@ -63,10 +62,6 @@ module PublishingApi
           url: speaker.image.url,
         }
       }
-    end
-
-    def links_for_policies
-      { policies: item.policy_content_ids }
     end
 
     def links_for_speaker

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -104,7 +104,7 @@ module SyncChecker
             (edition_expected_in_live.try(:topics) || []).map(&:content_id)
           ),
           Checks::LinksCheck.new(
-            "related_policies",
+            "policies",
             (edition_expected_in_live.try(:policies) || []).map(&:content_id)
           ),
           Checks::DetailsCheck.new(

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -4,9 +4,6 @@ module SyncChecker
       def checks_for_live(_locale)
         checks = super + [
           Checks::LinksCheck.new(
-            "policies", edition_expected_in_live.policy_content_ids
-          ),
-          Checks::LinksCheck.new(
             "topical_events",
             ::TopicalEvent
               .joins(:classification_memberships)

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -45,7 +45,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
     expected_links = {
       organisations: case_study.lead_organisations.map(&:content_id),
-      related_policies: [],
+      policies: [],
       topics: [],
       parent: [],
       world_locations: [],
@@ -136,7 +136,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     presented_item = present(case_study)
     expected_links_hash = {
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
-      related_policies: [],
+      policies: [],
       topics: [],
       parent: [],
       world_locations: [],
@@ -180,12 +180,12 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     assert_equal [wworg.content_id], presented_item.links[:worldwide_organisations]
   end
 
-  test 'links hash includes related policies' do
+  test 'links hash includes policies' do
     case_study = create(:published_case_study, policy_content_ids: [policy_1["content_id"]])
     presented_item = present(case_study)
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'case_study')
-    assert_equal [policy_area_1["content_id"], policy_1["content_id"]], presented_item.links[:related_policies]
+    assert_equal [policy_area_1["content_id"], policy_1["content_id"]], presented_item.links[:policies]
   end
 
   test "an unpublished document has a first_public_at of the document creation time" do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -81,7 +81,7 @@ module PublishingApi::ConsultationPresenterTest
         organisations
         parent
         policy_areas
-        related_policies
+        policies
         topics
       )
 

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -73,7 +73,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       organisations: detailed_guide.organisations.map(&:content_id),
       topics: [],
       parent: [],
-      related_policies: ["dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8"],
+      policies: ["dc6d2e0e-8f5d-4c3f-aaea-c890e07d0cf8"],
       policy_areas: detailed_guide.topics.map(&:content_id),
       related_guides: [],
       related_mainstream_content: [],

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -263,10 +263,10 @@ class PublishingApi::PublishedDocumentCollectionPresenterRelatedPolicyLinksTest 
     @presented_links = presented_document_collection.links
   end
 
-  test "it presents the policy_content_ids as links, related_policies" do
+  test "it presents the policy_content_ids as links, policies" do
     assert_equal(
       @document_collection.policy_content_ids,
-      @presented_links[:related_policies]
+      @presented_links[:policies]
     )
   end
 end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -85,7 +85,7 @@ module PublishingApi::NewsArticlePresenterTest
         organisations
         parent
         policy_areas
-        related_policies
+        policies
         topics
         world_locations
       )

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -67,7 +67,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       related_statistical_data_sets: [statistical_data_set.content_id],
       world_locations: [],
       topical_events: [topical_event.content_id],
-      related_policies: ['5d37821b-7631-11e4-a3cb-005056011aef'],
+      policies: ['5d37821b-7631-11e4-a3cb-005056011aef'],
       policy_areas: publication.topics.map(&:content_id)
     }
 
@@ -116,7 +116,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       related_statistical_data_sets: [],
       topical_events: [],
       policy_areas: publication.topics.map(&:content_id),
-      related_policies: []
+      policies: []
     }
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'publication')


### PR DESCRIPTION
https://github.com/alphagov/govuk-content-schemas/pull/532 makes all Whitehall formats consistently use `links#policies` rather than `links#related_policies`. 

This PR updates the format presenters to use the correct link name and the sync checks for edition formats to check it correctly.

Needs [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/532) to be deployed to get the tests to pass.