### PR TITLE
Sort topics on tagging form, and fix nil taxons bug

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -11,7 +11,7 @@ class Admin::EditionTagsController < Admin::BaseController
   def update
     @edition_tag_form = EditionTaxonomyTagForm.new(
       edition_content_id: @edition.content_id,
-      selected_taxons: params["edition_taxonomy_tag_form"]["taxons"].reject(&:blank?),
+      selected_taxons: params["edition_taxonomy_tag_form"].fetch("taxons", []).reject(&:blank?),
       previous_version: params["edition_taxonomy_tag_form"]["previous_version"]
     )
 

--- a/lib/taxonomy.rb
+++ b/lib/taxonomy.rb
@@ -14,7 +14,7 @@ module Taxonomy
   # https://github.com/alphagov/govuk_taxonomy_helpers/pull/1
   class LinkedEdition
     extend Forwardable
-    attr_reader :name, :content_id, :base_path, :children
+    attr_reader :name, :content_id, :base_path
     attr_accessor :parent_node
     def_delegators :tree, :map, :each
 
@@ -23,6 +23,10 @@ module Taxonomy
       @content_id = content_id
       @base_path = base_path
       @children = []
+    end
+
+    def children
+      @children.sort_by(&:name)
     end
 
     def <<(child_node)

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -44,6 +44,14 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     assert_publishing_api_patch_links(@edition.content_id, links: { taxons: [child_taxon_content_id] }, previous_version: "1")
   end
 
+  test 'should post empty array to publishing api if no taxons are selected' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+
+    put :update, edition_id: @edition, edition_taxonomy_tag_form: { previous_version: 1 }
+
+    assert_publishing_api_patch_links(@edition.content_id, links: { taxons: [] }, previous_version: "1")
+  end
+
   view_test 'should check a child taxon and its parents when only a child taxon is returned' do
     stub_publishing_api_links_with_taxons(@edition.content_id, [child_taxon_content_id])
 


### PR DESCRIPTION
- Topics should be displayed alphabetically
- When no taxons are selected, default to an empty array

There are no tests for Taxonomy module because we're going to replace it
with https://github.com/alphagov/govuk_taxonomy_helpers soon.

https://trello.com/c/h7TGge8t/465-change-the-tree-tagging-interface-in-whitehall-to-have-symmetric-checkbox-interactions