### PR TITLE
Revert "Remove Consultation presentation"

### DIFF
--- a/app/assets/stylesheets/frontend/base.scss
+++ b/app/assets/stylesheets/frontend/base.scss
@@ -92,6 +92,7 @@
 
 #whitehall-wrapper {
   @import "views/_biographical-page";
+  @import "views/_consultations";
   @import "views/_corporate-information-pages-worldwide-organisation";
   @import "views/_document-collection";
   @import "views/_email-signup";

--- a/app/assets/stylesheets/frontend/helpers/_browse.scss
+++ b/app/assets/stylesheets/frontend/helpers/_browse.scss
@@ -1,4 +1,4 @@
-.publications-index {
+.consultations-index, .publications-index {
 
   .block-3, .block-4 {
     float: left;

--- a/app/assets/stylesheets/frontend/views/_consultations.scss
+++ b/app/assets/stylesheets/frontend/views/_consultations.scss
@@ -1,0 +1,134 @@
+.consultation {
+  &.consultation-closed,
+  &.consultation-responded {
+    .status-block {
+      border-color: $govuk-blue;
+      margin: 0 $gutter-half ($gutter * 1.5) $gutter-half;
+      @include media(tablet) {
+        margin: 0 $gutter ($gutter * 1.5) $gutter;
+        h2 {
+          padding-top: 0;
+        }
+      }
+      p {
+        @include core-16;
+      }
+    }
+  }
+  &.consultation-responded {
+    .status-block {
+      h2 {
+        @include media(tablet) {
+          padding-bottom: 0;
+        }
+      }
+    }
+  }
+
+  .original-consultation {
+    @include heading-27;
+    border-top: 1px solid $border-colour;
+    font-weight: bold;
+    margin-bottom: $gutter-half;
+    padding-top: $gutter-half;
+    @include media(tablet) {
+      margin: $gutter-half;
+      padding-top: $gutter-half;
+    }
+  }
+
+  .consultation-block {
+    @extend %contain-floats;
+    @include white-links;
+    background: $govuk-blue;
+    color: $white;
+    padding: $gutter-half;
+    margin-bottom: $gutter * 1.5;
+    @include media(tablet) {
+      padding: $gutter;
+      margin: 0 $gutter-half $gutter*1.5;
+    }
+
+    .consultation-dates {
+      @include media(tablet) {
+        float: left;
+        width: $one-third;
+      }
+      p {
+        span {
+          display: block;
+          time {
+            @include core-24(1.4em);
+            &.date {
+              font-weight: bold;
+            }
+          }
+        }
+        @include media(tablet) {
+          padding-right: $gutter;
+        }
+      }
+    }
+
+    .consultation-summary {
+      @include media(tablet) {
+        float: left;
+        margin-top: 0;
+        width: $two-thirds;
+      }
+      .consultation-summary-inner {
+        border-top: 1px solid $white;
+        padding-top: $gutter-half;
+        margin-top: $gutter-half;
+
+        @include media(tablet) {
+          border-top: 0;
+          padding-top: 0;
+          margin-top: 0;
+          border-left: 1px solid $white;
+          padding-left: $gutter-half;
+          margin-left: -$gutter-half + 1px;
+        }
+      }
+      h2 {
+        @include heading-27;
+        font-weight: bold;
+        padding-top: 0;
+      }
+      h3 {
+        @include heading-24;
+        font-weight: bold;
+      }
+      p {
+        @include core-19;
+      }
+    }
+  }
+
+  .consultation-response {
+    margin-bottom: $gutter-half;
+  }
+
+  .participation {
+    .content {
+      @include core-19;
+    }
+    dd,
+    p {
+      margin-bottom: $gutter-half;
+    }
+    dt {
+      font-weight: bold;
+    }
+    .online {
+      @include core-24;
+      font-weight: bold;
+    }
+  }
+}
+
+.consultation-closed {
+  .original-consultation {
+    border-top: 0;
+  }
+}

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -3,4 +3,16 @@ class ConsultationsController < DocumentsController
     filter_params = params.except(:controller, :action, :format, :_)
     redirect_to publications_path(filter_params.merge(publication_filter_option: 'consultations'))
   end
+
+  def show
+    @related_policies = document_related_policies
+    set_meta_description(@document.summary)
+    expire_on_open_state_change(@document)
+  end
+
+  private
+
+  def document_class
+    Consultation
+  end
 end

--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -10,7 +10,7 @@ class ConsultationsController < DocumentsController
     expire_on_open_state_change(@document)
   end
 
-  private
+private
 
   def document_class
     Consultation

--- a/app/helpers/cache_control_helper.rb
+++ b/app/helpers/cache_control_helper.rb
@@ -11,6 +11,14 @@ module CacheControlHelper
     end
   end
 
+  def expire_on_open_state_change(consultation)
+    if consultation.opening_at.present? && consultation.opening_at >= Time.zone.now
+      expires_in max_age_for(consultation.opening_at), public: true
+    elsif consultation.closing_at.present? && consultation.closing_at >= Time.zone.now
+      expires_in max_age_for(consultation.closing_at), public: true
+    end
+  end
+
   def max_age_for(scheduled_publication)
     seconds_away = scheduled_publication - Time.zone.now
     if seconds_away > cache_max_age

--- a/app/helpers/consultations_helper.rb
+++ b/app/helpers/consultations_helper.rb
@@ -1,0 +1,13 @@
+module ConsultationsHelper
+  def consultation_css_class(consultation)
+    consultation_class = ''
+    if consultation.outcome_published?
+      consultation_class = 'consultation-responded'
+    elsif consultation.closed?
+      consultation_class = 'consultation-closed'
+    elsif consultation.open?
+      consultation_class = 'consultation-open'
+    end
+    "consultation #{consultation_class}"
+  end
+end

--- a/app/views/consultations/_document_summary.html.erb
+++ b/app/views/consultations/_document_summary.html.erb
@@ -1,0 +1,9 @@
+<div class="consultation-summary">
+  <div class="consultation-summary-inner">
+    <h2>Summary</h2>
+    <p><%= @document.summary %></p>
+    <% if @document.external? %>
+      <h3>This consultation <%= @document.open? ? 'is being' : 'was' %> held on <%= link_to "another website", @document.external_url, rel: "external" %></h3>
+    <% end %>
+  </div>
+</div>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -1,0 +1,172 @@
+<% page_title edition_page_title(@document), "Consultations" %>
+<% page_class consultation_css_class(@document) %>
+
+<%= content_tag_for :article, @document, nil, class: "document-page #{@document.type.downcase}" do %>
+  <header class="headings-block">
+    <div class="inner-block floated-children">
+      <%= render  partial: "documents/header", locals: {
+                    document: @document,
+                    footer_meta: true,
+                    header_title: @document.display_type,
+                    policies: @related_policies
+                  } %>
+    </div>
+
+    <% if @document.closed? %>
+      <div class="status-block">
+        <% if @document.outcome_published? %>
+          <h2>This consultation has concluded</h2>
+        <% else %>
+          <h2>We are analysing your feedback</h2>
+          <p>Visit this page again soon to download the outcome to this public feedback.</p>
+        <% end %>
+      </div>
+    <% end %>
+
+  </header>
+
+  <div class="heading-block">
+    <div class="inner-block">
+      <% if @document.open? %>
+        <div class="consultation-block <%= consultation_css_class(@document) %>">
+          <div class="consultation-dates">
+            <p>This consultation closes on <span><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+          </div>
+
+          <%= render partial: "document_summary", locals: { document: @document } %>
+        </div>
+      <% else %>
+        <% if @document.outcome_published? %>
+          <%= content_tag_for(:div, @document.outcome, class: 'consultation-response') do %>
+            <% if @document.outcome.attachments.any? %>
+              <%= render partial: "documents/attachment_full_width",
+                         locals: {
+                           document: @document.outcome,
+                           title: "Download the full outcome",
+                           summary: nil
+                         } %>
+            <% end %>
+            <% if @document.outcome.summary.present? %>
+              <section class="consultation-response-summary">
+                <div class="head-section">
+                  <h1>Detail of outcome</h1>
+                </div>
+                <div class="content">
+                  <article>
+                    <%= govspeak_to_html @document.outcome.summary %>
+                  </article>
+                </div>
+              </section>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <% if @document.public_feedback.present? %>
+          <%= content_tag_for(:div, @document.public_feedback, class: 'consultation-response') do %>
+            <% if @document.public_feedback.attachments.any? %>
+              <%= render partial: "documents/attachment_full_width",
+                        locals: { document: @document.public_feedback,
+                          title: "Feedback received",
+                          published_on: @document.public_feedback.published_on,
+                          summary: nil } %>
+            <% end %>
+
+            <section class="consultation-response-summary">
+              <div class="head-section">
+                <h1>Detail of feedback received</h1>
+              </div>
+              <div class="content">
+                <article>
+                  <%= govspeak_to_html @document.public_feedback.summary %>
+                </article>
+              </div>
+            </section>
+          <% end %>
+        <% end %>
+
+        <% if @document.closed? %>
+          <h2 class="original-consultation">Original consultation</h2>
+          <div class="consultation-block <%= consultation_css_class(@document) %>">
+            <div class="consultation-dates">
+              <p>This consultation ran from <span><%= absolute_time(@document.opening_at, class: 'opening-at') %> to<br><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+            </div>
+            <%= render partial: "document_summary", locals: { document: @document } %>
+          </div>
+        <% elsif @document.not_yet_open? && @document.opening_at.present? %>
+          <div class="status-block">
+            <h2>This consultation opens on <%= absolute_time(@document.opening_at, class: 'opening-at') %></h2>
+          </div>
+          <div class="consultation-block <%= consultation_css_class(@document) %>">
+            <div class="consultation-dates">
+              <p>This consultation opens on<br><span><%= absolute_time(@document.opening_at, class: 'opening-at') %></span></p>
+              <p>It closes on<br><span><%= absolute_time(@document.closing_at, class: 'closing-at') %></span></p>
+            </div>
+
+            <%= render partial: "document_summary", locals: { document: @document } %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <% if @document.attachments.any? %>
+        <%= render partial: "documents/attachment_full_width",
+                   locals: { document: @document, title: 'Documents' } %>
+      <% end %>
+
+      <section>
+        <div class="head-section">
+          <h1>Consultation description</h1>
+        </div>
+        <div class="content">
+          <article>
+            <%= govspeak_edition_to_html @document %>
+          </article>
+        </div>
+      </section>
+
+      <% unless @document.external? %>
+        <% if @document.open? && @document.has_consultation_participation? %>
+          <section id="response-formats" class="participation">
+            <div class="head-section">
+              <h1>Ways to respond</h1>
+            </div>
+            <div class="content">
+              <article>
+                <% if @document.consultation_participation.has_link? %>
+                  <p class="online"><%= link_to 'Respond online', @document.consultation_participation.link_url %></p>
+                <% end %>
+                <% if @document.consultation_participation.has_link? and (@document.consultation_participation.has_postal_address? or @document.consultation_participation.has_email?) %>
+                  <p class="or">or</p>
+                <% end %>
+                <% if @document.consultation_participation.has_email? or @document.consultation_participation.has_postal_address? %>
+                  <% if @document.consultation_participation.has_response_form? %>
+                    <p class="response-form">
+                      Complete a
+                      <%= link_to 'response form', @document.consultation_participation.consultation_response_form.file.url %>
+                      and either
+                    </p>
+                  <% end %>
+                  <dl>
+                    <% if @document.consultation_participation.has_email? %>
+                      <dt>Email to:</dt>
+                      <dd class="email"><%= mail_to @document.consultation_participation.email %></dd>
+                    <% end %>
+                    <% if @document.consultation_participation.has_postal_address? %>
+                      <dt>Write to:</dt>
+                      <dd class="postal-address"><%= format_with_html_line_breaks @document.consultation_participation.postal_address %></dd>
+                    <% end %>
+                  </dl>
+                <% end %>
+              </article>
+            </div>
+          </section>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+  <div class="inner-block">
+    <%= render partial: 'documents/share_links', locals: { document: @document } %>
+  </div>
+  <div class="inner-block">
+    <%= render partial: 'documents/document_footer_meta', locals: { document: @document, policies: @related_policies } %>
+  </div>
+<% end %>

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -17,20 +17,27 @@ Scenario: Publishing a submitted consultation
   And a submitted consultation "Beard Length Review" exists
   When I publish the consultation "Beard Length Review"
   Then I should see the consultation "Beard Length Review" in the list of published documents
+  And the consultation "Beard Length Review" should be visible to the public
+
+Scenario: Viewing an unopened consultation
+  Given I am an editor
+  And an unopened consultation exists
+  When I visit the consultation
+  Then the date the consultation opens should be viewable
 
 Scenario: Adding an outcome to a closed consultation
   Given I am an editor
   And a closed consultation exists
   When I add an outcome to the consultation
   And I save and publish the amended consultation
-  Then I can see that the consultation has been published
+  Then the consultation outcome should be viewable
 
 Scenario: Adding public feedback to a closed consultation
   Given I am an editor
   And a closed consultation exists
   When I add public feedback to the consultation
   And I save and publish the amended consultation
-  Then I can see that the consultation has been published
+  Then the public feedback should be viewable
 
 @javascript
 Scenario: Associating an offsite consultation with topical events

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -42,6 +42,7 @@ Scenario: Associating a consultation with a topical event
   When I draft a new consultation "A Consultation" relating it to topical event "An Event"
   And I force publish the consultation "A Consultation"
   Then I should see the consultation "A Consultation" in the consultations section of the topical event "An Event"
+  And the consultation "A Consultation" shows it is related to the topical event "An Event" on its public page
 
 Scenario: Featuring news on an topical event page
   Given a topical event called "An Event" with description "A topical event"

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -24,9 +24,13 @@ class ConsultationsControllerTest < ActionController::TestCase
 
   view_test 'show displays the summary of the published consultation response when there are response attachments' do
     closed_consultation = create(:published_consultation, opening_at: 2.days.ago, closing_at: 1.day.ago)
-    response = create(:consultation_outcome, consultation: closed_consultation, attachments: [
-      response_attachment = build(:file_attachment)
-    ])
+    response = create(
+      :consultation_outcome,
+      consultation: closed_consultation,
+      attachments: [
+        build(:file_attachment)
+      ]
+    )
 
     get :show, id: closed_consultation.document
 
@@ -60,7 +64,8 @@ class ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'show displays consultation participation link and email' do
-    consultation_participation = create(:consultation_participation,
+    consultation_participation = create(
+      :consultation_participation,
       link_url: "http://telluswhatyouthink.com",
       email: "contact@example.com"
     )
@@ -80,7 +85,8 @@ class ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'show does not display consultation participation email if none available' do
-    consultation_participation = create(:consultation_participation,
+    consultation_participation = create(
+      :consultation_participation,
       link_url: "http://telluswhatyouthink.com"
     )
     published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
@@ -89,7 +95,8 @@ class ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'show does not display consultation participation link if consultation finished' do
-    consultation_participation = create(:consultation_participation,
+    consultation_participation = create(
+      :consultation_participation,
       email: "contact@example.com",
       link_url: "http://telluswhatyouthink.com"
     )
@@ -100,11 +107,15 @@ class ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'show displays the postal address for participation' do
-    address = %q{123 Example Street
-London N123}
-    consultation_participation = create(:consultation_participation,
-                                        postal_address: address
-                                        )
+    address = <<-ADD.strip_heredoc
+      123 Example Street
+      London N123
+      ADD
+
+    consultation_participation = create(
+      :consultation_participation,
+      postal_address: address
+    )
     published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
     get :show, id: published_consultation.document
 

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -2,9 +2,114 @@ require "test_helper"
 
 class ConsultationsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
+  should_display_attachments_for :consultation
+  should_display_localised_attachments
+  should_display_inline_images_for :consultation
+  should_show_inapplicable_nations :consultation
+  should_set_meta_description_for :consultation
+  should_set_slimmer_analytics_headers_for :consultation
+  should_set_the_article_id_for_the_edition_for :consultation
+  should_show_share_links_for :consultation
 
   test 'index redirects to the publications index filtering consultations, retaining any other filter params' do
     get :index, topics: ["a-topic-slug"], departments: ['an-org-slug']
     assert_redirected_to publications_path(publication_filter_option: Whitehall::PublicationFilterOption::Consultation.slug, topics: ["a-topic-slug"], departments: ['an-org-slug'])
+  end
+
+  test 'show displays published consultations' do
+    published_consultation = create(:published_consultation)
+    get :show, id: published_consultation.document
+    assert_response :success
+  end
+
+  view_test 'show displays the summary of the published consultation response when there are response attachments' do
+    closed_consultation = create(:published_consultation, opening_at: 2.days.ago, closing_at: 1.day.ago)
+    response = create(:consultation_outcome, consultation: closed_consultation, attachments: [
+      response_attachment = build(:file_attachment)
+    ])
+
+    get :show, id: closed_consultation.document
+
+    assert_select '.consultation-response-summary article', text: response.summary
+  end
+
+  view_test 'show displays consultation dates when consultation has finished' do
+    opening_at = Time.zone.local(2011, 8, 10, 8, 15)
+    closing_at = Time.zone.local(2011, 11, 1, 19, 45)
+
+    published_consultation = create(:published_consultation, opening_at: opening_at, closing_at: closing_at)
+    get :show, id: published_consultation.document
+
+    assert_select ".opening-at[datetime='#{opening_at.iso8601}']"
+    assert_select ".closing-at[datetime='#{closing_at.iso8601}']"
+  end
+
+  view_test 'show displays consultation closing date on open consultation' do
+    closing_at = Time.zone.now + 2.days
+    published_consultation = create(:published_consultation, opening_at: DateTime.new(2010, 1, 1), closing_at: closing_at)
+    get :show, id: published_consultation.document
+    assert_select ".closing-at[datetime='#{closing_at.iso8601}']"
+  end
+
+  view_test "should not explicitly say that consultation applies to the whole of the UK" do
+    published_consultation = create(:published_consultation)
+
+    get :show, id: published_consultation.document
+
+    refute_select inapplicable_nations_selector
+  end
+
+  view_test 'show displays consultation participation link and email' do
+    consultation_participation = create(:consultation_participation,
+      link_url: "http://telluswhatyouthink.com",
+      email: "contact@example.com"
+    )
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
+    get :show, id: published_consultation.document
+    assert_select ".participation" do
+      assert_select ".online a[href=?]", "http://telluswhatyouthink.com", text: "Respond online"
+      assert_select ".email a[href=?]", "mailto:contact@example.com", text: "contact@example.com"
+    end
+  end
+
+  view_test 'show does not display consultation participation link if none available' do
+    consultation_participation = create(:consultation_participation, email: "contact@example.com")
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
+    get :show, id: published_consultation.document
+    refute_select ".participation .online"
+  end
+
+  view_test 'show does not display consultation participation email if none available' do
+    consultation_participation = create(:consultation_participation,
+      link_url: "http://telluswhatyouthink.com"
+    )
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
+    get :show, id: published_consultation.document
+    refute_select ".participation .email"
+  end
+
+  view_test 'show does not display consultation participation link if consultation finished' do
+    consultation_participation = create(:consultation_participation,
+      email: "contact@example.com",
+      link_url: "http://telluswhatyouthink.com"
+    )
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation, opening_at: 4.days.ago, closing_at: 2.days.ago)
+    get :show, id: published_consultation.document
+    refute_select ".participation .online"
+    refute_select ".participation .email"
+  end
+
+  view_test 'show displays the postal address for participation' do
+    address = %q{123 Example Street
+London N123}
+    consultation_participation = create(:consultation_participation,
+                                        postal_address: address
+                                        )
+    published_consultation = create(:published_consultation, consultation_participation: consultation_participation)
+    get :show, id: published_consultation.document
+
+    assert_select ".participation" do
+      assert_select ".postal-address", html: "123 Example Street<br>London N123"
+    end
   end
 end

--- a/test/integration/document_locale_param_canonicalisation_test.rb
+++ b/test/integration/document_locale_param_canonicalisation_test.rb
@@ -15,6 +15,7 @@ class DocumentLocaleParamCanonicalisationTest < ActionDispatch::IntegrationTest
   normal_document_types = [
     "world_location_news_article",
     "publication",
+    "consultation",
   ]
 
   (announcement_redir_document_types + document_types_with_no_index + normal_document_types).each do |doc_type|

--- a/test/unit/helpers/cache_control_helper_test.rb
+++ b/test/unit/helpers/cache_control_helper_test.rb
@@ -32,4 +32,22 @@ class CacheControlHelperTest < ActionView::TestCase
   test "never sends an expiry time longer than the default max cache time" do
     assert_equal Whitehall.default_cache_max_age, @controller.max_age_for(Whitehall.default_cache_max_age.from_now + 1.second)
   end
+
+  test "#expire_on_open_state_change should expire cache when upcoming consultation opens" do
+    consultation = build(:consultation, opening_at: 20.seconds.from_now, closing_at: 10.days.from_now)
+    @controller.expects(:expires_in).with(20, public: true)
+    @controller.expire_on_open_state_change(consultation)
+  end
+
+  test "#expire_on_open_state_change should expire cache when an open consultation closes" do
+    consultation = build(:consultation, opening_at: 10.days.ago, closing_at: 10.seconds.from_now)
+    @controller.expects(:expires_in).with(10, public: true)
+    @controller.expire_on_open_state_change(consultation)
+  end
+
+  test "#expire_on_open_state_change should not do anything for a finished consultation" do
+    consultation = build(:consultation, opening_at: 20.days.ago, closing_at: 10.days.ago)
+    @controller.expects(:expires_in).never
+    @controller.expire_on_open_state_change(consultation)
+  end
 end

--- a/test/unit/helpers/consultations_helper_test.rb
+++ b/test/unit/helpers/consultations_helper_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class ConsultationsHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "#consultation_css_class when an outcome exists" do
+    consultation = Consultation.new
+    consultation.build_outcome
+    assert_equal 'consultation consultation-responded', consultation_css_class(consultation)
+  end
+
+  test "#consultation_css_class when closed" do
+    consultation = Consultation.new
+    consultation.stubs(:outcome_published?).returns(false)
+    consultation.stubs(:closed?).returns(true)
+    assert_equal 'consultation consultation-closed', consultation_css_class(consultation)
+  end
+
+  test "#consultation_css_class when open" do
+    consultation = Consultation.new
+    consultation.stubs(:outcome_published?).returns(false)
+    consultation.stubs(:closed?).returns(false)
+    consultation.stubs(:open?).returns(true)
+    assert_equal 'consultation consultation-open', consultation_css_class(consultation)
+  end
+
+  test "#consultation_css_class when not-started" do
+    consultation = Consultation.new
+    consultation.stubs(:outcome_published?).returns(false)
+    consultation.stubs(:closed?).returns(false)
+    consultation.stubs(:open?).returns(false)
+    assert_equal 'consultation ', consultation_css_class(consultation)
+  end
+end


### PR DESCRIPTION
Reverts alphagov/whitehall#3006 We need to contnue to use Whitehall for preview until we implement the draft links as consultations can have `HtmlAttachment`s.