### PR TITLE
Set `Consultation` rendering app to Whitehall

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -66,7 +66,10 @@ class Consultation < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    # TODO rendered by Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    # but we need to return WHITEHALL_FRONTEND here to continue to use
+    # Whitehall for preview until draft links are implemented
+    Whitehall::RenderingApp::WHITEHALL_FRONTEND
   end
 
   def allows_inline_attachments?


### PR DESCRIPTION
We need to continue render `Consultation` preview from Whitehall for now as the format has attachments which require links.

When we implement the draft link functionality from Publishing API we can revert this commit.

Preview relies on the `Consultation#rendering_app` so returning `WHITEHALL_FRONTEND` from there will have the required effect.