### PR TITLE
Add feedback link to the topic tagging page

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
+++ b/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
@@ -22,3 +22,7 @@
   border-left: 1px solid #aaa;
   margin-left: 6px;
 }
+
+.feedback-link {
+  font-size: 16px;
+}

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -24,6 +24,10 @@
         </div>
       </div>
 
+      <p>
+        <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
+      </p>
+
       <h2>Selected topics</h2>
       <div class="content content-bordered hidden" data-module="breadcrumb-preview">
       </div>

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -34,6 +34,10 @@ module Whitehall
     Plek.new.website_uri.scheme
   end
 
+  def self.support_url
+    Plek.find('support')
+  end
+
   def self.available_locales
     [
       :en, :ar, :az, :be, :bg, :bn, :cs, :cy, :de, :dr, :el,


### PR DESCRIPTION
Added a link after the taxon checkboxes for editors to provide feedback.
This link takes the user to the homepage of the Support app.

Trello card:
https://trello.com/c/FscG0WuL/468-add-a-feedback-link-to-the-topic-tagging-page
![screen shot 2017-02-22 at 16 02 16](https://cloud.githubusercontent.com/assets/12881990/23221658/8c25f752-f91d-11e6-8402-4ced0c2fe38c.png)
