### PR TITLE
Prevent page crashing when edition has no expanded_links

### DIFF
--- a/app/services/expanded_links_fetcher.rb
+++ b/app/services/expanded_links_fetcher.rb
@@ -9,6 +9,18 @@ class ExpandedLinksFetcher
     ExpandedLinks.new(
       Whitehall.publishing_api_v2_client.get_expanded_links(content_id)
     )
+
+  rescue GdsApi::HTTPNotFound
+    MissingExpandedLinks.new
+  end
+
+  # TODO: This is a workaround, because Publishing API
+  # returns 404 when the document exists but there are no links
+  # This can be removed when that changes.
+  class MissingExpandedLinks
+    def selected_taxon_paths
+      []
+    end
   end
 
   class ExpandedLinks

--- a/test/unit/services/expanded_links_fetcher_test.rb
+++ b/test/unit/services/expanded_links_fetcher_test.rb
@@ -1,6 +1,24 @@
 require 'test_helper'
 
 class ExpandedLinksFetcherTest < ActiveSupport::TestCase
+  test "it returns '[]' if there are no expanded_links" do
+    content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
+
+    body = {
+      "error" => {
+        "code" => 404,
+        "message" => "Could not find link set with content_id: #{content_id}"
+      }
+    }.to_json
+
+    stub_request(:get, %r{.*/v2/expanded-links/#{content_id}.*})
+      .to_return(body: body, status: 404)
+
+    links_fetcher = ExpandedLinksFetcher.new(content_id)
+
+    assert_equal links_fetcher.fetch.selected_taxon_paths, []
+  end
+
   test "it returns '[]' if there are no taxons" do
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",


### PR DESCRIPTION
On whitehall, when a user creates a new document, and that document is then associated with an Education organisation (under lead organisations) and saves the page, it crashes the next page.

This is because 

>A draft can be tagged by the new taxonomy tagging form, but it doesn't receive other kinds of tags (set in the edit form) until publish time. All the tags except for taxons are coupled to the 2i workflow at the moment.

This commit rescues `GdsApi::HTTPNotFound ` and uses a new object, `MissingExpandedLinks`,
this object is responsible to solely return an empty array and prevent the view to crash.

Trello:
https://trello.com/c/nsuNcWNC/504-fix-bug-with-editing-a-draft-document-and-expanded-links

### Before
![screen shot 2017-02-22 at 18 16 26](https://cloud.githubusercontent.com/assets/136777/23225812/25e2ca34-f92b-11e6-9fa2-bb4a5a9b4a02.png)

### After

![screen shot 2017-02-22 at 18 16 49](https://cloud.githubusercontent.com/assets/136777/23225813/25f80782-f92b-11e6-9c4b-9eef242e481a.png)

