### PR TITLE
Republish remaining Publications

### DIFF
--- a/db/data_migration/20170223094749_republish_publications_migration_three.rb
+++ b/db/data_migration/20170223094749_republish_publications_migration_three.rb
@@ -1,0 +1,17 @@
+document_scope = Document.where(
+  id: Publication.where(state: %w(draft published withdrawn)).pluck(:document_id)
+)
+
+lowest_id_for_this_republish = 0
+highest_id_for_this_republish = 260000
+document_scope = document_scope.where(
+  id: lowest_id_for_this_republish..highest_id_for_this_republish
+).order(id: :desc)
+
+puts "Republishing #{document_scope.count} documents"
+
+document_scope.pluck(:id).each do |document_id|
+  print "."
+  PublishingApiDocumentRepublishingWorker
+    .perform_async_in_queue("bulk_republishing", document_id)
+end


### PR DESCRIPTION
This will switch the rendering of the remaining `Publication`s to government-frontend. 

This should be around ~60k documents. We successfully republished 50k yesterday without issues.