### PR TITLE
Use current government when Speech#delivered_on is future date or nil...

### DIFF
--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -52,7 +52,11 @@ class Speech < Announcement
 private
 
   def date_for_government
-    delivered_on.try(:to_date)
+    if delivered_on && delivered_on.past?
+      delivered_on.to_date
+    else
+      super
+    end
   end
 
   def skip_organisation_validation?

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -178,9 +178,15 @@ class SpeechTest < ActiveSupport::TestCase
     assert_equal previous_government, speech.government
   end
 
-  test '#government returns nil for an speech without a delivered_on' do
+  test '#government returns the current government for an speech delivered at an unspecified time' do
+    current_government = create(:current_government)
     speech = create(:imported_speech, delivered_on: nil)
-    assert_nil speech.government
+    assert_equal current_government, speech.government
   end
 
+  test '#government returns the current government for an speech in the future' do
+    current_government = create(:current_government)
+    speech = create(:imported_speech, delivered_on: 2.weeks.from_now)
+    assert_equal current_government, speech.government
+  end
 end


### PR DESCRIPTION
https://trello.com/c/JNmI4cqs/612-speech-migration-3-write-sync-checks-and-run-it-for-speech

`Speech#delivered_on` is used to determine the Government attributed to the item,
if this date is nil or in the future the government won't be attributed to the
speech. This causes problems for schema validation and doesn't make sense in
the frontend. So if no delivered on date is present save the speech against
the current government, and if the delivered_on date is in the future also
assume this to be a speech from the current government.