### PR TITLE
Fix editing taxons for never published drafts

### DIFF
--- a/app/models/edition_taxonomy_tag_form.rb
+++ b/app/models/edition_taxonomy_tag_form.rb
@@ -4,14 +4,25 @@ class EditionTaxonomyTagForm
   attr_accessor :selected_taxons, :edition_content_id, :previous_version
 
   def self.load(content_id)
-    content_item = Whitehall
-      .publishing_api_v2_client
-      .get_links(content_id)
+    begin
+      content_item = Whitehall
+        .publishing_api_v2_client
+        .get_links(content_id)
+
+      selected_taxons = content_item["links"]["taxons"] || []
+      previous_version = content_item["version"] || 0
+    rescue GdsApi::HTTPNotFound
+      # TODO: This is a workaround, because Publishing API
+      # returns 404 when the document exists but there are no links.
+      # This can be removed when that changes.
+      selected_taxons = []
+      previous_version = 0
+    end
 
     new(
-      selected_taxons: content_item["links"]["taxons"] || [],
+      selected_taxons: selected_taxons,
       edition_content_id: content_id,
-      previous_version: content_item["version"] || 0
+      previous_version: previous_version
     )
   end
 

--- a/test/unit/models/edition_taxonomy_tag_form_test.rb
+++ b/test/unit/models/edition_taxonomy_tag_form_test.rb
@@ -3,6 +3,24 @@ require 'test_helper'
 class EditionTaxonomyTagFormTest < ActiveSupport::TestCase
   include EducationTaxonomyHelper
 
+  test "#load when publishing-api returns 404, selected_taxons should be '[]'" do
+    content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
+
+    body = {
+      "error" => {
+        "code" => 404,
+        "message" => "Could not find link set with content_id: #{content_id}"
+      }
+    }.to_json
+
+    stub_request(:get, %r{.*/v2/links/#{content_id}.*})
+      .to_return(body: body, status: 404)
+
+    form = EditionTaxonomyTagForm.load(content_id)
+
+    assert_equal form.selected_taxons, []
+  end
+
   test '#load should request links to publishing-api' do
     content_id = "64aadc14-9bca-40d9-abb6-4f21f9792a05"
     taxons = ["c58fdadd-7743-46d6-9629-90bb3ccc4ef0"]


### PR DESCRIPTION
This is the same issue as af45e652b43316fcfe198dfa3d9b5e9f9034c12e
but on the tagging form itself.

Publishing API returns 404 for documents that don't have any links.  This is
always the case for brand new documents that have never been published, because
whitehall only sends the links captured at edit time when the draft is
published.