### PR TITLE
Republish Worldwide Organisation 373 and WLNA 309368

### DIFF
--- a/db/data_migration/20170223105903_republish_world_wide_organisation_and_document_for_309368.rb
+++ b/db/data_migration/20170223105903_republish_world_wide_organisation_and_document_for_309368.rb
@@ -1,0 +1,9 @@
+# Sync check is failing for WLNA with a document id 309368
+# for some reason the world wide organisation is out of sync so....
+# republish the associated world wide organisation and then
+# republish the document.
+
+wwo = WorldwideOrganisation.find(373)
+wwo.save if wwo
+
+PublishingApiDocumentRepublishingWorker.new.perform(309368)


### PR DESCRIPTION
Sync check is failing for WLNA with a document id 309368
For some reason the world wide organisation is out of sync so....
Republish the associated world wide organisation and then republish the
document as well.

[Trello](https://trello.com/c/DgBRDuIK)