### PR TITLE
Squish alternative_path in PublishingApiGoneWorker

### DIFF
--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -5,9 +5,11 @@ class PublishingApiGoneWorker < PublishingApiWorker
         .new.govspeak_to_html(explanation)
     end
 
+    alternative_path_with_no_trailing_space = alternative_path.rstrip if alternative_path
+
     Whitehall.publishing_api_v2_client.unpublish(
       content_id,
-      alternative_path: alternative_path,
+      alternative_path: alternative_path_with_no_trailing_space,
       explanation: rendered_explanation,
       type: "gone",
       locale: locale,

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -41,4 +41,22 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "alternative_path is sent without trailing spaces" do
+    request = stub_publishing_api_unpublish(
+      @uuid,
+      body: {
+        type: "gone",
+        alternative_path: "alternative_path",
+        explanation: "<div class=\"govspeak\"><p><em>why?</em></p>\n</div>",
+        locale: "de",
+        allow_draft: true
+      }
+    )
+
+    alternative_path_with_trailing_space = "alternative_path "
+    PublishingApiGoneWorker.new.perform(@uuid, alternative_path_with_trailing_space, "*why?*", "de", true)
+
+    assert_requested request
+  end
 end


### PR DESCRIPTION
Trailing spaces in `alternative_urls` are being sent to the publishing api. These are stored verbatim in the content store (with trailing spaces).

Sync checks subsequently fail because, although the sync checker strips off trailing spaces from the data returned from whitehall's database, it does not strip off spaces in alternative_urls brought back from the content store.

Fix the problem by squishing the data before we send it to the publishing api.

[Trello](https://trello.com/c/DgBRDuIK)