### PR TITLE
Withdrawn `DocumentCollection`s aren't linked

### DIFF
--- a/lib/sync_checker/formats/publication_check.rb
+++ b/lib/sync_checker/formats/publication_check.rb
@@ -7,7 +7,7 @@ module SyncChecker
             "document_collections",
             edition_expected_in_live
               .document_collections
-              .where(state: %w(published withdrawn))
+              .where(state: "published")
               .map(&:content_id)
           ),
           Checks::LinksCheck.new(


### PR DESCRIPTION
Publishing API does not include links for `withdrawn` document collections so we shouldn't check for them.