### PR TITLE
Republish NewsArticle

### DIFF
--- a/db/data_migration/20170224094245_republish_news_articles_to_switch_rendering.rb
+++ b/db/data_migration/20170224094245_republish_news_articles_to_switch_rendering.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(NewsArticle)
+republisher.perform


### PR DESCRIPTION
This data migration republishes all `NewsArticle` content to switch over rendering to government-frontend (added in #3061).

[Trello](https://trello.com/c/4tpycpbA/617-news-article-migration-5-final-tasks-deploy-1)