### PR TITLE
Switch WLNA rendering

### DIFF
--- a/app/models/world_location_news_article.rb
+++ b/app/models/world_location_news_article.rb
@@ -36,6 +36,6 @@ class WorldLocationNewsArticle < Newsesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 end

--- a/db/data_migration/20170224093758_republish_wlna_for_renderding_switch.rb
+++ b/db/data_migration/20170224093758_republish_wlna_for_renderding_switch.rb
@@ -1,0 +1,3 @@
+DataHygiene::PublishingApiDocumentRepublisher
+  .new(WorldLocationNewsArticle)
+  .perform

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -34,7 +34,7 @@ module SyncChecker
       end
 
       def rendering_app
-        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
       def root_path

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -41,8 +41,8 @@ class PublishingApi::WorldLocationNewsArticlePresenterTest < ActiveSupport::Test
     assert_equal 'whitehall', @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as whitehall-frontend" do
-    assert_equal 'whitehall-frontend', @presented_content[:rendering_app]
+  test "it presents the rendering_app as government-frontend" do
+    assert_equal 'government-frontend', @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as world_location_news_article" do

--- a/test/unit/world_location_news_article_test.rb
+++ b/test/unit/world_location_news_article_test.rb
@@ -44,8 +44,8 @@ class WorldLocationNewsArticleTest < ActiveSupport::TestCase
     refute world_article.valid?
   end
 
-  test 'specifies rendering app to be whitehall frontend' do
+  test 'specifies rendering app to be government frontend' do
     world_location_news_article = WorldLocationNewsArticle.new
-    assert world_location_news_article .rendering_app.include?(Whitehall::RenderingApp::WHITEHALL_FRONTEND)
+    assert world_location_news_article .rendering_app.include?(Whitehall::RenderingApp::GOVERNMENT_FRONTEND)
   end
 end


### PR DESCRIPTION
Switches WLNA rendering app to use `GOVERNMENT_FRONTEND` instead of `WHITEHALL_FRONTEND`

[Trello](https://trello.com/c/LLktT77F/553-wlna-migration-final-tasks-deploy-1-1)