### PR TITLE
Present the correct SpeechType to the Publishing API...

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "speech",
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         #TODO: rendering app is hard coded until format is ready
         #rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
@@ -51,6 +51,14 @@ module PublishingApi
     end
 
   private
+
+    def document_type
+      if SpeechType.non_statements.include?(item.speech_type)
+        "speech"
+      else
+        item.speech_type.key
+      end
+    end
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -107,4 +107,31 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "speech types" do
+    before do
+      Speech.any_instance.stubs(:change_history).returns({})
+      Speech.any_instance.stubs(:document).returns(document)
+    end
+
+    let(:document) { FactoryGirl.build(:document) }
+
+    [SpeechType::DraftText, SpeechType::SpeakingNotes, SpeechType::Transcript].each do |speech_type|
+      context "for #{speech_type.plural_name}" do
+        let(:speech) { FactoryGirl.build(:speech, speech_type: speech_type) }
+        it "is 'speech' for draft text" do
+          assert_equal(presented.content[:document_type], "speech")
+        end
+      end
+    end
+
+    [SpeechType::AuthoredArticle, SpeechType::OralStatement, SpeechType::WrittenStatement].each do |speech_type|
+      context "for #{speech_type.plural_name}" do
+        let(:speech) { FactoryGirl.build(:speech, speech_type: speech_type) }
+        it "is '#{speech_type.key}'" do
+          assert_equal(presented.content[:document_type], speech_type.key)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/JNmI4cqs/612-speech-migration-3-write-sync-checks-and-run-it-for-speech

Non-statement speech types should present a different document type
so that the frontend can render them in the correct context