### PR TITLE
Change event tracking data from checkboxes on topic tagging page

### DIFF
--- a/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
+++ b/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
@@ -49,10 +49,9 @@
         eventCategory: options.eventCategory,
         eventAction: action,
         eventLabel: options.eventLabel,
-        eventValue: 1,
-        cd1: options.cd1,
-        cd2: options.cd2,
-        cd4: options.cd4
+        dimension1: options.dimension1,
+        dimension2: options.dimension2,
+        dimension4: options.dimension4
       });
     };
 
@@ -69,9 +68,9 @@
         var options = {
           eventCategory: "pageElementInteraction",
           eventLabel: taxonName,
-          cd1: publicPath,
-          cd2: contentFormat,
-          cd4: contentId
+          dimension1: publicPath,
+          dimension2: contentFormat,
+          dimension4: contentId
         }
         /*
         Checking a checkbox also checks all of the ancestor taxons.

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -16,7 +16,7 @@
       <div class="form-group"
         data-module="taxonomy-tree-checkboxes"
         data-content-id="<%= @edition.content_id %>"
-        data-content-format="<%= @edition.display_type %>"
+        data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
         <div class="topic-tree">


### PR DESCRIPTION
Pull request #3062 added in event tracking to the checkboxes on the
topic tagging pages. This commit makes minor changes to the data sent to
GA:

- eventValue is not necessary, so no gets longer sent
- custom dimensions are renamed from 'cd1' to 'dimension1' etc. as they
  weren't being collected before
- document_type is now sent in the style of the content store
  document type (for example 'statutory_guidance' instead of 'Statutory
  guidance'

[Trello card](https://trello.com/c/pbtbMZer/469-add-event-tracking-to-checkboxes-on-topic-tagging-page)