### PR TITLE
Supersede `draft` Editions

### DIFF
--- a/db/data_migration/20170227153731_fix_publication_data.rb
+++ b/db/data_migration/20170227153731_fix_publication_data.rb
@@ -1,0 +1,15 @@
+stuck_draft_editions = [
+  #/government/statistics/statistical-release-provisional-uk-official-development-assistance-oda-as-a-proportion-of-gross-national-income-2012
+  167273,
+  #/government/statistics/statistical-release-provisional-uk-official-development-assistance-oda-tables-2012
+  167561
+]
+
+stuck_draft_editions.each do |edition_id|
+  stuck_draft = Edition.find(edition_id)
+  stuck_draft.state = "superseded"
+  stuck_draft.save(validate: false) #this is what the EditionPublisher service does, sorry.
+
+  PublishingApiDocumentRepublishingWorker.perform_async(stuck_draft.document_id)
+end
+


### PR DESCRIPTION
These two editions have subsequent published versions but for some
reason did not get transitioned to superseded state. This has caused
them to raise an error when we attempt to republish them to the
publishing api.

This commit updates their state and republishes their parent document.