### PR TITLE
Render speeches via government-frontend...

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -21,9 +21,7 @@ module PublishingApi
         details: details,
         document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
-        #TODO: rendering app is hard coded until format is ready
-        #rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-        rendering_app: "whitehall-frontend",
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "speech",
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -39,6 +39,10 @@ module SyncChecker
 
     private
 
+      def rendering_app
+        Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+      end
+
       def document_type(speech)
         if SpeechType.non_statements.include?(speech.speech_type)
           "speech"

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -60,7 +60,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       assert_equal("Speech title",        presented.content[:title])
       assert_equal("The description",     presented.content[:description])
       assert_equal("whitehall",           presented.content[:publishing_app])
-      assert_equal("whitehall-frontend",  presented.content[:rendering_app])
+      assert_equal("government-frontend", presented.content[:rendering_app])
 
       details = presented.content[:details]
       refute(details[:political])


### PR DESCRIPTION
https://trello.com/c/W729W7QN/614-speech-migration-5-final-tasks-deploy-1

This switches the rendering app for speeches to government-frontend.