### PR TITLE
Remove related_policies links check for Speeches

### DIFF
--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -24,6 +24,11 @@ module SyncChecker
           )
         end
 
+        # This is only necessary while we still add LinksCheck
+        # for related_policies as part of EditionBase#checks_for_live
+        checks.reject! { |chk|
+          chk.is_a?(Checks::LinksCheck) && chk.links_key == "related_policies" }
+
         checks
       end
 


### PR DESCRIPTION
https://trello.com/c/JNmI4cqs/612-speech-migration-3-write-sync-checks-and-run-it-for-speech

`PublishingApi::SpeechPresenter` doesn't present `related_policies` links as these
are keyed as `policies` so don't check for them.