### PR TITLE
Use `related_policies` in Speech links

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -44,8 +44,13 @@ module PublishingApi
     end
 
     def links
-      links = LinksPresenter.new(item).extract([:organisations, :policy_areas])
-      links.merge!(links_for_policies)
+      links = LinksPresenter.new(item).extract(
+        [
+          :organisations,
+          :policy_areas,
+          :related_policies
+        ]
+      )
       links.merge!(links_for_speaker)
       links.merge!(links_for_topical_events)
     end
@@ -71,10 +76,6 @@ module PublishingApi
           url: speaker.image.url,
         }
       }
-    end
-
-    def links_for_policies
-      { policies: item.policy_content_ids }
     end
 
     def links_for_speaker

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -4,7 +4,7 @@ module SyncChecker
       def checks_for_live(_locale)
         checks = super + [
           Checks::LinksCheck.new(
-            "policies", edition_expected_in_live.policy_content_ids
+            "related_policies", edition_expected_in_live.policy_content_ids
           ),
           Checks::LinksCheck.new(
             "topical_events",

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -87,12 +87,12 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
     it "contains the expected keys and values" do
       assert_includes(presented.links.keys, :organisations)
-      assert_includes(presented.links.keys, :policies)
+      assert_includes(presented.links.keys, :related_policies)
       assert_includes(presented.links.keys, :speaker)
       assert_includes(presented.links.keys, :topical_events)
 
       assert_includes(presented.links[:organisations], speech.organisations.first.content_id)
-      assert_includes(presented.links[:policies], policy_content_id)
+      assert_includes(presented.links[:related_policies], policy_content_id)
       assert_includes(presented.links[:speaker], person.content_id)
       assert_includes(presented.links[:topical_events], topical_event.content_id)
     end


### PR DESCRIPTION
We are going to use `related_policies` consistently when presenting
Whitehall formats to the publishing API.

This commit updates the `Speech` presenter accordingly.