### PR TITLE
Fix placeholder News Article images presented to the Publishing API

### DIFF
--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -142,7 +142,9 @@ module PublishingApi
       end
 
       def image_url
-        URI.join(Whitehall.public_asset_host, news_article.lead_image_path).to_s
+        ActionController::Base.helpers.image_url(
+          news_article.lead_image_path, host: Whitehall.public_asset_host
+        )
       end
     end
 

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -57,7 +57,10 @@ module PublishingApi
     end
 
     def image_url
-      URI.join(Whitehall.public_asset_host, presented_world_location_news_article.lead_image_path).to_s
+      ActionController::Base.helpers.image_url(
+        presented_world_location_news_article.lead_image_path,
+        host: Whitehall.public_asset_host,
+      )
     end
 
     def govspeak_renderer

--- a/lib/sync_checker/formats/news_article_check.rb
+++ b/lib/sync_checker/formats/news_article_check.rb
@@ -81,15 +81,15 @@ module SyncChecker
                        IMAGE_PLACEHOLDER
                      end
 
-        image_uri = URI(Whitehall.public_asset_host).tap do |uri|
-          uri.path = image_path
-        end
+        image_uri = ActionController::Base.helpers.image_url(
+          image_path, host: Whitehall.public_asset_host,
+        )
 
         {
           'image' => {
             'alt_text' => image_alt_text,
             'caption' => image_caption,
-            'url' => image_uri.to_s,
+            'url' => image_uri,
           }
         }
       end

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -84,15 +84,15 @@ module SyncChecker
                        IMAGE_PLACEHOLDER
                      end
 
-        image_uri = URI(Whitehall.public_asset_host).tap do |uri|
-          uri.path = image_path
-        end
+        image_uri = ActionController::Base.helpers.image_url(
+          image_path, host: Whitehall.public_asset_host,
+        )
 
         {
           'image' => {
             'alt_text' => image_alt_text,
             'caption' => image_caption,
-            'url' => image_uri.to_s,
+            'url' => image_uri,
           }
         }
       end

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -331,7 +331,7 @@ class PublishingApi::WorldLocationNewsArticlePlaceholderImageTest < ActiveSuppor
     expected_placeholder_image = {
       alt_text: "placeholder",
       caption: nil,
-      url: Whitehall.public_asset_host + "/placeholder.jpg"
+      url: Whitehall.public_asset_host + "/government/assets/placeholder.jpg"
     }
 
     assert_equal expected_placeholder_image, @presented_wlna.content[:details][:image]


### PR DESCRIPTION
Placeholder image URLs for News Articles and World Location News Articles need to be generated using the correct Rails asset helpers and configuration so that the generated URL is publicly accessible.

The host is overridden so that the frontend configuration is used as presentation happens under the backend configuration of the application.

Further work is needed so that News Articles and World Location News Articles are republished if the lead image changes.

[See Trello](https://trello.com/c/6X9zR6wW)