### PR TITLE
Republish World Locations to propagate translations

### DIFF
--- a/db/data_migration/20170301150702_republish_world_locations_to_propagate_translations.rb
+++ b/db/data_migration/20170301150702_republish_world_locations_to_propagate_translations.rb
@@ -1,0 +1,9 @@
+# We want to republish the following World Locations:
+# Ukrain, Romainia, Thailand, Armenia, Japan
+# because their translations seem not to have made their way into publishng api
+#
+ids = [7, 69, 113, 138, 154]
+
+world_locations = WorldLocation.find(ids)
+
+world_locations.each(&:save)


### PR DESCRIPTION
Some world locations are returning the English translation of their names
from the content-store (e.g. /api/content/government/world/japan.ja).
Republishing these world locations propagates the correct translation
through to publishing-api and content-store.

[Trello](https://trello.com/c/agLwuVNJ/552-wlna-migration-4-wraith-tests-1)