### PR TITLE
Track organisation pages as `finding` page in Google Analytics

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,6 +1,7 @@
 <% page_title "Departments, agencies and public bodies" %>
 <% page_class "index-list-page" %>
 <%= api_link_tag api_organisations_url %>
+<meta name="govuk:user-journey-stage" content="finding" />
 
 <div class="organisations-index">
   <div class="block-1">

--- a/app/views/organisations/not_live.html.erb
+++ b/app/views/organisations/not_live.html.erb
@@ -1,6 +1,7 @@
 <% page_title @organisation.name %>
 <% page_class "organisations-external" %>
 <%= organisation_wrapper(@organisation, class: "hcard group") do %>
+<meta name="govuk:user-journey-stage" content="finding" />
 
   <div class="block-1">
     <div class="inner-block">

--- a/app/views/organisations/show-promotional.html.erb
+++ b/app/views/organisations/show-promotional.html.erb
@@ -1,6 +1,7 @@
 <% page_title @organisation.name %>
 <% page_class "organisations-show-promotional" %>
 <% atom_discovery_link_tag atom_feed_url_for(@organisation), "Latest activity" %>
+<meta name="govuk:user-journey-stage" content="finding" />
 
 <%= organisation_wrapper(@organisation) do %>
   <% if @organisation.type.executive_office? %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,6 +2,7 @@
 <% page_class "organisations-show" %>
 <% atom_discovery_link_tag atom_feed_url_for(@organisation), "Latest activity" %>
 <%= api_link_tag api_organisation_url(@organisation) %>
+<meta name="govuk:user-journey-stage" content="finding" />
 
 <%= organisation_wrapper(@organisation) do %>
 <% if @organisation.court_or_hmcts_tribunal? %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -91,6 +91,12 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "test-govuk-component[data-template=govuk_component-beta_label]"
   end
 
+  view_test "should track the organisations index as a 'finding' page type" do
+    get :index
+
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+  end
+
   ### Describing :show ###
 
   view_test "showing an organisation without a list of contacts doesn't try to create one" do
@@ -901,11 +907,40 @@ class OrganisationsControllerTest < ActionController::TestCase
     refute_select "a", text: "Jobs"
   end
 
+  view_test "should track a live organisation page as a 'finding' page type" do
+    organisation = create(:organisation)
+
+    get :show, id: organisation
+
+    assert_user_journey_stage_tracked_as_finding_page
+  end
+
+  view_test "should track a non-live organisation page as a 'finding' page type" do
+    organisation = create(:organisation, govuk_status: 'exempt')
+
+    get :show, id: organisation
+
+    assert_user_journey_stage_tracked_as_finding_page
+  end
+
+  view_test "should track a promotional organisation page as a 'finding' page type" do
+    organisation = create(:executive_office, govuk_status: 'live')
+
+    get :show, id: organisation
+
+    assert_user_journey_stage_tracked_as_finding_page
+  end
+
   private
 
   def assert_disclaimer_present(organisation)
     assert_select "#organisation_disclaimer" do
       assert_select "a[href=?]", organisation.url
     end
+  end
+
+  def assert_user_journey_stage_tracked_as_finding_page
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1,
+      "Expected a Google Analytics meta tag for tracking that the user has visited a navigation page"
   end
 end


### PR DESCRIPTION
Add meta tag which marks the organisation homepage and individual organisation pages as being in the `finding` (navigation) stage of a user journey, as opposed to the `thing` (content) stage.

This will enable us to analyse how users navigate the site so that we can work out whether the new navigation pages are helping users find what they need.

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages