### PR TITLE
Index consultations hourly

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -22,6 +22,7 @@ class Consultation < Publicationesque
   scope :closed, -> { where("closing_at < ?",  Time.zone.now) }
   scope :closed_since, ->(time) { closed.where('closing_at >= ?', time) }
   scope :open, -> { where('closing_at >= ? AND opening_at <= ?', Time.zone.now, Time.zone.now) }
+  scope :open_since, ->(time) { open.where('opening_at >= ?', time) }
   scope :upcoming, -> { where('opening_at > ?', Time.zone.now) }
   scope :responded, -> { joins(:outcome) }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,5 +9,5 @@ every :day, at: ['3am', '12:45pm'], roles: [:admin] do
 end
 
 every :hour, roles: [:backend] do
-  rake "rummager:index:closed_consultations"
+  rake "rummager:index:consultations"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,6 +8,6 @@ every :day, at: ['3am', '12:45pm'], roles: [:admin] do
   rake "export:mappings"
 end
 
-every :day, at: ['1:30am'], roles: [:backend] do
+every :hour, roles: [:backend] do
   rake "rummager:index:closed_consultations"
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -29,11 +29,11 @@ namespace :rummager do
       index.commit
     end
 
-    # NOTE: Run daily to ensure consultation state is reflected in the search results
-    desc "indexes consultations which closed in the past day"
+    # NOTE: Run hourly to ensure consultation state is reflected in the search results
+    desc "indexes consultations which closed in the past 2 hours"
     task closed_consultations: :environment do
       index = Whitehall::SearchIndex.for(:government)
-      index.add_batch(Consultation.published.closed_since(25.hours.ago).map(&:search_index))
+      index.add_batch(Consultation.published.closed_since(2.hours.ago).map(&:search_index))
       index.commit
     end
 

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -30,9 +30,10 @@ namespace :rummager do
     end
 
     # NOTE: Run hourly to ensure consultation state is reflected in the search results
-    desc "indexes consultations which closed in the past 2 hours"
-    task closed_consultations: :environment do
+    desc "indexes consultations that opened or closed in the past 2 hours"
+    task consultations: :environment do
       index = Whitehall::SearchIndex.for(:government)
+      index.add_batch(Consultation.published.open_since(2.hours.ago).map(&:search_index))
       index.add_batch(Consultation.published.closed_since(2.hours.ago).map(&:search_index))
       index.commit
     end

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -119,6 +119,16 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal 0, Consultation.open.count
   end
 
+  test ".open_since only includes consultations open at or after the specified time" do
+    create(:consultation, opening_at: 1.month.ago)
+    open_three_days_ago = create(:consultation, opening_at: 3.days.ago)
+    open_two_days_ago = create(:consultation, opening_at: 2.days.ago)
+
+    assert_same_elements [], Consultation.open_since(1.days.ago)
+    assert_same_elements [open_two_days_ago], Consultation.open_since(2.days.ago)
+    assert_same_elements [open_two_days_ago, open_three_days_ago], Consultation.open_since(3.days.ago)
+  end
+
   test ".upcoming includes consultations opening in the future" do
     upcoming_consultation = create(:consultation, opening_at: 10.minutes.from_now, closing_at: 2.days.from_now)
 


### PR DESCRIPTION
Consultations can open in the future and close at any time. In order to make sure they can be easily
found we should index them frequently.

Related: https://govuk.zendesk.com/agent/tickets/1906179