### PR TITLE
Passing logging parameters to GovUkDelivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 40.0.0'
+  gem 'gds-api-adapters', '~> 40.2.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     ffi (1.9.14)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (40.0.0)
+    gds-api-adapters (40.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -478,7 +478,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 40.0.0)
+  gds-api-adapters (~> 40.2.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -64,7 +64,7 @@ Then(/^I should be signed up for the "(.*?)" world location mailing list$/) do |
 end
 
 Then(/^a govuk_delivery notification should have been sent to the mailing list I signed up for$/) do
-  mock_govuk_delivery_client.assert_method_called(:notify, with: ->(feed_urls, _subject, _body) {
+  mock_govuk_delivery_client.assert_method_called(:notify, with: ->(feed_urls, _subject, _body, logging_params) {
     feed_urls.include?(@feed_signed_up_to)
   })
 end

--- a/lib/whitehall/gov_uk_delivery/worker.rb
+++ b/lib/whitehall/gov_uk_delivery/worker.rb
@@ -14,7 +14,13 @@ module Whitehall
         endpoint = SubscriptionUrlGenerator.new(edition)
         email_formatter = EmailFormatter.new(edition, notification_date, options)
 
-        Whitehall.govuk_delivery_client.notify(endpoint.subscription_urls, email_formatter.display_title, email_formatter.email_body)
+        Whitehall.govuk_delivery_client.notify(
+          endpoint.subscription_urls,
+          email_formatter.display_title,
+          email_formatter.email_body,
+          content_id: edition.content_id,
+          public_updated_at: edition.major_change_published_at.iso8601,
+        )
       rescue GdsApi::HTTPErrorResponse => exception
         raise unless exception.code == 400
       end

--- a/test/integration/gov_uk_delivery_test.rb
+++ b/test/integration/gov_uk_delivery_test.rb
@@ -17,7 +17,15 @@ class GovUkDeliveryTest < ActiveSupport::TestCase
     Whitehall::GovUkDelivery::SubscriptionUrlGenerator.any_instance.stubs(:subscription_urls).returns(['http://example.com/feed'])
     Whitehall::GovUkDelivery::EmailFormatter.any_instance.stubs(:email_body).returns('body')
 
-    expected_payload = { feed_urls: ['http://example.com/feed'], subject: "Policy paper: #{publication.title}", body: 'body' }
+    expected_payload = {
+      feed_urls: ['http://example.com/feed'],
+      subject: "Policy paper: #{publication.title}",
+      body: 'body',
+      logging_params: {
+        content_id: publication.content_id,
+        public_updated_at: publication.major_change_published_at.iso8601,
+      },
+    }
     stub = stub_gov_uk_delivery_post_request('notifications', expected_payload).to_return(created_response_hash)
     stub_publishing_api_registration_for(publication)
     assert Whitehall.edition_services.publisher(publication).perform!
@@ -32,7 +40,15 @@ class GovUkDeliveryTest < ActiveSupport::TestCase
     Whitehall::GovUkDelivery::SubscriptionUrlGenerator.any_instance.stubs(:subscription_urls).returns(['http://example.com/feed'])
     Whitehall::GovUkDelivery::EmailFormatter.any_instance.stubs(:email_body).returns('body')
 
-    expected_payload = { feed_urls: ['http://example.com/feed'], subject: "Policy paper: #{publication.title}", body: 'body' }
+    expected_payload = {
+      feed_urls: ['http://example.com/feed'],
+      subject: "Policy paper: #{publication.title}",
+      body: 'body',
+      logging_params: {
+        content_id: publication.content_id,
+        public_updated_at: publication.major_change_published_at.iso8601,
+      },
+    }
     stub = stub_gov_uk_delivery_post_request('notifications', expected_payload).to_return(error_response_hash)
     stub_publishing_api_registration_for(publication)
 


### PR DESCRIPTION
This will allow logging of which topics are matched
and emailed via GovUkDelivery.