### PR TITLE
Track organisation homepage as a `finding` page in Google Analytics

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,6 +1,7 @@
 <% page_title "Departments, agencies and public bodies" %>
 <% page_class "index-list-page" %>
 <%= api_link_tag api_organisations_url %>
+<meta name="govuk:user-journey-stage" content="finding" />
 
 <div class="organisations-index">
   <div class="block-1">

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -91,6 +91,12 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "test-govuk-component[data-template=govuk_component-beta_label]"
   end
 
+  view_test "should track the organisations index as a 'finding' page type" do
+    get :index
+
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1
+  end
+
   ### Describing :show ###
 
   view_test "showing an organisation without a list of contacts doesn't try to create one" do
@@ -907,5 +913,10 @@ class OrganisationsControllerTest < ActionController::TestCase
     assert_select "#organisation_disclaimer" do
       assert_select "a[href=?]", organisation.url
     end
+  end
+
+  def assert_user_journey_stage_tracked_as_finding_page
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1,
+      "Expected a Google Analytics meta tag for tracking that the user has visited a navigation page"
   end
 end


### PR DESCRIPTION
Add meta tag which marks the organisation homepage as being in the `finding` (navigation) stage of a user journey, as opposed to the `thing` (content) stage.

This will enable us to analyse how users navigate the site so that we can work out whether the new navigation pages are helping users find what they need.

Most pages use the shared meta tags in static to track this value, but organisation homepages are not in the content store so this meta tag must be added separately.

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages