### PR TITLE
Fix publication scheduling

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -49,7 +49,6 @@ module Whitehall
     end
 
     def self.schedule_async(edition)
-      return unless served_from_content_store?(edition)
       publish_timestamp = edition.scheduled_publication.as_json
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
@@ -62,7 +61,6 @@ module Whitehall
     end
 
     def self.unschedule_async(edition)
-      return unless served_from_content_store?(edition)
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -55,7 +55,6 @@ module Whitehall
         PublishingApiScheduleWorker.perform_async(base_path, publish_timestamp)
         unless edition.document.published?
           PublishingApiComingSoonWorker.perform_async(edition.id, locale)
-                                      # perform_async(base_path, publish_timestamp, locale)
         end
       end
     end

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -5,7 +5,7 @@ class SchedulingTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
   setup do
-    @submitted_edition = create(:submitted_case_study,
+    @submitted_edition = create(:submitted_publication,
                                 scheduled_publication: 1.day.from_now)
     stub_legacy_sidekiq_scheduling
     stub_any_publishing_api_call
@@ -24,7 +24,7 @@ class SchedulingTest < ActiveSupport::TestCase
   end
 
   test "scheduling a subsequent edition publishes a publish intent to the Publishing API" do
-    published_edition = create(:published_case_study)
+    published_edition = create(:published_publication)
     new_draft = published_edition.create_draft(published_edition.creator)
     new_draft.change_note = 'changed'
     new_draft.scheduled_publication = 1.day.from_now


### PR DESCRIPTION
There was a guard clause when scheduling/unscheduling `Edition` publishing that prevented non-migrated content from using the `PublishingApiScheduleWorker` (which handles the reduction of cache time) when scheduling publication. This guard checked the `Edition#rendering_app` to ascertain the migrated status of the `Edition` format.

For the `Publication` format the `#rendering_app` has intentionally been left returning `whitehall-frontend` as this is used to determine the rendering app for preview and we currently can't preview this format with government-frontend due to the lack of draft links.

This has caused an issue where scheduled publishing of `Publication` documents appears to be delayed due to cacheing. The guard clause is no longer required as all formats likely to be scheduled are migrated. 

This PR removes it and updates the test to use `Publication` instead of `CaseStudy` as `CaseStudy`s are not generally time sensitive and don't make a particularly useful subject for testing this functionality.

[Trello](https://trello.com/c/BISE7y24/623-investigate-delay-in-scheduled-publishing-event)