### PR TITLE
Specify the `document_type` for all static pages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -19,6 +19,7 @@ class PublishStaticPages
       {
         content_id: "f56cfe74-8e5c-432d-bfcf-fd2521c5919c",
         title: "How government works",
+        document_type: "special_route",
         description: "About the UK system of government. Understand who runs government, and how government is run.",
         indexable_content: TemplateContent.new("home/how_government_works").indexable_content,
         base_path: "/government/how-government-works",
@@ -26,6 +27,7 @@ class PublishStaticPages
       {
         content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
         title: "Get involved",
+        document_type: "special_route",
         description: "Find out how you can engage with government directly, and take part locally, nationally or internationally.",
         indexable_content: TemplateContent.new("home/get_involved").indexable_content,
         base_path: "/government/get-involved",
@@ -33,6 +35,7 @@ class PublishStaticPages
       {
         content_id: "db95a864-874f-4f50-a483-352a5bc7ba18",
         title: "History of the UK government",
+        document_type: "special_route",
         description: "In this section you can read short biographies of notable people and explore the history of government buildings. You can also search our online records and read articles and blog posts by historians.",
         indexable_content: TemplateContent.new("histories/index").indexable_content,
         base_path: "/government/history",
@@ -40,6 +43,7 @@ class PublishStaticPages
       {
         content_id: "14aa298f-03a8-4e76-96de-483efa3d001f",
         title: "History of 10 Downing Street",
+        document_type: "special_route",
         description: "10 Downing Street, the locale of British prime ministers since 1735, vies with the White House as being the most important political building anywhere in the world in the modern era.",
         indexable_content: TemplateContent.new("histories/10_downing_street").indexable_content,
         base_path: "/government/history/10-downing-street",
@@ -47,30 +51,35 @@ class PublishStaticPages
       {
         content_id: "7be62825-1538-4ff5-aa29-cd09350349f2",
         title: "History of 1 Horse Guards Road",
+        document_type: "special_route",
         indexable_content: TemplateContent.new("histories/1_horse_guards_road").indexable_content,
         base_path: "/government/history/1-horse-guards-road",
       },
       {
         content_id: "9bdb6017-48c9-4590-b795-3c19d5e59320",
         title: "History of 11 Downing Street",
+        document_type: "special_route",
         indexable_content: TemplateContent.new("histories/11_downing_street").indexable_content,
         base_path: "/government/history/11-downing-street",
       },
       {
         content_id: "bd216990-c550-4d28-ac05-649329298601",
         title: "History of King Charles Street (FCO)",
+        document_type: "special_route",
         indexable_content: TemplateContent.new("histories/king_charles_street").indexable_content,
         base_path: "/government/history/king-charles-street",
       },
       {
         content_id: "60808448-769d-4915-981c-f34eb5f1b7bc",
         title: "History of Lancaster House (FCO)",
+        document_type: "special_route",
         indexable_content: TemplateContent.new("histories/lancaster_house").indexable_content,
         base_path: "/government/history/lancaster-house",
       },
       {
         content_id: "b13317e9-3753-47b2-95da-c173071e621d",
         title: "All publications",
+        document_type: "finder",
         description: "Find publications from across government including policy papers, consultations, statistics, research, transparency data and Freedom of Information responses.",
         indexable_content: "Find publications from across government including policy papers, consultations, statistics, research, transparency data and Freedom of Information responses.",
         base_path: "/government/publications",
@@ -78,6 +87,7 @@ class PublishStaticPages
       {
         content_id: "a34e9bb6-f4af-4e4f-a21c-8127e3d2edbf",
         title: "Statistics",
+        document_type: "finder",
         description: "Find statistics publications from across government, including statistical releases, live data tables, and National Statistics.",
         indexable_content: "Find statistics publications from across government, including statistical releases, live data tables, and National Statistics. statistics, live tables, live table, statistical release, stats",
         base_path: "/government/statistics",
@@ -85,6 +95,7 @@ class PublishStaticPages
       {
         content_id: "88936763-df8a-441f-8b96-9ea0dc0758a1",
         title: "Government announcements",
+        document_type: "finder",
         description: "Find news articles, speeches and statements from government organisations",
         indexable_content: "Find news articles, speeches and statements from government organisations news, press release, speech, press notice, statement, wms, oms",
         base_path: "/government/announcements",
@@ -92,6 +103,7 @@ class PublishStaticPages
       {
         content_id: "324e4708-2285-40a0-b3aa-cb13af14ec5f",
         title: "Ministers",
+        document_type: "finder",
         description: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business",
         indexable_content: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business government, parliament, parliamentary, minister, ministers, mp, rt hon, right honourable, secretary of state, westminster, whitehall, house of commons, house of lords",
         base_path: "/government/ministers",
@@ -100,6 +112,7 @@ class PublishStaticPages
         content_id: "430df081-f28e-4a1f-b812-8977fdac6e9a",
         title: "Find a British embassy, high commission or consulate",
         base_path: "/government/world/embassies",
+        document_type: "finder",
         description: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
         indexable_content: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
       },
@@ -124,7 +137,7 @@ class PublishStaticPages
         details: {},
         title: page[:title],
         description: page[:description],
-        document_type: "placeholder",
+        document_type: page[:document_type],
         schema_name: "placeholder",
         locale: "en",
         base_path: page[:base_path],

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -24,7 +24,7 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
         .with(
           page[:content_id],
           has_entries(
-            document_type: "placeholder",
+            document_type: page[:document_type],
             schema_name: "placeholder",
             base_path: page[:base_path],
             title: page[:title]

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -12,8 +12,10 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
 
   test 'static pages presented to the publishing api are valid placeholders' do
     publisher = PublishStaticPages.new
-    presented = publisher.present_for_publishing_api(publisher.pages.first)
-    expect_valid_placeholder(presented[:content])
+    publisher.pages.each do |page|
+      presented = publisher.present_for_publishing_api(page)
+      expect_valid_placeholder(presented[:content])
+    end
   end
 
   def expect_publishing(pages)


### PR DESCRIPTION
- Modify static publishing test so that it validates all static pages against the schemas
- Replace the very generic `placeholder` document type with something more specific for all the static pages added to the content store.

cc @tijmenb 

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages