### PR TITLE
Put cucumber gems into test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :test_coverage do
   gem 'simplecov-rcov'
 end
 
-group :cucumber do
+group :cucumber, :test do
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'launchy', '~> 2.4.3'
   gem 'capybara', '~> 2.4.4'


### PR DESCRIPTION
At some point between 1.10 and 1.14, Bundler's group handling behaviour changed in such a way as to affect the loading behaviour of any gems in `group :cucumber`. It isn't entirely clear which version causes the breaking change, or what the specific change was, but this commit ensures that dependencies are loaded correctly for any test run started with `bundle exec rake`.