### PR TITLE
Create placeholder with fingerprint for sync checks

### DIFF
--- a/lib/sync_checker/formats/news_article_check.rb
+++ b/lib/sync_checker/formats/news_article_check.rb
@@ -21,7 +21,7 @@ module SyncChecker
     private
 
       IMAGE_FORMAT = :s300
-      IMAGE_PLACEHOLDER = '/placeholder.jpg'
+      IMAGE_PLACEHOLDER = 'placeholder.jpg'
       LENGTH_OF_FRACTIONAL_SECONDS = 3
 
       def document_type(news_article)

--- a/lib/sync_checker/formats/world_location_news_article_check.rb
+++ b/lib/sync_checker/formats/world_location_news_article_check.rb
@@ -27,7 +27,7 @@ module SyncChecker
     private
 
       IMAGE_FORMAT = :s300
-      IMAGE_PLACEHOLDER = '/placeholder.jpg'
+      IMAGE_PLACEHOLDER = 'placeholder.jpg'
 
       def document_type(_edition)
         'world_location_news_article'


### PR DESCRIPTION
Placeholder images in WLNA and News Article sync checks are being created without the appended fingerprint. This is causing false failures in the sync checks because the placeholder images originally presented to the Publishing Api have an appended fingerprint. 

Removing the leading forward slash from the placeholder image ensures that the fingerprint is added when calling 
`ActionController::Base.helpers.image_url(image_path, host: Whitehall.public_asset_host)` in the sync check.