### PR TITLE
Remove deleted policies from speeches

### DIFF
--- a/db/data_migration/20170306115816_remove_deleted_policies_from_speeches.rb
+++ b/db/data_migration/20170306115816_remove_deleted_policies_from_speeches.rb
@@ -1,0 +1,18 @@
+# These policies don't exist in policy publisher
+# so disassociate them with speeches.
+deleted_policy_content_ids = %w(
+  5c8eab14-7631-11e4-a3cb-005056011aef
+  5e35d75c-7631-11e4-a3cb-005056011aef
+  5d376d68-7631-11e4-a3cb-005056011aef
+  5f1ab94f-7631-11e4-a3cb-005056011aef
+  5f1b09e6-7631-11e4-a3cb-005056011aef
+  5f52615a-7631-11e4-a3cb-005056011aef
+  3c04de88-9e4a-4ebb-bdc9-ef5946db17b9
+)
+
+EditionPolicy.destroy_all(policy_content_id: deleted_policy_content_ids)
+
+# This draft only Speech has a different content id to that stored
+# in the publishing api, it's easier to update in Whitehall.
+speech = Speech.find(content_id: "39c5a555-9f62-4303-8919-1795d2bf103a")
+speech.document.update!(content_id: "6778ffde-8d6c-43a2-ae74-2b255183b2fd")


### PR DESCRIPTION
https://trello.com/c/FsV8hMDm/625-speech-migration-final-failing-sync-checks-0-17

This data migration removes the policy content ids from speeches
where the policy no longer exists in policy publisher.