### PR TITLE
Present edition links in `DocumentCollectionPresenter#content`

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )
-      links.merge!(documents: item.documents.map(&:content_id))
+      links.merge!(documents: item.documents.map(&:content_id).uniq)
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -22,6 +22,7 @@ module PublishingApi
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "document_collection",
+        links: links,
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -133,7 +133,7 @@ class PublishingApi::DocumentCollectionPresenterGroupTest < ActiveSupport::TestC
       document_collection
     )
     @presented_details = presenter.content[:details]
-    @presented_links = presenter.links
+    @presented_links = presenter.content[:links]
   end
 
   test "it presents group 1 in collection_groups" do
@@ -167,7 +167,7 @@ class PublishingApi::DocumentCollectionPresenterDocumentLinksTestCase < ActiveSu
 
     @presented_links = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
-    ).links
+    ).content[:links]
   end
 
   test "it presents the document content_ids as links, documents" do
@@ -251,6 +251,56 @@ class PublishingApi::PublishedDocumentCollectionPresenterLinksTest < ActiveSuppo
   end
 end
 
+class PublishingApi::PublishedDocumentCollectionPresenterEditionLinksTest < ActiveSupport::TestCase
+  setup do
+    @document_collection = create(:document_collection)
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
+    @presented_links = presented_document_collection.content[:links]
+  end
+
+  test "it presents the documents content_ids as links, documents" do
+    assert_equal(
+      @document_collection.documents.map(&:content_id),
+      @presented_links[:documents]
+    )
+  end
+
+  test "it presents the organisation content_ids as links, organisations" do
+    assert_equal(
+      @document_collection.organisations.map(&:content_id),
+      @presented_links[:organisations]
+    )
+  end
+
+  test "it presents the policy area content_ids as links, policy_areas" do
+    assert_equal(
+      @document_collection.topics.map(&:content_id),
+      @presented_links[:policy_areas]
+    )
+  end
+
+  test "it presents the topic content_ids as links, topics" do
+    assert_equal(
+      @document_collection.specialist_sectors.map(&:content_id),
+      @presented_links[:topics]
+    )
+  end
+
+  test "it presents the topical_events content_ids as links, topical_events" do
+    assert_equal(
+      @document_collection.topical_events.map(&:content_id),
+      @presented_links[:topical_events]
+    )
+  end
+
+  test "it presentes the primary_specialist_sector content_ids as links, parent" do
+    assert_equal(
+      @document_collection.primary_specialist_sectors.map(&:content_id),
+      @presented_links[:parent]
+    )
+  end
+end
+
 class PublishingApi::PublishedDocumentCollectionPresenterRelatedPolicyLinksTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)
@@ -259,14 +309,20 @@ class PublishingApi::PublishedDocumentCollectionPresenterRelatedPolicyLinksTest 
       "a8b90171-7f0a-4dd5-986c-d9e414a2dc17",
       "7a892570-6428-4baa-b825-9ebc4faf5773"
     ])
-    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
-    @presented_links = presented_document_collection.links
+    @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
   end
 
   test "it presents the policy_content_ids as links, related_policies" do
     assert_equal(
       @document_collection.policy_content_ids,
-      @presented_links[:related_policies]
+      @presented_document_collection.links[:related_policies]
+    )
+  end
+
+  test "it presents the policy_content_ids as content, links, related_policies" do
+    assert_equal(
+      @document_collection.policy_content_ids,
+      @presented_document_collection.content[:links][:related_policies]
     )
   end
 end
@@ -275,14 +331,20 @@ class PublishingApi::PublishedDocumentCollectionPresenterTopicalEventsLinksTest 
   setup do
     document_collection = create(:document_collection)
     PublishingApi::PayloadBuilder::TopicalEvents.stubs(:for).with(document_collection).returns({ topical_events: ['bfa'] })
-    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
-    @presented_links = presented_document_collection.links
+    @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
   end
 
   test "it presents the topical events as links, topical_events" do
     assert_equal(
       ["bfa"],
-      @presented_links[:topical_events]
+      @presented_document_collection.links[:topical_events]
+    )
+  end
+
+  test "it presents the topical events as content, links, topical_events" do
+    assert_equal(
+      ["bfa"],
+      @presented_document_collection.content[:links][:topical_events]
     )
   end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -301,6 +301,36 @@ class PublishingApi::PublishedDocumentCollectionPresenterEditionLinksTest < Acti
   end
 end
 
+class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest < ActiveSupport::TestCase
+  setup do
+    @document_collection = create(:document_collection)
+    @document_collection.stubs(:documents).returns(
+      [
+        OpenStruct.new(content_id: "test"),
+        OpenStruct.new(content_id: "test"),
+        OpenStruct.new(content_id: "ers"),
+      ]
+    )
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
+    @presented_edition_links = presented_document_collection.content[:links]
+    @presented_links = presented_document_collection.links
+  end
+
+  test "it doesn't present duplicate content ids in content, links, documents" do
+    assert_equal(
+      ["test", "ers"],
+      @presented_edition_links[:documents]
+    )
+  end
+
+  test "it doesn't present duplicate content ids in links, documents" do
+    assert_equal(
+      ["test", "ers"],
+      @presented_links[:documents]
+    )
+  end
+end
+
 class PublishingApi::PublishedDocumentCollectionPresenterRelatedPolicyLinksTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -318,14 +318,14 @@ class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest 
 
   test "it doesn't present duplicate content ids in content, links, documents" do
     assert_equal(
-      ["test", "ers"],
+      %w(test ers),
       @presented_edition_links[:documents]
     )
   end
 
   test "it doesn't present duplicate content ids in links, documents" do
     assert_equal(
-      ["test", "ers"],
+      %w(test ers),
       @presented_links[:documents]
     )
   end


### PR DESCRIPTION
Publishing API now supports links within the `put_content` call.

This commit adds links to the payload sent for `DocumentCollection`. Once all of the `DocumentCollection` documents have been republished this will enable us to switch over preview to government-frontend as the draft content store will have the correct links.

This is the initial step in the process. We will need to republish in a separate step and then switch over `DocumentCollection#rendering_app` to return `government-frontend` as this controls which app is used for preview.

We will also be able to remove the [`patch_links` step ](https://github.com/alphagov/whitehall/blob/send-draft-links/app/workers/publishing_api_worker.rb#L28) from the worker once this work is complete for all formats.

[Trello](https://trello.com/c/s7LjBWav/634-use-draft-links-for-documentcollections)

Requires https://github.com/alphagov/govuk-content-schemas/pull/567 to be deployed before the tests will pass.