### PR TITLE
Render DocumentCollection preview with government-frontend

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -62,10 +62,7 @@ class DocumentCollection < Edition
   end
 
   def rendering_app
-    #this is overridden in the presenter for published content
-    #but maintained here to force preview to use Whitehall
-    #until a draft linkset is implemented in Publishing API
-    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
   private

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
         details: details,
         document_type: "document_collection",
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: item.rendering_app,
         schema_name: "document_collection",
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/test/unit/models/document_collection_test.rb
+++ b/test/unit/models/document_collection_test.rb
@@ -144,6 +144,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
 
   test 'specifies the rendering app as government frontend' do
     document_collection = DocumentCollection.new
-    assert_equal Whitehall::RenderingApp::WHITEHALL_FRONTEND, document_collection.rendering_app
+    assert_equal Whitehall::RenderingApp::GOVERNMENT_FRONTEND, document_collection.rendering_app
   end
 end


### PR DESCRIPTION
This sets the `DocumentCollection#rendering_app` to `government-frontend` explicitly. This was previously left returning `whitehall-frontend`, despite the format being migrated, as Whitehall uses
this value to determine the rendering app for preview.

Now that `DocumentCollection` is sending links within `DocumentCollectionPresenter#content` we no longer need to preview via Whitehall.

This is dependent on #3110 

[Trello](https://trello.com/c/s7LjBWav/634-use-draft-links-for-documentcollections)