### PR TITLE
Reslug Government veterinary services

### DIFF
--- a/db/data_migration/20170309175617_reslug_government_veterinary_services.rb
+++ b/db/data_migration/20170309175617_reslug_government_veterinary_services.rb
@@ -1,0 +1,4 @@
+veterinary_services = Organisation.find_by(slug: "civil-service-government-veterinary-surgeons")
+
+new_slug = "civil-service-government-veterinary-service"
+DataHygiene::OrganisationReslugger.new(veterinary_services, new_slug).run!


### PR DESCRIPTION
https://trello.com/c/6ZDUixvX/621-change-slug-and-redirect-for-civil-service-government-veterinary-services-small

Government veterinary surgeons has been re-named Government veterinary services. We are applying the change to its slug.