### PR TITLE
Reorder publishing api calls

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -24,8 +24,8 @@ class PublishingApiWorker < WorkerBase
 
   def send_item(payload, locale)
     save_draft(payload)
-    Whitehall.publishing_api_v2_client.publish(payload.content_id, payload.update_type, locale: locale)
     Whitehall.publishing_api_v2_client.patch_links(payload.content_id, links: payload.links)
+    Whitehall.publishing_api_v2_client.publish(payload.content_id, payload.update_type, locale: locale)
   end
 
   def save_draft(payload)


### PR DESCRIPTION
The `PublishingApiWorker` was calling `publish` before `patch_links` which meant that the item put onto the rabbit queue (on publish) was being sent before the links were updated.

This change in order should fix that.

/cc @jennyd @kevindew 