### PR TITLE
Add analytics meta tags to navigation pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,6 +8,8 @@ class OrganisationsController < PublicFacingController
   before_filter :set_cache_max_age, only: [:show]
 
   def index
+    @content_item = Whitehall.content_store.content_item("/government/organisations")
+
     if params[:courts_only]
       @courts = Organisation.courts.listable.ordered_by_name_ignoring_prefix
       @hmcts_tribunals = Organisation.hmcts_tribunals.listable.ordered_by_name_ignoring_prefix
@@ -21,6 +23,8 @@ class OrganisationsController < PublicFacingController
   end
 
   def show
+    @content_item = Whitehall.content_store.content_item(@organisation.base_path)
+
     recently_updated_source = @organisation.published_non_corporate_information_pages.in_reverse_chronological_order
     set_expiry 5.minutes
     respond_to do |format|

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -3,6 +3,7 @@ class TopicalEventsController < ClassificationsController
 
   def show
     @classification = TopicalEvent.friendly.find(params[:id])
+    @content_item = Whitehall.content_store.content_item(@classification.base_path)
     @publications = fetch_associated(:published_publications, PublicationesquePresenter)
     @consultations = fetch_associated(:published_consultations, PublicationesquePresenter)
     @announcements = fetch_associated(:published_announcements, AnnouncementPresenter)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,6 +4,7 @@ class TopicsController < ClassificationsController
 
   def show
     @classification = Topic.friendly.find(params[:id])
+    @content_item = Whitehall.content_store.content_item(@classification.base_path)
 
     respond_to do |format|
       format.html do

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -117,8 +117,12 @@ class Classification < ActiveRecord::Base
     policies.empty?
   end
 
-  def search_link
+  def base_path
     Whitehall.url_maker.topic_path(slug)
+  end
+
+  def search_link
+    base_path
   end
 
   def latest(limit = 3)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -383,8 +383,12 @@ class Organisation < ActiveRecord::Base
     end
   end
 
-  def search_link
+  def base_path
     Whitehall.url_maker.organisation_path(self)
+  end
+
+  def search_link
+    base_path
   end
 
   def search_organisations

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -60,8 +60,12 @@ class TopicalEvent < Classification
     slug.in?(%w[farming])
   end
 
-  def search_link
+  def base_path
     Whitehall.url_maker.topical_event_path(slug)
+  end
+
+  def search_link
+    base_path
   end
 
   private

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -10,6 +10,9 @@
 
     <%= meta_description_tag %>
 
+    <%= render partial: 'govuk_component/analytics_meta_tags',
+      locals: { content_item: @content_item } %>
+
     <title><%= page_title %></title>
     <%-
       stylesheet_base = local_assigns[:stylesheet] || "base"

--- a/features/announcements.feature
+++ b/features/announcements.feature
@@ -1,5 +1,8 @@
 Feature: Announcements
 
+Background:
+  Given I can navigate to the list of announcements
+
 @not-quite-as-fake-search
 Scenario: Viewing news articles and speeches together on the news and speeches page
   Given a published news article "Crackdown on tax avoidance" exists

--- a/features/email-signup-for-documents.feature
+++ b/features/email-signup-for-documents.feature
@@ -3,6 +3,7 @@ Feature: Email signup for documents
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And a list of publications exists
 
   Scenario: Signing up to unfiltered publications alerts
     When I visit the list of publications

--- a/features/fatalities.feature
+++ b/features/fatalities.feature
@@ -33,6 +33,7 @@ Feature: Fatalities
   Background:
     Given an organisation "MOD" has been assigned to handle fatalities
     And I am an editor in the organisation "MOD"
+    And I can navigate to the list of announcements
 
   Scenario: Editor adds field of operation
     When I create a new field of operation called "New Field" with description "Description"

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -2,6 +2,7 @@ Feature: Administering Organisations
 
 Background:
   Given I am an admin in the organisation "Ministry of Pop"
+  And a directory of organisations exists
   And a world location "United Kingdom" exists
 
 Scenario: Adding an Organisation

--- a/features/publications.feature
+++ b/features/publications.feature
@@ -72,6 +72,7 @@ Scenario: Viewing a publication that's been submitted for review with a PDF atta
 @not-quite-as-fake-search
 Scenario: Viewing published publications
   Given a published publication "Lamb chops on baker's faces" with a PDF attachment
+  And a list of publications exists
   When I visit the list of publications
   Then I should see the publication "Lamb chops on baker's faces"
   And I should see the summary of the publication "Lamb chops on baker's faces"

--- a/features/statistical-data-sets.feature
+++ b/features/statistical-data-sets.feature
@@ -10,6 +10,7 @@ Feature: Statistical data sets
     Given a published document collection "Free flow speeds" exists
     And a published publication that's part of the "Free flow speeds" document collection
     And a published statistical data set "Vehicle speeds 2010" that's part of the "Free flow speeds" document collection
+    And a list of publications exists
     When I visit the list of publications
     And I follow the link to the "Free flow speeds" document collection
     Then I should see the "Vehicle speeds 2010" statistical data set

--- a/features/step_definitions/announcement_steps.rb
+++ b/features/step_definitions/announcement_steps.rb
@@ -1,3 +1,9 @@
+Given /^I can navigate to the list of announcements$/ do
+  # 'visit homepage' means visiting the organisation homepage, because the
+  # homepage is not part of this application
+  stub_organisation_homepage_in_content_store
+end
+
 When /^I visit the list of announcements$/ do
   visit homepage
   click_link "Announcements"

--- a/features/step_definitions/contact_and_office_featuring_steps.rb
+++ b/features/step_definitions/contact_and_office_featuring_steps.rb
@@ -1,5 +1,5 @@
 Given /^there is an organisation with some contacts on its home page$/ do
-  @the_organisation = create(:organisation)
+  @the_organisation = create_org_and_stub_content_store(:organisation, name: "Name of org with contacts")
   contact_1 = create(:contact, contactable: @the_organisation, title: 'Main office')
   contact_2 = create(:contact, contactable: @the_organisation, title: 'Summer office by the lake')
   contact_3 = create(:contact, contactable: @the_organisation, title: 'Emergency bunker office')

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -109,6 +109,7 @@ end
 
 Given /^my organisation has a "(.*?)" corporate information page$/ do |page_title|
   @user.organisation ||= create(:organisation)
+  stub_organisation_in_content_store("Organisation name", @user.organisation.base_path)
   page_type = find_corporation_information_page_type_by_title(page_title)
   create(:corporate_information_page,
          corporate_information_page_type: page_type,

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -1,5 +1,5 @@
 Given /^the executive office organisation "([^"]*)" exists$/ do |organisation_name|
-  @executive_office = create(:executive_office, name: organisation_name)
+  @executive_office = create_org_and_stub_content_store(:executive_office, name: organisation_name)
 end
 
 Given /^the executive office has a promotional feature with an item$/ do

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -1,3 +1,7 @@
+Given /^a list of publications exists$/ do
+  stub_organisation_homepage_in_content_store
+end
+
 Given /^a published publication "([^"]*)" exists that is about "([^"]*)"$/ do |publication_title, world_location_name|
   world_location = WorldLocation.find_by!(name: world_location_name)
   create(:published_publication, title: publication_title, world_locations: [world_location])

--- a/features/step_definitions/session_steps.rb
+++ b/features/step_definitions/session_steps.rb
@@ -19,7 +19,7 @@ Given /^I am (?:a|an) (writer|editor|admin|GDS editor|GDS admin|importer|managin
 end
 
 Given /^I am (?:an?) (admin|writer|editor|GDS editor) in the organisation "([^"]*)"$/ do |role, organisation_name|
-  organisation = Organisation.find_by(name: organisation_name) || create(:ministerial_department, name: organisation_name)
+  organisation = Organisation.find_by(name: organisation_name) || create_org_and_stub_content_store(:ministerial_department, name: organisation_name)
   @user = case role
   when "admin"
     create(:user, organisation: organisation)

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -1,5 +1,6 @@
 Given /^a topic called "([^"]*)" exists$/ do |name|
   @topic = create(:topic, name: name)
+  stub_topic_in_content_store(name)
 end
 
 Given /^a topic called "([^"]*)" with description "([^"]*)"$/ do |name, description|
@@ -38,9 +39,13 @@ end
 
 Given(/^a (topic|topical event) called "(.*?)" exists with featured documents$/) do |type, name|
   classification = if type == 'topic'
-    create(:topic, name: name)
+    topic = create(:topic, name: name)
+    stub_topic_in_content_store(name)
+    topic
   else
-    create(:topical_event, name: name)
+    topical_event = create(:topical_event, name: name)
+    stub_topical_event_in_content_store(name)
+    topical_event
   end
 
   create(:classification_featuring, classification: classification)
@@ -52,12 +57,12 @@ Given(/^I have an offsite link "(.*?)" for the topic "(.*?)"$/) do |title, topic
 end
 
 When /^I create a new topic "([^"]*)" with description "([^"]*)"$/ do |name, description|
-  create_topic(name: name, description: description)
+  create_topic_and_stub_content_store(name: name, description: description)
 end
 
 When /^I create a new topic "([^"]*)" related to topic "([^"]*)"$/ do |name, related_name|
-  create_topic(name: related_name)
-  create_topic(name: name, related_classifications: [related_name])
+  create_topic_and_stub_content_store(name: related_name)
+  create_topic_and_stub_content_store(name: name, related_classifications: [related_name])
 end
 
 When /^I edit the topic "([^"]*)" to have description "([^"]*)"$/ do |name, description|

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -1,5 +1,6 @@
 Given(/^a topical event called "(.*?)" with description "(.*?)"$/) do |name, description|
   @topical_event = create(:topical_event, name: name, description: description)
+  stub_topical_event_in_content_store(name)
 end
 
 Given(/^I have an offsite link "(.*?)" for the topical event "(.*?)"$/) do |title, topical_event_name|
@@ -8,11 +9,11 @@ Given(/^I have an offsite link "(.*?)" for the topical event "(.*?)"$/) do |titl
 end
 
 When /^I create a new topical event "([^"]*)" with description "([^"]*)"$/ do |name, description|
-  create_topical_event(name: name, description: description)
+  create_topical_event_and_stub_in_content_store(name: name, description: description)
 end
 
 When /^I create a new topical event "([^"]*)" with description "([^"]*)" and it ends today$/ do |name, description|
-  create_topical_event(name: name, description: description, start_date: 2.months.ago.to_date.to_s, end_date: Date.today.to_s)
+  create_topical_event_and_stub_in_content_store(name: name, description: description, start_date: 2.months.ago.to_date.to_s, end_date: Date.today.to_s)
 end
 
 Then /^I should see the topical event "([^"]*)" on the frontend is archived$/ do |topical_event_name|
@@ -133,7 +134,8 @@ Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" topical event p
 end
 
 Given(/^I'm administering a topical event$/) do
-  event = create(:topical_event)
+  event = create(:topical_event, name: "Name of event")
+  stub_topical_event_in_content_store("Name of event")
   visit admin_topical_event_path(event)
 end
 
@@ -159,7 +161,9 @@ Then(/^a link to the event's about page is visible$/) do
 end
 
 Given /^a topical event with published documents$/ do
-  @topical_event = create(:topical_event, name: 'Topical Event with Published Documents')
+  name = 'Topical Event with Published Documents'
+  @topical_event = create(:topical_event, name: name)
+  stub_topical_event_in_content_store(name)
   create_recently_published_documents_for_topical_event(@topical_event)
 end
 

--- a/features/support/organisation_helper.rb
+++ b/features/support/organisation_helper.rb
@@ -3,6 +3,33 @@ module OrganisationHelper
     Organisation.find_by(name: name) || create(:organisation, name: name)
   end
 
+  def create_org_and_stub_content_store(*args)
+    organisation = create(*args)
+    stub_organisation_in_content_store(
+      args[1][:name],
+      organisation.base_path,
+      args[1][:translated_into])
+    organisation
+  end
+
+  def stub_organisation_in_content_store(name, base_path, locale=nil)
+    content_item = {
+      format: "organisation",
+      title: name,
+    }
+
+    translated_path = locale ? "#{base_path}.#{locale}" : base_path
+    content_store_has_item(translated_path, content_item)
+  end
+
+  def stub_organisation_homepage_in_content_store
+    content_item = {
+      format: "finder",
+      title: "Organisation homepage",
+    }
+    content_store_has_item("/government/organisations", content_item)
+  end
+
   def fill_in_organisation_translation_form(translation)
     translation = translation.stringify_keys
 

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -1,5 +1,5 @@
 module TopicalEventsHelper
-  def create_topical_event(options = {})
+  def create_topical_event_and_stub_in_content_store(options = {})
     visit admin_root_path
     click_link "Topical events"
     click_link "Create topical event"
@@ -8,6 +8,8 @@ module TopicalEventsHelper
     select_date (options[:start_date] || 1.day.ago.to_s), from: "Start Date"
     select_date (options[:end_date] || 1.month.from_now.to_s), from: "End Date"
     click_button "Save"
+
+    stub_topical_event_in_content_store(options[:name])
   end
 
   def create_recently_published_documents_for_topical_event(event)
@@ -26,6 +28,17 @@ module TopicalEventsHelper
       news_story: 'PM attends summit on topical events',
       statistics: 'Weekly topical event prices'
     }
+  end
+
+  def stub_topical_event_in_content_store(name)
+    content_item = {
+      format: "topical_event",
+      title: name,
+    }
+
+    base_path = topical_event_path(TopicalEvent.find_by!(name: name))
+
+    content_store_has_item(base_path, content_item)
   end
 end
 

--- a/features/support/topics_helper.rb
+++ b/features/support/topics_helper.rb
@@ -1,5 +1,5 @@
 module TopicsHelper
-  def create_topic(options = {})
+  def create_topic_and_stub_content_store(options = {})
     start_creating_topic(options)
     save_document
   end
@@ -13,6 +13,12 @@ module TopicsHelper
     (options[:related_classifications] || []).each do |related_name|
       select related_name, from: "Related policy areas"
     end
+  end
+
+  def stub_topic_in_content_store(name)
+    content_item = { format: "topic", title: name }
+    base_path = topic_path(Topic.find_by!(name: name))
+    content_store_has_item(base_path, content_item)
   end
 end
 

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -13,7 +13,7 @@ module OrganisationResluggerTest
     def setup
       stub_any_publishing_api_call
       DatabaseCleaner.clean_with :truncation
-      @organisation = create_organisation
+      @organisation = create_org_and_stub_content_store
       WebMock.reset! # clear the Publishing API calls after org creation
       stub_any_publishing_api_call
       @reslugger = DataHygiene::OrganisationReslugger.new(@organisation, 'corrected-slug')
@@ -63,7 +63,7 @@ module OrganisationResluggerTest
   class OrganisationTest < ActiveSupport::TestCase
     include SharedTests
 
-    def create_organisation
+    def create_org_and_stub_content_store
       create(:organisation, name: "Old slug")
     end
 
@@ -92,7 +92,7 @@ module OrganisationResluggerTest
   class WorldwideOrganisationTest < ActiveSupport::TestCase
     include SharedTests
 
-    def create_organisation
+    def create_org_and_stub_content_store
       create(:worldwide_organisation, name: "Old slug")
     end
 


### PR DESCRIPTION
Add meta tag component to pages which are used for navigation: organisations, policy areas, topical events and the organisations homepage.

The meta tag component requires a content item, so this change also loads the content item on each of those pages.

This will help us track users' journeys through the navigation and content elements of the site to work out whether they find the content they're looking for.

https://trello.com/c/R4CWwrua/498-tracking-finding-vs-thing-for-whitehall-formats

The change to the app code is quite small, but adding content store call to these pages has affected a lot of tests.