### PR TITLE
[DO NOT MERGE] Enable tagging to draft taxons

### DIFF
--- a/app/models/edition_taxonomy_tag_form.rb
+++ b/app/models/edition_taxonomy_tag_form.rb
@@ -37,7 +37,15 @@ class EditionTaxonomyTagForm
   end
 
   def education_taxons
-    Taxonomy.education
+    @education_taxons ||= Taxonomy.education
+  end
+
+  def live_education_taxons
+    education_taxons.children.reject(&:draft)
+  end
+
+  def draft_education_taxons
+    education_taxons.children.select(&:draft)
   end
 
   # Ignore any taxons that already have a more specific taxon selected

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -25,13 +25,27 @@
             <%= @edition_tag_form.education_taxons.name %>
           </p>
 
-          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children} %>
+          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.live_education_taxons} %>
         </div>
       </div>
 
       <p>
         <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
       </p>
+
+      <% if @edition_tag_form.draft_education_taxons.any? %>
+        <div class="topic-tree">
+
+          <p class="bold-taxon-name">
+            Draft topics
+          </p>
+
+          <p>These topic pages are in development, and are not shown on GOV.UK</p>
+
+          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.draft_education_taxons} %>
+        </div>
+      <% end %>
+    </div>
 
       <h2>Selected topics</h2>
       <div class="content content-bordered hidden" data-module="breadcrumb-preview">

--- a/lib/taxonomy.rb
+++ b/lib/taxonomy.rb
@@ -14,14 +14,15 @@ module Taxonomy
   # https://github.com/alphagov/govuk_taxonomy_helpers/pull/1
   class LinkedEdition
     extend Forwardable
-    attr_reader :name, :content_id, :base_path
+    attr_reader :name, :content_id, :base_path, :draft
     attr_accessor :parent_node
     def_delegators :tree, :map, :each
 
-    def initialize(name:, base_path:, content_id:)
+    def initialize(name:, base_path:, content_id:, draft:)
       @name = name
       @content_id = content_id
       @base_path = base_path
+      @draft = draft
       @children = []
     end
 
@@ -85,7 +86,8 @@ module Taxonomy
       @linked_edition = LinkedEdition.new(
         name: edition_response[name_field],
         content_id: edition_response["content_id"],
-        base_path: edition_response["base_path"]
+        base_path: edition_response["base_path"],
+        draft: edition_response["draft"]
       )
 
       @name_field = name_field
@@ -109,7 +111,8 @@ module Taxonomy
       nested_linked_edition = LinkedEdition.new(
         name: nested_item[name_field],
         content_id: nested_item["content_id"],
-        base_path: nested_item["base_path"]
+        base_path: nested_item["base_path"],
+        draft: nested_item["draft"]
       )
 
       child_taxons = nested_item["links"]["child_taxons"]


### PR DESCRIPTION
This commit splits the taxons on the taxonomy tagging page into live and draft taxons to make it clear to publishers which taxons will not appear on the live site.

Depends on https://github.com/alphagov/publishing-api/pull/833.

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall

Paired with @Davidslv 

![screen shot 2017-03-13 at 11 42 10](https://cloud.githubusercontent.com/assets/444232/23852939/3a04f6fc-07e2-11e7-993d-2705cab80064.png)
