### PR TITLE
Present edition links for Publications

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -28,6 +28,7 @@ module PublishingApi
         public_updated_at: item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: schema_name,
+        links: links,
       )
       content.merge!(PayloadBuilder::Routes.for(base_path))
     end

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
         #item.rendering_app is switched when preview is ready
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "publication",
+        links: links,
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -121,10 +121,11 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
   end
 
   test "#save_and_update_publishing_api saves the attachment" do
-    build(
+    publication = build(
       :draft_publication,
       html_attachments: [attachment = build(:html_attachment)]
     )
+    attachment.attachable = publication
     attachment.save_and_update_publishing_api
     assert attachment.persisted?, "Attachment has not been saved"
   end

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -49,7 +49,10 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     assert_equivalent_html expected_hash[:details].delete(:body),
       presented_content[:details].delete(:body)
 
-    assert_equal expected_hash, presented_content
+    expected_content = expected_hash.merge(links: presented_item.links)
+    assert_equal expected_content, presented_content
+
+    %i(organisations parent).each { |k| assert_includes(expected_content[:links].keys, k) }
   end
 
   test "HtmlAttachment presentation includes the correct locale" do

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -70,6 +70,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       related_policies: ['5d37821b-7631-11e4-a3cb-005056011aef'],
       policy_areas: publication.topics.map(&:content_id)
     }
+    expected_content.merge!(links: expected_links)
 
     presented_item = present(publication)
 
@@ -85,6 +86,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       presented_item.content[:details].delete(:body)
     assert_equal expected_content[:details], presented_item.content[:details].except(:body)
     assert_equal expected_links, presented_item.links
+    assert_equal expected_links, presented_item.content[:links]
     assert_equal publication.document.content_id, presented_item.content_id
   end
 
@@ -93,10 +95,15 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     create(:specialist_sector, topic_content_id: "content_id_1", edition: edition, primary: true)
     create(:specialist_sector, topic_content_id: "content_id_2", edition: edition, primary: false)
 
-    links = present(edition).links
+    presented = present(edition)
+    links = presented.links
+    edition_links = presented.content[:links]
 
     assert_equal links[:topics], %w(content_id_1 content_id_2)
     assert_equal links[:parent], %w(content_id_1)
+
+    assert_equal edition_links[:topics], %w(content_id_1 content_id_2)
+    assert_equal edition_links[:parent], %w(content_id_1)
   end
 
   test "links hash includes lead and supporting organisations in correct order" do
@@ -121,6 +128,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
     assert_equal expected_links_hash, presented_item.links
+    assert_equal expected_links_hash, presented_item.content[:links]
   end
 
   test "details hash includes full document history" do
@@ -146,6 +154,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     presented_item = present(publication)
     assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
     assert_equal [location.content_id], presented_item.links[:world_locations]
+    assert_equal [location.content_id], presented_item.content[:links][:world_locations]
   end
 
   test "documents include the alternative format contact email" do


### PR DESCRIPTION
https://trello.com/c/RWL7ppZ6/637-use-draft-links-for-publications

In order to make draft links previewable we should present the links as part of the content payload as these
do not get populated as part of the initial draft.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/569 for updated schema definitions.