### PR TITLE
Only throttle test step, not the whole CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,14 +12,6 @@ node {
         numToKeepStr: '50')
       ),
     [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
-    [$class: 'ThrottleJobProperty',
-      categories: [],
-      limitOneJobWithMatchingParams: true,
-      maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 0,
-      paramsToUseForLimit: 'whitehall',
-      throttleEnabled: true,
-      throttleOption: 'category'],
     [$class: 'ParametersDefinitionProperty',
       parameterDefinitions: [
         [$class: 'BooleanParameterDefinition',
@@ -75,12 +67,14 @@ node {
     }
 
     stage("Run tests") {
-      govuk.setEnvar("RAILS_ENV", "test")
-      if (params.IS_SCHEMA_TEST) {
-        echo "Running a subset of the tests to check the content schema changes"
-        govuk.runRakeTask("test:publishing_schemas --trace")
-      } else {
-        govuk.runRakeTask("ci:setup:minitest test:in_parallel --trace")
+      lock ("whitehall-$NODE_NAME-test") {
+        govuk.setEnvar("RAILS_ENV", "test")
+        if (params.IS_SCHEMA_TEST) {
+          echo "Running a subset of the tests to check the content schema changes"
+          govuk.runRakeTask("test:publishing_schemas --trace")
+        } else {
+          govuk.runRakeTask("ci:setup:minitest test:in_parallel --trace")
+        }
       }
     }
 


### PR DESCRIPTION
Delete the `ThrottleJobProperty` config from the Jenkinsfile. The Throttle Concurrent Builds plugin isn't fully compatible with pipeline jobs: the `maxConcurrentPerNode` setting is ignored, and the
`limitOneJobWithMatchingParams` setting was causing schema test builds to pile up in an executor queue because all of their parameters matched.

Since each job is executed in its own workspace, it should be safe to run multiple whitehall builds in parallel so the throttling parameters have been removed entirely.

It's not safe to run the tests in parallel though, so this commit adds a lock which prevents the tests being run on the same node.

This should speed up schema test builds because multiple whitehall schema tests can be run in parallel.

https://trello.com/c/zS6xM6Kl/18-whitehall-jobs-block-other-jobs