### PR TITLE
Use content store for policy links instead of linkables

### DIFF
--- a/app/models/featured_policy.rb
+++ b/app/models/featured_policy.rb
@@ -1,7 +1,7 @@
 class FeaturedPolicy < ActiveRecord::Base
   extend ActiveSupport::Concern
 
-  belongs_to :organisation, inverse_of: :featured_policies
+  belongs_to :organisation, inverse_of: :featured_policies, touch: true
 
   before_create :set_ordering, if: -> { ordering.blank? }
 

--- a/app/presenters/featured_policies_presenter.rb
+++ b/app/presenters/featured_policies_presenter.rb
@@ -1,0 +1,47 @@
+class FeaturedPoliciesPresenter
+  include Enumerable
+
+  delegate :empty?, to: :policies
+
+  Policy = Struct.new(:content_id, :title, :base_path) do
+    def link
+      base_path
+    end
+  end
+
+  def initialize(featured_policies, links)
+    @featured_policies = featured_policies
+    @links = links || {}
+  end
+
+  def each(&block)
+    policies.each { |policy| block.call(policy) }
+  end
+
+private
+
+  attr_reader :featured_policies, :links
+
+  def policies
+    @policies ||= featured_policies.map { |fp| policy(fp) }.compact
+  end
+
+  def policy(featured_policy)
+    policy = policy_from_links(featured_policy) || policy_from_linkables(featured_policy)
+    Policy.new(*policy.values) if policy
+  end
+
+  def policy_from_links(featured_policy)
+    link = links.find { |l| l["content_id"] == featured_policy.policy_content_id }
+    link.symbolize_keys.slice(:content_id, :title, :base_path) if link
+  end
+
+  def policy_from_linkables(featured_policy)
+    policy = linkables.find { |l| l.content_id == featured_policy.policy_content_id }
+    policy.as_json.symbolize_keys.slice(:content_id, :title, :base_path) if policy
+  end
+
+  def linkables
+    @linkables ||= ::Policy.all
+  end
+end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -25,6 +25,9 @@ module PublishingApi
         description: nil,
         details: details,
         document_type: item.class.name.underscore,
+        links: {
+          featured_policies: featured_policies_links,
+        },
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: schema_name,
@@ -69,6 +72,12 @@ module PublishingApi
     def brand
       brand_colour = item.organisation_brand_colour
       brand_colour ? brand_colour.class_name : nil
+    end
+
+    def featured_policies_links
+      # Publishing API will reject duplicate content_ids here so distinct is
+      # used
+      item.featured_policies.order(:ordering).distinct.pluck(:policy_content_id)
     end
   end
 end

--- a/test/unit/presenters/featured_policies_presenter_test.rb
+++ b/test/unit/presenters/featured_policies_presenter_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class FeaturedPoliciesPresenterTest < ActionView::TestCase
+  setup do
+    @featured_policies = [
+      build(:featured_policy, policy_content_id: SecureRandom.uuid),
+      build(:featured_policy, policy_content_id: SecureRandom.uuid),
+    ]
+    @content_ids = @featured_policies.map(&:policy_content_id)
+    @links = @content_ids.each_with_index.map do |content_id, i|
+      count = i + 1
+      {
+        "content_id" => content_id,
+        "title" => "Title #{count}",
+        "base_path" => "/government/page-#{count}",
+      }
+    end
+  end
+
+  test "can use enumerable methods" do
+    presenter = FeaturedPoliciesPresenter.new(@featured_policies, @links)
+    assert_respond_to presenter, :map
+    assert_respond_to presenter, :select
+    assert_respond_to presenter, :to_a
+  end
+
+  test "populates Policy with details from links" do
+    policy = FeaturedPoliciesPresenter.new(@featured_policies, @links).first
+    expected = FeaturedPoliciesPresenter::Policy.new(
+      @content_ids.first, "Title 1", "/government/page-1"
+    )
+    assert_equal policy, expected
+  end
+
+  test "fallsback to linkables when links aren't available" do
+    content_id = SecureRandom.uuid
+    featured_policies = [build(:featured_policy, policy_content_id: content_id)]
+
+    policies = [
+      {
+        content_id: content_id,
+        title: "Linkable",
+        publication_state: "published",
+        base_path: "/government/linkable",
+        internal_name: "Internal Name",
+      }
+    ]
+    publishing_api_has_linkables(policies, document_type: "policy")
+
+    policy = FeaturedPoliciesPresenter.new(featured_policies, {}).first
+    expected = FeaturedPoliciesPresenter::Policy.new(
+      content_id, "Linkable", "/government/linkable"
+    )
+    assert_equal policy, expected
+  end
+
+  test "empty when there aren't featured policies" do
+    presenter = FeaturedPoliciesPresenter.new([], @links)
+    assert_empty presenter
+  end
+
+  test "empty when it can't match links" do
+    featured_policies = [build(:featured_policy)]
+    presenter = FeaturedPoliciesPresenter.new(featured_policies, @links)
+    assert_empty presenter
+  end
+end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -22,6 +22,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       description: nil,
       schema_name: 'placeholder',
       document_type: 'organisation',
+      links: { featured_policies: [] },
       locale: 'en',
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',


### PR DESCRIPTION
This won't build green until https://github.com/alphagov/govuk-content-schemas/pull/563 is merged in.

This is a system that replaces Whitehall using the Publishing API's linkables endpoint to render frontend content. It works by publishing the featured policies as links to the organisations placeholder content item). Then when rendering a page it'll access the content item.

For a painless transition this falls back to linkables if there aren't links in the content item. Once we have republished everything we could remove the fall back.