### PR TITLE
Write report output to Rails.root by default

### DIFF
--- a/lib/attachment_data_reporter.rb
+++ b/lib/attachment_data_reporter.rb
@@ -7,7 +7,7 @@ class AttachmentDataReporter
   attr_reader :data_path, :start_date, :end_date
 
   def initialize(opts={})
-    @data_path  = opts.fetch(:data_path, ENV['HOME'])
+    @data_path  = opts.fetch(:data_path, Rails.root)
     @start_date = Date.parse(opts.fetch(:start_date, 1.month.ago.to_s))
     @end_date   = Date.parse(opts.fetch(:end_date,   1.day.since.to_s))
   end

--- a/lib/pdf_attachment_reporter.rb
+++ b/lib/pdf_attachment_reporter.rb
@@ -22,7 +22,7 @@ class PDFAttachmentReporter
   POLICY_GROUPS = 'Policy Groups'.freeze
 
   def initialize(opts = {})
-    @data_path = opts.fetch(:data_path, ENV['HOME'])
+    @data_path = opts.fetch(:data_path, Rails.root)
     @first_period_start_date = opts.fetch(:first_period_start_date, Date.parse('2016-01-01'))
     @last_time_period_days = opts.fetch(:last_time_period_days, 30)
   end


### PR DESCRIPTION
This is consistent with other apps. (See e.g https://github.com/alphagov/specialist-publisher/blob/master/lib/tasks/report.rake#L139 and https://github.com/alphagov/manuals-publisher/blob/master/bin/content_model_pdf_report#L10).

Note that the default location for the [collections report](https://github.com/alphagov/whitehall/blob/master/lib/tasks/reporting.rake#L22) was kept using an temp directory as this report outputs many CSV files at once and I don't think they should live in Rails.root by default.