### PR TITLE
Pluck document content ids for added efficiency

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )
-      links.merge!(documents: item.documents.map(&:content_id).uniq)
+      links.merge!(documents: item.documents.pluck(:content_id).uniq)
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
     end
 

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -158,12 +158,9 @@ end
 class PublishingApi::DocumentCollectionPresenterDocumentLinksTestCase < ActiveSupport::TestCase
   setup do
     document_collection = create(:document_collection)
-    document_collection.stubs(:documents).returns(
-      [
-        stub(content_id: "faf"),
-        stub(content_id: "afa")
-      ]
-    )
+    documents = mock('documents')
+    documents.expects(:pluck).with(:content_id).returns(%w(faf afa))
+    document_collection.stubs(:documents).returns(documents)
 
     @presented_links = PublishingApi::DocumentCollectionPresenter.new(
       document_collection
@@ -304,13 +301,9 @@ end
 class PublishingApi::PublishedDocumentCollectionPresenterDuplicateDocumentsTest < ActiveSupport::TestCase
   setup do
     @document_collection = create(:document_collection)
-    @document_collection.stubs(:documents).returns(
-      [
-        OpenStruct.new(content_id: "test"),
-        OpenStruct.new(content_id: "test"),
-        OpenStruct.new(content_id: "ers"),
-      ]
-    )
+    documents = mock('documents')
+    documents.expects(:pluck).twice.with(:content_id).returns(%w(test test ers))
+    @document_collection.stubs(:documents).returns(documents)
     presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
     @presented_edition_links = presented_document_collection.content[:links]
     @presented_links = presented_document_collection.links


### PR DESCRIPTION
https://trello.com/c/s7LjBWav/634-use-draft-links-for-documentcollections

A small enhancement to efficiently get the content ids of documents in a given document collection using pluck.