### PR TITLE
Remove duplicate ID from about pages

### DIFF
--- a/app/assets/stylesheets/frontend/views/_organisations.scss
+++ b/app/assets/stylesheets/frontend/views/_organisations.scss
@@ -761,7 +761,7 @@
   #special_representatives h1,
   #judges h1,
   #org-contacts h2,
-  #what-we-do h1, #who-we-are h1 {
+  #what-we-do-article h1, #who-we-are h1 {
     border-bottom-width: 5px;
     border-bottom-style: solid;
   }

--- a/app/views/corporate_information_pages/index.html.erb
+++ b/app/views/corporate_information_pages/index.html.erb
@@ -2,7 +2,7 @@
 <% page_class "organisations-about organisation-page" %>
 
 <%= organisation_wrapper(@organisation) do %>
-  <article id="what-we-do">
+  <article id="what-we-do-article">
     <div class="block-1">
       <div class="inner-block">
         <%= render_corporate_info_header_for(@organisation, @document) %>


### PR DESCRIPTION
The "About" pages have two elements with ID `what-we-do`. This is invalid HTML, which - as well as being bad practice - also prevents the page from loading in a development environment. This Pull Request renames one of these IDs (the one that isn't user-facing).

Annoyingly, the ID is also used in CSS. I've run Wraith [here](https://cdn.rawgit.com/alecgibson/govuk-wraith-results/2b9f23f876d53a1c4d02401cadbce0dea0577d3e/shots/gallery.html). The diffs are just from the Ofsted logo failing to load.