### PR TITLE
bump gds-api-adapters gem to 40.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 40.2.0'
+  gem 'gds-api-adapters', '~> 40.5.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     ffi (1.9.14)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (40.2.0)
+    gds-api-adapters (40.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -478,7 +478,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 40.2.0)
+  gds-api-adapters (~> 40.5.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)
@@ -547,4 +547,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.13.2
+   1.14.5


### PR DESCRIPTION
We need this gem to be updated so we can fetch expanded links from publishing-api with drafts as well.

https://github.com/alphagov/gds-api-adapters/pull/681

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall