### PR TITLE
Request draft taxons to publishing api

### DIFF
--- a/app/models/edition_taxonomy_tag_form.rb
+++ b/app/models/edition_taxonomy_tag_form.rb
@@ -40,9 +40,17 @@ class EditionTaxonomyTagForm
     Taxonomy.education
   end
 
+  def draft_taxons
+    Taxonomy.drafts
+  end
+
+  def all_taxons
+    education_taxons.tree + draft_taxons.flat_map(&:tree)
+  end
+
   # Ignore any taxons that already have a more specific taxon selected
   def most_specific_taxons
-    education_taxons.tree.each_with_object([]) do |taxon, list_of_taxons|
+    all_taxons.each_with_object([]) do |taxon, list_of_taxons|
       content_ids = taxon.descendants.map(&:content_id)
 
       any_descendants_selected = selected_taxons.any? do |selected_taxon|

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -29,6 +29,12 @@
         </div>
       </div>
 
+      <h2>Draft topics</h2>
+
+      <div class="topic-tree">
+        <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.draft_taxons} %>
+      </div>
+
       <p>
         <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
       </p>

--- a/lib/taxonomy.rb
+++ b/lib/taxonomy.rb
@@ -1,9 +1,21 @@
 module Taxonomy
   EDUCATION_CONTENT_ID = "c58fdadd-7743-46d6-9629-90bb3ccc4ef0".freeze
+  DRAFT_CONTENT_IDS = ["a544d48b-1e9e-47fb-b427-7a987c658c14", "206b7f3a-49b5-476f-af0f-fd27e2a68473"].freeze
+
+  def self.drafts
+    DRAFT_CONTENT_IDS.map do |content_id|
+      content_item = Whitehall.publishing_api_v2_client.get_content(content_id)
+      expanded_links = Whitehall.publishing_api_v2_client.get_expanded_links(content_id, with_drafts: true)
+
+      parser = PublishingApiLinkedEditionParser.new(content_item)
+      parser.add_expanded_links(expanded_links)
+      parser.linked_edition
+    end
+  end
 
   def self.education
     content_item = Whitehall.publishing_api_v2_client.get_content(EDUCATION_CONTENT_ID)
-    expanded_links = Whitehall.publishing_api_v2_client.get_expanded_links(EDUCATION_CONTENT_ID)
+    expanded_links = Whitehall.publishing_api_v2_client.get_expanded_links(EDUCATION_CONTENT_ID, with_drafts: false)
 
     parser = PublishingApiLinkedEditionParser.new(content_item)
     parser.add_expanded_links(expanded_links)
@@ -11,7 +23,7 @@ module Taxonomy
   end
 
   # TODO: move this to a gem
-  # https://github.com/alphagov/govuk_taxonomy_helpers/pull/1
+  # https://github.com/alphagov/govuk_taxonomy_helpers
   class LinkedEdition
     extend Forwardable
     attr_reader :name, :content_id, :base_path

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
     @edition = create(:publication, organisations: [organisation])
 
-    stub_education_taxonomy
+    stub_education_taxonomy_with_draft_expanded_links
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)
@@ -41,7 +41,13 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     put :update, edition_id: @edition, edition_taxonomy_tag_form: { taxons: [child_taxon_content_id], previous_version: 1 }
 
-    assert_publishing_api_patch_links(@edition.content_id, links: { taxons: [child_taxon_content_id] }, previous_version: "1")
+    assert_publishing_api_patch_links(
+      @edition.content_id,
+      links: {
+        taxons: [child_taxon_content_id]
+      },
+      previous_version: "1"
+    )
   end
 
   test 'should post empty array to publishing api if no taxons are selected' do

--- a/test/support/education_taxonomy_helper.rb
+++ b/test/support/education_taxonomy_helper.rb
@@ -3,6 +3,10 @@ module EducationTaxonomyHelper
     Taxonomy::EDUCATION_CONTENT_ID
   end
 
+  def draft_taxon_content_ids
+    Taxonomy::DRAFT_CONTENT_IDS
+  end
+
   def parent_taxon_content_id
     "904cfd73-2707-47b8-8754-5765ec5a5b68"
   end
@@ -15,21 +19,51 @@ module EducationTaxonomyHelper
     "7c75c541-403f-4cb1-9b34-4ddde816a80d"
   end
 
-  def stub_education_taxonomy
+  def stub_education_taxonomy_with_draft_expanded_links
     publishing_api_has_item({
       "title" => "Education",
       "base_path" => "/education",
       "content_id" => root_taxon_content_id
     })
 
-    publishing_api_has_expanded_links({
-        content_id: root_taxon_content_id,
-        expanded_links: {
-          "child_taxons" => [
-            grandparent_taxon
-          ]
-        }
+    live_links = {
+      content_id: root_taxon_content_id,
+      expanded_links: {
+        "child_taxons" => [
+          grandparent_taxon
+        ]
+      }
+    }
+
+    publishing_api_has_item({
+      "title" => "About your organisation",
+      "base_path" => "/about-your-organisation",
+      "content_id" => draft_taxon_content_ids.first
     })
+
+    draft_taxon_1 = {
+      content_id: draft_taxon_content_ids.first,
+      expanded_links: {
+        "child_taxons" => []
+      }
+    }
+
+    publishing_api_has_item({
+      "title" => "Parenting",
+      "base_path" => "/childcare-parenting",
+      "content_id" => draft_taxon_content_ids.last
+    })
+
+    draft_taxon_2 = {
+      content_id: draft_taxon_content_ids.last,
+      expanded_links: {
+        "child_taxons" => []
+      }
+    }
+
+    publishing_api_has_expanded_links(live_links, with_drafts: false)
+    publishing_api_has_expanded_links(draft_taxon_1, with_drafts: true)
+    publishing_api_has_expanded_links(draft_taxon_2, with_drafts: true)
   end
 
 private

--- a/test/unit/models/edition_taxonomy_tag_form_test.rb
+++ b/test/unit/models/edition_taxonomy_tag_form_test.rb
@@ -43,7 +43,7 @@ class EditionTaxonomyTagFormTest < ActiveSupport::TestCase
   end
 
   test '#most_specific_taxons ignores taxons if there is a more specific one' do
-    stub_education_taxonomy
+    stub_education_taxonomy_with_draft_expanded_links
 
     selected_taxons = [
       grandparent_taxon_content_id,


### PR DESCRIPTION
In this commit we have hardcoded the content_id of two taxons that we know are currently in draft state.
The intention is to allow users to tag documents to those two taxons, for that, we need to make a separate request to Publishing API for each draft taxon.

History

We thought of making two separate requests to Publishing API, the first
would only have live taxons and the second would have live and draft
taxons. We would then identify the ones not in the first request and
mark them as draft. Although this wasn't ideal because it was looking
into the Education Taxonomy only, that means that any draft taxon that
is not a child of Education wouldn't be considered.

Once the functionality has been tested we can then move it into https://github.com/alphagov/govuk_taxonomy_helpers

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall
### Look & Feel

<img width="1227" alt="screen shot 2017-03-22 at 13 01 56" src="https://cloud.githubusercontent.com/assets/136777/24199017/0e439594-0f00-11e7-9747-0c0392629f4b.png">
<img width="982" alt="screen shot 2017-03-22 at 13 03 16" src="https://cloud.githubusercontent.com/assets/136777/24199018/0e4895ee-0f00-11e7-8c71-cea6b722c153.png">

![Uploading Screen Shot 2017-03-22 at 13.07.26.png…]()
