### PR TITLE
Fix typo in data migrations

### DIFF
--- a/db/data_migration/20170317143146_republish_fatality_notices_with_ministers.rb
+++ b/db/data_migration/20170317143146_republish_fatality_notices_with_ministers.rb
@@ -5,5 +5,5 @@ ids = [
 ]
 Document.where(id: ids).each do |document|
   PublishingApiDocumentRepublishingWorker
-    .perform_async_in_queue("bulk_republishng", document.id)
+    .perform_async_in_queue("bulk_republishing", document.id)
 end

--- a/db/data_migration/20170317143952_republish_consultations_with_ministers.rb
+++ b/db/data_migration/20170317143952_republish_consultations_with_ministers.rb
@@ -205,5 +205,5 @@ ids = [
 ]
 Document.where(id: ids).each do |document|
   PublishingApiDocumentRepublishingWorker
-    .perform_async_in_queue("bulk_republishng", document.id)
+    .perform_async_in_queue("bulk_republishing", document.id)
 end


### PR DESCRIPTION
Data migrations for republishing Fatality Notices and Consultations have a typo "bulk_republishng" should be "bulk_republishing".

Related: https://github.com/alphagov/whitehall/pull/3125#discussion_r107390339