### PR TITLE
Lock all build steps which modify the database

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,12 +62,12 @@ node {
       govuk.rubyLinter('app test lib')
     }
 
-    stage("Set up the DB") {
-      sh("RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load")
-    }
+    lock ("whitehall-$NODE_NAME-test") {
+      stage("Set up the DB") {
+        sh("RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load")
+      }
 
-    stage("Run tests") {
-      lock ("whitehall-$NODE_NAME-test") {
+      stage("Run tests") {
         govuk.setEnvar("RAILS_ENV", "test")
         if (params.IS_SCHEMA_TEST) {
           echo "Running a subset of the tests to check the content schema changes"


### PR DESCRIPTION
This prevents a build from recreating the test database while another build on the same node is running tests.

I spotted this while showing someone the Jenkinsfile `lock` syntax. As far as I know it hasn't caused a problem on whitehall yet, but we fixed it elsewhere because of publishing-api build failures (alphagov/govuk-puppet#5641) so it seems worth fixing pre-emptively here.