### PR TITLE
Republish organisation about pages when dependees change

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -188,6 +188,15 @@ class Organisation < ActiveRecord::Base
   before_destroy { |r| r.destroyable? }
   after_save :ensure_analytics_identifier
 
+  # If the organisation has an about us page and the chart URL changes we need
+  # to republish the about us page as it contains the chart URL.
+  after_save do
+    if organisation_chart_url_changed? && about_us.present?
+      PublishingApiDocumentRepublishingWorker
+        .perform_async(about_us.document_id)
+    end
+  end
+
   def custom_logo_selected?
     organisation_logo_type_id == OrganisationLogoType::CustomLogo.id
   end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -35,13 +35,28 @@ module ServiceListeners
         api.discard_draft_async(edition)
       end
 
+      handle_corporate_information_pages(event)
       handle_html_attachments(event)
+      handle_publications(event)
     end
 
   private
 
+    def handle_corporate_information_pages(event)
+      return unless edition.is_a?(CorporateInformationPage)
+
+      PublishingApiCorporateInformationPagesWorker
+        .perform_async(edition.id, event)
+    end
+
     def handle_html_attachments(event)
       PublishingApiHtmlAttachmentsWorker.perform_async(edition.id, event)
+    end
+
+    def handle_publications(event)
+      return unless edition.is_a?(Publication)
+
+      PublishingApiPublicationsWorker.perform_async(edition.id, event)
     end
 
     def handle_translations

--- a/app/workers/publishing_api_corporate_information_pages_worker.rb
+++ b/app/workers/publishing_api_corporate_information_pages_worker.rb
@@ -1,0 +1,39 @@
+class PublishingApiCorporateInformationPagesWorker
+  extend Forwardable
+  include Sidekiq::Worker
+
+  def perform(edition_id, event)
+    self.corporate_information_page =
+      CorporateInformationPage.unscoped.find(edition_id)
+
+    send(event) if respond_to?(event)
+  end
+
+  def publish
+    return unless about_us_page.present?
+
+    PublishingApiDocumentRepublishingWorker.perform_async(
+      about_us_page.document_id,
+    )
+  end
+
+  alias :delete :publish
+  alias :force_publish :publish
+  alias :republish :publish
+  alias :unpublish :publish
+  alias :unwithdraw :publish
+  alias :update_draft :publish
+  alias :update_draft_translation :publish
+  alias :withdraw :publish
+
+private
+
+  attr_accessor :corporate_information_page
+  def_delegator :corporate_information_page, :organisation
+
+  def about_us_page
+    return unless organisation.present?
+
+    organisation.about_us
+  end
+end

--- a/app/workers/publishing_api_publications_worker.rb
+++ b/app/workers/publishing_api_publications_worker.rb
@@ -1,0 +1,50 @@
+class PublishingApiPublicationsWorker
+  extend Forwardable
+  include Sidekiq::Worker
+
+  def perform(edition_id, event)
+    self.publication =
+      Publication.unscoped.find(edition_id)
+
+    send(event) if respond_to?(event) && publication_effects_about_pages?
+  end
+
+  def publish
+    return unless about_us_pages.present?
+
+    about_us_pages
+      .map(&:document_id)
+      .each(&PublishingApiDocumentRepublishingWorker.method(:perform_async))
+  end
+
+  alias :delete :publish
+  alias :force_publish :publish
+  alias :republish :publish
+  alias :unpublish :publish
+  alias :unwithdraw :publish
+  alias :update_draft :publish
+  alias :update_draft_translation :publish
+  alias :withdraw :publish
+
+private
+
+  attr_accessor :publication
+  def_delegator :publication, :organisations
+  def_delegator :publication, :publication_type
+
+  def about_us_pages
+    return unless organisations.present?
+
+    organisations
+      .map(&:about_us)
+      .compact
+  end
+
+  def publication_effects_about_pages?
+    [
+      PublicationType::CorporateReport,
+      PublicationType::FoiRelease,
+      PublicationType::TransparencyData,
+    ].include?(publication_type)
+  end
+end

--- a/test/unit/services/listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/listeners/publishing_api_pusher_test.rb
@@ -2,8 +2,22 @@ require 'test_helper'
 
 module ServiceListeners
   class PublishingApiPusherTest < ActiveSupport::TestCase
+    def stub_corporate_information_pages_pusher(edition, event)
+      PublishingApiCorporateInformationPagesWorker
+        .any_instance
+        .expects(:perform)
+        .with(edition.id, event)
+    end
+
     def stub_html_attachment_pusher(edition, event)
       PublishingApiHtmlAttachmentsWorker
+        .any_instance
+        .expects(:perform)
+        .with(edition.id, event)
+    end
+
+    def stub_publications_pusher(edition, event)
+      PublishingApiPublicationsWorker
         .any_instance
         .expects(:perform)
         .with(edition.id, event)
@@ -13,6 +27,7 @@ module ServiceListeners
       edition = build(:draft_publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
+      stub_publications_pusher(edition, "update_draft")
       PublishingApiPusher.new(edition).push(event: "update_draft")
     end
 
@@ -24,6 +39,7 @@ module ServiceListeners
       )
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
+      stub_publications_pusher(edition, "update_draft")
       PublishingApiPusher.new(edition).push(event: "update_draft")
     end
 
@@ -31,6 +47,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "publish")
+      stub_publications_pusher(edition, "publish")
       PublishingApiPusher.new(edition).push(event: "publish")
     end
 
@@ -38,6 +55,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "force_publish")
+      stub_publications_pusher(edition, "force_publish")
       PublishingApiPusher.new(edition).push(event: "force_publish")
     end
 
@@ -45,6 +63,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
       stub_html_attachment_pusher(edition, "update_draft_translation")
+      stub_publications_pusher(edition, "update_draft_translation")
       PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
     end
 
@@ -57,6 +76,7 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:publish_withdrawal_async)
         .with(edition.document.content_id, edition.unpublishing.explanation, edition.primary_locale)
       stub_html_attachment_pusher(edition, "withdraw")
+      stub_publications_pusher(edition, "withdraw")
 
       PublishingApiPusher.new(edition).push(event: "withdraw")
     end
@@ -65,6 +85,7 @@ module ServiceListeners
       edition = create(:unpublished_publication)
       Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
       stub_html_attachment_pusher(edition, "unpublish")
+      stub_publications_pusher(edition, "unpublish")
       PublishingApiPusher.new(edition).push(event: "unpublish")
     end
 
@@ -72,6 +93,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "force_schedule")
+      stub_publications_pusher(edition, "force_schedule")
       PublishingApiPusher.new(edition).push(event: "force_schedule")
     end
 
@@ -79,6 +101,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "schedule")
+      stub_publications_pusher(edition, "schedule")
       PublishingApiPusher.new(edition).push(event: "schedule")
     end
 
@@ -86,6 +109,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
       stub_html_attachment_pusher(edition, "unschedule")
+      stub_publications_pusher(edition, "unschedule")
       PublishingApiPusher.new(edition).push(event: "unschedule")
     end
 
@@ -93,6 +117,7 @@ module ServiceListeners
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "delete")
+      stub_publications_pusher(edition, "delete")
       PublishingApiPusher.new(edition).push(event: "delete")
     end
 
@@ -138,6 +163,24 @@ module ServiceListeners
       )
 
       PublishingApiPusher.new(new_edition).push(event: "publish")
+    end
+
+    test 'handles corporate information pages' do
+      edition = build(:corporate_information_page, document: build(:document))
+
+      stub_corporate_information_pages_pusher(edition, 'update_draft')
+      stub_html_attachment_pusher(edition, 'update_draft')
+
+      PublishingApiPusher.new(edition).push(event: 'update_draft')
+    end
+
+    test 'handles publications' do
+      edition = build(:publication, document: build(:document))
+
+      stub_publications_pusher(edition, 'update_draft')
+      stub_html_attachment_pusher(edition, 'update_draft')
+
+      PublishingApiPusher.new(edition).push(event: 'update_draft')
     end
   end
 end

--- a/test/unit/workers/publishing_api_corporate_information_pages_worker_test.rb
+++ b/test/unit/workers/publishing_api_corporate_information_pages_worker_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class PublishingApiCorporateInformationPagesWorkerTest < ActiveSupport::TestCase
+  def assert_document_republished(document_id)
+    PublishingApiDocumentRepublishingWorker
+      .expects(:perform_async)
+      .with(document_id)
+
+    event = self.class.name.demodulize.underscore
+
+    PublishingApiCorporateInformationPagesWorker
+      .new
+      .perform(
+        corporate_information_page.id,
+        event,
+      )
+  end
+
+  def about_page
+    @about_page ||= create(
+      :about_corporate_information_page,
+      organisation: organisation,
+    )
+  end
+
+  def corporate_information_page
+    create(:corporate_information_page, organisation: organisation)
+  end
+
+  def organisation
+    @organisation ||= create(:organisation)
+  end
+
+  class Delete < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class ForcePublish < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class Publish < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class Republish < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class Unpublish < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class Unwithdraw < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class UpdateDraft < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class UpdateDraftTranslation < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+
+  class Withdraw < PublishingApiCorporateInformationPagesWorkerTest
+    test 'it republishes the corresponding about page' do
+      assert_document_republished about_page.document_id
+    end
+  end
+end

--- a/test/unit/workers/publishing_api_publications_worker_test.rb
+++ b/test/unit/workers/publishing_api_publications_worker_test.rb
@@ -1,0 +1,158 @@
+require 'test_helper'
+
+class PublishingApiPublicationsWorkerTest < ActiveSupport::TestCase
+  def about_pages
+    @about_pages ||= organisations.collect do |organisation|
+      create(:about_corporate_information_page, organisation: organisation)
+    end
+  end
+
+  def about_page_document_ids
+    @about_page_document_ids ||= about_pages.map(&:document_id)
+  end
+
+  def organisations
+    @organisations ||= create_list(:organisation, 2)
+  end
+
+  def call(publication_trait = nil)
+    publication = create(:publication, publication_trait,
+                         organisations: organisations)
+
+    PublishingApiPublicationsWorker
+      .new
+      .perform(
+        publication.id,
+        'delete',
+      )
+  end
+
+  class Publish < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page when related' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+
+    test 'it does not republish the corresponding about page when unrelated' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+            .never
+        }
+
+      call :statistics
+    end
+  end
+
+  class Delete < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class ForcePublish < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class Republish < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class Unpublish < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class Unwithdraw < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class UpdateDraft < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class UpdateDraftTranslation < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+
+  class Withdraw < PublishingApiPublicationsWorkerTest
+    test 'it republishes the corresponding about page' do
+      about_page_document_ids
+        .each { |document_id|
+          PublishingApiDocumentRepublishingWorker
+            .expects(:perform_async)
+            .with(document_id)
+        }
+
+      call :foi_release
+    end
+  end
+end


### PR DESCRIPTION
The contents of an Organisation's about Corporate Information Page can change for the following reasons:

- the Organisation changes it's chart URL
- the Organisation publishes a Corporate Information Page
- the Organisation publishes a Corporate Report Publication
- the Organisation publishes a Freedom of Information Release Publication
- the Organisation publishes a Transparency Data Publication

These changes ensure that the Organisation's about page is republished in any such case.

This behaviour currently exists at render [here](https://github.com/alphagov/whitehall/blob/master/app/views/corporate_information_pages/index.html.erb#L51-L53) and [here](https://github.com/alphagov/whitehall/blob/master/app/views/organisations/_corporate_information.html.erb). With the Publishing API the equivalent of a render is presenting the about page during republishing.

[See Trello](https://trello.com/c/ND2S0vBm)