### PR TITLE
Map URL to Email Alert API style matching hash

### DIFF
--- a/lib/tasks/url_to_subscriber_list_criteria.rake
+++ b/lib/tasks/url_to_subscriber_list_criteria.rake
@@ -1,0 +1,7 @@
+desc "Create disabled subscriber lists in email-alert-api from govuk-delivery CSV export"
+task :url_to_subscriber_list_criteria, [:csv_path, :perform_migration] => :environment do |_t, args|
+  migrator = UrlToSubscriberListCriteriaMigration.new(args[:csv_path], args[:perform_migration])
+
+  migrator.run
+  migrator.report
+end

--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -1,0 +1,157 @@
+require 'uri'
+
+class UrlToSubscriberListCriteria
+  MISSING_LOOKUP = "*** MISSING KEY ***"
+  EMAIL_SUPERTYPE = "email_document_supertype"
+  GOVERNMENT_SUPERTYPE = "government_document_supertype"
+  class UnprocessableUrl < StandardError; end
+
+  def initialize(url, static_data = StaticData)
+    @url = URI.parse(url.strip)
+    @static_data = static_data
+    @missing_lookups = []
+  end
+
+  def convert
+    @convert ||= begin
+      hash = map_url_to_hash.dup
+      if hash["links"]
+        links = hash["links"].each_with_object({}) do |(key, values), result|
+          result[key] = values.map { |value| lookup_content_id(key, value) }
+        end
+        hash.merge!("links" => links)
+      end
+      hash
+    end
+  end
+
+  def missing_lookup
+    convert
+    @missing_lookups.to_sentence if @missing_lookups.any?
+  end
+
+  def map_url_to_hash
+    @map_url_to_hash ||= begin
+      result = if @url.path.match(%r{^/government/statistics\.atom$})
+                 { "links" => from_params, EMAIL_SUPERTYPE => "publications", GOVERNMENT_SUPERTYPE => "statistics" }
+               elsif @url.path.match(%r{^/government/publications\.atom$})
+                 { "links" => from_params, EMAIL_SUPERTYPE => "publications" }
+               elsif @url.path.match(%r{^/government/announcements\.atom$})
+                 { "links" => from_params, EMAIL_SUPERTYPE => "announcements" }
+               elsif (path_match = @url.path.match(%r{^/government/world/(.*)\.atom$}))
+                 { "links" => from_params.merge("world_locations" => [path_match[1]]) }
+               elsif (path_match = @url.path.match(%r{^/government/people/(.*)\.atom$}))
+                 { "links" => from_params.merge("people" => [path_match[1]]) }
+               elsif (path_match = @url.path.match(%r{^/government/ministers/(.*)\.atom$}))
+                 { "links" => from_params.merge("roles" => [path_match[1]]) }
+               elsif (path_match = @url.path.match(%r{^/government/organisations/(.*)\.atom$}))
+                 { "links" => from_params.merge("organisations" => [path_match[1]]) }
+               elsif (path_match = @url.path.match(%r{^/government/topical-events/(.*)\.atom$}))
+                 { "links" => from_params.merge("topical_events" => [path_match[1]]) }
+               elsif (path_match = @url.path.match(%r{^/government/topics/(.*)\.atom$}))
+                 { "links" => from_params.merge(topic_map([path_match[1]]) => [path_match[1]]) }
+               elsif @url.path =~ %r{/government/feed}
+                 { 'links' => from_params }
+
+               else
+                 raise UnprocessableUrl, @url.to_s
+               end
+
+      if result.fetch("links", {})["publication_filter_option"]
+        result[GOVERNMENT_SUPERTYPE] = result["links"].delete("publication_filter_option")
+      end
+      if result.fetch("links", {})["announcement_filter_option"]
+        result[GOVERNMENT_SUPERTYPE] = result["links"].delete("announcement_filter_option")
+      end
+
+      result
+    end
+  end
+
+  def from_params
+    return {} if @url.query.blank?
+
+    result = Rack::Utils.parse_nested_query(@url.query)
+    {
+      'departments' => 'organisations',
+      'topics' => method(:topic_map),
+    }.each do |from_key, to_key|
+      next unless result.key?(from_key)
+
+      if to_key.is_a?(String)
+        result[to_key] = result.delete(from_key)
+      else
+        values = result.delete(from_key)
+        result[to_key.call(values)] = values
+      end
+    end
+    result
+  end
+
+  def topic_map(values)
+    @static_data.topical_event?(values) ? 'topical_events' : 'policy_areas'
+  end
+
+  def lookup_content_id(key, slug)
+    @static_data.content_id(key, slug).tap do |value|
+      @missing_lookups << "#{key}: #{slug}" if value == MISSING_LOOKUP
+    end
+  end
+
+  # Static data can currently be injected into the mapping process in two forms.
+  # This was done to allow optimisation of the process depending on the use case.
+  # - BulkStaticData which is designed to be used with the mass migration of data
+  #   and can be deleted once the migration is complete.
+  # - StaticData which uses standard DB queries and is expected to be used when
+  #   converting individual URLs.
+  class BulkStaticData
+    def topical_event?(values)
+      @topical_events ||= TopicalEvent.pluck(:slug)
+      (@topical_events & values).any?
+    end
+
+    def content_id(key, slug)
+      case key
+      when "world_locations"
+        @world_locations_lookup ||= Hash[WorldLocation.pluck(:slug, :content_id)]
+        @world_locations_lookup.fetch(slug, UrlToSubscriberListCriteria::MISSING_LOOKUP)
+      when "organisations"
+        @organisations_lookup ||= Hash[Organisation.pluck(:slug, :content_id)]
+        @organisations_lookup.fetch(slug, UrlToSubscriberListCriteria::MISSING_LOOKUP)
+      when "roles"
+        @roles_lookup ||= Hash[Role.pluck(:slug, :content_id)]
+        @roles_lookup.fetch(slug, UrlToSubscriberListCriteria::MISSING_LOOKUP)
+      when "people"
+        @people_lookup ||= Hash[Person.pluck(:slug, :content_id)]
+        @people_lookup.fetch(slug, UrlToSubscriberListCriteria::MISSING_LOOKUP)
+      when "policy_areas", "topical_events"
+        @classifications_lookup ||= Hash[Classification.pluck(:slug, :content_id)]
+        @classifications_lookup.fetch(slug, UrlToSubscriberListCriteria::MISSING_LOOKUP)
+      else
+        raise [key, slug].inspect
+      end
+    end
+  end
+
+  module StaticData
+    class UnknownStaticDataKey < StandardError; end
+
+    def self.topical_event?(values)
+      TopicalEvent.where(slug: values).any?
+    end
+
+    def self.content_id(key, slug)
+      lookup_map = {
+        "world_locations" => WorldLocation,
+        "organisations" => Organisation,
+        "roles" => Role,
+        "people" => Person,
+        "topical_events" => Classification,
+        "policy_areas" => Classification,
+      }
+
+      lookup_class = lookup_map[key] || raise(UnknownStaticDataKey, key)
+      lookup_class.find_by!(slug: slug).content_id
+    end
+  end
+end

--- a/lib/url_to_subscriber_list_criteria_migration.rb
+++ b/lib/url_to_subscriber_list_criteria_migration.rb
@@ -1,0 +1,112 @@
+require 'gds_api/helpers'
+require 'pp'
+
+class UrlToSubscriberListCriteriaMigration
+  include GdsApi::Helpers
+  class MissingCsvPath < StandardError; end
+
+  attr_reader :csv_path, :perform_migration
+  delegate :puts, :print, to: :@out_io
+
+  def initialize(csv_path, perform_migration, out_io = STDOUT)
+    @csv_path = csv_path || raise(MissingCsvPath)
+    @perform_migration = perform_migration == 'true'
+
+    @parsed = 0
+    @skipped = Hash.new(0)
+    @missing_lookup = []
+    @out_io = out_io
+  end
+
+  def run(static_data = UrlToSubscriberListCriteria::BulkStaticData.new)
+    CSV.foreach(csv_path, headers: true) do |row|
+      url = row['_id']
+      parser = UrlToSubscriberListCriteria.new(url, static_data)
+      if url =~ %r{/government/policies/.*/activity.atom} # these have already been migrated
+        @skipped[:policy_activity] += 1
+      elsif url =~ %r{/government/policies.atom} # these have already been migrated
+        @skipped[:policy] += 1
+      elsif url =~ /official_document_status=/ # to be removed
+        @skipped[:official_document_status] += 1
+      elsif url =~ /relevant_to_local_government=1/ # to be removed
+        @skipped[:relevant_to_local_government] += 1
+      elsif url =~ /finder-frontend.production.alphagov.co.uk/
+        @skipped[:finder] += 1
+      elsif parser.missing_lookup
+        @missing_lookup << [parser.missing_lookup, url, row['topic_id']]
+      else
+        @parsed += 1
+        if perform_migration
+          migrate(parser, row)
+        else
+          dry_run(parser, row)
+        end
+      end
+    end
+  end
+
+  def migrate(parser, row)
+    criteria = parser.convert.merge(
+      'gov_delivery_id' => row['topic_id'],
+      'created_at' => row['created'],
+    )
+
+    response = email_alert_api.find_or_create_subscriber_list(criteria)
+
+    if response['subscriber_list']['gov_delivery_id'] == row['topic_id']
+      if Date.parse(response['subscriber_list']['updated_at']) < Date.today
+        print '*' # Subscriber list already exists
+      else
+        print '.'
+      end
+    else
+      # As we are filtering on gov_delivery_id we should not be able to reach here
+      # if for any reason we do then something has gone wrong
+      puts "******* Error"
+      pp criteria
+      pp response['subscriber_list']
+      pp row.to_h
+      return
+    end
+  end
+
+  def dry_run(parser, row)
+    puts "******* GovUkDelivery details"
+    puts "Parsing #{row['topic_id']} - #{row['_id']}"
+
+    puts "******* Converted Hash values"
+    pp parser.map_url_to_hash
+    pp parser.convert
+
+    begin
+      criteria = parser.convert.merge('gov_delivery_id' => row['topic_id'])
+      response = email_alert_api.send(:search_subscriber_list, criteria)
+      puts "******* EmailAlertApi details"
+      pp response['subscriber_list']
+    rescue GdsApi::HTTPNotFound
+      puts "NOT FOUND"
+    end
+
+    puts ''
+  end
+
+  def report
+    puts "" if perform_migration
+    puts "#{@parsed} parsed"
+    puts "Skipped: #{@skipped}"
+
+    if @missing_lookup.any?
+      puts "Missing lookups"
+      @missing_lookup.group_by(&:first).each do |field, data|
+        puts field
+        data.each { |_, url, topic| puts "#{topic} - #{url}" }
+        puts ''
+      end
+    end
+  end
+
+  def pp(text)
+    # need to overwide the default `pp` method so that we can pass in the output stream to be used.
+    PP.pp(text, @out_io)
+  end
+end

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -1,0 +1,142 @@
+require 'test_helper'
+
+class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
+  test "can convert department to organisation" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
+      stub("StaticData", topical_event?: false),
+    )
+    assert_equal converter.map_url_to_hash, {
+      "links" => { "organisations" => ["advisory-committee-on-clinical-excellence-awards"] },
+    }
+  end
+
+  test "can convert when topic is not a topical_event" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?topics%5B%5D=wildlife-and-animal-welfare',
+      stub("StaticData", topical_event?: false),
+    )
+    assert_equal converter.map_url_to_hash, {
+      "links" => { "policy_areas" => ["wildlife-and-animal-welfare"] },
+    }
+  end
+
+  test "can convert when topic is a topical_event" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?topics%5B%5D=spending-round-2013',
+      stub("StaticData", topical_event?: true),
+    )
+    assert_equal converter.map_url_to_hash, {
+      "links" => { "topical_events" => ["spending-round-2013"] },
+    }
+  end
+
+  test "ignores trailing whitespace" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards  ',
+      stub("StaticData", topical_event?: false),
+    )
+    assert_equal converter.map_url_to_hash, {
+      "links" => {
+        "organisations" => ["advisory-committee-on-clinical-excellence-awards"],
+      },
+    }
+  end
+
+  test "can convert multiple options" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards&topics%5B%5D=employment ',
+      stub("StaticData", topical_event?: false),
+    )
+    assert_equal converter.map_url_to_hash, {
+      "links" => {
+        "organisations" => ["advisory-committee-on-clinical-excellence-awards"],
+        "policy_areas" => ["employment"],
+      },
+    }
+  end
+
+  test "will map links values to content_ids" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
+      stub("StaticData", topical_event?: false, content_id: 'aaaaa'),
+    )
+    assert_equal converter.convert, {
+      "links" => { "organisations" => ["aaaaa"] },
+    }
+  end
+
+  test "can extract `email_document_supertype` and `government_document_supertype` from announcement url" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/announcements.atom?announcement_filter_option=news-stories',
+      stub("StaticData"),
+    )
+    assert_equal converter.convert, {
+      "links" => {},
+      "email_document_supertype" => "announcements",
+      "government_document_supertype" => "news-stories",
+    }
+  end
+
+  test "can extract email `email_document_supertype` and `government_document_supertype` from publication url" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/publications.atom?publication_filter_option=transparency-data',
+      stub("StaticData"),
+    )
+
+    assert_equal converter.convert, {
+      "links" => {},
+      "email_document_supertype" => "publications",
+      "government_document_supertype" => "transparency-data",
+    }
+  end
+
+  test "can extract `email_document_supertype` and `government_document_supertype` from statistics url" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/statistics.atom',
+      stub("StaticData"),
+    )
+
+    assert_equal converter.convert, {
+      "links" => {},
+      "email_document_supertype" => "publications",
+      "government_document_supertype" => "statistics",
+    }
+  end
+
+  test "can detect missing mappings from slug to content_id" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=other',
+      stub("StaticData", topical_event?: false, content_id: UrlToSubscriberListCriteria::MISSING_LOOKUP),
+    )
+
+    assert_equal converter.convert, {
+      "links" => { "organisations" => ["*** MISSING KEY ***"] },
+    }
+    assert_equal converter.missing_lookup, "organisations: other"
+  end
+
+  test "can detect multiple missing mappings from slug to content_id" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=other&topics%5B%5D=unknown',
+      stub("StaticData", topical_event?: false, content_id: UrlToSubscriberListCriteria::MISSING_LOOKUP),
+    )
+
+    assert_equal converter.convert, {
+      "links" => {
+        "organisations" => ["*** MISSING KEY ***"],
+        "policy_areas" => ["*** MISSING KEY ***"],
+      },
+    }
+    assert_equal converter.missing_lookup, "organisations: other and policy_areas: unknown"
+  end
+
+  test "does not incorrectly detect missing mapping from slug to content id" do
+    converter = UrlToSubscriberListCriteria.new(
+      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
+      stub("StaticData", topical_event?: false, content_id: 'aaaaa-111111'),
+    )
+
+    assert !converter.missing_lookup
+  end
+end

--- a/test/unit/url_to_subscriber_list_migration_test.rb
+++ b/test/unit/url_to_subscriber_list_migration_test.rb
@@ -1,0 +1,224 @@
+require 'test_helper'
+
+class UrlToSubscriberListMigrationTest < ActiveSupport::TestCase
+  test "skips policy activities urls" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/policies/energy/activity.atom", created: Time.zone.now },
+    ]
+    output = run_migration_on(csv_data)
+    assert_match %r(Skipped: {:policy_activity=>1}), output
+  end
+
+  test "skips policies urls" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/policies.atom", created: Time.zone.now },
+    ]
+    output = run_migration_on(csv_data)
+    assert_match %r(Skipped: {:policy=>1}), output
+  end
+
+  test "skips official_document_status urls" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publication.atom?official_document_status=act_papers", created: Time.zone.now }
+    ]
+    output = run_migration_on(csv_data)
+    assert_match %r(Skipped: {:official_document_status=>1}), output
+  end
+
+  test "skips relevant_to_local_government urls" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publication.atom?relevant_to_local_government=1", created: Time.zone.now }
+    ]
+    output = run_migration_on(csv_data)
+    assert_match %r(Skipped: {:relevant_to_local_government=>1}), output
+  end
+
+  test "skips finder urls" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://finder-frontend.production.alphagov.co.uk/", created: Time.zone.now },
+    ]
+    output = run_migration_on(csv_data)
+    assert_match %r(Skipped: {:finder=>1}), output
+  end
+
+  test "logs when missing content ID lookup" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=other", created: Time.zone.now },
+    ]
+    static_data = mock('StaticData', content_id: UrlToSubscriberListCriteria::MISSING_LOOKUP)
+    output = run_migration_on(csv_data, static_data)
+    assert_match %r(Missing lookups\ntopic: other\nTOPIC_123 - http://test.com/government/publications\.atom\?topic\[\]=other)m, output
+  end
+
+  test "logs when dry run migration" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
+    ]
+    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+      body: {'subscriber_list' => { 'gov_delivery_id' => 'TOPIC_123' } }.to_json
+    )
+    static_data = mock('StaticData', content_id: "a1234")
+    output = run_migration_on(csv_data, static_data)
+    expected_output = <<-STR.strip_heredoc
+      ******* GovUkDelivery details
+      Parsing TOPIC_123 - http://test.com/government/publications.atom?topic[]=energy
+      ******* Converted Hash values
+      {"links"=>{"topic"=>["energy"]}, "email_document_supertype"=>"publications"}
+      {"links"=>{"topic"=>["a1234"]}, "email_document_supertype"=>"publications"}
+      ******* EmailAlertApi details
+      {"gov_delivery_id"=>"TOPIC_123"}
+
+      1 parsed
+      Skipped: {}
+    STR
+    assert_equal expected_output, output
+  end
+
+  test "migration fails if topic ID mismatch" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
+    ]
+    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+      body: {'subscriber_list' => { 'gov_delivery_id' => 'OTHER_TOPIC' } }.to_json
+    )
+    static_data = mock('StaticData', content_id: "a1234")
+    output = run_migration_on(csv_data, static_data, "true")
+    expected_output = <<-STR.strip_heredoc
+      ******* Error
+      {"links"=>{"topic"=>["a1234"]},
+       "email_document_supertype"=>"publications",
+       "gov_delivery_id"=>"TOPIC_123",
+       "created_at"=>"2011-11-11 11:11:11 +0000"}
+      {"gov_delivery_id"=>"OTHER_TOPIC"}
+      {"topic_id"=>"TOPIC_123",
+       "_id"=>"http://test.com/government/publications.atom?topic[]=energy",
+       "created"=>"2011-11-11 11:11:11 +0000"}
+
+      1 parsed
+      Skipped: {}
+    STR
+    assert_equal expected_output, output
+  end
+
+  test "migration success" do
+    csv_data = [
+      { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
+    ]
+    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+      body: {'subscriber_list' => { 'gov_delivery_id' => 'TOPIC_123', updated_at: '2011-11-11' } }.to_json
+    )
+    static_data = mock('StaticData', content_id: "a1234")
+    output = run_migration_on(csv_data, static_data, "true")
+    expected_output = <<-STR.strip_heredoc
+      .
+      1 parsed
+      Skipped: {}
+    STR
+    assert_equal expected_output, output
+  end
+
+  test "Correctly look up values using `UrlToSubscriberListCriteria::StaticData` class" do
+    database_lookup_test(UrlToSubscriberListCriteria::StaticData)
+  end
+
+  test "Correctly look up values using `UrlToSubscriberListCriteria::BulkStaticData` class" do
+    database_lookup_test(UrlToSubscriberListCriteria::BulkStaticData.new)
+  end
+
+  def database_lookup_test(static_data)
+    url = "https://www.gov.uk/government/publications.atom" +
+      "?departments%5B%5D=academy-for-justice-commissioning" +
+      "&world_locations%5B%5D=united-kingdom" +
+      "&topics%5B%5D=defence-and-armed-forces"
+
+    url_people = "https://www.gov.uk/government/people/david-cameron.atom"
+    url_role = "https://www.gov.uk/government/ministers/chancellor-of-the-exchequer.atom"
+    url_topic_event = "https://www.gov.uk/government/topical-events/autumn-statement-2016.atom"
+
+    csv_data = [
+      { topic_id: 'TOPIC_A', url: url, created: Time.zone.now },
+      { topic_id: 'TOPIC_B', url: url_people, created: Time.zone.now },
+      { topic_id: 'TOPIC_C', url: url_role, created: Time.zone.now },
+      { topic_id: 'TOPIC_D', url: url_topic_event, created: Time.zone.now },
+    ]
+
+    responses = csv_data.map do |row|
+      { body: {'subscriber_list' => { 'gov_delivery_id' => row[:topic_id], updated_at: '2011-11-11' } }.to_json }
+    end
+
+    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(*responses)
+
+    organisation = create(:organisation, slug: 'academy-for-justice-commissioning')
+    world_location = create(:world_location, slug: 'united-kingdom')
+    policy_area = create(:topic, slug: 'defence-and-armed-forces')
+    person = create(:person, slug: 'david-cameron')
+    role = create(:role, slug: 'chancellor-of-the-exchequer')
+    topical_event = create(:topical_event, slug: 'autumn-statement-2016')
+
+    output = run_migration_on(csv_data, static_data)
+    expected_output = <<-STR.strip_heredoc
+      ******* GovUkDelivery details
+      Parsing TOPIC_A - https://www.gov.uk/government/publications.atom?departments%5B%5D=academy-for-justice-commissioning&world_locations%5B%5D=united-kingdom&topics%5B%5D=defence-and-armed-forces
+      ******* Converted Hash values
+      {"links"=>
+        {"world_locations"=>["united-kingdom"],
+         "organisations"=>["academy-for-justice-commissioning"],
+         "policy_areas"=>["defence-and-armed-forces"]},
+       "email_document_supertype"=>"publications"}
+      {"links"=>
+        {"world_locations"=>["#{world_location.content_id}"],
+         "organisations"=>["#{organisation.content_id}"],
+         "policy_areas"=>["#{policy_area.content_id}"]},
+       "email_document_supertype"=>"publications"}
+      ******* EmailAlertApi details
+      {"gov_delivery_id"=>"TOPIC_A", "updated_at"=>"2011-11-11"}
+
+      ******* GovUkDelivery details
+      Parsing TOPIC_B - https://www.gov.uk/government/people/david-cameron.atom
+      ******* Converted Hash values
+      {"links"=>{"people"=>["david-cameron"]}}
+      {"links"=>{"people"=>["#{person.content_id}"]}}
+      ******* EmailAlertApi details
+      {"gov_delivery_id"=>"TOPIC_B", "updated_at"=>"2011-11-11"}
+
+      ******* GovUkDelivery details
+      Parsing TOPIC_C - https://www.gov.uk/government/ministers/chancellor-of-the-exchequer.atom
+      ******* Converted Hash values
+      {"links"=>{"roles"=>["chancellor-of-the-exchequer"]}}
+      {"links"=>{"roles"=>["#{role.content_id}"]}}
+      ******* EmailAlertApi details
+      {"gov_delivery_id"=>"TOPIC_C", "updated_at"=>"2011-11-11"}
+
+      ******* GovUkDelivery details
+      Parsing TOPIC_D - https://www.gov.uk/government/topical-events/autumn-statement-2016.atom
+      ******* Converted Hash values
+      {"links"=>{"topical_events"=>["autumn-statement-2016"]}}
+      {"links"=>{"topical_events"=>["#{topical_event.content_id}"]}}
+      ******* EmailAlertApi details
+      {"gov_delivery_id"=>"TOPIC_D", "updated_at"=>"2011-11-11"}
+
+      4 parsed
+      Skipped: {}
+    STR
+    assert_equal expected_output, output
+  end
+
+  def run_migration_on(data, static_data = mock, perform_migration = nil)
+    io = StringIO.new
+    t = Tempfile.new('csv')
+
+    t.write "topic_id,_id,created\n"
+    data.each do |row|
+      t.write [row[:topic_id], row[:url], row[:created].to_s].join(',')
+      t.write "\n"
+    end
+    t.rewind
+    migrator = UrlToSubscriberListCriteriaMigration.new(t.path, perform_migration, io)
+    migrator.run(static_data)
+    migrator.report
+    io.rewind
+    io.read
+  ensure
+    t.close
+  end
+end


### PR DESCRIPTION
This is dependant on: https://github.com/alphagov/gds-api-adapters/pull/684

Convert generated URL into hash syntax for sending to email
alert api for the pending data migration. This code will also
be used the front-end to support signup to both govuk delivery
and email alert api during the migration period.

The output of running the rake task (after doing the actual migration) 
can be seen here https://gist.github.com/dwhenry/4904b7e8e9b2741399629dd97b3568de

https://trello.com/c/F0P2vaaQ/155-3-url-to-criteria-mapping