### PR TITLE
Remove `NewsArticle` from path helper

### DIFF
--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -53,7 +53,7 @@ module NavigationHelpers
     case edition
     when Publication
       visit publications_path
-    when NewsArticle, Speech
+    when Speech
       visit announcements_path
     when Consultation
       visit consultations_path


### PR DESCRIPTION
We no longer test this path so it isn't required in the helper.