### PR TITLE
Present Corporate Information Pages to the Publishing API

### DIFF
--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -61,6 +61,7 @@ module PublishingApi
 
     def details
       base_details
+        .merge(CorporateInformationGroups.for(corporate_information_page))
         .merge(Organisation.for(corporate_information_page))
         .merge(PayloadBuilder::TagDetails.for(corporate_information_page))
     end
@@ -74,6 +75,166 @@ module PublishingApi
                           end
 
       public_updated_at.rfc3339
+    end
+
+    class CorporateInformationGroups
+      extend Forwardable
+
+      def self.for(corporate_information_page)
+        new(corporate_information_page).call
+      end
+
+      def initialize(corporate_information_page,
+                     context = ActionController::Base,
+                     url_maker = Whitehall.url_maker)
+        self.context = context
+        self.corporate_information_page = corporate_information_page
+        self.url_maker = url_maker
+      end
+
+      def call
+        return {} unless corporate_information_page.about_page? &&
+            organisation_has_any_transparency_pages?
+
+        {
+          corporate_information_groups: corporate_information_groups
+            .reject { |group| group[:contents].empty? },
+        }
+      end
+
+    private
+
+      attr_accessor :context, :corporate_information_page, :url_maker
+
+      def_delegator :context, :helpers
+      def_delegator :corporate_information_page, :owning_organisation, :organisation
+
+      def corporate_information_groups
+        [].tap do |groups|
+          groups << {
+            name: translation_for_group(:access_our_info),
+            contents: contents_for_access_our_info.compact,
+          }
+
+          groups << {
+            name: translation_for_group(:jobs_and_contacts),
+            contents: contents_for_jobs_and_contacts.compact,
+          } unless organisation.court_or_hmcts_tribunal?
+        end
+      end
+
+      def contents_for_access_our_info
+        [].tap do |contents|
+          contents.push(payload_for_organisation_chart)
+          contents.push(*page_content_ids_by_menu_heading(:our_information))
+          contents.push(payload_for_corporate_reports)
+          contents.push(payload_for_transparency_data)
+        end
+      end
+
+      def contents_for_jobs_and_contacts
+        [].tap do |contents|
+          contents.push(*page_content_ids_by_menu_heading(:jobs_and_contracts))
+          contents.push(payload_for_jobs)
+        end
+      end
+
+      def organisation_has_any_transparency_pages?
+        return unless organisation.present?
+
+        organisation_has_freedom_of_information_publications? ||
+          organisation_has_transparency_data_publications?
+      end
+
+      def organisation_has_corporate_report_publications?
+        return unless organisation.present?
+
+        organisation.has_published_publications_of_type?(
+          PublicationType::CorporateReport,
+        )
+      end
+
+      def organisation_has_chart_url?
+        return unless organisation.present?
+
+        organisation.organisation_chart_url.present?
+      end
+
+      def organisation_has_freedom_of_information_publications?
+        return unless organisation.present?
+
+        organisation.has_published_publications_of_type?(
+          PublicationType::FoiRelease,
+        )
+      end
+
+      def organisation_has_transparency_data_publications?
+        return unless organisation.present?
+
+        organisation.has_published_publications_of_type?(
+          PublicationType::TransparencyData,
+        )
+      end
+
+      def page_content_ids_by_menu_heading(menu_heading)
+        organisation
+          .corporate_information_pages
+          .published
+          .by_menu_heading(menu_heading)
+          .map(&:content_id)
+      end
+
+      def payload_for_corporate_reports
+        return unless organisation_has_corporate_report_publications?
+
+        corporate_reports_path =
+          url_maker
+            .publications_filter_path(
+              organisation,
+              publication_type: 'corporate-reports',
+            )
+
+        {
+          title: translation_for_group(:corporate_reports, :headings),
+          path: corporate_reports_path,
+        }
+      end
+
+      def payload_for_jobs
+        {
+          title: 'Jobs',
+          url: organisation.jobs_url,
+        }
+      end
+
+      def payload_for_organisation_chart
+        return unless organisation_has_chart_url?
+
+        {
+          title: translation_for_group(:organisation_chart),
+          url: organisation.organisation_chart_url,
+        }
+      end
+
+      def payload_for_transparency_data
+        return unless organisation_has_transparency_data_publications?
+
+        transparency_data_path =
+          url_maker
+            .publications_filter_path(
+              organisation,
+              publication_type: 'transparency-data',
+            )
+
+        {
+          title: translation_for_group(:transparency),
+          path: transparency_data_path,
+        }
+      end
+
+      def translation_for_group(group, namespace = :corporate_information)
+        helpers.t("organisation.#{namespace}.#{group}")
+      end
     end
 
     class Organisation

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -20,6 +20,7 @@ module PublishingApi
         .new(corporate_information_page)
         .base_attributes
         .merge(
+          document_type: display_type_key,
           schema_name: SCHEMA_NAME,
         )
     end
@@ -28,5 +29,7 @@ module PublishingApi
 
     attr_accessor :corporate_information_page
     attr_writer :update_type
+
+    def_delegator :corporate_information_page, :display_type_key
   end
 end

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -62,6 +62,7 @@ module PublishingApi
     def details
       base_details
         .merge(Organisation.for(corporate_information_page))
+        .merge(PayloadBuilder::TagDetails.for(corporate_information_page))
     end
 
     def public_updated_at

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -21,6 +21,7 @@ module PublishingApi
         .base_attributes
         .merge(
           document_type: display_type_key,
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: SCHEMA_NAME,
         )
     end

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -36,6 +36,7 @@ module PublishingApi
         .extract(
           %i(
             organisations
+            parent
           )
         )
     end

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -21,7 +21,9 @@ module PublishingApi
         .base_attributes
         .merge(
           description: corporate_information_page.summary,
+          details: details,
           document_type: display_type_key,
+          public_updated_at: public_updated_at,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: SCHEMA_NAME,
         )
@@ -33,5 +35,28 @@ module PublishingApi
     attr_writer :update_type
 
     def_delegator :corporate_information_page, :display_type_key
+
+    def body
+      Whitehall::GovspeakRenderer
+        .new
+        .govspeak_edition_to_html(corporate_information_page)
+    end
+
+    def details
+      {
+        body: body,
+      }
+    end
+
+    def public_updated_at
+      public_updated_at = corporate_information_page.public_timestamp ||
+        corporate_information_page.updated_at
+
+      public_updated_at = if public_updated_at.respond_to?(:to_datetime)
+                            public_updated_at.to_datetime
+                          end
+
+      public_updated_at.rfc3339
+    end
   end
 end

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -3,6 +3,8 @@ module PublishingApi
     extend Forwardable
     include UpdateTypeHelper
 
+    SCHEMA_NAME = 'corporate_information_page'
+
     attr_reader :update_type
 
     def initialize(corporate_information_page, update_type: nil)
@@ -17,6 +19,9 @@ module PublishingApi
       BaseItemPresenter
         .new(corporate_information_page)
         .base_attributes
+        .merge(
+          schema_name: SCHEMA_NAME,
+        )
     end
 
   private

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -1,0 +1,27 @@
+module PublishingApi
+  class CorporateInformationPagePresenter
+    extend Forwardable
+    include UpdateTypeHelper
+
+    attr_reader :update_type
+
+    def initialize(corporate_information_page, update_type: nil)
+      self.corporate_information_page = corporate_information_page
+      self.update_type =
+        update_type || default_update_type(corporate_information_page)
+    end
+
+    def_delegator :corporate_information_page, :content_id
+
+    def content
+      BaseItemPresenter
+        .new(corporate_information_page)
+        .base_attributes
+    end
+
+  private
+
+    attr_accessor :corporate_information_page
+    attr_writer :update_type
+  end
+end

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -19,6 +19,7 @@ module PublishingApi
       BaseItemPresenter
         .new(corporate_information_page)
         .base_attributes
+        .merge(PayloadBuilder::PublicDocumentPath.for(corporate_information_page))
         .merge(
           description: corporate_information_page.summary,
           details: details,

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -20,6 +20,7 @@ module PublishingApi
         .new(corporate_information_page)
         .base_attributes
         .merge(
+          description: corporate_information_page.summary,
           document_type: display_type_key,
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: SCHEMA_NAME,

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -7,6 +7,9 @@ module PublishingApiPresenters
   end
 
 private
+
+  FALLBACK_EDITION_PRESENTER = PublishingApi::GenericEditionPresenter
+
   def self.presenter_class_for(model)
     case model
     when ::Edition
@@ -50,6 +53,12 @@ private
       PublishingApi::CaseStudyPresenter
     when Consultation
       PublishingApi::ConsultationPresenter
+    when CorporateInformationPage
+      if edition.worldwide_organisation.present?
+        FALLBACK_EDITION_PRESENTER
+      else
+        PublishingApi::CorporateInformationPagePresenter
+      end
     when ::DocumentCollection
       PublishingApi::DocumentCollectionPresenter
     when ::DetailedGuide
@@ -67,11 +76,9 @@ private
     when WorldLocationNewsArticle
       PublishingApi::WorldLocationNewsArticlePresenter
     else
-      # This is a catch-all clause for the following classes:
-      # - CorporateInformationPage
       # The presenter implementation for all of these models is identical and
       # the structure of the presented payload is the same.
-      PublishingApi::GenericEditionPresenter
+      FALLBACK_EDITION_PRESENTER
     end
   end
 end

--- a/lib/sync_checker/formats/corporate_information_page_check.rb
+++ b/lib/sync_checker/formats/corporate_information_page_check.rb
@@ -1,0 +1,212 @@
+module SyncChecker
+  module Formats
+    class CorporateInformationPageCheck < EditionBase
+      def expected_details_hash(corporate_information_page, _)
+        super.tap do |details|
+          details.delete(:change_history)
+          details.delete(:first_public_at)
+
+          details.merge(
+            expected_corporate_information_groups(corporate_information_page)
+          ) if corporate_information_page.about_page?
+
+          details.merge(expected_organisation(corporate_information_page))
+          details.merge(expected_tags(corporate_information_page))
+        end
+      end
+
+      def rendering_app
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      end
+
+      def root_path
+        'government/organisations'
+      end
+
+      def checks_for_live(_locale)
+        super.tap do |checks|
+          if edition_expected_in_live.about_page?
+            checks << Checks::LinksCheck.new(
+              'corporate_information_pages',
+              expected_corporate_information_page_content_ids
+            )
+          end
+        end
+      end
+
+      def check_live(_response, _locale)
+        super unless edition_expected_in_live.worldwide_organisation.present?
+      end
+
+      def check_draft(_response, _locale)
+        super unless edition_expected_in_draft.worldwide_organisation.present?
+      end
+
+    private
+
+      def expected_corporate_information_page_content_ids
+        pages = edition_expected_in_live
+          .organisation
+          .corporate_information_pages
+          .published
+
+        [].tap { |ids|
+          ids.push(*pages.by_menu_heading(:jobs_and_contracts).map(&:content_id))
+          ids.push(*pages.by_menu_heading(:our_information).map(&:content_id))
+          ids.push(pages.for_slug('about-our-services').try(:content_id))
+          ids.push(pages.for_slug('personal-information-charter').try(:content_id))
+          ids.push(pages.for_slug('publication-scheme').try(:content_id))
+          ids.push(pages.for_slug('social-media-use').try(:content_id))
+          ids.push(pages.for_slug('welsh-language-scheme').try(:content_id))
+        }.compact
+      end
+
+      def top_level_fields_hash(corporate_information_page, _)
+        super.tap do |fields|
+          fields[:document_type] = corporate_information_page.display_type_key
+        end
+      end
+
+      def expected_tags(corporate_information_page)
+        topics = Array(corporate_information_page.primary_specialist_sector_tag) +
+          corporate_information_page.secondary_specialist_sector_tags
+
+        {
+          'tags' => {
+            'browse_pages' => [],
+            'policies' => [],
+            'topics' => topics.compact,
+          }
+        }
+      end
+
+      def expected_organisation(corporate_information_page)
+        {
+          organisation: corporate_information_page.organisation.content_id
+        }
+      end
+
+      def expected_corporate_information_groups(corporate_information_page)
+        {
+          corporate_information_groups: corporate_information_groups(corporate_information_page)
+            .reject { |group| group[:contents].empty? }
+        }
+      end
+
+      def corporate_information_groups(corporate_information_page)
+        [].tap do |groups|
+          groups << {
+            name: translation_for_group(:access_our_info),
+            contents: contents_for_access_our_info(corporate_information_page).compact
+          }
+
+          groups << {
+            name: translation_for_group(:jobs_and_contacts),
+            contents: contents_for_jobs_and_contacts(corporate_information_page).compact
+          } unless corporate_information_page.organisation.court_or_hmcts_tribunal?
+        end
+      end
+
+      def translation_for_group(group, namespace = :corporate_information)
+        I18n.t("organisation.#{namespace}.#{group}")
+      end
+
+      def contents_for_access_our_info(corporate_information_page)
+        [].tap do |contents|
+          contents.push(payload_for_organisation_chart(corporate_information_page))
+          contents.push(*page_content_ids_by_menu_heading(:our_information, corporate_information_page))
+          contents.push(payload_for_corporate_reports(corporate_information_page))
+          contents.push(payload_for_transparency_data(corporate_information_page))
+        end
+      end
+
+      def contents_for_jobs_and_contacts(corporate_information_page)
+        [].tap do |contents|
+          contents.push(*page_content_ids_by_menu_heading(:jobs_and_contracts, corporate_information_page))
+          contents.push(payload_for_jobs(corporate_information_page))
+        end
+      end
+
+      def page_content_ids_by_menu_heading(menu_heading, corporate_information_page)
+        corporate_information_page
+          .organisation
+          .corporate_information_pages
+          .published
+          .by_menu_heading(menu_heading)
+          .map(&:content_id)
+      end
+
+      def organisation_has_corporate_report_publications?(corporate_information_page)
+        return unless corporate_information_page.organisation.present?
+
+        corporate_information_page.organisation.has_published_publications_of_type?(
+          PublicationType::CorporateReport,
+        )
+      end
+
+      def organisation_has_chart_url?(corporate_information_page)
+        return unless corporate_information_page.organisation.present?
+
+        corporate_information_page.organisation.organisation_chart_url.present?
+      end
+
+
+      def organisation_has_transparency_data_publications?(corporate_information_page)
+        return unless corporate_information_page.organisation.present?
+
+        corporate_information_page.organisation.has_published_publications_of_type?(
+          PublicationType::TransparencyData,
+        )
+      end
+
+      def payload_for_corporate_reports(corporate_information_page)
+        return unless organisation_has_corporate_report_publications?(corporate_information_page)
+        url_maker = Whitehall.url_maker
+        corporate_reports_path =
+          url_maker
+            .publications_filter_path(
+              corporate_information_page.organisation,
+              publication_type: 'corporate-reports',
+            )
+
+        {
+          title: translation_for_group(:corporate_reports, :headings),
+          path: corporate_reports_path,
+        }
+      end
+
+      def payload_for_jobs(corporate_information_page)
+        {
+          title: 'Jobs',
+          url: corporate_information_page.organisation.jobs_url,
+        }
+      end
+
+      def payload_for_organisation_chart(corporate_information_page)
+        return unless organisation_has_chart_url?(corporate_information_page)
+
+        {
+          title: translation_for_group(:organisation_chart),
+          url: corporate_information_page.organisation.organisation_chart_url,
+        }
+      end
+
+      def payload_for_transparency_data(corporate_information_page)
+        return unless organisation_has_transparency_data_publications?(corporate_information_page)
+
+        url_maker = Whitehall.url_maker
+        transparency_data_path =
+          url_maker
+            .publications_filter_path(
+              corporate_information_page.organisation,
+              publication_type: 'transparency-data',
+            )
+
+        {
+          title: translation_for_group(:transparency),
+          path: transparency_data_path,
+        }
+      end
+    end
+  end
+end

--- a/lib/sync_checker/formats/corporate_information_page_check.rb
+++ b/lib/sync_checker/formats/corporate_information_page_check.rb
@@ -61,9 +61,12 @@ module SyncChecker
         }.compact
       end
 
-      def top_level_fields_hash(corporate_information_page, _)
+      def top_level_fields_hash(corporate_information_page, locale)
         super.tap do |fields|
-          fields[:document_type] = corporate_information_page.display_type_key
+          I18n.with_locale(locale) do
+            fields[:document_type] = corporate_information_page.display_type_key
+            fields[:title] = corporate_information_page.title
+          end
         end
       end
 

--- a/lib/sync_checker/formats/edition_base.rb
+++ b/lib/sync_checker/formats/edition_base.rb
@@ -136,12 +136,16 @@ module SyncChecker
       end
 
       def expected_details_hash(edition, _locale)
-        {
-          body: Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(edition),
-          change_history: edition.change_history.as_json,
-          emphasised_organisations: edition.lead_organisations.map(&:content_id),
-          first_public_at: first_public_at(edition)
-        }
+        {}.tap do |details|
+          details[:body] = Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(edition)
+          details[:change_history] = edition.change_history.as_json
+          details[:first_public_at] = first_public_at(edition)
+
+          if edition.respond_to?(:lead_organisations)
+            details[:emphasised_organisations] =
+              edition.lead_organisations.map(&:content_id)
+          end
+        end
       end
 
     private

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -14,6 +14,13 @@ FactoryGirl.define do
     corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
   end
 
+  factory :complaints_procedure_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::ComplaintsProcedure.id
+    )
+  end
+
   factory :published_worldwide_organisation_corporate_information_page, parent: :corporate_information_page, traits: [:published] do
     organisation nil
     association :worldwide_organisation, factory: :worldwide_organisation

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -14,6 +14,13 @@ FactoryGirl.define do
     corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
   end
 
+  factory :about_our_services_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::AboutOurServices.id,
+    )
+  end
+
   factory :complaints_procedure_corporate_information_page,
           parent: :published_corporate_information_page do
     corporate_information_page_type_id(
@@ -28,6 +35,13 @@ FactoryGirl.define do
     )
   end
 
+  factory :personal_information_charter_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::PersonalInformationCharter.id,
+    )
+  end
+
   factory :procurement_corporate_information_page,
           parent: :published_corporate_information_page do
     corporate_information_page_type_id(
@@ -35,10 +49,31 @@ FactoryGirl.define do
     )
   end
 
+  factory :publication_scheme_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::PublicationScheme.id,
+    )
+  end
+
   factory :recruitment_corporate_information_page,
           parent: :published_corporate_information_page do
     corporate_information_page_type_id(
       CorporateInformationPageType::Recruitment.id,
+    )
+  end
+
+  factory :social_media_use_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::SocialMediaUse.id,
+    )
+  end
+
+  factory :welsh_language_scheme_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::WelshLanguageScheme.id,
     )
   end
 

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -17,7 +17,28 @@ FactoryGirl.define do
   factory :complaints_procedure_corporate_information_page,
           parent: :published_corporate_information_page do
     corporate_information_page_type_id(
-      CorporateInformationPageType::ComplaintsProcedure.id
+      CorporateInformationPageType::ComplaintsProcedure.id,
+    )
+  end
+
+  factory :our_energy_use_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::OurEnergyUse.id,
+    )
+  end
+
+  factory :procurement_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::Procurement.id,
+    )
+  end
+
+  factory :recruitment_corporate_information_page,
+          parent: :published_corporate_information_page do
+    corporate_information_page_type_id(
+      CorporateInformationPageType::Recruitment.id,
     )
   end
 

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -48,6 +48,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_payload builder, data: -> { presented_content[:details] }
     end
 
+    def assert_links(key, value)
+      assert_equal value.sort, presented_links[key].sort
+    end
+
     def refute_details_attribute(attribute)
       refute presented_content[:details].key?(attribute)
     end
@@ -173,6 +177,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       self.corporate_information_page =
         create(:about_corporate_information_page, organisation: organisation)
 
+      @about_our_services_corporate_information_page =
+        create(:about_our_services_corporate_information_page,
+               organisation: organisation)
+
       @complaints_procedure_corporate_information_page =
         create(:complaints_procedure_corporate_information_page,
                organisation: organisation)
@@ -181,12 +189,28 @@ module PublishingApi::CorporateInformationPagePresenterTest
         create(:our_energy_use_corporate_information_page,
                organisation: organisation)
 
+      @personal_information_charter_corporate_information_page =
+        create(:personal_information_charter_corporate_information_page,
+               organisation: organisation)
+
       @procurement_corporate_information_page =
         create(:procurement_corporate_information_page,
                organisation: organisation)
 
+      @publication_scheme_corporate_information_page =
+        create(:publication_scheme_corporate_information_page,
+               organisation: organisation)
+
       @recruitment_corporate_information_page =
         create(:recruitment_corporate_information_page,
+               organisation: organisation)
+
+      @social_media_use_information_page =
+        create(:social_media_use_corporate_information_page,
+               organisation: organisation)
+
+      @welsh_language_scheme_corporate_information_page =
+        create(:welsh_language_scheme_corporate_information_page,
                organisation: organisation)
 
       create_list(:published_publication, 2, :corporate,
@@ -249,6 +273,22 @@ module PublishingApi::CorporateInformationPagePresenterTest
       ]
 
       assert_details_attribute :corporate_information_groups, expected_groups
+    end
+
+    test 'corporate information page links' do
+      expected_content_ids = [
+        @about_our_services_corporate_information_page.content_id,
+        @complaints_procedure_corporate_information_page.content_id,
+        @our_energy_use_corporate_information_page.content_id,
+        @personal_information_charter_corporate_information_page.content_id,
+        @procurement_corporate_information_page.content_id,
+        @publication_scheme_corporate_information_page.content_id,
+        @recruitment_corporate_information_page.content_id,
+        @social_media_use_information_page.content_id,
+        @welsh_language_scheme_corporate_information_page.content_id,
+      ]
+
+      assert_links :corporate_information_pages, expected_content_ids
     end
 
     test 'document type' do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+module PublishingApi::CorporateInformationPagePresenterTest
+  class TestCase < ActiveSupport::TestCase
+    attr_accessor :corporate_information_page, :update_type
+
+    def presented_corporate_information_page
+      PublishingApi::CorporateInformationPagePresenter.new(
+        corporate_information_page,
+        update_type: update_type,
+      )
+    end
+
+    def presented_content
+      presented_corporate_information_page.content
+    end
+  end
+
+  class BasicCorporateInformationPageTest < TestCase
+    setup do
+      self.corporate_information_page = create(:corporate_information_page)
+    end
+
+    test 'base' do
+      attributes_double = {
+        base_attribute_one: 'base_attribute_one',
+        base_attribute_two: 'base_attribute_two',
+        base_attribute_three: 'base_attribute_three',
+      }
+
+      PublishingApi::BaseItemPresenter
+        .expects(:new)
+        .with(corporate_information_page)
+        .returns(stub(base_attributes: attributes_double))
+
+      actual_content = presented_content
+      expected_content = actual_content.merge(attributes_double)
+
+      assert_equal actual_content, expected_content
+    end
+
+    test 'validity' do
+      skip
+      assert_valid_against_schema presented_content, 'corporate_information_page'
+    end
+  end
+
+  class CorporateInformationPageWithMajorChange < TestCase
+    setup do
+      self.corporate_information_page = create(:corporate_information_page,
+                                               minor_change: false)
+      self.update_type = 'major'
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_corporate_information_page.update_type
+    end
+  end
+
+  class CorporateInformationPageWithMinorChange < TestCase
+    setup do
+      self.corporate_information_page = create(:corporate_information_page,
+                                               minor_change: true)
+    end
+
+    test 'update type' do
+      assert_equal 'minor', presented_corporate_information_page.update_type
+    end
+  end
+
+  class CorporateInformationPageWithoutMinorChange < TestCase
+    setup do
+      self.corporate_information_page = create(:corporate_information_page,
+                                               minor_change: false)
+    end
+
+    test 'update type' do
+      assert_equal 'major', presented_corporate_information_page.update_type
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -22,6 +22,23 @@ module PublishingApi::CorporateInformationPagePresenterTest
     def assert_details_attribute(attribute, value)
       assert_equal value, presented_content[:details][attribute]
     end
+
+    def assert_payload(builder, data: -> { presented_content })
+      builder_double = builder.demodulize.underscore
+      payload_double = { :"#{builder_double}_key" => "#{builder_double}_value" }
+
+      builder
+        .constantize
+        .expects(:for)
+        .at_least_once
+        .with(corporate_information_page)
+        .returns(payload_double)
+
+      actual_data = data.call
+      expected_data = actual_data.merge(payload_double)
+
+      assert_equal expected_data, actual_data
+    end
   end
 
   class BasicCorporateInformationPageTest < TestCase
@@ -68,6 +85,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
 
     test 'document type' do
       assert_attribute :document_type, 'publication_scheme'
+    end
+
+    test 'public document path' do
+      assert_payload 'PublishingApi::PayloadBuilder::PublicDocumentPath'
     end
 
     test 'rendering app' do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -43,6 +43,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_equal actual_content, expected_content
     end
 
+    test 'description' do
+      assert_attribute :description, corporate_information_page.summary
+    end
+
     test 'document type' do
       assert_attribute :document_type, 'publication_scheme'
     end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -47,6 +47,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_attribute :document_type, 'publication_scheme'
     end
 
+    test 'rendering app' do
+      assert_attribute :rendering_app, 'whitehall-frontend'
+    end
+
     test 'schema name' do
       assert_attribute :schema_name, 'corporate_information_page'
     end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -15,6 +15,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       presented_corporate_information_page.content
     end
 
+    def presented_links
+      presented_corporate_information_page.links
+    end
+
     def assert_attribute(attribute, value)
       assert_equal value, presented_content[attribute]
     end
@@ -70,6 +74,35 @@ module PublishingApi::CorporateInformationPagePresenterTest
       expected_content = actual_content.merge(attributes_double)
 
       assert_equal actual_content, expected_content
+    end
+
+    test 'base links' do
+      expected_link_keys = %i(
+        organisations
+        parent
+      )
+
+      links_double = {
+        link_one: 'link_one',
+        link_two: 'link_two',
+        link_three: 'link_three',
+      }
+
+      PublishingApi::LinksPresenter
+        .expects(:new)
+        .with(corporate_information_page)
+        .returns(
+          mock('PublishingApi::LinksPresenter') {
+            expects(:extract)
+              .with(expected_link_keys)
+              .returns(links_double)
+          }
+        )
+
+      actual_links = presented_links
+      expected_links = actual_links.merge(links_double)
+
+      assert_equal actual_links, expected_links
     end
 
     test 'body details' do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -43,8 +43,44 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_equal actual_content, expected_content
     end
 
+    test 'document type' do
+      assert_attribute :document_type, 'publication_scheme'
+    end
+
     test 'schema name' do
       assert_attribute :schema_name, 'corporate_information_page'
+    end
+
+    test 'validity' do
+      skip
+      assert_valid_against_schema presented_content, 'corporate_information_page'
+    end
+  end
+
+  class AboutCorporateInformationPage < TestCase
+    setup do
+      self.corporate_information_page =
+        create(:about_corporate_information_page)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'about'
+    end
+
+    test 'validity' do
+      skip
+      assert_valid_against_schema presented_content, 'corporate_information_page'
+    end
+  end
+
+  class ComplaintsProcedureCorporateInformationPage < TestCase
+    setup do
+      self.corporate_information_page =
+        create(:complaints_procedure_corporate_information_page)
+    end
+
+    test 'document type' do
+      assert_attribute :document_type, 'complaints_procedure'
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -87,6 +87,15 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_attribute :document_type, 'publication_scheme'
     end
 
+    test 'organisation details' do
+      organisation = create(:organisation, content_id: '7bcea45b-57b1-4200-b35f-29d8324e9a68')
+
+      corporate_information_page
+        .stubs(owning_organisation: organisation)
+
+      assert_details_attribute :organisation, '7bcea45b-57b1-4200-b35f-29d8324e9a68'
+    end
+
     test 'public document path' do
       assert_payload 'PublishingApi::PayloadBuilder::PublicDocumentPath'
     end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -162,7 +162,6 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test 'validity' do
-      skip
       assert_valid_against_schema presented_content, 'corporate_information_page'
     end
   end
@@ -296,7 +295,6 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test 'validity' do
-      skip
       assert_valid_against_schema presented_content, 'corporate_information_page'
     end
   end
@@ -312,7 +310,6 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test 'validity' do
-      skip
       assert_valid_against_schema presented_content, 'corporate_information_page'
     end
   end

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -14,6 +14,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
     def presented_content
       presented_corporate_information_page.content
     end
+
+    def assert_attribute(attribute, value)
+      assert_equal value, presented_content[attribute]
+    end
   end
 
   class BasicCorporateInformationPageTest < TestCase
@@ -37,6 +41,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
       expected_content = actual_content.merge(attributes_double)
 
       assert_equal actual_content, expected_content
+    end
+
+    test 'schema name' do
+      assert_attribute :schema_name, 'corporate_information_page'
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -39,6 +39,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
 
       assert_equal expected_data, actual_data
     end
+
+    def assert_details_payload(builder)
+      assert_payload builder, data: -> { presented_content[:details] }
+    end
   end
 
   class BasicCorporateInformationPageTest < TestCase
@@ -106,6 +110,10 @@ module PublishingApi::CorporateInformationPagePresenterTest
 
     test 'schema name' do
       assert_attribute :schema_name, 'corporate_information_page'
+    end
+
+    test 'tags' do
+      assert_details_payload 'PublishingApi::PayloadBuilder::TagDetails'
     end
 
     test 'validity' do

--- a/test/unit/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/presenters/publishing_api_presenters_test.rb
@@ -37,9 +37,6 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a Generic Edition presenter for all models without a presenter class" do
     assert_equal PublishingApi::GenericEditionPresenter,
       PublishingApiPresenters.presenter_for(GenericEdition.new).class
-
-    assert_equal PublishingApi::GenericEditionPresenter,
-      PublishingApiPresenters.presenter_for(CorporateInformationPage.new).class
   end
 
   test ".presenter_for returns a Placeholder presenter for an organisation" do
@@ -132,5 +129,37 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
   test ".presenter_for returns a NewsArticlePresenter for a NewsArticle" do
     presenter = PublishingApiPresenters.presenter_for(build(:news_article))
     assert_equal PublishingApi::NewsArticlePresenter, presenter.class
+  end
+
+  test ".presenter_for returns a CorporateInformationPagePresenter for a " +
+    "CorporateInformationPage belonging to an Organisation" do
+    presenter = PublishingApiPresenters
+      .presenter_for(
+        build(
+          :corporate_information_page,
+          organisation: build(:organisation),
+        ),
+      )
+
+    assert_equal(
+      PublishingApi::CorporateInformationPagePresenter,
+      presenter.class,
+    )
+  end
+
+  test ".presenter_for returns a GenericEditionPresenter for a " +
+    "CorporateInformationPage belonging to an WorldwideOrganisation" do
+    presenter = PublishingApiPresenters
+      .presenter_for(
+        build(
+          :corporate_information_page,
+          worldwide_organisation: build(:worldwide_organisation),
+        ),
+      )
+
+    assert_equal(
+      PublishingApi::GenericEditionPresenter,
+      presenter.class,
+    )
   end
 end


### PR DESCRIPTION
Presents Corporate Information Pages to the Publishing API. Rendering is still within Whitehall.

Trello: https://trello.com/c/xk7pRD0H and https://trello.com/c/RH3BCQrt