### PR TITLE
Paginate the people finder

### DIFF
--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -15,7 +15,8 @@
       "format": "person"
     },
     "format_name": "All ministers and senior officials on GOV.UK",
-    "show_summaries": true
+    "show_summaries": true,
+    "default_documents_per_page": 50
   },
   "routes": [
     {


### PR DESCRIPTION
There are more than 1000 people, therefore only the first 1000 alphabetically are being displayed. Pagination will cut down the size of the page to 50 people and will allow all people to be shown.

Deployment checklist:

- [ ] Deploy whitehall
- [ ] Run the rake task `finders:publish` to re-publish all the finders