### PR TITLE
Update gds-api-adapters gem to get the latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.0'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 40.5.0'
+  gem 'gds-api-adapters', '~> 41.2.0'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     ffi (1.9.14)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gds-api-adapters (40.5.0)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -478,7 +478,7 @@ DEPENDENCIES
   equivalent-xml (= 0.5.1)
   factory_girl
   friendly_id (= 5.0.4)
-  gds-api-adapters (~> 40.5.0)
+  gds-api-adapters (~> 41.2.0)
   gds-sso (~> 11.0)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing