### PR TITLE
Republish Land Registry Corporate Information Page

### DIFF
--- a/db/data_migration/20170328123614_republish_land_registry.rb
+++ b/db/data_migration/20170328123614_republish_land_registry.rb
@@ -1,0 +1,1 @@
+PublishingApiDocumentRepublishingWorker.new.perform(253327)


### PR DESCRIPTION
Adds a migration to republish Land Registry Corporate Information Page.
This should push Land Registry through the Publishing Api and into the Content Store and fix an issue with sync checks.

This should be run after the following two PRs:

- [ ] Content Store: https://github.com/alphagov/content-store/pull/281
- [ ] Publishing Api: https://github.com/alphagov/publishing-api/pull/869
