### PR TITLE
Create SubscriberList on EmailAlertApi in background task

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -14,12 +14,17 @@ class EmailSignup
   def save
     if valid?
       ensure_govdelivery_topic_exists
+      EmailAlertApiSignupWorker.perform_async(topic_id, @feed)
       true
     end
   end
 
   def ensure_govdelivery_topic_exists
-    Whitehall.govuk_delivery_client.topic(feed, description)
+    @ensure_govdelivery_topic_exists ||= Whitehall.govuk_delivery_client.topic(feed, description)
+  end
+
+  def topic_id
+    ensure_govdelivery_topic_exists.parsed_content['partner_id']
   end
 
   def govdelivery_url

--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -8,7 +8,7 @@ class EmailSignup
 
   def initialize(attributes = {})
     @attributes = attributes
-    @feed = local_government ? add_local_government(attributes[:feed]) : attributes[:feed]
+    @feed = attributes[:feed]
   end
 
   def save
@@ -16,10 +16,6 @@ class EmailSignup
       ensure_govdelivery_topic_exists
       true
     end
-  end
-
-  def local_government
-    ActiveRecord::Type::Boolean.new.type_cast_from_database(@attributes[:local_government])
   end
 
   def ensure_govdelivery_topic_exists
@@ -47,10 +43,5 @@ protected
 
   def feed_url_validator
     @feed_url_validator ||= Whitehall::GovUkDelivery::FeedUrlValidator.new(feed)
-  end
-
-  def add_local_government(feed)
-    param_character = feed.include?('?') ? '&' : '?'
-    "#{feed}#{param_character}relevant_to_local_government=1"
   end
 end

--- a/app/workers/email_alert_api_signup_worker.rb
+++ b/app/workers/email_alert_api_signup_worker.rb
@@ -1,0 +1,24 @@
+# This is a temporary implementation to support the migration of
+# whitehall emailing from govuk_delivery to email_alert_api.
+# This has been implemented as a worker while the govuk_delivery
+# code has been left inline.
+# Once we have switched over to using email-alert-api for sending
+# emails and retired govuk_delivery this code should be moved to the
+# controller action and the govuk_delivery code deleted.
+require 'gds_api/helpers'
+
+class EmailAlertApiSignupWorker < WorkerBase
+  class UnexpectedTopicID < StandardError; end
+  include GdsApi::Helpers
+
+  sidekiq_options queue: "email_alert_api_signup"
+
+  def perform(topic_id, feed_url)
+    parser = UrlToSubscriberListCriteria.new(feed_url)
+    criteria = parser.convert.merge('gov_delivery_id' => topic_id)
+    response = email_alert_api.find_or_create_subscriber_list(criteria)
+    unless response['subscriber_list']['gov_delivery_id'] == topic_id
+      raise UnexpectedTopicID.new("#{response['subscriber_list']['gov_delivery_id']} <> #{topic_id}")
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,3 +10,4 @@
   - publishing_api
   - bulk_republishing
   - sync_checks
+  - email_alert_api_signup

--- a/features/email-signup-for-documents.feature
+++ b/features/email-signup-for-documents.feature
@@ -3,6 +3,7 @@ Feature: Email signup for documents
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And a list of publications exists
 
   Scenario: Signing up to unfiltered publications alerts

--- a/features/email-signup-for-organisations.feature
+++ b/features/email-signup-for-organisations.feature
@@ -3,6 +3,7 @@ Feature: Email signup for organisations
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And the organisation "Sledgehamster extermination inc." exists with a featured article
 
   Scenario: Signing up to organisation alerts

--- a/features/email-signup-for-people-and-roles.feature
+++ b/features/email-signup-for-people-and-roles.feature
@@ -3,6 +3,7 @@ Feature: Email signup for people and roles
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And "Marty McFly" is the "Minister of Anachronisms" for the "Department of Temporal Affairs"
     And a published news article "News from Marty McFly" associated with "Marty McFly"
 

--- a/features/email-signup-for-topical-events.feature
+++ b/features/email-signup-for-topical-events.feature
@@ -3,6 +3,7 @@ Feature: Email signup for topical events
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And a topical event called "Wombat management" exists with featured documents
 
   Scenario: Signing up to topical event alerts

--- a/features/email-signup-for-topics.feature
+++ b/features/email-signup-for-topics.feature
@@ -3,6 +3,7 @@ Feature: Email signup for topics
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And a topic called "Wombat management" exists with featured documents
 
   Scenario: Signing up to topic alerts

--- a/features/email-signup-for-world-locations.feature
+++ b/features/email-signup-for-world-locations.feature
@@ -3,6 +3,7 @@ Feature: Email signup for world locations
   Background:
     Given I am a GDS editor
     And govuk delivery exists
+    And email alert api exists
     And a world location "Best City" exists
 
   Scenario: Signing up to world location alerts

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -20,7 +20,11 @@ class EmailSignupsControllerTest < ActionController::TestCase
   end
 
   test 'POST :create with a valid email signup redirects to the govdelivery URL' do
+    response = mock('Response', parsed_content: { 'partner_id' => 'TOPIC-123', 'success' => true })
+    Whitehall.govuk_delivery_client.stubs(:topic).returns(response)
     Whitehall.govuk_delivery_client.stubs(:signup_url).returns('http://govdelivery_signup_url')
+    EmailAlertApiSignupWorker.stubs(:perform_async)
+
     topic = create(:topic)
     post :create, email_signup: { feed: atom_feed_url_for(topic) }
 

--- a/test/unit/workers/email_alert_api_signup_worker_test.rb
+++ b/test/unit/workers/email_alert_api_signup_worker_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+require "gds_api/test_helpers/email_alert_api"
+
+class EmailAlertApiSignupWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  setup do
+    @worker = EmailAlertApiSignupWorker.new
+  end
+
+  test 'creates a new email alert api entry' do
+    topic_id = "TOPIC_123"
+    feed_url = "http://test.com/government/publications.atom?topic[]=energy"
+    converted_hash = {"links" => {"topic" => ["a1234"]}, "email_document_supertype" => "publications"}
+    parser = mock("Parser", convert: converted_hash)
+    UrlToSubscriberListCriteria.expects(:new).with(feed_url).returns(parser)
+
+    email_alert_api_does_not_have_subscriber_list(converted_hash.merge('gov_delivery_id' => topic_id))
+    email_alert_api_creates_subscriber_list(converted_hash.merge('gov_delivery_id' => topic_id))
+
+    @worker.perform(topic_id, feed_url)
+  end
+
+  test 'happy with existing email alert api entry' do
+    topic_id = "TOPIC_123"
+    feed_url = "http://test.com/government/publications.atom?topic[]=energy"
+    converted_hash = {"links" => {"topic" => ["a1234"]}, "email_document_supertype" => "publications"}
+    parser = mock("Parser", convert: converted_hash)
+    UrlToSubscriberListCriteria.expects(:new).with(feed_url).returns(parser)
+
+    email_alert_api_has_subscriber_list(converted_hash.merge('gov_delivery_id' => topic_id))
+
+    @worker.perform(topic_id, feed_url)
+  end
+
+  test 'raises an error if the created subscriber list does not have the expected topic id' do
+    topic_id = "TOPIC_123"
+    feed_url = "http://test.com/government/publications.atom?topic[]=energy"
+    converted_hash = {"links" => {"topic" => ["a1234"]}, "email_document_supertype" => "publications"}
+    parser = mock("Parser", convert: converted_hash)
+    UrlToSubscriberListCriteria.expects(:new).with(feed_url).returns(parser)
+
+    email_alert_api_does_not_have_subscriber_list(converted_hash.merge('gov_delivery_id' => topic_id))
+    email_alert_api_creates_subscriber_list(converted_hash.merge('gov_delivery_id' => "WRONG_TOPIC"))
+
+    assert_raise EmailAlertApiSignupWorker::UnexpectedTopicID do
+      @worker.perform(topic_id, feed_url)
+    end
+  end
+end


### PR DESCRIPTION
Create a duplicate entry for the subscription on EmailAlertApi.
This is a temporary process as we migrate from GovUkDelivery
to EmailAlertApi. Entries created on EmailAlertApi will be
disabled to avoid duplicate emailing.

https://trello.com/c/Ptoh1EjD/125-1-create-new-topics-in-both-places-with-the-same-govdelivery-topic-id