### PR TITLE
Expose edition links through fatality notice presenter

### DIFF
--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -24,6 +24,7 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: "fatality_notice",
           details: details,
+          links: links,
         )
         content.merge!(PayloadBuilder::AccessLimitation.for(item))
         content.merge!(PayloadBuilder::FirstPublishedAt.for(item))

--- a/lib/sync_checker/formats/fatality_notice_check.rb
+++ b/lib/sync_checker/formats/fatality_notice_check.rb
@@ -9,6 +9,19 @@ module SyncChecker
         Whitehall::RenderingApp::GOVERNMENT_FRONTEND
       end
 
+      def checks_for_draft(locale)
+        super + [
+          Checks::LinksCheck.new(
+            "field_of_operation",
+            [edition_expected_in_draft.operational_field.content_id]
+          ),
+          Checks::LinksCheck.new(
+            "ministers",
+            expected_minister_content_ids(edition_expected_in_draft)
+          )
+        ]
+      end
+
       def checks_for_live(locale)
         super + [
           Checks::LinksCheck.new(
@@ -17,15 +30,15 @@ module SyncChecker
           ),
           Checks::LinksCheck.new(
             "ministers",
-            expected_minister_content_ids
+            expected_minister_content_ids(edition_expected_in_live)
           )
         ]
       end
 
     private
 
-      def expected_minister_content_ids
-        edition_expected_in_live
+      def expected_minister_content_ids(edition)
+        edition
           .role_appointments
           .try(:collect, &:person)
           .try(:collect, &:content_id)

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -2,11 +2,13 @@ require 'test_helper'
 
 class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   setup do
-    @fatality_notice = create(
+    @fatality_notice = build(
       :fatality_notice,
+      document: build(:document, id: 12345, slug: "fatality-notice-title"),
       title: "Fatality Notice title",
       summary: "Fatality Notice summary",
-      first_published_at: @first_published_at = Time.zone.now
+      first_published_at: @first_published_at = Time.zone.now,
+      updated_at: 1.year.ago,
     )
 
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -62,6 +62,15 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents the first_published_at in UTC" do
     assert_equal @first_published_at.utc, @presented_content[:first_published_at]
   end
+
+  test "it presents edition links" do
+    expected_links = {
+      organisations:  [],
+      policy_areas:   [],
+      field_of_operation: [@fatality_notice.operational_field.content_id]
+    }
+    assert_equal expected_links, @presented_content[:links]
+  end
 end
 
 class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupport::TestCase


### PR DESCRIPTION
https://trello.com/c/0XEmDdrp/642-fatality-notice-draft-preview

Exposes edition links in the Fatality Notice publishing API presenter.

Relies on https://github.com/alphagov/govuk-content-schemas/pull/601