### PR TITLE
Expose edition links through consultations presenter

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
           public_updated_at: public_updated_at,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: SCHEMA_NAME,
+          links: links,
         )
     end
 

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -24,10 +24,17 @@ module SyncChecker
         '/government/consultations/'
       end
 
+      def checks_for_draft(_locale)
+        super << Checks::LinksCheck.new(
+          "ministers",
+          expected_minister_content_ids(edition_expected_in_draft)
+        )
+      end
+
       def checks_for_live(_locale)
         super << Checks::LinksCheck.new(
           "ministers",
-          expected_minister_content_ids
+          expected_minister_content_ids(edition_expected_in_live)
         )
       end
 
@@ -198,8 +205,8 @@ module SyncChecker
         end
       end
 
-      def expected_minister_content_ids
-        edition_expected_in_live
+      def expected_minister_content_ids(edition)
+        edition
           .role_appointments
           .try(:collect, &:person)
           .try(:collect, &:content_id)

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -108,6 +108,17 @@ module PublishingApi::ConsultationPresenterTest
       assert_equal actual_links, expected_links
     end
 
+    test 'edition links' do
+      expected_links = {
+        organisations: consultation.organisations.map(&:content_id),
+        parent: [],
+        policy_areas: consultation.topics.map(&:content_id),
+        related_policies: [],
+        topics: []
+      }
+      assert_equal presented_content[:links], expected_links
+    end
+
     test 'body details' do
       body_double = Object.new
 


### PR DESCRIPTION
Consultations need to use the draft preview stack for links.