### PR TITLE
Include Has Content Ids in Roles

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,6 @@
 # @abstract
 class Role < ActiveRecord::Base
+  include HasContentId
   HISTORIC_ROLE_PARAM_MAPPINGS = { 'past-prime-ministers' => 'prime-minister',
                                    'past-chancellors'     => 'chancellor-of-the-exchequer',
                                    'past-foreign-secretaries' => 'foreign-secretary' }


### PR DESCRIPTION
All roles now must have a content id since they are now sent to publishing api for certain formats to help with email-alert-api work.

Currently new non-ministerial roles do not get a `content_id`. If one of these roles is then associated with a format that sends `roles` to the Publishing Api for consumption by Email Alert Api, a `[nil]` is sent......this fails.