### PR TITLE
Present unique HtmlAttachment organisation content_ids

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -36,7 +36,7 @@ module PublishingApi
     def links
       {
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
-        organisations: parent.organisations.pluck(:content_id),
+        organisations: parent.organisations.pluck(:content_id).uniq,
       }
     end
 

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -84,4 +84,15 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       assert_equal Time.zone.now, present(html_attachment).content[:details][:public_timestamp]
     end
   end
+
+  test "HtmlAttachment presents unique organisation content_ids" do
+    create(:publication, :with_html_attachment, :published)
+
+    html_attachment = HtmlAttachment.last
+    # if an organisation has multiple translations, pluck returns
+    # duplicate content_ids because it constructs a left outer join
+    html_attachment.attachable.organisations.expects(:pluck).with(:content_id).returns(%w(abcdef abcdef))
+
+    assert_equal ["abcdef"], present(html_attachment).links[:organisations]
+  end
 end


### PR DESCRIPTION
When an organisation has more than one translations, calling `.pluck(:content_id)` on the `HtmlAttachement.attachable.organisations` causes ActiveRecord to create a `LEFT OUTER` join against the `organisation_translations` table. This returns an array with duplicate
`organisation_ids`, which then fails when sending to Publishing Api.

This commit fixes the problem by ensuring we send `.uniq` `content_ids`.