### PR TITLE
Increase priority of the email_alert_api_signup Sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,6 @@
   - scheduled_publishing
   - default
   - publishing_api
+  - email_alert_api_signup
   - bulk_republishing
   - sync_checks
-  - email_alert_api_signup


### PR DESCRIPTION
This queue is low volume and it will make the logging in email-alert-api more
consistent if new subscriber lists are created there quickly after they're
first created by govuk-delivery, so this queue should take priority over
bulk_republishing. We can see the queue building up in Production while bulk
republishing is happening - thanks @gpeng for noticing :)