### PR TITLE
Use Time.zone in Government on_date

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -14,7 +14,7 @@ class Government < ActiveRecord::Base
   end
 
   def self.on_date(date)
-    return if date.to_date > Date.today
+    return if date.to_date > Time.zone.today
 
     where('start_date <= ?', date).order(start_date: :asc).last
   end


### PR DESCRIPTION
Scheduled publishings that occur between 00:00 and 01:00 during British Summer Time can fail when the Edition has `political = true`.

This is because when deciding what government to attach to an edition, we short circuit and return nil if `first_public_at > Date.today`.

This should never occur. Except during BST. When we schedule a publishing for 00:15 during BST, it sets the scheduled time in the database as 23:15 the day before. This is because our servers are set to UTC. 

At 23:15 UTC (00:15 the next day BST), the publishing occurs and sets `first_public_at` to be 00:15 (the time the user requested publishing occur)

When we subsequently pass `first_public_at` to `Governemnt#self.on_date`, we end up short circuiting the first condition:

```
return if date.to_date > Date.today
```

because we are comparing a date normalized for time zone vs one that isn't. This returns a nil and subsequently, when we try to set the `government` array to send to Publishing Api, we set it to `nil` which causes Publishing Api to reject the PUT request with a 422.

Using `Time.zone.today` should sort this out.