### PR TITLE
Add task to list possible failed scheduled publishings

### DIFF
--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -38,6 +38,22 @@ namespace :publishing do
       end
       puts ""
     end
+
+    desc "Finds editions that were meant to be published between 23:00 yesterday and 01:00 today - helps debug failed publications owing to British Summer Time"
+    task around_midnight: :environment do
+      yesterday = Date.yesterday
+      today = Date.today
+
+      time_from = Time.new(yesterday.year, yesterday.month, yesterday.day, 23, 0, 0)
+      time_to = Time.new(today.year, today.month, today.day, 0, 0, 0)
+
+      editions = Edition.where("scheduled_publication between ? and ?", time_from, time_to)
+
+      puts "Document Id, Edition Id, Slug, Type"
+      editions.each do |edition|
+        puts "#{edition.document.id}, #{edition.id}, #{edition.slug}, #{edition.type}"
+      end
+    end
   end
 
   namespace :overdue do


### PR DESCRIPTION
List publishings that were scheduled between 00:00 and 01:00 in
Whitehall Admin to help with debugging failed publishings during British
Summer Time.

Note that Whitehall Admin assumes local time, however data is written to
the database as UTC. Thus to search for these scheduled publishings we
actually search between 23:00 yesterday and 00:00 today.