### PR TITLE
No longer update publishing-api when saving html attachment

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -16,7 +16,7 @@ class Admin::AttachmentsController < Admin::BaseController
   def new; end
 
   def create
-    if save_attachment
+    if attachment.save
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       render :new
@@ -25,7 +25,7 @@ class Admin::AttachmentsController < Admin::BaseController
 
   def update
     attachment.attributes = attachment_params
-    if save_attachment
+    if attachment.save
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
@@ -172,14 +172,6 @@ private
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       raise
-    end
-  end
-
-  def save_attachment
-    if attachment.respond_to?(:save_and_update_publishing_api)
-      attachment.save_and_update_publishing_api
-    else
-      attachment.save
     end
   end
 end


### PR DESCRIPTION
- Previously when an attachment was saved, the user was not redirected to the attachments page or notified that their attachment have been saved or updated
- Do not need to update publishing-api when attachment is saved as this should be done when the parent edition is saved

## Trello

https://trello.com/c/uD0m5Km3/19-investigate-why-we-can-t-edit-html-attachments-once-they-are-created