### PR TITLE
Skip virus checks for attachments in development

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -53,13 +53,17 @@ class AttachmentData < ActiveRecord::Base
   end
 
   def virus_status
-    if File.exists?(infected_path)
+    if File.exist?(infected_path)
       :infected
-    elsif File.exists?(clean_path)
+    elsif File.exist?(clean_path) || skip_virus_check?
       :clean
     else
       :pending
     end
+  end
+
+  def skip_virus_check?
+    Rails.env.development? && !File.exist?(path)
   end
 
   # Newly instantiated AttachmentData will report the file path as in the incoming


### PR DESCRIPTION
The attachments that have been uploaded for documents in production
do not exist on our local development environment. Since these files
don’t exist, they don’t ever get moved to the `clean_path` (even with
[`govuk-puppet:85b989`](https://github.com/alphagov/govuk-puppet/pull/5710/commits/85b98996ee86ad3b28e5bfa89f03c840bc32b3d6)). Therefore, it looks like
there is a permanent virus check pending for all attachments, and it
isn’t possible to republish an existing document with attachments.

This change adds a check for the development environment, and whether
the file actually exists (hence retaining compatibility with the fake
virus checker implemented in the above `govuk-puppet` commit).