### PR TITLE
Change how OAuth ID and secret are set

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
   config.user_model   = "User"
-  config.oauth_id     = ENV.fetch("OAUTH_ID", "abcdefghjasndjkasndwhitehall")
-  config.oauth_secret = ENV.fetch("OAUTH_SECRET", "secret")
+  config.oauth_id     = ENV['OAUTH_ID'] || "abcdefghjasndjkasndwhitehall"
+  config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.find("signon")
 end


### PR DESCRIPTION
This commit changes how the OAuth ID and secret (and their fallbacks) are set so that it is consistent with other apps, and to allow the signon-munging script for development to configure signon for this app locally.