### PR TITLE
Stop deleting updated Person image

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,10 @@
 class ImageUploader < WhitehallUploader
   include CarrierWave::MiniMagick
 
+  configure do |config|
+    config.remove_previously_stored_files_after_update = false
+  end
+
   def extension_white_list
     %w(jpg jpeg gif png)
   end


### PR DESCRIPTION
Currently, when a `Person` has their image updated CarrierWave deletes the previous image. This wasn't a problem when Whitehall rendered its own content but now we are publishing content via Publishing API these images will still be referenced from content in the content store.

As `people` are only being published as placeholders they don't trigger dependency resolution and even when they do the deleted image will cause requests for it to 404 and a placeholder to be used in production while dependency resolution takes place.

This commit configures the `ImageUploader` to keep the previous versions of files for the which will at least prevent them 404-ing if they are changed.

This functionality is not tested as I have been unable to write a failing test. Previous 'versions' of files are not deleted when running a test. This behaviour persists regardless of whether the test is run with transactional or non-transactional fixtures and is possibly due to the way virus scanning has been implemented.