### PR TITLE
Send emails via SMTP by defining SMTP_PORT

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,12 @@ Whitehall::Application.configure do
   config.action_controller.perform_caching = false
   config.action_controller.action_on_unpermitted_parameters = :raise
 
+  # Send emails to the local MailHog instance
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port: 1025
+  }
+
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,5 +96,15 @@ Whitehall::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.action_mailer.delivery_method = :ses
+  # Send emails via SMTP if SMTP_PORT is set, otherwise send via SES
+  # This is mainly used for sending emails to MailHog in the training
+  # environment
+  if ENV['SMTP_PORT']
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      port: ENV['SMTP_PORT']
+    }
+  else
+    config.action_mailer.delivery_method = :ses
+  end
 end


### PR DESCRIPTION
This commit changes the whitehall config to send emails using SMTP in development by default, and in production when the `SMTP_PORT` env var is defined. After https://github.com/alphagov/govuk-puppet/pull/5745 is merged, this will allow sent emails to be viewed locally in MailHog.