### PR TITLE
Set worldwide corporate informage page rendering_app to Whitehall

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -117,7 +117,11 @@ class CorporateInformationPage < Edition
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    if worldwide_organisation.present?
+      Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    else
+      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    end
   end
 
   private


### PR DESCRIPTION
Corporate information pages were migrated, but worldwide versions were not.

Without the rendering_app logic, the preview on website button links to draft origin rather than Whitehall frontend. This then 404s.

Fixes https://govuk.zendesk.com/agent/tickets/2063923, so far as it now points users at Whitehall rather than a 404.

However they still can't see the preview of their current draft because of the redirect in routes:
https://github.com/alphagov/whitehall/blob/allow-worldwide-corp-info-previews/config/routes.rb#L141

cc @andrewgarner @gpeng 