### PR TITLE
CSV preview link fix

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -40,7 +40,7 @@ class AttachmentData < ActiveRecord::Base
   end
 
   def csv?
-    file_extension == "csv"
+    file_extension.downcase == "csv"
   end
 
   # Is in OpenDocument format? (see https://en.wikipedia.org/wiki/OpenDocument)


### PR DESCRIPTION
Trello: https://trello.com/c/3WHpYhwH/139-investigate-uploaded-csv-preview-problem

Currently, CSVs only show the "view online" link if the app _thinks_ the attachment is a CSV. This only happens when the extension of the file is "csv", case sensitive. We should remove the case sensitivity so that "CSV" files still match.