### PR TITLE
Preview Publication with government-frontend

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -53,13 +53,7 @@ class Publication < Publicationesque
   end
 
   def rendering_app
-    #TODO: This format is being rendered by government-frontend
-    #but this has been switched in the presenter
-    #as preview needs to be done by Whitehall until
-    #draft links are available in publishing api.
-    #Preview is switched dependent on the return value of this method
-    #in app/helpers/public_document_routes_helper.rb:49
-    Whitehall::RenderingApp::WHITEHALL_FRONTEND
+    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
   def allows_inline_attachments?

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -21,9 +21,7 @@ module PublishingApi
         details: details,
         document_type: item.display_type_key,
         public_updated_at: item.public_timestamp || item.updated_at,
-        #TODO: rendering app is hard coded until
-        #item.rendering_app is switched when preview is ready
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: item.rendering_app,
         schema_name: "publication",
         links: links,
       )

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -31,13 +31,9 @@ end
 Then /^I should see a link to the preview version of the publication "([^"]*)"$/ do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  preview_url_regexp = Regexp.new(
-    Regexp.escape(
-      preview_document_path(publication)
-    ).gsub(/cachebust=[0-9]+/, 'cachebust=[0-9]+')
-  )
+  expected_preview_url = "http://draft-origin.dev.gov.uk/government/publications/#{publication.slug}"
 
-  assert_match preview_url_regexp, find("a.preview_version")[:href]
+  assert_equal expected_preview_url, find("a.preview_version")[:href]
 end
 
 Then /^I should see that it was rejected by "([^"]*)"$/ do |rejected_by|


### PR DESCRIPTION
The `Publication` format is now sending edition level links to publishing API. All documents have been republished so should be previewable with government-frontend (via draft-origin) now so we can switch over preview.

This is achieved by returning `government-frontend` from `Publication#rendering_app`.

[Trello](https://trello.com/c/RWL7ppZ6/637-use-draft-links-for-publications)