### PR TITLE
Fix CSV thumbnails

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -138,7 +138,7 @@ module DocumentHelper
       image_tag('pub-cover-html.png', alt: '')
     elsif %w{doc docx odt}.include? attachment.file_extension
       image_tag('pub-cover-doc.png', alt: '')
-    elsif %w{xls xlsx ods csv}.include? attachment.file_extension
+    elsif %w{xls xlsx ods csv}.include? attachment.file_extension.downcase
       image_tag('pub-cover-spreadsheet.png', alt: '')
     else
       image_tag('pub-cover.png', alt: '')

--- a/test/fixtures/sample_case.CSV
+++ b/test/fixtures/sample_case.CSV
@@ -1,0 +1,3 @@
+Department,Budget,Amount spent
+Office for Facial Hair Studies,£12000000,£10000000
+Department of Grooming,£15000000,£15600000

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -73,6 +73,11 @@ class DocumentHelperTest < ActionView::TestCase
     assert_match /pub-cover-spreadsheet\.png/, attachment_thumbnail(attachment)
   end
 
+  test "should return spreadsheet specific thumbnail for spreadsheet files with any case file extension" do
+    attachment = create(:file_attachment, file: fixture_file_upload('sample_case.CSV', 'text/csv'))
+    assert_match(/pub-cover-spreadsheet\.png/, attachment_thumbnail(attachment))
+  end
+
   test "should return HTML specific thumbnail for HTML attachments" do
     publication = create(:published_publication, :with_html_attachment)
     assert_match /pub-cover-html\.png/, attachment_thumbnail(publication.attachments.first)


### PR DESCRIPTION
Trello: https://trello.com/c/3WHpYhwH/139-investigate-uploaded-csv-preview-problem

Similar to the preview issue, the wrong icon was showing for CSV files which don't have a specifically lower-case extension.

Note: This does not fix this issue with other file types, possible story to come.