### PR TITLE
Separates "ISBN" into "Web ISBN" and "Print ISBN"

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -103,7 +103,7 @@ private
 
   def attachment_params
     params.fetch(:attachment, {}).permit(
-      :title, :locale, :isbn, :unique_reference,
+      :title, :locale, :isbn, :web_isbn, :unique_reference,
       :command_paper_number, :unnumbered_command_paper, :hoc_paper_number,
       :unnumbered_hoc_paper, :parliamentary_session, :order_url, :price, :accessible,
       :external_url, :print_meta_data_contact_address,

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -47,6 +47,7 @@ class Admin::BulkUploadsController < Admin::BaseController
       :title,
       :locale,
       :isbn,
+      :web_isbn,
       :print_meta_data_contact_address,
       :unique_reference,
       :command_paper_number,

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if attachable.allows_attachment_references? %>
-    <%= render 'reference_fields', attachable: attachable, form: form %>
+    <%= render 'reference_fields', attachable: attachable, form: form, attachment: attachment %>
   <% end %>
 
   <% if attachment.is_a?(HtmlAttachment) %>

--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -4,8 +4,11 @@
   <%= form.select :locale, options_for_locales(attachable.translated_locales), include_blank: 'All languages' %>
 <% end %>
 
-<%= form.text_field :isbn, label_text: "ISBN (web version)" %>
-<%= form.text_area :print_meta_data_contact_address, rows: 5, label_text: "Organisation's Contact Details", placeholder: "This can contain the address, email, or telephone number" %>
+<%= form.text_field :isbn, label_text: "Print ISBN" %>
+<% if attachment.is_a?(HtmlAttachment) %>
+  <%= form.text_field :web_isbn, label_text: "Web ISBN" %>
+  <%= form.text_area :print_meta_data_contact_address, rows: 5, label_text: "Organisation's Contact Details", placeholder: "This can contain the address, email, or telephone number" %>
+<% end %>
 
 <%= form.text_field :unique_reference %>
 <div class="paper-number">

--- a/app/views/admin/bulk_uploads/set_titles.html.erb
+++ b/app/views/admin/bulk_uploads/set_titles.html.erb
@@ -14,7 +14,7 @@
               <%= attachment_fields.text_field :title %>
 
               <% if @edition.allows_attachment_references? %>
-                <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields %>
+                <%= render 'admin/attachments/reference_fields', attachable: @edition, form: attachment_fields, attachment: attachment %>
               <% end %>
 
               <%= attachment_fields.fields_for :attachment_data, attachment_fields.object.attachment_data, include_id: false do |attachment_data_fields| %>

--- a/app/views/html_attachments/_print_meta_data.html.erb
+++ b/app/views/html_attachments/_print_meta_data.html.erb
@@ -28,6 +28,12 @@
 
 <% unless @html_attachment.isbn.blank? %>
   <p>
-    Web ISBN: <%= @html_attachment.isbn %>
+    Print ISBN: <%= @html_attachment.isbn %>
   </p>
+<% end %>
+
+<% unless @html_attachment.web_isbn.blank? %>
+    <p>
+      Web ISBN: <%= @html_attachment.web_isbn %>
+    </p>
 <% end %>

--- a/db/migrate/20170411161614_add_web_isbn_to_attachments.rb
+++ b/db/migrate/20170411161614_add_web_isbn_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddWebIsbnToAttachments < ActiveRecord::Migration
+  def change
+    add_column :attachments, :web_isbn, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223180546) do
+ActiveRecord::Schema.define(version: 20170411161614) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20170223180546) do
     t.string   "content_id",                      limit: 255
     t.boolean  "deleted",                                     default: false, null: false
     t.string   "print_meta_data_contact_address", limit: 255
+    t.string   "web_isbn",                        limit: 255
   end
 
   add_index "attachments", ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type", using: :btree

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -59,8 +59,8 @@ Feature: Managing attachments on editions
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
-    And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783" and the contact address "Address 1"
+    And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783" and the web isbn "978-1-78246-569-0" and the contact address "Address 1"
     And I publish the draft edition for publication "Standard Beard Lengths"
     And I preview "Standard Beard Lengths"
-    Then previewing the html attachment "Beard Length Graphs 2012" in print mode includes the contact address "Address 1" and the isbn "9781474127783"
+    Then previewing the html attachment "Beard Length Graphs 2012" in print mode includes the contact address "Address 1" and the isbn "9781474127783" and the web isbn "978-1-78246-569-0"
 

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -124,10 +124,11 @@ Then(/^I should see the html attachment body "(.*?)"$/) do |attachment_body|
   assert page.has_content?(attachment_body)
 end
 
-When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)" and the contact address "(.*?)"$/) do |title, isbn, contact_address|
+When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)" and the contact address "(.*?)"$/) do |title, isbn, web_isbn, contact_address|
   click_on "Add new HTML attachment"
   fill_in "Title", with: title
-  fill_in "ISBN (web version)", with: isbn
+  fill_in "Print ISBN", with: isbn
+  fill_in "Web ISBN", with: web_isbn
   fill_in "Organisation's Contact Details", with: contact_address
   fill_in "Body", with: "Body"
   check "Manually numbered headings"
@@ -139,10 +140,11 @@ When(/^I publish the draft edition for publication "(.*?)"$/) do |publication_ti
   publication.update!(state: 'published', major_change_published_at: Date.today)
 end
 
-Then /^previewing the html attachment "(.*?)" in print mode includes the contact address "(.*?)" and the isbn "(.*?)"$/ do |attachment_title, contact_address, isbn|
+Then /^previewing the html attachment "(.*?)" in print mode includes the contact address "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)"$/ do |attachment_title, contact_address, isbn, web_isbn|
   html_attachment = HtmlAttachment.find_by title: attachment_title
   publication = html_attachment.attachable
   visit publication_html_attachment_path publication_id: publication.slug, id: html_attachment.slug, medium: "print"
   assert page.has_content? contact_address
   assert page.has_content? isbn
+  assert page.has_content? web_isbn
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/OEZIdXTE/135-separate-file-attachment-form-and-html-attachment-form)

Depends on: 
https://github.com/alphagov/govuk-content-schemas/pull/607
https://github.com/alphagov/government-frontend/pull/325

## Background
It was pointed out that the "ISBN (web version)" field is showing up not only in the HTML Attachments form, but also in the File Attachments form. Additionally, this was becoming confusing to people because they were used to entering the Print ISBN in that field (which was initially just called "ISBN"). The two forms will now show different content (see screenshots below).

## What this does
This PR will separate the "ISBN (web version)" field into "Print ISBN" and "Web ISBN". 
The HTML attachment form will show both Print and Web ISBN.
The File attachment form will only show the Print ISBN as that is the one being used. It was pointed out that the Web ISBN is not necessary here. 

Both fields are optional and will appear (if present) when an attachment is printed.

## UI

### 1. HTML Attachment Form
<img width="791" alt="screen shot 2017-04-12 at 11 32 42" src="https://cloud.githubusercontent.com/assets/1354439/25127335/5a5fa08e-242d-11e7-834d-f63e9c9fe879.png">

### 2. File Attachment Form
<img width="901" alt="screen shot 2017-04-12 at 11 31 52" src="https://cloud.githubusercontent.com/assets/1354439/25127377/7a79d362-242d-11e7-8213-0f779beb10ba.png">

