### PR TITLE
Allow Institute for Apprenticeships content to be tagged

### DIFF
--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -6,6 +6,7 @@ organisations_in_tagging_beta:
   - "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency
   - "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education
   - "60de9b00-a982-4449-a995-f2353e86fb95" # Higher Education Statistics Agency
+  - "a081cd5b-c41d-4389-ac65-982e7570680d" # Institute for Apprenticeships
   - "e1cbab66-b0d3-4186-917c-afd4f3fb6967" # National College for Teaching and Leadership
   - "e7f33769-a539-4fb4-b24f-f6c1cabc3f59" # Office of the Schools Adjudicator
   - "83f6e93f-bb2c-46ab-9b02-394f972b7030" # Ofqual


### PR DESCRIPTION
Added the Institute for Apprenticeships to the list of organisations
whose content can be tagged to the education taxonomy.

[Trello card](https://trello.com/c/u7oFzk6t/54-add-institute-for-apprenticeships-to-list-of-organisations-whose-content-can-be-tagged)