### PR TITLE
Fix GOVUK_APP_DOMAIN

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ node {
       if (params.IS_SCHEMA_TEST) {
         echo "Skipping precompile step because this is a schema test"
       } else {
-        sh("RAILS_ENV=production GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk bundle exec rake assets:precompile --trace")
+        sh("RAILS_ENV=production GOVUK_ASSET_ROOT=https://static.test.gov.uk bundle exec rake assets:precompile --trace")
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ node {
       if (params.IS_SCHEMA_TEST) {
         echo "Skipping precompile step because this is a schema test"
       } else {
-        sh("RAILS_ENV=production GOVUK_ASSET_ROOT=https://static.test.gov.uk bundle exec rake assets:precompile --trace")
+        sh("RAILS_ENV=production GOVUK_APP_DOMAIN=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk bundle exec rake assets:precompile --trace")
       }
     }
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,6 @@
 # to log level :warn reduces logging and increases execution speed.
 ENV["LOG_LEVEL"] = "warn"
 
-ENV['GOVUK_APP_DOMAIN'] = 'dev.gov.uk' unless ENV['GOVUK_APP_DOMAIN']
-
 require File.expand_path('../config/application', __FILE__)
 require 'ci/reporter/rake/minitest' if Rails.env.development? or Rails.env.test?
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,8 +52,8 @@ Whitehall::Application.configure do
 
   # These environment variables are required for Plek. Conditionally setting
   # them here means we don't have to explicitly set them just ro run tests.
-  ENV['GOVUK_APP_DOMAIN'] ||= 'test.alphagov.co.uk'
-  ENV['GOVUK_ASSET_ROOT'] ||= 'http://static.test.alphagov.co.uk'
+  ENV['GOVUK_APP_DOMAIN'] ||= 'test.gov.uk'
+  ENV['GOVUK_ASSET_ROOT'] ||= 'https://static.test.gov.uk'
 
   config.active_support.test_order = :random
 end

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -9,8 +9,8 @@ the Whitehall repository, or the location must be specified explicitly via the
 
 Two other environment variables can also be (optionally) set up, typically:
 
-    GOVUK_APP_DOMAIN=dev.gov.uk
-    GOVUK_ASSET_ROOT=http://static.dev.gov.uk
+    GOVUK_APP_DOMAIN=test.gov.uk
+    GOVUK_ASSET_ROOT=https://static.test.gov.uk
 
 Then run
 

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -31,7 +31,7 @@ end
 Then /^I should see a link to the preview version of the publication "([^"]*)"$/ do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  expected_preview_url = "http://draft-origin.dev.gov.uk/government/publications/#{publication.slug}"
+  expected_preview_url = "http://draft-origin.test.gov.uk/government/publications/#{publication.slug}"
 
   assert_equal expected_preview_url, find("a.preview_version")[:href]
 end

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -40,7 +40,7 @@ FactoryGirl.define do
 
   factory :unpublished_statistics_announcement, parent: :statistics_announcement do
     publishing_state "unpublished"
-    redirect_url "https://www.test.alphagov.co.uk/government/sparkle"
+    redirect_url "https://www.test.gov.uk/government/sparkle"
   end
 
   factory :statistics_announcement_requiring_redirect,

--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -32,7 +32,7 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
   end
 
   test "POST :create with valid params unpublishes the announcement" do
-    redirect_url = 'https://www.test.alphagov.co.uk/example'
+    redirect_url = 'https://www.test.gov.uk/example'
 
     stub_publishing_api_destroy_intent(@announcement.base_path)
 

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -96,7 +96,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   test "it deletes the publish intent when unpublished" do
     statistics_announcement = create(:statistics_announcement)
     statistics_announcement.update_attributes!(publishing_state: "unpublished",
-                                               redirect_url: "https://www.test.alphagov.co.uk/example")
+                                               redirect_url: "https://www.test.gov.uk/example")
 
     assert_publishing_api_delete_intent(statistics_announcement.base_path)
   end
@@ -132,7 +132,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     Whitehall::SearchIndex.stubs(:add)
     Whitehall::SearchIndex.stubs(:delete)
     statistics_announcement = create(:statistics_announcement,
-                                     redirect_url: "https://www.test.alphagov.co.uk/example")
+                                     redirect_url: "https://www.test.gov.uk/example")
 
     Whitehall::SearchIndex.expects(:delete).with(statistics_announcement)
     statistics_announcement.update_attributes!(publishing_state: "unpublished")
@@ -184,11 +184,11 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     statistics_announcement = create(:statistics_announcement)
 
     Whitehall::PublishingApi.expects(:publish_redirect_async)
-      .with(statistics_announcement.content_id, "https://www.test.alphagov.co.uk/government/something-else")
+      .with(statistics_announcement.content_id, "https://www.test.gov.uk/government/something-else")
 
     statistics_announcement.update_attributes!(
       publishing_state: "unpublished",
-      redirect_url: "https://www.test.alphagov.co.uk/government/something-else"
+      redirect_url: "https://www.test.gov.uk/government/something-else"
     )
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 $:.unshift(File.dirname(__FILE__))
 ENV["RAILS_ENV"] = "test"
-ENV["GOVUK_APP_DOMAIN"] = "test.alphagov.co.uk"
-ENV["GOVUK_ASSET_ROOT"] = "http://static.test.alphagov.co.uk"
 
 require File.expand_path('../../config/environment', __FILE__)
 

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -122,13 +122,13 @@ class PublicDocumentRoutesHelperTest < ActionView::TestCase
   test "Creates a preview URL with cachebust and edition parameters" do
     edition = create(:corporate_information_page)
     preview_url = preview_document_url(edition)
-    assert_equal "http://draft-origin.test.alphagov.co.uk/government/organisations/#{edition.organisation.slug}/about/publication-scheme", preview_url
+    assert_equal "http://draft-origin.test.gov.uk/government/organisations/#{edition.organisation.slug}/about/publication-scheme", preview_url
   end
 
   test "Creates a preview URL without parameters for edition formats that have migrated" do
     edition = create(:draft_case_study)
     preview_url = preview_document_url(edition)
-    assert_equal "http://draft-origin.test.alphagov.co.uk/government/case-studies/#{edition.slug}", preview_url
+    assert_equal "http://draft-origin.test.gov.uk/government/case-studies/#{edition.slug}", preview_url
   end
 
   test "organisations have the correct path generated" do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -255,7 +255,7 @@ module PublishingApi::ConsultationPresenterTest
 
     test 'ways to respond' do
       expected_ways_to_respond = {
-        attachment_url: 'https://www.test.alphagov.co.uk/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
+        attachment_url: 'https://www.test.gov.uk/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
         email: 'postmaster@example.com',
         link_url: 'http://www.example.com',
         postal_address: <<-ADDRESS.strip_heredoc.chop

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -60,7 +60,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     )
     presented_item = present(organisation)
 
-    expected_image_url = 'https://static.test.alphagov.co.uk' +
+    expected_image_url = 'https://static.test.gov.uk' +
       '/government/uploads/system/uploads/organisation/logo/1/960x640_jpeg.jpg'
 
     assert_equal(

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -29,7 +29,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement = build(:unpublished_statistics_announcement, redirect_url: "https://www.youtube.com")
     refute announcement.valid?
 
-    assert_match %r{must be in the form of https://www.test.alphagov.co.uk/example}, announcement.errors[:redirect_url].first
+    assert_match %r{must be in the form of https://www.test.gov.uk/example}, announcement.errors[:redirect_url].first
   end
 
   test 'when unpublished, it cannot redirect to itself' do
@@ -41,7 +41,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test 'when unpublished, is valid with a GOV.UK redirect_url' do
-    announcement = build(:unpublished_statistics_announcement, redirect_url: "https://www.test.alphagov.co.uk/government/statistics")
+    announcement = build(:unpublished_statistics_announcement, redirect_url: "https://www.test.gov.uk/government/statistics")
     assert announcement.valid?
   end
 

--- a/test/unit/sync_checker/request_queue_test.rb
+++ b/test/unit/sync_checker/request_queue_test.rb
@@ -24,7 +24,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     result_set = []
     queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
-    Typhoeus.stub("https://draft-content-store.test.alphagov.co.uk/content/one").and_return(response)
+    Typhoeus.stub("https://draft-content-store.test.gov.uk/content/one").and_return(response)
 
     document_check.expects(:check_draft).with(response, :en)
     queued_request.requests.map(&:run)
@@ -39,7 +39,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     result_set = []
     queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
-    Typhoeus.stub("https://content-store.test.alphagov.co.uk/content/one").and_return(response)
+    Typhoeus.stub("https://content-store.test.gov.uk/content/one").and_return(response)
 
     document_check.expects(:check_live).with(response, :en)
     queued_request.requests.map(&:run)
@@ -54,7 +54,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     result_set = []
     queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
-    Typhoeus.stub("https://content-store.test.alphagov.co.uk/content/one").and_return(response)
+    Typhoeus.stub("https://content-store.test.gov.uk/content/one").and_return(response)
 
     document_check.expects(:check_live).with(response, :en).returns(check_result = stub)
     queued_request.requests.map(&:run)
@@ -71,7 +71,7 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     result_set = []
     queued_request = SyncChecker::RequestQueue.new(document_check, result_set)
     response = Typhoeus::Response.new(code: 200, body: "{'content_id', 'booyah'}")
-    Typhoeus.stub("https://draft-content-store.test.alphagov.co.uk/content/one").and_return(response)
+    Typhoeus.stub("https://draft-content-store.test.gov.uk/content/one").and_return(response)
 
     document_check.expects(:check_draft).with(response, :en).returns(check_result = stub)
     queued_request.requests.map(&:run)
@@ -87,10 +87,10 @@ class SyncChecker::RequestQueueTest < Minitest::Test
     document_check = stub(id: 1, base_paths: base_paths)
     result_set = []
     Typhoeus::Request.expects(:new).with(
-      "https://draft-content-store.test.alphagov.co.uk/content/one",
+      "https://draft-content-store.test.gov.uk/content/one",
     ).returns(draft_request = stub(:on_complete))
     Typhoeus::Request.expects(:new).with(
-      "https://content-store.test.alphagov.co.uk/content/two",
+      "https://content-store.test.gov.uk/content/two",
     ).returns(live_request = stub(:on_complete))
 
     queued_request = SyncChecker::RequestQueue.new(document_check, result_set)

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -41,7 +41,7 @@ class UnpublishingTest < ActiveSupport::TestCase
   test 'alternative_url cannot be the same url as the edition' do
     document = create(:document, slug: 'document-path')
     edition = create(:detailed_guide, document: document)
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.dev.gov.uk/guidance/document-path', edition: edition)
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.test.gov.uk/guidance/document-path', edition: edition)
 
     refute unpublishing.valid?
     assert unpublishing.errors[:alternative_url].include?("cannot redirect to itself")
@@ -63,7 +63,7 @@ class UnpublishingTest < ActiveSupport::TestCase
   end
 
   test 'alternative_path returns the path of alternative_url' do
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.dev.gov.uk/guidance/document-path')
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: 'https://www.test.gov.uk/guidance/document-path')
     assert_equal "/guidance/document-path", unpublishing.alternative_path
   end
 

--- a/test/unit/url_to_subscriber_list_migration_test.rb
+++ b/test/unit/url_to_subscriber_list_migration_test.rb
@@ -54,7 +54,7 @@ class UrlToSubscriberListMigrationTest < ActiveSupport::TestCase
     csv_data = [
       { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
     ]
-    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+    stub_request(:get, %r{email-alert-api.test.gov.uk/subscriber-lists}).to_return(
       body: {'subscriber_list' => { 'gov_delivery_id' => 'TOPIC_123' } }.to_json
     )
     static_data = mock('StaticData', content_id: "a1234")
@@ -78,7 +78,7 @@ class UrlToSubscriberListMigrationTest < ActiveSupport::TestCase
     csv_data = [
       { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
     ]
-    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+    stub_request(:get, %r{email-alert-api.test.gov.uk/subscriber-lists}).to_return(
       body: {'subscriber_list' => { 'gov_delivery_id' => 'OTHER_TOPIC' } }.to_json
     )
     static_data = mock('StaticData', content_id: "a1234")
@@ -104,7 +104,7 @@ class UrlToSubscriberListMigrationTest < ActiveSupport::TestCase
     csv_data = [
       { topic_id: 'TOPIC_123', url: "http://test.com/government/publications.atom?topic[]=energy", created: Time.zone.now },
     ]
-    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(
+    stub_request(:get, %r{email-alert-api.test.gov.uk/subscriber-lists}).to_return(
       body: {'subscriber_list' => { 'gov_delivery_id' => 'TOPIC_123', updated_at: '2011-11-11' } }.to_json
     )
     static_data = mock('StaticData', content_id: "a1234")
@@ -146,7 +146,7 @@ class UrlToSubscriberListMigrationTest < ActiveSupport::TestCase
       { body: {'subscriber_list' => { 'gov_delivery_id' => row[:topic_id], updated_at: '2011-11-11' } }.to_json }
     end
 
-    stub_request(:get, %r{email-alert-api.test.alphagov.co.uk/subscriber-lists}).to_return(*responses)
+    stub_request(:get, %r{email-alert-api.test.gov.uk/subscriber-lists}).to_return(*responses)
 
     organisation = create(:organisation, slug: 'academy-for-justice-commissioning')
     world_location = create(:world_location, slug: 'united-kingdom')

--- a/test/unit/whitehall/rummageable_test.rb
+++ b/test/unit/whitehall/rummageable_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RummageableTest < ActiveSupport::TestCase
   def rummager_url
-    'http://search.dev.gov.uk'
+    'http://search.test.gov.uk'
   end
 
   def index_name


### PR DESCRIPTION
This is defined in a few places and was using `alphagov.co.uk`. This was causing inconsistencies depending on how tests were run. It is redefined in the Rakefile so tests run with rake were picking up different values from Plek than tests run directly. This resulted in tests that would fail when run individually in the VM but pass on CI and vice versa if the test was updated to pass locally.

This removes some of the definitions and updates the default value to `dev.gov.uk`. It also updates tests and factories to use the new URLs.