### PR TITLE
Seperate HtmlAttachments with same content_id

### DIFF
--- a/db/data_migration/20170421111521_separate_html_attachments_with_same_content_id.rb
+++ b/db/data_migration/20170421111521_separate_html_attachments_with_same_content_id.rb
@@ -1,0 +1,24 @@
+first_attachments = HtmlAttachment.where(
+  content_id: "64e8921a-0363-4665-b7c9-c317185769f5",
+  title: "HS220 More than one trade, profession or vocation (2017)"
+)
+
+new_content_id = SecureRandom.uuid
+
+first_attachments.update_all(
+  content_id: new_content_id,
+  slug: "hs220-more-than-one-trade-profession-or-vocation-2017"
+)
+
+second_attachments = HtmlAttachment.where(
+  content_id: "64e8921a-0363-4665-b7c9-c317185769f5",
+  title: "HS220 More than one business (2016)"
+)
+
+second_attachments.update_all(
+  slug: "hs220-more-than-one-business-2016"
+)
+
+parent_document_id = 243246
+
+PublishingApiDocumentRepublishingWorker.new.perform(parent_document_id)


### PR DESCRIPTION
Somehow, two separate `HtmlAttachment` have been created with the same `content_id`. This seems to be something to do with them being created with a slug, then deleted and then created again with the same slug and then... the title being edited. Complicated business...

As a result the two attachments are in a redirect loop with each other.

They look like this:
```
- 1438638:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: false'
  - 'created_at: 2016-03-02 13:02:04 +0000'
  - 'slug: test'
- 1997035:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: false'
  - 'created_at: 2017-03-08 17:04:16 +0000'
  - 'slug: test'
- 1997041:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one trade, profession or vocation (2017)'
  - 'deleted: false'
  - 'created_at: 2017-03-08 17:04:45 +0000'
  - 'slug: hs220-more-than-one-business-2016'
- 2061716:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one trade, profession or vocation (2017)'
  - 'deleted: true'
  - 'created_at: 2017-04-13 14:29:15 +0100'
  - 'slug: hs220-more-than-one-business-2016'
- 2061718:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: true'
  - 'created_at: 2017-04-13 14:29:15 +0100'
  - 'slug: test'
- 2061809:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one trade, profession or vocation (2017)'
  - 'deleted: true'
  - 'created_at: 2017-04-13 14:42:33 +0100'
  - 'slug: hs220-more-than-one-business-2016'
- 2061811:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: true'
  - 'created_at: 2017-04-13 14:42:33 +0100'
  - 'slug: test'
- 2069761:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one trade, profession or vocation (2017)'
  - 'deleted: true'
  - 'created_at: 2017-04-20 14:54:19 +0100'
  - 'slug: hs220-more-than-one-business-2016'
- 2069763:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: true'
  - 'created_at: 2017-04-20 14:54:19 +0100'
  - 'slug: test'
- 2069769:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one trade, profession or vocation (2017)'
  - 'deleted: false'
  - 'created_at: 2017-04-20 14:56:35 +0100'
  - 'slug: hs220-more-than-one-business-2016'
- 2069771:
  - 'content_id: 64e8921a-0363-4665-b7c9-c317185769f5'
  - 'title: HS220 More than one business (2016)'
  - 'deleted: false'
  - 'created_at: 2017-04-20 14:56:35 +0100'
  - 'slug: test'
```

This commit adds a data migration that:

Fixes the slug of 'HS220 More than one trade, profession or vocation
(2017)' and gives all instances a new `content_id`. This will cause it
to be created as a new item in publishing API with the correct slug.

Fixes the slug of 'HS220 More than one business (2016)'. This slug has
already been used on this `content_id`. When this attachmnent is
published it will update the content item and put a redirect in place if
the latest version of the `Edition` in publishing API is still at the
base path ending `/test`.

It then republishes the document restoring order.

This has been run [on integration today (21/4)](https://www-origin.integration.publishing.service.gov.uk/government/publications/more-than-one-business-hs220-self-assessment-helpsheet) which fixes the problem [evident in production](https://www-origin.integration.publishing.service.gov.uk/government/publications/more-than-one-business-hs220-self-assessment-helpsheet) 