### PR TITLE
Use featured image for speeches

### DIFF
--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -8,6 +8,7 @@ class Admin::FeaturesController < Admin::BaseController
 
   def create
     if @feature.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@feature.document_id) if @feature.document_id.present?
       redirect_to admin_feature_list_path(@feature_list), notice: "The document has been saved"
     else
       flash.now[:alert] = "Unable to create feature"

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -36,7 +36,7 @@ module PublishingApi
         delivered_on: item.delivered_on.iso8601,
         change_history: item.change_history.as_json,
       }
-      details.merge!(image_payload) if speaker_has_image?
+      details.merge!(image_payload) if has_image?
       details.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end
@@ -72,8 +72,8 @@ module PublishingApi
     def image_payload
       {
         image: {
-          alt_text: speaker.name,
-          url: speaker.image.url,
+          alt_text: alt_text,
+          url: image.url
         }
       }
     end
@@ -93,6 +93,38 @@ module PublishingApi
 
     def speaker_has_image?
       speaker && speaker.image && speaker.image.url
+    end
+
+    def speaker_image
+      speaker_has_image? ? speaker.image : nil
+    end
+
+    def has_featured_image?
+      !!(feature && feature.image)
+    end
+
+    def featured_image
+      has_featured_image? ? feature.image : nil
+    end
+
+    def feature
+      @feature ||= Feature.find_by(document_id: item.document_id)
+    end
+
+    def image
+      featured_image || speaker_image
+    end
+
+    def has_image?
+      !!image
+    end
+
+    def alt_text
+      if has_featured_image?
+        feature.alt_text
+      else
+        speaker.name
+      end
     end
   end
 end

--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -27,4 +27,22 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
     assert_equal Time.zone.now, feature.ended_at
   end
+
+  test "post :feature creates a feature and republishes the document" do
+    organisation = create(:organisation)
+    feature_list = create(:feature_list, featurable: organisation, locale: :en)
+    edition = create(:published_speech)
+
+    params = {
+      document_id: edition.document_id,
+      image: fixture_file_upload("images/960x640_gif.gif"),
+      alt_text: "some text",
+    }
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id)
+
+    post :create, feature_list_id: feature_list.id, feature: params
+
+    assert_equal edition.document_id, Feature.last.document_id
+  end
 end

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -146,4 +146,53 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "image" do
+    let(:person) do
+      create(
+        :person,
+        forename: "Tony",
+        image: File.open(
+          Rails.root.join("test", "fixtures", "images", "960x640_gif.gif"))
+      )
+    end
+
+    let(:speech) do
+      create(
+        :speech,
+        title: "Speech title",
+        summary: "The description",
+        body: "# Woo!\nSome content",
+        role_appointment: role_appointment
+      )
+    end
+
+
+    context "with featured image" do
+      let!(:feature) do
+        create(
+          :feature,
+          document: speech.document,
+          image: File.open(
+            Rails.root.join("test", "fixtures", "images", "960x640_gif.gif")
+          ),
+          alt_text: "featured image"
+        )
+      end
+
+      it "presents the featured image" do
+        details = presented.content[:details]
+        assert_equal("featured image", details[:image][:alt_text])
+        assert_match(/960x640_gif.gif$/, details[:image][:url])
+      end
+    end
+
+    context "with speaker with image" do
+      it "presents the speaker image" do
+        details = presented.content[:details]
+        assert_equal("Tony", details[:image][:alt_text])
+        assert_match(/960x640_gif.gif$/, details[:image][:url])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently the `Speech` format always uses the speaker's 'profile' image in the left side bar. When the speech has been featured with an image the expectation is that the image will be used on the speech page too.

This commit adds support for this functionality effectively allowing the publisher to add a more relevant image for featured content.

[Trello](https://trello.com/c/zhiEl78z/57-enable-custom-images-in-speeches-apr)