### PR TITLE
Correctly pluralize 'World locations'

### DIFF
--- a/app/views/world_locations/index.html.erb
+++ b/app/views/world_locations/index.html.erb
@@ -15,7 +15,7 @@
     <% @world_locations.each do |type, locations| %>
       <section id="<%= type.name.pluralize.parameterize %>" class="world-location-type js-filter-block">
         <header class="type-heading">
-          <h1><%= type.name %></h1>
+          <h1><%= type.name.pluralize %></h1>
           <p><span class="js-filter-count"><%= locations.length %></span> <span class="visuallyhidden">locations</span></p>
         </header>
         <div class="content">


### PR DESCRIPTION
This refers to the number of world locations and should be pluralized
accordingly.

## Before

<img width="679" alt="screen shot 2017-04-26 at 20 28 09" src="https://cloud.githubusercontent.com/assets/41963/25453768/164e7528-2ac2-11e7-9be5-cd527711d9a4.png">

## After

<img width="628" alt="screen shot 2017-04-26 at 20 41 35" src="https://cloud.githubusercontent.com/assets/41963/25453783/2289dc10-2ac2-11e7-8184-b34c10bf3c5a.png">

