### PR TITLE
Fix multiple image upload script and test

### DIFF
--- a/app/assets/javascripts/admin/multiple_file_upload.js
+++ b/app/assets/javascripts/admin/multiple_file_upload.js
@@ -13,7 +13,7 @@
         var id = parseInt($(referenceInput).attr("id").match(/_(\d+)_/)[1]);
         var newId = id + 1;
         clone.find(".field_with_errors *").unwrap();
-        clone.children("label").each(function(i, el) {
+        clone.find("label").each(function(i, el) {
           $(el).attr("for", $(el).attr("for").replace("_"+id+"_", "_"+newId+"_"));
         });
         clone.find("input,textarea").each(function(i, el) {
@@ -22,8 +22,8 @@
           }
           $(el).attr("name", $(el).attr("name").replace("["+id+"]", "["+newId+"]"));
         });
-        clone.children("input").val("");
-        clone.children(".already_uploaded").text("");
+        clone.find("input").val("");
+        clone.find(".already_uploaded").text("");
         $(this).parents(".file_upload").after(clone);
       });
     })

--- a/app/assets/javascripts/admin/multiple_file_upload.js
+++ b/app/assets/javascripts/admin/multiple_file_upload.js
@@ -23,6 +23,7 @@
           $(el).attr("name", $(el).attr("name").replace("["+id+"]", "["+newId+"]"));
         });
         clone.find("input").val("");
+        clone.find("textarea").val("");
         clone.find(".already_uploaded").text("");
         $(this).parents(".file_upload").after(clone);
       });

--- a/test/javascripts/unit/multiple_file_upload_test.js
+++ b/test/javascripts/unit/multiple_file_upload_test.js
@@ -111,6 +111,12 @@ test("should make the value of the text input blank for each set of new inputs a
   equal(latest_input.val(), "");
 });
 
+test("should make the value of the caption textarea blank for each set of new inputs added", function() {
+  this.fieldset.find('#edition_images_attributes_0_caption').append("not-blank")
+  fireClickEventOnLastFileInputOf(this.fieldset);
+  equal($('#edition_images_attributes_1_caption').val(), "");
+});
+
 test("should set the value of the hidden cache input to blank for each new input added", function() {
   $("input[type=hidden]:last").val("not-blank");
   fireClickEventOnLastFileInputOf(this.fieldset);

--- a/test/javascripts/unit/multiple_file_upload_test.js
+++ b/test/javascripts/unit/multiple_file_upload_test.js
@@ -1,20 +1,26 @@
 module("Uploading multiple files", {
   setup: function() {
-    this.fieldset = $('<fieldset id="attachment_fields" class="multiple_file_uploads"></fieldset>');
-    var file_upload = $('<div class="file_upload well"></div>');
-    this.first_input = $('<input id="edition_edition_attachments_attributes_0_attachment_attributes_file" name="edition[edition_attachments_attributes][0][attachment_attributes][file]" type="file" class="js-upload-image-input" />');
+    this.fieldset = $('\
+      <fieldset id="image_fields" class="images multiple_file_uploads">\
+        <div class="file_upload well">\
+          <div class="form-group">\
+            <label for="edition_images_attributes_0_image_data_attributes_file">File</label>\
+            <input id="edition_images_attributes_0_image_data_attributes_file" name="edition[images_attributes][0][image_data_attributes][file]" type="file" class="js-upload-image-input" />\
+            <input id="edition_images_attributes_0_image_data_attributes_file_cache" name="edition[images_attributes][0][image_data_attributes][file_cache]" type="hidden" />\
+          </div>\
+          <div class="form-group">\
+            <label for="edition_images_attributes_0_alt_text">Alt text</label>\
+            <input id="edition_images_attributes_0_alt_text" name="edition[images_attributes][0][alt_text]" type="text" />\
+          </div>\
+          <div class="form-group">\
+            <label for="edition_images_attributes_0_caption">Caption</label>\
+            <textarea id="edition_images_attributes_0_caption" name="edition[images_attributes][0][caption]"></textarea>\
+          </div>\
+        </div>\
+      </fieldset>')
 
-    file_upload.append('<label for="edition_edition_attachments_attributes_0_attachment_attributes_title">Title</label>');
-    file_upload.append('<input id="edition_edition_attachments_attributes_0_attachment_attributes_title" name="edition[edition_attachments_attributes][0][attachment_attributes][title]" size="30" type="text" />');
-    file_upload.append('<label for="edition_edition_attachments_attributes_0_attachment_attributes_caption">Caption</label>');
-    file_upload.append('<textarea id="edition_edition_attachments_attributes_0_attachment_attributes_caption" name="edition[edition_attachments_attributes][0][attachment_attributes][caption]"></textarea>');
-    file_upload.append('<label for="edition_edition_attachments_attributes_0_attachment_attributes_file">File</label>');
-    file_upload.append(this.first_input);
-    file_upload.append('<label for="edition_edition_attachments_attributes_0_attachment_attributes_accessible"><input id="edition_edition_attachments_attributes_0_attachment_attributes_accessible" name="edition[edition_attachments_attributes][0][attachment_attributes][accessible]" type="checkbox" value="1"> Acccessible</label>');
-    file_upload.append('<input id="edition_edition_attachments_attributes_0_attachment_attributes_file_cache" name="edition[edition_attachments_attributes][0][attachment_attributes][file_cache]" type="hidden" />');
-
-    this.fieldset.append(file_upload);
     $('#qunit-fixture').append(this.fieldset);
+    this.first_file_input = $("#edition_images_attributes_0_image_data_attributes_file")
     this.fieldset.enableMultipleFileUploads();
   }
 });
@@ -24,13 +30,13 @@ var fireClickEventOnLastFileInputOf = function(fieldset) {
 }
 
 test("should add a new file input when a file is selected", function() {
-  this.first_input.click();
+  this.first_file_input.click();
   equal(this.fieldset.children(".file_upload").length, 2);
 });
 
 test("should not add a new file input when a selected file is clicked", function() {
-  this.first_input.click();
-  this.first_input.click();
+  this.first_file_input.click();
+  this.first_file_input.click();
   equal(this.fieldset.children(".file_upload").length, 2);
 });
 
@@ -44,84 +50,58 @@ test("should continue adding new inputs as new files are selected", function() {
   equal(this.fieldset.children(".file_upload").length, 12);
 });
 
-test("should increment the referenced ID of the title label for each new set of inputs added", function() {
+test("should increment the ID and name of the alt text input for each set of new inputs added", function() {
   fireClickEventOnLastFileInputOf(this.fieldset);
-  var latest_input = this.fieldset.find("label:contains('Title'):last");
-  equal(latest_input.attr('for'), "edition_edition_attachments_attributes_1_attachment_attributes_title");
+  ok($('#edition_images_attributes_1_alt_text')[0], "input with id not found")
+  ok($("input[name='edition[images_attributes][1][alt_text]']")[0], 'input with name not found')
 
   fireClickEventOnLastFileInputOf(this.fieldset);
-  latest_input = this.fieldset.find("label:contains('Title'):last");
-  equal(latest_input.attr('for'), "edition_edition_attachments_attributes_2_attachment_attributes_title");
+  ok($('#edition_images_attributes_2_alt_text')[0], "input with id not found")
+  ok($("input[name='edition[images_attributes][2][alt_text]']")[0], 'input with name not found')
 });
 
-test("should increment the ID and name of the text input for each set of new inputs added", function() {
+test("should increment the ID and name of the caption textarea for each set of new inputs added", function() {
   fireClickEventOnLastFileInputOf(this.fieldset);
-  var latest_input = this.fieldset.find("input[type=text]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_1_attachment_attributes_title");
-  equal(latest_input.name, "edition[edition_attachments_attributes][1][attachment_attributes][title]");
+  ok($('#edition_images_attributes_1_caption')[0], "textarea with id not found")
+  ok($("textarea[name='edition[images_attributes][1][caption]']")[0], 'textarea with name not found')
 
   fireClickEventOnLastFileInputOf(this.fieldset);
-  latest_input = this.fieldset.find("input[type=text]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_2_attachment_attributes_title");
-  equal(latest_input.name, "edition[edition_attachments_attributes][2][attachment_attributes][title]");
-});
-
-test("should increment the ID and name of the textareas for each set of new inputs added", function() {
-  fireClickEventOnLastFileInputOf(this.fieldset);
-  var latest_input = this.fieldset.find("textarea:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_1_attachment_attributes_caption");
-  equal(latest_input.name, "edition[edition_attachments_attributes][1][attachment_attributes][caption]");
-
-  fireClickEventOnLastFileInputOf(this.fieldset);
-  latest_input = this.fieldset.find("textarea:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_2_attachment_attributes_caption");
-  equal(latest_input.name, "edition[edition_attachments_attributes][2][attachment_attributes][caption]");
-});
-
-test("should increment the ID and name of the checkboxes for each set of new inputs added", function() {
-  fireClickEventOnLastFileInputOf(this.fieldset);
-  var latest_input = this.fieldset.find("input[type=checkbox]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_1_attachment_attributes_accessible");
-  equal(latest_input.name, "edition[edition_attachments_attributes][1][attachment_attributes][accessible]");
-
-  fireClickEventOnLastFileInputOf(this.fieldset);
-  latest_input = this.fieldset.find("input[type=checkbox]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_2_attachment_attributes_accessible");
-  equal(latest_input.name, "edition[edition_attachments_attributes][2][attachment_attributes][accessible]");
+  ok($('#edition_images_attributes_2_caption')[0], "textarea with id not found")
+  ok($("textarea[name='edition[images_attributes][2][caption]']")[0], 'textarea with name not found')
 });
 
 test("should increment the referenced ID of the file label for each set of new inputs added", function() {
   fireClickEventOnLastFileInputOf(this.fieldset);
   var latest_input = this.fieldset.find("label:contains('File'):last");
-  equal(latest_input.attr('for'), "edition_edition_attachments_attributes_1_attachment_attributes_file");
+  equal(latest_input.attr('for'), "edition_images_attributes_1_image_data_attributes_file");
 
   fireClickEventOnLastFileInputOf(this.fieldset);
   latest_input = this.fieldset.find("label:contains('File'):last");
-  equal(latest_input.attr('for'), "edition_edition_attachments_attributes_2_attachment_attributes_file");
+  equal(latest_input.attr('for'), "edition_images_attributes_2_image_data_attributes_file");
 });
 
 test("should increment the ID and name of the file input for each set of new inputs added", function() {
   fireClickEventOnLastFileInputOf(this.fieldset);
   var latest_input = this.fieldset.find("input[type=file]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_1_attachment_attributes_file");
-  equal(latest_input.name, "edition[edition_attachments_attributes][1][attachment_attributes][file]");
+  equal(latest_input.id, "edition_images_attributes_1_image_data_attributes_file");
+  equal(latest_input.name, "edition[images_attributes][1][image_data_attributes][file]");
 
   fireClickEventOnLastFileInputOf(this.fieldset);
   latest_input = this.fieldset.find("input[type=file]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_2_attachment_attributes_file");
-  equal(latest_input.name, "edition[edition_attachments_attributes][2][attachment_attributes][file]");
+  equal(latest_input.id, "edition_images_attributes_2_image_data_attributes_file");
+  equal(latest_input.name, "edition[images_attributes][2][image_data_attributes][file]");
 });
 
 test("should increment the ID and name of the hidden cache input for each set of new inputs added", function() {
   fireClickEventOnLastFileInputOf(this.fieldset);
   var latest_input = this.fieldset.find("input[type=hidden]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_1_attachment_attributes_file_cache");
-  equal(latest_input.name, "edition[edition_attachments_attributes][1][attachment_attributes][file_cache]");
+  equal(latest_input.id, "edition_images_attributes_1_image_data_attributes_file_cache");
+  equal(latest_input.name, "edition[images_attributes][1][image_data_attributes][file_cache]");
 
   fireClickEventOnLastFileInputOf(this.fieldset);
   latest_input = this.fieldset.find("input[type=hidden]:last")[0];
-  equal(latest_input.id, "edition_edition_attachments_attributes_2_attachment_attributes_file_cache");
-  equal(latest_input.name, "edition[edition_attachments_attributes][2][attachment_attributes][file_cache]");
+  equal(latest_input.id, "edition_images_attributes_2_image_data_attributes_file_cache");
+  equal(latest_input.name, "edition[images_attributes][2][image_data_attributes][file_cache]");
 });
 
 test("should make the value of the text input blank for each set of new inputs added", function() {
@@ -149,17 +129,15 @@ test("should set the text of the already_uploaded element to blank for each new 
 module("Uploading multiple files after file field validation error", {
   setup: function() {
     this.fieldset = $('\
-      <fieldset id="attachment_fields" class="multiple_file_uploads">\
+      <fieldset id="image_fields" class="images multiple_file_uploads">\
         <div class="file_upload well">\
-          <label for="edition_edition_attachments_attributes_0_attachment_attributes_title">Title</label>\
-          <input id="edition_edition_attachments_attributes_0_attachment_attributes_title"\ name="edition[edition_attachments_attributes][0][attachment_attributes][title]" size="30" type="text" value="something" />\
           <div class="field_with_errors">\
-            <label for="edition_edition_attachments_attributes_0_attachment_attributes_file">File</label>\
+            <label for="edition_images_attributes_0_image_data_attributes_file">File</label>\
           </div>\
           <div class="field_with_errors">\
-            <input id="edition_edition_attachments_attributes_0_attachment_attributes_file"\ name="edition[edition_attachments_attributes][0][attachment_attributes][file]" type="file" class="js-upload-image-input" />\
+            <input id="edition_images_attributes_0_image_data_attributes_file"\ name="edition[images_attributes][0][image_data_attributes][file]" type="file" class="js-upload-image-input" />\
           </div>\
-          <input id="edition_edition_attachments_attributes_0_attachment_attributes_file_cache"\ name="edition[edition_attachments_attributes][0][attachment_attributes][file_cache]" type="hidden" />\
+          <input id="edition_images_attributes_0_image_data_attributes_file_cache"\ name="edition[images_attributes][0][image_data_attributes][file_cache]" type="hidden" />\
         </div>\
       </fieldset>\
     ');


### PR DESCRIPTION
For https://trello.com/c/fR2UqKRf/65-image-validation-in-whitehall-pre-populates-incorrect-fields-feb

This PR fixes the issue where the input fields of cloned image form elements were not cleared. This made it impossible for a user to save an edition when dealing with invalid images (as choosing a new valid image would create a new image form field with the settings of the invalid image). The problem was the JQuery's `children` method only looks at an element's immediate children, but the elements are more deeply nested. Replacing it with the `find` method makes it work as intended. Additionally the commit clears out the caption textarea, which previously was carried over from the previous element.

The JS test for this feature also appeared to be quite out of date. The commit refactors the test fixture to be a block of HTML rather than appending to an element programmatically, which matches the fixture lower down in the code and makes it easier to see the HTML structure at glance (which also helps to compare it to the view template). It also updates ids and names of the elements to match the rendered form. Some of the elements in the test fixture do not get rendered anymore (title, accessible), so we replace them with the new field (alt_text).

Rendered Image form element (from Production) used for reference to create the updated test fixture:
```
<fieldset id="image_fields" class="images multiple_file_uploads">
  <legend>Images</legend>

  <div class="file_upload well">
    <h3 class="remove-top-margin">New image</h3>

    <div class="form-group">
      <label for="edition_images_attributes_0_image_data_attributes_file">File</label>
      <input class="js-upload-image-input" type="file" name="edition[images_attributes][0][image_data_attributes][file]" id="edition_images_attributes_0_image_data_attributes_file" />
      <input type="hidden" name="edition[images_attributes][0][image_data_attributes][file_cache]" id="edition_images_attributes_0_image_data_attributes_file_cache" />
    </div>

    <div class="form-group">
      <label for="edition_images_attributes_0_alt_text">Alt text</label>
      <input class="form-control" type="text" name="edition[images_attributes][0][alt_text]" id="edition_images_attributes_0_alt_text" />
    </div>

    <div class="form-group">
      <label for="edition_images_attributes_0_caption">Caption</label>
      <textarea rows="2" class="form-control" name="edition[images_attributes][0][caption]" id="edition_images_attributes_0_caption">
      </textarea>
    </div>
  </div>
</fieldset>
```

TODO - clear out textarea as well