### PR TITLE
Add SVG support

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -1,13 +1,7 @@
 module LeadImagePresenterHelper
   def lead_image_path
-    if images.first
-      images.first.url(:s300)
-    elsif lead_organisations.any? && lead_organisations.first.default_news_image
-      lead_organisations.first.default_news_image.file.url(:s300)
-    elsif organisations.any? && organisations.first.default_news_image
-      organisations.first.default_news_image.file.url(:s300)
-    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
-      worldwide_organisations.first.default_news_image.file.url(:s300)
+    if image
+      image.url(:s300)
     else
       "placeholder.jpg"
     end
@@ -15,7 +9,7 @@ module LeadImagePresenterHelper
 
   def lead_image_alt_text
     if images.first
-      images.first.alt_text.squish
+      image.alt_text.squish
     else
       'placeholder'
     end
@@ -23,15 +17,23 @@ module LeadImagePresenterHelper
 
   def lead_image_caption
     if images.first
-      caption = images.first.caption && images.first.caption.strip
+      caption = image.caption && image.caption.strip
       caption.present? ? caption : nil
     end
   end
 
 private
 
-  def placeholder_image_exisits?
-    find_asset("organisation_default_news/s300_#{organisations.first.slug}.jpg")
+  def image
+    if images.first
+      images.first
+    elsif lead_organisations.any? && lead_organisations.first.default_news_image
+      lead_organisations.first.default_news_image.file
+    elsif organisations.any? && organisations.first.default_news_image
+      organisations.first.default_news_image.file
+    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
+      worldwide_organisations.first.default_news_image.file
+    end
   end
 
   def find_asset(asset)

--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -1,7 +1,7 @@
 module LeadImagePresenterHelper
   def lead_image_path
-    if image
-      image.url(:s300)
+    if image_data
+      image_url
     else
       "placeholder.jpg"
     end
@@ -9,7 +9,7 @@ module LeadImagePresenterHelper
 
   def lead_image_alt_text
     if images.first
-      image.alt_text.squish
+      images.first.alt_text.squish
     else
       'placeholder'
     end
@@ -17,23 +17,40 @@ module LeadImagePresenterHelper
 
   def lead_image_caption
     if images.first
-      caption = image.caption && image.caption.strip
+      caption = images.first.caption && images.first.caption.strip
       caption.present? ? caption : nil
     end
   end
 
 private
 
-  def image
-    if images.first
-      images.first
-    elsif lead_organisations.any? && lead_organisations.first.default_news_image
-      lead_organisations.first.default_news_image.file
-    elsif organisations.any? && organisations.first.default_news_image
-      organisations.first.default_news_image.file
-    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
-      worldwide_organisations.first.default_news_image.file
+  def image_url
+    content_type = file.content_type
+    if content_type && content_type =~ /svg/
+      image_data.file.url
+    else
+      image_data.file.url(:s300)
     end
+  end
+
+  def image_data
+    if images.first
+      images.first.image_data
+    elsif lead_organisations.any? && lead_organisations.first.default_news_image
+      lead_organisations.first.default_news_image
+    elsif organisations.any? && organisations.first.default_news_image
+      organisations.first.default_news_image
+    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
+      worldwide_organisations.first.default_news_image
+    end
+  end
+
+  def uploader
+    image_data.file
+  end
+
+  def file
+    uploader.file
   end
 
   def find_asset(asset)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,25 +6,30 @@ class ImageUploader < WhitehallUploader
   end
 
   def extension_white_list
-    %w(jpg jpeg gif png)
+    %w(jpg jpeg gif png svg)
   end
 
-  version :s960 do
+  version :s960, if: :bitmap? do
     process resize_to_fill: [960, 640]
   end
-  version :s712, from_version: :s960 do
+  version :s712, from_version: :s960, if: :bitmap? do
     process resize_to_fill: [712, 480]
   end
-  version :s630, from_version: :s712 do
+  version :s630, from_version: :s712, if: :bitmap? do
     process resize_to_fill: [630, 420]
   end
-  version :s465, from_version: :s630 do
+  version :s465, from_version: :s630, if: :bitmap? do
     process resize_to_fill: [465, 310]
   end
-  version :s300, from_version: :s465 do
+  version :s300, from_version: :s465, if: :bitmap? do
     process resize_to_fill: [300, 195]
   end
-  version :s216, from_version: :s300 do
+  version :s216, from_version: :s300, if: :bitmap? do
     process resize_to_fill: [216, 140]
+  end
+
+  def bitmap?(new_file)
+    return if new_file.nil?
+    !(new_file.content_type =~ /svg/)
   end
 end

--- a/app/validators/image_validator.rb
+++ b/app/validators/image_validator.rb
@@ -14,6 +14,7 @@ class ImageValidator < ActiveModel::Validator
 
   def validate(record)
     return unless file_for(record).present?
+    return if file_for(record).file.content_type =~ /svg/
 
     begin
       image = MiniMagick::Image.open file_for(record).path

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -28,3 +28,5 @@ Mime::Type.register "application/rdf+xml", :rdf
 Mime::Type.register "application/dxf", :dxf
 
 Mime::Type.register "application/gml+xml", :gml
+
+Mime::Type.register "image/svg+xml", :svg

--- a/test/fixtures/images/test-svg.svg
+++ b/test/fixtures/images/test-svg.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 960 680" style="enable-background:new 0 0 960 680;" xml:space="preserve">
+<style type="text/css">
+	.st0{font-family:'MyriadPro-Regular';}
+	.st1{font-size:72px;}
+	.st2{letter-spacing:67;}
+</style>
+<text transform="matrix(1 0 0 1 305.3965 309.2729)" class="st0 st1 st2">SVG</text>
+</svg>

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -83,7 +83,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   test 'POST :create can set a custom logo' do
     post :create, organisation: example_organisation_attributes.merge(
       organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-      logo: fixture_file_upload('logo.png')
+      logo: fixture_file_upload('logo.png', 'image/png')
     )
     assert_match /logo.png/, Organisation.last.logo.file.filename
   end

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -49,7 +49,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
 
   test "creating allows attachment of an image" do
     attributes = attributes_for(:person)
-    attributes[:image] = fixture_file_upload('minister-of-funk.960x640.jpg')
+    attributes[:image] = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
     post :create, person: attributes
 
     refute_nil Person.last.image
@@ -65,7 +65,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   view_test "editing shows form for editing a person" do
-    person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg'))
+    person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
     get :edit, id: person
 
     assert_select "form[action='#{admin_person_path}']" do
@@ -79,7 +79,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   view_test "editing shows existing image" do
-    person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg'))
+    person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
     get :edit, id: person
 
     assert_select "img[src='#{person.image_url}']"

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -21,8 +21,14 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   end
 
   test 'POST :create saves the new promotional item to the feature' do
-    post :create, organisation_id: @organisation, promotional_feature_id: @promotional_feature,
-                  promotional_feature_item: { summary: 'Summary text', image_alt_text: 'Alt text', image: fixture_file_upload('minister-of-funk.960x640.jpg')}
+    post :create,
+      organisation_id: @organisation,
+      promotional_feature_id: @promotional_feature,
+      promotional_feature_item: {
+        summary: 'Summary text',
+        image_alt_text: 'Alt text',
+        image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+      }
 
     assert promotional_feature_item = @promotional_feature.reload.promotional_feature_items.first
     assert_equal 'Alt text', promotional_feature_item.image_alt_text

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -30,7 +30,9 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
 
   test 'POST :create saves a new instance with the supplied valid params' do
     attrs = attributes_for(:take_part_page, title: 'Wear a monocle!')
-    post :create, take_part_page: attrs.merge(image: fixture_file_upload('minister-of-funk.960x640.jpg'))
+    post :create, take_part_page: attrs.merge(
+      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+    )
 
     puts assigns(:take_part_page).errors.full_messages
     assert assigns(:take_part_page).persisted?

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -301,7 +301,7 @@ module AdminEditionControllerTestHelpers
       end
 
       test 'creating an edition should attach image' do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text", caption: "longer-caption-for-image",
@@ -318,7 +318,7 @@ module AdminEditionControllerTestHelpers
       end
 
       test "creating an edition should result in a single instance of the uploaded image file being cached" do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
@@ -341,7 +341,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "creating an edition with invalid data should only allow a single image to be selected for upload" do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
@@ -356,7 +356,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "creating an edition with invalid data but valid image data should still display the image data" do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
@@ -373,7 +373,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test 'creating an edition with invalid data should not show any existing image info' do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
@@ -386,7 +386,7 @@ module AdminEditionControllerTestHelpers
       end
 
       test "creating an edition with multiple images should attach all files" do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => {alt_text: "some-alt-text",
@@ -407,7 +407,7 @@ module AdminEditionControllerTestHelpers
 
       view_test 'creating an edition with an invalid image should show an error' do
         attributes = controller_attributes_for(edition_type)
-        invalid_image = fixture_file_upload('horrible-image.64x96.jpg')
+        invalid_image = fixture_file_upload('horrible-image.64x96.jpg', 'image/jpg')
 
         post :create, edition: attributes.merge(
           images_attributes: {
@@ -419,7 +419,7 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test 'edit displays edition image fields' do
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         edition = create(edition_type)
         image = create(:image, alt_text: "blah", edition: edition,
                        image_data_attributes: attributes_for(:image_data, file: image))
@@ -490,7 +490,7 @@ module AdminEditionControllerTestHelpers
 
       test 'updating an edition should attach multiple images' do
         edition = create(edition_type)
-        image = fixture_file_upload('minister-of-funk.960x640.jpg')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = { images_attributes: {
           "0" => {alt_text: "some-alt-text",
                   image_data_attributes: attributes_for(:image_data, file: image)},

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -36,7 +36,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
 
     model = stub("AR Model", id: 1)
     uploader = AttachmentUploader.new(model, "mounted-as")
-    uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg'))
+    uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
 
     assert_nil uploader.thumbnail.path
 

--- a/test/unit/classification_featuring_test.rb
+++ b/test/unit/classification_featuring_test.rb
@@ -6,7 +6,7 @@ class ClassificationFeaturingTest < ActiveSupport::TestCase
   test "should build an image using nested attributes" do
     classification_featuring = build(:classification_featuring)
     classification_featuring.image_attributes = {
-      file: fixture_file_upload('minister-of-funk.960x640.jpg')
+      file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
     }
     classification_featuring.save!
 

--- a/test/unit/edition/images_test.rb
+++ b/test/unit/edition/images_test.rb
@@ -8,15 +8,26 @@ class Edition::ImagesTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
   test "editions can be created with multiple images" do
-    edition = EditionWithImages.create!(valid_edition_attributes.merge(
-      images_attributes: [
-      {alt_text: "Something about this image",
-       caption: "Text to be visible along with the image",
-       image_data_attributes: {file: fixture_file_upload('minister-of-funk.960x640.jpg')}},
-      {alt_text: "alt-text-2",
-       caption: "caption-2",
-       image_data_attributes: {file: fixture_file_upload('minister-of-funk.960x640.jpg')}}
-    ]))
+    edition = EditionWithImages.create!(
+      valid_edition_attributes.merge(
+        images_attributes: [
+          {
+            alt_text: "Something about this image",
+            caption: "Text to be visible along with the image",
+            image_data_attributes: {
+              file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+            }
+          },
+          {
+            alt_text: "alt-text-2",
+            caption: "caption-2",
+            image_data_attributes: {
+              file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+            }
+          }
+        ]
+      )
+    )
 
     assert_equal 2, edition.images.count
     assert_equal "Something about this image", edition.images[0].alt_text
@@ -71,7 +82,7 @@ class Edition::ImagesTest < ActiveSupport::TestCase
         alt_text: "image smaller than 960x640",
         caption: "some-caption",
         image_data_attributes: {
-          file: fixture_file_upload('horrible-image.64x96.jpg')
+          file: fixture_file_upload('horrible-image.64x96.jpg', 'image/jpg')
         }
       }]
     ))
@@ -94,7 +105,7 @@ class Edition::ImagesTest < ActiveSupport::TestCase
         alt_text: "alt-text",
         caption: "original-caption",
         image_data_attributes: {
-          file: fixture_file_upload('minister-of-funk.960x640.jpg')
+          file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         }
       }]
     ))

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -33,7 +33,18 @@ class ImageUploaderTest < ActiveSupport::TestCase
     end
   end
 
-  private
+  test "stores the original svg only" do
+    model = stub("AR Model", id: 1)
+    @uploader = ImageUploader.new(model, "mounted-as")
+
+    @uploader.store!(fixture_file_upload('images/test-svg.svg', 'image/svg+xml'))
+
+    [[712, 480], [630, 420], [465, 310], [300, 195], [216, 140]].each do |(width, _height)|
+      assert_nil @uploader.send(:url, :"s#{width}")
+    end
+  end
+
+private
 
   def assert_image_size(dimensions, uploader_version)
     width, height = dimensions

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -11,9 +11,9 @@ class ImageUploaderTest < ActiveSupport::TestCase
     ImageUploader.enable_processing = false
   end
 
-  test "should only allow JPG, GIF or PNG images" do
+  test "should only allow JPG, GIF, PNG or SVG images" do
     uploader = ImageUploader.new
-    assert_equal %w(jpg jpeg gif png), uploader.extension_white_list
+    assert_equal %w(jpg jpeg gif png svg), uploader.extension_white_list
   end
 
   test "should store uploads in a directory that persists across deploys" do
@@ -22,11 +22,11 @@ class ImageUploaderTest < ActiveSupport::TestCase
     assert_match /^system/, uploader.store_dir
   end
 
-  test "should create resized versions of the image" do
+  test "should create resized versions of a bitmap image" do
     model = stub("AR Model", id: 1)
     @uploader = ImageUploader.new(model, "mounted-as")
 
-    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg'))
+    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
 
     [[712, 480], [630, 420], [465, 310], [300, 195], [216, 140]].each do |(width, height)|
       assert_image_size [width, height], @uploader.send(:"s#{width}")

--- a/test/unit/lead_image_presenter_helper_test.rb
+++ b/test/unit/lead_image_presenter_helper_test.rb
@@ -9,7 +9,8 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
 
   test "should use first image with version :s300 if an image is present" do
     presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
-    image = stub("Image", url: "url", alt_text: "alt_text")
+    image = stub("Image", alt_text: "alt_text")
+    image.expects(:url).with(:s300).returns("url")
     presenter.stubs(images: [image])
     assert_equal 'url', presenter.lead_image_path
     assert_equal 'alt_text', presenter.lead_image_alt_text

--- a/test/unit/lead_image_presenter_helper_test.rb
+++ b/test/unit/lead_image_presenter_helper_test.rb
@@ -9,8 +9,23 @@ class LeadImagePresenterHelperTest < ActiveSupport::TestCase
 
   test "should use first image with version :s300 if an image is present" do
     presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
-    image = stub("Image", alt_text: "alt_text")
-    image.expects(:url).with(:s300).returns("url")
+    file = stub("File", content_type: "image/jpg")
+    uploader = stub("Uploader", file: file)
+    image_data = stub("ImageData", file: uploader)
+    image = stub("Image", alt_text: "alt_text", image_data: image_data)
+    uploader.expects(:url).with(:s300).returns("url")
+    presenter.stubs(images: [image])
+    assert_equal 'url', presenter.lead_image_path
+    assert_equal 'alt_text', presenter.lead_image_alt_text
+  end
+
+  test "uses unversioned url if the image is an SVG" do
+    presenter = stub("Target", images: [], lead_organisations: [], organisations: []).extend(LeadImagePresenterHelper)
+    file = stub("File", content_type: "image/svg+xml")
+    uploader = stub("Uploader", file: file)
+    image_data = stub("ImageData", file: uploader)
+    image = stub("Image", alt_text: "alt_text", image_data: image_data)
+    uploader.expects(:url).with.returns("url")
     presenter.stubs(images: [image])
     assert_equal 'url', presenter.lead_image_path
     assert_equal 'alt_text', presenter.lead_image_alt_text

--- a/test/unit/validators/image_validator_test.rb
+++ b/test/unit/validators/image_validator_test.rb
@@ -42,6 +42,11 @@ class ImageValidatorTest < ActiveSupport::TestCase
     }
   end
 
+  test "it allows SVG" do
+    subject = ImageValidator.new(size: [960, 640])
+    assert_validates_as_valid(subject, "test-svg.svg")
+  end
+
   private
 
   def assert_validates_as_valid(validator, image_file_name)
@@ -59,10 +64,25 @@ class ImageValidatorTest < ActiveSupport::TestCase
   def build_example(file_name)
     if file_name.present?
       File.open(File.join(Rails.root, 'test/fixtures/images', file_name)) do |file|
-        EXAMPLE_MODEL.new(file: file)
+        EXAMPLE_MODEL.new(file: file).tap do |image_data|
+          carrierwave_file = image_data.file.file
+          carrierwave_file.content_type = content_type(file_name)
+        end
       end
     else
       EXAMPLE_MODEL.new
+    end
+  end
+
+  def content_type(file_name)
+    extension = File.extname(file_name)
+    case extension
+    when ".jpg"
+      "image/jpg"
+    when ".svg"
+      "image/svg+xml"
+    when ".gif"
+      "image/gif"
     end
   end
 end


### PR DESCRIPTION
We are going to recommend to publishers that they use the SVG file format for graphs, charts etc but currently Whitehall doesn't support the format.

This adds support in the publishing app and for formats still rendered by Whitehall.

[Trello](https://trello.com/c/xgjd9XDu/64-investigate-adding-svg-support-to-attachments-feb)