### PR TITLE
Add `election:remove_mp_letters` task

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -1,0 +1,13 @@
+namespace :election do
+  task remove_mp_letters: :environment do
+    puts "Removing MP from MP's letters:"
+    Person.where('letters LIKE "%MP%"').each do |person|
+      puts "updating #{person.name}"
+      new_letters = person.letters.gsub(/(^|\s)MP(\s|$)/, '')
+      if person.letters != new_letters
+        person.update_attribute(:letters, new_letters)
+      end
+      puts "changed to #{person.name}"
+    end
+  end
+end


### PR DESCRIPTION
When parliament is disolved prior to a general election we need to remove the 'MP' letters from current members of parliament.

This commit adds a rake task to allow this to be automated.

[Trello](https://trello.com/c/4vMhtqfg/19-remove-mp-titles)