### PR TITLE
Handle previews of CSVs with mixed newlines

### DIFF
--- a/test/fixtures/csv_encodings/mixed-newlines.csv
+++ b/test/fixtures/csv_encodings/mixed-newlines.csv
@@ -1,0 +1,3 @@
+this,header row,"has an embedded new
+line but",it is different to,the row separator
+this,is,the,second,line in the file

--- a/test/fixtures/malformed.csv
+++ b/test/fixtures/malformed.csv
@@ -1,9 +1,9 @@
 "Please read the additional data fields descriptions before entering information into this template. Completed templates must be returned to your organisation's main, parent or sponsoring department. They will provide one return to Cabinet Office capturing information for all their relevant organisations.
 (NB: This data sheet is password protected. Contact Cabinet Office if you require the password.",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Organisation name,"Organisation 
-type","Main, parent or 
-sponsoring department: ",Payroll staff,,,,,,,,,,,,,,Number of non-payroll staff (contingent labour and consultants/consultancy),,,,,,,,,,"Grand Total 
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Organisation name,"Organisation
+type","Main, parent or
+sponsoring department: ",Payroll staff,,,,,,,,,,,,,,Number of non-payroll staff (contingent labour and consultants/consultancy),,,,,,,,,,"Grand Total
 (workforce numbers)",,Payroll staff costs,,,,,,,Non-Payroll staff (contingent labour/consultancy) costs,,,Grand Total paybill/staffing (payroll and non-payroll) costs,"Comments
 (NB: These will be published alongside your row of information)","Notes for Cabinet Office
 (Not for publication)"

--- a/test/unit/csv_preview_test.rb
+++ b/test/unit/csv_preview_test.rb
@@ -90,6 +90,17 @@ class CsvPreviewTest < ActiveSupport::TestCase
     end
   end
 
+  test 'handles files with a newline embedded in a cell in the first row that is not the same as the newlines used to separate the rows' do
+    mixed_newlines_preview = CsvPreview.new(Rails.root.join('test/fixtures/csv_encodings/mixed-newlines.csv'))
+
+    assert_equal ['this', 'header row', "has an embedded new\nline but", 'it is different to', 'the row separator'],
+      mixed_newlines_preview.headings
+
+    expected_data = [['this', 'is', 'the', 'second', 'line in the file']]
+
+    assert_csv_data(expected_data, mixed_newlines_preview)
+  end
+
 private
 
   def assert_csv_data(expected_data, preview)


### PR DESCRIPTION
For: https://trello.com/c/3WHpYhwH/139-investigate-uploaded-csv-preview-problem

The ruby CSV library tries to automatically detect the row separator used
in a file that it opens.  It does so by scanning ahead for the first
newline sequence it can find in the data and assuming that this is the row
separator.  What this means is that an embedded newline in a cell on the
first row can cause problems if it is a different sequence to that used in
the rest of the file.

See the description of `row_sep` in the ruby-doc for CSV.new for an
explanation[1].

We've occasionally seen files with this problem so we can try to mitigate
against it.  We try to open the file and read the first row.  If this
raises a MalformedCSV error we try to open the file again with an explicit
`row_sep` of `\r\n`.  If this still raises a MalformedCSV error we raise
the original version.

We've only seen an embedded `\n` in an otherwise `\r\n` file so that's all
we try to resolve the problem.  We might want to add extra retries to cycle
through all possible newline sequences.

Note that we have to edit `test/fixtures/malformed.csv` to make it even more
malformed.  Without editing this file can now be handled by the `CsvPreview`
as it exhibits the exact problem we've mitigated.  We make it more broken
by adding an extra `\r` to one of the line endings.

[1]: http://ruby-doc.org/stdlib-2.2.3/libdoc/csv/rdoc/CSV.html#method-c-new