### PR TITLE
Update sync check docs

### DIFF
--- a/docs/migration_sync_checks.md
+++ b/docs/migration_sync_checks.md
@@ -52,7 +52,8 @@ while to complete for the larger formats.
 
 ## Automatically queued checks
 
-All content that is sent to publishing API now queues a check to run 5 minutes
-after the changes are saved. The results of these checks are saved in the
-`sync_check_results` table and will be used in the future for ongoing
-monitoring.
+There is functionality to automatically queue a check to run 5 minutes
+after the changes are saved for each document that is sent to publishing API. 
+The results of these checks are saved in the `sync_check_results` table and will 
+be used in the future for ongoing monitoring. This is currently disabled from [this
+PR](https://github.com/alphagov/whitehall/pull/2940) until such time as we get the tests more stable.

--- a/docs/migration_sync_checks.md
+++ b/docs/migration_sync_checks.md
@@ -36,6 +36,10 @@ e.g `bundle exec rails runner script/run_sync_checks -i 1234,1235,1236 Publicati
 not be used for large numbers of documents as it is synchronous and will
 timeout from time to time making results unreliable.
 
+`-b` allows a range of document ids to be specified. e.g. `-b 1000,2000` will check documents
+with ids between 1000 and 2000. This can also be used in conjunction with `-r` to
+republish those documents.
+
 ## On integration/staging/production
 
 To run on an environment other than the dev VM the correct env needs to be


### PR DESCRIPTION
Adds documentation for the `-b` range/between option and updates the auto sync check docs to note that they are currently disabled.