### PR TITLE
[DO NOT MERGE] Minimal WLNA -> NewsArticle conversion

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -58,6 +58,10 @@ class NewsArticle < Newsesque
     world_locations.any?
   end
 
+  def locale_can_be_changed?
+    new_record?
+  end
+
   #-----------------------
 
   private

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -52,6 +52,14 @@ class NewsArticle < Newsesque
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
+  #PROTOTYPE STUFF
+
+  def skip_organisation_validation?
+    world_locations.any?
+  end
+
+  #-----------------------
+
   private
 
   def only_news_article_allowed_invalid_data_can_be_awaiting_type

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -5,6 +5,11 @@ class NewsArticle < Newsesque
   include Edition::AlternativeFormatProvider
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
 
+  #---PROTOTYPE
+
+  include Edition::WorldwideOrganisations
+  #------
+
   validates :news_article_type_id, presence: true
   validate :only_news_article_allowed_invalid_data_can_be_awaiting_type
 
@@ -55,7 +60,7 @@ class NewsArticle < Newsesque
   #PROTOTYPE STUFF
 
   def skip_organisation_validation?
-    world_locations.any?
+    worldwide_organisations.any?
   end
 
   def locale_can_be_changed?

--- a/lib/tasks/migrate_wlna.rake
+++ b/lib/tasks/migrate_wlna.rake
@@ -1,0 +1,24 @@
+namespace :wlna do
+  desc "
+    Convert a WorldLocationNewsArticle to a NewsArticle
+    Usage
+      rake 'wlna:convert_to_news[<document_id>]
+  "
+  task :convert_to_news, [:document_id] => :environment do |_, args|
+    document = Document.find(args.document_id)
+    raise "Document isn't a WLNA" unless document.document_type == "WorldLocationNewsArticle"
+
+    editions = document.editions
+    Document.transaction do
+      document.update_column(:document_type, "NewsArticle")
+      editions.each do |edition|
+        edition.update_columns(
+          type: "NewsArticle",
+          news_article_type_id: NewsArticleType::NewsStory.id,
+        )
+      end
+    end
+
+    PublishingApiDocumentRepublishingWorker.perform_async(document.id)
+  end
+end


### PR DESCRIPTION
This is a minimal 'prototype' implementation of a conversion process to migrate a document of the `WorldLocationNewsArticle` format to a `NewsArticle`.

This adds support for `WorldwideOrganisation` relationships to `NewsArticle` and disables the presence validation on `lead_organisation` when there are any associated `WorldwideOrganisation`.  It doesn't add the UI for this.

The addition of the `locale_can_be_changed?` method adds support for foreign language only documents to both WLNA and `NewsArticle` and enables the appropriate UI on the `NewsArticle` form.

