### PR TITLE
Add UI support for multiple taxonomies

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
+++ b/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
@@ -1,4 +1,14 @@
 .topic-tree {
+  summary {
+    margin-bottom: 10px;
+    display: inline;
+    @extend a;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
   label {
     font-size: 16px;
     font-weight: normal;

--- a/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
+++ b/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
@@ -1,36 +1,44 @@
 .topic-tree {
-  summary {
-    margin-bottom: 10px;
-    display: inline;
-    @extend a;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
-  label {
-    font-size: 16px;
-    font-weight: normal;
-    input[type="checkbox"] {
-      margin-right: 10px;
-    }
-
-    input[type="checkbox"]:checked + span {
-      font-weight: bold;
-    }
-  }
-
-  p.bold-taxon-name {
+  .taxon-name {
     font-size: 16px;
     font-weight: bold;
-  }
-}
+    margin-bottom: 10px;
+    display: inline-block;
 
-.topics {
-  padding-left: 36px;
-  border-left: 1px solid #aaa;
-  margin-left: 6px;
+    &:hover, &:focus {
+      text-decoration: none;
+    }
+
+    .icon {
+      &:before {
+        font-family: 'Glyphicons Halflings';
+        content: '\e159'; // .glyphicon-collapse-down
+      }
+    }
+  }
+  .taxon-name.collapsed .icon {
+    &:before {
+      content: '\e158'; // .glyphicon-expand
+    }
+  }
+
+  .topics {
+    padding-left: 36px;
+    border-left: 1px solid #aaa;
+    margin-left: 6px;
+
+    label {
+      font-size: 16px;
+      font-weight: normal;
+      input[type="checkbox"] {
+        margin-right: 10px;
+      }
+
+      input[type="checkbox"]:checked + span {
+        font-weight: bold;
+      }
+    }
+  }
 }
 
 .feedback-link {

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -5,6 +5,7 @@ class Admin::EditionTagsController < Admin::BaseController
 
   def edit
     @edition_tag_form = EditionTaxonomyTagForm.load(@edition.content_id)
+    @published_taxonomies = Taxonomy.all_taxonomy_trees
   end
 
   def update

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -5,7 +5,7 @@ class Admin::EditionTagsController < Admin::BaseController
 
   def edit
     @edition_tag_form = EditionTaxonomyTagForm.load(@edition.content_id)
-    @published_taxonomies = Taxonomy.all_taxonomy_trees
+    @published_taxonomies = published_taxonomies
   end
 
   def update
@@ -44,5 +44,12 @@ private
   def find_edition
     edition = Edition.find(params[:edition_id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def published_taxonomies
+    taxonomies = Taxonomy.all_taxonomy_trees
+    taxonomies.map do |root_taxon|
+      TopicTreePresenter.new(root_taxon, taxonomies.count)
+    end
   end
 end

--- a/app/models/edition_taxonomy_tag_form.rb
+++ b/app/models/edition_taxonomy_tag_form.rb
@@ -34,16 +34,12 @@ class EditionTaxonomyTagForm
       )
   end
 
-  def education_taxons
-    Taxonomy::Tree.new(Taxonomy.root_taxons.first).root_taxon
-  end
-
   def draft_taxons
     Taxonomy.drafts
   end
 
   def all_taxons
-    education_taxons.tree + draft_taxons.flat_map(&:tree)
+    Taxonomy.all_taxonomy_trees.flat_map(&:tree) + draft_taxons.flat_map(&:tree)
   end
 
   # Ignore any taxons that already have a more specific taxon selected

--- a/app/presenters/topic_tree_presenter.rb
+++ b/app/presenters/topic_tree_presenter.rb
@@ -1,0 +1,18 @@
+class TopicTreePresenter < SimpleDelegator
+  def initialize(taxon, number_of_taxonomies)
+    @number_of_taxonomies = number_of_taxonomies
+    super(taxon)
+  end
+
+  def toggle_classes
+    toggle_classes = ["taxon-name"]
+    toggle_classes << "collapsed" if @number_of_taxonomies > 1
+    toggle_classes.join(" ")
+  end
+
+  def tree_classes
+    tree_classes = ["collapse"]
+    tree_classes << "in" if @number_of_taxonomies == 1
+    tree_classes.join(" ")
+  end
+end

--- a/app/views/admin/edition_tags/_taxonomy.html.erb
+++ b/app/views/admin/edition_tags/_taxonomy.html.erb
@@ -1,3 +1,4 @@
+<div class="topics">
 <% taxons.each do |taxon| %>
   <p>
     <label>
@@ -6,10 +7,9 @@
     </label>
   </p>
 
-  <div class="topics">
-    <% if taxon.children.present? %>
-      <%= render partial: "taxonomy",
-            locals: { form: form, taxons: taxon.children } %>
-    <% end %>
-  </div>
+  <% if taxon.children.present? %>
+    <%= render partial: "taxonomy",
+          locals: { form: form, taxons: taxon.children } %>
+  <% end %>
 <% end %>
+</div>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -21,11 +21,19 @@
         data-content-public-path="<%= public_document_path(@edition) %>">
 
         <% @published_taxonomies.each do |root_taxon| %>
-          <details class="topic-tree">
-            <summary class="bold-taxon-name"><%= root_taxon.name %></summary>
+          <% toggle_classes = ["taxon-name"] %>
+          <% toggle_classes << "collapsed" unless @published_taxonomies.size == 1 %>
 
-            <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
-          </details>
+          <% tree_classes = ["collapse"] %>
+          <% tree_classes << "in" if @published_taxonomies.size == 1 %>
+
+          <div class="topic-tree">
+            <a class="<%= toggle_classes.join(" ") %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'>&nbsp;</span><%= root_taxon.name %></a>
+
+            <div class="<%= tree_classes.join(" ") %>" id="<%= root_taxon.content_id %>">
+              <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
+            </div>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -21,16 +21,10 @@
         data-content-public-path="<%= public_document_path(@edition) %>">
 
         <% @published_taxonomies.each do |root_taxon| %>
-          <% toggle_classes = ["taxon-name"] %>
-          <% toggle_classes << "collapsed" unless @published_taxonomies.size == 1 %>
-
-          <% tree_classes = ["collapse"] %>
-          <% tree_classes << "in" if @published_taxonomies.size == 1 %>
-
           <div class="topic-tree">
-            <a class="<%= toggle_classes.join(" ") %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'>&nbsp;</span><%= root_taxon.name %></a>
+            <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'>&nbsp;</span><%= root_taxon.name %></a>
 
-            <div class="<%= tree_classes.join(" ") %>" id="<%= root_taxon.content_id %>">
+            <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
               <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
             </div>
           </div>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -1,15 +1,16 @@
 <% page_title "Edit topics: " + @edition.title %>
 
 <div class="row">
-  <div class="col-md-9">
-    <h1>Edit topics</h1>
-    <p class="lead add-top-margin add-bottom-margin">
-      <strong><%= @edition.title %></strong>
-    </p>
-  </div>
+  <h1><%= @edition.title %></h1>
 </div>
 <div class="row">
   <div class="col-md-12">
+    <h2>Topics (new taxonomy)</h2>
+    <p>
+      <%= link_to "Send feedback about the new taxonomy", Whitehall.support_url, class: "feedback-link" %>
+    </p>
+    <hr>
+
     <%= form_for @edition_tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
       <%= form.hidden_field :previous_version %>
 
@@ -19,14 +20,13 @@
         data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
-        <div class="topic-tree">
+        <% @published_taxonomies.each do |root_taxon| %>
+          <details class="topic-tree">
+            <summary class="bold-taxon-name"><%= root_taxon.name %></summary>
 
-          <p class="bold-taxon-name">
-            <%= @edition_tag_form.education_taxons.name %>
-          </p>
-
-          <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: @edition_tag_form.education_taxons.children } %>
-        </div>
+            <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
+          </details>
+        <% end %>
       </div>
 
       <h2>Draft topics</h2>

--- a/lib/taxonomy.rb
+++ b/lib/taxonomy.rb
@@ -25,4 +25,8 @@ module Taxonomy
         .map { |taxon_hash| Taxon.new(taxon_hash.symbolize_keys) }
     end
   end
+
+  def self.all_taxonomy_trees
+    root_taxons.map { |root_taxon| Taxonomy::Tree.new(root_taxon).root_taxon }
+  end
 end

--- a/test/unit/presenters/topic_tree_presenter_test.rb
+++ b/test/unit/presenters/topic_tree_presenter_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class TopicTreePresenterTest < ActiveSupport::TestCase
+  test ".toggle_classes when there is only a single taxonomy" do
+    result = TopicTreePresenter.new(nil, 1).toggle_classes
+    assert_equal "taxon-name", result
+  end
+
+  test ".toggle_classes when there are multiple taxonomies" do
+    result = TopicTreePresenter.new(nil, 2).toggle_classes
+    assert_equal "taxon-name collapsed", result
+  end
+
+  test ".tree_classes when there is only a single taxonomy" do
+    result = TopicTreePresenter.new(nil, 1).tree_classes
+    assert_equal "collapse in", result
+  end
+
+  test ".tree_classes when there are multiple taxonomies" do
+    result = TopicTreePresenter.new(nil, 2).tree_classes
+    assert_equal "collapse", result
+  end
+
+  test "other method calls are delegated to the taxon" do
+    result = TopicTreePresenter.new(:taxon, nil).to_s
+    assert_equal "taxon", result
+  end
+end


### PR DESCRIPTION
It is now possible to tag an edition to multiple taxonomies.

By default, the taxonomy trees are collapsed when the page is loaded.

<img width="961" alt="screen shot 2017-05-04 at 17 58 39" src="https://cloud.githubusercontent.com/assets/608867/25722287/86c5b5b0-310b-11e7-97fc-b5f1939851a8.png">

However since we only have a single published taxonomy in production today, it will load the page with that taxonomy tree fully expanded by default. 

<img width="939" alt="screen shot 2017-05-04 at 17 55 17" src="https://cloud.githubusercontent.com/assets/608867/25722288/8aada930-310b-11e7-9231-b114a31a2bc2.png">

[Trello](https://trello.com/c/wHZQz5Yk/64-build-joe-s-designs-to-allow-publishers-to-tag-across-multiple-themes-in-whitehall)