### PR TITLE
Allow news articles to be created as translations only

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -52,6 +52,10 @@ class NewsArticle < Newsesque
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
 
+  def locale_can_be_changed?
+    new_record?
+  end
+
   private
 
   def only_news_article_allowed_invalid_data_can_be_awaiting_type

--- a/features/non-english-news-article.feature
+++ b/features/non-english-news-article.feature
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+Feature: News article specific to native language speakers
+
+  As an publisher dealing with world wide content (eg FCO),
+  I want the ability to publish a News article without having to have an English language edition,
+  So that I do not need to spend the time translating content into English
+
+  -------
+
+  Some content is only for audiences local to the location and so an English version is not relevant or desired.
+
+  Background:
+    Given I am a GDS editor
+
+  Scenario: Create a News article in a non-English language
+    Given a world location "France" exists with a translation for the locale "Français"
+    When I draft a French-only news article associated with "France"
+    Then I should see the news article listed in admin with an indication that it is in French
+    When I publish the French-only news article
+    Then I should only see the news article on the French version of the public "France" location page

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -105,3 +105,44 @@ When(/^I filter the announcements list by "(.*?)"$/) do |announcement_type|
   select announcement_type, from: "Announcement type"
   click_on "Refresh results"
 end
+
+When /^I draft a French\-only news article associated with "([^"]*)"$/ do |location_name|
+  begin_drafting_news_article title: "French-only news article", body: 'test-body', summary: 'test-summary'
+
+  select "Français", from: "Document language"
+  select location_name, from: "Select the world locations this news article is about"
+  click_button "Save"
+
+  @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
+end
+
+When /^I publish the French-only news article$/ do
+  visit admin_edition_path(@news_article)
+  publish(force: true)
+end
+
+When(/^I publish a news article "(.*?)" for "(.*?)"$/) do |title, location_name|
+  begin_drafting_news_article(title: title)
+
+  select location_name, from: "Select the world locations this news article is about"
+
+  click_button "Save"
+
+  publish(force: true)
+end
+
+Then /^I should see the news article listed in admin with an indication that it is in French$/ do
+  assert_path admin_edition_path(@news_article)
+  assert page.has_content?("This document is French-only")
+end
+
+Then /^I should only see the news article on the French version of the public "([^"]*)" location page$/ do |world_location_name|
+  world_location = WorldLocation.find_by!(name: world_location_name)
+  visit world_location_path(world_location, locale: :fr)
+  within record_css_selector(@news_article) do
+    assert page.has_content?(@news_article.title)
+  end
+
+  visit world_location_path(world_location)
+  assert page.has_no_css?(record_css_selector(@news_article))
+end

--- a/features/support/news_article_helper.rb
+++ b/features/support/news_article_helper.rb
@@ -1,0 +1,9 @@
+module NewsArticleHelper
+  def find_news_article_in_locale!(locale, title)
+    I18n.with_locale locale do
+      NewsArticle.find_by!(title: title)
+    end
+  end
+end
+
+World(NewsArticleHelper)

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -32,7 +32,7 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
   end
 
   test 'locale_can_be_changed? returns false for other edition types' do
-    Edition.concrete_descendants.reject {|k| k == WorldLocationNewsArticle }.each do |klass|
+    Edition.concrete_descendants.reject {|k| [WorldLocationNewsArticle, NewsArticle].include?(k) }.each do |klass|
       refute klass.new.locale_can_be_changed?, "Instance of #{klass} should not allow the changing of primary locale"
     end
   end


### PR DESCRIPTION
For https://trello.com/c/fZPPfJhf/86-allow-news-articles-to-be-created-with-only-non-english-content

Mirrors the cucumber test introduced in https://github.com/alphagov/whitehall/pull/576 --> https://github.com/alphagov/whitehall/blob/master/features/non-english-world-location-news.feature, but excludes the last line `And I should only be able to view the news article article in French` as news articles are rendered in government-frontend now. Also remove references to world organisations as these do not (yet) associate to news articles.