### PR TITLE
Fix integration URL for startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -9,8 +9,8 @@ if [ -z "$SHOW_PRODUCTION_IMAGES" ]; then
 else
   echo "Showing production images"
 fi
-# Serve static shared assets from preview so static doesn't need to be running
-: ${STATIC_DEV:="https://assets-origin.preview.alphagov.co.uk"}
+# Serve static shared assets from integration so static doesn't need to be running
+: ${STATIC_DEV:="https://assets-origin.integration.publishing.service.gov.uk"}
 export STATIC_DEV
 echo
 bundle install


### PR DESCRIPTION
This commit changes the integration URL in the startup script to point to `gov.uk` rather than `alphagov.co.uk`.