### PR TITLE
Require testtask for rake tasks

### DIFF
--- a/lib/tasks/test_performance.rake
+++ b/lib/tasks/test_performance.rake
@@ -1,5 +1,7 @@
 # Use this rake task to run performance tests against the "benchmark"
 # environment. See test/benchmark_helper.rb for more details.
+require 'rake/testtask'
+
 namespace :test do
   Rake::TestTask.new(:alt_benchmarks => ['test:benchmark_mode']) do |t|
     t.libs << 'test'

--- a/lib/tasks/test_presenters.rake
+++ b/lib/tasks/test_presenters.rake
@@ -1,3 +1,5 @@
+require 'rake/testtask'
+
 namespace :test do
   Rake::TestTask.new(:presenters => "test:prepare") do |t|
     t.libs << 'test'

--- a/lib/tasks/test_publishing_schemas.rake
+++ b/lib/tasks/test_publishing_schemas.rake
@@ -1,3 +1,5 @@
+require 'rake/testtask'
+
 namespace :test do
   Rake::TestTask.new(:publishing_schemas => "test:prepare") do |t|
     t.libs << 'test'


### PR DESCRIPTION
This commit requires `rake/testtask` for rake tasks that use `Rake::TestTask`.