### PR TITLE
Change toggle glyph icon to ▶︎ and ▼

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
+++ b/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
@@ -10,15 +10,17 @@
     }
 
     .icon {
+      display: inline-block;
+      width: 15px;
+
       &:before {
-        font-family: 'Glyphicons Halflings';
-        content: '\e159'; // .glyphicon-collapse-down
+        content: '\25BE';
       }
     }
   }
   .taxon-name.collapsed .icon {
     &:before {
-      content: '\e158'; // .glyphicon-expand
+      content: '\25B8';
     }
   }
 

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -22,7 +22,7 @@
 
         <% @published_taxonomies.each do |root_taxon| %>
           <div class="topic-tree">
-            <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'>&nbsp;</span><%= root_taxon.name %></a>
+            <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'></span><%= root_taxon.name %></a>
 
             <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
               <%= render partial: "taxonomy", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>


### PR DESCRIPTION
From this:

<img width="365" alt="screen shot 2017-05-08 at 11 16 28" src="https://cloud.githubusercontent.com/assets/608867/25800110/d853ec22-33df-11e7-9b8e-e7f12d5d6931.png">

To this:

<img width="321" alt="screen shot 2017-05-08 at 11 16 35" src="https://cloud.githubusercontent.com/assets/608867/25800116/db75ce02-33df-11e7-91f0-6720e7e1727a.png">

On the "Tagging to new taxonomy" page.

[Trello](https://trello.com/c/wHZQz5Yk/64-build-joe-s-designs-to-allow-publishers-to-tag-across-multiple-themes-in-whitehall)

