### PR TITLE
Replace filters with actions

### DIFF
--- a/app/concerns/translation_controller_concern.rb
+++ b/app/concerns/translation_controller_concern.rb
@@ -2,8 +2,8 @@ module TranslationControllerConcern
   extend ActiveSupport::Concern
 
   included do
-    before_filter :load_translatable_item
-    before_filter :load_translated_models, except: [:index]
+    before_action :load_translatable_item
+    before_action :load_translated_models, except: [:index]
     helper_method :translation_locale
   end
 

--- a/app/controllers/admin/about_pages_controller.rb
+++ b/app/controllers/admin/about_pages_controller.rb
@@ -1,6 +1,6 @@
 class Admin::AboutPagesController < Admin::BaseController
-  before_filter :find_topical_event
-  before_filter :find_page, except: [:new, :create]
+  before_action :find_topical_event
+  before_action :find_page, except: [:new, :create]
 
   helper_method :model_name, :human_friendly_model_name
 

--- a/app/controllers/admin/access_and_opening_times_controller.rb
+++ b/app/controllers/admin/access_and_opening_times_controller.rb
@@ -1,5 +1,5 @@
 class Admin::AccessAndOpeningTimesController < Admin::BaseController
-  before_filter :load_accessible
+  before_action :load_accessible
   helper_method :accessible_path
 
   def edit

--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -1,6 +1,6 @@
 class Admin::AttachmentsController < Admin::BaseController
-  before_filter :limit_attachable_access, if: :attachable_is_an_edition?
-  before_filter :check_attachable_allows_attachment_type
+  before_action :limit_attachable_access, if: :attachable_is_an_edition?
+  before_action :check_attachable_allows_attachment_type
 
   rescue_from Mysql2::Error, with: :handle_duplicate_key_errors_caused_by_double_create_requests
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,9 +3,9 @@ class Admin::BaseController < ApplicationController
   include PermissionsChecker
 
   layout 'admin'
-  prepend_before_filter :skip_slimmer
-  prepend_before_filter :authenticate_user!
-  before_filter :require_signin_permission!
+  prepend_before_action :skip_slimmer
+  prepend_before_action :authenticate_user!
+  before_action :require_signin_permission!
 
   def limit_edition_access!
     enforce_permission!(:see, @edition)

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -1,8 +1,8 @@
 class Admin::BulkUploadsController < Admin::BaseController
-  before_filter :find_edition
-  before_filter :limit_edition_access!
-  before_filter :enforce_permissions!
-  before_filter :prevent_modification_of_unmodifiable_edition
+  before_action :find_edition
+  before_action :limit_edition_access!
+  before_action :enforce_permissions!
+  before_action :prevent_modification_of_unmodifiable_edition
 
   def new
     @zip_file = BulkUpload::ZipFile.new

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -1,6 +1,6 @@
 class Admin::CabinetMinistersController < Admin::BaseController
 
-  before_filter :enforce_permissions!
+  before_action :enforce_permissions!
 
   def show
     @cabinet_minister_roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)

--- a/app/controllers/admin/classification_featurings_controller.rb
+++ b/app/controllers/admin/classification_featurings_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ClassificationFeaturingsController < Admin::BaseController
-  before_filter :load_classification
-  before_filter :load_featuring, only: [:edit, :destroy]
+  before_action :load_classification
+  before_action :load_featuring, only: [:edit, :destroy]
 
   def index
     filter_params = params.slice(:page, :type, :author, :organisation, :title).

--- a/app/controllers/admin/classifications_controller.rb
+++ b/app/controllers/admin/classifications_controller.rb
@@ -1,9 +1,9 @@
 class Admin::ClassificationsController < Admin::BaseController
   helper_method :model_class, :model_name, :human_friendly_model_name
 
-  before_filter :build_object, only: [:new]
-  before_filter :load_object, only: [:show, :edit]
-  before_filter :remove_blank_parameters, only: [:create, :update]
+  before_action :build_object, only: [:new]
+  before_action :load_object, only: [:show, :edit]
+  before_action :remove_blank_parameters, only: [:create, :update]
 
   def index
     @classifications = model_class.includes(:related_classifications).order(:name)

--- a/app/controllers/admin/consultations_controller.rb
+++ b/app/controllers/admin/consultations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ConsultationsController < Admin::EditionsController
-  before_filter :cope_with_consultation_response_form_data_action_params, only: [:update]
+  before_action :cope_with_consultation_response_form_data_action_params, only: [:update]
 
   private
 

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ContactsController < Admin::BaseController
-  before_filter :find_contactable
-  before_filter :find_contact, only: [:edit, :update, :destroy, :remove_from_home_page, :add_to_home_page]
-  before_filter :destroy_blank_contact_numbers, only: [:create, :update]
+  before_action :find_contactable
+  before_action :find_contact, only: [:edit, :update, :destroy, :remove_from_home_page, :add_to_home_page]
+  before_action :destroy_blank_contact_numbers, only: [:create, :update]
 
   def index
   end

--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -1,5 +1,5 @@
 class Admin::CorporateInformationPagesController < Admin::EditionsController
-  prepend_before_filter :find_organisation
+  prepend_before_action :find_organisation
 
   class FakeEditionFilter < Struct.new(:editions, :page_title, :show_stats, :hide_type)
   end

--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseController
-  before_filter :load_document_collection
-  before_filter :load_document_collection_group
-  before_filter :find_document, only: :create
+  before_action :load_document_collection
+  before_action :load_document_collection_group
+  before_action :find_document, only: :create
 
   def create
     membership = DocumentCollectionGroupMembership.new(document: @document, document_collection_group: @group)

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DocumentCollectionGroupsController < Admin::BaseController
-  before_filter :load_document_collection
-  before_filter :load_document_collection_group, only: [:delete, :destroy, :edit, :update]
+  before_action :load_document_collection
+  before_action :load_document_collection_group, only: [:delete, :destroy, :edit, :update]
 
   def index
     @groups = @collection.groups

--- a/app/controllers/admin/document_sources_controller.rb
+++ b/app/controllers/admin/document_sources_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DocumentSourcesController < Admin::BaseController
-  before_filter :require_import_permission!
-  before_filter :find_edition
+  before_action :require_import_permission!
+  before_action :find_edition
 
   def update
     @document_sources = params[:document_sources]

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -1,7 +1,7 @@
 class Admin::EditionTagsController < Admin::BaseController
-  before_filter :find_edition
-  before_filter :enforce_permissions!
-  before_filter :limit_edition_access!
+  before_action :find_edition
+  before_action :enforce_permissions!
+  before_action :limit_edition_access!
 
   def edit
     @edition_tag_form = EditionTaxonomyTagForm.load(@edition.content_id)

--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -1,6 +1,6 @@
 class Admin::EditionUnpublishingController < Admin::BaseController
-  before_filter :load_unpublishing
-  before_filter :enforce_permissions!
+  before_action :load_unpublishing
+  before_action :enforce_permissions!
 
   def update
     services = Whitehall.edition_services

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -1,13 +1,13 @@
 class Admin::EditionWorkflowController < Admin::BaseController
   include PublicDocumentRoutesHelper
 
-  before_filter :find_edition
-  before_filter :enforce_permissions!
-  before_filter :limit_edition_access!
-  before_filter :lock_edition
-  before_filter :set_change_note
-  before_filter :set_minor_change_flag
-  before_filter :ensure_reason_given_for_force_publishing, only: :force_publish
+  before_action :find_edition
+  before_action :enforce_permissions!
+  before_action :limit_edition_access!
+  before_action :lock_edition
+  before_action :set_change_note
+  before_action :set_minor_change_flag
+  before_action :ensure_reason_given_for_force_publishing, only: :force_publish
 
   rescue_from ActiveRecord::StaleObjectError do
     redirect_to admin_edition_path(@edition), alert: "This document has been edited since you viewed it; you are now viewing the latest version"

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,21 +1,21 @@
 class Admin::EditionsController < Admin::BaseController
-  before_filter :remove_blank_parameters
-  before_filter :clean_edition_parameters, only: [:create, :update]
-  before_filter :build_array_out_of_need_ids_string, only: [:create, :update]
-  before_filter :clear_scheduled_publication_if_not_activated, only: [:create, :update]
-  before_filter :find_edition, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
-  before_filter :prevent_modification_of_unmodifiable_edition, only: [:edit, :update]
-  before_filter :delete_absent_edition_organisations, only: [:create, :update]
-  before_filter :build_edition, only: [:new, :create]
-  before_filter :detect_other_active_editors, only: [:edit]
-  before_filter :set_edition_defaults, only: :new
-  before_filter :build_blank_image, only: [:new, :edit]
-  before_filter :enforce_permissions!
-  before_filter :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
-  before_filter :redirect_to_controller_for_type, only: [:show]
-  before_filter :deduplicate_specialist_sectors, only: [:create, :update]
-  before_filter :trigger_previously_published_validations, only: [:create], if: :document_can_be_previously_published
-  before_filter :forbid_editing_of_historic_content!, only: [:create, :edit, :update, :submit, :destory, :revise]
+  before_action :remove_blank_parameters
+  before_action :clean_edition_parameters, only: [:create, :update]
+  before_action :build_array_out_of_need_ids_string, only: [:create, :update]
+  before_action :clear_scheduled_publication_if_not_activated, only: [:create, :update]
+  before_action :find_edition, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
+  before_action :prevent_modification_of_unmodifiable_edition, only: [:edit, :update]
+  before_action :delete_absent_edition_organisations, only: [:create, :update]
+  before_action :build_edition, only: [:new, :create]
+  before_action :detect_other_active_editors, only: [:edit]
+  before_action :set_edition_defaults, only: :new
+  before_action :build_blank_image, only: [:new, :edit]
+  before_action :enforce_permissions!
+  before_action :limit_edition_access!, only: [:show, :edit, :update, :submit, :revise, :diff, :reject, :destroy]
+  before_action :redirect_to_controller_for_type, only: [:show]
+  before_action :deduplicate_specialist_sectors, only: [:create, :update]
+  before_action :trigger_previously_published_validations, only: [:create], if: :document_can_be_previously_published
+  before_action :forbid_editing_of_historic_content!, only: [:create, :edit, :update, :submit, :destory, :revise]
 
   def forbid_editing_of_historic_content!
     unless can?(:modify, @edition)

--- a/app/controllers/admin/editorial_remarks_controller.rb
+++ b/app/controllers/admin/editorial_remarks_controller.rb
@@ -1,7 +1,7 @@
 class Admin::EditorialRemarksController < Admin::BaseController
-  before_filter :find_edition
-  before_filter :enforce_permissions!
-  before_filter :limit_edition_access!
+  before_action :find_edition
+  before_action :enforce_permissions!
+  before_action :limit_edition_access!
 
   def enforce_permissions!
     enforce_permission!(:make_editorial_remark, @edition)

--- a/app/controllers/admin/fact_check_requests_controller.rb
+++ b/app/controllers/admin/fact_check_requests_controller.rb
@@ -1,11 +1,11 @@
 class Admin::FactCheckRequestsController < Admin::BaseController
-  before_filter :load_fact_check_request, only: [:show, :edit, :update]
-  before_filter :load_edition, only: [:create]
-  before_filter :enforce_permissions!, only: [:create]
-  before_filter :limit_edition_access!, only: [:create]
-  before_filter :check_edition_availability, only: [:show, :edit]
-  skip_before_filter :authenticate_user!, except: [:create]
-  skip_before_filter :require_signin_permission!, except: [:create]
+  before_action :load_fact_check_request, only: [:show, :edit, :update]
+  before_action :load_edition, only: [:create]
+  before_action :enforce_permissions!, only: [:create]
+  before_action :limit_edition_access!, only: [:create]
+  before_action :check_edition_availability, only: [:show, :edit]
+  skip_before_action :authenticate_user!, except: [:create]
+  skip_before_action :require_signin_permission!, except: [:create]
 
   def show
   end

--- a/app/controllers/admin/fatality_notices_controller.rb
+++ b/app/controllers/admin/fatality_notices_controller.rb
@@ -1,6 +1,6 @@
 class Admin::FatalityNoticesController < Admin::EditionsController
-  before_filter :require_fatality_handling_permission!, except: :show
-  before_filter :build_fatality_notice_casualties, only: [:new, :edit]
+  before_action :require_fatality_handling_permission!, except: :show
+  before_action :build_fatality_notice_casualties, only: [:new, :edit]
 
   private
 

--- a/app/controllers/admin/feature_lists_controller.rb
+++ b/app/controllers/admin/feature_lists_controller.rb
@@ -1,5 +1,5 @@
 class Admin::FeatureListsController < Admin::BaseController
-  before_filter :find_feature_list
+  before_action :find_feature_list
 
   def show
     redirect_to feature_list_path(@feature_list)

--- a/app/controllers/admin/featured_policies_controller.rb
+++ b/app/controllers/admin/featured_policies_controller.rb
@@ -1,5 +1,5 @@
 class Admin::FeaturedPoliciesController < Admin::BaseController
-  before_filter :load_organisation
+  before_action :load_organisation
 
   def index
     @featured_policies = @organisation.featured_policies.order(:ordering)

--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -1,7 +1,7 @@
 class Admin::FeaturesController < Admin::BaseController
-  before_filter :find_feature_list
-  before_filter :build_feature
-  before_filter :find_edition, :find_topical_event, :find_offsite_link, only: [:new]
+  before_action :find_feature_list
+  before_action :build_feature
+  before_action :find_edition, :find_topical_event, :find_offsite_link, only: [:new]
 
   def new
   end

--- a/app/controllers/admin/financial_reports_controller.rb
+++ b/app/controllers/admin/financial_reports_controller.rb
@@ -1,6 +1,6 @@
 class Admin::FinancialReportsController < Admin::BaseController
-  before_filter :load_organisation
-  before_filter :load_financial_report, only: [:edit, :update, :destroy]
+  before_action :load_organisation
+  before_action :load_financial_report, only: [:edit, :update, :destroy]
 
   def new
     @financial_report = @organisation.financial_reports.build(year: Time.zone.now.year)

--- a/app/controllers/admin/get_involved_controller.rb
+++ b/app/controllers/admin/get_involved_controller.rb
@@ -1,5 +1,5 @@
 class Admin::GetInvolvedController < Admin::BaseController
-  before_filter :enforce_permissions!
+  before_action :enforce_permissions!
 
   def enforce_permissions!
     enforce_permission!(:administer, :get_involved_section)

--- a/app/controllers/admin/governments_controller.rb
+++ b/app/controllers/admin/governments_controller.rb
@@ -1,5 +1,5 @@
 class Admin::GovernmentsController < Admin::BaseController
-  before_filter :enforce_permissions!, except: :index
+  before_action :enforce_permissions!, except: :index
 
   def index
     @governments = Government.order(start_date: :desc)

--- a/app/controllers/admin/historical_accounts_controller.rb
+++ b/app/controllers/admin/historical_accounts_controller.rb
@@ -1,6 +1,6 @@
 class Admin::HistoricalAccountsController < Admin::BaseController
-  before_filter :load_person
-  before_filter :load_historical_account, only: [:edit, :update, :destroy]
+  before_action :load_person
+  before_action :load_historical_account, only: [:edit, :update, :destroy]
 
   def index
     @historical_accounts = @person.historical_accounts.includes(roles: :translations)

--- a/app/controllers/admin/home_page_list_controller.rb
+++ b/app/controllers/admin/home_page_list_controller.rb
@@ -60,7 +60,7 @@ module Admin::HomePageListController
           compact
       end
     end
-    self.before_filter :extract_show_on_home_page_param, only: [:create, :update]
+    self.before_action :extract_show_on_home_page_param, only: [:create, :update]
     include home_page_list_controller_methods
   end
 end

--- a/app/controllers/admin/links_reports_controller.rb
+++ b/app/controllers/admin/links_reports_controller.rb
@@ -1,5 +1,5 @@
 class Admin::LinksReportsController < Admin::BaseController
-  before_filter :find_reportable
+  before_action :find_reportable
 
   def create
     @links_report = LinksReport.queue_for!(@reportable)

--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -1,6 +1,6 @@
 class Admin::OffsiteLinksController < Admin::BaseController
-  before_filter :load_parent
-  before_filter :load_offsite_link, except: [:new, :create]
+  before_action :load_parent
+  before_action :load_offsite_link, except: [:new, :create]
 
   def new
     @offsite_link = OffsiteLink.new

--- a/app/controllers/admin/operational_fields_controller.rb
+++ b/app/controllers/admin/operational_fields_controller.rb
@@ -1,5 +1,5 @@
 class Admin::OperationalFieldsController < Admin::BaseController
-  before_filter :require_fatality_handling_permission!
+  before_action :require_fatality_handling_permission!
 
   def index
     @operational_fields = OperationalField.order(:name)

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,6 +1,6 @@
 class Admin::OrganisationsController < Admin::BaseController
-  before_filter :load_organisation, except: [:index, :new, :create]
-  before_filter :enforce_permissions!, only: [:new, :create, :edit, :update]
+  before_action :load_organisation, except: [:index, :new, :create]
+  before_action :enforce_permissions!, only: [:new, :create, :edit, :update]
 
   def index
     @organisations = Organisation.alphabetical

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PeopleController < Admin::BaseController
-  before_filter :load_person, only: [:show, :edit, :update, :destroy]
+  before_action :load_person, only: [:show, :edit, :update, :destroy]
   def index
     @people = Person.order(:surname, :forename).includes(:translations)
   end

--- a/app/controllers/admin/policy_groups_controller.rb
+++ b/app/controllers/admin/policy_groups_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PolicyGroupsController < Admin::BaseController
-  before_filter :enforce_permissions!, only: [:destroy]
+  before_action :enforce_permissions!, only: [:destroy]
 
   def index
     @policy_groups = PolicyGroup.order(:name)

--- a/app/controllers/admin/preview_controller.rb
+++ b/app/controllers/admin/preview_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PreviewController < Admin::BaseController
-  before_filter :find_attachments
-  before_filter :limit_attachment_access!
+  before_action :find_attachments
+  before_action :limit_attachment_access!
 
   def preview
     if Govspeak::HtmlValidator.new(params[:body]).valid?

--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PromotionalFeatureItemsController < Admin::BaseController
-  before_filter :load_organisation
-  before_filter :load_promotional_feature
-  before_filter :load_promotional_feature_item, only: [:edit, :update, :destroy]
+  before_action :load_organisation
+  before_action :load_promotional_feature
+  before_action :load_promotional_feature_item, only: [:edit, :update, :destroy]
 
   def new
     @promotional_feature_item = @promotional_feature.promotional_feature_items.build

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PromotionalFeaturesController < Admin::BaseController
-  before_filter :load_organisation
-  before_filter :load_promotional_feature, only: [:show, :edit, :update, :destroy]
+  before_action :load_organisation
+  before_action :load_promotional_feature, only: [:show, :edit, :update, :destroy]
 
   def index
     @promotional_features = @organisation.promotional_features

--- a/app/controllers/admin/publications_controller.rb
+++ b/app/controllers/admin/publications_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PublicationsController < Admin::EditionsController
-  before_filter :pre_fill_edition_from_statistics_announcement, only: :new, if: :statistics_announcement
+  before_action :pre_fill_edition_from_statistics_announcement, only: :new, if: :statistics_announcement
 
   private
 

--- a/app/controllers/admin/responses_controller.rb
+++ b/app/controllers/admin/responses_controller.rb
@@ -1,9 +1,9 @@
 class Admin::ResponsesController < Admin::BaseController
-  before_filter :find_consultation
-  before_filter :limit_edition_access!
-  before_filter :enforce_edition_permissions!
-  before_filter :prevent_modification_of_unmodifiable_edition
-  before_filter :find_response, only: [:edit, :update]
+  before_action :find_consultation
+  before_action :limit_edition_access!
+  before_action :enforce_edition_permissions!
+  before_action :prevent_modification_of_unmodifiable_edition
+  before_action :find_response, only: [:edit, :update]
 
   def show
     @response = response_class.find_by(edition_id: @edition) || response_class.new(published_on: Date.today)

--- a/app/controllers/admin/role_appointments_controller.rb
+++ b/app/controllers/admin/role_appointments_controller.rb
@@ -1,5 +1,5 @@
 class Admin::RoleAppointmentsController < Admin::BaseController
-  before_filter :load_role_appointment, only: [:edit, :update, :destroy]
+  before_action :load_role_appointment, only: [:edit, :update, :destroy]
 
   def new
     role = Role.find(params[:role_id])

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,5 +1,5 @@
 class Admin::RolesController < Admin::BaseController
-  before_filter :load_role, only: [:edit, :update, :destroy]
+  before_action :load_role, only: [:edit, :update, :destroy]
 
   def index
     @roles = Role.includes(:role_appointments, :current_people, :translations, organisations: [:translations]).

--- a/app/controllers/admin/sitewide_settings_controller.rb
+++ b/app/controllers/admin/sitewide_settings_controller.rb
@@ -1,5 +1,5 @@
 class Admin::SitewideSettingsController <  Admin::BaseController
-  before_filter :enforce_permissions!
+  before_action :enforce_permissions!
 
   def enforce_permissions!
     enforce_permission!(:administer, :sitewide_settings_section)

--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -1,7 +1,7 @@
 class Admin::SocialMediaAccountsController < Admin::BaseController
-  before_filter :find_socialable
-  before_filter :find_social_media_account, only: [:edit, :update, :destroy]
-  before_filter :strip_whitespace_from_url
+  before_action :find_socialable
+  before_action :find_social_media_account, only: [:edit, :update, :destroy]
+  before_action :strip_whitespace_from_url
 
   def index
     @social_media_accounts = @socialable.social_media_accounts

--- a/app/controllers/admin/speeches_controller.rb
+++ b/app/controllers/admin/speeches_controller.rb
@@ -1,5 +1,5 @@
 class Admin::SpeechesController < Admin::EditionsController
-  before_filter :clear_role_appointment_param_on_override, only: [:update, :create]
+  before_action :clear_role_appointment_param_on_override, only: [:update, :create]
 
   private
 

--- a/app/controllers/admin/statistics_announcement_date_changes_controller.rb
+++ b/app/controllers/admin/statistics_announcement_date_changes_controller.rb
@@ -1,6 +1,6 @@
 class Admin::StatisticsAnnouncementDateChangesController < Admin::BaseController
-  before_filter :find_statistics_announcement
-  before_filter :redirect_to_announcement_if_cancelled
+  before_action :find_statistics_announcement
+  before_action :redirect_to_announcement_if_cancelled
 
   def new
     @statistics_announcement_date_change = build_date_change

--- a/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
+++ b/app/controllers/admin/statistics_announcement_unpublishings_controller.rb
@@ -1,6 +1,6 @@
 class Admin::StatisticsAnnouncementUnpublishingsController < Admin::BaseController
-  before_filter :find_statistics_announcement
-  before_filter :enforce_permissions!
+  before_action :find_statistics_announcement
+  before_action :enforce_permissions!
 
   def new
   end

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -1,6 +1,6 @@
 class Admin::StatisticsAnnouncementsController < Admin::BaseController
-  before_filter :find_statistics_announcement, only: [:show, :edit, :update, :cancel, :publish_cancellation, :cancel_reason]
-  before_filter :redirect_to_show_if_cancelled, only: [:cancel, :publish_cancellation]
+  before_action :find_statistics_announcement, only: [:show, :edit, :update, :cancel, :publish_cancellation, :cancel_reason]
+  before_action :redirect_to_show_if_cancelled, only: [:cancel, :publish_cancellation]
   helper_method :unlinked_announcements_count, :show_unlinked_announcements_warning?
 
   def index

--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -1,5 +1,5 @@
 class Admin::TakePartPagesController < Admin::BaseController
-  before_filter :enforce_permissions!
+  before_action :enforce_permissions!
   def enforce_permissions!
     enforce_permission!(:administer, :get_involved_section)
   end

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -1,6 +1,6 @@
 class Admin::TopicalEventsController < Admin::ClassificationsController
-  before_filter :build_associated_objects, only: [:new, :edit]
-  before_filter :destroy_blank_social_media_accounts, only: [:create, :update]
+  before_action :build_associated_objects, only: [:new, :edit]
+  before_action :destroy_blank_social_media_accounts, only: [:create, :update]
 
   def update
     @classification = TopicalEvent.friendly.find(params[:id])

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_filter :load_user, only: [:show, :edit, :update]
+  before_action :load_user, only: [:show, :edit, :update]
 
   def index
     @users = User.enabled.includes(organisation: [:translations]).sort_by { |u| u.fuzzy_last_name.downcase }

--- a/app/controllers/admin/world_locations_controller.rb
+++ b/app/controllers/admin/world_locations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::WorldLocationsController < Admin::BaseController
-  before_filter :load_world_location, only: [:edit, :update, :show, :features]
+  before_action :load_world_location, only: [:edit, :update, :show, :features]
 
   def index
     @active_world_locations, @inactive_world_locations = WorldLocation.ordered_by_name.partition { |wl| wl.active? }

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -1,6 +1,6 @@
 class Admin::WorldwideOfficesController < Admin::BaseController
-  before_filter :find_worldwide_organisation
-  before_filter :find_worldwide_office, only: [:edit, :update, :destroy, :add_to_home_page, :remove_from_home_page]
+  before_action :find_worldwide_organisation
+  before_action :find_worldwide_office, only: [:edit, :update, :destroy, :add_to_home_page, :remove_from_home_page]
 
   def index
   end

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -1,7 +1,7 @@
 class Admin::WorldwideOrganisationsController < Admin::BaseController
   respond_to :html
 
-  before_filter :find_worldwide_organisation, except: [:index, :new, :create]
+  before_action :find_worldwide_organisation, except: [:index, :new, :create]
 
   def index
     respond_with @worldwide_organisations = WorldwideOrganisation.ordered_by_name

--- a/app/controllers/api/governments_controller.rb
+++ b/app/controllers/api/governments_controller.rb
@@ -1,5 +1,5 @@
 class Api::GovernmentsController < PublicFacingController
-  skip_before_filter :restrict_request_formats
+  skip_before_action :restrict_request_formats
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,5 +1,5 @@
 class Api::OrganisationsController < PublicFacingController
-  skip_before_filter :restrict_request_formats
+  skip_before_action :restrict_request_formats
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/world_locations_controller.rb
+++ b/app/controllers/api/world_locations_controller.rb
@@ -1,5 +1,5 @@
 class Api::WorldLocationsController < PublicFacingController
-  skip_before_filter :restrict_request_formats
+  skip_before_action :restrict_request_formats
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/worldwide_organisations_controller.rb
+++ b/app/controllers/api/worldwide_organisations_controller.rb
@@ -1,5 +1,5 @@
 class Api::WorldwideOrganisationsController < PublicFacingController
-  skip_before_filter :restrict_request_formats
+  skip_before_action :restrict_request_formats
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,13 +8,13 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
-  before_filter :set_slimmer_application_name
-  before_filter :set_slimmer_show_organisations_filter
-  before_filter :set_audit_trail_whodunnit
-  before_filter :set_authenticated_user_header
+  before_action :set_slimmer_application_name
+  before_action :set_slimmer_show_organisations_filter
+  before_action :set_audit_trail_whodunnit
+  before_action :set_authenticated_user_header
 
   layout 'frontend'
-  after_filter :set_slimmer_template
+  after_action :set_slimmer_template
 
   private
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,7 +1,7 @@
 class AttachmentsController < PublicUploadsController
   include PublicDocumentRoutesHelper
 
-  before_filter :reject_non_previewable_attachments, only: :preview
+  before_action :reject_non_previewable_attachments, only: :preview
 
   def preview
     if attachment_visible? && attachment_visibility.visible_edition

--- a/app/controllers/corporate_information_pages_controller.rb
+++ b/app/controllers/corporate_information_pages_controller.rb
@@ -1,6 +1,6 @@
 class CorporateInformationPagesController < DocumentsController
-  prepend_before_filter :find_organisation
-  before_filter :set_slimmer_headers_for_document, only: [:show, :index]
+  prepend_before_action :find_organisation
+  before_action :set_slimmer_headers_for_document, only: [:show, :index]
 
   def show
     @corporate_information_page = @document

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,9 +3,9 @@ class DocumentsController < PublicFacingController
   include PermissionsChecker
   include PublicDocumentRoutesHelper
 
-  before_filter :redirect_to_canonical_url
-  before_filter :find_document, only: [:show]
-  before_filter :set_slimmer_headers_for_document, only: [:show]
+  before_action :redirect_to_canonical_url
+  before_action :find_document, only: [:show]
+  before_action :set_slimmer_headers_for_document, only: [:show]
 
 private
 

--- a/app/controllers/historic_appointments_controller.rb
+++ b/app/controllers/historic_appointments_controller.rb
@@ -1,5 +1,5 @@
 class HistoricAppointmentsController < PublicFacingController
-  before_filter :load_role, except: [:past_chancellors]
+  before_action :load_role, except: [:past_chancellors]
   helper_method :previous_appointments_with_unique_people
 
   def index

--- a/app/controllers/html_attachments_controller.rb
+++ b/app/controllers/html_attachments_controller.rb
@@ -4,8 +4,8 @@ class HtmlAttachmentsController < PublicFacingController
 
   layout 'html_attachments'
 
-  before_filter :find_edition, :redirect_if_unpublished, :find_html_attachment
-  around_filter :set_locale_from_attachment
+  before_action :find_edition, :redirect_if_unpublished, :find_html_attachment
+  around_action :set_locale_from_attachment
 
   def show
     set_meta_description(@edition.summary)

--- a/app/controllers/latest_controller.rb
+++ b/app/controllers/latest_controller.rb
@@ -1,7 +1,7 @@
 class LatestController < PublicFacingController
   include CacheControlHelper
 
-  before_filter :redirect_unless_subject
+  before_action :redirect_unless_subject
 
   def index
   end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,10 +2,10 @@ class OrganisationsController < PublicFacingController
   include CacheControlHelper
 
   enable_request_formats show: [:atom]
-  before_filter :load_organisation, only: [:show]
-  before_filter :set_organisation_slimmer_headers, only: [:show]
-  skip_before_filter :set_cache_control_headers, only: [:show]
-  before_filter :set_cache_max_age, only: [:show]
+  before_action :load_organisation, only: [:show]
+  before_action :set_organisation_slimmer_headers, only: [:show]
+  skip_before_action :set_cache_control_headers, only: [:show]
+  before_action :set_cache_max_age, only: [:show]
 
   def index
     @content_item = Whitehall.content_store.content_item("/government/organisations")

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -1,11 +1,11 @@
 class PublicFacingController < ApplicationController
   helper :all
 
-  before_filter :set_cache_control_headers
-  before_filter :restrict_request_formats
-  before_filter :set_x_frame_options
+  before_action :set_cache_control_headers
+  before_action :restrict_request_formats
+  before_action :set_x_frame_options
 
-  around_filter :set_locale
+  around_action :set_locale
 
   include LocalisedUrlPathHelper
 

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,8 +1,8 @@
 class PublicationsController < DocumentsController
   enable_request_formats index: [:json, :atom]
-  before_filter :expire_cache_when_next_publication_published
-  before_filter :redirect_statistics_filtering, only: [:index]
-  before_filter :redirect_statistics_documents, only: [:show]
+  before_action :expire_cache_when_next_publication_published
+  before_action :redirect_statistics_filtering, only: [:index]
+  before_action :redirect_statistics_documents, only: [:show]
 
   def index
     @filter = build_document_filter

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,7 +1,7 @@
 class StatisticsController < DocumentsController
   enable_request_formats index: [:json, :atom]
-  before_filter :inject_statistics_publication_filter_option_param, only: :index
-  before_filter :expire_cache_when_next_publication_published
+  before_action :inject_statistics_publication_filter_option_param, only: :index
+  before_action :expire_cache_when_next_publication_published
 
   def index
     @filter = build_document_filter

--- a/app/controllers/world_location_news_articles_controller.rb
+++ b/app/controllers/world_location_news_articles_controller.rb
@@ -1,5 +1,5 @@
 class WorldLocationNewsArticlesController < DocumentsController
-  before_filter :set_analytics_format, only: :show
+  before_action :set_analytics_format, only: :show
 
   def show
     # so it can pretend to have orgs

--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -1,6 +1,6 @@
 class WorldLocationsController < PublicFacingController
   enable_request_formats index: [:json], show: [:atom, :json]
-  before_filter :load_world_location, only: :show
+  before_action :load_world_location, only: :show
 
   def index
     respond_to do |format|

--- a/app/controllers/worldwide_offices_controller.rb
+++ b/app/controllers/worldwide_offices_controller.rb
@@ -1,5 +1,5 @@
 class WorldwideOfficesController < PublicFacingController
-  before_filter :load_worldwide_organisation
+  before_action :load_worldwide_organisation
 
   def show
     @worldwide_office = @worldwide_organisation.offices.find(params[:id])

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -1,7 +1,7 @@
 class WorldwideOrganisationsController < PublicFacingController
   include CacheControlHelper
   enable_request_formats show: :json
-  before_filter :load_worldwide_organisation
+  before_action :load_worldwide_organisation
 
   respond_to :html, :json
 


### PR DESCRIPTION
This commit replaces the deprecated `before_filter`, `after_filter` and friends with the equivalent `before_action`, `after_action` and similar methods.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails