### PR TITLE
Replace “text” with “plain” for rendering text

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -212,7 +212,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
     if params[:lock_version]
       @edition.lock_version = params[:lock_version]
     else
-      render text: 'All workflow actions require a lock version', status: 422
+      render plain: 'All workflow actions require a lock version', status: 422
     end
   end
 

--- a/app/controllers/admin/fact_check_requests_controller.rb
+++ b/app/controllers/admin/fact_check_requests_controller.rb
@@ -68,7 +68,7 @@ private
     if @fact_check_request
       @edition = Edition.unscoped.find(@fact_check_request.edition_id)
     else
-      render text: "Not found", status: :not_found
+      render plain: "Not found", status: :not_found
     end
   end
 

--- a/app/controllers/admin/find_in_admin_bookmarklet_controller.rb
+++ b/app/controllers/admin/find_in_admin_bookmarklet_controller.rb
@@ -4,7 +4,7 @@ class Admin::FindInAdminBookmarkletController < Admin::BaseController
     when "ie", "other" then
       render params[:browser]
     else
-      render text: "Not found", status: :not_found
+      render plain: "Not found", status: :not_found
     end
   end
 

--- a/app/controllers/admin/preview_controller.rb
+++ b/app/controllers/admin/preview_controller.rb
@@ -8,7 +8,7 @@ class Admin::PreviewController < Admin::BaseController
       @alternative_format_contact_email = alternative_format_contact_email
       render layout: false
     else
-      render text: "Content contains possible XSS exploits", status: :forbidden
+      render plain: "Content contains possible XSS exploits", status: :forbidden
     end
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -83,6 +83,6 @@ private
   end
 
   def reject_non_previewable_attachments
-    render(text: "Not found", status: :not_found) unless attachment_data.csv?
+    render(plain: "Not found", status: :not_found) unless attachment_data.csv?
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -44,7 +44,7 @@ private
         end
       else
         expires_in 5.minutes, public: true
-        render text: "Not found", status: :not_found
+        render plain: "Not found", status: :not_found
       end
     end
   end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -5,7 +5,7 @@ class HistoriesController < PublicFacingController
     if valid_names.include?(params[:id])
       render template: "histories/#{params[:id].underscore}"
     else
-      render text: "Not found", status: :not_found
+      render plain: "Not found", status: :not_found
     end
   end
 

--- a/app/controllers/past_foreign_secretaries_controller.rb
+++ b/app/controllers/past_foreign_secretaries_controller.rb
@@ -5,7 +5,7 @@ class PastForeignSecretariesController < PublicFacingController
     if valid_names.include?(params[:id])
       render template: "past_foreign_secretaries/#{params[:id].underscore}"
     else
-      render text: "Not found", status: :not_found
+      render plain: "Not found", status: :not_found
     end
   end
 

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -42,14 +42,14 @@ class PublicFacingController < ApplicationController
   end
 
   def render_not_found
-    render text: "Not found", status: :not_found
+    render plain: "Not found", status: :not_found
   end
 
   private
 
   def log_error_and_render_500(exception)
     logger.error "\n#{exception.class} (#{exception.message}):\n#{exception.backtrace.join("\n")}\n\n"
-    render text: 'API Timed Out', status: :internal_server_error
+    render plain: 'API Timed Out', status: :internal_server_error
   end
 
   def set_locale(&block)
@@ -62,7 +62,7 @@ class PublicFacingController < ApplicationController
 
   def restrict_request_formats
     unless can_handle_format?(request.format)
-      render status: :not_acceptable, text: "Request format #{request.format} not handled."
+      render status: :not_acceptable, plain: "Request format #{request.format} not handled."
     end
   end
 

--- a/app/controllers/public_uploads_controller.rb
+++ b/app/controllers/public_uploads_controller.rb
@@ -19,7 +19,7 @@ class PublicUploadsController < ApplicationController
       if incoming_upload_exists? upload_path
         redirect_to_placeholder
       else
-        render text: "Not found", status: :not_found
+        render plain: "Not found", status: :not_found
       end
     end
   end

--- a/test/functional/application_controller_analytics_test.rb
+++ b/test/functional/application_controller_analytics_test.rb
@@ -8,12 +8,12 @@ class ApplicationControllerAnalyticsTest < ActionController::TestCase
     def test_organisations
       orgs = [Organisation.new("D1"), Organisation.new("D2")]
       set_slimmer_organisations_header(orgs)
-      render text: "ok"
+      render plain: "ok"
     end
 
     def test_format
       set_slimmer_format_header("format_name")
-      render text: "ok"
+      render plain: "ok"
     end
   end
 

--- a/test/functional/application_controller_search_parameters_test.rb
+++ b/test/functional/application_controller_search_parameters_test.rb
@@ -7,13 +7,13 @@ class ApplicationControllerSearchParametersTest < ActionController::TestCase
     def test_scoped
       org = Organisation.new("org1", true, "o1")
       set_slimmer_page_owner_header(org)
-      render text: "ok"
+      render plain: "ok"
     end
 
     def test_unscoped
       org = Organisation.new("org2", false, "o2")
       set_slimmer_page_owner_header(org)
-      render text: "ok"
+      render plain: "ok"
     end
   end
 

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -5,25 +5,25 @@ class PublicFacingControllerTest < ActionController::TestCase
     enable_request_formats json: :json, js_or_atom: [:js, :atom]
 
     def test
-      render text: 'ok'
+      render html: 'ok'
     end
 
     def locale
-      render text: I18n.locale.to_s
+      render html: I18n.locale.to_s
     end
 
     def json
       respond_to do |format|
-        format.html { render text: 'html' }
-        format.json { render text: '{}' }
+        format.html { render html: 'html' }
+        format.json { render html: '{}' }
       end
     end
 
     def js_or_atom
       respond_to do |format|
-        format.html  { render text: 'html' }
-        format.js    { render text: 'javascript' }
-        format.atom  { render text: 'atom' }
+        format.html  { render html: 'html' }
+        format.js    { render html: 'javascript' }
+        format.atom  { render html: 'atom' }
       end
     end
 

--- a/test/integration/csrf_test.rb
+++ b/test/integration/csrf_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CsrfTest < ActionController::TestCase
   class TestAdminController < Admin::BaseController
     def create
-      render text: 'OK'
+      render plain: 'OK'
     end
   end
   tests TestAdminController

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -72,7 +72,7 @@ class OrganisationHelperTest < ActionView::TestCase
 
   test 'organisation_count_paragraph includes the number of orgs in a filterable container' do
     orgs = [build(:organisation), build(:organisation)]
-    render text: organisation_count_paragraph(orgs)
+    render plain: organisation_count_paragraph(orgs)
     assert_select '.js-filter-count', text: '2'
   end
 


### PR DESCRIPTION
`render: plain` is replacing `render: text` for rendering plain text since `render: text` actually sent the response as `text/html` rather than `text/plain` and is now deprecated.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails