### PR TITLE
Inherit models from ApplicationRecord

### DIFF
--- a/app/models/about_page.rb
+++ b/app/models/about_page.rb
@@ -1,4 +1,4 @@
-class AboutPage < ActiveRecord::Base
+class AboutPage < ApplicationRecord
   include Searchable
   include PublishesToPublishingApi
 

--- a/app/models/access_and_opening_times.rb
+++ b/app/models/access_and_opening_times.rb
@@ -1,4 +1,4 @@
-class AccessAndOpeningTimes < ActiveRecord::Base
+class AccessAndOpeningTimes < ApplicationRecord
   belongs_to :accessible, polymorphic: true
 
   validates_with SafeHtmlValidator

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,5 @@
 # Abstract base class for Attachments.
-class Attachment < ActiveRecord::Base
+class Attachment < ApplicationRecord
   include HasContentId
   belongs_to :attachable, polymorphic: true
   has_one :attachment_source

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -1,6 +1,6 @@
 require 'pdf-reader'
 
-class AttachmentData < ActiveRecord::Base
+class AttachmentData < ApplicationRecord
   mount_uploader :file, AttachmentUploader, mount_on: :carrierwave_file
 
   has_many :attachments, inverse_of: :attachment_data

--- a/app/models/attachment_source.rb
+++ b/app/models/attachment_source.rb
@@ -1,3 +1,3 @@
-class AttachmentSource < ActiveRecord::Base
+class AttachmentSource < ApplicationRecord
   belongs_to :attachment
 end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,5 +1,5 @@
 # @abstract
-class Classification < ActiveRecord::Base
+class Classification < ApplicationRecord
   include Searchable
   include SimpleWorkflow
   include PublishesToPublishingApi

--- a/app/models/classification_featuring.rb
+++ b/app/models/classification_featuring.rb
@@ -1,4 +1,4 @@
-class ClassificationFeaturing < ActiveRecord::Base
+class ClassificationFeaturing < ApplicationRecord
   belongs_to :edition, inverse_of: :classification_featurings
   belongs_to :offsite_link
   belongs_to :classification, inverse_of: :classification_featurings

--- a/app/models/classification_featuring_image_data.rb
+++ b/app/models/classification_featuring_image_data.rb
@@ -1,4 +1,4 @@
-class ClassificationFeaturingImageData < ActiveRecord::Base
+class ClassificationFeaturingImageData < ApplicationRecord
   mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
 
   validates :file, presence: true, if: :image_changed?

--- a/app/models/classification_membership.rb
+++ b/app/models/classification_membership.rb
@@ -1,4 +1,4 @@
-class ClassificationMembership < ActiveRecord::Base
+class ClassificationMembership < ApplicationRecord
   belongs_to :edition
   belongs_to :classification, foreign_key: :classification_id, inverse_of: :classification_memberships
   belongs_to :topical_event, foreign_key: :classification_id

--- a/app/models/classification_policy.rb
+++ b/app/models/classification_policy.rb
@@ -1,3 +1,3 @@
-class ClassificationPolicy < ActiveRecord::Base
+class ClassificationPolicy < ApplicationRecord
   belongs_to :classification
 end

--- a/app/models/classification_relation.rb
+++ b/app/models/classification_relation.rb
@@ -1,4 +1,4 @@
-class ClassificationRelation < ActiveRecord::Base
+class ClassificationRelation < ApplicationRecord
   belongs_to :classification, inverse_of: :classification_relations
   belongs_to :related_classification, foreign_key: :related_classification_id, class_name: "Classification"
 

--- a/app/models/consultation_participation.rb
+++ b/app/models/consultation_participation.rb
@@ -1,4 +1,4 @@
-class ConsultationParticipation < ActiveRecord::Base
+class ConsultationParticipation < ApplicationRecord
   belongs_to :consultation, foreign_key: 'edition_id'
   belongs_to :consultation_response_form
   accepts_nested_attributes_for :consultation_response_form,

--- a/app/models/consultation_response_form.rb
+++ b/app/models/consultation_response_form.rb
@@ -1,4 +1,4 @@
-class ConsultationResponseForm < ActiveRecord::Base
+class ConsultationResponseForm < ApplicationRecord
   has_one :consultation_participation
   belongs_to :consultation_response_form_data
 

--- a/app/models/consultation_response_form_data.rb
+++ b/app/models/consultation_response_form_data.rb
@@ -1,4 +1,4 @@
-class ConsultationResponseFormData < ActiveRecord::Base
+class ConsultationResponseFormData < ApplicationRecord
   mount_uploader :file, ConsultationResponseFormUploader, mount_on: :carrierwave_file
 
   has_one :consultation_response_form

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,4 @@
-class Contact < ActiveRecord::Base
+class Contact < ApplicationRecord
   include Dependable
   include PublishesToPublishingApi
 

--- a/app/models/contact_number.rb
+++ b/app/models/contact_number.rb
@@ -1,4 +1,4 @@
-class ContactNumber < ActiveRecord::Base
+class ContactNumber < ApplicationRecord
   belongs_to :contact
   validates :label, :number, presence: true, length: { maximum: 255 }
 

--- a/app/models/data_migration_record.rb
+++ b/app/models/data_migration_record.rb
@@ -1,2 +1,2 @@
-class DataMigrationRecord < ActiveRecord::Base
+class DataMigrationRecord < ApplicationRecord
 end

--- a/app/models/default_news_organisation_image_data.rb
+++ b/app/models/default_news_organisation_image_data.rb
@@ -1,4 +1,4 @@
-class DefaultNewsOrganisationImageData < ActiveRecord::Base
+class DefaultNewsOrganisationImageData < ApplicationRecord
   mount_uploader :file, ImageUploader, mount_on: :carrierwave_image
   validates :file, presence: true
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,6 @@
 # All {Edition}s have one document, this model contains the slug and
 # handles the logic for slug regeneration.
-class Document < ActiveRecord::Base
+class Document < ApplicationRecord
   extend FriendlyId
 
   friendly_id :sluggable_string, use: :scoped, scope: :document_type

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -1,4 +1,4 @@
-class DocumentCollectionGroup < ActiveRecord::Base
+class DocumentCollectionGroup < ApplicationRecord
   belongs_to :document_collection, inverse_of: :groups, touch: true
   has_many :memberships,
            -> { order('document_collection_group_memberships.ordering') } ,

--- a/app/models/document_collection_group_membership.rb
+++ b/app/models/document_collection_group_membership.rb
@@ -1,4 +1,4 @@
-class DocumentCollectionGroupMembership < ActiveRecord::Base
+class DocumentCollectionGroupMembership < ApplicationRecord
   BANNED_DOCUMENT_TYPES = ["DocumentCollection"]
 
   belongs_to :document, inverse_of: :document_collection_group_memberships

--- a/app/models/document_source.rb
+++ b/app/models/document_source.rb
@@ -1,4 +1,4 @@
-class DocumentSource < ActiveRecord::Base
+class DocumentSource < ApplicationRecord
   belongs_to :document
 
   validates :url, presence: true, uniqueness: true, uri: true

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,6 +1,6 @@
 # The base class for almost all editoral content.
 # @abstract Using STI should not create editions directly.
-class Edition < ActiveRecord::Base
+class Edition < ApplicationRecord
   include Edition::Traits
 
   include Edition::NullImages

--- a/app/models/edition_author.rb
+++ b/app/models/edition_author.rb
@@ -1,4 +1,4 @@
-class EditionAuthor < ActiveRecord::Base
+class EditionAuthor < ApplicationRecord
   belongs_to :edition
   belongs_to :user
 end

--- a/app/models/edition_dependency.rb
+++ b/app/models/edition_dependency.rb
@@ -1,4 +1,4 @@
-class EditionDependency < ActiveRecord::Base
+class EditionDependency < ApplicationRecord
   belongs_to :edition
   belongs_to :dependable, polymorphic: true
 end

--- a/app/models/edition_organisation.rb
+++ b/app/models/edition_organisation.rb
@@ -1,4 +1,4 @@
-class EditionOrganisation < ActiveRecord::Base
+class EditionOrganisation < ApplicationRecord
   belongs_to :edition
   belongs_to :organisation, inverse_of: :edition_organisations
 

--- a/app/models/edition_policy.rb
+++ b/app/models/edition_policy.rb
@@ -1,2 +1,2 @@
-class EditionPolicy < ActiveRecord::Base
+class EditionPolicy < ApplicationRecord
 end

--- a/app/models/edition_relation.rb
+++ b/app/models/edition_relation.rb
@@ -1,4 +1,4 @@
-class EditionRelation < ActiveRecord::Base
+class EditionRelation < ApplicationRecord
   belongs_to :edition
   belongs_to :document, inverse_of: :edition_relations
 

--- a/app/models/edition_role_appointment.rb
+++ b/app/models/edition_role_appointment.rb
@@ -1,4 +1,4 @@
-class EditionRoleAppointment < ActiveRecord::Base
+class EditionRoleAppointment < ApplicationRecord
   belongs_to :edition
   belongs_to :role_appointment
 end

--- a/app/models/edition_statistical_data_set.rb
+++ b/app/models/edition_statistical_data_set.rb
@@ -1,4 +1,4 @@
-class EditionStatisticalDataSet < ActiveRecord::Base
+class EditionStatisticalDataSet < ApplicationRecord
   belongs_to :edition
   belongs_to :document
 end

--- a/app/models/edition_world_location.rb
+++ b/app/models/edition_world_location.rb
@@ -1,4 +1,4 @@
-class EditionWorldLocation < ActiveRecord::Base
+class EditionWorldLocation < ApplicationRecord
   belongs_to :edition
   belongs_to :world_location, inverse_of: :edition_world_locations
 

--- a/app/models/edition_worldwide_organisation.rb
+++ b/app/models/edition_worldwide_organisation.rb
@@ -1,4 +1,4 @@
-class EditionWorldwideOrganisation < ActiveRecord::Base
+class EditionWorldwideOrganisation < ApplicationRecord
   belongs_to :edition
   belongs_to :worldwide_organisation, inverse_of: :edition_worldwide_organisations
 

--- a/app/models/editorial_remark.rb
+++ b/app/models/editorial_remark.rb
@@ -1,4 +1,4 @@
-class EditorialRemark < ActiveRecord::Base
+class EditorialRemark < ApplicationRecord
   belongs_to :edition
   belongs_to :author, class_name: "User"
 

--- a/app/models/fact_check_request.rb
+++ b/app/models/fact_check_request.rb
@@ -1,4 +1,4 @@
-class FactCheckRequest < ActiveRecord::Base
+class FactCheckRequest < ApplicationRecord
   include Whitehall::RandomKey
   self.random_key_length = 16
 

--- a/app/models/fatality_notice_casualty.rb
+++ b/app/models/fatality_notice_casualty.rb
@@ -1,4 +1,4 @@
-class FatalityNoticeCasualty < ActiveRecord::Base
+class FatalityNoticeCasualty < ApplicationRecord
   belongs_to :fatality_notice
   validates :personal_details, presence: true
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,4 +1,4 @@
-class Feature < ActiveRecord::Base
+class Feature < ApplicationRecord
   belongs_to :document
   belongs_to :topical_event
   belongs_to :offsite_link

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,4 +1,4 @@
-class FeatureFlag < ActiveRecord::Base
+class FeatureFlag < ApplicationRecord
   def self.set(key, value)
     flag = find_by!(key: key)
     flag.update(enabled: value)

--- a/app/models/feature_list.rb
+++ b/app/models/feature_list.rb
@@ -1,4 +1,4 @@
-class FeatureList < ActiveRecord::Base
+class FeatureList < ApplicationRecord
   has_many :features, -> { order(:ordering) }, dependent: :destroy, before_add: :ensure_ordering!
   belongs_to :featurable, polymorphic: true
 

--- a/app/models/featured_link.rb
+++ b/app/models/featured_link.rb
@@ -1,4 +1,4 @@
-class FeaturedLink < ActiveRecord::Base
+class FeaturedLink < ApplicationRecord
   extend ActiveSupport::Concern
 
   DEFAULT_SET_SIZE = 5

--- a/app/models/featured_policy.rb
+++ b/app/models/featured_policy.rb
@@ -1,4 +1,4 @@
-class FeaturedPolicy < ActiveRecord::Base
+class FeaturedPolicy < ApplicationRecord
   extend ActiveSupport::Concern
 
   belongs_to :organisation, inverse_of: :featured_policies, touch: true

--- a/app/models/financial_report.rb
+++ b/app/models/financial_report.rb
@@ -1,4 +1,4 @@
-class FinancialReport < ActiveRecord::Base
+class FinancialReport < ApplicationRecord
   belongs_to :organisation
   validates_associated :organisation
 

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -1,4 +1,4 @@
-class Government < ActiveRecord::Base
+class Government < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :start_date, presence: true

--- a/app/models/govspeak_content.rb
+++ b/app/models/govspeak_content.rb
@@ -1,4 +1,4 @@
-class GovspeakContent < ActiveRecord::Base
+class GovspeakContent < ApplicationRecord
   belongs_to :html_attachment, inverse_of: :govspeak_content
 
   validates :body, :html_attachment, presence: true

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -1,4 +1,4 @@
-class HistoricalAccount < ActiveRecord::Base
+class HistoricalAccount < ApplicationRecord
   belongs_to :person, inverse_of: :historical_accounts
   has_many   :historical_account_roles
   has_many   :roles, through: :historical_account_roles

--- a/app/models/historical_account_role.rb
+++ b/app/models/historical_account_role.rb
@@ -1,4 +1,4 @@
-class HistoricalAccountRole < ActiveRecord::Base
+class HistoricalAccountRole < ApplicationRecord
   belongs_to :role
   belongs_to :historical_account
 end

--- a/app/models/home_page_list.rb
+++ b/app/models/home_page_list.rb
@@ -1,4 +1,4 @@
-class HomePageList < ActiveRecord::Base
+class HomePageList < ApplicationRecord
   belongs_to :owner,
              polymorphic: true
   validates :owner, presence: true

--- a/app/models/home_page_list_item.rb
+++ b/app/models/home_page_list_item.rb
@@ -1,4 +1,4 @@
-class HomePageListItem < ActiveRecord::Base
+class HomePageListItem < ApplicationRecord
   belongs_to :home_page_list
   belongs_to :item, polymorphic: true
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,4 @@
-class Image < ActiveRecord::Base
+class Image < ApplicationRecord
   belongs_to :image_data
   belongs_to :edition
 

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -1,6 +1,6 @@
 require 'mini_magick'
 
-class ImageData < ActiveRecord::Base
+class ImageData < ApplicationRecord
   has_many :images
 
   mount_uploader :file, ImageUploader, mount_on: :carrierwave_image

--- a/app/models/links_report.rb
+++ b/app/models/links_report.rb
@@ -1,4 +1,4 @@
-class LinksReport < ActiveRecord::Base
+class LinksReport < ApplicationRecord
   serialize :links, Array
   serialize :broken_links, Array
 

--- a/app/models/nation_inapplicability.rb
+++ b/app/models/nation_inapplicability.rb
@@ -1,4 +1,4 @@
-class NationInapplicability < ActiveRecord::Base
+class NationInapplicability < ApplicationRecord
   delegate :name, to: :nation
 
   belongs_to :edition

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,4 +1,4 @@
-class OffsiteLink < ActiveRecord::Base
+class OffsiteLink < ApplicationRecord
   module LinkTypes
     def self.all
       @types ||= %w(alert blog_post campaign careers manual nhs_content service)

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -1,4 +1,4 @@
-class OperationalField < ActiveRecord::Base
+class OperationalField < ApplicationRecord
   include PublishesToPublishingApi
   include Searchable
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,4 @@
-class Organisation < ActiveRecord::Base
+class Organisation < ApplicationRecord
   include PublishesToPublishingApi
   include Searchable
   include MinisterialRole::MinisterialRoleReindexingConcern

--- a/app/models/organisation_classification.rb
+++ b/app/models/organisation_classification.rb
@@ -1,4 +1,4 @@
-class OrganisationClassification < ActiveRecord::Base
+class OrganisationClassification < ApplicationRecord
   belongs_to :organisation
 
   # DID YOU MEAN: Policy Area?

--- a/app/models/organisation_role.rb
+++ b/app/models/organisation_role.rb
@@ -1,4 +1,4 @@
-class OrganisationRole < ActiveRecord::Base
+class OrganisationRole < ApplicationRecord
   include MinisterialRole::MinisterialRoleReindexingConcern
 
   belongs_to :organisation, inverse_of: :organisation_roles

--- a/app/models/organisational_relationship.rb
+++ b/app/models/organisational_relationship.rb
@@ -1,4 +1,4 @@
-class OrganisationalRelationship < ActiveRecord::Base
+class OrganisationalRelationship < ApplicationRecord
   belongs_to :parent_organisation, class_name: "Organisation"
   belongs_to :child_organisation, class_name: "Organisation"
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,4 @@
-class Person < ActiveRecord::Base
+class Person < ApplicationRecord
   include PublishesToPublishingApi
   include Searchable
   include MinisterialRole::MinisterialRoleReindexingConcern

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -1,4 +1,4 @@
-class PolicyGroup < ActiveRecord::Base
+class PolicyGroup < ApplicationRecord
   include Searchable
   include ::Attachable
   include PublishesToPublishingApi

--- a/app/models/promotional_feature.rb
+++ b/app/models/promotional_feature.rb
@@ -1,4 +1,4 @@
-class PromotionalFeature < ActiveRecord::Base
+class PromotionalFeature < ApplicationRecord
   belongs_to :organisation
   has_many :promotional_feature_items, inverse_of: :promotional_feature, dependent: :destroy
 

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -1,4 +1,4 @@
-class PromotionalFeatureItem < ActiveRecord::Base
+class PromotionalFeatureItem < ApplicationRecord
   belongs_to :promotional_feature, inverse_of: :promotional_feature_items
   has_one :organisation, through: :promotional_feature
   has_many :links, class_name: 'PromotionalFeatureLink', dependent: :destroy, inverse_of: :promotional_feature_item

--- a/app/models/promotional_feature_link.rb
+++ b/app/models/promotional_feature_link.rb
@@ -1,4 +1,4 @@
-class PromotionalFeatureLink < ActiveRecord::Base
+class PromotionalFeatureLink < ApplicationRecord
   belongs_to :promotional_feature_item, inverse_of: :links
 
   validates :url, presence: true, uri: true

--- a/app/models/recent_edition_opening.rb
+++ b/app/models/recent_edition_opening.rb
@@ -1,4 +1,4 @@
-class RecentEditionOpening < ActiveRecord::Base
+class RecentEditionOpening < ApplicationRecord
   belongs_to :edition
   belongs_to :editor, class_name: "User"
 

--- a/app/models/related_mainstream.rb
+++ b/app/models/related_mainstream.rb
@@ -1,4 +1,4 @@
-class RelatedMainstream < ActiveRecord::Base
+class RelatedMainstream < ApplicationRecord
   belongs_to :edition, foreign_key: :edition_id
   validates :content_id, presence: true, uniqueness: {scope: :edition_id}
   validates :edition_id, presence: true

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,4 +1,4 @@
-class Response < ActiveRecord::Base
+class Response < ApplicationRecord
   include Attachable
 
   belongs_to :consultation, foreign_key: :edition_id

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,5 @@
 # @abstract
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   include HasContentId
   HISTORIC_ROLE_PARAM_MAPPINGS = { 'past-prime-ministers' => 'prime-minister',
                                    'past-chancellors'     => 'chancellor-of-the-exchequer',

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -1,4 +1,4 @@
-class RoleAppointment < ActiveRecord::Base
+class RoleAppointment < ApplicationRecord
   include MinisterialRole::MinisterialRoleReindexingConcern
 
   CURRENT_CONDITION = {ended_at: nil}

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -1,4 +1,4 @@
-class SitewideSetting < ActiveRecord::Base
+class SitewideSetting < ApplicationRecord
   validates :govspeak, presence: true, if: :on
   validates :key, presence: true
   validates_uniqueness_of :key

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -1,4 +1,4 @@
-class SocialMediaAccount < ActiveRecord::Base
+class SocialMediaAccount < ApplicationRecord
   belongs_to :socialable, polymorphic: true
   belongs_to :social_media_service
 

--- a/app/models/social_media_service.rb
+++ b/app/models/social_media_service.rb
@@ -1,3 +1,3 @@
-class SocialMediaService < ActiveRecord::Base
+class SocialMediaService < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/specialist_sector.rb
+++ b/app/models/specialist_sector.rb
@@ -3,7 +3,7 @@
 # (https://www.gov.uk/government/topics)
 # "Topic" is the newer name for "specialist sector"
 # (https://www.gov.uk/topic)
-class SpecialistSector < ActiveRecord::Base
+class SpecialistSector < ApplicationRecord
   belongs_to :edition
 
   validates :edition, presence: true

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -1,4 +1,4 @@
-class Sponsorship < ActiveRecord::Base
+class Sponsorship < ApplicationRecord
   belongs_to :organisation
   belongs_to :worldwide_organisation
 end

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -10,7 +10,7 @@
 # the index page is still rendered from Whitehall.
 #
 # Statistics announcements are not versioned/editioned.
-class StatisticsAnnouncement < ActiveRecord::Base
+class StatisticsAnnouncement < ApplicationRecord
   extend FriendlyId
   friendly_id :title
   include PublishesToPublishingApi

--- a/app/models/statistics_announcement_date.rb
+++ b/app/models/statistics_announcement_date.rb
@@ -1,4 +1,4 @@
-class StatisticsAnnouncementDate < ActiveRecord::Base
+class StatisticsAnnouncementDate < ApplicationRecord
   PRECISION = { exact: 0, one_month: 1, two_month: 2 }
 
   belongs_to :statistics_announcement, touch: true

--- a/app/models/statistics_announcement_organisation.rb
+++ b/app/models/statistics_announcement_organisation.rb
@@ -1,4 +1,4 @@
-class StatisticsAnnouncementOrganisation < ActiveRecord::Base
+class StatisticsAnnouncementOrganisation < ApplicationRecord
   belongs_to :statistics_announcement, inverse_of: :statistics_announcement_organisations
   belongs_to :organisation, inverse_of: :statistics_announcement_organisations
 

--- a/app/models/statistics_announcement_topic.rb
+++ b/app/models/statistics_announcement_topic.rb
@@ -1,4 +1,4 @@
-class StatisticsAnnouncementTopic < ActiveRecord::Base
+class StatisticsAnnouncementTopic < ApplicationRecord
   belongs_to :statistics_announcement, inverse_of: :statistics_announcement_topics
 
   # DID YOU MEAN: Policy Area?

--- a/app/models/sync_check_result.rb
+++ b/app/models/sync_check_result.rb
@@ -1,4 +1,4 @@
-class SyncCheckResult < ActiveRecord::Base
+class SyncCheckResult < ApplicationRecord
   # Used to store results of Sync Checks when running migrations. The check_class
   # will be one from the `SyncChecker::Formats` namespace. This is a developer-only
   # model, and will be used to drive a dashboard that measures the progress of

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -1,4 +1,4 @@
-class TakePartPage < ActiveRecord::Base
+class TakePartPage < ApplicationRecord
 
   validates_with SafeHtmlValidator
   validates :title, :summary, presence: true, length: { maximum: 255 }

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -1,6 +1,6 @@
 require "securerandom"
 
-class Unpublishing < ActiveRecord::Base
+class Unpublishing < ApplicationRecord
   belongs_to :edition
 
   validates :edition, :unpublishing_reason, :document_type, :slug, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   # This stops the attr_accessible call in the SSO module messing things up
   extend AttrAccessibleNoop
   include GDS::SSO::User

--- a/app/models/user_world_location.rb
+++ b/app/models/user_world_location.rb
@@ -1,4 +1,4 @@
-class UserWorldLocation < ActiveRecord::Base
+class UserWorldLocation < ApplicationRecord
   belongs_to :user
   belongs_to :world_location
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,4 +1,4 @@
-class Version < ActiveRecord::Base
+class Version < ApplicationRecord
   belongs_to :item, polymorphic: true
   validates_presence_of :event
   belongs_to :user, foreign_key: 'whodunnit'

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,4 +1,4 @@
-class WorldLocation < ActiveRecord::Base
+class WorldLocation < ApplicationRecord
   has_many :edition_world_locations, inverse_of: :world_location
   has_many :editions,
             through: :edition_world_locations

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -1,4 +1,4 @@
-class WorldwideOffice < ActiveRecord::Base
+class WorldwideOffice < ApplicationRecord
   has_one :contact, as: :contactable, dependent: :destroy
   belongs_to :worldwide_organisation
   has_many :worldwide_office_worldwide_services, dependent: :destroy, inverse_of: :worldwide_office

--- a/app/models/worldwide_office_worldwide_service.rb
+++ b/app/models/worldwide_office_worldwide_service.rb
@@ -1,4 +1,4 @@
-class WorldwideOfficeWorldwideService < ActiveRecord::Base
+class WorldwideOfficeWorldwideService < ApplicationRecord
 
   belongs_to :worldwide_office, inverse_of: :worldwide_office_worldwide_services
   belongs_to :worldwide_service, inverse_of: :worldwide_office_worldwide_services

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -1,4 +1,4 @@
-class WorldwideOrganisation < ActiveRecord::Base
+class WorldwideOrganisation < ApplicationRecord
   include HasCorporateInformationPages
 
   PRIMARY_ROLES = [AmbassadorRole, HighCommissionerRole, GovernorRole]

--- a/app/models/worldwide_organisation_role.rb
+++ b/app/models/worldwide_organisation_role.rb
@@ -1,4 +1,4 @@
-class WorldwideOrganisationRole < ActiveRecord::Base
+class WorldwideOrganisationRole < ApplicationRecord
   belongs_to :worldwide_organisation
   belongs_to :role
 

--- a/app/models/worldwide_organisation_world_location.rb
+++ b/app/models/worldwide_organisation_world_location.rb
@@ -1,4 +1,4 @@
-class WorldwideOrganisationWorldLocation < ActiveRecord::Base
+class WorldwideOrganisationWorldLocation < ApplicationRecord
   belongs_to :worldwide_organisation
   belongs_to :world_location
 end

--- a/app/models/worldwide_service.rb
+++ b/app/models/worldwide_service.rb
@@ -1,4 +1,4 @@
-class WorldwideService < ActiveRecord::Base
+class WorldwideService < ApplicationRecord
 
   validates :name, :service_type_id, presence: true
   has_many :worldwide_office_worldwide_services, dependent: :destroy, inverse_of: :worldwide_service

--- a/db/migrate/20140820093930_update_attachment_legislative_list_syntax.rb
+++ b/db/migrate/20140820093930_update_attachment_legislative_list_syntax.rb
@@ -1,5 +1,5 @@
 class UpdateAttachmentLegislativeListSyntax < ActiveRecord::Migration
-  class Attachment < ActiveRecord::Base; end
+  class Attachment < ApplicationRecord; end
 
   def self.fix_attachment(attachment)
     # This regex is the one used for matching legislative lists in the previous

--- a/db/migrate/20141020094819_create_featured_links.rb
+++ b/db/migrate/20141020094819_create_featured_links.rb
@@ -1,8 +1,8 @@
 class CreateFeaturedLinks < ActiveRecord::Migration
-  class FeaturedServicesAndGuidance < ActiveRecord::Base
+  class FeaturedServicesAndGuidance < ApplicationRecord
     self.table_name = :featured_services_and_guidance
   end
-  class TopTasks < ActiveRecord::Base
+  class TopTasks < ApplicationRecord
   end
 
   def up

--- a/db/migrate/20141020104406_add_homepage_type_to_organisation.rb
+++ b/db/migrate/20141020104406_add_homepage_type_to_organisation.rb
@@ -1,5 +1,5 @@
 class AddHomepageTypeToOrganisation < ActiveRecord::Migration
-  class FeaturedServicesAndGuidance < ActiveRecord::Base
+  class FeaturedServicesAndGuidance < ApplicationRecord
     self.table_name = :featured_services_and_guidance
   end
 

--- a/test/unit/searchable_test.rb
+++ b/test/unit/searchable_test.rb
@@ -4,7 +4,7 @@ class SearchableTest < ActiveSupport::TestCase
   # re-using an existing table to make these tests much clearer
   # as all the searchable definition is in one place (and it doesn't
   # lend itself to redefinition)
-  class SearchableTestTopic < ActiveRecord::Base
+  class SearchableTestTopic < ApplicationRecord
     self.table_name = 'classifications'
 
     include Searchable


### PR DESCRIPTION
This commit changes all models to inherit from the new `ApplicationRecord` rather than directly from `ActiveRecord::Base`. This is a precursor to the Rails 5 upgrade.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails