### PR TITLE
Pass strings rather than classes to ActiveRecord

### DIFF
--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -163,7 +163,7 @@ module Admin::TaggableContentHelper
     @_taggable_ministerial_role_appointments_cache_digest ||= begin
       calculate_digest(RoleAppointment.
                         joins(:role).
-                        where(roles: { type: MinisterialRole}).
+                        where(roles: { type: "MinisterialRole" }).
                         order("role_appointments.id"), 'ministerial-role-appointments')
     end
   end
@@ -185,19 +185,19 @@ module Admin::TaggableContentHelper
   # Returns an MD5 digest representing all the detailed guides. This wil change
   # if any detailed guides are added or updated.
   def taggable_detailed_guides_cache_digest
-    @_taggable_detailed_guides_cache_digest ||= calculate_digest(Document.where(document_type: DetailedGuide).order(:id), 'detailed-guides')
+    @_taggable_detailed_guides_cache_digest ||= calculate_digest(Document.where(document_type: "DetailedGuide").order(:id), 'detailed-guides')
   end
 
   # Returns an MD5 digest representing the taggable statistical data sets. This
   # will change if any statistical data set is added or updated.
   def taggable_statistical_data_sets_cache_digest
-    @_taggable_statistical_data_sets_cache_digest ||= calculate_digest(Document.where(document_type: StatisticalDataSet).order(:id), 'statistical-data-sets')
+    @_taggable_statistical_data_sets_cache_digest ||= calculate_digest(Document.where(document_type: "StatisticalDataSet").order(:id), 'statistical-data-sets')
   end
 
   # Returns an MD5 digest representing the taggable policies. This will change
   # if any policies are added or updated.
   def taggable_policies_cache_digest
-    @_taggable_policies_cache_digest ||= calculate_digest(Document.where(document_type: Policy).order(:id), 'policies')
+    @_taggable_policies_cache_digest ||= calculate_digest(Document.where(document_type: "Policy").order(:id), 'policies')
   end
 
   # Returns an MD5 digest representing the taggable world locations. This will
@@ -217,7 +217,7 @@ module Admin::TaggableContentHelper
   # groups. This will change if any document collection or group within
   # the collection is changed or any new ones are added.
   def taggable_document_collection_groups_cache_digest
-    @_taggable_document_collection_groups_cache_digest ||= calculate_digest(Document.where(document_type: DocumentCollection).order(:id), 'document-collection-groups')
+    @_taggable_document_collection_groups_cache_digest ||= calculate_digest(Document.where(document_type: "DocumentCollection").order(:id), 'document-collection-groups')
   end
 
   # Returns an MD5 digest representing the taggable worldwide organisations.

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -115,7 +115,7 @@ module Attachable
   end
 
   def next_ordering
-    max = Attachment.where(attachable_id: id, attachable_type: self.class.base_class).maximum(:ordering)
+    max = Attachment.where(attachable_id: id, attachable_type: self.class.base_class.to_s).maximum(:ordering)
     max ? max + 1 : 0
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -57,6 +57,7 @@ class Document < ApplicationRecord
   end
 
   def self.at_slug(document_types, slug)
+    document_types = Array(document_types).map(&:to_s)
     where(document_type: document_types, slug: slug).first
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -170,7 +170,7 @@ class Edition < ApplicationRecord
 
   # used by Admin::EditionFilter
   def self.by_type(type)
-    where(type: type)
+    where(type: type.to_s)
   end
 
   # used by Admin::EditionFilter

--- a/app/models/home_page_list.rb
+++ b/app/models/home_page_list.rb
@@ -20,7 +20,7 @@ class HomePageList < ApplicationRecord
     name = opts[:called]
     build_if_missing = opts.has_key?(:build_if_missing) ? opts[:build_if_missing] : true
     raise ArgumentError, "Must supply owned_by: and called: options" if (owner.nil? || name.nil?)
-    scoping = where(owner_id: owner.id, owner_type: owner.class, name: name)
+    scoping = where(owner_id: owner.id, owner_type: owner.class.to_s, name: name)
     if list = scoping.first
       list
     elsif build_if_missing
@@ -43,7 +43,7 @@ class HomePageList < ApplicationRecord
 
   def remove_item(item)
     persist_if_required
-    home_page_list_items.where(item_id: item.id, item_type: item.class).destroy_all
+    home_page_list_items.where(item_id: item.id, item_type: item.class.to_s).destroy_all
   end
 
   def reorder_items!(items_in_order)

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -3,8 +3,8 @@ class MinisterialRole < Role
   include PublishesToPublishingApi
 
   has_many :editions, -> { uniq }, through: :role_appointments
-  has_many :consultations, -> { where("editions.type" => Consultation).uniq }, through: :role_appointments
-  has_many :news_articles, -> { where("editions.type" => NewsArticle).uniq }, through: :role_appointments
+  has_many :consultations, -> { where("editions.type" => "Consultation").uniq }, through: :role_appointments
+  has_many :news_articles, -> { where("editions.type" => "NewsArticle").uniq }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
   def published_policies

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -8,15 +8,15 @@ class RoleAppointment < ApplicationRecord
 
   # All this nonsense is because of all the intermediary associations
   has_many :consultations,
-            ->  { where("editions.type" => Consultation) },
+            -> { where("editions.type" => "Consultation") },
             through: :edition_role_appointments,
             source: :edition
   has_many :publications,
-            ->  { where("editions.type" => Publication) },
+            -> { where("editions.type" => "Publication") },
             through: :edition_role_appointments,
             source: :edition
   has_many :news_articles,
-            ->  { where("editions.type" => NewsArticle) },
+            -> { where("editions.type" => "NewsArticle") },
             through: :edition_role_appointments,
             source: :edition
 


### PR DESCRIPTION
Rails 5 deprecates the passing of classes to ActiveRecord. In preparation for that upgrade, this commit changes code to pass strings instead.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails