### PR TITLE
Remove test_track gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,6 @@ group :test do
   gem 'webmock', '~> 2.1', require: false
   gem 'ci_reporter_minitest'
   gem 'database_cleaner', '1.4.0'
-  gem 'test_track', '~> 0.1.0', git: 'https://github.com/alphagov/test_track'
   gem 'govuk-content-schema-test-helpers', '1.4.0'
   gem 'minitest-fail-fast'
   gem 'maxitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/test_track
-  revision: 1f997082e2f1be94274d294c2f8d34ab0b21bb7f
-  specs:
-    test_track (0.1.0)
-      rails (>= 3.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -532,7 +525,6 @@ DEPENDENCIES
   stackprof
   statsd-ruby (~> 1.2.1)
   test-queue (= 0.2.11)
-  test_track (~> 0.1.0)!
   timecop
   transitions
   typhoeus (~> 1.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,6 +59,5 @@ Whitehall::Application.configure do
 end
 
 require Rails.root.join("test/support/skip_slimmer")
-TestTrack.application_manifest = "all"
 
 Whitehall.skip_safe_html_validation = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,4 @@ Whitehall::Application.routes.draw do
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "attachments#preview", as: :preview_attachment
   get '/government/uploads/*path.:extension' => "public_uploads#show", as: :public_upload
-
-  mount TestTrack::Engine => "test" if Rails.env.test?
 end


### PR DESCRIPTION
The `test_track` gem has not been updated for a long time and is not compatible with Rails 5. This commit removes the gem since it is not required for the JavaScript tests to run.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails