### PR TITLE
Use named parameters for cucumber assertions

### DIFF
--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -209,33 +209,33 @@ end
 
 Then /^I should see in the preview that "([^"]*)" should be in the "([^"]*)" and "([^"]*)" topics$/ do |title, first_topic, second_topic|
   visit_document_preview title
-  assert has_css?(".meta a", text: first_topic, exact: false)
-  assert has_css?(".meta a", text: second_topic, exact: false)
+  assert has_css?(".meta a", text: first_topic)
+  assert has_css?(".meta a", text: second_topic)
 end
 
 Then /^I should see in the preview that "([^"]*)" was produced by the "([^"]*)" and "([^"]*)" organisations$/ do |title, first_org, second_org|
   visit_document_preview title
-  assert has_css?(".meta a", text: first_org, exact: false)
-  assert has_css?(".meta a", text: second_org, exact: false)
+  assert has_css?(".meta a", text: first_org)
+  assert has_css?(".meta a", text: second_org)
 end
 
 Then /^I should see in the preview that "([^"]*)" is associated with "([^"]*)" and "([^"]*)"$/ do |title, minister_1, minister_2|
   visit_document_preview title
-  assert has_css?(".meta a", text: minister_1, exact: false)
-  assert has_css?(".meta a", text: minister_2, exact: false)
+  assert has_css?(".meta a", text: minister_1)
+  assert has_css?(".meta a", text: minister_2)
 end
 
 Then /^I should see in the preview that "([^"]*)" does not apply to the nations:$/ do |title, nation_names|
   visit_document_preview title
   nation_names.raw.flatten.each do |nation_name|
-    assert has_css?(".meta", text: nation_name, exact: false)
+    assert has_css?(".meta", text: nation_name)
   end
 end
 
 Then /^I should see in the preview that "([^"]*)" should related to "([^"]*)" and "([^"]*)" policies$/ do |title, related_policy_1, related_policy_2|
   visit_document_preview title
-  assert has_css?(".meta a", text: related_policy_1, exact: false)
-  assert has_css?(".meta a", text: related_policy_2, exact: false)
+  assert has_css?(".meta a", text: related_policy_1)
+  assert has_css?(".meta a", text: related_policy_2)
 end
 
 Then /^I should see the conflict between the (publication|policy|news article|consultation|speech) titles "([^"]*)" and "([^"]*)"$/ do |document_type, new_title, latest_title|

--- a/features/step_definitions/latest_document_steps.rb
+++ b/features/step_definitions/latest_document_steps.rb
@@ -29,7 +29,7 @@ end
 
 Then /^I can see a link back to the topical event page$/ do
   topical_event_page = topical_event_path(@topical_event)
-  assert page.has_link?(@topical_event.name, topical_event_page)
+  assert page.has_link?(@topical_event.name, href: topical_event_page)
 end
 
 Then /^I can see links to get alerts$/ do

--- a/features/step_definitions/minister_steps.rb
+++ b/features/step_definitions/minister_steps.rb
@@ -50,7 +50,7 @@ end
 
 Then /^I should see that the minister is associated with the "([^"]*)"$/ do |organisation_name|
   organisation = Organisation.find_by!(name: organisation_name)
-  assert page.has_css?('.meta', /organisation was missing/)
+  assert page.has_css?('.meta', text: organisation_name)
 end
 
 Then /^I should see that the minister has responsibilities "([^"]*)"$/ do |responsibilities|

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -428,7 +428,7 @@ end
 Then /^the featured links for the organisation "([^"]*)" should be visible on the public site$/ do |organisation_name|
   visit_organisation organisation_name
   within ".featured-links" do
-    assert page.has_css?("a[href='https://www.gov.uk/mainstream/tool-alpha']", "Tool Alpha")
+    assert page.has_css?("a[href='https://www.gov.uk/mainstream/tool-alpha']", text: "Tool Alpha")
   end
 end
 
@@ -447,7 +447,7 @@ end
 Then /^the featured services and guidance for the organisation "([^"]*)" should be visible on the public site$/ do |organisation_name|
   visit_organisation organisation_name
   within ".featured-links" do
-    assert page.has_css?("a[href='https://www.gov.uk/example/service']", "Example Service")
+    assert page.has_css?("a[href='https://www.gov.uk/example/service']", text: "Example Service")
   end
 end
 

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -109,7 +109,7 @@ Then /^I should see the promotional feature on the executive office page$/ do
 
   within record_css_selector(@executive_office) do
     within 'section.features' do
-      assert page.has_css?('.promotional_feature h2', @promotional_feature.title)
+      assert page.has_css?('.promotional_feature h2', text: @promotional_feature.title)
 
       within record_css_selector(@promotional_feature) do
         @promotional_feature.items.each do |item|

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -72,7 +72,7 @@ Then /^I should see in the preview that "([^"]*)" is taken from the live data in
   publish(force: true)
   click_on title
   click_on "View on website"
-  assert has_css?(".meta a", text: data_set_name, exact: false)
+  assert has_css?(".meta a", text: data_set_name)
 end
 
 Then /^I should see a link to the PDF attachment$/ do
@@ -85,12 +85,12 @@ end
 
 Then /^I should see the summary of the publication "([^"]*)"$/ do |publication_title|
   publication = Publication.published.find_by!(title: publication_title)
-  assert has_css?("#{record_css_selector(publication)} h3", publication.title)
+  assert has_css?("#{record_css_selector(publication)} h3", text: publication.title)
 end
 
 Then /^I should see the summary of the draft publication "([^"]*)"$/ do |publication_title|
   publication = Publication.find_by!(title: publication_title)
-  assert has_css?("h1", publication.title)
+  assert has_css?("h1", text: publication.title)
 end
 
 Then /^I should see "([^"]*)" is a corporate publication of the "([^"]*)"$/ do |title, organisation|

--- a/features/step_definitions/topic_steps.rb
+++ b/features/step_definitions/topic_steps.rb
@@ -236,7 +236,7 @@ end
 Then /^the featured links for the topic "([^"]*)" should be visible on the public site$/ do |topic_name|
   visit_topic topic_name
   within ".featured-links" do
-    assert page.has_css?("a[href='https://www.gov.uk/mainstream/tool-alpha']", "Tool Alpha")
+    assert page.has_css?("a[href='https://www.gov.uk/mainstream/tool-alpha']", text: "Tool Alpha")
   end
 end
 

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -35,7 +35,7 @@ Then /^the "([^"]*)" logo should show correctly with the HMG crest$/ do |name|
 end
 
 Then /^I should see that it is part of the "([^"]*)"$/ do |sponsoring_organisation|
-  assert page.has_css?(".sponsoring-organisation", sponsoring_organisation)
+  assert page.has_css?(".sponsoring-organisation", text: sponsoring_organisation)
 end
 
 Then /^I should see the worldwide organisation listed on the page$/ do


### PR DESCRIPTION
This commit changes cucumber assertions to use named parameters. The use of unnamed parameters is deprecated in newer versions of cucumber/capybara.

`exact` is also removed from some assertions because in those cases, it has no effect.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails