### PR TITLE
Add worldwide news type

### DIFF
--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -52,14 +52,47 @@ class NewsArticleType
     'news_article'
   end
 
-  NewsStory = create(id: 1, key: "news_story", singular_name: "News story", plural_name: "News stories", prevalence: :primary)
-  PressRelease = create(id: 2, key: "press_release", singular_name: "Press release", plural_name: "Press releases", prevalence: :primary)
-  GovernmentResponse = create(id: 3, key: "government_response", singular_name: "Government response", plural_name: "Government responses", prevalence: :primary)
-  WorldwideNewsStory = create(id: 4, key: "worldwide_news_story", singular_name: "Worldwide news story", plural_name: "Worldwide news stories", prevalence: :primary)
-
-  # Temporary to allow migration
-  Unknown                = create(id: 999, key: "announcement", singular_name: "Announcement", plural_name: "Announcements", prevalence: :migration)
+  NewsStory = create(
+    id: 1,
+    key: "news_story",
+    singular_name: "News story",
+    plural_name: "News stories",
+    prevalence: :primary
+  )
+  PressRelease = create(
+    id: 2,
+    key: "press_release",
+    singular_name: "Press release",
+    plural_name: "Press releases",
+    prevalence: :primary
+  )
+  GovernmentResponse = create(
+    id: 3,
+    key: "government_response",
+    singular_name: "Government response",
+    plural_name: "Government responses",
+    prevalence: :primary
+  )
+  WorldwideNewsStory = create(
+    id: 4,
+    key: "worldwide_news_story",
+    singular_name: "Worldwide news story",
+    plural_name: "Worldwide news stories",
+    prevalence: :primary
+  )
+  Unknown = create(
+    id: 999,
+    key: "announcement",
+    singular_name: "Announcement",
+    plural_name: "Announcements",
+    prevalence: :migration
+  )
   # For imported news with a blank news_article_type field
-  ImportedAwaitingType   = create(id: 1000, key: "imported", singular_name: "Imported - awaiting type", plural_name: "Imported - awaiting type", prevalence: :migration)
-
+  ImportedAwaitingType = create(
+    id: 1000,
+    key: "imported",
+    singular_name: "Imported - awaiting type",
+    plural_name: "Imported - awaiting type",
+    prevalence: :migration
+  )
 end

--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -9,6 +9,7 @@ class NewsArticleType
     1 => "<p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>",
     2 => "<p>Unedited press releases as sent to the media, and official statements from the organisation or a minister.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>",
     3 => "<p>Government statements in response to media coverage, such as rebuttals and ‘myth busters’.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>",
+    4 => "<p>Announcements specific to one or more world location. Don’t duplicate news published by another department.</p>",
     999 => "<p>DO NOT USE. This is a legacy category for content created before sub-types existed.</p>",
     1000 => "<p>DO NOT USE. This is a holding category for content that has been imported automatically.</p>",
   }.to_json.freeze
@@ -54,6 +55,7 @@ class NewsArticleType
   NewsStory = create(id: 1, key: "news_story", singular_name: "News story", plural_name: "News stories", prevalence: :primary)
   PressRelease = create(id: 2, key: "press_release", singular_name: "Press release", plural_name: "Press releases", prevalence: :primary)
   GovernmentResponse = create(id: 3, key: "government_response", singular_name: "Government response", plural_name: "Government responses", prevalence: :primary)
+  WorldwideNewsStory = create(id: 4, key: "worldwide_news_story", singular_name: "Worldwide news story", plural_name: "Worldwide news stories", prevalence: :primary)
 
   # Temporary to allow migration
   Unknown                = create(id: 999, key: "announcement", singular_name: "Announcement", plural_name: "Announcements", prevalence: :migration)

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -181,13 +181,6 @@ ar:
         few:
         many:
         other: "إحصائيات - إحصائيات محلية"
-      nhs_content:
-        zero:
-        one:
-        two:
-        few:
-        many:
-        other:
       news_article:
         zero:
         one: "مقال إخباري"
@@ -202,6 +195,13 @@ ar:
         few:
         many:
         other: "قصص إخبارية"
+      nhs_content:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       notice:
         zero:
         one:
@@ -321,6 +321,13 @@ ar:
         few:
         many:
         other: "بيانات تتعلق بالشفافية"
+      worldwide_news_story:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       written_statement:
         zero:
         one: "تصريح خطي"
@@ -474,6 +481,8 @@ ar:
     email: "بريد إلكتروني"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -70,6 +70,8 @@ az:
     email: elektron poçt
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,15 +196,15 @@ az:
       national_statistics:
         one: Statistika - milli statistika
         other: Statistika - milli statistika
-      nhs_content:
-        one:
-        other:
       news_article:
         one: məqalə
         other: məqalələr
       news_story:
         one: Xəbərlər
         other: Xəbərlər
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -254,6 +256,9 @@ az:
       transparency:
         one: "Şəffaf məlumat"
         other: "Şəffaf məlumat"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Parlamentə yazılı müraciət
         other: Parlamentə yazılı müraciət

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -16,16 +16,16 @@ be:
         few:
         many:
         other: "Аб'явы"
-      blog_post:
-        one:
-        few:
-        many:
-        other:
       authored_article:
         one: "Аўтарскі артыкул"
         few:
         many:
         other: "Аўтарскія артыкулы"
+      blog_post:
+        one:
+        few:
+        many:
+        other:
       case_study:
         one: "Тэматычнае даследаванне"
         few:
@@ -131,11 +131,6 @@ be:
         few:
         many:
         other: "Статыстыка - нацыянальная статыстыка"
-      nhs_content:
-        one:
-        few:
-        many:
-        other:
       news_article:
         one: "Артыкул"
         few:
@@ -146,6 +141,11 @@ be:
         few:
         many:
         other: "Навіны"
+      nhs_content:
+        one:
+        few:
+        many:
+        other:
       notice:
         one:
         few:
@@ -231,6 +231,11 @@ be:
         few:
         many:
         other: "Адкрытыя дадзеныя"
+      worldwide_news_story:
+        one:
+        few:
+        many:
+        other:
       written_statement:
         one: "Пісьмовая заява ў парламенце"
         few:
@@ -374,6 +379,8 @@ be:
     email: "Электронная пошта"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -81,15 +81,15 @@ bg:
       national_statistics:
         one: "Статистика- национална статистика"
         other: "Статистики- национални статистики"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "Новинарска статия"
         other: "Новинарски статии"
       news_story:
         one: "Новина"
         other: "Новини"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ bg:
       transparency:
         one: "Информация за прозрачността"
         other: "Информация за прозрачността"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "Писмено изявление до парламента"
         other: "Писмени изявления до парламента"
@@ -278,6 +281,8 @@ bg:
     email: "И-мейл"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -81,13 +81,13 @@ bn:
       national_statistics:
         one:
         other:
-      nhs_content:
-        one:
-        other:
       news_article:
         one:
         other:
       news_story:
+        one:
+        other:
+      nhs_content:
         one:
         other:
       notice:
@@ -139,6 +139,9 @@ bn:
         one:
         other:
       transparency:
+        one:
+        other:
+      worldwide_news_story:
         one:
         other:
       written_statement:
@@ -272,6 +275,8 @@ bn:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -106,10 +106,6 @@ cs:
         one: Statistiky - národní statistiky
         few:
         other: Statistiky - národní statistiky
-      nhs_content:
-        one:
-        few:
-        other:
       news_article:
         one: Nový článek
         few:
@@ -118,6 +114,10 @@ cs:
         one: Zpráva
         few:
         other: Zprávy
+      nhs_content:
+        one:
+        few:
+        other:
       notice:
         one:
         few:
@@ -186,6 +186,10 @@ cs:
         one: Transparenost
         few:
         other: Transparentnost
+      worldwide_news_story:
+        one:
+        few:
+        other:
       written_statement:
         one: Písemná prohlášení do parlamentu
         few:
@@ -326,6 +330,8 @@ cs:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -181,13 +181,6 @@ cy:
         few:
         many:
         other: Ystadegau - ystadegau gwladol
-      nhs_content:
-        zero:
-        one:
-        two:
-        few:
-        many:
-        other:
       news_article:
         zero:
         one: Erthygl newyddion
@@ -202,6 +195,13 @@ cy:
         few:
         many:
         other: Straeon newyddion
+      nhs_content:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       notice:
         zero:
         one:
@@ -321,6 +321,13 @@ cy:
         few:
         many:
         other: Data tryloywder
+      worldwide_news_story:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
       written_statement:
         zero:
         one: Datganiad ysgrifenedig i'r Senedd
@@ -475,6 +482,8 @@ cy:
     email: E-bost
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme: gyhoeddi yn y Gymraeg
       title:
         about: Amdanom ni
         about_our_services: Gwybodaeth am ein gwasanaethau
@@ -496,8 +505,6 @@ cy:
         statistics: Ystadegau yn %{organisation_name}
         terms_of_reference: Cylch gorchwyl
         welsh_language_scheme: Cynllun iaith Gymraeg
-      link_text:
-        welsh_language_scheme: gyhoeddi yn y Gymraeg
   date:
     formats:
       default: "%d %B %Y"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -81,15 +81,15 @@ de:
       national_statistics:
         one: Statistik - Nationale Statistik
         other: Statistik - Nationale Statistik
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artikel
         other: Artikel
       news_story:
         one: Meldung
         other: Meldungen
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ de:
       transparency:
         one: Transparenz-Daten
         other: Transparenz-Daten
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Schriftliche Erklärung vor dem Parlament
         other: Schriftliche Erklärungen vor dem Parlament
@@ -275,6 +278,8 @@ de:
     email: E-Mail
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -81,15 +81,15 @@ dr:
       national_statistics:
         one: "احصایه ها - احصایه های ملی"
         other: "احصایه ها - احصایه های ملی"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "مقاله جدید"
         other: "مقاله خبری"
       news_story:
         one: "گزارش خبری"
         other: "گزارش های خبری"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ dr:
       transparency:
         one: "ارقام شفافیت"
         other: "ارقام شفافیت"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "بیانیه تحریری به پارلمان"
         other: "بیانیه های تحریری به پارلمان"
@@ -274,6 +277,8 @@ dr:
     email: "ایمیل"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -81,15 +81,15 @@ el:
       national_statistics:
         one: "Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία"
         other: "Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "Είδηση"
         other: "Ειδήσεις"
       news_story:
         one: "Νέα"
         other: "Νέα"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ el:
       transparency:
         one: "Στοιχεία διαφάνειας"
         other: "Στοιχεία διαφάνειας"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "Γραπτή  δήλωση στη Βουλή"
         other: "Γραπτές δηλώσεις στη Βουλή"
@@ -276,6 +279,8 @@ el:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,9 @@ en:
       written_statement:
         one: Written statement to Parliament
         other: Written statements to Parliament
+      worldwide_news_story:
+        one: Worldwide news story
+        other: Worldwide news stories
       authored_article:
         one: Authored article
         other: Authored articles

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -81,15 +81,15 @@ es-419:
       national_statistics:
         one: Estadísticas - cifras nacionales
         other: Estadísticas - cifras nacionales
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artículo
         other: Artículos
       news_story:
         one: Noticia
         other: Noticias
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ es-419:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Declaración escrita al Parlamento
         other: Declaraciones escritas al Parlamento
@@ -275,6 +278,8 @@ es-419:
     email: Correo electrónico
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -81,15 +81,15 @@ es:
       national_statistics:
         one: Estadísticas - cifras nacionales
         other: Estadísticas - cifras nacionales
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artículo
         other: Artículos
       news_story:
         one: Noticia
         other: Noticias
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ es:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Declaración escrita
         other: Declaraciones escritas
@@ -275,6 +278,8 @@ es:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -81,15 +81,15 @@ et:
       national_statistics:
         one: Statistika - rahvuslikud statistikaandmed
         other: Statistika - rahvuslikud statistikaandmed
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artikkel
         other: Artiklid
       news_story:
         one: Uudis
         other: Uudised
+      nhs_content:
+        one:
+        other:
       notice:
         one: Teade
         other: Teated
@@ -141,6 +141,9 @@ et:
       transparency:
         one: Läbipaistvusteave
         other: Läbipaistvusteave
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Kirjalik avaldus parlamendile
         other: Kirjalikud avaldused parlamendile
@@ -276,6 +279,8 @@ et:
     email: E-post
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about: Meist
         about_our_services: Meie teenustest

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -72,6 +72,8 @@ fa:
     email: "ایمیل"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -196,15 +198,15 @@ fa:
       national_statistics:
         one: "آمار - آمار ملی"
         other: "آمار - آمار ملی"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "مقاله ی خبری"
         other: "مقالات خبری"
       news_story:
         one: "خبر"
         other: "اخبار"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -256,6 +258,9 @@ fa:
       transparency:
         one: "داده های شفاف سازی"
         other: "داده های شفاف سازی"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "گزارش کتبی به پارلمان"
         other: "گزارش های کتبی به پارلمان"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -81,15 +81,15 @@ fr:
       national_statistics:
         one: Statistiques - statistiques nationales
         other: Statistiques - statistiques nationales
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Actualités
         other: Actualités
       news_story:
         one: Actualités
         other: Actualités
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ fr:
       transparency:
         one: Transparence des données
         other: Transparence des données
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Communiqué
         other: Communiqués
@@ -275,6 +278,8 @@ fr:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -131,11 +131,6 @@ he:
         two:
         many:
         other: "סטטיסטיקות- סטטסטיקה לאומית"
-      nhs_content:
-        one:
-        two:
-        many:
-        other:
       news_article:
         one: "מאמר חדשות"
         two:
@@ -146,6 +141,11 @@ he:
         two:
         many:
         other: "חדשות"
+      nhs_content:
+        one:
+        two:
+        many:
+        other:
       notice:
         one:
         two:
@@ -231,6 +231,11 @@ he:
         two:
         many:
         other: "שקיפות מידע"
+      worldwide_news_story:
+        one:
+        two:
+        many:
+        other:
       written_statement:
         one: "הצהרה בכתב לפרלמנט"
         two:
@@ -375,6 +380,8 @@ he:
     email: "דואר אלקטרוני"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -81,15 +81,15 @@ hi:
       national_statistics:
         one: "सांख्यिकी - राष्ट्रीय सांख्यिकी"
         other: "सांख्यिकी - राष्ट्रीय सांख्यिकी"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "समाचार लेख"
         other: "समाचार लेख"
       news_story:
         one: "समाचार कथा"
         other: "समाचार कथाएं"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ hi:
       transparency:
         one: "पारदर्शिता आंकड़े"
         other: "पारदर्शिता आंकड़े"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "संसद में लिखित बयान"
         other: "संसद में लिखित बयान"
@@ -275,6 +278,8 @@ hi:
     email: "ईमेल"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -73,6 +73,8 @@ hu:
     email: E-mail
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -197,15 +199,15 @@ hu:
       national_statistics:
         one: Statisztikák - nemzeti adatok
         other: Statisztikák - nemzeti adatok
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Cikk
         other: Cikkek
       news_story:
         one: Hír
         other: Hírek
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -257,6 +259,9 @@ hu:
       transparency:
         one: "Átláthatósági adatok"
         other: "Átláthatósági adatok"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "Írásbeli parlamenti nyilatkozat"
         other: "Írásbeli parlamenti nyilatkozatok"

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -81,15 +81,15 @@ hy:
       national_statistics:
         one: "Վիճակագրություն-ազգային վիճակագրություն"
         other: "Վիճակագրություն-ազգային վիճակագրություններ"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "Տեղեկատվական հոդված"
         other: "Տեղեկատվական հոդվածներ"
       news_story:
         one: "Լուր"
         other: "Լուրեր"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ hy:
       transparency:
         one: "Բաց տեղեկատվություն"
         other: "Բաց տեղեկատվություններ"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "Գրավոր դիմում խորհրդարան"
         other: "Գրավոր դիմումներ խորհրդարան"
@@ -275,6 +278,8 @@ hy:
     email: "Էլելտրոնային հասցե"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -72,6 +72,8 @@ id:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -196,15 +198,15 @@ id:
       national_statistics:
         one: Statistik-statistik nasional
         other: Statistik-statistik nasional
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artikel berita
         other: Artikel-artikel berita
       news_story:
         one: Berita
         other: Berita-berita
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -256,6 +258,9 @@ id:
       transparency:
         one: Transparansi data
         other: Transparansi data
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Pernyataan tertulis kepada parlemen
         other: Pernyataan-pernyatan tertulis kepada parlemen

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -81,15 +81,15 @@ it:
       national_statistics:
         one: Statistica - statistica nazionale
         other: Statistica - statistica nazionale
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Articolo
         other: Articoli
       news_story:
         one: Notizia
         other: Notizie
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ it:
       transparency:
         one: Dati sulla trasparenza
         other: Dati sulla trasparenza
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Dichiarazione scritta al parlamento
         other: Dichiarazioni scritte al parlamento
@@ -275,6 +278,8 @@ it:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -71,6 +71,8 @@ ja:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -195,15 +197,15 @@ ja:
       national_statistics:
         one: "国家統計"
         other: "国家統計"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "ニュース"
         other: "ニュース"
       news_story:
         one: "ニュース"
         other: "ニュース"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -255,6 +257,9 @@ ja:
       transparency:
         one: "透明性データ"
         other: "透明性データ"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "閣僚声明文"
         other: "閣僚声明文"

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -70,6 +70,8 @@ ka:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,13 +196,13 @@ ka:
       national_statistics:
         one:
         other:
-      nhs_content:
-        one:
-        other:
       news_article:
         one:
         other:
       news_story:
+        one:
+        other:
+      nhs_content:
         one:
         other:
       notice:
@@ -252,6 +254,9 @@ ka:
         one:
         other:
       transparency:
+        one:
+        other:
+      worldwide_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -71,6 +71,8 @@ ko:
     email: "이메일"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -195,15 +197,15 @@ ko:
       national_statistics:
         one: "통계 - 국가 통계"
         other: "통계 - 국가 통계"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "뉴스"
         other: "뉴스"
       news_story:
         one: "뉴스 스토리"
         other: "뉴스 스토리"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -255,6 +257,9 @@ ko:
       transparency:
         one: "투명성 데이타"
         other: "투명성 데이타"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "의회로 서면 성명"
         other: "의회로 서면 성명"

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -106,10 +106,6 @@ lt:
         one: 'Statistika - nacionalinė statistika '
         few:
         other: 'Statistika - nacionalinė statistika '
-      nhs_content:
-        one:
-        few:
-        other:
       news_article:
         one: Straipsnis
         few:
@@ -118,6 +114,10 @@ lt:
         one: Naujiena
         few:
         other: Naujienos
+      nhs_content:
+        one:
+        few:
+        other:
       notice:
         one:
         few:
@@ -186,6 +186,10 @@ lt:
         one: Skaidrumo informacija
         few:
         other: Skaidrumo informacija
+      worldwide_news_story:
+        one:
+        few:
+        other:
       written_statement:
         one: Rašytinis kreipimasis į parlamentą
         few:
@@ -324,6 +328,8 @@ lt:
     email: El.paštas
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -81,15 +81,15 @@ lv:
       national_statistics:
         one: Statistika - valsts dati
         other: Statistika - valsts dati
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Raksts
         other: Raksti
       news_story:
         one: Ziņa
         other: Ziņas
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ lv:
       transparency:
         one: Atklātības dati
         other: Atklātības dati
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Rakstisks ziņojums parlamentam
         other: Rakstiski ziņojumi parlamentam
@@ -274,6 +277,8 @@ lv:
     email: E-pasts
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -70,6 +70,8 @@ ms:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,13 +196,13 @@ ms:
       national_statistics:
         one:
         other:
-      nhs_content:
-        one:
-        other:
       news_article:
         one:
         other:
       news_story:
+        one:
+        other:
+      nhs_content:
         one:
         other:
       notice:
@@ -252,6 +254,9 @@ ms:
         one:
         other:
       transparency:
+        one:
+        other:
+      worldwide_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -131,11 +131,6 @@ pl:
         few:
         many:
         other: Statystyki - statystyki narodowe
-      nhs_content:
-        one:
-        few:
-        many:
-        other:
       news_article:
         one: Artykuł prasowy
         few:
@@ -146,6 +141,11 @@ pl:
         few:
         many:
         other: Aktualności
+      nhs_content:
+        one:
+        few:
+        many:
+        other:
       notice:
         one:
         few:
@@ -231,6 +231,11 @@ pl:
         few:
         many:
         other: Dane o transparentności
+      worldwide_news_story:
+        one:
+        few:
+        many:
+        other:
       written_statement:
         one: Pisemne oświadczenie przed parlamentem
         few:
@@ -376,6 +381,8 @@ pl:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -81,15 +81,15 @@ ps:
       national_statistics:
         one: "شمیرنه - ملی شمیرنې"
         other: "شمیرنه - ملی شمیرنې"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "خبری مقاله"
         other: "خبری مقالی"
       news_story:
         one: "خبری راپور"
         other: "خبری راپورونه"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ ps:
       transparency:
         one: "د روڼوالې اطلاعات"
         other: "د روڼوالي اطلاعات"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "پارلمان ته لیکلې اعلامیه"
         other: "پارلمان ته لیکلې اعلامیې"
@@ -274,6 +277,8 @@ ps:
     email: "برښنالیک"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -81,15 +81,15 @@ pt:
       national_statistics:
         one: Estatística - estatística nacional
         other: Estatísticas - estatísticas nacionais
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Notícia - Artigo
         other: Notícias - Artigos
       news_story:
         one: Notícia
         other: Notícias
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ pt:
       transparency:
         one: Dado de Transparência
         other: Dados de Transparência
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Declaração escrita ao Parlamento
         other: Declarações escritas ao Parlamento
@@ -274,6 +277,8 @@ pt:
     email: E-mail
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -106,10 +106,6 @@ ro:
         one: Statistici - statistici naționale
         few:
         other: Statistici - statistici naționale
-      nhs_content:
-        one:
-        few:
-        other:
       news_article:
         one: "Știre"
         few:
@@ -118,6 +114,10 @@ ro:
         one: "Știre"
         few:
         other: "Știri"
+      nhs_content:
+        one:
+        few:
+        other:
       notice:
         one:
         few:
@@ -183,6 +183,10 @@ ro:
         few:
         other: Transcrieri
       transparency:
+        one:
+        few:
+        other:
+      worldwide_news_story:
         one:
         few:
         other:
@@ -324,6 +328,8 @@ ro:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -131,11 +131,6 @@ ru:
         few:
         many:
         other: "Статистика - национальная статистика"
-      nhs_content:
-        one:
-        few:
-        many:
-        other:
       news_article:
         one: "Новостная статья"
         few:
@@ -146,6 +141,11 @@ ru:
         few:
         many:
         other: "Новостные заметки"
+      nhs_content:
+        one:
+        few:
+        many:
+        other:
       notice:
         one:
         few:
@@ -231,6 +231,11 @@ ru:
         few:
         many:
         other: "Прозрачность данных"
+      worldwide_news_story:
+        one:
+        few:
+        many:
+        other:
       written_statement:
         one: "Письменное заявление парламенту"
         few:
@@ -373,6 +378,8 @@ ru:
     email: "Электронный адрес"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -81,15 +81,15 @@ si:
       national_statistics:
         one: "සංඛ්යාන - ජාතික සංඛ්යාන"
         other: "සංඛ්යාන - ජාතික සංඛ්යාන"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "පුවත් ලිපිය"
         other: "පුවත් ලිපි"
       news_story:
         one: "පුවත් වාර්තාව"
         other: "පුවත් වාර්තා"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ si:
       transparency:
         one: "විනිවිධභාවයේ දත්ත"
         other: "විනිවිධභාවයේ දත්ත"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශය"
         other: "පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ"
@@ -274,6 +277,8 @@ si:
     email: "විද්‍යුත් තැපැල්"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -106,15 +106,15 @@ sk:
         one:
         few:
         other:
-      nhs_content:
-        one:
-        few:
-        other:
       news_article:
         one:
         few:
         other:
       news_story:
+        one:
+        few:
+        other:
+      nhs_content:
         one:
         few:
         other:
@@ -183,6 +183,10 @@ sk:
         few:
         other:
       transparency:
+        one:
+        few:
+        other:
+      worldwide_news_story:
         one:
         few:
         other:
@@ -322,6 +326,8 @@ sk:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -81,15 +81,15 @@ so:
       national_statistics:
         one: Istaatistik - istaatistik qaran
         other: Istaatistik - istaatistik qaran
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Maqaal wareed
         other: Maqaallo wareed
       news_story:
         one: Sheeko wareed
         other: Sheekooyin wareed
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ so:
       transparency:
         one: Xog daahfurnaan
         other: Xog daahfurnaan
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Hadal qoran oo loo gudbiyo baarlamaanka
         other: Hadallo qoran oo loo gudbiyo baarlamaanka
@@ -276,6 +279,8 @@ so:
     email: E-mail
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -81,15 +81,15 @@ sq:
       national_statistics:
         one: Statistika - statistika kombetare
         other: Statistika - statistika kombetare
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Artikull lajm
         other: Artikuj lajme
       news_story:
         one: Ngjarje
         other: Ngjarje
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ sq:
       transparency:
         one: Te dhena per transparencen
         other: Te dhena per transparencen
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Deklarate me shkrim per Parlamentin
         other: Deklarata me shkrim per Parlamentin
@@ -275,6 +278,8 @@ sq:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -131,10 +131,6 @@ sr:
         few:
         many:
         other: statistika - nacionalna statistika
-      nhs_content:
-        one:
-        few:
-        other:
       news_article:
         one: Vest
         few:
@@ -145,6 +141,11 @@ sr:
         few:
         many:
         other: Vesti
+      nhs_content:
+        one:
+        few:
+        many:
+        other:
       notice:
         one:
         few:
@@ -230,6 +231,11 @@ sr:
         few:
         many:
         other: podaci o transparentnosti
+      worldwide_news_story:
+        one:
+        few:
+        many:
+        other:
       written_statement:
         one: Pisana predstavka Parlamentu
         few:
@@ -374,6 +380,8 @@ sr:
     email: e-mail
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -81,13 +81,13 @@ sw:
       national_statistics:
         one:
         other:
-      nhs_content:
-        one:
-        other:
       news_article:
         one:
         other:
       news_story:
+        one:
+        other:
+      nhs_content:
         one:
         other:
       notice:
@@ -139,6 +139,9 @@ sw:
         one:
         other:
       transparency:
+        one:
+        other:
+      worldwide_news_story:
         one:
         other:
       written_statement:
@@ -272,6 +275,8 @@ sw:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -81,15 +81,15 @@ ta:
       national_statistics:
         one: "புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்"
         other: "புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "செய்திக் கட்டுரை"
         other: "செய்திக் கட்டுரைகள்"
       news_story:
         one: "செய்திக் கதை"
         other: "செய்திக் கதைகள்"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ ta:
       transparency:
         one: "வெளிப்படையான தரவு"
         other: "வெளிப்படையான தரவு"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கை"
         other: "பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்"
@@ -276,6 +279,8 @@ ta:
     email: "மின்னஞ்சல்"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -71,6 +71,8 @@ th:
     email: "อีเมล์"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -195,15 +197,15 @@ th:
       national_statistics:
         one: "สถิติ-สถิติแห่งชาน"
         other: "สถิติ-สถิติแห่งชาติ"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "บทความข่าว"
         other: "บทความข่าว"
       news_story:
         one: "ข่าว"
         other: "ข่าว"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -255,6 +257,9 @@ th:
       transparency:
         one: "ข้อมูลโปร่งใส"
         other: "ข้อมูลโปร่งใส"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
         other: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -81,13 +81,13 @@ tk:
       national_statistics:
         one:
         other:
-      nhs_content:
-        one:
-        other:
       news_article:
         one:
         other:
       news_story:
+        one:
+        other:
+      nhs_content:
         one:
         other:
       notice:
@@ -139,6 +139,9 @@ tk:
         one:
         other:
       transparency:
+        one:
+        other:
+      worldwide_news_story:
         one:
         other:
       written_statement:
@@ -272,6 +275,8 @@ tk:
     email:
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -72,6 +72,8 @@ tr:
     email: E-posta
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -196,15 +198,15 @@ tr:
       national_statistics:
         one: "İstatistikler - ulusal istatistikler"
         other: "İstatistikler - ulusal istatistikler"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Makale
         other: Makaleler
       news_story:
         one: Haber
         other: Haberler
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -256,6 +258,9 @@ tr:
       transparency:
         one: Veri saydamlığı
         other: Veri saydamlığı
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Parlamento'ya yapılan yazılı açıklama
         other: Parlamento'ya yapılan yazılı açıklamalar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -131,11 +131,6 @@ uk:
         few:
         many:
         other: "Статистика - національна статистика"
-      nhs_content:
-        one:
-        few:
-        many:
-        other:
       news_article:
         one: "Стаття"
         few:
@@ -146,6 +141,11 @@ uk:
         few:
         many:
         other: "Новини"
+      nhs_content:
+        one:
+        few:
+        many:
+        other:
       notice:
         one:
         few:
@@ -231,6 +231,11 @@ uk:
         few:
         many:
         other: "Прозорість інформації"
+      worldwide_news_story:
+        one:
+        few:
+        many:
+        other:
       written_statement:
         one: "Письмова заява у парламенті"
         few:
@@ -374,6 +379,8 @@ uk:
     email: "Електронна пошта"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -81,15 +81,15 @@ ur:
       national_statistics:
         one: "شماریات- قومی اعدادوشمار"
         other: "شماریات- قومی اعدادوشمار"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "نیوزآرٹیکل"
         other: "نیوزآرٹیکلز"
       news_story:
         one: "نیوز اسٹوری"
         other: "نیوزاسٹوریز"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ ur:
       transparency:
         one: "ٹرانسپیرنسی ڈیٹا"
         other: "ٹرانسپیرنسی ڈیٹا"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "پارلیمنٹ میں تحریری بیان"
         other: "پارلیمنٹ میں تحریری بیانات"
@@ -275,6 +278,8 @@ ur:
     email: "ای میل"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -81,15 +81,15 @@ uz:
       national_statistics:
         one: Statistika - milliy statistika
         other: Statistika - milliy statistika
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Yangi maqola
         other: Yangi maqolalar
       news_story:
         one: Yangilik
         other: Yangiliklar
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -141,6 +141,9 @@ uz:
       transparency:
         one: Ochiqlikka oid ma'lumotlar
         other: Ochiqlikka oid ma'lumotlar
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Parlament uchun yozma hisobot
         other: Parlament uchun yozma hisobotlar
@@ -274,6 +277,8 @@ uz:
     email: Elektron manzil
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -72,6 +72,8 @@ vi:
     email: Email
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -196,15 +198,15 @@ vi:
       national_statistics:
         one: Thống kê - Thống kê quốc gia
         other: Thống kê - Thống kê quốc gia
-      nhs_content:
-        one:
-        other:
       news_article:
         one: Tin tức
         other: Tin tức
       news_story:
         one: Câu chuyện tin tức
         other: Câu chuyện tin tức
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -256,6 +258,9 @@ vi:
       transparency:
         one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: Tuyên bố bằng văn bản tới quốc hội
         other: Các Tuyên bố bằng văn bản tới quốc hội

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -70,6 +70,8 @@ zh-hk:
     email: "電子郵件"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,15 +196,15 @@ zh-hk:
       national_statistics:
         one: "國家統計數據"
         other: "其他國家統計數據"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "新聞"
         other: "其他新聞"
       news_story:
         one: "新聞"
         other: "其他新聞"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -254,6 +256,9 @@ zh-hk:
       transparency:
         one: "透明化數據"
         other: "其他透明化數據"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "提交國會的書面聲明"
         other: "提交國會的其他書面聲明"

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -70,6 +70,8 @@ zh-tw:
     email: "電子郵件"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,15 +196,15 @@ zh-tw:
       national_statistics:
         one: "國家統計數據"
         other: "國家統計數據"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "新聞"
         other: "其他新聞"
       news_story:
         one: "新聞"
         other: "其他新聞"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -254,6 +256,9 @@ zh-tw:
       transparency:
         one: "透明化數據"
         other: "透明化數據"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "提交國會的書面聲明"
         other: "提交國會的其他書面聲明"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -70,6 +70,8 @@ zh:
     email: "邮件"
   corporate_information_page:
     type:
+      link_text:
+        welsh_language_scheme:
       title:
         about:
         about_our_services:
@@ -194,15 +196,15 @@ zh:
       national_statistics:
         one: "统计数据 - 国家数据"
         other: "统计数据 - 国家数据"
-      nhs_content:
-        one:
-        other:
       news_article:
         one: "新闻文章"
         other: "新闻文章"
       news_story:
         one: "新闻报道"
         other: "新闻报道"
+      nhs_content:
+        one:
+        other:
       notice:
         one:
         other:
@@ -254,6 +256,9 @@ zh:
       transparency:
         one: "透明化数据"
         other: "透明化数据"
+      worldwide_news_story:
+        one:
+        other:
       written_statement:
         one: "对议会的书面声明"
         other: "对议会的书面声明"

--- a/test/unit/news_article_type_test.rb
+++ b/test/unit/news_article_type_test.rb
@@ -12,7 +12,7 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
   end
 
   test "should list all slugs" do
-    assert_equal "news-stories, press-releases, government-responses, announcements and imported-awaiting-type", NewsArticleType.all_slugs
+    assert_equal "news-stories, press-releases, government-responses, worldwide-news-stories, announcements and imported-awaiting-type", NewsArticleType.all_slugs
   end
 
   test 'search_format_types tags the type with the key, prefixed with news-article-' do


### PR DESCRIPTION
Adds a `NewsArticleType` for `WorldwideNews` which will be used when we merger the `WorldwideNewsArticle` format into `NewsArticle`.

[Trello](https://trello.com/c/VygNbQmD/88-create-a-new-worldwide-news-article-subtype)