### PR TITLE
Populate contacts from html attachments

### DIFF
--- a/app/services/service_listeners/attachment_dependency_populator.rb
+++ b/app/services/service_listeners/attachment_dependency_populator.rb
@@ -1,0 +1,21 @@
+module ServiceListeners
+  class AttachmentDependencyPopulator
+    attr_reader :edition
+
+    def initialize(edition)
+      @edition = edition
+    end
+
+    def populate!
+      return unless edition.respond_to?(:html_attachments)
+      edition.html_attachments.each do |attachment|
+        extractor = Govspeak::ContactsExtractor.new(attachment.govspeak_content_body)
+        extractor.contacts.each do |contact|
+          unless edition.depended_upon_contacts.exists?(contact.id)
+            edition.depended_upon_contacts << contact
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -23,6 +23,10 @@ Whitehall.edition_services.tap do |coordinator|
       .new(edition)
       .populate!
 
+    ServiceListeners::AttachmentDependencyPopulator
+      .new(edition)
+      .populate!
+
     ServiceListeners::AnnouncementClearer
       .new(edition)
       .clear!

--- a/test/integration/attachment_dependency_populator_test.rb
+++ b/test/integration/attachment_dependency_populator_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AttachmentDependencyPopulatorTest < ActiveSupport::TestCase
+  def test_contact_added_to_edition
+    publication = create(:publication)
+    contact = create(:contact)
+    attachment = publication.html_attachments.first
+    attachment.govspeak_content.body = "Test [Contact:#{contact.id}]"
+    attachment.govspeak_content.save
+    publication.reload
+
+    populator = ServiceListeners::AttachmentDependencyPopulator.new(publication)
+    populator.populate!
+
+    publication.reload
+    assert publication.depended_upon_contacts.exists?(contact.id)
+  end
+end

--- a/test/unit/services/listeners/attachment_dependency_populator_test.rb
+++ b/test/unit/services/listeners/attachment_dependency_populator_test.rb
@@ -1,0 +1,88 @@
+require "minitest/autorun"
+require "mocha/setup"
+require_relative "../../../../lib/govspeak/contacts_extractor"
+require_relative "../../../../app/services/service_listeners/attachment_dependency_populator"
+
+module ServiceListeners
+  class AttachmentDependencyPopulatorTest < MiniTest::Test
+    class TestAssociation
+      attr_reader :collection
+      def initialize
+        @collection = []
+      end
+
+      def <<(value)
+        collection << value
+      end
+
+      def exists?
+        raise "stub me"
+      end
+
+      def to_a
+        collection
+      end
+    end
+
+    def subject(edition)
+      AttachmentDependencyPopulator.new(edition)
+    end
+
+    def test_populate_ignores_editions_that_do_not_have_html_attachments
+      edition = stub
+      subject(edition).populate!
+    end
+
+    def test_populate_adds_any_contacts_in_attachments_to_the_edition
+      attachments = [
+        stub(govspeak_content_body: "[Contact:1]"),
+        stub(govspeak_content_body: "booyah")
+      ]
+      edition = stub(html_attachments: attachments)
+      edition.stubs(:depended_upon_contacts).returns(edition_contacts = TestAssociation.new)
+      edition_contacts.stubs(:exists?).returns(false)
+
+      Govspeak::ContactsExtractor.expects(:new).with("booyah").returns(stub(contacts: []))
+      Govspeak::ContactsExtractor.expects(:new).with("[Contact:1]")
+        .returns(stub(contacts: [contact = stub(id: 1)]))
+      subject(edition).populate!
+
+      assert_equal [contact], edition_contacts.to_a
+    end
+
+    def test_populate_adds_any_contacts_from_multiple_attachments_to_the_edition
+      attachments = [
+        stub(govspeak_content_body: "[Contact:1]"),
+        stub(govspeak_content_body: "[Contact:2]")
+      ]
+      edition = stub(html_attachments: attachments)
+      edition.stubs(:depended_upon_contacts).returns(edition_contacts = TestAssociation.new)
+      edition_contacts.stubs(:exists?).returns(false)
+
+      Govspeak::ContactsExtractor.expects(:new).with("[Contact:1]")
+        .returns(stub(contacts: [contact_one = stub(id: 1)]))
+      Govspeak::ContactsExtractor.expects(:new).with("[Contact:2]")
+        .returns(stub(contacts: [contact_two = stub(id: 2)]))
+
+      subject(edition).populate!
+
+      assert_equal [contact_one, contact_two], edition_contacts.to_a
+    end
+
+    def test_populate_doesnt_add_existing_contacts
+      attachments = [
+        stub(govspeak_content_body: "[Contact:1]"),
+      ]
+      edition = stub(html_attachments: attachments)
+      edition.stubs(:depended_upon_contacts).returns(edition_contacts = TestAssociation.new)
+      edition_contacts.stubs(:exists?).with(1).returns(true)
+
+      Govspeak::ContactsExtractor.expects(:new).with("[Contact:1]")
+        .returns(stub(contacts: [stub(id: 1)]))
+
+      subject(edition).populate!
+
+      assert_equal [], edition_contacts.to_a
+    end
+  end
+end


### PR DESCRIPTION
When an Edition is published any inline contact tags (e.g. [Contact:1234]) from the govspeak body are parsed out and saved as an `EditionDependency`. This allows Whitehall to republish these documents when a `Contact` is updated. `HtmlAttachment` can also include inline contact tags but currently they are not registered as dependencies of the parent `Edition` and consequently are not updated when the `Contact` details change.

This PR adds a service listener that parses contacts out of the bodies of any `HtmlAttachment` and registers the dependency on the parent `Edition`.

[Trello](https://trello.com/c/Jlx1oE51/880-bug-fix-update-to-whitehall-contact-card-not-showing-in-html-attachment)