### PR TITLE
Add Rails.cache support for expensive API calls

### DIFF
--- a/lib/taxonomy/tree.rb
+++ b/lib/taxonomy/tree.rb
@@ -2,11 +2,12 @@ module Taxonomy
   class Tree
     attr_reader :root_taxon
 
-    def initialize(root_taxon)
+    def initialize(root_taxon, expanded_links_hash)
       @root_taxon = root_taxon
-      expanded_links = Services.publishing_api.get_expanded_links(root_taxon.content_id, with_drafts: false)
-      root_taxon.children = parse_taxons(expanded_links.to_h)
+      root_taxon.children = parse_taxons(expanded_links_hash)
     end
+
+  private
 
     def parse_taxons(item_hash, key: 'expanded_links')
       child_nodes(item_hash, key).map do |child|
@@ -15,8 +16,6 @@ module Taxonomy
         taxon
       end
     end
-
-  private
 
     def child_nodes(item_hash, key)
       item_hash

--- a/test/unit/taxonomy/tree_test.rb
+++ b/test/unit/taxonomy/tree_test.rb
@@ -1,20 +1,9 @@
 require 'test_helper'
 
 class Taxonomy::TreeTest < ActiveSupport::TestCase
-  setup do
-    Services.publishing_api
-      .stubs(:get_expanded_links)
-      .returns(api_response)
-
-    @root_taxon_id = :id
-  end
-
-  test ".new fetches data from publishing-api" do
-    Services.publishing_api
-      .expects(:get_expanded_links)
-      .with(@root_taxon_id, with_drafts: false)
-
-    Taxonomy::Tree.new(root_taxon)
+  test ".new sets the root_taxon property" do
+    subject = Taxonomy::Tree.new(root_taxon, {})
+    assert_equal root_taxon, subject.root_taxon
   end
 
   # Example of expanded links hash:
@@ -41,11 +30,11 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
   #   }
   # }
 
-  test ".parse_taxons returns an empty array when there are no child taxons" do
-    assert parsed_result({ "expanded_links" => {} }).empty?
+  test "it parses an empty set of child_taxons" do
+    assert result({ "expanded_links" => {} }).empty?
   end
 
-  test ".parse_taxons parses a single child_taxon" do
+  test "it parses a single child_taxon" do
     single_root_node = {
       "expanded_links" => {
         "child_taxons" => [
@@ -54,12 +43,11 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
       }
     }
 
-    result = parsed_result(single_root_node)
-    assert is_an_array_of_taxons(result)
-    assert result.length == 1
+    assert is_an_array_of_taxons result(single_root_node)
+    assert result(single_root_node).length == 1
   end
 
-  test ".parse_taxons parses two child_taxons" do
+  test "it parses two child_taxons" do
     two_root_nodes = {
       "expanded_links" => {
         "child_taxons" => [
@@ -69,12 +57,11 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
       }
     }
 
-    result = parsed_result(two_root_nodes)
-    assert is_an_array_of_taxons(result)
-    assert result.length == 2
+    assert is_an_array_of_taxons result(two_root_nodes)
+    assert result(two_root_nodes).length == 2
   end
 
-  test ".parse_taxons parses descendants of root node" do
+  test "it parses descendants of root node" do
     single_root_with_descendant = {
       "expanded_links" => {
         "child_taxons" => [
@@ -83,13 +70,12 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
       }
     }
 
-    result = parsed_result(single_root_with_descendant)
-    assert result.length == 1
-    assert is_an_array_of_taxons(result.first.children)
-    assert result.first.children.length == 1
+    assert result(single_root_with_descendant).length == 1
+    assert is_an_array_of_taxons result(single_root_with_descendant).first.children
+    assert result(single_root_with_descendant).first.children.length == 1
   end
 
-  test ".parse_taxons sorts the taxon list alphabetically" do
+  test "it sorts the taxon list alphabetically" do
     taxons = {
       "expanded_links" => {
         "child_taxons" => [
@@ -102,22 +88,20 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
     taxons["expanded_links"]["child_taxons"][0]["title"] = "zaphod"
     taxons["expanded_links"]["child_taxons"][1]["title"] = "allen"
 
-    result = parsed_result(taxons)
-
-    assert result.first.name == "allen"
-    assert result.second.name == "zaphod"
+    assert result(taxons).first.name == "allen"
+    assert result(taxons).second.name == "zaphod"
   end
 
   def root_taxon
-    @_root_taxon ||= stub(content_id: @root_taxon_id, 'children=': [])
+    @_root_taxon ||= Taxonomy::Taxon.new(
+      title: 'root',
+      base_path: '/root',
+      content_id: 'root_id'
+    )
   end
 
-  def api_response
-    @_api_response ||= stub(to_h: {})
-  end
-
-  def parsed_result(expanded_links)
-    Taxonomy::Tree.new(root_taxon).parse_taxons(expanded_links)
+  def result(expanded_links = {})
+    Taxonomy::Tree.new(root_taxon, expanded_links).root_taxon.children
   end
 
   def is_an_array_of_taxons(arr)


### PR DESCRIPTION
Calls to publishing-api were often timing out in Integration for
the `get_expanded_links` endpoint. Here we add some explicit
application-side caching for the results of these calls.

[Trello](https://trello.com/c/50YXlNYI/53-fix-whitehall-timeouts-on-integration)

Paired with @whoojemaflip 