### PR TITLE
Remove unused `NewsArticleType`

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -6,7 +6,6 @@ class NewsArticle < Newsesque
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
 
   validates :news_article_type_id, presence: true
-  validate :only_news_article_allowed_invalid_data_can_be_awaiting_type
 
   def self.subtypes
     NewsArticleType.all
@@ -50,13 +49,5 @@ class NewsArticle < Newsesque
 
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-  end
-
-  private
-
-  def only_news_article_allowed_invalid_data_can_be_awaiting_type
-    unless self.can_have_some_invalid_data?
-      errors.add(:news_article_type, 'must be changed') if NewsArticleType.migration.include?(self.news_article_type)
-    end
   end
 end

--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -11,7 +11,6 @@ class NewsArticleType
     3 => "<p>Government statements in response to media coverage, such as rebuttals and ‘myth busters’.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>",
     4 => "<p>Announcements specific to one or more world location. Don’t duplicate news published by another department.</p>",
     999 => "<p>DO NOT USE. This is a legacy category for content created before sub-types existed.</p>",
-    1000 => "<p>DO NOT USE. This is a holding category for content that has been imported automatically.</p>",
   }.to_json.freeze
 
   attr_accessor :id, :singular_name, :plural_name, :prevalence, :key
@@ -85,14 +84,6 @@ class NewsArticleType
     key: "announcement",
     singular_name: "Announcement",
     plural_name: "Announcements",
-    prevalence: :migration
-  )
-  # For imported news with a blank news_article_type field
-  ImportedAwaitingType = create(
-    id: 1000,
-    key: "imported",
-    singular_name: "Imported - awaiting type",
-    plural_name: "Imported - awaiting type",
     prevalence: :migration
   )
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -34,33 +34,6 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert news_article.valid?
   end
 
-  test 'imported news article are valid when the news_article_type is \'imported-awaiting-type\'' do
-    news_article = build(:news_article, state: 'imported', news_article_type: NewsArticleType.find_by_slug('imported-awaiting-type'))
-    assert news_article.valid?
-  end
-
-  test 'imported news article are not valid_as_draft? when the news_article_type is \'imported-awaiting-type\'' do
-    news_article = build(:news_article, state: 'imported', news_article_type: NewsArticleType.find_by_slug('imported-awaiting-type'))
-    refute news_article.valid_as_draft?
-  end
-
-  test 'imported news article are valid when the first_published_at is blank' do
-    news_article = build(:news_article, state: 'imported', first_published_at: nil)
-    assert news_article.valid?
-  end
-
-  test 'imported news article are not valid_as_draft? when the first_published_at is blank, but draft articles are' do
-    refute build(:news_article, state: 'imported', first_published_at: nil).valid_as_draft?
-    assert build(:news_article, state: 'draft', first_published_at: nil).valid_as_draft?
-  end
-
-  [:draft, :scheduled, :published, :submitted, :rejected].each do |state|
-    test "#{state} news article is not valid when the news article type is 'imported-awaiting-type'" do
-      news_article = build(:news_article, state: state, news_article_type: NewsArticleType.find_by_slug('imported-awaiting-type'))
-      refute news_article.valid?
-    end
-  end
-
   test "search_index should include people" do
     news_article = create(:news_article, role_appointments: [create(:role_appointment), create(:role_appointment)])
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]

--- a/test/unit/news_article_type_test.rb
+++ b/test/unit/news_article_type_test.rb
@@ -12,7 +12,7 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
   end
 
   test "should list all slugs" do
-    assert_equal "news-stories, press-releases, government-responses, worldwide-news-stories, announcements and imported-awaiting-type", NewsArticleType.all_slugs
+    assert_equal "news-stories, press-releases, government-responses, worldwide-news-stories and announcements", NewsArticleType.all_slugs
   end
 
   test 'search_format_types tags the type with the key, prefixed with news-article-' do

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -209,7 +209,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     topic = create(:topic)
     organisation = create(:ministerial_department)
     @edition = create(:news_article, organisations: [organisation])
-    @edition.stubs(:news_article_type).returns(NewsArticleType::ImportedAwaitingType)
+    @edition.stubs(:news_article_type).returns(NewsArticleType::WorldwideNewsStory)
     @edition.stubs(:topics).returns [topic]
 
     refute urls_for(@edition).any? { |feed_url| feed_url =~ /announcement_filter_option\=/ }


### PR DESCRIPTION
This removes a `NewsArticleType` that is no longer used. (`NewsArticleType::ImportedAwaitingType`). It also removes some related tests for `NewsArticle` in imported state which is also no longer used.

Loosely related to -> [Trello](https://trello.com/c/VygNbQmD/88-create-a-new-worldwide-news-article-subtype)