### PR TITLE
Re-slug 'Initial teacher training allocations' statistics

### DIFF
--- a/db/data_migration/20170510140754_reslug_initial_teacher_training_allocations_academic_year_2016_to_2017.rb
+++ b/db/data_migration/20170510140754_reslug_initial_teacher_training_allocations_academic_year_2016_to_2017.rb
@@ -1,0 +1,7 @@
+current_slug = 'initial-teacher-training-allocations-academic-year-2016-to-2017'
+new_slug = 'initial-teacher-training-allocations-academic-year-2017-to-2018'
+
+document = Document.find_by(slug: current_slug)
+document.update_attribute(:slug, new_slug)
+
+PublishingApiDocumentRepublishingWorker.perform_async(document.id)


### PR DESCRIPTION
Slug created in error. See https://govuk.zendesk.com/agent/tickets/2131509