### PR TITLE
Rename worldwide news story sub type

### DIFF
--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -72,11 +72,11 @@ class NewsArticleType
     plural_name: "Government responses",
     prevalence: :primary
   )
-  WorldwideNewsStory = create(
+  WorldNewsStory = create(
     id: 4,
-    key: "worldwide_news_story",
-    singular_name: "Worldwide news story",
-    plural_name: "Worldwide news stories",
+    key: "world_news_story",
+    singular_name: "World news story",
+    plural_name: "World news stories",
     prevalence: :primary
   )
   Unknown = create(

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -321,7 +321,7 @@ ar:
         few:
         many:
         other: "بيانات تتعلق بالشفافية"
-      worldwide_news_story:
+      world_news_story:
         zero:
         one:
         two:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -256,7 +256,7 @@ az:
       transparency:
         one: "Şəffaf məlumat"
         other: "Şəffaf məlumat"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -231,7 +231,7 @@ be:
         few:
         many:
         other: "Адкрытыя дадзеныя"
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         many:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -141,7 +141,7 @@ bg:
       transparency:
         one: "Информация за прозрачността"
         other: "Информация за прозрачността"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -141,7 +141,7 @@ bn:
       transparency:
         one:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -186,7 +186,7 @@ cs:
         one: Transparenost
         few:
         other: Transparentnost
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         other:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -321,7 +321,7 @@ cy:
         few:
         many:
         other: Data tryloywder
-      worldwide_news_story:
+      world_news_story:
         zero:
         one:
         two:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -141,7 +141,7 @@ de:
       transparency:
         one: Transparenz-Daten
         other: Transparenz-Daten
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -141,7 +141,7 @@ dr:
       transparency:
         one: "ارقام شفافیت"
         other: "ارقام شفافیت"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -141,7 +141,7 @@ el:
       transparency:
         one: "Στοιχεία διαφάνειας"
         other: "Στοιχεία διαφάνειας"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,7 +236,7 @@ en:
       written_statement:
         one: Written statement to Parliament
         other: Written statements to Parliament
-      worldwide_news_story:
+      world_news_story:
         one: Worldwide news story
         other: Worldwide news stories
       authored_article:

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -141,7 +141,7 @@ es-419:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -141,7 +141,7 @@ es:
       transparency:
         one: Datos sobre transparencia
         other: Datos sobre transparencia
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -141,7 +141,7 @@ et:
       transparency:
         one: Läbipaistvusteave
         other: Läbipaistvusteave
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -258,7 +258,7 @@ fa:
       transparency:
         one: "داده های شفاف سازی"
         other: "داده های شفاف سازی"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,7 +141,7 @@ fr:
       transparency:
         one: Transparence des données
         other: Transparence des données
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -231,7 +231,7 @@ he:
         two:
         many:
         other: "שקיפות מידע"
-      worldwide_news_story:
+      world_news_story:
         one:
         two:
         many:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -141,7 +141,7 @@ hi:
       transparency:
         one: "पारदर्शिता आंकड़े"
         other: "पारदर्शिता आंकड़े"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -259,7 +259,7 @@ hu:
       transparency:
         one: "Átláthatósági adatok"
         other: "Átláthatósági adatok"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -141,7 +141,7 @@ hy:
       transparency:
         one: "Բաց տեղեկատվություն"
         other: "Բաց տեղեկատվություններ"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -258,7 +258,7 @@ id:
       transparency:
         one: Transparansi data
         other: Transparansi data
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -141,7 +141,7 @@ it:
       transparency:
         one: Dati sulla trasparenza
         other: Dati sulla trasparenza
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -257,7 +257,7 @@ ja:
       transparency:
         one: "透明性データ"
         other: "透明性データ"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -256,7 +256,7 @@ ka:
       transparency:
         one:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -257,7 +257,7 @@ ko:
       transparency:
         one: "투명성 데이타"
         other: "투명성 데이타"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -186,7 +186,7 @@ lt:
         one: Skaidrumo informacija
         few:
         other: Skaidrumo informacija
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         other:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -141,7 +141,7 @@ lv:
       transparency:
         one: Atklātības dati
         other: Atklātības dati
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -256,7 +256,7 @@ ms:
       transparency:
         one:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -231,7 +231,7 @@ pl:
         few:
         many:
         other: Dane o transparentności
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         many:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -141,7 +141,7 @@ ps:
       transparency:
         one: "د روڼوالې اطلاعات"
         other: "د روڼوالي اطلاعات"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -141,7 +141,7 @@ pt:
       transparency:
         one: Dado de Transparência
         other: Dados de Transparência
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -186,7 +186,7 @@ ro:
         one:
         few:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         other:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -231,7 +231,7 @@ ru:
         few:
         many:
         other: "Прозрачность данных"
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         many:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -141,7 +141,7 @@ si:
       transparency:
         one: "විනිවිධභාවයේ දත්ත"
         other: "විනිවිධභාවයේ දත්ත"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -186,7 +186,7 @@ sk:
         one:
         few:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         other:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -141,7 +141,7 @@ so:
       transparency:
         one: Xog daahfurnaan
         other: Xog daahfurnaan
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -141,7 +141,7 @@ sq:
       transparency:
         one: Te dhena per transparencen
         other: Te dhena per transparencen
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -231,7 +231,7 @@ sr:
         few:
         many:
         other: podaci o transparentnosti
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         many:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -141,7 +141,7 @@ sw:
       transparency:
         one:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -141,7 +141,7 @@ ta:
       transparency:
         one: "வெளிப்படையான தரவு"
         other: "வெளிப்படையான தரவு"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -257,7 +257,7 @@ th:
       transparency:
         one: "ข้อมูลโปร่งใส"
         other: "ข้อมูลโปร่งใส"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -141,7 +141,7 @@ tk:
       transparency:
         one:
         other:
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -258,7 +258,7 @@ tr:
       transparency:
         one: Veri saydamlığı
         other: Veri saydamlığı
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -231,7 +231,7 @@ uk:
         few:
         many:
         other: "Прозорість інформації"
-      worldwide_news_story:
+      world_news_story:
         one:
         few:
         many:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -141,7 +141,7 @@ ur:
       transparency:
         one: "ٹرانسپیرنسی ڈیٹا"
         other: "ٹرانسپیرنسی ڈیٹا"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -141,7 +141,7 @@ uz:
       transparency:
         one: Ochiqlikka oid ma'lumotlar
         other: Ochiqlikka oid ma'lumotlar
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -258,7 +258,7 @@ vi:
       transparency:
         one: Dữ liệu kịch bản
         other: Dữ liệu kịch bản
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -256,7 +256,7 @@ zh-hk:
       transparency:
         one: "透明化數據"
         other: "其他透明化數據"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -256,7 +256,7 @@ zh-tw:
       transparency:
         one: "透明化數據"
         other: "透明化數據"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -256,7 +256,7 @@ zh:
       transparency:
         one: "透明化数据"
         other: "透明化数据"
-      worldwide_news_story:
+      world_news_story:
         one:
         other:
       written_statement:

--- a/test/unit/news_article_type_test.rb
+++ b/test/unit/news_article_type_test.rb
@@ -12,7 +12,7 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
   end
 
   test "should list all slugs" do
-    assert_equal "news-stories, press-releases, government-responses, worldwide-news-stories and announcements", NewsArticleType.all_slugs
+    assert_equal "news-stories, press-releases, government-responses, world-news-stories and announcements", NewsArticleType.all_slugs
   end
 
   test 'search_format_types tags the type with the key, prefixed with news-article-' do

--- a/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/subscription_url_generator_test.rb
@@ -209,7 +209,7 @@ class Whitehall::GovUkDelivery::SubscriptionUrlGeneratorTest < ActiveSupport::Te
     topic = create(:topic)
     organisation = create(:ministerial_department)
     @edition = create(:news_article, organisations: [organisation])
-    @edition.stubs(:news_article_type).returns(NewsArticleType::WorldwideNewsStory)
+    @edition.stubs(:news_article_type).returns(NewsArticleType::WorldNewsStory)
     @edition.stubs(:topics).returns [topic]
 
     refute urls_for(@edition).any? { |feed_url| feed_url =~ /announcement_filter_option\=/ }


### PR DESCRIPTION
Changes to `world-news-story` as `wide` was considered redundant in this context and `world-news-story` is consistent with the non-world flavour.

[Trello](https://trello.com/c/VygNbQmD/88-create-a-new-worldwide-news-article-subtype)