### PR TITLE
Add govuk_ab_testing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'parallel', '1.4.1'
 gem 'responders', '~> 2.0'
 gem 'ruby-progressbar', require: false
 gem 'equivalent-xml', '0.5.1', require: false
+gem 'govuk_ab_testing', '~> 2.2.0'
 
 gem 'deprecated_columns', '0.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     govuk-lint (2.1.0)
       rubocop (~> 0.43.0)
       scss_lint
+    govuk_ab_testing (2.2.0)
     govuk_admin_template (4.2.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
@@ -479,6 +480,7 @@ DEPENDENCIES
   govspeak (~> 3.6.2)
   govuk-content-schema-test-helpers
   govuk-lint
+  govuk_ab_testing (~> 2.2.0)
   govuk_admin_template (= 4.2.0)
   govuk_frontend_toolkit (= 5.0.3)
   govuk_sidekiq (= 0.0.4)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,10 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.project_root = Rails.root
 end
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :capybara
+end
+
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
   include ModelHelpers


### PR DESCRIPTION
This commit adds the `govuk_ab_testing` gem to whitehall as a precursor to carrying out an A/B test for worldwide content.

Trello: https://trello.com/c/O53D34GC/94-integrate-a-b-testing-framework-into-whitehall