### PR TITLE
Convert foreign language to checkbox

### DIFF
--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -9,7 +9,7 @@
 
       this.showChangeNotesIfMajorChange();
       this.showFormatAdviceForSelectedSubtype();
-      this.setupNonEnglishSupport();
+      this.toggleLanguageSelect();
       this.toggleFirstPublishedDate();
 
       GOVUK.formChangeProtection.init($('#edit_edition'), 'You have unsaved changes that will be lost if you leave this page.');
@@ -54,39 +54,30 @@
       }).change();
     },
 
-    setupNonEnglishSupport: function setupNonEnglishSupport() {
+    toggleLanguageSelect: function toggleLanguageSelect() {
       if ( !this.$form.hasClass('js-supports-non-english') ) return;
 
       var $form = this.$form;
 
       $().ready(function() {
-        // hide locale fieldsets
         var $localeInput = $(this).find('#edition_primary_locale');
-        var $fieldset = $localeInput.parents('fieldset');
 
-        // add link for changing the default locale
-        var $revealLink = $('<p><a href="#" class="foreign-language-only">Designate as a foreign language only document</a></p>');
-        $revealLink.insertBefore($fieldset);
-        $revealLink.on('click', 'a', function (evt) {
-          // reveal the locale selector
-          $revealLink.hide();
-          $fieldset.show();
-          evt.preventDefault();
-        });
+        var toggleVisibility = function() {
+          if ($('input#create_foreign_language_only').prop('checked')) {
+            $('.foreign-language-select').show();
+          } else {
+            $('.foreign-language-select').hide();
 
-        // add link to cancel and reset back to the default locale
-        var $resetLink = $('<a href="#" class="add-left-margin cancel-foreign-language-only">Cancel</a>');
-        $resetLink.insertAfter($localeInput);
-        $resetLink.on('click', function (evt) {
-          // hide the fieldset and reset the locale selector
-          $fieldset.hide();
-          $revealLink.show();
-          $localeInput.val('');
-          $form.find('fieldset').removeClass('right-to-left');
-          evt.preventDefault();
-        });
+            // reset back to the default locale
+            $localeInput.val('');
+            $form.find('fieldset').removeClass('right-to-left');
+          }
+        }
 
-        // setup observer to apply right-to-left classes as appropriate
+        $('input#create_foreign_language_only').change(toggleVisibility)
+        toggleVisibility();
+
+        // setup observer to apply right-to-left classes to all form fieldsets
         $('#edition_primary_locale').change(function () {
           if ( $.inArray($(this).val(), GOVUK.adminEditionsForm.rightToLeftLocales) > -1) {
             $form.find('fieldset').addClass('right-to-left');
@@ -95,7 +86,6 @@
           }
         });
       })
-
     },
 
     toggleFirstPublishedDate: function toggleFirstPublishedDate() {

--- a/app/assets/javascripts/admin/views/editions/_form.js
+++ b/app/assets/javascripts/admin/views/editions/_form.js
@@ -10,6 +10,7 @@
       this.showChangeNotesIfMajorChange();
       this.showFormatAdviceForSelectedSubtype();
       this.toggleLanguageSelect();
+      this.toggleNonEnglishSupport();
       this.toggleFirstPublishedDate();
 
       GOVUK.formChangeProtection.init($('#edit_edition'), 'You have unsaved changes that will be lost if you leave this page.');
@@ -52,6 +53,38 @@
           $container.append(adviceHTML);
         }
       }).change();
+    },
+
+    toggleNonEnglishSupport: function toggleNonEnglishSupport() {
+      if ( !this.$form.hasClass('js-supports-non-english') ) return;
+      // only toggle foreign language fields when news article type is editable
+      if ( $( "select#edition_news_article_type_id" ).length == 0 ) return;
+
+      var $form = this.$form;
+
+      $().ready(function() {
+        var $newsTypeSelect = $('select#edition_news_article_type_id')
+        var $foreignLanguageFieldset = $(this).find('fieldset.foreign-language');
+        var $foreignLanguageToggle = $('input#create_foreign_language_only')
+        var $localeInput = $(this).find('#edition_primary_locale');
+        var worldNewsStoryType = 4
+
+        var toggleVisibility = function() {
+          if ($newsTypeSelect.val() == worldNewsStoryType) {
+            $foreignLanguageFieldset.show();
+          } else {
+            $foreignLanguageFieldset.hide();
+
+            // reset foreign language options
+            $foreignLanguageToggle.prop("checked", false)
+            $localeInput.val('');
+            $form.find('fieldset').removeClass('right-to-left');
+          }
+        }
+
+        $newsTypeSelect.change(toggleVisibility)
+        toggleVisibility();
+      })
     },
 
     toggleLanguageSelect: function toggleLanguageSelect() {

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -131,7 +131,6 @@ module Admin::EditionsHelper
     form_classes << 'js-supports-non-english' if edition.locale_can_be_changed?
 
     form_for form_url_for_edition(edition), as: :edition, html: { class: form_classes } do |form|
-      concat render('locale_fields', form: form, edition: edition)
       concat edition_information(@information) if @information
       concat form.errors
       concat render("standard_fields", form: form, edition: edition)

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -6,6 +6,7 @@ class NewsArticle < Newsesque
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
 
   validates :news_article_type_id, presence: true
+  validate :non_english_primary_locale_only_for_world_news_story
 
   def self.subtypes
     NewsArticleType.all
@@ -53,5 +54,11 @@ class NewsArticle < Newsesque
 
   def locale_can_be_changed?
     new_record?
+  end
+
+  def non_english_primary_locale_only_for_world_news_story
+    if non_english_edition? && news_article_type != NewsArticleType::WorldNewsStory
+      errors.add(:foreign_language, 'is not allowed')
+    end
   end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -50,4 +50,8 @@ class NewsArticle < Newsesque
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
+
+  def locale_can_be_changed?
+    new_record?
+  end
 end

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,6 +1,11 @@
 <% if edition.locale_can_be_changed? %>
-  <fieldset class="js-hidden">
-    <div class="form-group">
+  <fieldset>
+    <div class="checkbox">
+      <%= label_tag :create_foreign_language_only, nil, class: [:checkbox, "js-toggle-scheduled-publication-date-picker"] do %>
+        <%= check_box_tag :create_foreign_language_only, "1", form.object.primary_locale != "en" %> Create a foreign language only news article
+      <% end %>
+    </div>
+    <div class="form-group foreign-language-select js-hidden">
       <%= form.label :primary_locale, 'Document language' %>
       <div class="form-inline add-label-margin">
         <%= form.select :primary_locale, options_for_foreign_language_locale(edition), {}, {class: 'form-control input-md-6'} %>

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -10,7 +10,7 @@
       <div class="form-inline add-label-margin">
         <%= form.select :primary_locale, options_for_foreign_language_locale(edition), {}, {class: 'form-control input-md-6'} %>
       </div>
-      <p class="warning">Warning: Foreign language only documents do not allow additional translations.</p>
+      <p class="warning">Warning: News stories without an English version cannot have other translations.</p>
     </div>
   </fieldset>
 <% end %>

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,5 +1,5 @@
 <% if edition.locale_can_be_changed? %>
-  <fieldset>
+  <fieldset class="foreign-language">
     <div class="checkbox">
       <%= label_tag :create_foreign_language_only, nil, class: [:checkbox, "js-toggle-scheduled-publication-date-picker"] do %>
         <%= check_box_tag :create_foreign_language_only, "1", form.object.primary_locale != "en" %> Create a foreign language only news article

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -1,5 +1,6 @@
 <%= content_tag :fieldset, class: ("right-to-left" if edition.rtl?) do %>
   <%= render "subtype_fields", form: form, edition: form.object %>
+  <%= render "locale_fields", form: form, edition: edition %>
 
   <%= form.hidden_field :lock_version %>
   <% if form.object.document %>

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -1,0 +1,26 @@
+Feature: News articles
+  Background:
+    Given I am an GDS editor
+
+  Scenario: Create a news article of type 'News story'
+    When I draft a valid news article of type "News story" with title "You will never guess"
+    Then the news article "You will never guess" should have been created
+
+  Scenario: Create a news article of type 'Press release'
+    When I draft a valid news article of type "Press release" with title "This is serious"
+    Then the news article "This is serious" should have been created
+
+  Scenario: Create a news article of type 'Government response'
+    When I draft a valid news article of type "Government response" with title "Yes we can"
+    Then the news article "Yes we can" should have been created
+
+  Scenario: Create a news article of type 'World news story'
+    When I draft a valid news article of type "World news story" with title "A thing happened in X"
+    Then the news article "A thing happened in X" should have been created
+
+  Scenario: Create a News article of type 'world news story' in a non-English language
+    Given a world location "France" exists with a translation for the locale "Français"
+    When I draft a French-only news article of type "World news story" associated with "France"
+    Then I should see the news article listed in admin with an indication that it is in French
+    When I publish the French-only news article
+    Then I should only see the news article on the French version of the public "France" location page

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -1,20 +1,20 @@
-Given /^a published news article "([^"]*)" with related published policies "([^"]*)" and "([^"]*)"$/ do |news_article_title, policy_title_1, policy_title_2|
+Given(/^a published news article "([^"]*)" with related published policies "([^"]*)" and "([^"]*)"$/) do |news_article_title, policy_title_1, policy_title_2|
   policies = publishing_api_has_policies([policy_title_1, policy_title_2])
 
   create(:published_news_article, title: news_article_title, policy_content_ids: policies.map {|p| p['content_id']})
 end
 
-Given /^a published news article "([^"]*)" associated with "([^"]*)"$/ do |title, appointee|
+Given(/^a published news article "([^"]*)" associated with "([^"]*)"$/) do |title, appointee|
   person = find_person(appointee)
   appointment = find_person(appointee).current_role_appointments.last
   create(:published_news_article, title: title, role_appointments: [appointment])
 end
 
-Given /^a published news article "([^"]*)" which isn't explicitly associated with "([^"]*)"$/ do |title, thing|
+Given(/^a published news article "([^"]*)" which isn't explicitly associated with "([^"]*)"$/) do |title, thing|
   create(:published_news_article, title: title)
 end
 
-When /^I draft a new news article "([^"]*)"$/ do |title|
+When(/^I draft a new news article "([^"]*)"$/) do |title|
   begin_drafting_news_article title: title, summary: "here's a simple summary"
   within ".images" do
     attach_file "File", jpg_image, match: :first
@@ -23,7 +23,7 @@ When /^I draft a new news article "([^"]*)"$/ do |title|
   click_button "Save"
 end
 
-When /^I draft a new news article "([^"]*)" relating it to the policies "([^"]*)" and "([^"]*)"$/ do |title, first_policy, second_policy|
+When(/^I draft a new news article "([^"]*)" relating it to the policies "([^"]*)" and "([^"]*)"$/) do |title, first_policy, second_policy|
   publishing_api_has_policies([first_policy, second_policy])
 
   begin_drafting_news_article title: title
@@ -32,7 +32,7 @@ When /^I draft a new news article "([^"]*)" relating it to the policies "([^"]*)
   click_button "Save"
 end
 
-When /^I publish a news article "([^"]*)" associated with "([^"]*)"$/ do |title, person_name|
+When(/^I publish a news article "([^"]*)" associated with "([^"]*)"$/) do |title, person_name|
   begin_drafting_news_article title: title
   fill_in_news_article_fields(first_published: Date.today.to_s)
   select person_name, from: "Ministers"
@@ -40,7 +40,7 @@ When /^I publish a news article "([^"]*)" associated with "([^"]*)"$/ do |title,
   publish(force: true)
 end
 
-When /^I publish a news article "([^"]*)" associated with the (topic|topical event) "([^"]*)"$/ do |title, type, topic_name|
+When(/^I publish a news article "([^"]*)" associated with the (topic|topical event) "([^"]*)"$/) do |title, type, topic_name|
   begin_drafting_news_article title: title, skip_topic_selection: (type == 'topic')
 
   if type == 'topic'
@@ -64,33 +64,33 @@ When(/^I publish a news article "(.*?)" associated with the organisation "(.*?)"
   publish(force: true)
 end
 
-When /^I attempt to add the article image into the markdown$/ do
+When(/^I attempt to add the article image into the markdown$/) do
   fill_in "Body", with: "body copy\n!!1\nmore body"
 end
 
-Then /^the news article tag is the same as the person in the text$/ do
+Then(/^the news article tag is the same as the person in the text$/) do
   visit admin_edition_path(NewsArticle.last)
   click_button "Create new edition"
   appointment = NewsArticle.last.role_appointments.first
   assert has_css?("select#edition_role_appointment_ids option[value='#{appointment.id}'][selected=selected]")
 end
 
-Then /^I should see both the news articles for the Deputy Prime Minister role$/ do
+Then(/^I should see both the news articles for the Deputy Prime Minister role$/) do
   assert has_css?(".news_article", text: "News from Don, Deputy PM")
   assert has_css?(".news_article", text: "News from Harriet, Deputy PM")
 end
 
-Then /^I should see both the news articles for Harriet Home$/ do
+Then(/^I should see both the news articles for Harriet Home$/) do
   assert has_css?(".news_article", text: "News from Harriet, Deputy PM")
   assert has_css?(".news_article", text: "News from Harriet, Home Sec")
 end
 
-Then /^I should be informed I shouldn't use this image in the markdown$/ do
+Then(/^I should be informed I shouldn't use this image in the markdown$/) do
   click_on "Edit draft"
   assert has_no_css?("fieldset#image_fields .image input[value='!!1']")
 end
 
-When /^I browse to the announcements index$/ do
+When(/^I browse to the announcements index$/) do
   visit announcements_path
 end
 
@@ -114,7 +114,7 @@ When(/^I draft a French\-only news article of type "([^"]*)" associated with "([
   @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
 end
 
-When /^I publish the French-only news article$/ do
+When(/^I publish the French-only news article$/) do
   visit admin_edition_path(@news_article)
   publish(force: true)
 end
@@ -126,12 +126,12 @@ When(/^I publish a news article "(.*?)" for "(.*?)"$/) do |title, location_name|
   publish(force: true)
 end
 
-Then /^I should see the news article listed in admin with an indication that it is in French$/ do
+Then(/^I should see the news article listed in admin with an indication that it is in French$/) do
   assert_path admin_edition_path(@news_article)
   assert page.has_content?("This document is French-only")
 end
 
-Then /^I should only see the news article on the French version of the public "([^"]*)" location page$/ do |world_location_name|
+Then(/^I should only see the news article on the French version of the public "([^"]*)" location page$/) do |world_location_name|
   world_location = WorldLocation.find_by!(name: world_location_name)
   visit world_location_path(world_location, locale: :fr)
   within record_css_selector(@news_article) do

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -105,3 +105,47 @@ When(/^I filter the announcements list by "(.*?)"$/) do |announcement_type|
   select announcement_type, from: "Announcement type"
   click_on "Refresh results"
 end
+
+When(/^I draft a French\-only news article of type "([^"]*)" associated with "([^"]*)"$/) do |announcement_type, location_name|
+  begin_drafting_news_article title: "French-only news article", body: 'test-body', summary: 'test-summary', announcement_type: "World news story"
+  select "Français", from: "Document language"
+  select location_name, from: "Select the world locations this news article is about"
+  click_button "Save"
+  @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
+end
+
+When /^I publish the French-only news article$/ do
+  visit admin_edition_path(@news_article)
+  publish(force: true)
+end
+
+When(/^I publish a news article "(.*?)" for "(.*?)"$/) do |title, location_name|
+  begin_drafting_news_article(title: title)
+  select location_name, from: "Select the world locations this news article is about"
+  click_button "Save"
+  publish(force: true)
+end
+
+Then /^I should see the news article listed in admin with an indication that it is in French$/ do
+  assert_path admin_edition_path(@news_article)
+  assert page.has_content?("This document is French-only")
+end
+
+Then /^I should only see the news article on the French version of the public "([^"]*)" location page$/ do |world_location_name|
+  world_location = WorldLocation.find_by!(name: world_location_name)
+  visit world_location_path(world_location, locale: :fr)
+  within record_css_selector(@news_article) do
+    assert page.has_content?(@news_article.title)
+  end
+  visit world_location_path(world_location)
+  assert page.has_no_css?(record_css_selector(@news_article))
+end
+
+When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do |news_type, title|
+  begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)
+  click_button "Save"
+end
+
+Then(/^the news article "([^"]*)" should have been created$/) do |title|
+  refute NewsArticle.find_by(title: title).nil?
+end

--- a/features/support/news_article_helper.rb
+++ b/features/support/news_article_helper.rb
@@ -1,0 +1,9 @@
+module NewsArticleHelper
+  def find_news_article_in_locale!(locale, title)
+    I18n.with_locale locale do
+      NewsArticle.find_by!(title: title)
+    end
+  end
+end
+
+World(NewsArticleHelper)

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -2,15 +2,23 @@ module("admin-edition-form: ", {
   setup: function() {
     $('#qunit-fixture').append(
       '<form id="non-english" class="js-supports-non-english">' +
-        '<fieldset class="js-hidden">' +
-          '<label for="edition_primary_locale">Document language</label>' +
-          '<select id="edition_primary_locale" name="edition[primary_locale]">' +
-            '<option value="" selected="selected">Choose foreign language</option>' +
-            '<option value="en" selected="selected">English (English)</option>' +
-            '<option value="ar">العربية (Arabic)</option>' +
-            '<option value="cy">Cymraeg (Welsh)</option>' +
-          '</select>' +
-          '<p class="warning">Warning: Foreign language documents do not support translations.</p>' +
+        '<fieldset>' +
+          '<div class="checkbox">' +
+            '<label class="checkbox" for="create_foreign_language_only">' +
+              '<input type="checkbox" name="create_foreign_language_only" id="create_foreign_language_only" value="1" /> Create a foreign language only news article' +
+            '</label>' +
+          '</div>' +
+          '<div class="form-group foreign-language-select js-hidden">' +
+            '<label for="edition_primary_locale">Document language</label>' +
+            '<div class="form-inline add-label-margin">' +
+              '<select class="form-control input-md-6" name="edition[primary_locale]" id="edition_primary_locale">' +
+                '<option value="">Choose foreign language...</option>' +
+                '<option value="ar">العربية (Arabic)</option>' +
+                '<option value="cy">Cymraeg (Welsh)</option>' +
+              '</select>' +
+            '</div>' +
+            '<p class="warning">Warning: Foreign language only documents do not allow additional translations.</p>' +
+          '</div>' +
         '</fieldset>' +
         '<fieldset>' +
           '<label for="edition_title">Title</label>' +
@@ -73,38 +81,33 @@ module("admin-edition-form: ", {
   }
 });
 
-test("the fieldset containing the locale input fields should initially be hidden", function () {
-  ok($('form#non-english:first-child fieldset').is(':hidden'), 'fieldset containing locale inputs is not hidden');
+test("the div containing the locale input fields should initially be hidden", function () {
+  ok($('div.foreign-language-select').is(':hidden'), 'div containing locale inputs is not hidden');
 });
 
-test("all other fieldsets should be visible", function () {
-  ok($('form#non-english:not(:first-child fieldset)').is(':visible'), 'other fieldsets should still be visible');
+test("checking 'Create a foreign language only news article' reveals the locale input fields", function () {
+  $('input#create_foreign_language_only').click()
+
+  ok($('div.foreign-language-select').is(':visible'), 'div containing locale inputs becomes visible');
 });
 
-test("inserts a link that reveals the locale input fields when clicked", function () {
-  equal($('form#non-english a.foreign-language-only').length, 1, "A link exists for foreign-language only documents");
-
-  $('a.foreign-language-only').click();
-  ok($('form#non-english:first-child fieldset').is(':visible'), 'fieldset containing locale inputs becomes visible');
-  ok($('form#non-english:not(:first-child fieldset)').is(':visible'), 'other fieldsets should still be visible');
-});
-
-test("cancelling foreign language only document hides and resets the locale fields", function () {
-  $('a.foreign-language-only').click();
+test("unchecking 'Create a foreign language only news article' hides and resets the locale fields", function () {
+  $('input#create_foreign_language_only').click()
+  ok($('div.foreign-language-select').is(':visible'), 'div containing locale inputs has become visible');
 
   // choose another language
   $('#edition_primary_locale').val('cy').change();
   equal($('#edition_primary_locale option:selected').val(), 'cy', 'foreign-language selected');
 
   // reset the form
-  $('a.cancel-foreign-language-only').click();
+  $('input#create_foreign_language_only').click()
 
   equal($('#edition_primary_locale option:selected').val(), '', 'locale reset back to English');
-  ok($('form#non-english:first-child fieldset').is(':hidden'), 'fieldset containing locale inputs has become hidden');
+  ok($('div.foreign-language-select').is(':hidden'), 'div containing locale inputs has become hidden');
 });
 
 test("selecting and deselecting right-to-left languages applies the appropriate classes to the fieldsets", function () {
-  $('a.foreign-language-only').click();
+  $('input#create_foreign_language_only').click()
 
   $('#edition_primary_locale').val('ar').change();
   ok($('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets have "right-to-left" class');
@@ -115,7 +118,7 @@ test("selecting and deselecting right-to-left languages applies the appropriate 
   // also resets on cancel
   $('#edition_primary_locale').val('ar').change();
   ok($('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets have "right-to-left" class');
-  $('a.cancel-foreign-language-only').click();
+  $('input#create_foreign_language_only').click()
   ok(!$('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets no longer have "right-to-left" class');
 });
 

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -1,77 +1,86 @@
-module("admin-edition-form: ", {
-  setup: function() {
-    $('#qunit-fixture').append(
-      '<form id="non-english" class="js-supports-non-english">' +
-        '<fieldset>' +
-          '<div class="checkbox">' +
-            '<label class="checkbox" for="create_foreign_language_only">' +
-              '<input type="checkbox" name="create_foreign_language_only" id="create_foreign_language_only" value="1" /> Create a foreign language only news article' +
-            '</label>' +
-          '</div>' +
-          '<div class="form-group foreign-language-select js-hidden">' +
-            '<label for="edition_primary_locale">Document language</label>' +
-            '<div class="form-inline add-label-margin">' +
-              '<select class="form-control input-md-6" name="edition[primary_locale]" id="edition_primary_locale">' +
-                '<option value="">Choose foreign language...</option>' +
-                '<option value="ar">العربية (Arabic)</option>' +
-                '<option value="cy">Cymraeg (Welsh)</option>' +
-              '</select>' +
-            '</div>' +
-            '<p class="warning">Warning: Foreign language only documents do not allow additional translations.</p>' +
-          '</div>' +
-        '</fieldset>' +
-        '<fieldset>' +
-          '<label for="edition_title">Title</label>' +
-          '<input id="edition_title" name="edition[title]" size="30" type="text" />' +
-        '</fieldset>' +
-        '<fieldset class="first-published-date well">' +
-          '<p class="required">This document <span>*</span></p>' +
-          '<label class="radio" for="edition_previously_published_false">' +
-            '<input id="edition_previously_published_false" name="edition[previously_published]" type="radio" value="true">' +
-            'has never been published before. It is new.' +
-        '</label>' +
-          '<label class="radio" for="edition_previously_published_true">' +
-            '<input id="edition_previously_published_true" name="edition[previously_published]" type="radio" value="false">' +
-            'has previously been published on another website.' +
-        '</label>' +
-          '<div class="js-show-first-published" style="display: none;">' +
-              '<label class="required extra-label" for="edition_first_published_at">Its original publication date was <span>*</span></label>' +
-            '<select class="date" id="edition_first_published_at_1i" name="edition[first_published_at(1i)]">' +
-        '<option value=""></option>' +
-        '<option value="2014">2014</option>' +
-        '<option value="2013">2013</option>' +
-        '<option value="2012">2012</option>' +
+var form =
+  '<form id="non-english" class="js-supports-non-english"></form>'
+
+var foreignLanguageFieldset =
+  '<fieldset class="foreign-language">' +
+    '<div class="checkbox">' +
+      '<label class="checkbox" for="create_foreign_language_only">' +
+        '<input type="checkbox" name="create_foreign_language_only" id="create_foreign_language_only" value="1" /> Create a foreign language only news article' +
+      '</label>' +
+    '</div>' +
+    '<div class="form-group foreign-language-select js-hidden">' +
+      '<label for="edition_primary_locale">Document language</label>' +
+      '<div class="form-inline add-label-margin">' +
+        '<select class="form-control input-md-6" name="edition[primary_locale]" id="edition_primary_locale">' +
+          '<option value="">Choose foreign language...</option>' +
+          '<option value="ar">العربية (Arabic)</option>' +
+          '<option value="cy">Cymraeg (Welsh)</option>' +
+        '</select>' +
+      '</div>' +
+      '<p class="warning">Warning: Foreign language only documents do not allow additional translations.</p>' +
+    '</div>' +
+  '</fieldset>'
+
+var titleFieldset =
+  '<fieldset>' +
+    '<label for="edition_title">Title</label>' +
+    '<input id="edition_title" name="edition[title]" size="30" type="text" />' +
+  '</fieldset>'
+
+var firstPublishedAtFieldset =
+  '<fieldset class="first-published-date well">' +
+    '<p class="required">This document <span>*</span></p>' +
+    '<label class="radio" for="edition_previously_published_false">' +
+      '<input id="edition_previously_published_false" name="edition[previously_published]" type="radio" value="true">' +
+      'has never been published before. It is new.' +
+  '</label>' +
+  '<label class="radio" for="edition_previously_published_true">' +
+    '<input id="edition_previously_published_true" name="edition[previously_published]" type="radio" value="false">' +
+    'has previously been published on another website.' +
+  '</label>' +
+    '<div class="js-show-first-published" style="display: none;">' +
+        '<label class="required extra-label" for="edition_first_published_at">Its original publication date was <span>*</span></label>' +
+        '<select class="date" id="edition_first_published_at_1i" name="edition[first_published_at(1i)]">' +
+          '<option value=""></option>' +
+          '<option value="2014">2014</option>' +
+          '<option value="2013">2013</option>' +
+          '<option value="2012">2012</option>' +
         '</select>' +
         '<select class="date" id="edition_first_published_at_2i" name="edition[first_published_at(2i)]">' +
-        '<option value=""></option>' +
-        '<option value="1">January</option>' +
-        '<option value="2">February</option>' +
-        '<option value="3">March</option>' +
+          '<option value=""></option>' +
+          '<option value="1">January</option>' +
+          '<option value="2">February</option>' +
+          '<option value="3">March</option>' +
         '</select>' +
         '<select class="date" id="edition_first_published_at_3i" name="edition[first_published_at(3i)]">' +
-        '<option value=""></option>' +
-        '<option value="1">1</option>' +
-        '<option value="2">2</option>' +
-        '<option value="3">3</option>' +
+          '<option value=""></option>' +
+          '<option value="1">1</option>' +
+          '<option value="2">2</option>' +
+          '<option value="3">3</option>' +
         '</select>' +
          '— <select class="date" id="edition_first_published_at_4i" name="edition[first_published_at(4i)]">' +
-        '<option value=""></option>' +
-        '<option value="00">00</option>' +
-        '<option value="01">01</option>' +
-        '<option value="02" selected="selected">02</option>' +
-        '<option value="03">03</option>' +
+          '<option value=""></option>' +
+          '<option value="00">00</option>' +
+          '<option value="01">01</option>' +
+          '<option value="02" selected="selected">02</option>' +
+          '<option value="03">03</option>' +
         '</select>' +
          ': <select class="date" id="edition_first_published_at_5i" name="edition[first_published_at(5i)]">' +
-        '<option value=""></option>' +
-        '<option value="00">00</option>' +
-        '<option value="01">01</option>' +
-        '<option value="02">02</option>' +
-        '<option value="03" selected="selected">03</option>' +
+          '<option value=""></option>' +
+          '<option value="00">00</option>' +
+          '<option value="01">01</option>' +
+          '<option value="02">02</option>' +
+          '<option value="03" selected="selected">03</option>' +
         '</select>' +
-            '<span class="explanation">Only complete this field if the document is not new.</span>' +
-          '</div>' +
-          '</fieldset>' +
-      '</form>');
+      '<span class="explanation">Only complete this field if the document is not new.</span>' +
+    '</div>' +
+  '</fieldset>'
+
+module("admin-edition-form-foreign-language: ", {
+  setup: function() {
+    $('#qunit-fixture').append(form)
+    $('form').append(foreignLanguageFieldset)
+    $('form').append(titleFieldset)
 
     GOVUK.adminEditionsForm.init({
       selector: 'form#non-english',
@@ -122,6 +131,19 @@ test("selecting and deselecting right-to-left languages applies the appropriate 
   ok(!$('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets no longer have "right-to-left" class');
 });
 
+module("admin-edition-form-first-published-at: ", {
+  setup: function() {
+    $('#qunit-fixture').append(form)
+    $('form').append(firstPublishedAtFieldset)
+
+    GOVUK.adminEditionsForm.init({
+      selector: 'form#non-english',
+      right_to_left_locales:["ar"]
+    });
+    $('.js-hidden').hide();
+  }
+});
+
 test("first_published time fields default to 00 if not set", function() {
   // original field values should not be changed
   equal($('#edition_first_published_at_4i').val(), '02', 'hour field has original value');
@@ -145,4 +167,3 @@ test("previously_published radio buttons toggle visibility of first_published da
   $('#edition_previously_published_false').click();
   ok($('.js-show-first-published').is(':hidden'), 'date selector hidden when "document is new" selected');
 });
-

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -1,6 +1,27 @@
 var form =
   '<form id="non-english" class="js-supports-non-english"></form>'
 
+var newsArticleTypeSelect =
+  '<div class="form-group">' +
+    '<label class="required" for="edition_news_article_type_id">News article type</label>' +
+    '<select class="chzn-select form-control subtype"' +
+            'data-placeholder="Choose News article type…"' +
+            'data-format-advice="' +
+              '{&quot;1&quot;:&quot;<p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>&quot;,' +
+              '&quot;2&quot;:&quot;<p>Unedited press releases as sent to the media, and official statements from the organisation or a minister.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>&quot;,' +
+              '&quot;3&quot;:&quot;<p>Government statements in response to media coverage, such as rebuttals and ‘myth busters’.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>&quot;,' +
+              '&quot;4&quot;:&quot;<p>Announcements specific to one or more world location. Don’t duplicate news published by another department.</p>&quot;,&quot;999&quot;:&quot;<p>DO NOT USE. This is a legacy category for content created before sub-types existed.</p>&quot;}"' +
+            'name="edition[news_article_type_id]"' +
+            'id="edition_news_article_type_id">' +
+      '<optgroup label="Common types">' +
+        '<option value="1">News story</option>' +
+        '<option value="2">Press release</option>' +
+        '<option value="3">Government response</option>' +
+        '<option value="4">World news story</option>' +
+      '</optgroup>' +
+    '</select>' +
+  '</div>'
+
 var foreignLanguageFieldset =
   '<fieldset class="foreign-language">' +
     '<div class="checkbox">' +
@@ -129,6 +150,59 @@ test("selecting and deselecting right-to-left languages applies the appropriate 
   ok($('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets have "right-to-left" class');
   $('input#create_foreign_language_only').click()
   ok(!$('form#non-english fieldset').hasClass('right-to-left'), 'form fieldsets no longer have "right-to-left" class');
+});
+
+module("admin-edition-form-foreign-language-for-news-articles: ", {
+  setup: function() {
+    $('#qunit-fixture').append(form)
+    $('form').append(newsArticleTypeSelect)
+    $('form').append(foreignLanguageFieldset)
+    $('form').append(titleFieldset)
+
+    GOVUK.adminEditionsForm.init({
+      selector: 'form#non-english',
+      right_to_left_locales:["ar"]
+    });
+    $('.js-hidden').hide();
+  }
+});
+
+test("the foreign language fieldset should initially be hidden", function () {
+  ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
+});
+
+test("the foreign language fieldset should only be visible when selecting the 'World news story' News Article type", function () {
+  $select = $('select#edition_news_article_type_id')
+
+  $select.find("option:contains(News story)").prop('selected', true).change();
+  ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
+
+  $select.find("option:contains(Press release)").prop('selected', true).change();
+  ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
+
+  $select.find("option:contains(Government response)").prop('selected', true).change();
+  ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
+
+  $select.find("option:contains(World news story)").prop('selected', true).change();
+  ok($('fieldset.foreign-language').is(':visible'), 'fieldset containing foreign language options is not visible');
+});
+
+test("unselecting 'World news story' hides and resets the locale fields", function () {
+  $select = $('select#edition_news_article_type_id')
+
+  $select.find("option:contains(World news story)").prop('selected', true).change();
+  ok($('fieldset.foreign-language').is(':visible'), 'fieldset containing foreign language options is not visible');
+
+  $('input#create_foreign_language_only').click()
+  ok($('div.foreign-language-select').is(':visible'), 'div containing locale inputs has become visible');
+
+  $('#edition_primary_locale').val('cy').change();
+  equal($('#edition_primary_locale option:selected').val(), 'cy', 'foreign-language selected');
+
+  $select.find("option:contains(News story)").prop('selected', true).change();
+
+  equal($('#edition_primary_locale option:selected').val(), '', 'locale reset back to English');
+  ok($('fieldset.foreign-language').is(':hidden'), 'fieldset containing foreign language options is not hidden');
 });
 
 module("admin-edition-form-first-published-at: ", {

--- a/test/javascripts/unit/admin/views/editions/_form_test.js
+++ b/test/javascripts/unit/admin/views/editions/_form_test.js
@@ -38,7 +38,7 @@ var foreignLanguageFieldset =
           '<option value="cy">Cymraeg (Welsh)</option>' +
         '</select>' +
       '</div>' +
-      '<p class="warning">Warning: Foreign language only documents do not allow additional translations.</p>' +
+      '<p class="warning">Warning: News stories without an English version cannot have other translations.</p>' +
     '</div>' +
   '</fieldset>'
 

--- a/test/unit/edition/translatable_test.rb
+++ b/test/unit/edition/translatable_test.rb
@@ -32,7 +32,7 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
   end
 
   test 'locale_can_be_changed? returns false for other edition types' do
-    Edition.concrete_descendants.reject {|k| k == WorldLocationNewsArticle }.each do |klass|
+    Edition.concrete_descendants.reject { |k| [WorldLocationNewsArticle, NewsArticle].include?(k) }.each do |klass|
       refute klass.new.locale_can_be_changed?, "Instance of #{klass} should not allow the changing of primary locale"
     end
   end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -34,6 +34,26 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert news_article.valid?
   end
 
+  test "non-English should be invalid for non-world-news-story types" do
+    non_foreign_language_news_types = [
+      NewsArticleType::NewsStory,
+      NewsArticleType::PressRelease,
+      NewsArticleType::GovernmentResponse,
+    ]
+
+    non_foreign_language_news_types.each do |news_type|
+      news_article = build(:news_article, news_article_type: news_type)
+      news_article.primary_locale = 'fr'
+      refute news_article.valid?
+    end
+  end
+
+  test "non-English should be valid for world news story type" do
+    news_article = build(:news_article, news_article_type: NewsArticleType::WorldNewsStory)
+    news_article.primary_locale = 'fr'
+    assert news_article.valid?
+  end
+
   test "search_index should include people" do
     news_article = create(:news_article, role_appointments: [create(:role_appointment), create(:role_appointment)])
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]


### PR DESCRIPTION
For https://trello.com/c/fZPPfJhf/86-allow-news-articles-to-be-created-with-only-non-english-content

Changes the 'foreign language only' link for World Location News Articles into a checkbox
Adds the checkbox to NewsArticle (for type 'World news story' only, visibility is toggled by JS).

The biggest pain point were the JS tests. I've broken up the QUnit fixture for the admin form a bit (loosely following advice on https://qunitjs.com/cookbook/#keeping-tests-atomic), which made it easier to add dedicated tests for the NewsArticle form. Hopefully it doesn't make it too much harder to read...

# Before
## World Location News Article

Before clicking link
![screen shot 2017-05-15 at 10 18 42](https://cloud.githubusercontent.com/assets/5112255/26051326/c448e636-3959-11e7-98e8-ced895737f93.png)

After clicking link
![screen shot 2017-05-15 at 10 18 53](https://cloud.githubusercontent.com/assets/5112255/26051332/c8c6f2de-3959-11e7-9546-4f70279b7ae1.png)

# After
## World Location News Article
Before ticking checkbox
![screen shot 2017-05-15 at 10 33 25](https://cloud.githubusercontent.com/assets/5112255/26051401/f84f717a-3959-11e7-83ca-61aedd436077.png)

After ticking checkbox
![screen shot 2017-05-15 at 10 17 41](https://cloud.githubusercontent.com/assets/5112255/26051314/bc003114-3959-11e7-852a-f6d797f62712.png)

## News Article
![screen shot 2017-05-15 at 10 35 58](https://cloud.githubusercontent.com/assets/5112255/26051515/5285f8da-395a-11e7-843d-da0317f7962f.png)


