### PR TITLE
Upgrade more gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,26 +27,26 @@ gem 'mini_magick', '~> 3.8.1'
 gem 'shared_mustache', '~> 0.2.1'
 gem 'rails-i18n', '~> 0.7.3'
 gem 'link_header'
-gem 'logstasher', '0.6.2'
+gem 'logstasher', '~> 1.2.1'
 gem 'chronic'
 gem 'jbuilder'
 gem 'rack_strip_client_ip', '0.0.1'
 gem 'invalid_utf8_rejector', '~> 0.0.3'
 gem 'govuk_sidekiq', '0.0.4'
 gem 'redis-namespace'
-gem 'raindrops', '0.15.0'
+gem 'raindrops', '0.18.0'
 gem 'airbrake', '4.1.0'
-gem 'pdf-reader', '1.3.3'
+gem 'pdf-reader', '~> 2.0'
 gem 'typhoeus', '~> 1.1'
 gem 'dalli'
-gem 'rails_translation_manager', '0.0.1'
+gem 'rails_translation_manager', '~> 0.0.2'
 gem 'sprockets', '~> 3.0'
 gem 'sprockets-rails', '2.3.3'
 gem 'rinku', require: 'rails_rinku'
-gem 'parallel', '1.4.1'
-gem 'responders', '~> 2.0'
+gem 'parallel', '~> 1.11.1'
+gem 'responders', '~> 2.4'
 gem 'ruby-progressbar', require: false
-gem 'equivalent-xml', '0.5.1', require: false
+gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'govuk_ab_testing', '~> 2.2.0'
 
 gem 'deprecated_columns', '0.1.1'
@@ -54,7 +54,7 @@ gem 'deprecated_columns', '0.1.1'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 41.2.0'
+  gem 'gds-api-adapters', '~> 45.0.0'
 end
 
 if ENV['GLOBALIZE_DEV']
@@ -75,8 +75,8 @@ else
   gem 'govuk_frontend_toolkit', '5.0.3'
 end
 
-gem 'sass', '3.4.9'
-gem 'sassc-rails'
+gem 'sass', '~> 3.4.23'
+gem 'sassc-rails', '~> 1.3.0'
 gem 'uglifier'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
-    equivalent-xml (0.5.1)
+    equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     ethon (0.10.1)
@@ -134,7 +134,7 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (41.2.0)
+    gds-api-adapters (45.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -214,9 +214,10 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
-    logstash-event (1.1.5)
-    logstasher (0.6.2)
-      logstash-event (~> 1.1.0)
+    logstash-event (1.2.02)
+    logstasher (1.2.1)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
       request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -263,14 +264,14 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.4.1)
+    parallel (1.11.2)
     parallel_tests (2.14.1)
       parallel
     parser (2.4.0.0)
       ast (~> 2.2)
-    pdf-reader (1.3.3)
+    pdf-reader (2.0.0)
       Ascii85 (~> 1.0.0)
-      afm (~> 0.2.0)
+      afm (~> 0.2.1)
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
@@ -318,7 +319,7 @@ GEM
       loofah (~> 2.0)
     rails-i18n (0.7.4)
       i18n (~> 0.5)
-    rails_translation_manager (0.0.1)
+    rails_translation_manager (0.0.2)
       activesupport
       rails-i18n
     railties (4.2.8)
@@ -328,7 +329,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    raindrops (0.15.0)
+    raindrops (0.18.0)
     rake (10.1.0)
     redis (3.3.3)
     redis-namespace (1.5.3)
@@ -355,7 +356,7 @@ GEM
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.4.9)
+    sass (3.4.23)
     sassc (1.11.2)
       bundler
       ffi (~> 1.9.6)
@@ -367,9 +368,9 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
-    scss_lint (0.40.1)
-      rainbow (~> 2.0)
-      sass (~> 3.4.1)
+    scss_lint (0.53.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     shared_mustache (0.2.1)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
@@ -467,10 +468,10 @@ DEPENDENCIES
   database_cleaner
   deprecated_columns (= 0.1.1)
   dotenv-rails
-  equivalent-xml (= 0.5.1)
+  equivalent-xml (~> 0.6.0)
   factory_girl
   friendly_id (~> 5.2.1)
-  gds-api-adapters (~> 41.2.0)
+  gds-api-adapters (~> 45.0.0)
   gds-sso (~> 13.2)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)
@@ -488,7 +489,7 @@ DEPENDENCIES
   kaminari (~> 0.17.0)
   launchy
   link_header
-  logstasher (= 0.6.2)
+  logstasher (~> 1.2.1)
   maxitest
   mime-types (= 1.25.1)
   mini_magick (~> 3.8.1)
@@ -497,9 +498,9 @@ DEPENDENCIES
   mysql2
   newrelic_rpm
   nokogiri (~> 1.6.8.1)
-  parallel (= 1.4.1)
+  parallel (~> 1.11.1)
   parallel_tests
-  pdf-reader (= 1.3.3)
+  pdf-reader (~> 2.0)
   plek (~> 2.0)
   poltergeist
   pry-byebug
@@ -509,16 +510,16 @@ DEPENDENCIES
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.8)
   rails-i18n (~> 0.7.3)
-  rails_translation_manager (= 0.0.1)
-  raindrops (= 0.15.0)
+  rails_translation_manager (~> 0.0.2)
+  raindrops (= 0.18.0)
   rake (= 10.1.0)
   redis-namespace
-  responders (~> 2.0)
+  responders (~> 2.4)
   rinku
   ruby-prof
   ruby-progressbar
-  sass (= 3.4.9)
-  sassc-rails
+  sass (~> 3.4.23)
+  sassc-rails (~> 1.3.0)
   shared_mustache (~> 0.2.1)
   simplecov
   simplecov-rcov


### PR DESCRIPTION
This PR updates gems in preparation for the Rails 5 upgrade.

Trello: https://trello.com/c/eg61wStW/78-upgrade-whitehall-to-a-supported-version-of-rails