### PR TITLE
Support `world-news-story` in announcement filter

### DIFF
--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -43,6 +43,10 @@ class NewsArticleType
     by_prevalence[:migration]
   end
 
+  def self.search_format_types
+    all.map(&:search_format_types).flatten
+  end
+
   def search_format_types
     ['news-article-' + self.key.gsub('_', ' ').parameterize]
   end

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -113,7 +113,7 @@ module Whitehall::DocumentFilter
         elsif include_world_location_news
           [Announcement.search_format_type]
         else
-          Announcement.concrete_descendant_search_format_types - [WorldLocationNewsArticle.search_format_type]
+          non_world_announcement_types
         end
       {search_format_types: announcement_types}
     end
@@ -130,6 +130,21 @@ module Whitehall::DocumentFilter
 
     def documents
       @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+    end
+
+  private
+
+    def all_announcement_types
+      all_descendants = Announcement.concrete_descendant_search_format_types
+      descendants_without_news = all_descendants - [NewsArticle.search_format_type]
+      news_article_subtypes = NewsArticleType.search_format_types
+      descendants_without_news + news_article_subtypes
+    end
+
+    def non_world_announcement_types
+      types = all_announcement_types
+      types = types - NewsArticleType::WorldNewsStory.search_format_types
+      types - [WorldLocationNewsArticle.search_format_type]
     end
   end
 end

--- a/test/unit/news_article_type_test.rb
+++ b/test/unit/news_article_type_test.rb
@@ -20,4 +20,15 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
       assert news_article_type.search_format_types.include?('news-article-' + news_article_type.key.gsub('_', ' ').parameterize)
     end
   end
+
+  test "NewsArticleType.search_format_types returns all of the type #search_format_types" do
+    expected = [
+      "news-article-news-story",
+      "news-article-press-release",
+      "news-article-government-response",
+      "news-article-world-news-story",
+      "news-article-announcement",
+    ]
+    assert_equal expected, NewsArticleType.search_format_types
+  end
 end

--- a/test/unit/whitehall/document_filter/rummager_test.rb
+++ b/test/unit/whitehall/document_filter/rummager_test.rb
@@ -16,15 +16,26 @@ module Whitehall::DocumentFilter
           has_entry({ search_format_types: format_types }))
     end
 
-    test 'announcements_search looks for NewsArticles, FatalityNotices and Speeches by default' do
+    test 'announcements_search looks for all announcements exluding world types by default' do
       rummager = Rummager.new({})
-      expect_search_by_format_types(format_types(FatalityNotice, NewsArticle, Speech))
+      expected_types = [
+        "fatality-notice",
+        "speech",
+        "news-article-news-story",
+        "news-article-press-release",
+        "news-article-government-response",
+        "news-article-announcement"
+      ]
+      expect_search_by_format_types(expected_types)
       rummager.announcements_search
     end
 
     test 'announcements_search looks for all Announcements if we need to include world location news' do
       rummager = Rummager.new({include_world_location_news: '1'})
-      expect_search_by_format_types(format_types(Announcement))
+      expected_types = [
+        "announcement"
+      ]
+      expect_search_by_format_types(expected_types)
       rummager.announcements_search
     end
 


### PR DESCRIPTION
By default the announcements filter on `/government/announcements` does not include `WorldLocationNewsArticles`. There is a 'Include local news from UK embassies and other world 
organisations' checkbox which actually overrides the 'Announcement type' selection and enables the inclusion of all announcement types including WLNA.

To enable this behaviour in the new world of `world-news-story` type `NewsArticles` this commit also excludes those from the rummager parameters and includes them when the world location 
checkbox is selected. `WorldLocationNewsArticle` are still excluded/included via the checkbox so this PR is backwards compatible.

[Trello](https://trello.com/c/qIEMzXsq/92-change-the-announcements-wlna-filtering-checkbox-to-work-with-the-new-world-news-articles)