### PR TITLE
Corporate information page edition links

### DIFF
--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -27,19 +27,17 @@ module PublishingApi
           public_updated_at: public_updated_at,
           rendering_app: corporate_information_page.rendering_app,
           schema_name: SCHEMA_NAME,
+          links: links,
         )
     end
 
     def links
-      LinksPresenter
-        .new(corporate_information_page)
-        .extract(
-          %i(
-            organisations
-            parent
-          )
+      links_presenter.extract(
+        %i(
+          organisations
+          parent
         )
-        .merge(CorporateInformationPages.for(corporate_information_page))
+      ).merge(CorporateInformationPages.for(corporate_information_page))
     end
 
   private
@@ -66,6 +64,10 @@ module PublishingApi
         .merge(CorporateInformationGroups.for(corporate_information_page))
         .merge(Organisation.for(corporate_information_page))
         .merge(PayloadBuilder::TagDetails.for(corporate_information_page))
+    end
+
+    def links_presenter
+      @links_presenter ||= LinksPresenter.new(corporate_information_page)
     end
 
     def public_updated_at

--- a/lib/sync_checker/formats/corporate_information_page_check.rb
+++ b/lib/sync_checker/formats/corporate_information_page_check.rb
@@ -23,13 +23,18 @@ module SyncChecker
         'government/organisations'
       end
 
+      def checks_for_draft(_locale)
+        super.tap do |checks|
+          if edition_expected_in_draft.about_page?
+            checks << links_checks
+          end
+        end
+      end
+
       def checks_for_live(_locale)
         super.tap do |checks|
           if edition_expected_in_live.about_page?
-            checks << Checks::LinksCheck.new(
-              'corporate_information_pages',
-              expected_corporate_information_page_content_ids
-            )
+            checks << links_checks
           end
         end
       end
@@ -43,6 +48,13 @@ module SyncChecker
       end
 
     private
+
+      def links_checks
+        Checks::LinksCheck.new(
+          'corporate_information_pages',
+          expected_corporate_information_page_content_ids
+        )
+      end
 
       def expected_corporate_information_page_content_ids
         pages = edition_expected_in_live

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -109,6 +109,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
       assert_equal actual_links, expected_links
     end
 
+
     test 'body details' do
       body_double = Object.new
 
@@ -134,6 +135,35 @@ module PublishingApi::CorporateInformationPagePresenterTest
 
     test 'document type' do
       assert_attribute :document_type, 'publication_scheme'
+    end
+
+    test 'links' do
+      expected_link_keys = %i(
+        organisations
+        parent
+      )
+
+      links_double = {
+        link_one: 'link_one',
+        link_two: 'link_two',
+        link_three: 'link_three',
+      }
+
+      PublishingApi::LinksPresenter
+        .stubs(:new)
+        .with(corporate_information_page)
+        .returns(
+          mock('PublishingApi::LinksPresenter') {
+            stubs(:extract)
+              .with(expected_link_keys)
+              .returns(links_double)
+          }
+        )
+
+      actual_links = presented_links
+      expected_links = actual_links.merge(links_double)
+
+      assert_attribute :links, expected_links
     end
 
     test 'organisation details' do


### PR DESCRIPTION
Publishing API now supports links being sent during the `put_content` call. This PR adds a links key to the `#content` result in the CorporateInformationPagePresenter.

This allows links to be saved with initial draft versions of this format.

The sync check for this format has also been updated to check links on the draft content store.