### PR TITLE
Add worldwide organisations to news articles

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -10,6 +10,7 @@ class NewsArticle < Newsesque
   validates :news_article_type_id, presence: true
   validates :worldwide_organisations, absence: true, unless: :world_news_story?
   validate :non_english_primary_locale_only_for_world_news_story
+  validate :organisations_are_not_associated, if: :world_news_story?
   validate :policies_are_not_associated, unless: :can_be_related_to_policies?
 
   def self.subtypes
@@ -74,11 +75,21 @@ class NewsArticle < Newsesque
     !world_news_story?
   end
 
+  def skip_organisation_validation?
+    world_news_story?
+  end
+
   def can_be_related_to_policies?
     !world_news_story?
   end
 
 private
+
+  def organisations_are_not_associated
+    unless edition_organisations.empty?
+      errors.add(:base, "You can't tag a world news story to organisations, please remove organisation")
+    end
+  end
 
   def policies_are_not_associated
     unless edition_policies.empty?

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -4,9 +4,11 @@ class NewsArticle < Newsesque
   include ::Attachable
   include Edition::AlternativeFormatProvider
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
+  include Edition::WorldwideOrganisations
 
   validate :ministers_are_not_associated, if: :world_news_story?
   validates :news_article_type_id, presence: true
+  validates :worldwide_organisations, absence: true, unless: :world_news_story?
   validate :non_english_primary_locale_only_for_world_news_story
   validate :policies_are_not_associated, unless: :can_be_related_to_policies?
 
@@ -58,14 +60,18 @@ class NewsArticle < Newsesque
     new_record?
   end
 
+  def world_news_story?
+    news_article_type == NewsArticleType::WorldNewsStory
+  end
+
   def non_english_primary_locale_only_for_world_news_story
-    if non_english_edition? && news_article_type != NewsArticleType::WorldNewsStory
+    if non_english_edition? && !world_news_story?
       errors.add(:foreign_language, 'is not allowed')
     end
   end
 
-  def world_news_story?
-    news_article_type == NewsArticleType::WorldNewsStory
+  def skip_worldwide_organisations_validation?
+    !world_news_story?
   end
 
   def can_be_related_to_policies?

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -39,6 +39,7 @@ module PublishingApi
         related_policies
         topics
         world_locations
+        worldwide_organisations
       )
 
       LinksPresenter

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -18,6 +18,7 @@
 
       <%= render 'appointment_fields', form: form, edition: edition %>
       <%= render 'topical_event_fields', form: form, edition: edition %>
+      <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
       <%= render 'specialist_sector_fields', form: form, edition: edition %>

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -20,7 +20,13 @@ Feature: News articles
 
   Scenario: Create a News article of type 'world news story' in a non-English language
     Given a world location "France" exists with a translation for the locale "Français"
-    When I draft a French-only news article of type "World news story" associated with "France"
+    When I draft a French-only "World news story" news article associated with "France"
     Then I should see the news article listed in admin with an indication that it is in French
     When I publish the French-only news article
     Then I should only see the news article on the French version of the public "France" location page
+
+  Scenario: Associate a news article of type worldwide news story with a worldwide organisation
+    Given the worldwide organisation "Spanish Department" exists
+    When I draft a valid "World news story" news article with title "Spanish News" associated to "Spanish Department"
+    And I force publish the news article "Spanish News"
+    Then the worldwide organisation "Spanish Department" should be associated to the news article "Spanish News"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -113,6 +113,7 @@ When(/^I draft a French\-only "World news story" news article associated with "(
   select "Français", from: "Document language"
   select location_name, from: "Select the world locations this news article is about"
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
+  select "", from: "edition_lead_organisation_ids_1"
 
   click_button "Save"
   @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
@@ -150,6 +151,7 @@ When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do
     create(:worldwide_organisation, name: "Afghanistan embassy")
     begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)
     select "Afghanistan embassy", from: "Select the worldwide organisations associated with this news article"
+    select "", from: "edition_lead_organisation_ids_1"
   else
     begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)
   end
@@ -161,9 +163,10 @@ Then(/^the news article "([^"]*)" should have been created$/) do |title|
   refute NewsArticle.find_by(title: title).nil?
 end
 
-When(/^I draft a valid "(.*?)" news article with title "(.*?)" associated to "(.*?)"$/) do |announcement_type, title, worldwide_org|
-  begin_drafting_news_article(title: title, announcement_type: announcement_type)
+When(/^I draft a valid "World news story" news article with title "(.*?)" associated to "(.*?)"$/) do |title, worldwide_org|
+  begin_drafting_news_article(title: title, announcement_type: "World news story")
   select worldwide_org, from: "edition_worldwide_organisation_ids"
+  select "", from: "edition_lead_organisation_ids_1"
 
   click_button "Save"
 end

--- a/lib/sync_checker/formats/news_article_check.rb
+++ b/lib/sync_checker/formats/news_article_check.rb
@@ -15,6 +15,10 @@ module SyncChecker
         super.tap do |checks|
           checks << Checks::LinksCheck.new('ministers',
                                            expected_minister_content_ids)
+          checks << Checks::LinksCheck.new(
+            'worldwide_organisations',
+            expected_worldwide_organisation_content_ids,
+          )
         end
       end
 
@@ -120,6 +124,10 @@ module SyncChecker
             'topics' => topics.compact,
           }
         }
+      end
+
+      def expected_worldwide_organisation_content_ids
+        edition_expected_in_live.worldwide_organisations.map(&:content_id)
       end
     end
   end

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -44,5 +44,9 @@ FactoryGirl.define do
 
   factory :news_article_world_news_story, parent: :news_article do
     news_article_type_id { NewsArticleType::WorldNewsStory.id }
+
+    after :build do |news_article, evaluator|
+      news_article.worldwide_organisations = [FactoryGirl.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
+    end
   end
 end

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -45,6 +45,10 @@ FactoryGirl.define do
   factory :news_article_world_news_story, parent: :news_article do
     news_article_type_id { NewsArticleType::WorldNewsStory.id }
 
+    transient do
+      create_default_organisation { false }
+    end
+
     after :build do |news_article, evaluator|
       news_article.worldwide_organisations = [FactoryGirl.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
     end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -152,4 +152,19 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     assert_equal ["You can't tag a world news story to ministers, please remove minister"],
       article.errors[:base]
   end
+
+  test "is valid when not associating an organisation" do
+    news_article = build(:news_article_world_news_story)
+    news_article.organisations = []
+    assert news_article.valid?
+  end
+
+  test "is invalid when associating an organisation" do
+    news_article = build(:news_article_world_news_story)
+    news_article.edition_organisations.build(organisation: FactoryGirl.build(:organisation))
+
+    refute news_article.valid?
+    assert_equal ["You can't tag a world news story to organisations, please remove organisation"],
+      news_article.errors[:base]
+  end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -7,7 +7,7 @@ class NewsArticleTest < ActiveSupport::TestCase
   should_have_first_image_pulled_out
   should_protect_against_xss_and_content_attacks_on :title, :body, :summary, :change_note
 
-  test "should be able to relate to other editions" do
+  test "can be related to other editions" do
     article = build(:news_article)
     assert article.can_be_related_to_policies?
   end
@@ -19,12 +19,12 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert_equal [news_article], topical_event.news_articles
   end
 
-  test "should allow setting of news article type" do
+  test "allows setting of news article type" do
     news_article = build(:news_article_press_release)
     assert news_article.valid?
   end
 
-  test "should be invalid without a news article type" do
+  test "is invalid without a news article type" do
     news_article = build(:news_article, news_article_type: nil)
     refute news_article.valid?
   end
@@ -34,7 +34,7 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert news_article.valid?
   end
 
-  test "non-English should be invalid for non-world-news-story types" do
+  test "non-English locale is invalid for non-world-news-story types" do
     non_foreign_language_news_types = [
       NewsArticleType::NewsStory,
       NewsArticleType::PressRelease,
@@ -48,7 +48,7 @@ class NewsArticleTest < ActiveSupport::TestCase
     end
   end
 
-  test "search_index should include people" do
+  test "search_index includes people" do
     news_article = create(:news_article, role_appointments: [create(:role_appointment), create(:role_appointment)])
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]
   end
@@ -69,7 +69,7 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert news_article.search_format_types.include?('other-thing')
   end
 
-  test "should be translatable" do
+  test "is translatable" do
     assert build(:news_article).translatable?
   end
 
@@ -117,7 +117,7 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     assert article.world_news_story?
   end
 
-  test "non-English primary locale should be valid" do
+  test "non-English primary locale is valid" do
     news_article = build(:news_article_world_news_story)
     news_article.primary_locale = 'fr'
     assert news_article.valid?

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -88,6 +88,7 @@ module PublishingApi::NewsArticlePresenterTest
         related_policies
         topics
         world_locations
+        worldwide_organisations
       )
 
       links_double = {


### PR DESCRIPTION
For https://trello.com/c/428XJAua/87-allow-worldwide-news-articles-to-be-tagged-to-worldwide-organisations

Adds the worldwide organisation association to NewsArticles, specifically to the World News Story subtype. The fields get hidden in the UI by JavaScript. The PublishingApi presenters also get updated to send worldwide organisations as links. The sync checks also get updated.

Also adds the logic for _not_ associating Organisations to 'World news article' News articles. Again, JS is used to hide the whole Organisation form fieldset when selecting the 'World news story' sub type and model validations also get added.

---------------------

### Preview of new validation errors:

<img width="795" alt="screen shot 2017-05-18 at 15 03 28" src="https://cloud.githubusercontent.com/assets/5112255/26205953/474add7c-3bdb-11e7-8f0b-9cc99d4a9bd0.png">