### PR TITLE
Revert "Remove worldwide services"

### DIFF
--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -1,6 +1,8 @@
 class WorldwideOffice < ApplicationRecord
   has_one :contact, as: :contactable, dependent: :destroy
   belongs_to :worldwide_organisation
+  has_many :worldwide_office_worldwide_services, dependent: :destroy, inverse_of: :worldwide_office
+  has_many :services, through: :worldwide_office_worldwide_services, source: :worldwide_service
   has_one  :access_and_opening_times, as: :accessible, dependent: :destroy
   has_one :default_access_and_opening_times, through: :worldwide_organisation, source: :access_and_opening_times
   validates :worldwide_organisation, :contact, :worldwide_office_type_id, presence: true

--- a/app/models/worldwide_office_worldwide_service.rb
+++ b/app/models/worldwide_office_worldwide_service.rb
@@ -1,0 +1,6 @@
+class WorldwideOfficeWorldwideService < ApplicationRecord
+  belongs_to :worldwide_office, inverse_of: :worldwide_office_worldwide_services
+  belongs_to :worldwide_service, inverse_of: :worldwide_office_worldwide_services
+
+  validates :worldwide_service, :worldwide_office, presence: true
+end

--- a/app/models/worldwide_service.rb
+++ b/app/models/worldwide_service.rb
@@ -1,0 +1,13 @@
+class WorldwideService < ApplicationRecord
+  validates :name, :service_type_id, presence: true
+  has_many :worldwide_office_worldwide_services, dependent: :destroy, inverse_of: :worldwide_service
+  has_many :offices, through: :worldwide_office_worldwide_services, source: :worldwide_office
+
+  def service_type
+    WorldwideServiceType.find_by_id(service_type_id)
+  end
+
+  def service_type=(service_type)
+    self.service_type_id = service_type && service_type.id
+  end
+end

--- a/app/models/worldwide_service_type.rb
+++ b/app/models/worldwide_service_type.rb
@@ -1,0 +1,20 @@
+require 'active_record_like_interface'
+
+class WorldwideServiceType
+  include ActiveRecordLikeInterface
+
+  attr_accessor :id, :name
+
+  def slug
+    name.downcase.gsub(/[^a-z]+/, "-")
+  end
+
+  def self.find_by_slug(slug)
+    all.detect { |pt| pt.slug == slug }
+  end
+
+  AssistanceServices  = create(id: 1, name: 'Assistance Services')
+  DocumentaryServices = create(id: 2, name: 'Documentary Services')
+
+  OtherServices       = create(id: 99, name: 'Other Services')
+end

--- a/app/presenters/api/worldwide_organisation_presenter.rb
+++ b/app/presenters/api/worldwide_organisation_presenter.rb
@@ -56,7 +56,8 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
         type: office_worldwide_organisation.worldwide_office_type.name
       }
     }.merge(office_addresss_as_json(office_worldwide_organisation)).
-      merge(office_contact_numbers_as_json(office_worldwide_organisation))
+      merge(office_contact_numbers_as_json(office_worldwide_organisation)).
+      merge(office_services_as_json(office_worldwide_organisation))
   end
 
   def office_access_and_opening_times_as_json(office_worldwide_organisation)
@@ -77,6 +78,17 @@ class Api::WorldwideOrganisationPresenter < Api::BasePresenter
         {
           label: contact_number.label,
           number: contact_number.number
+        }
+      end
+    }
+  end
+
+  def office_services_as_json(office_worldwide_organisation)
+    {
+      services: office_worldwide_organisation.services.map do |service|
+        {
+          title: service.name,
+          type: service.service_type.name
         }
       end
     }

--- a/app/views/admin/worldwide_offices/_form.html.erb
+++ b/app/views/admin/worldwide_offices/_form.html.erb
@@ -26,6 +26,28 @@
           <%= office_form.labelled_radio_button('no', :show_on_home_page, '0', checked: !worldwide_organisation.office_shown_on_home_page?(office_form.object)) %>
         <% end %>
       </div>
+
+      <fieldset class="services">
+        <legend>Services</legend>
+        <% # without this hidden field, once a service has been selected and saved, all services cannot be de-selected.
+           # http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha %>
+        <%= hidden_field_tag 'worldwide_office[service_ids][]', nil %>
+        <% WorldwideService.all.group_by{|ws| ws.service_type}.each do |service_type, services| %>
+          <div class="form-group">
+            <p class="bold add-label-margin"><%= service_type.name %></p>
+            <% services.each do |service| %>
+              <div class="checkbox">
+                <%= label_tag "worldwide_office_service_ids_#{service.id}" do %>
+                  <%= check_box_tag 'worldwide_office[service_ids][]', service.id,
+                    office_form.object.services.include?(service), id: "worldwide_office_service_ids_#{service.id}" %>
+                  <%= service.name %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </fieldset>
+
       <%= render partial: 'admin/contacts/form_fields', locals: { contact_form: contact_form } %>
     <% end %>
   </fieldset>

--- a/db/data_migration/20140403114042_rename_marriage_worldwide_service.rb
+++ b/db/data_migration/20140403114042_rename_marriage_worldwide_service.rb
@@ -1,0 +1,3 @@
+service = WorldwideService.find_by(name: 'Marriage and Civil Partnership ceremonies')
+service.name = 'Issue certificate of no impediment'
+service.save!

--- a/db/migrate/20170511082208_remove_worldwide_services.rb
+++ b/db/migrate/20170511082208_remove_worldwide_services.rb
@@ -1,6 +1,0 @@
-class RemoveWorldwideServices < ActiveRecord::Migration
-  def change
-    drop_table :worldwide_office_worldwide_services
-    drop_table :worldwide_services
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170511082208) do
+ActiveRecord::Schema.define(version: 20170411161614) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -1206,6 +1206,13 @@ ActiveRecord::Schema.define(version: 20170511082208) do
   add_index "world_locations", ["slug"], name: "index_world_locations_on_slug", using: :btree
   add_index "world_locations", ["world_location_type_id"], name: "index_world_locations_on_world_location_type_id", using: :btree
 
+  create_table "worldwide_office_worldwide_services", force: :cascade do |t|
+    t.integer  "worldwide_office_id",  limit: 4, null: false
+    t.integer  "worldwide_service_id", limit: 4, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "worldwide_offices", force: :cascade do |t|
     t.integer  "worldwide_organisation_id", limit: 4
     t.datetime "created_at"
@@ -1263,6 +1270,13 @@ ActiveRecord::Schema.define(version: 20170511082208) do
 
   add_index "worldwide_organisations", ["default_news_organisation_image_data_id"], name: "index_worldwide_organisations_on_image_data_id", using: :btree
   add_index "worldwide_organisations", ["slug"], name: "index_worldwide_organisations_on_slug", unique: true, using: :btree
+
+  create_table "worldwide_services", force: :cascade do |t|
+    t.string   "name",            limit: 255, null: false
+    t.integer  "service_type_id", limit: 4,   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   add_foreign_key "related_mainstreams", "editions"
 end

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -90,11 +90,19 @@ Given /^a worldwide organisation "([^"]*)" exists for the world location "([^"]*
   create(:worldwide_organisation, name: name, world_locations: [country])
 end
 
-When /^I add an "([^"]*)" office for the home page with address and phone number$/ do |description|
+When /^I add an "([^"]*)" office for the home page with address, phone number, and some services$/ do |description|
+  service1 = create(:worldwide_service, name: 'Dance lessons')
+  service2 = create(:worldwide_service, name: 'Courses in advanced sword fighting')
+  service3 = create(:worldwide_service, name: 'Beard grooming')
+
   visit admin_worldwide_organisation_worldwide_offices_path(WorldwideOrganisation.last)
   click_link "Add"
   fill_in_contact_details(title: description, feature_on_home_page: 'yes')
   select WorldwideOfficeType.all.sample.name, from: 'Office type'
+
+  check service1.name
+  check service3.name
+
   click_on "Save"
 end
 
@@ -110,6 +118,16 @@ Then /^the "([^"]*)" office details should be shown on the public website$/ do |
     end
     assert page.has_css?('.tel', text: worldwide_office.contact.contact_numbers.first.number)
   end
+end
+
+Then(/^I should be able to remove all services from the "(.*?)" office$/) do |description|
+  worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: description }).first
+  visit edit_admin_worldwide_organisation_worldwide_office_path(worldwide_organisation_id: WorldwideOrganisation.last.id, id: worldwide_office.id)
+  available_services = worldwide_office.services.each { |service| uncheck "worldwide_office_service_ids_#{service.id}" }
+  click_on "Save"
+
+  visit edit_admin_worldwide_organisation_worldwide_office_path(worldwide_organisation_id: WorldwideOrganisation.last.id, id: worldwide_office.id)
+  available_services.each { |service| assert page.has_unchecked_field? "worldwide_office_service_ids_#{service.id}" }
 end
 
 Given /^that the world location "([^"]*)" exists$/ do |country_name|

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -10,6 +10,7 @@ Feature: Administering worldwide organisation
     * a unique name e.g. "British Embassy in Madrid" and a URL "/world/offices/british-embassy-in-madrid" which is generated from the name
     * multiple social media links (like orgs)
     * multiple sets of office information (like orgs)
+      * with the addition of a list of services (chosen from a set) that the office provides
     * a logo formatted name (always using the standard HMG crest for now)
   * Each world organisation can be associated with 1+ world locations, and shows on the world locations page to which they are associated (see mock up on the [ticket](https://www.pivotaltracker.com/story/show/41026113))
   * Each can have corporate information pages (like orgs)
@@ -37,8 +38,9 @@ Feature: Administering worldwide organisation
 
   Scenario: Managing office information
     Given a worldwide organisation "Department of Beards in France"
-    When I add an "Hair division" office for the home page with address and phone number
+    When I add an "Hair division" office for the home page with address, phone number, and some services
     Then the "Hair division" office details should be shown on the public website
+    And I should be able to remove all services from the "Hair division" office
 
   Scenario: Creating a worldwide organisation in a particular world location
     Given that the world location "France" exists

--- a/test/factories/worldwide_office_worldwide_services.rb
+++ b/test/factories/worldwide_office_worldwide_services.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :worldwide_office_worldwide_service do
+    worldwide_office
+    worldwide_service
+  end
+end

--- a/test/factories/worldwide_services.rb
+++ b/test/factories/worldwide_services.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :worldwide_service do
+    name { 'worldwide-service-name' }
+    service_type_id { WorldwideServiceType::DocumentaryServices.id }
+  end
+end

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -82,6 +82,26 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     refute worldwide_organisation.office_shown_on_home_page?(new_office)
   end
 
+  test "post create creates worldwide office with services" do
+    service1 = create(:worldwide_service)
+    service2 = create(:worldwide_service)
+    worldwide_organisation = create(:worldwide_organisation)
+
+    post :create,
+      worldwide_office: {
+        worldwide_office_type_id: WorldwideOfficeType::Other.id,
+        contact_attributes: {
+          title: "Main office",
+          contact_type_id: ContactType::General.id
+        },
+        service_ids: [service2.id, service1.id]
+      },
+      worldwide_organisation_id: worldwide_organisation.id
+
+    assert_equal 1, worldwide_organisation.offices.count
+    assert_equal [service1, service2], worldwide_organisation.offices.first.services.sort_by(&:id)
+  end
+
   test "post create creates associated phone numbers" do
     worldwide_organisation = create(:worldwide_organisation)
 
@@ -172,6 +192,21 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
 
     assert_equal "Head office", office.reload.contact.title
     assert worldwide_organisation.office_shown_on_home_page?(office)
+  end
+
+  test "put update updates an offices services" do
+    service2 = create(:worldwide_service)
+    service3 = create(:worldwide_service)
+    worldwide_organisation, office = create_worldwide_organisation_and_office
+
+    put :update,
+      worldwide_office: {
+        service_ids: [service3.id, service2.id]
+      },
+      id: office,
+      worldwide_organisation_id: worldwide_organisation
+
+    assert_equal [service2, service3], office.reload.services.sort_by(&:id)
   end
 
   test "put update updates associated phone numbers" do

--- a/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/api/worldwide_organisation_presenter_test.rb
@@ -5,6 +5,7 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     @access_times = stub_record(:access_and_opening_times, body: 'never')
     @main_sponsor = stub_translatable_record(:organisation)
     @office = stub_record(:worldwide_office, contact: stub_translatable_record(:contact, contact_numbers: []),
+                                             services: [],
                                              worldwide_organisation: nil,
                                              access_and_opening_times: @access_times)
     @world_org = stub_translatable_record(:worldwide_organisation, sponsoring_organisations: [@main_sponsor],
@@ -125,9 +126,11 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
 
   test 'json includes main and other offices in offices with separate keys' do
     office1 = stub_record(:worldwide_office, contact: stub_translatable_record(:contact, title: 'best-office', contact_numbers: []),
+                                             services: [],
                                              worldwide_organisation: nil,
                                              access_and_opening_times: @access_times)
     office2 = stub_record(:worldwide_office, contact: stub_translatable_record(:contact, title: 'worst-office', contact_numbers: []),
+                                             services: [],
                                              worldwide_organisation: nil,
                                              access_and_opening_times: @access_times)
 
@@ -152,6 +155,18 @@ class Api::WorldwideOrganisationPresenterTest < PresenterTestCase
     assert_equal expected_contact_num_json, office_as_json[:contact_numbers][0]
     expected_contact_num_json = {label: 'contact-number-two', number: '5678'}
     assert_equal expected_contact_num_json, office_as_json[:contact_numbers][1]
+  end
+
+  test 'json includes office services in offices array as services' do
+    services = [stub_record(:worldwide_service, name: 'service-one', service_type: WorldwideServiceType::AssistanceServices),
+                stub_record(:worldwide_service, name: 'service-two', service_type: WorldwideServiceType::OtherServices)]
+    @office.stubs(:services).returns services
+    office_as_json = @presenter.as_json[:offices][:main]
+    assert_equal 2, office_as_json[:services].size
+    expected_service_json = { title: 'service-one', type: WorldwideServiceType::AssistanceServices.name }
+    assert_equal expected_service_json, office_as_json[:services][0]
+    expected_service_json = { title: 'service-two', type: WorldwideServiceType::OtherServices.name }
+    assert_equal expected_service_json, office_as_json[:services][1]
   end
 
   test 'json includes office contact address in offices array' do

--- a/test/unit/worldwide_office_worldwide_service_test.rb
+++ b/test/unit/worldwide_office_worldwide_service_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class WorldwideOfficeWorldwideServiceTest < ActiveSupport::TestCase
+  %w{worldwide_office worldwide_service}.each do |param|
+    test "should not be valid without a #{param}" do
+      refute build(:worldwide_office_worldwide_service, param.to_sym => nil).valid?
+    end
+  end
+end

--- a/test/unit/worldwide_service_test.rb
+++ b/test/unit/worldwide_service_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class WorldwideOfficeTest < ActiveSupport::TestCase
+  %w{name service_type_id}.each do |param|
+    test "should not be valid without a #{param}" do
+      refute build(:worldwide_service, param.to_sym => nil).valid?
+    end
+  end
+
+  test "should allow setting of service type" do
+    worldwide_service = build(:worldwide_service, service_type: WorldwideServiceType::OtherServices)
+    assert worldwide_service.valid?
+  end
+end

--- a/test/unit/worldwide_service_type_test.rb
+++ b/test/unit/worldwide_service_type_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class WorldwideServiceTypeTest < ActiveSupport::TestCase
+  test "should provide slugs for every service type" do
+    service_types = WorldwideServiceType.all
+    assert_equal service_types.length, service_types.map(&:slug).compact.length
+  end
+
+  test "should be findable by slug" do
+    service_type = WorldwideServiceType.find_by_id(1)
+    assert_equal service_type, WorldwideServiceType.find_by_slug(service_type.slug)
+  end
+end


### PR DESCRIPTION
Reverts alphagov/whitehall#3214

`smart-answers` uses worldwide services so we need to put them back until they're ready to move off it.