### PR TITLE
Allow tagging to singular root taxons

### DIFF
--- a/app/views/admin/edition_tags/_taxonomy.html.erb
+++ b/app/views/admin/edition_tags/_taxonomy.html.erb
@@ -1,11 +1,15 @@
 <% root_taxons.each do |root_taxon| %>
   <% root_taxon = TopicTreePresenter.new(root_taxon, collapsed: root_taxons.size > 1) %>
 
-  <div class="topic-tree">
-    <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'></span><%= root_taxon.name %></a>
+  <% if root_taxon.children.empty? %>
+    <%= render partial: "sub_taxons", locals: { form: @edition_tag_form, taxons: [root_taxon] } %>
+  <% else %>
+    <div class="topic-tree">
+      <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'></span><%= root_taxon.name %></a>
 
-    <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
-      <%= render partial: "sub_taxons", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
+      <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
+        <%= render partial: "sub_taxons", locals: {form: @edition_tag_form, taxons: root_taxon.children } %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
We sometimes need to let publishers tag content to a singular, non-hierarchical taxon.

<img width="492" alt="screen shot 2017-05-16 at 15 17 53" src="https://cloud.githubusercontent.com/assets/608867/26110654/ddd1a7d6-3a4a-11e7-8b6f-4f87fd67a9bf.png">

[Trello](https://trello.com/c/BxsxoXqb/101-promote-parenting-childcare-and-children-s-services-and-corporate-information-to-taggable-draft-taxonomies-in-whitehall)