### PR TITLE
Fixes issue preventing draft taxon tree resolution

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -7,11 +7,11 @@ module Taxonomy
     end
 
     def published_taxon_data
-      @_published_data ||= get_root_taxons
+      @_published_data ||= get_root_taxons(with_drafts: false)
     end
 
     def tree_data(content_id)
-      get_expanded_links_hash(content_id, cache_expiry: 1.hour)
+      get_expanded_links_hash(content_id, cache_expiry: 1.hour, with_drafts: true)
     end
 
   private
@@ -20,13 +20,13 @@ module Taxonomy
       @_all_data ||= get_root_taxons(with_drafts: true)
     end
 
-    def get_root_taxons(with_drafts: false)
+    def get_root_taxons(with_drafts:)
       get_expanded_links_hash(HOMEPAGE_CONTENT_ID, cache_expiry: 24.hours, with_drafts: with_drafts)
         .fetch('expanded_links', {})
         .fetch('root_taxons', [])
     end
 
-    def get_expanded_links_hash(content_id, cache_expiry:, with_drafts: false)
+    def get_expanded_links_hash(content_id, cache_expiry:, with_drafts:)
       Rails.cache.fetch("#{self.class.name}_expanded_links_#{content_id}_#{with_drafts}", expires_in: cache_expiry) do
         Services.publishing_api.get_expanded_links(content_id, with_drafts: with_drafts).to_h
       end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -30,7 +30,7 @@ module TaxonomyHelper
     }
 
     publishing_api_has_expanded_links(homepage_links, with_drafts: false)
-    publishing_api_has_expanded_links(root_taxon, with_drafts: false)
+    publishing_api_has_expanded_links(root_taxon, with_drafts: true)
 
     homepage_links_with_drafts = {
       content_id: homepage_content_id,

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -46,6 +46,6 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
   end
 
   def setup_expanded_taxon_data(taxon)
-    publishing_api_has_expanded_links(taxon, with_drafts: false)
+    publishing_api_has_expanded_links(taxon, with_drafts: true)
   end
 end


### PR DESCRIPTION
Owing to poor default arguments in a private method, Whitehall doesn't
query publishing-api for the draft children of a taxon. This prevented
it from rendering a full taxonomy tree for draft root taxons.

This only became an issue today, when a full draft taxonomy was released
to editors for tagging.

[Trello](https://trello.com/c/BxsxoXqb/101-promote-parenting-childcare-and-children-s-services-and-corporate-information-to-taggable-draft-taxonomies-in-whitehall)