### PR TITLE
Add `#world_news_story?` to `NewsArticle`

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -61,4 +61,8 @@ class NewsArticle < Newsesque
       errors.add(:foreign_language, 'is not allowed')
     end
   end
+
+  def world_news_story?
+    news_article_type == NewsArticleType::WorldNewsStory
+  end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -82,4 +82,21 @@ class NewsArticleTest < ActiveSupport::TestCase
   test "is not translatable when non-English" do
     refute build(:news_article, primary_locale: :es).translatable?
   end
+
+  test "#world_news_story returns false" do
+    article = build(:news_article)
+
+    refute article.world_news_story?
+  end
+end
+
+class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
+  test "#world_news_story returns true" do
+    article = build(
+      :news_article,
+      news_article_type: NewsArticleType::WorldNewsStory
+    )
+
+    assert article.world_news_story?
+  end
 end


### PR DESCRIPTION
This method will be used to enabled/disable validations and features for the `NewsArticleType::WorldNewsStory` `NewsArticle` subtype.

[Trello](https://trello.com/c/428XJAua/87-allow-worldwide-news-articles-to-be-tagged-to-worldwide-organisations) and [Other Trello](https://trello.com/c/OW1PrFWc/89-add-specific-validation-rules-for-the-new-world-news-article-subtype)