### PR TITLE
Add `WorldNewsStory` factory and tidy up a bit...

### DIFF
--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -41,4 +41,8 @@ FactoryGirl.define do
   factory :news_article_government_response, parent: :news_article do
     news_article_type_id { NewsArticleType::GovernmentResponse.id }
   end
+
+  factory :news_article_world_news_story, parent: :news_article do
+    news_article_type_id { NewsArticleType::WorldNewsStory.id }
+  end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -29,7 +29,7 @@ class NewsArticleTest < ActiveSupport::TestCase
     refute news_article.valid?
   end
 
-  test 'superseded news articles are valid with the "unknown" news_article_type' do
+  test "superseded news articles are valid with the 'unknown' news_article_type" do
     news_article = build(:superseded_news_article, news_article_type: NewsArticleType::Unknown)
     assert news_article.valid?
   end
@@ -53,13 +53,13 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]
   end
 
-  test 'search_format_types tags the news article as a news-article and announcement' do
+  test "search_format_types tags the news article as a news-article and announcement" do
     news_article = build(:news_article)
     assert news_article.search_format_types.include?('news-article')
     assert news_article.search_format_types.include?('announcement')
   end
 
-  test 'search_format_types includes search_format_types of the speech_type' do
+  test "search_format_types includes search_format_types of the speech_type" do
     news_article_type = mock
     news_article_type.responds_like(NewsArticleType.new)
     news_article_type.stubs(:search_format_types).returns (['stuff-innit', 'other-thing'])

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -20,7 +20,7 @@ class NewsArticleTest < ActiveSupport::TestCase
   end
 
   test "should allow setting of news article type" do
-    news_article = build(:news_article, news_article_type: NewsArticleType::PressRelease)
+    news_article = build(:news_article_press_release)
     assert news_article.valid?
   end
 
@@ -46,12 +46,6 @@ class NewsArticleTest < ActiveSupport::TestCase
       news_article.primary_locale = 'fr'
       refute news_article.valid?
     end
-  end
-
-  test "non-English should be valid for world news story type" do
-    news_article = build(:news_article, news_article_type: NewsArticleType::WorldNewsStory)
-    news_article.primary_locale = 'fr'
-    assert news_article.valid?
   end
 
   test "search_index should include people" do
@@ -91,11 +85,14 @@ class NewsArticleTest < ActiveSupport::TestCase
 end
 
 class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
+  test "non-English primary locale should be valid" do
+    news_article = build(:news_article_world_news_story)
+    news_article.primary_locale = 'fr'
+    assert news_article.valid?
+  end
+
   test "#world_news_story returns true" do
-    article = build(
-      :news_article,
-      news_article_type: NewsArticleType::WorldNewsStory
-    )
+    article = build(:news_article_world_news_story)
 
     assert article.world_news_story?
   end


### PR DESCRIPTION
There are factories available for the other `NewsArticleType`s. This PR adds one for `WorldNewsStory` and updates the tests to use it. Also some small changes to the unit tests for consistency.