### PR TITLE
Add policies validation for world news stories

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -8,6 +8,8 @@ class NewsArticle < Newsesque
   validates :news_article_type_id, presence: true
   validate :non_english_primary_locale_only_for_world_news_story
 
+  validate :policies_are_not_associated, unless: :can_be_related_to_policies?
+
   def self.subtypes
     NewsArticleType.all
   end
@@ -68,5 +70,13 @@ class NewsArticle < Newsesque
 
   def can_be_related_to_policies?
     !world_news_story?
+  end
+
+private
+
+  def policies_are_not_associated
+    unless edition_policies.empty?
+      errors.add(:base, "You can't tag a world news story to policies, please remove policy")
+    end
   end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -65,4 +65,8 @@ class NewsArticle < Newsesque
   def world_news_story?
     news_article_type == NewsArticleType::WorldNewsStory
   end
+
+  def can_be_related_to_policies?
+    !world_news_story?
+  end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -104,18 +104,16 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
   end
 
   test "can't be related to policies" do
-    article = build(
-      :news_article,
-      news_article_type: NewsArticleType::WorldNewsStory
-    )
+    article = build(:news_article_world_news_story)
 
     refute article.can_be_related_to_policies?
   end
 
   test "is invalid if a policy is associated" do
-    article = build(
-      :news_article,
-      news_article_type: NewsArticleType::WorldNewsStory
-    )
+    article = build(:news_article_world_news_story)
+    article.stubs(:edition_policies).returns([Policy.new({})])
+
+    refute article.valid?
+    assert_equal ["You can't tag a world news story to policies, please remove policy"], article.errors[:base]
   end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -82,6 +82,12 @@ class NewsArticleTest < ActiveSupport::TestCase
 
     refute article.world_news_story?
   end
+
+  test "can be related to policies" do
+    article = build(:news_article)
+
+    assert article.can_be_related_to_policies?
+  end
 end
 
 class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
@@ -95,5 +101,21 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     article = build(:news_article_world_news_story)
 
     assert article.world_news_story?
+  end
+
+  test "can't be related to policies" do
+    article = build(
+      :news_article,
+      news_article_type: NewsArticleType::WorldNewsStory
+    )
+
+    refute article.can_be_related_to_policies?
+  end
+
+  test "is invalid if a policy is associated" do
+    article = build(
+      :news_article,
+      news_article_type: NewsArticleType::WorldNewsStory
+    )
   end
 end


### PR DESCRIPTION
Adds a validation rule for `NewsArticle` of type `NewsArticle::WorldNewsStory` that validates for the absence of related policies. We are currently migrating `WorldLocationNewsArticle` to this format. This will maintain the behaviour of that format after migration. 

![image](https://cloud.githubusercontent.com/assets/5216/26161500/014d851e-3b1c-11e7-8ebf-9493ac759b92.png)

[Trello](https://trello.com/c/OW1PrFWc/89-add-specific-validation-rules-for-the-new-world-news-article-subtype)
