### PR TITLE
Add ministers validation for world news stories

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -5,9 +5,9 @@ class NewsArticle < Newsesque
   include Edition::AlternativeFormatProvider
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
 
+  validate :ministers_are_not_associated, if: :world_news_story?
   validates :news_article_type_id, presence: true
   validate :non_english_primary_locale_only_for_world_news_story
-
   validate :policies_are_not_associated, unless: :can_be_related_to_policies?
 
   def self.subtypes
@@ -77,6 +77,12 @@ private
   def policies_are_not_associated
     unless edition_policies.empty?
       errors.add(:base, "You can't tag a world news story to policies, please remove policy")
+    end
+  end
+
+  def ministers_are_not_associated
+    if is_associated_with_a_minister?
+      errors.add(:base, "You can't tag a world news story to ministers, please remove minister")
     end
   end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -116,4 +116,13 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     refute article.valid?
     assert_equal ["You can't tag a world news story to policies, please remove policy"], article.errors[:base]
   end
+
+  test "are invalid if associated with a minister" do
+    article = build(:news_article_world_news_story)
+    article.role_appointments << build(:ministerial_role_appointment)
+
+    refute article.valid?
+    assert_equal ["You can't tag a world news story to ministers, please remove minister"],
+      article.errors[:base]
+  end
 end


### PR DESCRIPTION
`NewsArticle` of type `NewsArticle::WorldNewsStory` cannot be associated with ministers. This commit adds validation to check that they are not.

This is part of the work to migrate `WorldLocationNewsArticle` to`NewsArticle` and is behaviour that is being carried across from that format.

![image](https://cloud.githubusercontent.com/assets/5216/26162586/050e2034-3b1f-11e7-89db-ea84891cc597.png)

[Trello](https://trello.com/c/OW1PrFWc/89-add-specific-validation-rules-for-the-new-world-news-article-subtype)