### PR TITLE
Send publishing_app, rendering_app & document_type to search

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -288,7 +288,6 @@ class Edition < ApplicationRecord
     is_historic: :historic?,
     is_withdrawn: :withdrawn?,
     government_name: :search_government_name,
-    content_store_document_type: :content_store_document_type,
   )
 
   def search_title
@@ -677,10 +676,6 @@ class Edition < ApplicationRecord
 
   def detailed_format
     display_type.parameterize
-  end
-
-  def content_store_document_type
-    PublishingApiPresenters.presenter_for(self).content.fetch(:document_type)
   end
 
 private

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -29,7 +29,9 @@ module Searchable
     :people,
     :public_timestamp,
     :publication_type,
+    :publishing_app,
     :release_timestamp,
+    :rendering_app,
     :search_format_types,
     :slug,
     :speech_type,
@@ -69,6 +71,9 @@ module Searchable
       self.searchable_options = options.reverse_merge \
         format:         -> (o) { o.class.model_name.element },
         content_id:     -> (o) { o.try(:content_id) },
+        rendering_app: :content_store_rendering_app,
+        publishing_app: :content_store_publishing_app,
+        content_store_document_type: :content_store_document_type,
         index_after:    :save,
         unindex_after:  :destroy,
         only:           :all,
@@ -128,6 +133,24 @@ module Searchable
 
     def rummager_index
       :government
+    end
+
+    def content_store_document_type
+      publishing_api_presenter.fetch(:document_type)
+    end
+
+    def content_store_rendering_app
+      publishing_api_presenter.fetch(:rendering_app)
+    end
+
+    def content_store_publishing_app
+      publishing_api_presenter.fetch(:publishing_app)
+    end
+
+  private
+
+    def publishing_api_presenter
+      @publishing_api_presenter ||= PublishingApiPresenters.presenter_for(self).content
     end
 
     module ClassMethods

--- a/app/presenters/publishing_api/base_item_presenter.rb
+++ b/app/presenters/publishing_api/base_item_presenter.rb
@@ -4,8 +4,8 @@ module PublishingApi
 
     def initialize(item, title: nil, need_ids: nil, locale: I18n.locale.to_s)
       self.item = item
-      self.title = title || item.title
-      self.need_ids = need_ids || item.need_ids
+      self.title = title || item.try(:title)
+      self.need_ids = need_ids || item.try(:need_ids)
       self.locale = locale
     end
 


### PR DESCRIPTION
This commit makes sure we send publishing_app, rendering_app & document_type to search for all documents. Previously we only sent document_type for editions (but now too for things like organisations and policy areas).

@fofr 