### PR TITLE
Fix breadcrumb preview box for new taxonomy

### DIFF
--- a/app/views/admin/edition_tags/_sub_taxons.html.erb
+++ b/app/views/admin/edition_tags/_sub_taxons.html.erb
@@ -1,4 +1,4 @@
-<div class="topics">
+<div class="topics topic-tree">
 <% taxons.each do |taxon| %>
   <p>
     <label>

--- a/lib/taxonomy/tree.rb
+++ b/lib/taxonomy/tree.rb
@@ -5,7 +5,10 @@ module Taxonomy
 
     def initialize(expanded_root_taxon_hash)
       @root_taxon = build_taxon(expanded_root_taxon_hash)
-      root_taxon.children = parse_taxons(expanded_root_taxon_hash['expanded_links_hash'])
+      root_taxon.children = parse_taxons(
+        root_taxon,
+        expanded_root_taxon_hash['expanded_links_hash']
+      )
     end
 
   private
@@ -14,10 +17,11 @@ module Taxonomy
       Taxon.new taxon_hash.symbolize_keys.slice(:title, :base_path, :content_id)
     end
 
-    def parse_taxons(item_hash, key: 'expanded_links')
+    def parse_taxons(parent, item_hash, key: 'expanded_links')
       child_nodes(item_hash, key).map do |child|
         taxon = build_taxon(child)
-        taxon.children = parse_taxons(child, key: 'links')
+        taxon.parent_node = parent
+        taxon.children = parse_taxons(taxon, child, key: 'links')
         taxon
       end
     end


### PR DESCRIPTION
Made childless draft taxons appear in preview box by giving them the
`topic-tree` class.

Gave each taxon a `parent_node` as we recurse through the taxons when
building the Taxonomy Tree. This is necessary in order to give the
taxon checkboxes the correct `data-ancestors` property for the breadcrumb
preview box.

### Before:
![screen shot 2017-05-18 at 17 19 45](https://cloud.githubusercontent.com/assets/12881990/26212762/9164b1d6-3bee-11e7-85ab-e4ac03ba734d.png)

### After:
![screen shot 2017-05-18 at 17 21 37](https://cloud.githubusercontent.com/assets/12881990/26212776/9fa7dd40-3bee-11e7-8e53-962f433762ad.png)

[Trello](https://trello.com/c/ihpJNOIU/99-whitehall-breadcrumb-preview-for-selected-topics-stopped-working-a-while-ago)