### PR TITLE
Add world location validation for world news story

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -83,6 +83,10 @@ class NewsArticle < Newsesque
     !world_news_story?
   end
 
+  def skip_world_location_validation?
+    !world_news_story?
+  end
+
 private
 
   def organisations_are_not_associated

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -24,9 +24,3 @@ Feature: News articles
     Then I should see the news article listed in admin with an indication that it is in French
     When I publish the French-only news article
     Then I should only see the news article on the French version of the public "France" location page
-
-  Scenario: Associate a news article of type worldwide news story with a worldwide organisation
-    Given the worldwide organisation "Spanish Department" exists
-    When I draft a valid "World news story" news article with title "Spanish News" associated to "Spanish Department"
-    And I force publish the news article "Spanish News"
-    Then the worldwide organisation "Spanish Department" should be associated to the news article "Spanish News"

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -164,16 +164,3 @@ end
 Then(/^the news article "([^"]*)" should have been created$/) do |title|
   refute NewsArticle.find_by(title: title).nil?
 end
-
-When(/^I draft a valid "World news story" news article with title "(.*?)" associated to "(.*?)"$/) do |title, worldwide_org|
-  begin_drafting_news_article(title: title, announcement_type: "World news story")
-  select worldwide_org, from: "edition_worldwide_organisation_ids"
-  select "", from: "edition_lead_organisation_ids_1"
-
-  click_button "Save"
-end
-
-Then(/^the worldwide organisation "(.*?)" should be associated to the news article "(.*?)"$/) do |world_org_name, title|
-  news_article = NewsArticle.find_by(title: title)
-  assert news_article.worldwide_organisations.map(&:name).include?(world_org_name)
-end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -149,8 +149,10 @@ end
 When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do |news_type, title|
   if news_type == "World news story"
     create(:worldwide_organisation, name: "Afghanistan embassy")
+    create(:world_location, name: "Afghanistan")
     begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)
     select "Afghanistan embassy", from: "Select the worldwide organisations associated with this news article"
+    select "Afghanistan", from: "Select the world locations this news article is about"
     select "", from: "edition_lead_organisation_ids_1"
   else
     begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -8,9 +8,14 @@ FactoryGirl.define do
       relevant_to_local_government { false }
     end
 
-    after(:build) do |object, evaluator|
+    after(:build) do |news_article, evaluator|
       if evaluator.relevant_to_local_government
-        object.related_documents = [FactoryGirl.create(:published_policy, :with_document, relevant_to_local_government: true)].map(&:document)
+        document = create(
+          :published_policy,
+          :with_document,
+          relevant_to_local_government: true
+        ).document
+        news_article.related_documents << document
       end
     end
   end
@@ -50,12 +55,14 @@ FactoryGirl.define do
     end
 
     after :build do |news_article, evaluator|
-      news_article.worldwide_organisations = [FactoryGirl.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
+      if evaluator.worldwide_organisations.empty?
+        news_article.worldwide_organisations << build(:worldwide_organisation)
+      end
     end
 
-    after :build do |object, evaluator|
+    after :build do |news_article, evaluator|
       if evaluator.world_locations.empty?
-        object.world_locations << build(:world_location)
+        news_article.world_locations << build(:world_location)
       end
     end
   end

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -52,5 +52,11 @@ FactoryGirl.define do
     after :build do |news_article, evaluator|
       news_article.worldwide_organisations = [FactoryGirl.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
     end
+
+    after :build do |object, evaluator|
+      if evaluator.world_locations.empty?
+        object.world_locations << build(:world_location)
+      end
+    end
   end
 end

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -167,4 +167,13 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     assert_equal ["You can't tag a world news story to organisations, please remove organisation"],
       news_article.errors[:base]
   end
+
+  test "is invalid without a world_location" do
+    article = build(:news_article_world_news_story)
+    article.world_locations.clear
+
+    refute article.valid?
+    assert_equal ["at least one required"],
+      article.errors[:world_locations]
+  end
 end


### PR DESCRIPTION
Adds a validation to `NewsArticle`s of type `NewsArticleType::WorldNewsStory` that requires the presence of at least one world location.

[Trello](https://trello.com/c/OW1PrFWc/89-add-specific-validation-rules-for-the-new-world-news-article-subtype)