### PR TITLE
Update organisation validation for World news story

### DIFF
--- a/app/models/edition/organisations.rb
+++ b/app/models/edition/organisations.rb
@@ -13,7 +13,7 @@ module Edition::Organisations
     has_many :edition_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations
 
-    before_save :mark_for_destruction_all_edition_organisations_for_destruction
+    before_validation :mark_for_destruction_all_edition_organisations_for_destruction
     after_save :clear_edition_organisations_touched_or_destroyed_by_lead_or_supporting_organisations_setters
 
     validate :at_least_one_lead_organisation

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -90,9 +90,13 @@ class NewsArticle < Newsesque
 private
 
   def organisations_are_not_associated
-    unless edition_organisations.empty?
+    if edition_organisations.present? && !all_edition_organisations_marked_for_destruction?
       errors.add(:base, "You can't tag a world news story to organisations, please remove organisation")
     end
+  end
+
+  def all_edition_organisations_marked_for_destruction?
+    edition_organisations.reject(&:marked_for_destruction?).blank?
   end
 
   def policies_are_not_associated

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -176,4 +176,15 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
     assert_equal ["at least one required"],
       article.errors[:world_locations]
   end
+
+  test "is valid when removing an organisation after changing type" do
+    news_article = create(:news_article_news_story)
+
+    news_article.news_article_type = NewsArticleType::WorldNewsStory
+    news_article.worldwide_organisations.build(name: "Zimbabwean Embassy")
+    news_article.world_locations << build(:world_location)
+    news_article.lead_organisation_ids = []
+
+    assert news_article.valid?
+  end
 end


### PR DESCRIPTION
The organisation validation for ‘World news story’ NewsArticles would previously fail if the NewsArticle had an organisation associated before it would be turned into a ‘World news story’.

For example, in the Admin UI:
1.) Create a ‘News Story’ News article with an associated Organisation
2.) Edit that News article by changing its type to ‘World news story’ and remove the Organisation
3.) On hitting ‘Save’, the form would show a validation error, saying ‘Can’t have an associated Organisation’

The problem was related to the fact that removing Organisation associations are handled via [the `.marked_for_destruction` method](https://github.com/alphagov/whitehall/blob/master/app/models/edition/organisations.rb#L16-L17). See https://apidock.com/rails/ActiveRecord/AutosaveAssociation/mark_for_destruction.

By updating the ‘marking_for_destruction’ logic to happen before validation (rather than before save), we can query the associations in the validation method and thereby get the intended behaviour.