### PR TITLE
Fix person_helper bug

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -18,7 +18,10 @@ module PersonHelper
   end
 
   def forename_surname(person)
-    [person.forename, person.surname].join(' ')
+    [
+      person.forename.try(:strip),
+      person.surname.try(:strip)
+    ].join(' ')
   end
 
   def disambiguate_option(person)

--- a/test/unit/helpers/person_helper_test.rb
+++ b/test/unit/helpers/person_helper_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class PersonHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "it disambiguates names with trailing spaces" do
+    person_one = build(:person, forename: "Peter ", surname: "Jones")
+    person_two = build(:person, forename: "Peter", surname: "Jones")
+    person_one.stubs(:name_with_disambiguator).returns(
+      "Peter Jones - Executive Director, Prisons"
+    )
+    person_two.stubs(:name_with_disambiguator).returns(
+      "Peter Jones - Director, Overseas Territories"
+    )
+
+    Person.stubs(:includes).returns([person_one, person_two])
+
+    expected_result = [
+      ["Peter Jones - Executive Director, Prisons", person_one.id],
+      ["Peter Jones - Director, Overseas Territories", person_two.id],
+    ]
+    assert_equal expected_result, disambiguated_people_names
+  end
+end


### PR DESCRIPTION
Many of the `Person` names in the Whitehall DB have a trailing space. The `PersonHelper` generates a list of person names for select options and where there is more than one person with the same name it disambiguates the name by appending the person's role.

This fixes a bug where if there are two people with the same name but one has a trailing space and one doesn't the disambiguation the names would not be disambiguated and only one of the users would appear in the select options in the admin UI.

[Trello](https://trello.com/c/RZwgbes3/135-bug-adding-a-new-person-to-an-organisation)