### PR TITLE
World news stories are always political

### DIFF
--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -60,10 +60,15 @@ private
   end
 
   def always_political_format?
-    ALWAYS_POLITICAL_FORMATS.include?(edition.class)
+    ALWAYS_POLITICAL_FORMATS.include?(edition.class) ||
+      edition_is_a_world_news_story?
   end
 
   def never_political_format?
     edition.is_a?(FatalityNotice) || stats_publication?
+  end
+
+  def edition_is_a_world_news_story?
+    edition.is_a?(NewsArticle) && edition.world_news_story?
   end
 end

--- a/test/unit/political_content_identifier_test.rb
+++ b/test/unit/political_content_identifier_test.rb
@@ -23,6 +23,12 @@ class PoliticalContentIdentifierTest < ActiveSupport::TestCase
     assert political?(world_location_news_article)
   end
 
+  test 'world-news-story news articles are always political' do
+    world_news_story = create(:news_article_world_news_story)
+
+    assert political?(world_news_story)
+  end
+
   test 'political formats associated with a political orgs are political' do
     political_organisation = create(:organisation, :political)
     edition = create(:consultation, lead_organisations: [political_organisation])


### PR DESCRIPTION
WorldNewsArticles are always considered political. As part of the migration of this format to NewsArticle this PR updates `PoliticalContentIdentifier` to always consider `NewsArticle` of type `NewsArticleType::WorldNewsStory` as political.

[Trello](https://trello.com/c/voHKjF2S/107-tag-all-world-news-stories-as-political)