### PR TITLE
Enable B variant for world locations A/B test

### DIFF
--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -13,6 +13,10 @@
     <%= render partial: 'govuk_component/analytics_meta_tags',
       locals: { content_item: @content_item } %>
 
+    <% if @requested_variant.present? %>
+      <%= @requested_variant.analytics_meta_tag.html_safe %>
+    <% end %>
+
     <title><%= page_title %></title>
     <%-
       stylesheet_base = local_assigns[:stylesheet] || "base"

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,0 +1,12 @@
+--- !map:HashWithIndifferentAccess
+sample:
+  - title: Help for British nationals in Sample
+    description: Travel documents and help with emergencies.
+    base_path: help-for-british-nationals
+    tagged_content:
+      - title: Get a new or replacement UK passport
+        description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
+        base_path: /apply-renew-passport
+      - title: Get emergency UK travel documents
+        description: If you're abroad, need to travel and can't get a passport in time.
+        base_path: /emergency-travel-document

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ GovukContentSchemaTestHelpers.configure do |config|
 end
 
 GovukAbTesting.configure do |config|
-  config.acceptance_test_framework = :capybara
+  config.acceptance_test_framework = :active_support
 end
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
This commit adds support for displaying the B variant of worldwide locations based on the content `worldwide_publishing_taxonomy_ab_test_content.yml`.

Trello: https://trello.com/c/IcRVNu4D/132-change-the-worldwide-location-index-controller-to-work-with-the-a-b-test