### PR TITLE
Add task to republish political content

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -10,4 +10,21 @@ namespace :election do
       puts "changed to #{person.name}"
     end
   end
+
+  task republish_political_content: :environment do
+    political_document_ids = Edition
+      .where(political: true)
+      .pluck(:document_id)
+      .uniq
+
+    puts "Republishing #{political_document_ids.count} documents"
+
+    political_document_ids.each do |document_id|
+      print "."
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+        "bulk_republishing",
+        document_id
+      )
+    end
+  end
 end


### PR DESCRIPTION
Editions that are `political: true` need to be republished following the election if we update the government record. This will enable history mode on that content and display the 'Published under' banner.

This commit adds a rake task to facilitate this.

[Trello](https://trello.com/c/mAfGFT4x/156-political-content-needs-to-be-republished-post-government-change)