### PR TITLE
Enable translation links for A/B test locations

### DIFF
--- a/app/assets/stylesheets/frontend/views/_worldwide_publishing_taxonomy.scss
+++ b/app/assets/stylesheets/frontend/views/_worldwide_publishing_taxonomy.scss
@@ -3,7 +3,8 @@
   .grid-row {
     margin: 0 -15px;
 
-    .column-two-thirds {
+    .column-two-thirds,
+    .column-one-third {
       padding: 0 15px;
       -webkit-box-sizing: border-box;
       -moz-box-sizing: border-box;
@@ -16,6 +17,11 @@
       .column-two-thirds {
         float: left;
         width: 66.66667%;
+      }
+
+      .column-one-third {
+        float: right;
+        width: 33.33333%;
       }
     }
   }

--- a/app/views/worldwide_publishing_taxonomy/show.html.erb
+++ b/app/views/worldwide_publishing_taxonomy/show.html.erb
@@ -41,39 +41,51 @@
             <p><%= parent_taxon[:description] %></p>
           </div>
         </div>
+        <% if b_variant_page_content[:translations].present? %>
+        <div class="column-one-third">
+          <div class="available-languages">
+            <ul>
+              <li class="translation">
+                <span>English</span>
+              </li>
+              <% b_variant_page_content[:translations].each_with_index do |translation, index| %>
+                <li class="translation <%= "last" if index == b_variant_page_content[:translations].size - 1 %>">
+                  <a lang="<%= translation[:code] %>" href="/government/world/<%= @world_location.slug %>.<%= translation[:code] %>?ABTest-WorldwidePublishingTaxonomy=A"><%= translation[:name] %></a>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+        <% end %>
       </div>
-      <% if accordion_content.present? %>
-        <div class="grid-row child-topic-contents">
-          <div class="column-two-thirds">
-            <div class="topic-content">
-              <div data-module="accordion-with-descriptions" class="js-hidden">
-                <div class="subsection-wrapper">
-                  <% accordion_content.each_with_index do |taxon, section_index| %>
-                    <div class="subsection js-subsection" id="<%= taxon[:base_path] %>" data-track-count="accordionSection">
-                      <div class="subsection-header js-subsection-header">
-                        <h2 class="subsection-title js-subsection-title"><%= taxon[:title] %></h2>
-                        <% if taxon[:description].present? %>
-                          <p class="subsection-description"><%= taxon[:description] %></p>
-                        <% end %>
-                      </div>
-                      <div class="subsection-content js-subsection-content" id="subsection_content_<%= section_index + 1 %>">
-                        <ol class="subsection-list">
-                          <% taxon[:tagged_content].each_with_index do |content_item, content_index| %>
-                            <li class="subsection-list-item">
-                              <%= link_to(content_item[:title], content_item[:base_path]) %>
-                              <p><%= content_item[:description] %></p>
-                            </li>
-                          <% end %>
-                        </ol>
-                      </div>
+      <div class="grid-row child-topic-contents">
+        <div class="column-two-thirds">
+          <div class="topic-content">
+            <div data-module="accordion-with-descriptions" class="js-hidden">
+              <div class="subsection-wrapper">
+                <% b_variant_page_content[:taxonomy].each_with_index do |taxon, section_index| %>
+                  <div class="subsection js-subsection" id="<%= taxon[:base_path] %>" data-track-count="accordionSection">
+                    <div class="subsection-header js-subsection-header">
+                      <h2 class="subsection-title js-subsection-title"><%= taxon[:title] %></h2>
+                      <p class="subsection-description"><%= taxon[:description] %></p>
                     </div>
-                  <% end %>
-                </div>
+                    <div class="subsection-content js-subsection-content" id="subsection_content_<%= section_index + 1 %>">
+                      <ol class="subsection-list">
+                        <% taxon[:tagged_content].each_with_index do |content_item, content_index| %>
+                          <li class="subsection-list-item">
+                            <%= link_to(content_item[:title], content_item[:base_path]) %>
+                            <p><%= content_item[:description] %></p>
+                          </li>
+                        <% end %>
+                      </ol>
+                    </div>
+                  </div>
+                <% end %>
               </div>
             </div>
           </div>
         </div>
-      <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,12 +1,16 @@
 --- !map:HashWithIndifferentAccess
 sample:
-  - title: Help for British nationals in Sample
-    description: Travel documents and help with emergencies.
-    base_path: help-for-british-nationals
-    tagged_content:
-      - title: Get a new or replacement UK passport
-        description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-        base_path: /apply-renew-passport
-      - title: Get emergency UK travel documents
-        description: If you're abroad, need to travel and can't get a passport in time.
-        base_path: /emergency-travel-document
+  translations:
+    - name: Samplese
+      code: zz
+  taxonomy:
+    - title: Help for British nationals in Sample
+      description: Travel documents and help with emergencies.
+      base_path: help-for-british-nationals
+      tagged_content:
+        - title: Get a new or replacement UK passport
+          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
+          base_path: /apply-renew-passport
+        - title: Get emergency UK travel documents
+          description: If you're abroad, need to travel and can't get a passport in time.
+          base_path: /emergency-travel-document

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -361,7 +361,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
       # `worldwide_publishing_taxonomy_ab_test_content.yml` and will therefore
       # display the taxonomy page
       world_location = create(:world_location, slug: 'sample')
-      get :show, id: world_location
+      get :show, id: world_location, locale: 'en'
 
       assert_select '.taxon-page'
       refute_select '.world_location'


### PR DESCRIPTION
This commit enables the translation picker for A/B test world locations that have translations. The translated content is rendered in the existing template and the user is re-assigned to the “A” bucket to prevent the confusion of switching between the “A” and “B” layouts of the page depending on the language.

Trello: https://trello.com/c/wcAClg8f/157-add-translation-toggle-to-taxon-pages-that-need-them-for-a-b-test

<img width="312" alt="screen shot 2017-05-25 at 10 18 47" src="https://cloud.githubusercontent.com/assets/444232/26444257/923f6778-4133-11e7-8e22-b840e81c1096.png">