### PR TITLE
Change world location page title for A/B test

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -65,7 +65,7 @@ class WorldLocationsController < PublicFacingController
 
   def parent_taxon
     {
-      title: @world_location.title,
+      title: "#{@world_location.name} and the UK",
       description: "Accessing UK services from #{@world_location.name}, advice for travelling to the UK, and help with trading between the UK and #{@world_location.name}."
     }
   end

--- a/app/views/worldwide_publishing_taxonomy/show.html.erb
+++ b/app/views/worldwide_publishing_taxonomy/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title @world_location.title, "UK and the world" %>
+<% page_title parent_taxon[:title], "UK and the world" %>
 
 <div class="block world-locations">
   <div class="inner-block">
@@ -20,7 +20,7 @@
           },
           {
             title: "World",
-            url: "/world",
+            url: "/government/world",
             is_page_parent: true
           },
           {


### PR DESCRIPTION
This commit changes the world location page title for the “B” variant from “UK and Country” to “Country and the UK” and fixes the breadcrumb link to `/government/world`.