### PR TITLE
Redirect B bucket worldwide organisation pages

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -31,13 +31,18 @@ private
     requested_variant.configure_response(response)
 
     if requested_variant.variant_b? &&
-        worldwide_test_helper.is_under_test?(@worldwide_organisation)
+        worldwide_test_helper.is_under_test?(@worldwide_organisation) &&
+        locale_is_en?
       redirect_to worldwide_test_helper.location_for(@worldwide_organisation)
     end
   end
 
   def worldwide_test_helper
     @helper ||= WorldwideAbTestHelper.new
+  end
+
+  def locale_is_en?
+    I18n.locale == :en
   end
 
   def load_worldwide_organisation

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -93,4 +93,33 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
       assert_response :ok
     end
   end
+
+  test "show redirects B group users to their hardcoded location page if present" do
+    world_location = create(:world_location)
+
+    hard_coded_redirects = {
+      "british-high-commission-pretoria" => "south-africa",
+      "british-consulate-general-los-angeles" => "usa",
+      "did-south-africa" => "south-africa",
+      "british-deputy-high-commission-kolkata" => "india",
+      "uk-science-and-innovation-network" => "australia",
+    }
+
+    hard_coded_redirects.each do |organisation_slug, location_slug|
+      hard_coded_location = create(:world_location, slug: location_slug)
+      worldwide_organisation = create(
+        :worldwide_organisation,
+        slug: organisation_slug,
+        world_locations: [
+          world_location,
+          hard_coded_location,
+        ]
+      )
+
+      with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+        get :show, id: worldwide_organisation
+        assert_redirected_to world_location_path(hard_coded_location)
+      end
+    end
+  end
 end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -94,6 +94,20 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  test "show doesn't redirect B group users if they are viewing a non-en locale" do
+    location_under_test_slug = "india"
+    world_location = create(:world_location, slug: location_under_test_slug)
+    worldwide_organisation = create(:worldwide_organisation, world_locations: [world_location])
+
+    LocalisedModel.new(worldwide_organisation, :fr)
+      .update_attributes(name: "Le embassy de india")
+
+    with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      get :show, id: worldwide_organisation, locale: "fr"
+      assert_response :ok
+    end
+  end
+
   test "show redirects B group users to their hardcoded location page if present" do
     world_location = create(:world_location)
 


### PR DESCRIPTION
As part of the worldwide taxonomy A/B we no longer want visitors assigned to the 'B' group to use the worldwide organisation pages for the countries under test.

This PR redirects 'B' group members to an appropriate world location URL where they will be served the new taxon page under test. In most cases this is the `WorldLocation` that is associated with the requested organisation. In a small number of cases the organisation is related to more than one location so these are hard coded to redirect to the correct location for the test.

[Trello](https://trello.com/c/6mugcukv/159-redirect-users-in-the-b-bucket-of-the-a-b-test-who-land-on-worldwide-organisation-pages)