### PR TITLE
Add world news page for a b test

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,0 +1,29 @@
+class WorldLocationNewsController < PublicFacingController
+  enable_request_formats index: [:atom, :json]
+  before_action :load_world_location, only: :index
+
+  def index
+    recently_updated_source = @world_location.published_editions.with_translations(I18n.locale).in_reverse_chronological_order
+    respond_to do |format|
+      format.html do
+        set_meta_description("What the UK government is doing in #{@world_location.name}.")
+        set_slimmer_world_locations_header([@world_location])
+
+        @recently_updated = recently_updated_source.limit(3)
+        @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
+      end
+      format.json do
+        redirect_to api_world_location_path(@world_location, format: :json)
+      end
+      format.atom do
+        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
+      end
+    end
+  end
+
+private
+
+  def load_world_location
+    @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
+  end
+end

--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,16 +1,21 @@
 class WorldLocationNewsController < PublicFacingController
   enable_request_formats index: [:atom, :json]
   before_action :load_world_location, only: :index
+  before_action :setup_a_b_test, only: :index
 
   def index
     recently_updated_source = @world_location.published_editions.with_translations(I18n.locale).in_reverse_chronological_order
     respond_to do |format|
       format.html do
-        set_meta_description("What the UK government is doing in #{@world_location.name}.")
-        set_slimmer_world_locations_header([@world_location])
+        if render_b_variant?
+          set_meta_description("What the UK government is doing in #{@world_location.name}.")
+          set_slimmer_world_locations_header([@world_location])
 
-        @recently_updated = recently_updated_source.limit(3)
-        @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
+          @recently_updated = recently_updated_source.limit(3)
+          @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
+        else
+          redirect_to world_location_path(@world_location)
+        end
       end
       format.json do
         redirect_to api_world_location_path(@world_location, format: :json)
@@ -25,5 +30,25 @@ private
 
   def load_world_location
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
+  end
+
+  def setup_a_b_test
+    ab_test = GovukAbTesting::AbTest.new("WorldwidePublishingTaxonomy", dimension: 45)
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+  end
+
+  def render_b_variant?
+    @requested_variant.variant_b? &&
+      worldwide_test_helper.is_under_test?(@world_location) &&
+      locale_is_english?
+  end
+
+  def worldwide_test_helper
+    @_helper ||= WorldwideAbTestHelper.new
+  end
+
+  def locale_is_english?
+    locale == :en
   end
 end

--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -40,7 +40,7 @@ class WorldLocationsController < PublicFacingController
         if render_b_variant?
           render "worldwide_publishing_taxonomy/show", locals: {
             parent_taxon: parent_taxon,
-            b_variant_page_content: b_variant_page_content
+            b_variant_page_content: worldwide_test_helper.content_for(@world_location.slug)
           }
         end
       end
@@ -60,7 +60,17 @@ class WorldLocationsController < PublicFacingController
   end
 
   def render_b_variant?
-    @requested_variant.variant_b? && b_variant_page_content.present? && params[:locale] == "en"
+    @requested_variant.variant_b? &&
+      worldwide_test_helper.is_under_test?(@world_location) &&
+      locale_is_english?
+  end
+
+  def worldwide_test_helper
+    @_helper ||= WorldwideAbTestHelper.new
+  end
+
+  def locale_is_english?
+    locale == :en
   end
 
   def parent_taxon
@@ -69,9 +79,4 @@ class WorldLocationsController < PublicFacingController
       description: "Accessing UK services from #{@world_location.name}, advice for travelling to the UK, and help with trading between the UK and #{@world_location.name}."
     }
   end
-
-  def b_variant_page_content
-    @worldwide_publishing_taxonomy_ab_test_content ||= YAML.load_file(Rails.root + "config/worldwide_publishing_taxonomy_ab_test_content.yml")[@world_location.slug]
-  end
-
 end

--- a/app/views/world_location_news/index.atom.builder
+++ b/app/views/world_location_news/index.atom.builder
@@ -1,0 +1,8 @@
+atom_feed language: 'en-GB', root_url: root_url do |feed|
+  feed.title [@world_location.name, 'Activity on GOV.UK'].join(' - ')
+  feed.author do |author|
+    author.name 'HM Government'
+  end
+
+  documents_as_feed_entries(@documents, feed)
+end

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -1,0 +1,40 @@
+<% page_title @world_location.title, "UK and the world" %>
+<% page_class "world-locations-show" %>
+<% atom_discovery_link_tag atom_feed_url_for(@world_location), t("feeds.latest_activity") %>
+
+<%= content_tag_for(:article, @world_location) do %>
+  <header class="block headings-block">
+    <div class="inner-block floated-children">
+      <%= render partial: 'shared/heading',
+                locals: { type: "World location news",
+                          heading: @world_location.title,
+                          extra: true, big: true } %>
+      <aside class="heading-extra">
+        <div class="inner-heading">
+          <%= render 'shared/available_languages', object: @world_location %>
+          <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set %>
+        </div>
+      </aside>
+    </div>
+  </header>
+
+  <div class="block news-block">
+    <div class="inner-block">
+      <section class="featured-news items-<%= @feature_list.current_feature_count %>" id="featured-documents">
+        <% if @feature_list.any_current_features? %>
+          <%= render partial: 'shared/featured',
+                     collection: @feature_list.current_featured,
+                     as: :feature,
+                     locals: { show_meta: true,
+                               extra_class: "secondary" } %>
+        <% end %>
+
+        <%= render partial: 'shared/recently_updated',
+                  locals: { recently_updated: @recently_updated,
+                            atom_url: atom_feed_url_for(@world_location),
+                            extra_class: 'panel',
+                            see_all_link: latest_path(world_locations: [@world_location])} %>
+      </section>
+    </div>
+  </div>
+<% end %>

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -11,7 +11,25 @@
                           extra: true, big: true } %>
       <aside class="heading-extra">
         <div class="inner-heading">
-          <%= render 'shared/available_languages', object: @world_location %>
+          <!-- copied from _available_languages partial as we need to add the AB testing query param -->
+          <% if @world_location.available_in_multiple_languages? %>
+            <div class="available-languages">
+              <ul>
+                <% sorted_locales(@world_location.translated_locales).each.with_index do |locale, i| %>
+                  <li class="translation<%= ' last' if i == @world_location.translated_locales.length-1 %>">
+                    <% if locale == I18n.locale %>
+                      <span><%= native_language_name_for(locale) %></span>
+                    <% else %>
+                      <a lang="<%= locale %>" href="/government/world/<%= @world_location.slug %>.<%= locale %>?ABTest-WorldwidePublishingTaxonomy=A">
+                        <%= native_language_name_for(locale) %>
+                      </a>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
           <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set %>
         </div>
       </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,9 @@ Whitehall::Application.routes.draw do
 
     resources :embassies, path: 'world/embassies', only: [:index]
 
-    resources :world_locations, path: 'world', only: [:index, :show], localised: true
+    resources :world_locations, path: 'world', only: [:index, :show], localised: true do
+      resources :world_location_news, path: 'news', only: [:index]
+    end
 
     constraints(AdminRequest) do
       namespace :admin do

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -1,0 +1,166 @@
+require "test_helper"
+
+class WorldLocationNewsControllerTest < ActionController::TestCase
+  include FilterRoutesHelper
+  include FeedHelper
+
+  should_be_a_public_facing_controller
+
+  def assert_featured_editions(editions)
+    assert_equal editions, assigns(:feature_list).current_featured.map(&:edition)
+  end
+
+  view_test "index displays world location title" do
+    world_location = create(:world_location,
+      title: "UK in country-name",
+    )
+    get :index, world_location_id: world_location
+    assert_select "p.type", text: "World location news"
+    assert_select "h1", text: "UK in country-name"
+  end
+
+  test "index responds with not found if appropriate translation doesn't exist" do
+    world_location = create(:world_location)
+    assert_raise(ActiveRecord::RecordNotFound) do
+      get :index, world_location_id: world_location, locale: 'fr'
+    end
+  end
+
+  test "index when asked for json should redirect to the api controller" do
+    world_location = create(:world_location)
+    get :index, world_location_id: world_location, format: :json
+    assert_redirected_to api_world_location_path(world_location, format: :json)
+  end
+
+  view_test 'index has atom feed autodiscovery link' do
+    world_location = create(:world_location)
+
+    get :index, world_location_id: world_location
+
+    assert_select_autodiscovery_link atom_feed_url_for(world_location)
+  end
+
+  view_test 'index includes a link to the atom feed' do
+    world_location = create(:world_location)
+
+    get :index, world_location_id: world_location
+
+    assert_select "a.feed[href=?]", atom_feed_url_for(world_location)
+  end
+
+  view_test "index generates an atom feed with entries for latest activity" do
+    world_location = create(:world_location)
+    pub = create(:published_publication, world_locations: [world_location], first_published_at: 1.week.ago.to_date)
+    news = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
+
+    get :index, world_location_id: world_location, format: :atom
+
+    assert_select_atom_feed do
+      assert_select_atom_entries([news, pub])
+    end
+  end
+
+  test "shows the latest published edition for a featured document" do
+    world_location = create(:world_location)
+
+    news = create(:published_news_article, first_published_at: 2.days.ago)
+    editor = create(:departmental_editor)
+    draft = news.create_draft(editor)
+
+    feature_list = create(:feature_list, featurable: world_location, locale: :en)
+    create(:feature, feature_list: feature_list, document: news.document)
+
+    get :index, world_location_id: world_location
+
+    assert_featured_editions [news]
+  end
+
+  test "shows featured items in defined order for locale" do
+    world_location = create(:world_location)
+    LocalisedModel.new(world_location, :fr).update_attributes(name: "Territoire antarctique britannique")
+
+    less_recent_news_article = create(:published_news_article, first_published_at: 2.days.ago)
+    more_recent_news_article = create(:published_publication, first_published_at: 1.day.ago)
+    english = FeatureList.create!(featurable: world_location, locale: :en)
+    create(:feature, feature_list: english, ordering: 1, document: less_recent_news_article.document)
+
+    french = FeatureList.create!(featurable: world_location, locale: :fr)
+    create(:feature, feature_list: french, ordering: 1, document: less_recent_news_article.document)
+    create(:feature, feature_list: french, ordering: 2, document: more_recent_news_article.document)
+
+    get :index, world_location_id: world_location, locale: :fr
+    assert_featured_editions [less_recent_news_article, more_recent_news_article]
+
+    get :index, world_location_id: world_location, locale: :en
+    assert_featured_editions [less_recent_news_article]
+  end
+
+  test "excludes ended features" do
+    world_location = create(:world_location)
+
+    news = create(:published_news_article, first_published_at: 2.days.ago)
+    feature_list = create(:feature_list, featurable: world_location, locale: :en)
+    create(:feature, feature_list: feature_list, document: news.document, started_at: 2.days.ago, ended_at: 1.day.ago)
+
+    get :index, world_location_id: world_location
+    assert_featured_editions []
+  end
+
+  test "shows a maximum of 5 featured news articles" do
+    world_location = create(:world_location)
+    english = FeatureList.create!(featurable: world_location, locale: :en)
+    6.times do
+      news_article = create(:published_news_article)
+      create(:feature, feature_list: english, document: news_article.document)
+    end
+
+    get :index, world_location_id: world_location
+
+    assert_equal 5, assigns(:feature_list).current_feature_count
+  end
+
+  test "show should set world location slimmer headers" do
+    world_location = create(:world_location)
+
+    get :index, world_location_id: world_location.id
+
+    assert_equal "<#{world_location.analytics_identifier}>", response.headers["X-Slimmer-World-Locations"]
+  end
+
+  test "should only display translated recently updated editions when requested for a locale" do
+    world_location = create(:world_location, translated_into: [:fr])
+
+    translated_publication = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
+    untranslated_publication = create(:published_publication, world_locations: [world_location])
+
+    get :index, world_location_id: world_location, locale: 'fr'
+
+    assert_equal [translated_publication], assigns(:recently_updated)
+  end
+
+  view_test "restricts atom feed entries to those with the current locale" do
+    world_location = create(:world_location, translated_into: [:fr])
+
+    translated_edition = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
+    untranslated_edition = create(:published_publication, world_locations: [world_location])
+
+    get :index, world_location_id: world_location, format: :atom, locale: 'fr'
+
+    assert_select_atom_feed do
+      with_locale :fr do
+        assert_select_atom_entries([translated_edition])
+      end
+    end
+  end
+
+  view_test "should show featured links if there are some" do
+    world_location = create(:world_location)
+    featured_link = create(:featured_link, linkable: world_location)
+
+    get :index, world_location_id: world_location
+
+    assert_select '.featured-links' do
+      assert_select "a[href='#{featured_link.url}']", text: featured_link.title
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/KV9diS41/158-create-a-new-version-of-the-worldwide-location-template-with-only-news

This adds a new News page for world locations. It will be used for the A/B test for a number of selected countries. It’s a slimmed down version of the WorldLocation page, showing just featured and latest documents.

Also updates the WorldLocationController to use the latest `WorldwideAbTestHelper` class

----------------------------------
![screen shot 2017-05-25 at 16 48 37](https://cloud.githubusercontent.com/assets/5112255/26458031/11135df8-416a-11e7-8e12-d2747270857c.png)

