### PR TITLE
Add primary language and translations available to CSV export

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -28,7 +28,9 @@ class DocumentListExportPresenter
       'Specialist sectors',
       'Collections',
       'Can have history-mode',
-      'History-mode applied'
+      'History-mode applied',
+      'Primary language',
+      'Translations available',
     ]
   end
 
@@ -52,6 +54,8 @@ class DocumentListExportPresenter
       collections,
       edition.political?,
       edition.historic?,
+      primary_language,
+      translations_available,
     ]
   end
 
@@ -152,6 +156,23 @@ class DocumentListExportPresenter
         elem
       end
     end
+  end
+
+  def primary_language
+    edition.primary_language_name
+  end
+
+  def translations_available
+    # we don't use available_in_multiple_languages? here because it
+    # returns true for editions with one english version and only one
+    # other language version; which is not exactly what we want here
+    return 'none' unless edition.translated_locales.count > 1
+
+    edition.
+      translated_locales.
+      reject { |locale_code| locale_code.to_s == edition.primary_locale.to_s }.
+      sort_by(&:to_s).
+      map { |locale_code| Locale.new(locale_code).english_language_name }
   end
 
 end

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -76,4 +76,34 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
     presenter = DocumentListExportPresenter.new(unpublished_edition)
     assert_equal "unpublished", presenter.state
   end
+
+  test '#primary_language returns the language of the main edition' do
+    french_edition = create(:edition, primary_locale: 'fr')
+    presenter = DocumentListExportPresenter.new(french_edition)
+    assert_equal 'French', presenter.primary_language
+  end
+
+  test '#translations_available returns "none" when a document is only available in english' do
+    edition = create(:edition)
+    presenter = DocumentListExportPresenter.new(edition)
+    assert_equal 'none', presenter.translations_available
+  end
+
+  test '#translations_available returns "none" when a document is only available in a foreign language' do
+    french_edition = with_locale(:fr) { create(:edition, primary_locale: 'fr') }
+    presenter = DocumentListExportPresenter.new(french_edition)
+    assert_equal 'none', presenter.translations_available
+  end
+
+  test '#translations_available returns the language name of a documents translation' do
+    edition_also_available_in_welsh = create(:edition, :translated, primary_locale: 'en', translated_into: 'cy')
+    presenter = DocumentListExportPresenter.new(edition_also_available_in_welsh)
+    assert_equal %w(Welsh), presenter.translations_available
+  end
+
+  test '#translations_available returns a list of all the language names of a documents translation, sorted by language code' do
+    edition_translated_many_times = create(:edition, :translated, primary_locale: 'en', translated_into: %w(ms ar cy))
+    presenter = DocumentListExportPresenter.new(edition_translated_many_times)
+    assert_equal %w(Arabic Welsh Malay), presenter.translations_available
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/p3x8gE9F/162-add-translation-column-to-whitehall-csv-export

Not all editions have english as their primary language, and not all
editions have been translated.  Adding these columns to the CSV export
lets content analysts filter documents to find translated content quickly.

Note that in the presenter we use `edition.translated_locales.count > 1`
as a guard clause instead of the seemingly more obvious
`edition.available_in_multiple_languages?`.  The latter assumes english
as a default and reports true if the edition has any non-english
translations.  There are some editions that are not available in
english at all and so available_in_multiple_languages? reports true, when
they may only be available in one language.  It might be that
`Edition#available_in_multiple_languages?` would be better renamed as
`Edition#available_in_languages_other_than_english?` to avoid this
confusion.