### PR TITLE
Add embassy contact page template

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -53,7 +53,7 @@ class WorldLocationsController < PublicFacingController
     end
   end
 
-  private
+private
 
   def load_world_location
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:id])

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -34,13 +34,25 @@ class WorldwideOrganisationsController < PublicFacingController
     set_slimmer_organisations_header([@worldwide_organisation] + @worldwide_organisation.sponsoring_organisations)
 
     if b_variant? && @embassy_data
-      render template: 'embassies/show'
+      if locale_is_en?
+        render template: 'embassies/show'
+      else
+        redirect_and_exit_group_if_non_en_locale
+      end
     else
       redirect_to @worldwide_organisation
     end
   end
 
 private
+
+  def redirect_and_exit_group_if_non_en_locale
+    redirect_to worldwide_organisation_path(
+      @worldwide_organisation,
+      "ABTest-WorldwidePublishingTaxonomy" => "A",
+      locale: I18n.locale
+    )
+  end
 
   def redirect_if_required_for_ab_test
     if b_variant? &&

--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -23,6 +23,10 @@ class WorldwideOrganisationsController < PublicFacingController
     end
   end
 
+  def show_b_variant
+    render template: 'embassies/show'
+  end
+
 private
 
   def redirect_if_required_for_ab_test

--- a/app/views/embassies/show.html.erb
+++ b/app/views/embassies/show.html.erb
@@ -51,7 +51,7 @@
       <div class="content">
         <p class="summary"><%= @embassy_data[:summary] %></p>
         <div class="description">
-          <%= @embassy_data[:body] %>
+          <%= govspeak_to_html @embassy_data[:body] %>
         </div>
       </div>
     </div>

--- a/app/views/embassies/show.html.erb
+++ b/app/views/embassies/show.html.erb
@@ -1,0 +1,107 @@
+<% page_title @worldwide_organisation.name %>
+<% page_class "worldwide-organisations-show" %>
+
+<div class="block world-locations">
+  <div class="inner-block">
+    <%=
+      render(
+        partial: 'govuk_component/beta_label',
+        locals: {
+          message: 'This is a test version of the layout of this page.'
+        }
+      )
+    %>
+    <%=
+      render(
+        partial: 'govuk_component/breadcrumbs',
+        locals: {
+          breadcrumbs: [
+            {
+              title: "Home",
+              url: "/",
+              is_page_parent: false
+            },
+            {
+              title: "World",
+              url: "/government/world",
+              is_page_parent: true
+            },
+            {
+              title: @world_location,
+              url: "/government/world/#{@world_location}",
+              is_current_page: false
+            },
+            {
+              title: @embassy_data[:title],
+              is_current_page: true
+            }
+            ],
+            collapse_on_mobile: true
+        }
+      )
+    %>
+  </div>
+</div>
+
+<%= render partial: 'header', locals: { organisation: @worldwide_organisation, world_locations: @world_locations } %>
+
+<section class="block about-block" id="about-us">
+  <div class="inner-block floated-children">
+    <div class="about-us">
+      <div class="content">
+        <p class="summary"><%= @embassy_data[:summary] %></p>
+        <div class="description">
+          <%= @embassy_data[:body] %>
+        </div>
+      </div>
+    </div>
+    <% if @worldwide_organisation.social_media_accounts.any? %>
+      <aside class="social-media-links">
+        <div class="content">
+          <h1><%= t('worldwide_organisation.headings.follow_us') %></h1>
+            <%= render 'shared/social_media_accounts', socialable: @worldwide_organisation, followus: true %>
+        </div>
+      </aside>
+    <% end %>
+  </div>
+</section>
+
+<% if ([@primary_role]+@other_roles).compact.any?(&:has_appointment?) %>
+  <section class="block people" id="people">
+    <div class="inner-block floated-children">
+      <h1 class="keyline-header"><%= t('worldwide_organisation.headings.our_people' ) %></h1>
+      <%= render( partial: 'people/person',
+                  locals: {
+                    person: @primary_role.current_person,
+                    roles: [@primary_role],
+                    hlevel: 'h2',
+                    wrapping_element: :div }) if @primary_role %>
+      <ul class="people-list">
+        <% clear_person = 0 %>
+        <% @other_roles.each do |role| %>
+          <%= render( partial: 'people/person',
+                      locals: {
+                        person: role.current_person,
+                        roles: [role],
+                        hlevel: 'h2',
+                        hide_image: true,
+                        extra_class: ((clear_person += 1) % 3 == 1 ? 'clear-person' : '')}) %>
+        <% end %>
+      </ul>
+    </div>
+  </section>
+<% end %>
+
+<% if @main_office %>
+  <section class="block contact-us" id="contact-us">
+    <div class="inner-block floated-children">
+      <h1 class="keyline-header"><%= t('worldwide_organisation.headings.contact_us' ) %></h1>
+      <%= render partial: 'contacts/contact', locals: {contact: @main_office, is_main: true} %>
+      <%= render partial: 'contacts/contact', collection: @home_page_offices %>
+    </div>
+  </section>
+<% end %>
+
+<% if @worldwide_organisation.corporate_information_pages.any? %>
+  <%= render partial: 'corporate_information', locals: { organisation: @worldwide_organisation } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Whitehall::Application.routes.draw do
 
     resources :world_locations, path: 'world', only: [:index, :show], localised: true do
       resources :world_location_news, path: 'news', only: [:index]
+      resources :worldwide_organisations, path: '', only: [:show], to: 'worldwide_organisations#show_b_variant'
     end
 
     constraints(AdminRequest) do

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class WorldwideOrganisationsControllerTest < ActionController::TestCase
   include GovukAbTesting::MinitestHelpers
   should_be_a_public_facing_controller
+  include GovukAbTesting::MinitestHelpers
 
   test "shows worldwide organisation information" do
     organisation = create(:worldwide_organisation)
@@ -151,6 +152,29 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
         get :show, id: worldwide_organisation
         assert_redirected_to world_location_path(hard_coded_location)
       end
+    end
+  end
+
+  test "should redirect to the worldwide_organisation if the user is in the 'A' cohort" do
+    with_variant WorldwidePublishingTaxonomy: "A", assert_meta_tag: false do
+      organisation = create(:worldwide_organisation)
+      world_location = create(:world_location)
+
+      get :show_b_variant, id: organisation.id, world_location_id: world_location.id
+
+      assert_redirected_to worldwide_organisation_path(organisation)
+    end
+  end
+
+  test "should redirect to the worldwide_organisation page if the user is in the B cohort but the world_location is not in the test data" do
+    with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      organisation = create(:worldwide_organisation)
+      world_location = create(:world_location)
+      WorldwideAbTestHelper.any_instance.expects(:has_content_for?).returns(nil)
+
+      get :show_b_variant, id: organisation.id, world_location_id: world_location.id
+
+      assert_redirected_to worldwide_organisation_path(organisation)
     end
   end
 end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -177,4 +177,32 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
       assert_redirected_to worldwide_organisation_path(organisation)
     end
   end
+
+  test "should return 200 if in the B cohort and there is data" do
+    with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      worldwide_organisation = create(:worldwide_organisation)
+      world_location = create(:world_location)
+
+      data = sample_yaml(worldwide_organisation)
+      WorldwideAbTestHelper.any_instance.stubs(:has_content_for?).returns(true)
+      WorldwideAbTestHelper.any_instance.expects(:content_for).with(world_location.slug).at_least_once.returns(data)
+      get :show_b_variant, id: worldwide_organisation.slug, world_location_id: world_location.slug
+
+      assert_response 200
+    end
+  end
+
+  def sample_yaml(worldwide_organisation)
+    {
+      "embassies" => {
+        worldwide_organisation.slug => [
+          {
+            "title" => "British High Commission Sample City",
+            "summary" => "Summary",
+            "body" => "The Body"
+          }
+        ]
+      }
+    }
+  end
 end


### PR DESCRIPTION
This PR adds a new Embassy Contact page that will replace the worldwide organisation pages for users in the B group of the worldwide taxonomy A/B test.

Users in the B group attempting that request a translated version of the page will be shown the current page as we aren't supporting translations for the A/B test.

Trello: https://trello.com/c/9AWsaa3N/154-add-embassy-contact-page-template-to-whitehall