### PR TITLE
Add helper class for Worldwide taxonomy A/B test

### DIFF
--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,5 +1,5 @@
 --- !map:HashWithIndifferentAccess
-sample:
+india:
   translations:
     - name: Samplese
       code: zz

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,5 +1,5 @@
 --- !map:HashWithIndifferentAccess
-india:
+sample:
   translations:
     - name: Samplese
       code: zz

--- a/lib/worldwide_ab_test_helper.rb
+++ b/lib/worldwide_ab_test_helper.rb
@@ -1,8 +1,8 @@
 class WorldwideAbTestHelper
   attr_reader :content
 
-  def initialize
-    @content = YAML.load_file(file_path)
+  def initialize(content_file_path = nil)
+    @content = YAML.load_file(content_file_path || file_path)
   end
 
   def has_content_for?(location_slug)

--- a/lib/worldwide_ab_test_helper.rb
+++ b/lib/worldwide_ab_test_helper.rb
@@ -1,0 +1,59 @@
+class WorldwideAbTestHelper
+  attr_reader :content
+
+  def initialize
+    @content = YAML.load_file(file_path)
+  end
+
+  def has_content_for?(location_slug)
+    !!content_for(location_slug)
+  end
+
+  def content_for(location_slug)
+    content[location_slug]
+  end
+
+  def location_for(worldwide_organisation)
+    hard_coded_location_for(worldwide_organisation) ||
+      worldwide_organisation.world_locations.first
+  end
+
+  def is_under_test?(testable_object)
+    location = testable_object
+    if testable_object.respond_to?(:world_locations)
+      location = location_for(testable_object)
+    end
+    has_content_for?(location.slug)
+  end
+
+private
+
+  def root
+    Rails.root
+  end
+
+  def file_path
+    File.join(root, "config/worldwide_publishing_taxonomy_ab_test_content.yml")
+  end
+
+  def hard_coded_location_slugs
+    {
+      "british-high-commission-pretoria" => "south-africa",
+      "british-consulate-general-los-angeles" => "usa",
+      "did-south-africa" => "south-africa",
+      "british-deputy-high-commission-kolkata" => "india",
+      "uk-science-and-innovation-network" => "australia",
+    }
+  end
+
+  def hard_coded_location_for(worldwide_organisation)
+    wwo_slug = worldwide_organisation.slug
+    hard_coded_value = hard_coded_location_slugs[wwo_slug]
+    return unless hard_coded_value.present?
+
+    locations = worldwide_organisation.world_locations
+    locations.find do |location|
+      location.slug == hard_coded_value
+    end
+  end
+end

--- a/test/unit/worldwide_ab_test_helper_test.rb
+++ b/test/unit/worldwide_ab_test_helper_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class WorldwideAbHelperTest < ActiveSupport::TestCase
+  def subject
+    WorldwideAbTestHelper.new
+  end
+
+  test "content returns the parsed file " do
+    result = subject.content
+    assert result[:india].present?
+  end
+
+  test "has_content_for? returns true if the key is present" do
+    assert subject.has_content_for?(:india)
+  end
+
+  test "has_content_for? returns true if the string key is present" do
+    assert subject.has_content_for?("india")
+  end
+
+  test "has_content_for? returns false if the key is not present" do
+    refute subject.has_content_for?("eggnogg")
+  end
+
+  test "content_for returns content for the key if present" do
+    assert_not_nil subject.content_for("india")
+  end
+
+  test "content_for returns nil if the key is not present" do
+    assert_nil subject.content_for("booyah")
+  end
+
+  test "location_for returns the first worldwide_location" do
+    location = stub(slug: "turkey")
+    org = stub(
+      slug: "british-embassy-turkey",
+      world_locations: [location]
+    )
+
+    assert_equal location, subject.location_for(org)
+  end
+
+  test "location_for returns hard coded location where present" do
+    location = stub(slug: "turkey")
+    hard_coded_location = stub(slug: "india")
+    organisation = stub(
+      slug: "british-deputy-high-commission-kolkata",
+      world_locations: [location, hard_coded_location]
+    )
+
+    assert_equal hard_coded_location, subject.location_for(organisation)
+  end
+
+  test "is_under_test? returns true if location is first location" do
+    location = stub(slug: "india")
+    organisation = stub(
+      slug: "british-deputy-high-commission-indialand",
+      world_locations: [location]
+    )
+
+    assert subject.is_under_test?(organisation)
+  end
+
+  test "is_under_test? returns true if organisation slug is hard coded" do
+    location = stub(slug: "embassy")
+    other_location = stub(slug: "india")
+    organisation = stub(
+      slug: "british-deputy-high-commission-kolkata",
+      world_locations: [location, other_location]
+    )
+
+    assert subject.is_under_test?(organisation)
+  end
+
+  test "is_under_test? returns false if the organisation isn't related to a location under test" do
+    location = stub(slug: "germany")
+    organisation = stub(
+      slug: "embassy-in-germany",
+      world_locations: [location]
+    )
+
+    refute subject.is_under_test?(organisation)
+  end
+
+  test "is_under_test? returns true if supplied with a location with content" do
+    location = stub(slug: "india")
+    assert subject.is_under_test?(location)
+  end
+
+  test "is_under_test? return false if the supplied with a location without content" do
+    location = WorldLocation.new(slug: "germany")
+    refute subject.is_under_test?(location)
+  end
+end

--- a/test/unit/worldwide_ab_test_helper_test.rb
+++ b/test/unit/worldwide_ab_test_helper_test.rb
@@ -1,94 +1,148 @@
 require 'test_helper'
 
 class WorldwideAbHelperTest < ActiveSupport::TestCase
-  def subject
-    WorldwideAbTestHelper.new
+  def subject(file_path = nil)
+    WorldwideAbTestHelper.new(file_path)
+  end
+
+  def with_fixture_file
+    content = <<-CONTENT.strip_heredoc
+      --- !map:HashWithIndifferentAccess
+      india:
+        translations:
+          - name: Samplese
+            code: zz
+        taxonomy:
+          - title: Help for British nationals in Sample
+            description: Travel documents and help with emergencies.
+            base_path: help-for-british-nationals
+            tagged_content:
+              - title: Get a new or replacement UK passport
+                description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
+                base_path: /apply-renew-passport
+              - title: Get emergency UK travel documents
+                description: If you're abroad, need to travel and can't get a passport in time.
+                base_path: /emergency-travel-document
+
+    CONTENT
+
+    Tempfile.open("ww_content_fixture") do |f|
+      f.write content
+      f.rewind
+      yield f.path
+    end
   end
 
   test "content returns the parsed file " do
-    result = subject.content
-    assert result[:india].present?
+    with_fixture_file do |file_path|
+      result = subject(file_path).content
+      assert result[:india].present?
+    end
   end
 
   test "has_content_for? returns true if the key is present" do
-    assert subject.has_content_for?(:india)
+    with_fixture_file do |file_path|
+      assert subject(file_path).has_content_for?(:india)
+    end
   end
 
   test "has_content_for? returns true if the string key is present" do
-    assert subject.has_content_for?("india")
+    with_fixture_file do |file_path|
+      assert subject(file_path).has_content_for?("india")
+    end
   end
 
   test "has_content_for? returns false if the key is not present" do
-    refute subject.has_content_for?("eggnogg")
+    with_fixture_file do |file_path|
+      refute subject(file_path).has_content_for?("eggnogg")
+    end
   end
 
   test "content_for returns content for the key if present" do
-    assert_not_nil subject.content_for("india")
+    with_fixture_file do |file_path|
+      assert_not_nil subject(file_path).content_for("india")
+    end
   end
 
   test "content_for returns nil if the key is not present" do
-    assert_nil subject.content_for("booyah")
+    with_fixture_file do |file_path|
+      assert_nil subject(file_path).content_for("booyah")
+    end
   end
 
   test "location_for returns the first worldwide_location" do
-    location = stub(slug: "turkey")
-    org = stub(
-      slug: "british-embassy-turkey",
-      world_locations: [location]
-    )
+    with_fixture_file do |file_path|
+      location = stub(slug: "turkey")
+      org = stub(
+        slug: "british-embassy-turkey",
+        world_locations: [location]
+      )
 
-    assert_equal location, subject.location_for(org)
+      assert_equal location, subject(file_path).location_for(org)
+    end
   end
 
   test "location_for returns hard coded location where present" do
-    location = stub(slug: "turkey")
-    hard_coded_location = stub(slug: "india")
-    organisation = stub(
-      slug: "british-deputy-high-commission-kolkata",
-      world_locations: [location, hard_coded_location]
-    )
+    with_fixture_file do |file_path|
+      location = stub(slug: "turkey")
+      hard_coded_location = stub(slug: "india")
+      organisation = stub(
+        slug: "british-deputy-high-commission-kolkata",
+        world_locations: [location, hard_coded_location]
+      )
 
-    assert_equal hard_coded_location, subject.location_for(organisation)
+      assert_equal hard_coded_location, subject(file_path).location_for(organisation)
+    end
   end
 
   test "is_under_test? returns true if location is first location" do
-    location = stub(slug: "india")
-    organisation = stub(
-      slug: "british-deputy-high-commission-indialand",
-      world_locations: [location]
-    )
+    with_fixture_file do |file_path|
+      location = stub(slug: "india")
+      organisation = stub(
+        slug: "british-deputy-high-commission-indialand",
+        world_locations: [location]
+      )
 
-    assert subject.is_under_test?(organisation)
+      assert subject(file_path).is_under_test?(organisation)
+    end
   end
 
   test "is_under_test? returns true if organisation slug is hard coded" do
-    location = stub(slug: "embassy")
-    other_location = stub(slug: "india")
-    organisation = stub(
-      slug: "british-deputy-high-commission-kolkata",
-      world_locations: [location, other_location]
-    )
+    with_fixture_file do |file_path|
+      location = stub(slug: "embassy")
+      other_location = stub(slug: "india")
+      organisation = stub(
+        slug: "british-deputy-high-commission-kolkata",
+        world_locations: [location, other_location]
+      )
 
-    assert subject.is_under_test?(organisation)
+      assert subject(file_path).is_under_test?(organisation)
+    end
   end
 
   test "is_under_test? returns false if the organisation isn't related to a location under test" do
-    location = stub(slug: "germany")
-    organisation = stub(
-      slug: "embassy-in-germany",
-      world_locations: [location]
-    )
+    with_fixture_file do |file_path|
+      location = stub(slug: "germany")
+      organisation = stub(
+        slug: "embassy-in-germany",
+        world_locations: [location]
+      )
 
-    refute subject.is_under_test?(organisation)
+      refute subject(file_path).is_under_test?(organisation)
+    end
   end
 
   test "is_under_test? returns true if supplied with a location with content" do
-    location = stub(slug: "india")
-    assert subject.is_under_test?(location)
+    with_fixture_file do |file_path|
+      location = stub(slug: "india")
+      assert subject(file_path).is_under_test?(location)
+    end
   end
 
   test "is_under_test? return false if the supplied with a location without content" do
-    location = WorldLocation.new(slug: "germany")
-    refute subject.is_under_test?(location)
+    with_fixture_file do |file_path|
+      location = WorldLocation.new(slug: "germany")
+      refute subject(file_path).is_under_test?(location)
+    end
   end
 end


### PR DESCRIPTION
Centralises logic for redirects and access to the YAML content file to help with the implementation of the Worldwide taxonomy A/B test.

Also provides methods to simplify checking if a particular location or organisation should be included in the test.