### PR TITLE
Fix incorrect rendering of multiple same Id

### DIFF
--- a/app/views/worldwide_organisations/_worldwide_organisation.html.erb
+++ b/app/views/worldwide_organisations/_worldwide_organisation.html.erb
@@ -2,11 +2,11 @@
   <div class="worldwide-organisation-detail">
     <div class="content">
       <% worldwide_organisation.sponsoring_organisations.each do |organisation| %>
-        <%= content_tag_for(:div, organisation, :class => 'sponsoring-organisation') do %>
+        <div class="organisation sponsoring-organisation">
           <span class="<%= logo_classes(class_name: 'single-identity', size: 'medium', stacked: false) %>">
             <%= organisation.name %>
           </span>
-        <% end %>
+        </div>
       <% end %>
       <h2 class="name"><%= link_to worldwide_organisation.name, worldwide_organisation %></h2>
       <p><%= worldwide_organisation.summary %></p>


### PR DESCRIPTION
The current use of `content_tag_for` in the `worldwide_organisation` partial is causing html to be rendered such that we have multiple Ids that are the same on a single page. This is incorrect.

Remove `content_tag_for` and replace it with a hand coded div.
Drop the use of `id` in the div.

The current html being produced will look something like this:

```
<div class="organisation sponsoring-organisation" id="organisation_13">
```

As can be seen on, for example, https://www.gov.uk/government/world/france

The fix will create html like so:

```
<div class="organisation sponsoring-organisation">
```