### PR TITLE
Remove translations from worldwide ab test content

### DIFF
--- a/app/views/worldwide_publishing_taxonomy/show.html.erb
+++ b/app/views/worldwide_publishing_taxonomy/show.html.erb
@@ -41,22 +41,23 @@
             <p><%= parent_taxon[:description] %></p>
           </div>
         </div>
-        <% if b_variant_page_content[:translations].present? %>
         <div class="column-one-third">
           <div class="available-languages">
             <ul>
-              <li class="translation">
-                <span>English</span>
-              </li>
-              <% b_variant_page_content[:translations].each_with_index do |translation, index| %>
-                <li class="translation <%= "last" if index == b_variant_page_content[:translations].size - 1 %>">
-                  <a lang="<%= translation[:code] %>" href="/government/world/<%= @world_location.slug %>.<%= translation[:code] %>?ABTest-WorldwidePublishingTaxonomy=A"><%= translation[:name] %></a>
+              <% sorted_locales(@world_location.translated_locales).each.with_index do |locale, i| %>
+                <li class="translation<%= ' last' if i == @world_location.translated_locales.length-1 %>">
+                  <% if locale == I18n.locale %>
+                    <span><%= native_language_name_for(locale) %></span>
+                  <% else %>
+                    <a lang="<%= locale %>" href="/government/world/<%= @world_location.slug %>.<%= locale %>?ABTest-WorldwidePublishingTaxonomy=A">
+                      <%= native_language_name_for(locale) %>
+                    </a>
+                  <% end %>
                 </li>
               <% end %>
             </ul>
           </div>
         </div>
-        <% end %>
       </div>
       <div class="grid-row child-topic-contents">
         <div class="column-two-thirds">

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,8 +1,5 @@
 --- !map:HashWithIndifferentAccess
 sample:
-  translations:
-    - name: Samplese
-      code: zz
   taxonomy:
     - title: Help for British nationals in Sample
       description: Travel documents and help with emergencies.
@@ -38,9 +35,6 @@ australia:
           If you’re in Australia and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the High Commission](#contact-us) for information about our other services.
 brazil:
-  translations:
-    - name: Portugese
-      code: pt
   taxonomy:
     - title: Help for British nationals in Brazil
       description: Travel documents and help with emergencies.
@@ -64,9 +58,6 @@ brazil:
           If you’re in Brazil and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the Embassy](#contact-us) for information about our other services.
 india:
-  translations:
-    - name: Hindi
-      code: hi
   taxonomy:
     - title: Help for British nationals in India
       description: Travel documents and help with emergencies.
@@ -113,9 +104,6 @@ south-africa:
           If you’re in South Africa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the High Commission](#contact-us) for information about our other services.
 thailand:
-  translations:
-    - name: Thai
-      code: th
   taxonomy:
     - title: Help for British nationals in Thailand
       description: Travel documents and help with emergencies.
@@ -139,9 +127,6 @@ thailand:
           If you’re in Thailand and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the Embassy](#contact-us) for information about our other services.
 turkey:
-  translations:
-    - name: Turkish
-      code: tr
   taxonomy:
     - title: Help for British nationals in Turkey
       description: Travel documents and help with emergencies.


### PR DESCRIPTION
These were previously added to `worldwide_publishing_taxonomy_ab_test_content.yml` to support additional translations. We can instead rely on the translations linked to the world locations and remove these from the YML file.
The same approach is already being used in the WorldLocationNews controller and view.