### PR TITLE
Add worldwide A/B content

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -76,7 +76,7 @@ private
   def parent_taxon
     {
       title: "#{@world_location.name} and the UK",
-      description: "Accessing UK services from #{@world_location.name}, advice for travelling to the UK, and help with trading between the UK and #{@world_location.name}."
+      description: "Services if you're living, studying, working or visiting #{@world_location.name}. Includes information about trading with and doing business in the UK."
     }
   end
 end

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,16 +1,4 @@
 --- !map:HashWithIndifferentAccess
-sample:
-  taxonomy:
-    - title: Help for British nationals in Sample
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
-          base_path: /emergency-travel-document
 australia:
   taxonomy:
     - title: Help for British nationals in Australia

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1556,27 +1556,192 @@ south-africa:
           - [Pretoria](/government/world/south-africa/british-high-commission-pretoria)
 thailand:
   taxonomy:
-    - title: Help for British nationals in Thailand
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Contact the British Embassy Bangkok
+          description: Contact details if you need urgent help.
+          base_path: /government/world/thailand/british-embassy-bangkok
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/information-relating-to-deaths-in-thailand
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: Lists of lawyers, translators and interpreters
+          description: 
+          base_path: /government/publications/thailand-list-of-lawyers
+        - title: List of medical facilities
+          description: 
+          base_path: /government/publications/thailand-list-of-medical-facilitiespractitioners
+        - title: Living in Thailand
+          description: Advice for British people living in Thailand, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-thailand
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-thailand
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to Thailand
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+        - title: Thailand travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/thailand
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in Thailand
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-thailand
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in Thailand, includes news and events.
+      tagged_content: 
+        - title: News and events in Thailand
+          description: What is the UK government doing in Thailand.
+          base_path: /government/world/thailand/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Embassy Bangkok
+          description: 
+          base_path: /government/world/thailand/british-embassy-bangkok
   embassies:
     british-embassy-bangkok:
       - title: British Embassy Bangkok
-        summary: The summary
+        summary: The British Embassy in Bangkok represents the UK government and provides services to British nationals in Thailand.
         body: |
-          The British Embassy in Bangkok represents the UK government and provides services to British nationals in Thailand.
-          We help sustain and develop the important relationship between the UK and Thailand.
-          You can access UK government services while in [Thailand](https://www.gov.uk/government/world/thailand)
-          ##Urgent assistance
-          If you’re in Thailand and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the Embassy](#contact-us) for information about our other services.
+          We help sustain and develop the important relationship between the UK and Thailand. 
+           
+          You can [access UK government services while in Thailand](/government/world/thailand).
+           
+          #Urgent assistance
+           
+          If you’re in Thailand and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +66(0)2 305 8333. If you’re in the UK and worried about a British national in Thailand, call 020 7008 1500. 
+           
+          [Contact the embassy](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Bangkok can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/thailand-consular-fees). 
 turkey:
   taxonomy:
     - title: Help for British nationals in Turkey

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1809,7 +1809,7 @@ turkey:
           base_path: /marriage-abroad 
         - title: Get or renew a passport
           description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
-          base_path: /overseas-passports"
+          base_path: /overseas-passports
         - title: List of funeral directors
           description: 
           base_path: /government/publications/turkey-list-of-funeral-directors
@@ -1958,7 +1958,7 @@ turkey:
         body: |
           We help sustain and develop the important relationship between the UK and Turkey. 
            
-          You can [access UK government services while in Turkey](/government/world/turkey)
+          You can [access UK government services while in Turkey](/government/world/turkey).
            
           #Urgent assistance
            
@@ -2045,6 +2045,7 @@ turkey:
           We also provide services in:
            
           - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
           - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
           - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
           - [Izmir](/government/world/turkey/british-consulate-izmir)
@@ -2076,6 +2077,7 @@ turkey:
           We also provide services in:
            
           - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
           - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
           - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
           - [Izmir](/government/world/turkey/british-consulate-izmir)
@@ -2107,6 +2109,7 @@ turkey:
           We also provide services in:
            
           - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
           - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
           - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
           - [Izmir](/government/world/turkey/british-consulate-izmir)
@@ -2117,7 +2120,7 @@ turkey:
         body: |
           We help sustain and develop the important relationship between the UK and Izmir.
            
-          You can [access UK government services while in Izmir](/government/world/turkey).
+          You can [access UK government services while in Turkey](/government/world/turkey).
            
           #Urgent assistance
            
@@ -2138,6 +2141,7 @@ turkey:
           We also provide services in:
            
           - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
           - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
           - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
           - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
@@ -2148,7 +2152,7 @@ turkey:
         body: |
           We help sustain and develop the important relationship between the UK and Turkey.
            
-          You can [access UK government services while in Turkey](ADD LINK TO NAV PAGE).
+          You can [access UK government services while in Turkey](/government/world/turkey).
            
           #Urgent assistance
            
@@ -2169,6 +2173,7 @@ turkey:
           We also provide services in:
            
           - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
           - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
           - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
           - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1319,32 +1319,241 @@ india:
           - [New Delhi](/government/world/india/british-high-commission-new-delhi)
 south-africa:
   taxonomy:
-    - title: Help for British nationals in South Africa
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Contact the British Consulate-General Cape Town
+          description: Contact details if you need urgent help.
+          base_path: /government/world/south-africa/british-consulate-general-cape-town
+        - title: Contact the British High Commission Pretoria
+          description: Contact details if you need urgent help.
+          base_path: /government/world/south-africa/british-high-commission-pretoria
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/south-africa-bereavement-information-pack
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: List of funeral directors
+          description: 
+          base_path: /government/publications/list-of-funeral-directors-south-africa
+        - title: Lists of lawyers
+          description: 
+          base_path: /government/publications/south-africa-list-of-lawyers
+        - title: List of medical facilities
+          description: 
+          base_path: /government/publications/south-africa-list-of-medical-facilities
+        - title: Lists of translators and interpreters
+          description: 
+          base_path: /government/publications/south-africa-list-of-translators
+        - title: Living in South Africa
+          description: Advice for British people living in South Africa, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-south-africa
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-south-africa
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to South Africa
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: South Africa travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/south-africa
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in South Africa
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-south-africa
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in South Africa
+          description: 
+          base_path: /government/world/organisations/uk-science-innovation-network-in-south-africa
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in South Africa, includes news and events.
+      tagged_content: 
+        - title: Department for International Development in South Africa
+          description: 
+          base_path: /government/world/organisations/dfid-south-africa
+        - title: News and events in South Africa
+          description: What is the UK government doing in South Africa.
+          base_path: /government/world/south-africa/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Consulate-General Cape Town
+          description: 
+          base_path: /government/world/south-africa/british-consulate-general-cape-town
+        - title: British High Commission Pretoria
+          description: 
+          base_path: /government/world/south-africa/british-high-commission-pretoria
   embassies:
     british-high-commission-pretoria:
       - title: British High Commission Pretoria
-        summary: The summary
+        summary: The British High Commission in Pretoria represents the UK government and provides services to British nationals in South Africa, Lesotho and Swaziland.
         body: |
-          The British High Commission in Pretoria represents the UK government and provides services to British nationals in South Africa.
-          We help sustain and develop the important relationship between the UK and South Africa.
-          You can access UK government services while in [South Africa](https://www.gov.uk/government/world/south-africa)
-          ##Urgent assistance
-          If you’re in South Africa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the High Commission](#contact-us) for information about our other services.
-    did-south-africa:
-      - title: Department of International Development in South Africa
-        summary: The summary
+          We help sustain and develop the important relationship between the UK and South Africa. 
+           
+          You can [access UK government services while in South Africa](/government/world/south-africa).
+           
+          #Urgent assistance
+           
+          If you’re in Pretoria and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +27 12 421 7500. If you’re in the UK and worried about a British national in South Africa, call 020 7008 1500. 
+           
+          [Contact the British High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Pretoria can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](/government/publications/south-africa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Cape Town](/government/world/south-africa/british-consulate-general-cape-town)
+    british-consulate-general-cape-town:
+      - title: British Consulate Cape Town
+        summary: The British Consulate General in Cape Town represents the UK government and provides services to British nationals in South Africa’s parliamentary capital, and the 3 Cape Provinces.
         body: |
-          Department of International Development in South Africa
+          We help sustain and develop the important relationship between the UK and South Africa. 
+           
+          You can [access UK government services while in South Africa](/government/world/south-africa).
+           
+          #Urgent assistance
+           
+          If you’re in Cape Town and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +27 21 405 2400. If you’re in the UK and worried about a British national in South Africa, call 020 7008 1500. 
+           
+          [Contact the British Consulate](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Cape Town can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](/government/publications/south-africa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Pretoria](/government/world/south-africa/british-high-commission-pretoria)
 thailand:
   taxonomy:
     - title: Help for British nationals in Thailand

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -723,7 +723,7 @@ brazil:
           - [Belo Horizonte](/government/world/brazil/british-consulate-general-belo-horizonte)
           - [Brasilia](/government/world/brazil/british-embassy-brazil)
           - [Recife](/government/world/brazil/british-consulate-general-recife)
-          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)"
+          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)
     british-consulate-general-recife:
       - title: British Consulate-General Recife
         summary: The British Consulate-General in Recife represents the UK government and provides services to British nationals in Brazil.

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1157,7 +1157,7 @@ india:
            
           #Urgent assistance
            
-          If you’re in Goa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+          If you’re in Goa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (832) 6636 777. If you’re in the UK and worried about a British national in India, call 020 7008 1500.
            
           [Contact the Deputy High Commission](#contact-us) for information about our other services. 
            
@@ -1175,7 +1175,7 @@ india:
            
           - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
           - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
-          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
           - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
           - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
           - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
@@ -1243,7 +1243,7 @@ india:
            
           - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
           - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
-          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
           - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
           - [Goa](/government/world/india/british-nationals-assistance-office-goa)
           - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
@@ -1276,7 +1276,7 @@ india:
           We also provide services in:
            
           - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
-          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
           - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
           - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
           - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
@@ -1311,7 +1311,7 @@ india:
            
           - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
           - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
-          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
           - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
           - [Goa](/government/world/india/british-nationals-assistance-office-goa)
           - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -2175,34 +2175,540 @@ turkey:
           - [Izmir](/government/world/turkey/british-consulate-izmir)
 usa:
   taxonomy:
-    - title: Help for British nationals in USA
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Contact the British Consulate General Atlanta
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-atlanta
+        - title: Contact the British Consulate General Boston
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-boston
+        - title: Contact the British Consulate General Chicago
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-chicago
+        - title: Contact the British Consulate General Houston
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-houston
+        - title: Contact the British Consulate General Los Angeles
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-los-angeles
+        - title: Contact the British Consulate General Miami
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-miami
+        - title: Contact the British Consulate General New York
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-new-york
+        - title: Contact the British Consulate General San Francisco
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-consulate-general-san-francisco
+        - title: Contact the British Embassy Washington
+          description: Contact details if you need urgent help.
+          base_path: /government/world/usa/british-embassy-washington
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: Support if you've been affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/support-if-youre-affected-by-a-crisis-abroad
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /guidance/usa-bereavement-guide
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad 
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: Lists of lawyers
+          description: 
+          base_path: /government/publications/usa-list-of-lawyers
+        - title: Living in the USA
+          description: Advice for British people living in USA, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-the-usa
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-the-usa
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to the USA
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+        - title: USA travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/usa
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in the USA
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-in-the-usa
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in the USA
+          description: 
+          base_path: /government/world/organisations/uk-science-and-innovation-network-in-the-usa
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in the USA, includes news and events.
+      tagged_content: 
+        - title: News and events in the USA
+          description: What is the UK government doing in the USA.
+          base_path: /government/world/usa/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Consulate General Atlanta
+          description: 
+          base_path: /government/world/usa/british-consulate-general-atlanta
+        - title: British Consulate General Boston
+          description: 
+          base_path: /government/world/usa/british-consulate-general-boston
+        - title: British Consulate General Chicago
+          description: 
+          base_path: /government/world/usa/british-consulate-general-chicago
+        - title: British Consulate General Houston
+          description: 
+          base_path: /government/world/usa/british-consulate-general-houston
+        - title: British Consulate General Los Angeles
+          description: 
+          base_path: /government/world/usa/british-consulate-general-los-angeles
+        - title: British Consulate General Miami
+          description: 
+          base_path: /government/world/usa/british-consulate-general-miami
+        - title: British Consulate General New York
+          description: 
+          base_path: /government/world/usa/british-consulate-general-new-york
+        - title: British Consulate General San Francisco
+          description: 
+          base_path: /government/world/usa/british-consulate-general-san-francisco
+        - title: British Embassy Washington
+          description: 
+          base_path: /government/world/usa/british-embassy-washington
+        - title: British defence staff in the USA
+          description: 
+          base_path: /government/world/organisations/british-defence-staff-in-the-usa
   embassies:
+    british-consulate-general-atlanta:
+      - title: British Consulate General Atlanta
+        summary: The Consulate General in Atlanta represents the UK government and provides services to British nationals in Alabama, Georgia, Mississippi, North Carolina, South Carolina, and Tennessee.
+        body: |
+          We help sustain and develop the important relationship between the UK and USA. 
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Alabama, Georgia, Mississippi, North Carolina, South Carolina, and Tennessee and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 404 954 7700. If you’re in the UK and worried about a British national in USA, call 020 7008 1500. 
+           
+          [Contact the Consulate General](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Atlanta can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+
+          - [Boston](/government/world/usa/british-consulate-general-boston) 
+          - [Chicago](/government/world/usa/british-consulate-general-chicago) 
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york) 
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington) 
+    british-consulate-general-boston:
+      - title: British Consulate General Boston
+        summary: The Consulate General in Boston represents the UK government and provides services to British nationals in Massachusetts, Maine, New Hampshire, Vermont, Rhode Island, and Connecticut (except Fairfield County). 
+        body: |
+          We help sustain and develop the important relationship between the UK and USA. 
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Massachusetts, Maine, New Hampshire, Vermont, Rhode Island, and Connecticut (except Fairfield County) and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 617 245 4500. If you’re in the UK and worried about a British national in USA, call 020 7008 1500. 
+           
+          [Contact the Consulate General](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Boston can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta) 
+          - [Chicago](/government/world/usa/british-consulate-general-chicago) 
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york) 
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington) 
+    british-consulate-general-chicago:
+      - title: British Consulate General Chicago
+        summary: The Consulate General in Chicago represents the UK government and provides services to British nationals in Illinois, Indiana, Iowa, Kansas, Kentucky, Michigan, Minnesota, Missouri, Nebraska, North Dakota, Ohio, South Dakota, and Wisconsin.
+        body: |
+          We help sustain and develop the important relationship between the UK and USA. 
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Illinois, Indiana, Iowa, Kansas, Kentucky, Michigan, Minnesota, Missouri, Nebraska, North Dakota, Ohio, South Dakota, and Wisconsin. and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 312 970 3800. If you’re in the UK and worried about a British national in [Chicago], call 020 7008 1500. 
+           
+          [Contact the Consulate General](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in [Chicago] can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta) 
+          - [Boston](/government/world/usa/british-consulate-general-boston) 
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york) 
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington) 
+    british-consulate-general-houston:
+      - title: British Consulate General Houston
+        summary: The British Consulate General in Houston represents the UK government and provides services to British nationals in Texas, Arkansas, Colorado, Louisiana, New Mexico and Oklahoma.
+        body: |
+          We help sustain and develop the important relationship between the UK and the USA.
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Texas, Arkansas, Colorado, Louisiana, New Mexico or Oklahoma and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 713 210 4000. 
+           
+          If you’re in the UK and worried about a British national in Texas, Arkansas, Colorado, Louisiana, New Mexico or Oklahoma, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Houston can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta)
+          - [Boston](/government/world/usa/british-consulate-general-boston)
+          - [Chicago](/government/world/usa/british-consulate-general-chicago)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york)
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington)
+    british-consulate-general-los-angeles :
+      - title: British Consulate General Los Angeles
+        summary: The British Consulate General in Los Angeles represents the UK government and provides services to British nationals in southern California, Nevada, Arizona, Hawaii, Utah, Guam, Northern Mariana Islands, and American Samoa.
+        body: |
+          We help sustain and develop the important relationship between the UK and the USA.
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in southern California, Nevada, Arizona, Hawaii, Utah, Guam, Northern Mariana Islands or American Samoa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 310 789 0031.
+           
+          If you’re in the UK and worried about a British national in southern California, Nevada, Arizona, Hawaii, Utah, Guam, Northern Mariana Islands or American Samoa, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Los Angeles can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta)
+          - [Boston](/government/world/usa/british-consulate-general-boston)
+          - [Chicago](/government/world/usa/british-consulate-general-chicago)
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york)
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington)
+    british-consulate-general-miami :
+      - title: British Consulate General Miami
+        summary: The British Consulate General in Miami represents the UK government and provides services to British nationals in Florida, Puerto Rico and the US Virgin Islands.
+        body: |
+          We help sustain and develop the important relationship between the UK and the USA.
+           
+          You can [access UK government services while in USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Florida, Puerto Rico and the US Virgin Islands and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 305 400 6400. If you’re in the UK and worried about a British national in Florida, Puerto Rico and the US Virgin Islands, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Miami can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta)
+          - [Boston](/government/world/usa/british-consulate-general-boston)
+          - [Chicago](/government/world/usa/british-consulate-general-chicago)
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [New York](/government/world/usa/british-consulate-general-new-york)
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington)
+    british-consulate-general-new-york:
+      - title: British Consulate General New York
+        summary: The British Consulate General in New York represents the UK government and provides services to British nationals in New York, New Jersey, Pennsylvania, and Fairfield County in Connecticut.
+        body: |
+          We help sustain and develop the important relationship between the UK and USA. 
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Washington and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 202 588 6500. If you’re in the UK and worried about a British national in USA, call 020 7008 1500. 
+           
+          [Contact the Embassy](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Washington can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta) 
+          - [Boston](/government/world/usa/british-consulate-general-boston) 
+          - [Chicago](/government/world/usa/british-consulate-general-chicago) 
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york) 
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
+          - [Washington DC](/government/world/usa/british-embassy-washington)
+           
+          ##White House tours
+           
+          At this time, we are unable to process any White House tour applications for the general public. 
+           
+          We understand that the White House website asks foreign citizens interested in a tour to contact their embassy. However, the US Department of State requires that foreigners be accompanied by a very senior diplomat. Unfortunately, due to the time and resource required, White House tours cannot be made available to the British public.  
+           
+          You may wish to consider tours of the [US Capitol Building,](http://www.visitthecapitol.gov/) where visitors are able to make tour reservations up to three months in advance or obtain same-day tour passes. Passports or other forms of ID are not required for entry into the U.S. Capitol. You can also book a [Pentagon Tour](https://pentagontours.osd.mil/Tours/). Non-US Nationals will need to submit the British Embassy's address instead of their home address. Further assistance regarding the online booking process should be directed to the Pentagon Tour Office +1 703 697 1776. 
+           
+          [You can also take a virtual tour of the White House.](https://www.google.com/culturalinstitute/beta/u/0/partner/the-white-house#!collection:museumview&8129907598665562501=the-white-house&projectId=art-project)
+    british-consulate-general-san-francisco:
+      - title: British Consulate General San Francisco
+        summary: The British Consulate General in San Francisco represents the UK government and provides services to British nationals in northern California, Alaska, Idaho, Montana, Oregon, Washington, and Wyoming.
+        body: |
+          We help sustain and develop the important relationship between the UK and the USA.
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in northern California, Alaska, Idaho, Montana, Oregon, Washington, and Wyoming and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 415 617 1300.
+           
+          If you’re in the UK and worried about a British national in northern California, Alaska, Idaho, Montana, Oregon, Washington, and Wyoming, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in San Francisco can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta)
+          - [Boston](/government/world/usa/british-consulate-general-boston)
+          - [Chicago](/government/world/usa/british-consulate-general-chicago)
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york)
+          - [Washington DC](/government/world/usa/british-embassy-washington)
     british-embassy-washington:
       - title: British Embassy Washington
-        summary: The summary
+        summary: The Embassy in Washington represents the UK government and provides services to British nationals in USA. 
         body: |
-          The British Embassy in Ankara represents the UK government and provides services to British nationals in the USA.
-          We help sustain and develop the important relationship between the UK and the USA.
-          You can access UK government services while in the [USA](https://www.gov.uk/government/world/usa)
-          ##Urgent assistance
-          If you’re in the USA and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the Embassy](#contact-us) for information about our other services.
-    british-consulate-general-los-angeles:
-      - title: British Consulate General Los Angeles
-        summary: The summary
-        body: |
-          The British Consulate in Los Angeles represents the UK government and provides services to British nationals in the USA.
-          We help sustain and develop the important relationship between the UK and the USA.
-          You can access UK government services while in the [USA](https://www.gov.uk/government/world/usa)
-          ##Urgent assistance
-          If you’re in the USA and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the Embassy](#contact-us) for information about our other services.
+          We help sustain and develop the important relationship between the UK and USA. 
+           
+          You can [access UK government services while in the USA](/government/world/usa).
+           
+          #Urgent assistance
+           
+          If you’re in Washington and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 202 588 6500. If you’re in the UK and worried about a British national in USA, call 020 7008 1500. 
+           
+          [Contact the Embassy](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Washington can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/usa-consular-fees).
+           
+          We also provide services in:
+           
+          - [Atlanta](/government/world/usa/british-consulate-general-atlanta) 
+          - [Boston](/government/world/usa/british-consulate-general-boston) 
+          - [Chicago](/government/world/usa/british-consulate-general-chicago) 
+          - [Houston](/government/world/usa/british-consulate-general-houston)
+          - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
+          - [Miami](/government/world/usa/british-consulate-general-miami)
+          - [New York](/government/world/usa/british-consulate-general-new-york) 
+          - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -435,27 +435,355 @@ australia:
           - [Melbourne](/government/world/australia/british-consulate-general-melbourne) 
 brazil:
   taxonomy:
-    - title: Help for British nationals in Brazil
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Contact the British Consulate-General Belo Horizonte
+          description: Contact details if you need urgent help.
+          base_path: /government/world/brazil/british-consulate-general-belo-horizonte
+        - title: Contact the British Consulate-General Recife
+          description: Contact details if you need urgent help.
+          base_path: /government/world/brazil/british-consulate-general-recife
+        - title: Contact the British Consulate-General Rio de Janeiro
+          description: Contact details if you need urgent help.
+          base_path: /government/world/brazil/british-consulate-general-rio-de-janeiro
+        - title: Contact the British Consulate-General São Paulo
+          description: Contact details if you need urgent help.
+          base_path: /government/world/brazil/british-consulate-general-sao-paulo
+        - title: Contact the British Embassy Brasilia
+          description: Contact details if you need urgent help.
+          base_path: /government/world/brazil/british-embassy-brazil
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/brazil-bereavement-packinformation
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: Living in Brazil
+          description: Advice for British people living in Brazil, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-brazil
+        - title: List of funeral directors
+          description: 
+          base_path: /government/publications/brazil-list-of-funeral-directors-brazil
+        - title: Lists of lawyers 
+          description: 
+          base_path: /government/publications/brazil-list-of-lawyers
+        - title: List of medical facilities and practitioners
+          description: 
+          base_path: /government/publications/list-of-doctors--2
+        - title: Lists of translators and interpreters
+          description: 
+          base_path: /government/publications/brazil-list-of-lawyers
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-brazil
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to Brazil
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Brazil travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/brazil
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in Brazil
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-brazil
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in Brazil
+          description: 
+          base_path: /government/world/organisations/uk-science-innovation-network-in-brazil  
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in Brazil, includes news and events.
+      tagged_content: 
+        - title: Department for International Development in Brazil
+          description: 
+          base_path: /government/world/organisations/dfid-brazil
+        - title: News and events in Brazil
+          description: What is the UK government doing in Brazil.
+          base_path: /government/world/brazil/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Consulate-General Belo Horizonte
+          description: 
+          base_path: /government/world/brazil/british-consulate-general-belo-horizonte 
+        - title: British Consulate-General Recife
+          description: 
+          base_path: /government/world/brazil/british-consulate-general-recife
+        - title: British Consulate-General Rio de Janeiro
+          description: 
+          base_path: /government/world/brazil/british-consulate-general-rio-de-janeiro
+        - title: British Consulate-General São Paulo
+          description: 
+          base_path: /government/world/brazil/british-consulate-general-sao-paulo
+        - title: British Embassy Brasilia
+          description: 
+          base_path: /government/world/brazil/british-embassy-brazil
   embassies:
+    british-consulate-general-belo-horizonte:
+      - title: British Consulate General Belo Horizonte
+        summary: The British Consulate General in Belo Horizonte represents the UK government and provides services to British nationals in Minas Gerais.
+        body: |
+          We help sustain and develop the important relationship between the UK and Brazil.
+           
+          You can [access UK government services while in Minas Gerais](/government/world/brazil).
+           
+          #Urgent assistance
+           
+          If you’re in Minas Gerais and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +55 21 2555 9600. If you’re in the UK and worried about a British national in Brazil, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Belo Horizonte can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/brazil-consular-fees).
+           
+          We also provide services in:
+           
+          - [Brasilia](/government/world/brazil/british-embassy-brazil)
+          - [Recife](/government/world/brazil/british-consulate-general-recife)
+          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)
+          - [São Paulo](/government/world/brazil/british-consulate-general-sao-paulo)
+    british-consulate-general-rio-de-janeiro:
+      - title: British Consulate-General Rio de Janeiro
+        summary: The British Consulate-General in Rio de Janeiro represents the UK government and provides services to British nationals in Rio de Janeiro.
+        body: |
+          We help sustain and develop the important relationship between the UK and Brazil.
+           
+          You can [access UK government services while in Rio de Janeiro](/government/world/brazil).
+           
+          #Urgent assistance
+           
+          If you’re in Rio de Janeiro and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +55 21 2555 9600. If you’re in the UK and worried about a British national in Brazil, call 020 7008 1500.
+           
+          [Contact the British Consulate-General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Rio de Janeiro can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/brazil-consular-fees).
+           
+          We also provide services in:
+           
+          - [Belo Horizonte](/government/world/brazil/british-consulate-general-belo-horizonte)
+          - [Brasilia](/government/world/brazil/british-embassy-brazil)
+          - [Recife](/government/world/brazil/british-consulate-general-recife)
+          - [São Paulo](/government/world/brazil/british-consulate-general-sao-paulo)
+    british-consulate-general-sao-paulo:
+      - title: British Consulate São Paulo 
+        summary: The British Consulate in São Paulo represents the UK government and provides services to British nationals in São Paulo.
+        body: |
+          We help sustain and develop the important relationship between the UK and Brazil.
+           
+          You can [access UK government services while in São Paulo](/government/world/brazil).
+           
+          #Urgent assistance
+           
+          If you’re in São Paulo and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +55 11 3094 2700. If you’re in the UK and worried about a British national in Brazil, call 020 7008 1500.
+           
+          [Contact the British Consulate](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in São Paulo can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/brazil-consular-fees).
+           
+          We also provide services in:
+           
+          - [Belo Horizonte](/government/world/brazil/british-consulate-general-belo-horizonte)
+          - [Brasilia](/government/world/brazil/british-embassy-brazil)
+          - [Recife](/government/world/brazil/british-consulate-general-recife)
+          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)"
+    british-consulate-general-recife:
+      - title: British Consulate-General Recife
+        summary: The British Consulate-General in Recife represents the UK government and provides services to British nationals in Brazil.
+        body: |
+          We help sustain and develop the important relationship between the UK and Brazil.
+           
+          You can [access UK government services while in Brazil](/government/world/brazil).
+           
+          #Urgent assistance
+           
+          If you’re in Recife and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +55 81 2127 0200. If you’re in the UK and worried about a British national in Brazil, call 020 7008 1500.
+           
+          [Contact the British Consulate-General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Recife can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/brazil-consular-fees).
+           
+          We also provide services in:
+           
+          - [Belo Horizonte](/government/world/brazil/british-consulate-general-belo-horizonte)
+          - [Brasilia](/government/world/brazil/british-embassy-brazil)
+          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)
+          - [São Paulo](/government/world/brazil/british-consulate-general-sao-paulo)
     british-embassy-brazil:
       - title: British Embassy Brasilia
-        summary: The summary
+        summary: The British Embassy in Brasilia represents the UK government and provides services to British nationals in Brazil.
         body: |
-          The Embassy in Brasilia represents the UK government and provides services to British nationals in Brazil.
           We help sustain and develop the important relationship between the UK and Brazil.
-          You can access UK government services while in [Brazil](https://www.gov.uk/government/world/brazil)
-          ##Urgent assistance
-          If you’re in Brazil and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the Embassy](#contact-us) for information about our other services.
+           
+          You can [access UK government services while in Brazil](/government/world/brazil).
+           
+          #Urgent assistance
+           
+          If you’re in Brasilia and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +55 61 3329 2300. If you’re in the UK and worried about a British national in Brazil, call 020 7008 1500.
+           
+          [Contact the British Embassy](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Brasilia can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/brazil-consular-fees).
+           
+          We also provide services in:
+           
+          - [Belo Horizonte](/government/world/brazil/british-consulate-general-belo-horizonte)
+          - [Recife](/government/world/brazil/british-consulate-general-recife)
+          - [Rio de Janeiro](/government/world/brazil/british-consulate-general-rio-de-janeiro)
+          - [São Paulo](/government/world/brazil/british-consulate-general-sao-paulo)
 india:
   taxonomy:
     - title: Help for British nationals in India

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -786,37 +786,537 @@ brazil:
           - [São Paulo](/government/world/brazil/british-consulate-general-sao-paulo)
 india:
   taxonomy:
-    - title: Help for British nationals in India
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Contact the British Deputy High Commission Ahmedabad
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-ahmedabad
+        - title: Contact the British Deputy High Commission Bengaluru
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-bangalore
+        - title: Contact the British Deputy High Commission Chandigarh
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-chandigarh
+        - title: Contact the British Deputy High Commission Chennai
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commissioner-chennai
+        - title: Contact the British Deputy High Commission Hyderabad
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-hyderabad
+        - title: Contact the British Deputy High Commission Kolkata
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-kolkata
+        - title: Contact the British Deputy High Commission Mumbai
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-deputy-high-commission-mumbai
+        - title: Contact the British High Commission New Delhi
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-high-commission-new-delhi
+        - title: Contact the British Nationals Assistance Office Goa
+          description: Contact details if you need urgent help.
+          base_path: /government/world/india/british-nationals-assistance-office-goa
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk 
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/bereavement-information-pack-india
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad 
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: Hospitals in India
+          description: 
+          base_path: /government/publications/india-list-of-hospitals
+        - title: List of funeral directors
+          description: 
+          base_path: /government/publications/india-list-of-funeral-directors
+        - title: Lists of lawyers
+          description: 
+          base_path: /government/publications/india-list-of-lawyers
+        - title: Lists of translators and interpreters abroad
+          description: 
+          base_path: /government/publications/india-list-of-translators-and-interpreters
+        - title: Living in India
+          description: Advice for British people living in India, including information on health, education, benefits, residence requirements and more.
+          base_path: /guidance/living-in-india
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-india
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to India
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: India travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/india
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in India
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-india
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in India
+          description: 
+          base_path: /government/world/organisations/uk-science-innovation-network-in-india
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in India, includes news and events.
+      tagged_content: 
+        - title: Department for International Development in India
+          description: 
+          base_path: /government/world/organisations/dfid-india
+        - title: News and events in India
+          description: What is the UK government doing in India.
+          base_path: /government/world/india/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Deputy High Commission Ahmedabad
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-ahmedabad
+        - title: British Deputy High Commission Bengaluru
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-bangalore
+        - title: British Deputy High Commission Chandigarh
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-chandigarh
+        - title: British Deputy High Commission Chennai
+          description: 
+          base_path: /government/world/india/british-deputy-high-commissioner-chennai
+        - title: British Deputy High Commission Hyderabad
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-hyderabad
+        - title: British Deputy High Commission Kolkata
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-kolkata
+        - title: British Deputy High Commission Mumbai
+          description: 
+          base_path: /government/world/india/british-deputy-high-commission-mumbai
+        - title: British High Commission New Delhi
+          description: 
+          base_path: /government/world/india/british-high-commission-new-delhi
+        - title: British Nationals Assistance Office Goa
+          description: 
+          base_path: /government/world/india/british-nationals-assistance-office-goa
   embassies:
     british-high-commission-new-delhi:
       - title: British High Commission New Delhi
-        summary: The summary
+        summary: The High Commission in New Delhi represents the UK government and provides services to British nationals in India.
         body: |
-          The British High Commission in New Delhi represents the UK government and provides services to British nationals in India.
-          We help sustain and develop the important relationship between the UK and India.
-          You can access UK government services while in [India](https://www.gov.uk/government/world/india)
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
           ##Urgent assistance
-          If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the High Commission](#contact-us) for information about our other services.
+          
+          If you’re in New Delhi and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500 . 
+           
+          [Contact the High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in New Delhi can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). 
+           
+          You might have to [pay a fee](https://www.gov.uk/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+    british-deputy-high-commission-ahmedabad:
+      - title: British Deputy High Commission Ahmedabad
+        summary: The Deputy High Commission in Ahmedabad represents the UK government and provides services to British nationals in India. 
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Ahmedabad and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in Ahmedabad, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Ahmedabad can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-deputy-high-commission-bangalore:
+      - title: British Deputy High Commission Bangaluru
+        summary: The Deputy High Commission in Bangaluru represents the UK government and provides services to British nationals in India. 
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Bangaluru and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Bengaluru can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-deputy-high-commissioner-chennai:
+      - title: Deputy High Commission Chennai
+        summary: The Deputy High Commission in Chennai represents the UK government and provides services to British nationals in India. 
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Chennai and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Chennai can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandigarh)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-nationals-assistance-office-goa: 
+      - title: Deputy High Commission Goa
+        summary: The British Nationals Assistance Office Goa represents the UK government and provides services to British nationals.
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Goa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in India can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-deputy-high-commission-chandigarh:
+      - title: British Deputy High Commission Chandigarh
+        summary: The Deputy High Commission in Chandigarh represents the UK government and provides services to British nationals in India.
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Chandigarh and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Chandigarh can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-deputy-high-commission-hyderabad:
+      - title: British Deputy High Commission Hyderabad
+        summary: The Deputy High Commission in Hyderabad represents the UK government and provides services to British nationals in India.
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Hyderabad and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500.
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Hyderabad can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
     british-deputy-high-commission-kolkata:
       - title: British Deputy High Commission Kolkata
-        summary: The summary
+        summary: The Deputy High Commission in Kolkata represents the UK government and provides services to British nationals in India.
         body: |
-          The British Deputy High Commission in Kolkata represents the UK government and provides services to British nationals in India.
-          We help sustain and develop the important relationship between the UK and India.
-          You can access UK government services while in [India](https://www.gov.uk/government/world/india)
-          ##Urgent assistance
-          If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the High Commission](#contact-us) for information about our other services.
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Kolkata and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commision](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Kolkata can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](government/collections/notarial-services). You might have to [pay a fee](/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Mumbai](/government/world/india/british-deputy-high-commission-mumbai)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
+    british-deputy-high-commission-mumbai:
+      - title: British Deputy High Commission Mumbai
+        summary: The Deputy High Commission in Mumbai represents the UK government and provides services to British nationals in India.
+        body: |
+          We help sustain and develop the important relationship between the UK and India. 
+           
+          You can [access UK government services while in India](/government/world/india)
+           
+          #Urgent assistance
+           
+          If you’re in Mumbai and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +91 (11) 2419 2100. If you’re in the UK and worried about a British national in India, call 020 7008 1500. 
+           
+          [Contact the Deputy High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Mumbai can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/india-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ahmedabad](/government/world/india/british-deputy-high-commission-ahmedabad)
+          - [Bengaluru](/government/world/india/british-deputy-high-commission-bangalore)
+          - [Chandigarh](/government/world/india/british-deputy-high-commission-chandiga)
+          - [Chennai](/government/world/india/british-deputy-high-commissioner-chennai)
+          - [Goa](/government/world/india/british-nationals-assistance-office-goa)
+          - [Hyderabad](/government/world/india/british-deputy-high-commission-hyderabad)
+          - [Kolkata](/government/world/india/british-deputy-high-commission-kolkata)
+          - [New Delhi](/government/world/india/british-high-commission-new-delhi)
 south-africa:
   taxonomy:
     - title: Help for British nationals in South Africa

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -2471,15 +2471,15 @@ usa:
           You can [access UK government services while in the USA](/government/world/usa).
            
           #Urgent assistance
-           
-          If you’re in Illinois, Indiana, Iowa, Kansas, Kentucky, Michigan, Minnesota, Missouri, Nebraska, North Dakota, Ohio, South Dakota, and Wisconsin. and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 312 970 3800. If you’re in the UK and worried about a British national in [Chicago], call 020 7008 1500. 
-           
-          [Contact the Consulate General](#contact-us) for information about our other services. 
-           
+
+          If you’re in Illinois, Indiana, Iowa, Kansas, Kentucky, Michigan, Minnesota, Missouri, Nebraska, North Dakota, Ohio, South Dakota, and Wisconsin. and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 312 970 3800. If you’re in the UK and worried about a British national in USA, call 020 7008 1500.
+
+          [Contact the Consulate General](#contact-us) for information about our other services.
+
           #Other consular services
-           
-          Consular staff in [Chicago] can:
-           
+
+          Consular staff in Chicago can:
+
           - administer an oath, affirmation or affidavit
           - witness a signature
           - make a certified copy of a document
@@ -2611,15 +2611,15 @@ usa:
           You can [access UK government services while in the USA](/government/world/usa).
            
           #Urgent assistance
-           
-          If you’re in Washington and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 202 588 6500. If you’re in the UK and worried about a British national in USA, call 020 7008 1500. 
-           
-          [Contact the Embassy](#contact-us) for information about our other services. 
-           
+
+          If you’re in New York and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +1 212 745 0200. If you’re in the UK and worried about a British national in USA, call 020 7008 1500.
+
+          [Contact the Embassy](#contact-us) for information about our other services.
+
           #Other consular services
-           
-          Consular staff in Washington can:
-           
+
+          Consular staff in New York can:
+
           - administer an oath, affirmation or affidavit
           - witness a signature
           - make a certified copy of a document
@@ -2634,19 +2634,8 @@ usa:
           - [Houston](/government/world/usa/british-consulate-general-houston)
           - [Los Angeles](/government/world/usa/british-consulate-general-los-angeles)
           - [Miami](/government/world/usa/british-consulate-general-miami)
-          - [New York](/government/world/usa/british-consulate-general-new-york) 
           - [San Francisco](/government/world/usa/british-consulate-general-san-francisco)
           - [Washington DC](/government/world/usa/british-embassy-washington)
-           
-          ##White House tours
-           
-          At this time, we are unable to process any White House tour applications for the general public. 
-           
-          We understand that the White House website asks foreign citizens interested in a tour to contact their embassy. However, the US Department of State requires that foreigners be accompanied by a very senior diplomat. Unfortunately, due to the time and resource required, White House tours cannot be made available to the British public.  
-           
-          You may wish to consider tours of the [US Capitol Building,](http://www.visitthecapitol.gov/) where visitors are able to make tour reservations up to three months in advance or obtain same-day tour passes. Passports or other forms of ID are not required for entry into the U.S. Capitol. You can also book a [Pentagon Tour](https://pentagontours.osd.mil/Tours/). Non-US Nationals will need to submit the British Embassy's address instead of their home address. Further assistance regarding the online booking process should be directed to the Pentagon Tour Office +1 703 697 1776. 
-           
-          [You can also take a virtual tour of the White House.](https://www.google.com/culturalinstitute/beta/u/0/partner/the-white-house#!collection:museumview&8129907598665562501=the-white-house&projectId=art-project)
     british-consulate-general-san-francisco:
       - title: British Consulate General San Francisco
         summary: The British Consulate General in San Francisco represents the UK government and provides services to British nationals in northern California, Alaska, Idaho, Montana, Oregon, Washington, and Wyoming.

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1,32 +1,438 @@
 --- !map:HashWithIndifferentAccess
 australia:
   taxonomy:
-    - title: Help for British nationals in Australia
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
       tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Contact the British Consulate General Melbourne
+          description: Contact details if you need urgent help.
+          base_path: /government/world/australia/british-consulate-general-melbourne
+        - title: Contact the British Consulate General Sydney
+          description: Contact details if you need urgent help.
+          base_path: /government/world/australia/british-consulate-general-sydney
+        - title: Contact the British Consulate Brisbane
+          description: Contact details if you need urgent help.
+          base_path: /government/world/australia/british-consulate-brisbane
+        - title: Contact the British Consulate Perth
+          description: Contact details if you need urgent help.
+          base_path: /government/world/australia/british-consulate-perth
+        - title: Contact the British High Commission Canberra
+          description: Contact details if you need urgent help.
+          base_path: /government/world/australia/british-high-commission-canberra
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content:
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/bereavement-information
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports
+        - title: List of funeral directors
+          description: 
+          base_path: /government/publications/australia-list-of-funeral-directors
+        - title: List of lawyers
+          description: 
+          base_path: /government/publications/australia-list-of-lawyers
+        - title: List of medical facilities and practitioners
+          description: 
+          base_path: /government/publications/australia-list-of-medical-facilitiespractitioners
+        - title: Living in Australia
+          description: Advice for British people living in Australia, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-australia
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content:
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content:
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk 
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to Australia
+      description: Includes travel advice and how to get married abroad.
+      tagged_content:
+        - title: Australia travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/australia
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad 
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content:
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in Australia
+          description: 
+          base_path: /government/world/organisations/uk-trade-investment-australia
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in Australia
+          description: 
+          base_path: /government/world/organisations/uk-science-and-innovation-network-in-australia
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in Australia, includes news and events.
+      tagged_content:
+        - title: News and events in Australia
+          description: What is the UK government doing in Australia.
+          base_path: /government/world/australia/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content:
+        - title: Contact the British Consulate Brisbane
+          description: 
+          base_path: /government/world/australia/british-consulate-brisbane
+        - title: Contact the British Consulate General Melbourne
+          description: 
+          base_path: /government/world/australia/british-consulate-general-melbourne
+        - title: Contact the British Consulate General Sydney
+          description: 
+          base_path: /government/world/australia/british-consulate-general-sydney
+        - title: Contact the British Consulate Perth
+          description: 
+          base_path: /government/world/australia/british-consulate-perth
+        - title: Contact the British High Commission Canberra
+          description: 
+          base_path: /government/world/australia/british-high-commission-canberra
   embassies:
     british-high-commission-canberra:
       - title: British High Commission Canberra
-        summary: The summary
+        summary: The British High Commission in Canberra represents the UK government and provides services to British nationals in Australia.
         body: |
-          The High Commission in Canberra represents the UK government and provides services to British nationals in Australia.
-          We help sustain and develop the important relationship between the UK and Australia.
-          You can access UK government services while in [Australia](https://www.gov.uk/government/world/australia)
-          ##Urgent assistance
-          If you’re in Australia and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the High Commission](#contact-us) for information about our other services.
-    uk-science-and-innovation-network:
-      - title: Uk Science and Innovation Network
-        summary: The summary
+          We help sustain and develop the important relationship between the UK and Australia. 
+           
+          You can [access UK government services while in Australia](/government/world/australia).
+           
+          #Urgent assistance
+           
+          If you’re in Canberra and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call the nearest British Consulate. If you’re in the UK and worried about a British national in Australia, call 020 7008 1500. 
+           
+          [Contact the British High Commission](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          ##Registering a same-sex marriage 
+
+          We register same-sex marriages at all our consulates in Australia. 
+
+          Find out how to register using the ['Getting married abroad' tool](/marriage-abroad). 
+
+          We no longer register new civil partnerships in our consulates.
+
+          ##Convert a civil partnership into a marriage 
+
+          We can convert an existing civil partnership into a marriage. You must have been living in Australia for 28 days. There is a [fee](/government/publications/australia-consular-fees--3).
+
+          You don’t have to convert your civil partnership into a marriage in the country you formed it in.
+
+          Find out more about [eligibility and what documents you need to bring](https://www.gov.uk/convert-civil-partnership/convert-a-civil-partnership-abroad).
+
+          [Book an appointment to convert a civil partnership in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/converting-a-civil-partnership/slot_picker).
+
+          Bookings are reservations only. Please don’t make formal arrangements until our staff have confirmed the date and time.
+
+          ##Notarial services
+
+          Our consulates around Australia cannot carry out notarial acts under the Commissioner of Oaths Act 1889, and on instruction from the Foreign and Commonwealth Office in London. This includes certifying documents as true copies of originals, administering oaths or taking affidavits. 
+
+          For these or other notarial acts, or the legalising of documents, please [contact a notary public](http://www.notarylocator.com.au/).
+           
+          We also provide services in:
+           
+          - [Brisbane](/government/world/australia/british-consulate-brisbane)
+          - [Melbourne](/government/world/australia/british-consulate-general-melbourne)
+          - [Perth](/government/world/australia/british-consulate-perth)
+          - [Sydney](/government/world/australia/british-consulate-general-sydney) 
+           
+          We also have a network of honorary consuls in Adelaide, Alice Springs, Cairns, Darwin and Hobart who we call on to provide urgent assistance when needed. 
+    british-consulate-brisbane:
+      - title: British Consulate Brisbane
+        summary: The British Consulate in Brisbane represents the UK government and provides services to British nationals in Queensland and Northern Territory.
         body: |
-          Uk Science and Innovation Network
+          We help sustain and develop the important relationship between the UK and Australia. 
+           
+          You can [access UK government services while in Australia](/government/world/australia).
+           
+          #Urgent assistance
+           
+          If you’re in Queensland or Northern Territory and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +61 (0)7 3223 3200. If you’re in the UK and worried about a British national in Australia, call 020 7008 1500. 
+           
+          [Contact the British Consulate](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          ##Registering a same-sex marriage 
+
+          We register same-sex marriages at all our consulates in Australia. 
+
+          Find out how to register using the ['Getting married abroad' tool](/marriage-abroad). 
+
+          We no longer register new civil partnerships in our consulates.
+
+          ##Convert a civil partnership into a marriage 
+
+          We can convert an existing civil partnership into a marriage. You must have been living in Australia for 28 days. There is a [fee](/government/publications/australia-consular-fees--3).
+
+          You don’t have to convert your civil partnership into a marriage in the country you formed it in.
+
+          Find out more about [eligibility and what documents you need to bring](https://www.gov.uk/convert-civil-partnership/convert-a-civil-partnership-abroad).
+
+          [Book an appointment to convert a civil partnership in Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/converting-a-civil-partnership/slot_picker).
+
+          Bookings are reservations only. Please don’t make formal arrangements until our staff have confirmed the date and time.
+
+          ##Notarial services
+
+          Our consulates around Australia cannot carry out notarial acts under the Commissioner of Oaths Act 1889, and on instruction from the Foreign and Commonwealth Office in London. This includes certifying documents as true copies of originals, administering oaths or taking affidavits. 
+
+          For these or other notarial acts, or the legalising of documents, please [contact a notary public](http://www.notarylocator.com.au/).
+           
+          We also provide services in:
+           
+          - [Canberra](/government/world/australia/british-high-commission-canberra)
+          - [Melbourne](/government/world/australia/british-consulate-general-melbourne)
+          - [Perth](/government/world/australia/british-consulate-perth)
+          - [Sydney](/government/world/australia/british-consulate-general-sydney) 
+    british-consulate-perth:
+      - title: British Consulate Perth
+        summary: The British Consulate in Perth represents the UK government and provides services to British nationals in Western Australia.
+        body: |
+          We help sustain and develop the important relationship between the UK and Australia. 
+           
+          You can [access UK government services while in Australia](/government/world/australia).
+           
+          #Urgent assistance
+           
+          If you’re in Western Australia and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +61 (0)8 9224 4700. If you’re in the UK and worried about a British national in Australia, call 020 7008 1500. 
+           
+          [Contact the British Consulate](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          ##Registering a same-sex marriage 
+
+          We register same-sex marriages at all our consulates in Australia. 
+
+          Find out how to register using the ['Getting married abroad' tool](/marriage-abroad). 
+
+          We no longer register new civil partnerships in our consulates.
+
+          ##Convert a civil partnership into a marriage 
+
+          We can convert an existing civil partnership into a marriage. You must have been living in Australia for 28 days. There is a [fee](/government/publications/australia-consular-fees--3).
+
+          You don’t have to convert your civil partnership into a marriage in the country you formed it in.
+
+          Find out more about [eligibility and what documents you need to bring](https://www.gov.uk/convert-civil-partnership/convert-a-civil-partnership-abroad).
+
+          [Book an appointment to convert a civil partnership in Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/converting-a-civil-partnership/slot_picker).
+
+          Bookings are reservations only. Please don’t make formal arrangements until our staff have confirmed the date and time.
+
+          ##Notarial services
+
+          Our consulates around Australia cannot carry out notarial acts under the Commissioner of Oaths Act 1889, and on instruction from the Foreign and Commonwealth Office in London. This includes certifying documents as true copies of originals, administering oaths or taking affidavits. 
+
+          For these or other notarial acts, or the legalising of documents, please [contact a notary public](http://www.notarylocator.com.au/).
+           
+          We also provide services in:
+           
+          - [Brisbane](/government/world/australia/british-consulate-brisbane)
+          - [Canberra](/government/world/australia/british-high-commission-canberra)
+          - [Melbourne](/government/world/australia/british-consulate-general-melbourne)
+          - [Sydney](/government/world/australia/british-consulate-general-sydney) 
+    british-consulate-general-melbourne:
+      - title: British Consulate General Melbourne
+        summary: The British Consulate General in Melbourne represents the UK government and provides services to British nationals in South Australia, Tasmania and Victoria.
+        body: |
+          We help sustain and develop the important relationship between the UK and Australia. 
+           
+          You can [access UK government services while in Australia](/government/world/australia).
+           
+          #Urgent assistance
+           
+          If you’re in South Australia, Tasmania or Victoria and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +61 (0)3 9652 1600. If you’re in the UK and worried about a British national in Australia, call 020 7008 1500. 
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          ##Registering a same-sex marriage 
+
+          We register same-sex marriages at all our consulates in Australia. 
+
+          Find out how to register using the ['Getting married abroad' tool](/marriage-abroad). 
+
+          We no longer register new civil partnerships in our consulates.
+
+          ##Convert a civil partnership into a marriage 
+
+          We can convert an existing civil partnership into a marriage. You must have been living in Australia for 28 days. There is a [fee](/government/publications/australia-consular-fees--3).
+
+          You don’t have to convert your civil partnership into a marriage in the country you formed it in.
+
+          Find out more about [eligibility and what documents you need to bring](https://www.gov.uk/convert-civil-partnership/convert-a-civil-partnership-abroad).
+
+          [Book an appointment to convert a civil partnership in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/converting-a-civil-partnership/slot_picker).
+
+          Bookings are reservations only. Please don’t make formal arrangements until our staff have confirmed the date and time.
+
+          ##Notarial services
+
+          Our consulates around Australia cannot carry out notarial acts under the Commissioner of Oaths Act 1889, and on instruction from the Foreign and Commonwealth Office in London. This includes certifying documents as true copies of originals, administering oaths or taking affidavits. 
+
+          For these or other notarial acts, or the legalising of documents, please [contact a notary public](http://www.notarylocator.com.au/).
+           
+          We also provide services in:
+           
+          - [Brisbane](/government/world/australia/british-consulate-brisbane)
+          - [Canberra](/government/world/australia/british-high-commission-canberra)
+          - [Perth](/government/world/australia/british-consulate-perth)
+          - [Sydney](/government/world/australia/british-consulate-general-sydney)
+    british-consulate-general-sydney:
+      - title: British Consulate General Sydney
+        summary: The British Consulate General in Sydney represents the UK government and provides services to British nationals in New South Wales.
+        body: |
+          We help sustain and develop the important relationship between the UK and Australia. 
+           
+          You can [access UK government services while in Australia](/government/world/australia).
+           
+          #Urgent assistance
+           
+          If you’re in New South Wales and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +61 (0)2 9247 7521. If you’re in the UK and worried about a British national in Australia, call 020 7008 1500. 
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          ##Registering a same-sex marriage 
+
+          We register same-sex marriages at all our consulates in Australia. 
+
+          Find out how to register using the ['Getting married abroad' tool](/marriage-abroad). 
+
+          We no longer register new civil partnerships in our consulates.
+
+          ##Convert a civil partnership into a marriage 
+
+          We can convert an existing civil partnership into a marriage. You must have been living in Australia for 28 days. There is a [fee](/government/publications/australia-consular-fees--3).
+
+          You don’t have to convert your civil partnership into a marriage in the country you formed it in.
+
+          Find out more about [eligibility and what documents you need to bring](https://www.gov.uk/convert-civil-partnership/convert-a-civil-partnership-abroad).
+
+          [Book an appointment to convert a civil partnership in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/converting-a civil-partnership/slot_picker).
+
+          Bookings are reservations only. Please don’t make formal arrangements until our staff have confirmed the date and time.
+
+          ##Notarial services
+
+          Our consulates around Australia cannot carry out notarial acts under the Commissioner of Oaths Act 1889, and on instruction from the Foreign and Commonwealth Office in London. This includes certifying documents as true copies of originals, administering oaths or taking affidavits. 
+
+          For these or other notarial acts, or the legalising of documents, please [contact a notary public](http://www.notarylocator.com.au/).
+           
+          We also provide services in:
+           
+          - [Brisbane](/government/world/australia/british-consulate-brisbane)
+          - [Canberra](/government/world/australia/british-high-commission-canberra)
+          - [Perth](/government/world/australia/british-consulate-perth)
+          - [Melbourne](/government/world/australia/british-consulate-general-melbourne) 
 brazil:
   taxonomy:
     - title: Help for British nationals in Brazil

--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -1744,27 +1744,435 @@ thailand:
           See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/thailand-consular-fees). 
 turkey:
   taxonomy:
-    - title: Help for British nationals in Turkey
-      description: Travel documents and help with emergencies.
-      base_path: help-for-british-nationals
-      tagged_content:
-        - title: Get a new or replacement UK passport
-          description: Forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport.
-          base_path: /apply-renew-passport
-        - title: Get emergency UK travel documents
-          description: If you're abroad, need to travel and can't get a passport in time.
+    - title: Emergency help for British nationals
+      description: Get help if you're the victim of crime or you've been arrested. 
+      tagged_content: 
+        - title: Compensation for victims of terrorist attacks abroad
+          description: Compensation for terrorist attacks abroad - eligibility, acts of terrorism covered, application form, helpline.
+          base_path: /compensation-victim-terrorist-attack
+        - title: Compensation if you're a victim of crime abroad
+          description: If you're a UK resident and have been injured because of a violent crime abroad, you can usually apply for compensation.
+          base_path: /compensation-victim-crime-abroad
+        - title: Contact the British Consulate General Istanbul
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-consulate-general-istanbul
+        - title: Contact the British Consulate Izmir
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-consulate-izmir
+        - title: Contact the British Embassy Ankara
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-embassy-ankara
+        - title: Contact the British Vice Consulate Antalya
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-vice-consulate-antalya
+        - title: Contact the British Honorary Consulate Bodrum
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-honorary-consulate-bodrum
+        - title: Contact the British Honorary Consulate Fethiye
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-honorary-consulate-fethiye
+        - title: Contact the British Honorary Consulate Marmaris
+          description: Contact details if you need urgent help.
+          base_path: /government/world/turkey/british-honorary-consulate-marmaris
+        - title: Get an emergency travel document
+          description: Apply for an emergency travel document if you're outside the UK and haven't got a valid British passport - apply online, how to apply, fee, timings.
           base_path: /emergency-travel-document
+        - title: Get help if you're the victim of crime abroad
+          description: Contact the nearest British embassy, commission or consulate to get help if you're the victim of crime abroad.
+          base_path: /victim-crime-abroad
+        - title: Get help if you've been arrested abroad
+          description: Find out what the Foreign and Commonwealth Office can do to help if you or someone you know is arrested abroad.
+          base_path: /help-if-you-are-arrested-abroad
+        - title: "Rape and sexual assault abroad: returning to the UK"
+          description: Information for British nationals affected by rape or sexual assault abroad and returning to the UK, including how to access medical treatment and legal advice in the UK.
+          base_path: /government/publications/rape-and-sexual-assault-abroad-returning-to-the-uk
+        - title: What to do if you’re affected by a crisis abroad
+          description: Advice for British nationals affected by crises abroad, including terrorist attacks, natural disasters and major political unrest, and information on what help the Foreign and Commonwealth Office (FCO) can provide.
+          base_path: /guidance/how-to-deal-with-a-crisis-overseas
+    - title: Living abroad
+      description: Includes how to renew your passport, claim your pension and access healthcare.
+      tagged_content: 
+        - title: Apply for or renew a British passport if you're visiting the UK
+          description: You can apply for or renew a British passport while you're visiting the UK - as long as you expect to be in the UK for long enough.
+          base_path: /passport-application-while-visiting-uk
+        - title: Bereavement support
+          description: Information to help you deal with practical arrangements following the death of a British national.
+          base_path: /government/publications/turkey-bereavement-guide
+        - title: Check if a document can be legalised
+          description: Find out which documents the Legalisation Office can legalise - confirming the signature, seal or stamp on a document is genuine.
+          base_path: /legalisation-document-checker
+        - title: Get a document legalised
+          description: Use the online service to get a UK document legalised.
+          base_path: /get-document-legalised
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad 
+        - title: Get or renew a passport
+          description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes.
+          base_path: /overseas-passports"
+        - title: List of funeral directors
+          description: 
+          base_path: /government/publications/turkey-list-of-funeral-directors
+        - title: List of medical practitioners
+          description: 
+          base_path: /government/publications/turkey-list-of-medical-practitioners
+        - title: Lists of lawyers
+          description: 
+          base_path: /government/publications/turkey-list-of-lawyers
+        - title: Lists of translators and interpreters
+          description: 
+          base_path: /government/publications/turkey-list-of-translators-and-interpreters
+        - title: Living in Turkey
+          description: Advice for British people living in Turkey, including information on health, education, benefits, residence requirements and more. 
+          base_path: /guidance/living-in-turkey
+        - title: Moving or retiring abroad
+          description: What you need to know if you move or retire abroad - tax, pensions, voting and contacting your local council.
+          base_path: /moving-or-retiring-abroad
+        - title: Notarial and documentary services
+          description: 
+          base_path: /guidance/notarial-and-documentary-services-guide-for-turkey
+        - title: Register a birth
+          description: Parents must register the birth in the country where the child was born - find out if you can also register the birth in the UK.
+          base_path: /register-a-birth
+        - title: Register a death
+          description: Find out how to register a death abroad.
+          base_path: /after-a-death/death-abroad
+        - title: Voting when you're abroad
+          description: How to vote if you're going to be abroad temporarily on election day, and what to do if you're moving overseas long term.
+          base_path: /voting-when-abroad
+    - title: Tax, benefits, pensions and working abroad
+      description: Includes how to pay tax, claim State Pension and get tax credits abroad. 
+      tagged_content: 
+        - title: Claiming benefits if you live, move or travel abroad
+          description: Benefits you can claim if you go abroad and countries with social security arrangements with the UK.
+          base_path: /claim-benefits-abroad
+        - title: National Insurance if you go abroad
+          description: Contact HM Revenue and Customs (HMRC) to find out if you need to pay National Insurance when you work abroad.
+          base_path: /national-insurance-if-you-go-abroad
+        - title: State Pension if you retire abroad
+          description: How to claim State Pension if you're overseas - payment, tax, change of circumstances - contact the International Pension Centre.
+          base_path: /state-pension-if-you-retire-abroad
+        - title: Tax credits if you leave or move to the UK
+          description: Tax credits if you live abroad, go travelling, are a cross-border worker or subject to immigration control.
+          base_path: /tax-credits-if-moving-country-or-travelling
+        - title: Tax on foreign income
+          description: Find out whether you need to pay UK tax on foreign income - residence and ‘non-dom’ status, tax returns, claiming relief if you’re taxed twice (including certificates of residence).
+          base_path: /tax-foreign-income
+        - title: Tax on your UK income if you live abroad
+          description: Find out whether you need to pay tax on your UK income while you're living abroad - non-resident landlord scheme, tax returns, claiming relief if you’re taxed twice, personal allowance of tax-free income, form R43.
+          base_path: /tax-uk-income-live-abroad
+        - title: Work in another EU country
+          description: UK citizens can work in any European Economic Area country and Switzerland without a work permit - where you can work, your rights, protection for posted workers and National Insurance payments.
+          base_path: /working-abroad
+    - title: Coming to the UK
+      description: Get a visa to study, work or visit the UK.
+      tagged_content: 
+        - title: Check if you need a UK visa
+          description: You may need a visa to come to the UK to visit, study or work.
+          base_path: /check-uk-visa
+        - title: Chevening Scholarships
+          description: Chevening Scholarships are one-year Masters’ degrees for graduates from eligible countries who could be future leaders. Find out about eligibility and how to apply.
+          base_path: /guidance/chevening-scholarships-for-students-from-overseas
+        - title: Contact UK Visas and Immigration from outside the UK
+          description: Contact UKVI via email or telephone if you're outside the UK.
+          base_path: /contact-ukvi-outside-uk
+        - title: Get your visa, immigration or citizenship documents back
+          description: Get your documents returned if you've made a UK visa, immigration or citizenship application but need them back urgently.
+          base_path: /visa-documents-returned
+    - title: Travelling to Turkey
+      description: Includes travel advice and how to get married abroad.
+      tagged_content: 
+        - title: Driving abroad
+          description: You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries.
+          base_path: /driving-abroad
+        - title: Get married abroad
+          description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees.
+          base_path: /marriage-abroad
+        - title: Foreign travel advice for people with mental health needs
+          description: Advice for British nationals with mental health needs to prepare for travelling and living abroad, and how the FCO can help.
+          base_path: /guidance/foreign-travel-advice-for-people-with-mental-health-issues
+        - title: How to reduce your risk of terrorism abroad
+          description: How to minimise your risk and what to do in the event of a terrorist attack.
+          base_path: /guidance/reduce-your-risk-from-terrorism-while-abroad
+        - title: Taking a vehicle out of the UK
+          description: Taking your car out of the UK - when VAT is not payable on a car you are exporting, procedures, registration and vehicle tax.
+          base_path: /taking-vehicles-out-of-uk
+        - title: Turkey travel advice
+          description: Latest travel advice including safety and security, entry requirements, travel warnings and health.
+          base_path: /foreign-travel-advice/turkey
+    - title: Trade and invest in the UK
+      description: Find out how to set up a business in the UK, invest in the UK and what support you can get.
+      tagged_content: 
+        - title: "Business investment in the UK: Guidance for overseas businesses"
+          description: Guidance on why overseas companies should set up and locate their businesses in the UK. Includes information on UK business investment and Foreign Direct Investment (FDI) opportunities.
+          base_path: /government/collections/investment-in-the-uk-guidance-for-overseas-businesses
+        - title: Department for International Trade in Turkey
+          description: 
+          base_path: /government/world/organisations/department-for-international-trade-turkey
+        - title: Exporting and doing business abroad
+          description: What to do within or outside the EU, including checking if you need a licence.
+          base_path: /starting-to-export
+        - title: International treaties
+          description: 
+          base_path: /government/publications?keywords=&publication_filter_option=international-treaties&topics%5B%5D=all&departments%5B%5D=all&official_document_status=all&world_locations%5B%5D=all&from_date=&to_date=
+        - title: Set up a business 
+          description: "What you need to do to start a business: choose a legal structure, see if you need licences and insurance, learn about reliefs and benefits."
+          base_path: /set-up-business
+        - title: UK Science and Innovation Network in Turkey
+          description: 
+          base_path: /government/world/organisations/uk-science-and-innovation-network-in-turkey
+    - title: Diplomacy and development
+      description: Find out what the UK government is doing in Turkey, includes news and events.
+      tagged_content: 
+        - title: News and events in Turkey
+          description: What is the UK government doing in Turkey.
+          base_path: /government/world/turkey/news
+    - title: British Embassy
+      description: Includes contact details, opening hours and consular fees.
+      tagged_content: 
+        - title: British Consulate General Istanbul
+          description: 
+          base_path: /government/world/turkey/british-consulate-general-istanbul
+        - title: British Consulate Izmir
+          description: 
+          base_path: /government/world/turkey/british-consulate-izmir
+        - title: British Embassy Ankara
+          description: 
+          base_path: /government/world/turkey/british-embassy-ankara
+        - title: British Honorary Consulate Bodrum
+          description: 
+          base_path: /government/world/turkey/british-honorary-consulate-bodrum
+        - title: British Honorary Consulate Fethiye
+          description: 
+          base_path: /government/world/turkey/british-honorary-consulate-fethiye
+        - title: British Honorary Consulate Marmaris
+          description: 
+          base_path: /government/world/turkey/british-honorary-consulate-marmaris
+        - title: British Vice Consulate Antalya
+          description: 
+          base_path: /government/world/turkey/british-vice-consulate-antalya
   embassies:
-    british-embassy-bangkok:
+    british-embassy-ankara:
       - title: British Embassy Ankara
-        summary: The summary
+        summary: The British Embassy in Ankara represents the UK government and provides services to British nationals in Turkey.
         body: |
-          The British Embassy in Ankara represents the UK government and provides services to British nationals in Turkey.
+          We help sustain and develop the important relationship between the UK and Turkey. 
+           
+          You can [access UK government services while in Turkey](/government/world/turkey)
+           
+          #Urgent assistance
+           
+          If you’re in Ankara and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 312 455 3344. If you’re in the UK and worried about a British national in Turkey, call 020 7008 1500. 
+           
+          [Contact the British Embassy](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Ankara can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/turkey-consular-fees).
+           
+          We also run a regional visa hub for entry to the UK.
+           
+          We also provide services in:
+           
+          - [Antalya](/government/world/turkey/british-vice-consulate-antalya)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-vice-consulate-antalya:
+      - title: British Vice Consulate Antalya
+        summary: The British Vice Consulate in Antalya represents the UK government and provides services to British nationals in Antalya. 
+        body: |
+          We help sustain and develop the important relationship between the UK and Turkey. 
+           
+          You can [access UK government services while in Turkey](/government/world/turkey)
+           
+          #Urgent assistance
+           
+          If you’re in Antalya and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 242 228 28 11. If you’re in the UK and worried about a British national in Turkey, call 020 7008 1500. 
+           
+          [Contact the British Vice Consulate](#contact-us) for information about our other services. 
+           
+          #Other consular services
+           
+          Consular staff in Antalya can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-honorary-consulate-bodrum:
+      - title: British Honorary Consulate Bodrum
+        summary: The British Honorary Consulate in Bodrum represents the UK government and provides services to British nationals in Bodrum.
+        body: |
           We help sustain and develop the important relationship between the UK and Turkey.
-          You can access UK government services while in [Turkey](https://www.gov.uk/government/world/turkey)
-          ##Urgent assistance
-          If you’re in Turkey and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
-          [Contact the Embassy](#contact-us) for information about our other services.
+           
+          You can [access UK government services while in Turkey](/government/world/turkey).
+           
+          #Urgent assistance
+           
+          If you’re in Bodrum and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 252 412 64 88. If you’re in the UK and worried about a British national in Bodrum, call 020 7008 1500.
+           
+          [Contact the British Honorary Consulate](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Bodrum can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-honorary-consulate-fethiye:
+      - title: British Honorary Consulate Fethiye
+        summary: The British Honorary Consulate in Fethiye represents the UK government and provides services to British nationals in Fethiye.
+        body: |
+          We help sustain and develop the important relationship between the UK and Turkey.
+           
+          You can [access UK government services while in Turkey](/government/world/turkey).
+           
+          #Urgent assistance
+           
+          If you’re in Fethiye and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 252 614 63 02. If you’re in the UK and worried about a British national in Fethiye, call 020 7008 1500.
+           
+          [Contact the British Honorary Consulate](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Fethiye can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-consulate-general-istanbul:
+      - title: British Consulate General Istanbul
+        summary: The British Consulate General in Istanbul represents the UK government and provides services to British nationals in Istanbul.
+        body: |
+          We help sustain and develop the important relationship between the UK and Turkey.
+           
+          You can [access UK government services while in Turkey](/government/world/turkey).
+           
+          #Urgent assistance
+           
+          If you’re in Istanbul and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 212 334 64 00. If you’re in the UK and worried about a British national in Turkey, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Istanbul can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-consulate-izmir:
+      - title: British Consulate General Izmir
+        summary: The British Consulate General in Izmir represents the UK government and provides services to British nationals in Izmir.
+        body: |
+          We help sustain and develop the important relationship between the UK and Izmir.
+           
+          You can [access UK government services while in Izmir](/government/world/turkey).
+           
+          #Urgent assistance
+           
+          If you’re in Izmir and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 232 463 51 51. If you’re in the UK and worried about a British national in Izmir, call 020 7008 1500.
+           
+          [Contact the British Consulate General](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Izmir can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Marmaris](/government/world/turkey/british-honorary-consulate-marmaris)
+    british-honorary-consulate-marmaris:
+      - title: British Honorary Consulate Marmaris
+        summary: The British Honorary Consulate in Marmaris represents the UK government and provides services to British nationals in Marmaris.
+        body: |
+          We help sustain and develop the important relationship between the UK and Turkey.
+           
+          You can [access UK government services while in Turkey](ADD LINK TO NAV PAGE).
+           
+          #Urgent assistance
+           
+          If you’re in Marmaris and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +90 252 412 64 88. If you’re in the UK and worried about a British national in Marmaris, call 020 7008 1500.
+           
+          [Contact the British Honorary Consulate](#contact-us) for information about our other services.
+           
+          #Other consular services
+           
+          Consular staff in Marmaris can:
+           
+          - administer an oath, affirmation or affidavit
+          - witness a signature
+          - make a certified copy of a document
+           
+          See the [full list of services](https://www.gov.uk/government/collections/notarial-services). You might have to [pay a fee](https://www.gov.uk/government/publications/turkey-consular-fees).
+           
+          We also provide services in:
+           
+          - [Ankara](/government/world/turkey/british-embassy-ankara)
+          - [Bodrum](/government/world/turkey/british-honorary-consulate-bodrum)
+          - [Fethiye](/government/world/turkey/british-honorary-consulate-fethiye)
+          - [Istanbul](/government/world/turkey/british-consulate-general-istanbul)
+          - [Izmir](/government/world/turkey/british-consulate-izmir)
 usa:
   taxonomy:
     - title: Help for British nationals in USA

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -357,10 +357,10 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
   view_test "should use the taxonomy template if the user is in the 'B' cohort" do
     with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
-      # Use the 'sample' slug since it is defined in
+      # 'india' is one of the test world locations in
       # `worldwide_publishing_taxonomy_ab_test_content.yml` and will therefore
       # display the taxonomy page
-      world_location = create(:world_location, slug: 'sample')
+      world_location = create(:world_location, slug: 'india')
       get :show, id: world_location, locale: 'en'
 
       assert_select '.taxon-page'

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -134,7 +134,6 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
       "british-consulate-general-los-angeles" => "usa",
       "did-south-africa" => "south-africa",
       "british-deputy-high-commission-kolkata" => "india",
-      "uk-science-and-innovation-network" => "australia",
     }
 
     hard_coded_redirects.each do |organisation_slug, location_slug|

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -132,7 +132,6 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     hard_coded_redirects = {
       "british-high-commission-pretoria" => "south-africa",
       "british-consulate-general-los-angeles" => "usa",
-      "did-south-africa" => "south-africa",
       "british-deputy-high-commission-kolkata" => "india",
     }
 


### PR DESCRIPTION
Adds content for the worldwide content A/B test. Alternative content will be provided for country 'taxon' pages at `/government/world/<country>` and consulates and embassies at `/government/world/<country>/<organisation>` in an A/B test comparing performance of that content structure against the existing `/government/world/<country>` and `/government/world/organisations/<organisation>` pages.

[Trello](https://trello.com/c/R1O7h6hb/131-add-content-for-the-a-b-test-into-a-yaml-file-in-whitehall)