### PR TITLE
Display translations on taxon pages only when available

### DIFF
--- a/app/views/worldwide_publishing_taxonomy/show.html.erb
+++ b/app/views/worldwide_publishing_taxonomy/show.html.erb
@@ -42,21 +42,23 @@
           </div>
         </div>
         <div class="column-one-third">
-          <div class="available-languages">
-            <ul>
-              <% sorted_locales(@world_location.translated_locales).each.with_index do |locale, i| %>
-                <li class="translation<%= ' last' if i == @world_location.translated_locales.length-1 %>">
-                  <% if locale == I18n.locale %>
-                    <span><%= native_language_name_for(locale) %></span>
-                  <% else %>
-                    <a lang="<%= locale %>" href="/government/world/<%= @world_location.slug %>.<%= locale %>?ABTest-WorldwidePublishingTaxonomy=A">
-                      <%= native_language_name_for(locale) %>
-                    </a>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
+          <% if @world_location.available_in_multiple_languages? %>
+            <div class="available-languages">
+              <ul>
+                <% sorted_locales(@world_location.translated_locales).each.with_index do |locale, i| %>
+                  <li class="translation<%= ' last' if i == @world_location.translated_locales.length-1 %>">
+                    <% if locale == I18n.locale %>
+                      <span><%= native_language_name_for(locale) %></span>
+                    <% else %>
+                      <a lang="<%= locale %>" href="/government/world/<%= @world_location.slug %>.<%= locale %>?ABTest-WorldwidePublishingTaxonomy=A">
+                        <%= native_language_name_for(locale) %>
+                      </a>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="grid-row child-topic-contents">


### PR DESCRIPTION
Translation links on the worldwide publishing taxon pages should only be displayed if there multpile translations. Currently, the `available_translations` div displays even when the world location is
only available in English.

Fix this to only display the `available_languages` div if there are multiple languages available for the world location.