### PR TITLE
Fix duplicate empty Ids in taxon page

### DIFF
--- a/app/views/worldwide_publishing_taxonomy/show.html.erb
+++ b/app/views/worldwide_publishing_taxonomy/show.html.erb
@@ -65,7 +65,7 @@
             <div data-module="accordion-with-descriptions" class="js-hidden">
               <div class="subsection-wrapper">
                 <% b_variant_page_content[:taxonomy].each_with_index do |taxon, section_index| %>
-                  <div class="subsection js-subsection" id="<%= taxon[:base_path] %>" data-track-count="accordionSection">
+                  <div class="subsection js-subsection" id="section_content_<%= section_index + 1 %>" data-track-count="accordionSection">
                     <div class="subsection-header js-subsection-header">
                       <h2 class="subsection-title js-subsection-title"><%= taxon[:title] %></h2>
                       <p class="subsection-description"><%= taxon[:description] %></p>


### PR DESCRIPTION
Setting the Id of the "outer" wrapper of the accordion to `taxon[:base_path]` fails because `:base_path` does not exist at this level of the YAML hierarchy.

This causes Slimmer errors and creates pages with empty Ids.

Change the Id to be numerical and thus unique instead.