### PR TITLE
Do not redirect organisations that are not under AB test

### DIFF
--- a/config/worldwide_publishing_taxonomy_ab_test_content.yml
+++ b/config/worldwide_publishing_taxonomy_ab_test_content.yml
@@ -34,6 +34,11 @@ australia:
           ##Urgent assistance
           If you’re in Australia and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the High Commission](#contact-us) for information about our other services.
+    uk-science-and-innovation-network:
+      - title: Uk Science and Innovation Network
+        summary: The summary
+        body: |
+          Uk Science and Innovation Network
 brazil:
   taxonomy:
     - title: Help for British nationals in Brazil
@@ -80,6 +85,16 @@ india:
           ##Urgent assistance
           If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the High Commission](#contact-us) for information about our other services.
+    british-deputy-high-commission-kolkata:
+      - title: British Deputy High Commission Kolkata
+        summary: The summary
+        body: |
+          The British Deputy High Commission in Kolkata represents the UK government and provides services to British nationals in India.
+          We help sustain and develop the important relationship between the UK and India.
+          You can access UK government services while in [India](https://www.gov.uk/government/world/india)
+          ##Urgent assistance
+          If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
+          [Contact the High Commission](#contact-us) for information about our other services.
 south-africa:
   taxonomy:
     - title: Help for British nationals in South Africa
@@ -103,6 +118,11 @@ south-africa:
           ##Urgent assistance
           If you’re in South Africa and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
           [Contact the High Commission](#contact-us) for information about our other services.
+    did-south-africa:
+      - title: Department of International Development in South Africa
+        summary: The summary
+        body: |
+          Department of International Development in South Africa
 thailand:
   taxonomy:
     - title: Help for British nationals in Thailand
@@ -167,6 +187,16 @@ usa:
         summary: The summary
         body: |
           The British Embassy in Ankara represents the UK government and provides services to British nationals in the USA.
+          We help sustain and develop the important relationship between the UK and the USA.
+          You can access UK government services while in the [USA](https://www.gov.uk/government/world/usa)
+          ##Urgent assistance
+          If you’re in the USA and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
+          [Contact the Embassy](#contact-us) for information about our other services.
+    british-consulate-general-los-angeles:
+      - title: British Consulate General Los Angeles
+        summary: The summary
+        body: |
+          The British Consulate in Los Angeles represents the UK government and provides services to British nationals in the USA.
           We help sustain and develop the important relationship between the UK and the USA.
           You can access UK government services while in the [USA](https://www.gov.uk/government/world/usa)
           ##Urgent assistance

--- a/lib/worldwide_ab_test_helper.rb
+++ b/lib/worldwide_ab_test_helper.rb
@@ -9,6 +9,12 @@ class WorldwideAbTestHelper
     !!content_for(location_slug)
   end
 
+  def has_embassy_content_for?(location_slug, embassy_slug)
+    return false unless has_content_for?(location_slug)
+
+    !!content_for(location_slug)["embassies"][embassy_slug]
+  end
+
   def content_for(location_slug)
     content[location_slug]
   end
@@ -22,6 +28,8 @@ class WorldwideAbTestHelper
     location = testable_object
     if testable_object.respond_to?(:world_locations)
       location = location_for(testable_object)
+
+      return false unless has_embassy_content_for?(location.slug, testable_object.slug)
     end
     has_content_for?(location.slug)
   end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -68,7 +68,9 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
   test "show redirects users in the b group to /government/world/<location>" do
     location_under_test_slug = "india"
     world_location = create(:world_location, slug: location_under_test_slug)
-    worldwide_organisation = create(:worldwide_organisation, world_locations: [world_location])
+    worldwide_organisation = create(:worldwide_organisation,
+                                    slug: "british-high-commission-new-delhi",
+                                    world_locations: [world_location])
     with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
       get :show, id: worldwide_organisation
       assert_redirected_to world_location_path(world_location)
@@ -88,6 +90,21 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     location_not_under_test_slug = "germany"
     world_location = create(:world_location, slug: location_not_under_test_slug)
     worldwide_organisation = create(:worldwide_organisation, world_locations: [world_location])
+    with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      get :show, id: worldwide_organisation
+      assert_response :ok
+    end
+  end
+
+  test "show doesn't redirect B group users for organisations that aren't in the test" do
+    location_under_test_slug = "usa"
+    world_location = create(:world_location, slug: location_under_test_slug)
+
+    org_not_under_test_slug = "emerging-risks-directorate"
+    worldwide_organisation = create(:worldwide_organisation,
+                                    slug: org_not_under_test_slug,
+                                    world_locations: [world_location])
+
     with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
       get :show, id: worldwide_organisation
       assert_response :ok

--- a/test/unit/worldwide_ab_test_helper_test.rb
+++ b/test/unit/worldwide_ab_test_helper_test.rb
@@ -23,6 +23,27 @@ class WorldwideAbHelperTest < ActiveSupport::TestCase
               - title: Get emergency UK travel documents
                 description: If you're abroad, need to travel and can't get a passport in time.
                 base_path: /emergency-travel-document
+        embassies:
+          british-high-commission-new-delhi:
+            - title: British High Commission New Delhi
+              summary: The summary
+              body: |
+                The British High Commission in New Delhi represents the UK government and provides services to British nationals in India.
+                We help sustain and develop the important relationship between the UK and India.
+                You can access UK government services while in [India](https://www.gov.uk/government/world/india)
+                ##Urgent assistance
+                If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
+                [Contact the High Commission](#contact-us) for information about our other services.
+          british-deputy-high-commission-kolkata:
+            - title: British Deputy High Commission Kolkata
+              summary: The summary
+              body: |
+                The British High Commission in Kolkata represents the UK government and provides services to British nationals in India.
+                We help sustain and develop the important relationship between the UK and India.
+                You can access UK government services while in [India](https://www.gov.uk/government/world/india)
+                ##Urgent assistance
+                If you’re in India and you need urgent help (for example, you’ve been attacked, arrested or someone has died), call +41 (12) 345 6789. If you’re in the UK and worried about a British national in Sample, call 020 7008 1500.
+                [Contact the High Commission](#contact-us) for information about our other services.
 
     CONTENT
 
@@ -99,7 +120,7 @@ class WorldwideAbHelperTest < ActiveSupport::TestCase
     with_fixture_file do |file_path|
       location = stub(slug: "india")
       organisation = stub(
-        slug: "british-deputy-high-commission-indialand",
+        slug: "british-high-commission-new-delhi",
         world_locations: [location]
       )
 
@@ -143,6 +164,18 @@ class WorldwideAbHelperTest < ActiveSupport::TestCase
     with_fixture_file do |file_path|
       location = WorldLocation.new(slug: "germany")
       refute subject(file_path).is_under_test?(location)
+    end
+  end
+
+  test "is_under_test? returns false if the organisation is not listed under the location under test" do
+    with_fixture_file do |file_path|
+      location = stub(slug: "india")
+      organisation = stub(
+        slug: "organisation-which-is-not-listed-in-the-yml",
+        world_locations: [location]
+      )
+
+      refute subject(file_path).is_under_test?(organisation)
     end
   end
 end


### PR DESCRIPTION
For the countries in the AB tests, we do not list some organisations (eg department-for-international-trade-in-the-usa). We should not redirect to the world location pages for those organisations. This commit updates the worldwide AV helper to check if an organisation is listed in the YML under a location. The test data and yml had to be updated to add any organisations that we expect to be in the final YML file.