### PR TITLE
Send `primary_publishing_organisation` to publishing-api

### DIFF
--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -2,6 +2,7 @@ module PublishingApi
   class LinksPresenter
     LINK_NAMES_TO_METHODS_MAP = {
       organisations: :organisation_ids,
+      primary_publishing_organisation: :primary_publishing_organisation_id,
       policy_areas: :policy_area_ids,
       related_policies: :related_policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
@@ -16,6 +17,10 @@ module PublishingApi
     end
 
     def extract(filter_links)
+      if filter_links.include?(:organisations)
+        filter_links << :primary_publishing_organisation
+      end
+
       filter_links.reduce(Hash.new) do |links, link_name|
         private_method_name = LINK_NAMES_TO_METHODS_MAP[link_name]
         links[link_name] = send(private_method_name)
@@ -41,6 +46,11 @@ module PublishingApi
 
     def organisation_ids
       (item.try(:organisations) || []).map(&:content_id)
+    end
+
+    def primary_publishing_organisation_id
+      lead_organisations = item.try(:lead_organisations) || []
+      [lead_organisations.map(&:content_id).first].compact
     end
 
     def world_location_ids

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,6 +74,10 @@ class ActiveSupport::TestCase
     assert_equal array1.to_set, array2.to_set, "Different elements in #{array1.inspect} and #{array2}.inspect"
   end
 
+  def assert_hash_includes(hash, should_exist)
+    assert should_exist.to_a.all? { |e| hash.to_a.include?(e) }, "#{hash} doesn't include #{should_exist}"
+  end
+
   def assert_all_requested(array)
     array.each { |request| assert_requested request }
   end

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -64,7 +64,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       presented_item.content[:details].delete(:body)
     )
     assert_equal expected_content[:details], presented_item.content[:details].except(:body)
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal case_study.document.content_id, presented_item.content_id
   end
 

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -144,7 +144,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     }
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'case_study')
-    assert_equal expected_links_hash, presented_item.links
+    assert_hash_includes presented_item.links, expected_links_hash
   end
 
   test "details hash includes full document history" do

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -116,7 +116,8 @@ module PublishingApi::ConsultationPresenterTest
         related_policies: [],
         topics: []
       }
-      assert_equal presented_content[:links], expected_links
+
+      assert_hash_includes presented_content[:links], expected_links
     end
 
     test 'body details' do

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -83,7 +83,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected_content.except(:details), presented_item.content.except(:details)
     assert_equivalent_html expected_content[:details].delete(:body), presented_item.content[:details].delete(:body)
     assert_equal expected_content[:details], presented_item.content[:details].except(:body)
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal detailed_guide.document.content_id, presented_item.content_id
   end
 

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -66,6 +66,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   test "it presents edition links" do
     expected_links = {
       organisations:  [],
+      primary_publishing_organisation: [],
       policy_areas:   [],
       field_of_operation: [@fatality_notice.operational_field.content_id]
     }

--- a/test/unit/presenters/publishing_api/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/links_presenter_test.rb
@@ -21,7 +21,15 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
 
     links = links_for(edition, [:topics, :parent, :organisations])
 
-    assert_equal({ topics: %w(content_id_1), parent: [], organisations: [] }, links)
+    assert_equal(
+      {
+        topics: %w(content_id_1),
+        parent: [],
+        organisations: [],
+        primary_publishing_organisation: []
+      },
+      links
+    )
   end
 
   test 'it treats the primary specialist sector of the item as the parent' do
@@ -36,6 +44,7 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
         topics: %w(content_id_1 content_id_2),
         parent: %w(content_id_1),
         organisations: [],
+        primary_publishing_organisation: [],
       },
       links
     )
@@ -50,6 +59,22 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
         topics: [],
         parent: [],
         organisations: [],
+        primary_publishing_organisation: [],
+      },
+      links
+    )
+  end
+
+  test "adds primary publishing organisation" do
+    organisation = create(:organisation)
+    edition = create(:detailed_guide, lead_organisations: [organisation])
+
+    links = links_for(edition, [:organisations])
+
+    assert_equal(
+      {
+        organisations: [organisation.content_id],
+        primary_publishing_organisation: [organisation.content_id],
       },
       links
     )

--- a/test/unit/presenters/publishing_api/ministerial_role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministerial_role_presenter_test.rb
@@ -31,7 +31,7 @@ class PublishingApi::MinisterialRolePresenterTest < ActiveSupport::TestCase
     presented_item = present(ministerial_role)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal ministerial_role.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -44,7 +44,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal organisation.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -29,7 +29,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
     presented_item = present(person)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/policy_area_placeholder_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/policy_area_placeholder_presenter_test.rb
@@ -29,7 +29,7 @@ class PublishingApi::PolicyAreaPlaceholderPresenterTest < ActionView::TestCase
     presented_item = present(policy_area)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal policy_area.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -87,7 +87,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     assert_equivalent_html expected_content[:details].delete(:body),
       presented_item.content[:details].delete(:body)
     assert_equal expected_content[:details], presented_item.content[:details].except(:body)
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal expected_links, presented_item.content[:links]
     assert_equal publication.document.content_id, presented_item.content_id
   end

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -62,6 +62,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     expected_links = {
       topics: [],
       parent: [],
+      primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       organisations: publication.lead_organisations.map(&:content_id),
       ministers: [minister.person.content_id],
       related_statistical_data_sets: [statistical_data_set.content_id],
@@ -116,21 +117,14 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
                         lead_organisations: [lead_org_1, lead_org_2],
                         supporting_organisations: [supporting_org])
     presented_item = present(publication)
+
     expected_links_hash = {
-      topics: [],
-      parent: [],
       organisations: [lead_org_1.content_id, lead_org_2.content_id, supporting_org.content_id],
-      world_locations: [],
-      ministers: [],
-      related_statistical_data_sets: [],
-      topical_events: [],
-      policy_areas: publication.topics.map(&:content_id),
-      related_policies: []
     }
 
     assert_valid_against_links_schema({ links: presented_item.links }, 'publication')
-    assert_equal expected_links_hash, presented_item.links
-    assert_equal expected_links_hash, presented_item.content[:links]
+    assert_hash_includes presented_item.links, expected_links_hash
+    assert_hash_includes presented_item.content[:links], expected_links_hash
   end
 
   test "details hash includes full document history" do

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -37,7 +37,7 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal expected_update_type, presented_item.update_type
 
     assert_valid_against_schema(presented_item.content, "generic")

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -47,7 +47,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       presented_content[:details].delete(:body)
 
     assert_equal expected_content, presented_content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
   end
 
   test "a cancelled statistics announcement presents the correct values" do
@@ -94,7 +94,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       presented_content[:details].delete(:body)
 
     assert_equal expected_content, presented_content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
   end
 
   test "a statistics announcement with a date change presents both dates and a notice" do
@@ -143,6 +143,6 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
       presented_content[:details].delete(:body)
 
     assert_equal expected_content, presented_content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
   end
 end

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -30,7 +30,7 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
     presented_item = present(world_location)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal world_location.content_id, presented_item.content_id
 

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -30,7 +30,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     presented_item = present(worldwide_org)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal expected_links, presented_item.links
+    assert_hash_includes presented_item.links, expected_links
     assert_equal "major", presented_item.update_type
     assert_equal worldwide_org.content_id, presented_item.content_id
 


### PR DESCRIPTION
This sends the `primary_publishing_organisation` to the publishing-api. It uses the first of the lead organisations to do this.

The field will be indexed in search and used when auditing content.

Tests will fail until https://github.com/alphagov/govuk-content-schemas/pull/622 is deployed.

https://trello.com/c/86sDRf3t