### PR TITLE
Add Schools Commissioners Group to tagging list

### DIFF
--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -15,3 +15,4 @@ organisations_in_tagging_beta:
   - "3e5a6924-b369-4eb3-8b06-3c0814701de4" # Skills Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
   - "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
   - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
+  - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group


### PR DESCRIPTION
This is a new-ish education organisation, DfE will handle tagging on
their behalf.

Trello: https://trello.com/c/cyWcmn7f/164-add-schools-commissioners-group-to-list-of-organisations-whose-content-can-be-tagged