### PR TITLE
Add contact info to group B embassy pages

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -26,6 +26,8 @@ class WorldwideOrganisationsController < PublicFacingController
 
   def show_b_variant
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
+    @main_office = @worldwide_organisation.main_office if @worldwide_organisation.main_office
+    @home_page_offices = @worldwide_organisation.home_page_offices
     @embassy_data = embassy_test_data(params[:id])
     @primary_role = primary_role
     @other_roles = ([secondary_role] + office_roles).compact


### PR DESCRIPTION
New embassy pages should also show contact information as it currently displays on the worldwide organisation pages.

### Screenshots

#### With main and home page offices
![with_home_page_offices](https://cloud.githubusercontent.com/assets/647311/26669472/ed650ff0-46a5-11e7-8152-bc1d6924f922.png)

#### With main offices but without home page offices
![without_home_page_offices](https://cloud.githubusercontent.com/assets/647311/26669490/00928d6e-46a6-11e7-8938-b38dbabaa4f7.png)

Had a quick chat with Lucy and she advised to include both in the page since. 