### PR TITLE
Fix error for missing organisations from test data

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -95,7 +95,7 @@ private
   end
 
   def embassy_test_data(embassy)
-    embassies_test_data[embassy][0] if embassies_test_data
+    embassies_test_data[embassy].first if embassies_test_data && embassies_test_data[embassy]
   end
 
   def setup_a_b_test

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -178,6 +178,22 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     end
   end
 
+  test "should redirect to the worldwide_organisation page for B cohort but the world_organisation is not in the test data" do
+    with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      worldwide_organisation = create(:worldwide_organisation, slug: "not-an-embassy")
+      world_location = create(:world_location)
+
+      data = {
+        "embassies" => {}
+      }
+      WorldwideAbTestHelper.any_instance.stubs(:has_content_for?).returns(true)
+      WorldwideAbTestHelper.any_instance.expects(:content_for).with(world_location.slug).at_least_once.returns(data)
+      get :show_b_variant, id: worldwide_organisation.slug, world_location_id: world_location.slug
+
+      assert_redirected_to worldwide_organisation_path(worldwide_organisation)
+    end
+  end
+
   test "should return 200 if in the B cohort and there is data" do
     with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
       worldwide_organisation = create(:worldwide_organisation)


### PR DESCRIPTION
When visiting a slug for a worldwide organisation in the B bucket which was not in data yml, the code errored as it was trying the access the first element of array which was actually `nil`.
Instead it should redirect to the old worldwide organisation page.

eg `/government/world/brazil/dfid-brazil` would error, as it's not an organisation that we list as an embassy in the worldwide ab test yml.