### PR TITLE
Return AB test path for WorldwideOrganisation

### DIFF
--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -1,9 +1,17 @@
+require "localised_url_path_helper"
+
 module WorldwideOrganisationsHelper
+  include LocalisedUrlPathHelper
+
   def worldwide_organisation_path(worldwide_organisation, options = {})
-    worldwide_organisation_url(
-      worldwide_organisation,
-      options.merge(only_path: true)
-    )
+    if ab_test_helper.is_under_test?(worldwide_organisation)
+      worldwide_organisation_url(
+        worldwide_organisation,
+        options.merge(only_path: true)
+      )
+    else
+      super
+    end
   end
 
   def worldwide_organisation_url(worldwide_organisation, options = {})

--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -1,7 +1,5 @@
-require "localised_url_path_helper"
-
 module WorldwideOrganisationsHelper
-  include LocalisedUrlPathHelper
+  include ActionDispatch::Routing::PolymorphicRoutes
 
   def worldwide_organisation_path(worldwide_organisation, options = {})
     if ab_test_helper.is_under_test?(worldwide_organisation)
@@ -24,16 +22,6 @@ module WorldwideOrganisationsHelper
       File.join(location_path_or_url, worldwide_organisation.slug)
     else
       super
-    end
-  end
-
-  # LocalliseUrlPathHelper rewrites many helpers to look into
-  # params[:locale] before deciding what url to produce, we need this to
-  # make sure we can cope with that.
-  # Copied somewhat from lib/whitehall/url_maker.rb
-  unless defined?(params)
-    define_method(:params) do
-      {}
     end
   end
 

--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -1,0 +1,27 @@
+module WorldwideOrganisationsHelper
+  def worldwide_organisation_path(worldwide_organisation, options = {})
+    worldwide_organisation_url(
+      worldwide_organisation,
+      options.merge(only_path: true)
+    )
+  end
+
+  def worldwide_organisation_url(worldwide_organisation, options = {})
+    if ab_test_helper.is_under_test?(worldwide_organisation)
+      location = ab_test_helper.location_for(worldwide_organisation)
+      location_path_or_url = world_location_url(location, options)
+      # this is 'wrong' but URI::join needs a host which we may or may not have
+      # so for the purposes of the AB test this seems pragmatic and simple
+      # it will run on linux and join on /
+      File.join(location_path_or_url, worldwide_organisation.slug)
+    else
+      super
+    end
+  end
+
+private
+
+  def ab_test_helper
+    @ab_test_helper ||= WorldwideAbTestHelper.new
+  end
+end

--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -27,6 +27,16 @@ module WorldwideOrganisationsHelper
     end
   end
 
+  # LocalliseUrlPathHelper rewrites many helpers to look into
+  # params[:locale] before deciding what url to produce, we need this to
+  # make sure we can cope with that.
+  # Copied somewhat from lib/whitehall/url_maker.rb
+  unless defined?(params)
+    define_method(:params) do
+      {}
+    end
+  end
+
 private
 
   def ab_test_helper

--- a/lib/whitehall/url_maker.rb
+++ b/lib/whitehall/url_maker.rb
@@ -3,6 +3,7 @@ module Whitehall
     include Rails.application.routes.url_helpers
     include PublicDocumentRoutesHelper
     include FilterRoutesHelper
+    include WorldwideOrganisationsHelper
     include Admin::EditionRoutesHelper
     include LocalisedUrlPathHelper
 

--- a/lib/worldwide_ab_test_helper.rb
+++ b/lib/worldwide_ab_test_helper.rb
@@ -25,10 +25,11 @@ class WorldwideAbTestHelper
   end
 
   def is_under_test?(testable_object)
+    return false unless valid_testable_object?(testable_object)
     location = testable_object
     if testable_object.respond_to?(:world_locations)
       location = location_for(testable_object)
-
+      return false unless valid_testable_object?(location)
       return false unless has_embassy_content_for?(location.slug, testable_object.slug)
     end
     has_content_for?(location.slug)
@@ -63,5 +64,9 @@ private
     locations.find do |location|
       location.slug == hard_coded_value
     end
+  end
+
+  def valid_testable_object?(object_to_validate)
+    object_to_validate.respond_to?(:slug)
   end
 end

--- a/test/unit/helpers/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/worldwide_organisations_helper_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class WorldwideOrganisationsHelperTest < ActionView::TestCase
+  test "path returns /government/world/organisations/<slug> for a non test org" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "/government/world/organisations/none-test-slug",
+      worldwide_organisation_path(org)
+    )
+  end
+
+  test "url returns <host>/government/world/organisations/slug for a non test org" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "http://test.host/government/world/organisations/none-test-slug",
+      worldwide_organisation_url(org)
+    )
+  end
+
+  test "path returns /government/world/<location>/<slug> for an org under A/B test" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "british-high-commission-new-delhi",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "/government/world/india/british-high-commission-new-delhi",
+      worldwide_organisation_path(org)
+    )
+  end
+
+  test "url returns /government/world/<location>/<slug> for an org under A/B test" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "british-high-commission-new-delhi",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "http://test.host/government/world/india/british-high-commission-new-delhi",
+      worldwide_organisation_url(org)
+    )
+  end
+end

--- a/test/unit/helpers/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/worldwide_organisations_helper_test.rb
@@ -64,4 +64,26 @@ class WorldwideOrganisationsHelperTest < ActionView::TestCase
       worldwide_organisation_url(org)
     )
   end
+
+  test "path appends locale if supplied for non test organisations" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    #the LocalisedUrlPathHelper module that has the 'super'
+    #implementation of `worldwide_organisation_path`
+    #only appends the locale to the path if this method
+    #returns true
+    org.stubs(:available_in_locale?).returns(true)
+
+    assert_equal(
+      "/government/world/organisations/none-test-slug.fr",
+      worldwide_organisation_path(org, locale: "fr")
+    )
+  end
 end

--- a/test/unit/worldwide_ab_test_helper_test.rb
+++ b/test/unit/worldwide_ab_test_helper_test.rb
@@ -178,4 +178,12 @@ class WorldwideAbHelperTest < ActiveSupport::TestCase
       refute subject(file_path).is_under_test?(organisation)
     end
   end
+
+  test "is_under_test? returns false if the testable_object is nil" do
+    refute subject.is_under_test?(nil)
+  end
+
+  test "is_under_test? returns false if the testable_object is a string" do
+    refute subject.is_under_test?("world-location-test-string-1")
+  end
 end


### PR DESCRIPTION
For the worldwide AB test we require that the usual worldwide organisation path for embassies that are part of the test redirect to the parent location.

In certain circumstances we still need to link to the embassy from pages e.g. corporate information pages and this requires that the links are updated with the new path to avoid the redirect and go to the new embassy pages.

This commit temporarily overrides the path and url helpers for `WorldwideOrganisation` to achieve this for the duration of the test.

[Trello](https://trello.com/c/Biya5HFW/167-fix-link-to-embassies-under-test-from-corporate-information-pages)

This helper is used to generate links on the embassy pages (which are replaced in the test with hard coded links to the new URL) and world location news article pages in the metadata component. The latter links should probably point to the embassy contact pages for the test. There may be other inline links but there don't appear to be any internally when checked with a Google link search. External links for B group users will be directed to the country taxon pages as intended.
