### PR TITLE
Revert "Add contact info to group B embassy pages"

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -26,8 +26,6 @@ class WorldwideOrganisationsController < PublicFacingController
 
   def show_b_variant
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
-    @main_office = @worldwide_organisation.main_office if @worldwide_organisation.main_office
-    @home_page_offices = @worldwide_organisation.home_page_offices
     @embassy_data = embassy_test_data(params[:id])
     @primary_role = primary_role
     @other_roles = ([secondary_role] + office_roles).compact


### PR DESCRIPTION
Reverts alphagov/whitehall#3261

In discussion, we have decided to only show the `main_office` rather than both `main_office` and `home_office`