### PR TITLE
Only show main office contact info on embassy page

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -27,7 +27,6 @@ class WorldwideOrganisationsController < PublicFacingController
   def show_b_variant
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
     @main_office = @worldwide_organisation.main_office if @worldwide_organisation.main_office
-    @home_page_offices = @worldwide_organisation.home_page_offices
     @embassy_data = embassy_test_data(params[:id])
     @primary_role = primary_role
     @other_roles = ([secondary_role] + office_roles).compact

--- a/app/views/embassies/show.html.erb
+++ b/app/views/embassies/show.html.erb
@@ -97,7 +97,6 @@
     <div class="inner-block floated-children">
       <h1 class="keyline-header"><%= t('worldwide_organisation.headings.contact_us' ) %></h1>
       <%= render partial: 'contacts/contact', locals: {contact: @main_office, is_main: true} %>
-      <%= render partial: 'contacts/contact', collection: @home_page_offices %>
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
Embassy pages in the B group do not need to show contact information for every other embassy in the country. This commit ensures we only show contact information for the `main` page.

## Current:
![with_home_page_offices](https://cloud.githubusercontent.com/assets/647311/26671058/10557774-46ac-11e7-832d-8c0ccab7cc94.png)

## New:
![without_home_page_offices](https://cloud.githubusercontent.com/assets/647311/26671065/1a4e2cf8-46ac-11e7-8c83-f192cdfbbf36.png)


