### PR TITLE
Use world location slug in breadcrumb on embassy page

### DIFF
--- a/app/views/embassies/show.html.erb
+++ b/app/views/embassies/show.html.erb
@@ -28,7 +28,7 @@
             },
             {
               title: @world_location,
-              url: "/government/world/#{@world_location}",
+              url: "/government/world/#{@world_location.slug}",
               is_current_page: false
             },
             {


### PR DESCRIPTION
Breadcrumbs for pages in the B cohort are broken if the world location includes a hyphen. Use the `slug` instead to ensure the breadcrumb presents a valid hyperlink.