### PR TITLE
Migrate WorldLocationNewsArticle to NewsArticle

### DIFF
--- a/lib/tasks/convert_wlna_to_news_article.rake
+++ b/lib/tasks/convert_wlna_to_news_article.rake
@@ -1,0 +1,61 @@
+namespace :wlna do
+  task :migrate_to_news_article, [:start_document_id, :end_document_id] => :environment do |_t, args|
+    start_id = args[:start_document_id]
+    end_id = args[:end_document_id]
+    raise "start_document_id and end_document_id must be supplied" unless start_id && end_id
+
+    documents = Document.where(id: start_id..end_id)
+      .where(document_type: "WorldLocationNewsArticle")
+
+    puts "Migrating #{documents.count} WLNA -> NewsArticle"
+    documents.each do |wlna_document|
+      begin
+        #setting sluggable_string causes #should_generate_new_friendly_id?
+        #to return true. This will regenerate the slug and
+        #disambiguate if there is already a news article with the slug
+        wlna_document.sluggable_string = wlna_document.slug
+        wlna_document.update_attributes(
+          document_type: "NewsArticle",
+        )
+      rescue ActiveRecord::RecordNotUnique
+        puts "NotUnique: #{wlna_document.id}"
+      end
+
+      editions = editions_including_deleted(wlna_document.id)
+
+      update_db_records_to_news_article(editions)
+      update_unpublishings(editions)
+      update_rummager(editions)
+
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", wlna_document.id)
+
+      print "."
+    end
+
+    unless documents.empty?
+      puts "First document id #{documents.first.id}"
+      puts "Last document id #{documents.last.id}"
+    end
+  end
+end
+
+def update_db_records_to_news_article(editions)
+  editions.update_all(
+    type: "NewsArticle",
+    news_article_type_id: NewsArticleType::WorldNewsStory.id
+  )
+end
+
+def update_unpublishings(editions)
+  edition_ids = editions.pluck(:id)
+  unpublishings = Unpublishing.where(edition_id: edition_ids)
+  unpublishings.update_all(document_type: "NewsArticle")
+end
+
+def update_rummager(editions)
+  editions.each(&:save)
+end
+
+def editions_including_deleted(document_id)
+  Edition.unscoped.where(document_id: document_id)
+end


### PR DESCRIPTION
This PR adds a data migration that converts all existing `WorldLocationNewsArticle` documents to `NewsArticle`.

The conversion involves a few steps:

* change the `Document#document_type` to `NewsArticle`.
* set the `Document#sluggable_string` to the existing slug. This causes it to be regenerated. If there is an existing `NewsArticle` with the slug of the `WorldNewsArticle` the slug will be disambiguated in the same way as articles with the same title are treated (appending `--n` to the slug). The document is saved at this point.
* Update the `type` STI field on all of the documents `Edition`s. This is done using `update_all` to bypass validation as changing of the document's type when it is in `published` state is disallowed.
* Update the `news_article_type` of all of the editions to `NewsArticleType::WorldNewsStory`
* Republish the document to update publishing API and content store and to create a redirect to the new URL. `/government/world-location-news/<slug>` -> `/government/news/<slug>`

Also updates the `NewsArticle` sync check to handle `nil` policies which is valid for WLNA.

[Trello](https://trello.com/c/9odHKy0o/139-migrate-existing-wlna-to-newsarticle-format)