### PR TITLE
Link to B Worldwide Organisation in Corporate Information header

### DIFF
--- a/app/controllers/corporate_information_pages_controller.rb
+++ b/app/controllers/corporate_information_pages_controller.rb
@@ -4,6 +4,7 @@ class CorporateInformationPagesController < DocumentsController
 
   def show
     @corporate_information_page = @document
+    @user_is_in_b_test_group = user_is_in_b_test_group?
 
     if @organisation.is_a? WorldwideOrganisation
       render 'show_worldwide_organisation'
@@ -56,5 +57,11 @@ private
       else
         raise ActiveRecord::RecordNotFound
       end
+  end
+
+  def user_is_in_b_test_group?
+    ab_test = GovukAbTesting::AbTest.new("WorldwidePublishingTaxonomy", dimension: 45)
+    requested_variant = ab_test.requested_variant(request.headers)
+    requested_variant.variant_b?
   end
 end

--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -1,9 +1,9 @@
 module WorldwideOrganisationsHelper
-  def worldwide_organisation_link_for_ab_test(worldwide_organisation)
-    if ab_test_helper.is_under_test?(worldwide_organisation)
+  def worldwide_organisation_link_for_ab_test(worldwide_organisation, user_is_in_b_test_group)
+    if ab_test_helper.is_under_test?(worldwide_organisation) && user_is_in_b_test_group
       b_url(worldwide_organisation)
     else
-      worldwide_organisation_url
+      worldwide_organisation_path(worldwide_organisation)
     end
   end
 

--- a/app/helpers/worldwide_organisations_helper.rb
+++ b/app/helpers/worldwide_organisations_helper.rb
@@ -1,0 +1,24 @@
+module WorldwideOrganisationsHelper
+  def worldwide_organisation_link_for_ab_test(worldwide_organisation)
+    if ab_test_helper.is_under_test?(worldwide_organisation)
+      b_url(worldwide_organisation)
+    else
+      worldwide_organisation_url
+    end
+  end
+
+private
+
+  def b_url(worldwide_organisation)
+    location = ab_test_helper.location_for(worldwide_organisation)
+    location_path_or_url = world_location_url(location)
+    # this is 'wrong' but URI::join needs a host which we may or may not have
+    # so for the purposes of the AB test this seems pragmatic and simple
+    # it will run on linux and join on /
+    File.join(location_path_or_url, worldwide_organisation.slug)
+  end
+
+  def ab_test_helper
+    @ab_test_helper ||= WorldwideAbTestHelper.new
+  end
+end

--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -1,7 +1,7 @@
 <% page_title @corporate_information_page.title %>
 <% page_class "corporate-information-pages-show-worldwide-organisation" %>
 
-<%= render partial: 'worldwide_organisations/header', locals: { organisation: @organisation, link_to_organisation: true, object_for_translation: @corporate_information_page } %>
+<%= render partial: 'worldwide_organisations/header', locals: { organisation: @organisation, link_to_organisation: true, object_for_translation: @corporate_information_page, user_is_in_b_test_group: @user_is_in_b_test_group } %>
 <article class="block article">
   <div class="inner-block floated-children">
     <% headers = govspeak_headers(@corporate_information_page.body) %>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -2,6 +2,7 @@
   world_locations ||= organisation.world_locations
   link_to_organisation ||= false
   object_for_translation ||= organisation
+  user_is_in_b_test_group ||= false
 %>
 <header class="block worldwide-organisation-header">
   <div class="inner-block floated-children">
@@ -9,7 +10,7 @@
       <h1>
         <% if link_to_organisation %>
           <%= link_to content_tag(:span, organisation_logo_name(organisation)),
-                worldwide_organisation_link_for_ab_test(organisation),
+                worldwide_organisation_link_for_ab_test(organisation, user_is_in_b_test_group),
                 class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
         <% else %>
           <%= content_tag :span, content_tag(:span, organisation_logo_name(organisation)), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>

--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -8,7 +8,9 @@
     <div class="logo">
       <h1>
         <% if link_to_organisation %>
-          <%= link_to content_tag(:span, organisation_logo_name(organisation)), organisation, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
+          <%= link_to content_tag(:span, organisation_logo_name(organisation)),
+                worldwide_organisation_link_for_ab_test(organisation),
+                class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
         <% else %>
           <%= content_tag :span, content_tag(:span, organisation_logo_name(organisation)), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
         <% end %>

--- a/lib/worldwide_ab_test_helper.rb
+++ b/lib/worldwide_ab_test_helper.rb
@@ -25,10 +25,11 @@ class WorldwideAbTestHelper
   end
 
   def is_under_test?(testable_object)
+    return false unless valid_testable_object?(testable_object)
     location = testable_object
     if testable_object.respond_to?(:world_locations)
       location = location_for(testable_object)
-
+      return false unless valid_testable_object?(location)
       return false unless has_embassy_content_for?(location.slug, testable_object.slug)
     end
     has_content_for?(location.slug)
@@ -63,5 +64,9 @@ private
     locations.find do |location|
       location.slug == hard_coded_value
     end
+  end
+
+  def valid_testable_object?(object_to_validate)
+    object_to_validate.respond_to?(:slug)
   end
 end

--- a/test/unit/helpers/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/worldwide_organisations_helper_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class WorldwideOrganisationsHelperTest < ActionView::TestCase
+  test "path returns /government/world/organisations/<slug> for a non test org" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "/government/world/organisations/none-test-slug",
+      worldwide_organisation_path(org)
+    )
+  end
+
+  test "url returns <host>/government/world/organisations/slug for a non test org" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "http://test.host/government/world/organisations/none-test-slug",
+      worldwide_organisation_url(org)
+    )
+  end
+
+  test "link for ab test returns /government/world/<location>/<slug> for an org under A/B test" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "british-high-commission-new-delhi",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "http://test.host/government/world/india/british-high-commission-new-delhi",
+      worldwide_organisation_link_for_ab_test(org)
+    )
+  end
+end

--- a/test/unit/helpers/worldwide_organisations_helper_test.rb
+++ b/test/unit/helpers/worldwide_organisations_helper_test.rb
@@ -33,7 +33,23 @@ class WorldwideOrganisationsHelperTest < ActionView::TestCase
     )
   end
 
-  test "link for ab test returns /government/world/<location>/<slug> for an org under A/B test" do
+  test "link for ab test returns government/world/organisations/<slug> for an org under A/B test with user in A cohort" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "british-high-commission-new-delhi",
+      world_locations: [
+        location
+      ]
+    )
+
+    assert_equal(
+      "/government/world/organisations/british-high-commission-new-delhi",
+      worldwide_organisation_link_for_ab_test(org, false)
+    )
+  end
+
+  test "link for ab test returns /government/world/<location>/<slug> for an org under A/B test with user in B cohort" do
     location = create(:world_location, slug: "india")
     org = create(
       :worldwide_organisation,
@@ -45,7 +61,29 @@ class WorldwideOrganisationsHelperTest < ActionView::TestCase
 
     assert_equal(
       "http://test.host/government/world/india/british-high-commission-new-delhi",
-      worldwide_organisation_link_for_ab_test(org)
+      worldwide_organisation_link_for_ab_test(org, true)
+    )
+  end
+
+  test "path appends locale if supplied for non test organisations" do
+    location = create(:world_location, slug: "india")
+    org = create(
+      :worldwide_organisation,
+      slug: "none-test-slug",
+      world_locations: [
+        location
+      ]
+    )
+
+    #the LocalisedUrlPathHelper module that has the 'super'
+    #implementation of `worldwide_organisation_path`
+    #only appends the locale to the path if this method
+    #returns true
+    org.stubs(:available_in_locale?).returns(true)
+
+    assert_equal(
+      "/government/world/organisations/none-test-slug.fr",
+      worldwide_organisation_path(org, locale: "fr")
     )
   end
 end

--- a/test/unit/worldwide_ab_test_helper_test.rb
+++ b/test/unit/worldwide_ab_test_helper_test.rb
@@ -178,4 +178,12 @@ class WorldwideAbHelperTest < ActiveSupport::TestCase
       refute subject(file_path).is_under_test?(organisation)
     end
   end
+
+  test "is_under_test? returns false if the testable_object is nil" do
+    refute subject.is_under_test?(nil)
+  end
+
+  test "is_under_test? returns false if the testable_object is a string" do
+    refute subject.is_under_test?("world-location-test-string-1")
+  end
 end


### PR DESCRIPTION
Some Corporate Information Pages have the propensity to link back to the Worldwide Organisation on clicking the logo in the page's header. If we are in the B cohort, we should link back to the B appropriate page.

This commit adds a small helper to create the correct A or B appropriate link in the front end.

[Trello](https://trello.com/c/Biya5HFW) ticket.

This PR supersedes https://github.com/alphagov/whitehall/pull/3264