### PR TITLE
Update NewsArticle sync check

### DIFF
--- a/lib/sync_checker/formats/news_article_check.rb
+++ b/lib/sync_checker/formats/news_article_check.rb
@@ -120,7 +120,7 @@ module SyncChecker
         {
           'tags' => {
             'browse_pages' => [],
-            'policies' => policies.compact,
+            'policies' => (policies || []).compact,
             'topics' => topics.compact,
           }
         }


### PR DESCRIPTION
This PR updates the `NewsArticle` sync check to handle nil `policies` as the new type, `NewsArticleType::WorldNewsStory` doesn't have a policies association.

[Trello](https://trello.com/c/9odHKy0o/139-migrate-existing-wlna-to-newsarticle-format)