### PR TITLE
Remove 'The' from the Scottish Government logo

### DIFF
--- a/db/data_migration/20170607130246_remove_the_from_the_scottish_government_logo.rb
+++ b/db/data_migration/20170607130246_remove_the_from_the_scottish_government_logo.rb
@@ -1,0 +1,6 @@
+the_scottish_government = Organisation.find_by(slug: "the-scottish-government")
+new_logo_formatted_name = "Scottish \r\nGovernment"
+
+the_scottish_government.update_attributes(
+  logo_formatted_name: new_logo_formatted_name
+)


### PR DESCRIPTION
This commit removes 'The' from the `#logo_formatted_name` for 'The Scottish Government'. This is necessary to support use by the organisations register of the organisations API.

[Trello](https://trello.com/c/Kg79H6E7/189-change-logo-formatted-name-in-organisations-api---the-scottish-government)