### PR TITLE
Fix typo in withdraw message for withdrawing HE press releases

### DIFF
--- a/db/data_migration/20170605142559_withdraw_highways_england_press_releases.rb
+++ b/db/data_migration/20170605142559_withdraw_highways_england_press_releases.rb
@@ -16,9 +16,9 @@ class WithdrawHighwaysEnglandPressReleases
         unpublishing: {
           unpublishing_reason: ::UnpublishingReason::Withdrawn,
           explanation: <<-explanation.strip_heredoc
-            These bulletins are now sent directly to journalists. Contact the [Highways England Press Office](https://www.gov.uk/government/organisations/highways-england/about/media-enquiries) directly to be added to the circulation list
+            These bulletins are now sent directly to journalists. Contact the [Highways England Press Office](https://www.gov.uk/government/organisations/highways-england/about/media-enquiries) directly to be added to the circulation list.
 
-            Otherwise you can check on the [live roadworks search tool](http://roads.highways.gov.uk/)",
+            Otherwise you can check on the [live roadworks search tool](http://roads.highways.gov.uk/).
           explanation
         }
       )


### PR DESCRIPTION
Was not crossing `t`s and dotting `i`s when reviewing #3282.