### PR TITLE
Remove AB testing logic from world location news pages

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,21 +1,16 @@
 class WorldLocationNewsController < PublicFacingController
   enable_request_formats index: [:atom, :json]
   before_action :load_world_location, only: :index
-  before_action :setup_a_b_test, only: :index
 
   def index
     recently_updated_source = @world_location.published_editions.with_translations(I18n.locale).in_reverse_chronological_order
     respond_to do |format|
       format.html do
-        if render_b_variant?
-          set_meta_description("What the UK government is doing in #{@world_location.name}.")
-          set_slimmer_world_locations_header([@world_location])
+        set_meta_description("What the UK government is doing in #{@world_location.name}.")
+        set_slimmer_world_locations_header([@world_location])
 
-          @recently_updated = recently_updated_source.limit(3)
-          @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
-        else
-          redirect_to world_location_path(@world_location)
-        end
+        @recently_updated = recently_updated_source.limit(3)
+        @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
       end
       format.json do
         redirect_to api_world_location_path(@world_location, format: :json)
@@ -30,25 +25,5 @@ private
 
   def load_world_location
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:world_location_id])
-  end
-
-  def setup_a_b_test
-    ab_test = GovukAbTesting::AbTest.new("WorldwidePublishingTaxonomy", dimension: 45)
-    @requested_variant = ab_test.requested_variant(request.headers)
-    @requested_variant.configure_response(response)
-  end
-
-  def render_b_variant?
-    @requested_variant.variant_b? &&
-      worldwide_test_helper.is_under_test?(@world_location) &&
-      locale_is_english?
-  end
-
-  def worldwide_test_helper
-    @_helper ||= WorldwideAbTestHelper.new
-  end
-
-  def locale_is_english?
-    locale == :en
   end
 end

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -11,25 +11,7 @@
                           extra: true, big: true } %>
       <aside class="heading-extra">
         <div class="inner-heading">
-          <!-- copied from _available_languages partial as we need to add the AB testing query param -->
-          <% if @world_location.available_in_multiple_languages? %>
-            <div class="available-languages">
-              <ul>
-                <% sorted_locales(@world_location.translated_locales).each.with_index do |locale, i| %>
-                  <li class="translation<%= ' last' if i == @world_location.translated_locales.length-1 %>">
-                    <% if locale == I18n.locale %>
-                      <span><%= native_language_name_for(locale) %></span>
-                    <% else %>
-                      <a lang="<%= locale %>" href="/government/world/<%= @world_location.slug %>.<%= locale %>?ABTest-WorldwidePublishingTaxonomy=A">
-                        <%= native_language_name_for(locale) %>
-                      </a>
-                    <% end %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
-
+          <%= render 'shared/available_languages', object: @world_location %>
           <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set %>
         </div>
       </aside>


### PR DESCRIPTION
For https://trello.com/c/jL5RbbKM/180-create-new-news-pages

We've finished the AB test so can remove any logic related to it.

Note: This should only be merged once we finish the AB test for WorldwidePublishing.