### PR TITLE
Changes separator for CSV export

### DIFF
--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -17,7 +17,7 @@ private
   end
 
   def generate_csv(filter)
-    CSV.generate do |csv|
+    CSV.generate(col_sep: "|") do |csv|
       csv << DocumentListExportPresenter.header_row
       filter.each_edition_for_csv do |edition|
         presenter = DocumentListExportPresenter.new(edition)

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -14,7 +14,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   end
 
   test 'generate_csv calls presenter once for each edition' do
-    filter = mock()
+    filter = mock
     filter.expects(:each_edition_for_csv).multiple_yields(1, 2, 3)
     @worker.stubs(:create_filter).returns(filter)
     @worker.stubs(:send_mail)
@@ -23,11 +23,23 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   end
 
   test 'sends mail with CSV to user' do
-    csv = 'this,is,my,csv'
+    csv = 'this|is|my|csv'
     title = "Everyone's editions"
     @worker.stubs(:create_filter).returns(stub(page_title: title))
     @worker.stubs(generate_csv: csv)
     Notifications.expects(:document_list).with(csv, @user.email, title).returns(stub(:deliver_now))
     @worker.perform({"state" =>"draft"}, @user.id)
+  end
+
+  test 'generates CSV with custom separator' do
+    edition  = stub(page_title: "title")
+    editions = [edition].to_enum
+    filter = mock
+    filter.expects(:each_edition_for_csv).multiple_yields(editions)
+    @worker.stubs(:create_filter).returns(filter)
+    DocumentListExportPresenter.expects(:header_row).returns(%w(this is my header))
+    DocumentListExportPresenter.expects(:new).with(edition).returns(stub(row: %w(this is my edition)))
+    csv = @worker.send(:generate_csv, filter)
+    assert_equal csv, "this|is|my|header\nthis|is|my|edition\n"
   end
 end


### PR DESCRIPTION
The separator when generating CSV files is now the pipe symbol "|", replacing the default comma "," separator.

For: [Trello card](https://trello.com/c/flfZHIXI/167-change-separator-on-whitehall-csv-export)