### PR TITLE
Add other sections to world location news

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -10,6 +10,10 @@ class WorldLocationNewsController < PublicFacingController
         set_slimmer_world_locations_header([@world_location])
 
         @recently_updated = recently_updated_source.limit(3)
+        publications = Publication.published.in_world_location(@world_location)
+        @non_statistics_publications = latest_presenters(publications.not_statistics, translated: true, count: 2)
+        @statistics_publications = latest_presenters(publications.statistics, translated: true, count: 2)
+        @announcements = latest_presenters(Announcement.published.in_world_location(@world_location), translated: true, count: 2)
         @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
       end
       format.json do

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -37,4 +37,56 @@
       </section>
     </div>
   </div>
+
+  <div class="block our-mission">
+    <div class="inner-block">
+      <section class="article-section">
+        <h1 class="keyline-header"><%= t('world_location.headings.mission') %></h1>
+        <p>
+          <span class="mission_statement"><%= govspeak_to_html(@world_location.mission_statement) %></span>
+        </p>
+      </section>
+    </div>
+  </div>
+
+  <% if (@non_statistics_publications + @announcements + @statistics_publications).any? %>
+    <div class="block documents-grid">
+      <div class="inner-block">
+        <h1 class="block-title"><%= t('world_location.headings.documents') %></h1>
+        <% if @announcements.any? %>
+          <section id="announcements" class="document-block documents-<%= document_block_counter %>">
+            <h1><%= t('world_location.headings.announcements') %></h1>
+            <div class="content">
+              <%= render partial: "shared/list_description", locals: { editions: @announcements } %>
+              <p class="see-all">
+                <%= link_to t_see_all_our(:announcement), announcements_filter_path(@world_location, include_world_location_news: '1') %>
+              </p>
+            </div>
+          </section>
+        <% end %>
+        <% if @non_statistics_publications.any? %>
+          <section id="publications" class="document-block documents-<%= document_block_counter %>">
+            <h1><%= t('world_location.headings.publications') %></h1>
+            <div class="content">
+              <%= render partial: "shared/list_description", locals: { editions: @non_statistics_publications } %>
+              <p class="see-all">
+                <%= link_to t_see_all_our(:publication), publications_filter_path(@world_location) %>
+              </p>
+            </div>
+          </section>
+        <% end %>
+        <% if @statistics_publications.any? %>
+          <section id="statistics-publications" class="document-block documents-<%= document_block_counter %>">
+            <h1><%= t('world_location.headings.statistics') %></h1>
+            <div class="content">
+              <%= render partial: "shared/list_description", locals: { editions: @statistics_publications } %>
+              <p class="see-all">
+                <%= link_to t_see_all_our(:statistics), publications_filter_path(@world_location, publication_filter_option: 'statistics') %>
+              </p>
+            </div>
+          </section>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -11,13 +11,19 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
   end
 
   setup do
-    @world_location = create(:world_location, title: "UK and India", slug: "india")
+    @world_location = create(:world_location,
+                             title: "UK and India",
+                             slug: "india",
+                             mission_statement: "country-mission-statement")
+
+    @translated_world_location = create(:world_location, translated_into: [:fr])
   end
 
-  view_test "index displays world location title" do
+  view_test "index displays world location title and mission-statement" do
     get :index, world_location_id: @world_location
     assert_select "p.type", text: "World location news"
     assert_select "h1", text: "UK and India"
+    assert_select ".mission_statement", text: "country-mission-statement"
   end
 
   test "index responds with not found if appropriate translation doesn't exist" do
@@ -68,22 +74,21 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
   end
 
   test "shows featured items in defined order for locale" do
-    world_location = create(:world_location)
-    LocalisedModel.new(world_location, :fr).update_attributes(name: "Territoire antarctique britannique")
+    LocalisedModel.new(@world_location, :fr).update_attributes(name: "Territoire antarctique britannique")
 
     less_recent_news_article = create(:published_news_article, first_published_at: 2.days.ago)
     more_recent_news_article = create(:published_publication, first_published_at: 1.day.ago)
-    english = FeatureList.create!(featurable: world_location, locale: :en)
+    english = FeatureList.create!(featurable: @world_location, locale: :en)
     create(:feature, feature_list: english, ordering: 1, document: less_recent_news_article.document)
 
-    french = FeatureList.create!(featurable: world_location, locale: :fr)
+    french = FeatureList.create!(featurable: @world_location, locale: :fr)
     create(:feature, feature_list: french, ordering: 1, document: less_recent_news_article.document)
     create(:feature, feature_list: french, ordering: 2, document: more_recent_news_article.document)
 
-    get :index, world_location_id: world_location, locale: :fr
+    get :index, world_location_id: @world_location, locale: :fr
     assert_featured_editions [less_recent_news_article, more_recent_news_article]
 
-    get :index, world_location_id: world_location, locale: :en
+    get :index, world_location_id: @world_location, locale: :en
     assert_featured_editions [less_recent_news_article]
   end
 
@@ -108,19 +113,150 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     assert_equal 5, assigns(:feature_list).current_feature_count
   end
 
-  test "show should set world location slimmer headers" do
+  test "should set world location slimmer headers" do
     get :index, world_location_id: @world_location.id
 
     assert_equal "<#{@world_location.analytics_identifier}>", response.headers["X-Slimmer-World-Locations"]
   end
 
+  test "should display world_location's latest two announcements in reverse chronological order" do
+    announcement2 = create(:published_news_article, world_locations: [@world_location], first_published_at: 2.days.ago)
+    announcement1 = create(:published_news_article, world_locations: [@world_location], first_published_at: 1.day.ago)
+    create(:published_speech, world_locations: [@world_location], first_published_at: 3.days.ago)
+
+    get :index, world_location_id: @world_location
+
+    assert_equal [announcement1, announcement2], assigns[:announcements].object
+  end
+
+  view_test "should display 2 announcements with details and a link to announcements filter if there are many announcements" do
+    announcement2 = create(:published_news_article, world_locations: [@world_location], first_published_at: 2.days.ago)
+    announcement3 = create(:published_speech, world_locations: [@world_location], first_published_at: 3.days.ago)
+    announcement1 = create(:published_news_article, world_locations: [@world_location], first_published_at: 1.day.ago)
+
+    get :index, world_location_id: @world_location
+
+    assert_select "#announcements" do
+      assert_select_object announcement1 do
+        assert_select '.publication-date time[datetime=?]', 1.days.ago.iso8601
+        assert_select '.document-type', "Press release"
+      end
+      assert_select_object announcement2
+      refute_select_object announcement3
+      # there mey be other args and we can't guarantee the order
+      # so just specifiy the bits we care about
+      assert_select "a[href^='#{announcements_path}'][href*='world_locations%5B%5D=#{@world_location.to_param}']"
+    end
+  end
+
+  test "should display world_location's latest two non-statistics publications in reverse chronological order" do
+    publication2 = create(:published_publication, world_locations: [@world_location], first_published_at: 2.days.ago)
+    publication1 = create(:published_publication, world_locations: [@world_location], first_published_at: 1.day.ago)
+    create(:published_publication, world_locations: [@world_location], first_published_at: 3.days.ago)
+
+    create(:published_statistics, world_locations: [@world_location], first_published_at: 1.day.ago)
+
+    get :index, world_location_id: @world_location
+
+    assert_equal [publication1, publication2], assigns[:non_statistics_publications].object
+  end
+
+  view_test "should display 2 non-statistics publications with details and a link to publications filter if there are many publications" do
+    publication2 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
+    publication3 = create(:published_policy_paper, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
+    publication1 = create(:published_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
+
+    get :index, world_location_id: @world_location
+
+    assert_select "#publications" do
+      assert_select_object publication2 do
+        assert_select '.publication-date time[datetime=?]', 2.days.ago.to_date.to_datetime.iso8601
+        assert_select '.document-type', "Policy paper"
+      end
+      assert_select_object publication3
+      refute_select_object publication1
+      assert_select "a[href='#{publications_filter_path(@world_location)}']"
+    end
+  end
+
+  test "should display world location's latest two statistics publications in reverse chronological order" do
+    publication2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago)
+    publication1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago)
+    create(:published_statistics, world_locations: [@world_location], first_published_at: 3.days.ago)
+
+    get :index, world_location_id: @world_location
+    assert_equal [publication1, publication2], assigns[:statistics_publications].object
+  end
+
+  view_test "should display 2 statistics publications with details and a link to publications filter if there are many publications" do
+    publication2 = create(:published_statistics, world_locations: [@world_location], first_published_at: 2.days.ago.to_date)
+    publication3 = create(:published_statistics, world_locations: [@world_location], first_published_at: 3.days.ago.to_date)
+    publication1 = create(:published_national_statistics, world_locations: [@world_location], first_published_at: 1.day.ago.to_date)
+
+    get :index, world_location_id: @world_location
+
+    assert_select "#statistics-publications" do
+      assert_select_object publication1 do
+        assert_select '.publication-date time[datetime=?]', 1.days.ago.to_date.to_datetime.iso8601
+        assert_select '.document-type', "National Statistics"
+      end
+      assert_select_object publication2
+      refute_select_object publication3
+      assert_select "a[href=?]", publications_filter_path(@world_location, publication_filter_option: 'statistics')
+    end
+  end
+
+  view_test "should display translated page labels when requested in a different locale" do
+    create(:published_publication, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_news_article, world_locations: [@translated_world_location], translated_into: [:fr])
+
+    get :index, world_location_id: @translated_world_location, locale: 'fr'
+
+    assert_select ".type", "World location news"
+    assert_select "#publications .see-all a", /Voir toutes nos publications/
+  end
+
+  test "should only display translated announcements when requested for a locale" do
+    translated_speech = create(:published_speech, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_speech, world_locations: [@translated_world_location])
+
+    get :index, world_location_id: @translated_world_location, locale: 'fr'
+
+    assert_equal [translated_speech], assigns(:announcements).object
+  end
+
+  test "should only display translated publications when requested for a locale" do
+    translated_publication = create(:published_publication, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_publication, world_locations: [@translated_world_location])
+
+    get :index, world_location_id: @translated_world_location, locale: 'fr'
+
+    assert_equal [translated_publication], assigns(:non_statistics_publications).object
+  end
+
+  test "should only display translated statistics when requested for a locale" do
+    translated_statistics = create(:published_statistics, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_statistics, world_locations: [@translated_world_location])
+
+    get :index, world_location_id: @translated_world_location, locale: 'fr'
+
+    assert_equal [translated_statistics], assigns(:statistics_publications).object
+  end
+
+  test "should only display translated recently updated editions when requested for a locale" do
+    translated_publication = create(:published_publication, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_publication, world_locations: [@translated_world_location])
+
+    get :index, world_location_id: @translated_world_location, locale: 'fr'
+
+    assert_equal [translated_publication], assigns(:recently_updated)
+  end
+
   view_test "restricts atom feed entries to those with the current locale" do
-    world_location = create(:world_location, translated_into: [:fr])
+    translated_edition = create(:published_publication, world_locations: [@translated_world_location], translated_into: [:fr])
+    create(:published_publication, world_locations: [@translated_world_location])
 
-    translated_edition = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
-    create(:published_publication, world_locations: [world_location])
-
-    get :index, world_location_id: world_location.id, format: :atom, locale: 'fr'
+    get :index, world_location_id: @translated_world_location.id, format: :atom, locale: 'fr'
 
     assert_select_atom_feed do
       with_locale :fr do


### PR DESCRIPTION
For https://trello.com/c/HkrHASeb/215-add-our-mission-and-documents-blocks-back-into-the-new-news-pages

FCO have requested for us to port over the Mission Statement and Publications pages.
This copies over the relevant view and controller logic as well as tests.

Branches off https://github.com/alphagov/whitehall/pull/3288

------------------------------------------

# Screenshots

## Before
![screen shot 2017-06-14 at 14 16 56](https://user-images.githubusercontent.com/5112255/27134086-5e3c43ea-510c-11e7-93d4-914510c1cbe2.png)


## After
![screen shot 2017-06-14 at 14 16 23](https://user-images.githubusercontent.com/5112255/27134094-61a67226-510c-11e7-818e-db343a0f08cd.png)
