### PR TITLE
Increase timeout threshold for publishing-api calls

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -5,7 +5,7 @@ module Services
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.find('publishing-api'),
       bearer_token: (ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'),
-      timeout: 10,
+      timeout: 20,
     )
   end
 end


### PR DESCRIPTION
We've been seeing a number of timeouts, especially when retrieving the extended-links.
This obviously isn't the greatest solution long term, but it should buy us some time to get to grips with the underlying problem in publishing-api.