### PR TITLE
Send custom dimension including organisation slug to ga

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'gds-sso', '~> 13.2'
 gem 'addressable', ">= 2.3.7"
 gem 'unicorn', '5.3.0'
 gem 'kaminari', '~> 1.0.1'
-gem 'govuk_admin_template', '6.0.0'
+gem 'govuk_admin_template', '~> 6.2'
 gem 'bootstrap-kaminari-views', '0.0.5'
 gem 'mime-types', '1.25.1'
 gem 'whenever', '~> 0.9.7', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       multi_json
     arel (6.0.4)
     ast (2.3.0)
-    autoprefixer-rails (7.0.1)
+    autoprefixer-rails (7.1.1.2)
       execjs
     babosa (1.0.2)
     better_errors (2.1.1)
@@ -167,9 +167,9 @@ GEM
       rubocop (~> 0.43.0)
       scss_lint
     govuk_ab_testing (2.2.0)
-    govuk_admin_template (6.0.0)
+    govuk_admin_template (6.2.0)
       bootstrap-sass (= 3.3.5.1)
-      jquery-rails (~> 4.1.1)
+      jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
     govuk_frontend_toolkit (5.0.3)
       rails (>= 3.1.0)
@@ -197,7 +197,7 @@ GEM
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2)
-    jquery-rails (4.1.1)
+    jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -488,7 +488,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.2.0)
-  govuk_admin_template (= 6.0.0)
+  govuk_admin_template (~> 6.2)
   govuk_frontend_toolkit (= 5.0.3)
   govuk_sidekiq (= 0.0.4)
   graphviz_transitions

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -115,5 +115,11 @@
   <%= javascript_tag(yield :javascript_initialisers) %>
 <% end %>
 
+<% if user_signed_in? && current_user.has_email? %>
+  <% content_for :before_pageview_js do %>
+    GOVUKAdmin.setDimension(8, "<%= current_user.organisation_slug.present? ? current_user.organisation_slug : '(not set)' %>")
+  <% end %>
+<% end %>
+
 <%# use the govuk_admin_template layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>

--- a/test/integration/admin_analytics_test.rb
+++ b/test/integration/admin_analytics_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AdminAnalyticsTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  def log_out
+    GDS::SSO.test_user = nil
+  end
+
+  setup do
+    ENV['GDS_SSO_MOCK_INVALID'] = '1'
+  end
+
+  teardown do
+    ENV.delete('GDS_SSO_MOCK_INVALID')
+  end
+
+  # GA is noisy in tests because all GA calls become console.log so we
+  # don't want it enabled for all tests, use this to selectively turn it on
+  def with_ga_enabled
+    begin
+      GovukAdminTemplate.configure { |c| c.enable_google_analytics_in_tests = true }
+      yield
+    ensure
+      GovukAdminTemplate.configure { |c| c.enable_google_analytics_in_tests = false }
+    end
+  end
+
+  def refute_dimension_is_set(dimension)
+    refute_match(/#{Regexp.escape("GOVUKAdmin.setDimension(#{dimension}")}/, page.body)
+  end
+
+  def assert_dimension_is_set(dimension, with_value: nil)
+    dimension_set_js_code = "GOVUKAdmin.setDimension(#{dimension}"
+    dimension_set_js_code += ", \"#{with_value}\")" if with_value.present?
+    assert_match(/#{Regexp.escape(dimension_set_js_code)}/, page.body)
+  end
+
+  test "send a GA event including the users org slug when successfully signed-in" do
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: "ministry-of-lindy-hop"))
+      visit admin_root_path
+      assert_dimension_is_set(8, with_value: "ministry-of-lindy-hop")
+    end
+  end
+
+  test "send a GA event including '(not set)' for the org slug when the user has no org" do
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: nil))
+      visit admin_root_path
+      assert_dimension_is_set(8, with_value: "(not set)")
+    end
+  end
+
+  test "does not send GA event for logged in users on non admin pages" do
+    with_ga_enabled do
+      login_as(create(:user, name: "user-name", email: "user@example.com", organisation_slug: "ministry-of-lindy-hop"))
+      visit admin_root_path
+      assert_dimension_is_set(8)
+
+      # this is a public page that requires no db setup
+      visit get_involved_path
+      refute_dimension_is_set(8)
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/svo2ZN6s/131-custom-dimension-send-user-email-domain-to-ga-for-signon-apps

We want to know which departments are using our publishing apps and we've agreed with the performance team that the best way to do this is to send the organisation slug of the logged in user to GA as a custom dimension. If the user doesn't have an organisation we'll send `(not set)` instead.  Many users don't have organisations in signon, but they're mostly local government users that are unlikely to use any of the apps we're interested in measuring at the moment.  As a test we'll be doing this to signon and whitehall to see what kinds of results we get.

This relies on alphagov/govuk_admin_template#152 and will need the first and final commits squashing once that PR is available in a released version of govuk_admin_template.