### PR TITLE
Changes separator for CSV export

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -144,7 +144,7 @@ class DocumentListExportPresenter
     data.map do |elem|
       case elem
       when Array
-        elem.join(', ')
+        elem.join(' | ')
       when Time
         # YYYY-MM-DD hh:mm:ss, which seems to be best understood by spreadsheets.
         elem.to_formatted_s(:db)

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -17,7 +17,7 @@ private
   end
 
   def generate_csv(filter)
-    CSV.generate(col_sep: "|") do |csv|
+    CSV.generate do |csv|
       csv << DocumentListExportPresenter.header_row
       filter.each_edition_for_csv do |edition|
         presenter = DocumentListExportPresenter.new(edition)

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -38,7 +38,7 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
   test '#format_elements formats arrays, dates and booleans but leaves strings alone' do
     pr = DocumentListExportPresenter.new('')
     data = [%w(list of elements), Time.new(2014, 10, 5, 10, 15), 'normal string', true, false]
-    assert_equal(['list, of, elements', '2014-10-05 10:15:00', 'normal string', 'yes', 'no',], pr.format_elements(data))
+    assert_equal(['list | of | elements', '2014-10-05 10:15:00', 'normal string', 'yes', 'no',], pr.format_elements(data))
   end
 
   test '#lead_organisations returns list of lead org names' do

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -30,16 +30,4 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
     Notifications.expects(:document_list).with(csv, @user.email, title).returns(stub(:deliver_now))
     @worker.perform({"state" =>"draft"}, @user.id)
   end
-
-  test 'generates CSV with custom separator' do
-    edition  = stub(page_title: "title")
-    editions = [edition].to_enum
-    filter = mock
-    filter.expects(:each_edition_for_csv).multiple_yields(editions)
-    @worker.stubs(:create_filter).returns(filter)
-    DocumentListExportPresenter.expects(:header_row).returns(%w(this is my header))
-    DocumentListExportPresenter.expects(:new).with(edition).returns(stub(row: %w(this is my edition)))
-    csv = @worker.send(:generate_csv, filter)
-    assert_equal csv, "this|is|my|header\nthis|is|my|edition\n"
-  end
 end


### PR DESCRIPTION
Follow up to: https://github.com/alphagov/whitehall/commit/34b63c72b023dbeca1ac3ec7f7fd204ec264020a

In the commit referenced above, the separator for the entire CSV file was changed to be "|".

However, the original request was actually to use that separator inside the actual fields where there are multiple entries (multiple organisations in the same field for example).
These were normally separated by commas and will now be separated by pipes.

For: [Trello card](https://trello.com/c/flfZHIXI/167-change-separator-on-whitehall-csv-export)