### PR TITLE
Add organisations eligible for world tagging

### DIFF
--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -4,15 +4,15 @@ module Edition::TaggableOrganisations
   def can_be_tagged_to_taxonomy?
     organisations_content_ids = organisations.map(&:content_id)
 
-    organisations_in_tagging_beta?(organisations_content_ids)
+    organisations_in_education_tagging_beta?(organisations_content_ids)
   end
 
 private
 
-  def organisations_in_tagging_beta?(org_content_ids)
+  def organisations_in_education_tagging_beta?(org_content_ids)
     return false if org_content_ids.empty?
 
-    organisations_in_tagging_beta = Whitehall.organisations_in_tagging_beta
+    organisations_in_tagging_beta = Whitehall.organisations_in_tagging_beta["education_related"]
 
     org_content_ids.any? do |id|
       organisations_in_tagging_beta.include?(id)

--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -3,16 +3,23 @@
 # - This is part of the work performed by Finding Things team.
 
 organisations_in_tagging_beta:
-  - "71381a6e-aa5c-43ae-a982-be9bfd46ea5b" # Education & Skills Funding Agency
-  - "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
-  - "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education
-  - "60de9b00-a982-4449-a995-f2353e86fb95" # Higher Education Statistics Agency
-  - "a081cd5b-c41d-4389-ac65-982e7570680d" # Institute for Apprenticeships
-  - "e1cbab66-b0d3-4186-917c-afd4f3fb6967" # National College for Teaching and Leadership
-  - "e7f33769-a539-4fb4-b24f-f6c1cabc3f59" # Office of the Schools Adjudicator
-  - "83f6e93f-bb2c-46ab-9b02-394f972b7030" # Ofqual
-  - "ad5f6169-ac7b-4382-9eb6-e58af71a2f00" # Ofsted
-  - "3e5a6924-b369-4eb3-8b06-3c0814701de4" # Skills Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
-  - "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
-  - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
-  - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
+  education_related:
+    - "71381a6e-aa5c-43ae-a982-be9bfd46ea5b" # Education & Skills Funding Agency
+    - "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
+    - "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education
+    - "60de9b00-a982-4449-a995-f2353e86fb95" # Higher Education Statistics Agency
+    - "a081cd5b-c41d-4389-ac65-982e7570680d" # Institute for Apprenticeships
+    - "e1cbab66-b0d3-4186-917c-afd4f3fb6967" # National College for Teaching and Leadership
+    - "e7f33769-a539-4fb4-b24f-f6c1cabc3f59" # Office of the Schools Adjudicator
+    - "83f6e93f-bb2c-46ab-9b02-394f972b7030" # Ofqual
+    - "ad5f6169-ac7b-4382-9eb6-e58af71a2f00" # Ofsted
+    - "3e5a6924-b369-4eb3-8b06-3c0814701de4" # Skills Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
+    - "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
+    - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
+    - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
+  worldwide_related:
+    - "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
+    - "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
+    - "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
+    - "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
+    - "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union


### PR DESCRIPTION
Add FCO, UKVI, DIT, DFID, DExEU to the list of organisations allowed to
tag documents in Whitehall admin.

Added some hierarchy to the YAML file containing the list of organisations for whom tagging is allowed so we differentiate between organisations that are in the education related tagging beta and those that will be tagging worldwide content. This is because the logic to decide which document and publication types for worldwide content is slightly different to the education related workflow.

[Trello](https://trello.com/c/6MObnZSc/211-enable-the-whitehall-tagging-interface-for-worldwide-content)

Paired with @davidbasalla 