### PR TITLE
Add worldwide tagging

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -425,6 +425,10 @@ class Edition < ApplicationRecord
     false
   end
 
+  def must_be_tagged_to_taxonomy?
+    false
+  end
+
   def has_been_tagged?
     api_response = Services.publishing_api.get_links(content_id)
 

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -43,10 +43,18 @@ private
   end
 
   def organisations_in_world_tagging?
-    (organisations_content_ids & Whitehall.organisations_in_tagging_beta["worldwide_related"]).present?
+    (organisations_content_ids & worldwide_taggable_organisation_ids).present?
   end
 
   def organisations_in_education_tagging_beta?
-    (organisations_content_ids & Whitehall.organisations_in_tagging_beta["education_related"]).present?
+    (organisations_content_ids & education_taggable_organisation_ids).present?
+  end
+
+  def worldwide_taggable_organisation_ids
+    Whitehall.organisations_in_tagging_beta["worldwide_related"].to_a
+  end
+
+  def education_taggable_organisation_ids
+    Whitehall.organisations_in_tagging_beta["education_related"].to_a
   end
 end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -8,6 +8,12 @@ module Edition::TaggableOrganisations
     PublicationType::Form,
   ].freeze
 
+  # Only Education based organisations have validation to prevent publishing if
+  # they have not been tagged
+  def must_be_tagged_to_taxonomy?
+    education_taggable?
+  end
+
   def can_be_tagged_to_taxonomy?
     education_taggable? || world_taggable?
   end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -1,15 +1,46 @@
 module Edition::TaggableOrganisations
   extend ActiveSupport::Concern
 
-  def can_be_tagged_to_taxonomy?
-    organisations_content_ids = organisations.map(&:content_id)
+  WORLD_TAGGABLE_DOCUMENT_TYPES = %w(Publication DetailedGuide).freeze
 
-    organisations_in_education_tagging_beta?(organisations_content_ids)
+  WORLD_TAGGABLE_PUBLICATION_TYPES = [
+    PublicationType::Guidance,
+    PublicationType::Form,
+  ].freeze
+
+  def can_be_tagged_to_taxonomy?
+    education_taggable? || world_taggable?
   end
 
 private
 
-  def organisations_in_education_tagging_beta?(org_content_ids)
-    (org_content_ids & Whitehall.organisations_in_tagging_beta["education_related"]).present?
+  def education_taggable?
+    organisations_in_education_tagging_beta?
+  end
+
+  def world_taggable?
+    return unless edition_in_world_taggable_document_types?
+    return if self.class == Publication && !publication_is_world_taggable_publication_type?
+    organisations_in_world_tagging?
+  end
+
+  def organisations_content_ids
+    @_org_ids ||= organisations.map(&:content_id)
+  end
+
+  def edition_in_world_taggable_document_types?
+    WORLD_TAGGABLE_DOCUMENT_TYPES.include?(self.class.name)
+  end
+
+  def publication_is_world_taggable_publication_type?
+    WORLD_TAGGABLE_PUBLICATION_TYPES.include?(self.publication_type)
+  end
+
+  def organisations_in_world_tagging?
+    (organisations_content_ids & Whitehall.organisations_in_tagging_beta["worldwide_related"]).present?
+  end
+
+  def organisations_in_education_tagging_beta?
+    (organisations_content_ids & Whitehall.organisations_in_tagging_beta["education_related"]).present?
   end
 end

--- a/app/validators/taxon_validator.rb
+++ b/app/validators/taxon_validator.rb
@@ -11,6 +11,6 @@ class TaxonValidator < ActiveModel::Validator
 private
 
   def missing_taxons?(edition)
-    edition.can_be_tagged_to_taxonomy? && !edition.has_been_tagged?
+    edition.must_be_tagged_to_taxonomy? && !edition.has_been_tagged?
   end
 end

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -54,7 +54,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_template :confirm_force_publish
   end
 
-  test 'GET #confirm_force_publish redirects when edition has no taxons' do
+  test 'GET #confirm_force_publish redirects when edition must tagged be taxons but is not' do
     publishing_api_has_links(
       {
         "content_id" => draft_edition.content_id,
@@ -65,7 +65,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
       }
     )
 
-    Publication.any_instance.stubs(:can_be_tagged_to_taxonomy?).returns(true)
+    Publication.any_instance.stubs(:must_be_tagged_to_taxonomy?).returns(true)
 
     get :confirm_force_publish, id: draft_edition, lock_version: draft_edition.lock_version
 

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -16,6 +16,12 @@ class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::
 
     assert edition.can_be_tagged_to_taxonomy?
   end
+
+  test '#must_be_tagged_to_taxonomy? is true for NewsArticle' do
+    edition = create(:news_article, organisations: [@lead_org])
+
+    assert edition.must_be_tagged_to_taxonomy?
+  end
 end
 
 class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::TestCase
@@ -26,6 +32,13 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
       "worldwide_related" => [@lead_org.content_id]
     }
     Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
+  end
+
+  # Users are not required to tag World taggable editions in order to publish
+  test '#must_be_tagged_to_taxonomy? is false for DetailedGuide' do
+    edition = create(:detailed_guide, organisations: [@lead_org])
+
+    refute edition.must_be_tagged_to_taxonomy?
   end
 
   test '#can_be_tagged_to_taxonomy? is true for Publication Guidance' do

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::TestCase
+  def setup
+    @lead_org = create(:organisation)
+    orgs_in_tagging_beta = {
+      "education_related" => [@lead_org.content_id],
+      "worldwide_related" => []
+    }
+    Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
+  end
+
+  # method will return `true` for all other edition types, we choose NewsArticle as example
+  test '#can_be_tagged_to_taxonomy? is true for NewsArticle' do
+    edition = create(:news_article, organisations: [@lead_org])
+
+    assert edition.can_be_tagged_to_taxonomy?
+  end
+end
+
+class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::TestCase
+  def setup
+    @lead_org = create(:organisation)
+    orgs_in_tagging_beta = {
+      "education_related" => [],
+      "worldwide_related" => [@lead_org.content_id]
+    }
+    Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
+  end
+
+  test '#can_be_tagged_to_taxonomy? is true for Publication Guidance' do
+    edition = create(:publication,
+                     :draft,
+                     access_limited: false,
+                     publication_type_id: PublicationType::Guidance.id,
+                     organisations: [@lead_org])
+
+    assert edition.can_be_tagged_to_taxonomy?
+  end
+
+  test '#can_be_tagged_to_taxonomy? is true for Publication Form' do
+    edition = create(:publication,
+                     :draft,
+                     access_limited: false,
+                     publication_type_id: PublicationType::Form.id,
+                     organisations: [@lead_org])
+
+    assert edition.can_be_tagged_to_taxonomy?
+  end
+
+  test '#can_be_tagged_to_taxonomy? is false for other Publication types' do
+    other_publication_types = PublicationType.all.reject do |publication_type|
+      [PublicationType::Guidance, PublicationType::Form].include?(publication_type) ||
+        publication_type.prevalence == :migration
+    end
+
+    other_publication_types.each_with_index do |publication_type, index|
+      edition = create(:publication,
+                       :draft,
+                       title: "Title #{index}",
+                       access_limited: false,
+                       publication_type_id: publication_type.id,
+                       organisations: [@lead_org])
+
+      refute edition.can_be_tagged_to_taxonomy?
+    end
+  end
+
+  test '#can_be_tagged_to_taxonomy? is true for DetailedGuide' do
+    edition = create(:detailed_guide, organisations: [@lead_org])
+
+    assert edition.can_be_tagged_to_taxonomy?
+  end
+
+  # method will return `false` for all other edition types, we choose NewsArticle as example
+  test '#can_be_tagged_to_taxonomy? is false for NewsArticle' do
+    edition = create(:news_article, organisations: [@lead_org])
+
+    refute edition.can_be_tagged_to_taxonomy?
+  end
+end

--- a/test/unit/validators/taxon_validator_test.rb
+++ b/test/unit/validators/taxon_validator_test.rb
@@ -7,7 +7,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
 
   test 'is invalid when edition has not been tagged to a taxon' do
     edition = create(:draft_edition)
-    edition.stubs(:can_be_tagged_to_taxonomy?).returns(true)
+    edition.stubs(:must_be_tagged_to_taxonomy?).returns(true)
 
     publishing_api_has_links(
       {
@@ -35,7 +35,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
 
   test 'is valid when edition has been tagged to a taxon' do
     edition = create(:draft_edition)
-    edition.stubs(:can_be_tagged_to_taxonomy?).returns(true)
+    edition.stubs(:must_be_tagged_to_taxonomy?).returns(true)
 
     publishing_api_has_links(
       {


### PR DESCRIPTION
Enable the tagging interface for certain content types created by organisations that create the majority of worldwide content. The organisations are FCO, UKVI, DIT, DFID and DExEU. The content types we want to allow for `/world` tagging are Detailed Guide, Publication:Guidance and Publication:Form.

For https://trello.com/b/1h7Tvb3W/govuk-worldwide-publishing-doing

Related to https://github.com/alphagov/whitehall/pull/3296 

Pairing with @bevanloon 

Note that at the time of merging this will have no visibly effect since we have removed the Organisations from the yml that enable this new tagging behaviour. We'll be adding those organisations back in when we're ready to go live. See https://github.com/alphagov/whitehall/pull/3305