### PR TITLE
Proactively cache expensive Taxonomy calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'responders', '~> 2.4'
 gem 'ruby-progressbar', require: false
 gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'govuk_ab_testing', '~> 2.2.0'
-
+gem 'mlanett-redis-lock'
 gem 'deprecated_columns', '0.1.1'
 
 if ENV['GDS_API_ADAPTERS_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,8 @@ GEM
     minitest (5.10.2)
     minitest-fail-fast (0.1.0)
       minitest (~> 5)
+    mlanett-redis-lock (0.2.7)
+      redis
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
@@ -504,6 +506,7 @@ DEPENDENCIES
   mime-types (= 1.25.1)
   mini_magick (~> 3.8.1)
   minitest-fail-fast
+  mlanett-redis-lock
   mocha
   mysql2
   newrelic_rpm

--- a/app/workers/rebuild_taxonomy_cache_worker.rb
+++ b/app/workers/rebuild_taxonomy_cache_worker.rb
@@ -1,0 +1,23 @@
+require 'redis-lock'
+
+class RebuildTaxonomyCacheWorker
+  include Sidekiq::Worker
+
+  def perform
+    run_on_one_app_instance_only do
+      Taxonomy::RedisCacheAdapter.new.rebuild_caches
+    end
+  end
+
+private
+
+  def run_on_one_app_instance_only
+    Redis.current.lock(key, life: 600, acquire: 1) do
+      yield
+    end
+  end
+
+  def key
+    "rebuild_taxonomy_cache_worker_lock"
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,3 +11,7 @@ end
 every :hour, roles: [:backend] do
   rake "rummager:index:consultations"
 end
+
+every :hour, roles: [:backend] do
+  rake "taxonomy:rebuild_cache"
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -1,0 +1,5 @@
+namespace :taxonomy do
+  task rebuild_cache: [:environment] do
+    RebuildTaxonomyCacheWorker.perform_async
+  end
+end

--- a/lib/taxonomy/govuk_taxonomy.rb
+++ b/lib/taxonomy/govuk_taxonomy.rb
@@ -7,16 +7,13 @@ module Taxonomy
 
     def children
       @_children ||= begin
-        @adapter.published_taxon_data
-          .map { |taxon_hash| build_tree(taxon_hash) }
+        @adapter.published_taxon_data.map { |taxon_hash| build_tree(taxon_hash) }
       end
     end
 
     def draft_child_taxons
       @_draft_child_taxons ||= begin
-        @adapter.draft_taxon_data
-          .select { |taxon_hash| visible_to_departmental_editors?(taxon_hash) }
-          .map { |taxon_hash| build_tree(taxon_hash) }
+        @adapter.draft_taxon_data.map { |taxon_hash| build_tree(taxon_hash) }
       end
     end
 
@@ -26,13 +23,7 @@ module Taxonomy
 
   private
 
-    def visible_to_departmental_editors?(taxon_hash)
-      taxon_hash.fetch('details', {})['visible_to_departmental_editors']
-    end
-
     def build_tree(taxon_hash)
-      tree_data = @adapter.tree_data(taxon_hash['content_id'])
-      taxon_hash['expanded_links_hash'] = tree_data
       @tree_builder_class.new(taxon_hash).root_taxon
     end
   end

--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -24,7 +24,9 @@ module Taxonomy
 
     def expand_taxon_array(taxons)
       taxons.map do |taxon_hash|
-        taxon_hash['expanded_links_hash'] = tree_data(taxon_hash['content_id'])
+        taxon_hash.tap do |hash|
+          hash['expanded_links_hash'] = tree_data(taxon_hash['content_id'])
+        end
       end
     end
 

--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -3,18 +3,34 @@ module Taxonomy
     HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
 
     def draft_taxon_data
-      @_draft_data ||= all_taxon_data_including_draft - published_taxon_data
+      @_draft_data ||= begin
+        taxons = all_taxon_data_including_draft - published_taxon_data
+        expand_taxon_array only_visible_taxons(taxons)
+      end
     end
 
     def published_taxon_data
-      @_published_data ||= get_root_taxons(with_drafts: false)
+      @_published_data ||= begin
+        taxons = get_root_taxons(with_drafts: false)
+        expand_taxon_array(taxons)
+      end
+    end
+
+  private
+
+    def only_visible_taxons(taxons)
+      taxons.select { |taxon_hash| taxon_hash.fetch('details', {})['visible_to_departmental_editors'] }
+    end
+
+    def expand_taxon_array(taxons)
+      taxons.map do |taxon_hash|
+        taxon_hash['expanded_links_hash'] = tree_data(taxon_hash['content_id'])
+      end
     end
 
     def tree_data(content_id)
       get_expanded_links_hash(content_id, cache_expiry: 1.hour, with_drafts: true)
     end
-
-  private
 
     def all_taxon_data_including_draft
       @_all_data ||= get_root_taxons(with_drafts: true)

--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -1,0 +1,30 @@
+module Taxonomy
+  class RedisCacheAdapter
+    DRAFT_TAXONS_CACHE_KEY = "govuk_taxonomy_draft_taxons".freeze
+    PUBLISHED_TAXONS_CACHE_KEY = "govuk_taxonomy_published_taxons".freeze
+
+    def initialize(redis_client = Redis.new, adapter = PublishingApiAdapter.new)
+      @redis_client = redis_client
+      @adapter = adapter
+    end
+
+    def rebuild_caches
+      set_draft_taxon_data
+      set_published_taxon_data
+    end
+
+  private
+
+    attr_reader :redis_client, :adapter
+
+    def set_draft_taxon_data
+      data = adapter.draft_taxon_data
+      redis_client.set DRAFT_TAXONS_CACHE_KEY, JSON.dump(data)
+    end
+
+    def set_published_taxon_data
+      data = adapter.published_taxon_data
+      redis_client.set PUBLISHED_TAXONS_CACHE_KEY, JSON.dump(data)
+    end
+  end
+end

--- a/test/unit/taxonomy/govuk_taxonomy_test.rb
+++ b/test/unit/taxonomy/govuk_taxonomy_test.rb
@@ -2,110 +2,31 @@ require 'test_helper'
 
 class Taxonomy::GovukTaxonomyTest < ActiveSupport::TestCase
   setup do
-    @tree_builder_class = stub
     @test_adapter = stub
+    @taxon_tree = stub
+    @taxon = stub(root_taxon: @taxon_tree)
+    @tree_builder_class = stub(new: @taxon)
 
     @subject = Taxonomy::GovukTaxonomy.new(adapter: @test_adapter, tree_builder_class: @tree_builder_class)
   end
 
   test "#children" do
-    tree_instance = stub(root_taxon: :root_taxon)
-    setup_test_doubles_for_two_published_taxons(tree_instance)
-
+    @test_adapter.stubs(:published_taxon_data).returns([:taxon, :taxon])
     result = @subject.children
-    assert_equal [:root_taxon, :root_taxon], result
+    assert_equal result, [@taxon_tree, @taxon_tree]
   end
 
   test "#draft_child_taxons" do
-    tree_instance = stub(root_taxon: :root_taxon)
-    setup_test_doubles_including_one_visible_draft_taxon(tree_instance)
-
+    @test_adapter.stubs(:draft_taxon_data).returns([:taxon, :taxon])
     result = @subject.draft_child_taxons
-    assert_equal [:root_taxon], result
+    assert_equal result, [@taxon_tree, @taxon_tree]
   end
 
   test "#all_taxons" do
-    tree_instance = stub(root_taxon: stub(tree: [:sub_taxon]))
-    setup_test_doubles_with_one_published_and_one_visible_draft(tree_instance)
-
+    @test_adapter.stubs(:published_taxon_data).returns([:taxon, :taxon])
+    @test_adapter.stubs(:draft_taxon_data).returns([:taxon, :taxon])
+    @taxon_tree.stubs(:tree).returns(:root_taxon)
     result = @subject.all_taxons
-    assert_equal [:sub_taxon, :sub_taxon], result
-  end
-
-  class TestTaxon
-    attr_reader :id
-
-    def initialize
-      @id = 5.times.map { |_| ('a'..'z').to_a.sample }.join
-    end
-
-    def to_h
-      { "content_id" => id }
-    end
-
-    def tree
-      "dummy_taxonomy_tree"
-    end
-
-    def expanded_links
-      taxon_hash = self.to_h
-      taxon_hash["expanded_links_hash"] = tree
-      taxon_hash
-    end
-  end
-
-  class VisibleDraftTaxon < TestTaxon
-    def to_h
-      {
-        "content_id" => id,
-        "details" => {
-          "visible_to_departmental_editors" => true
-        }
-      }
-    end
-  end
-
-  def setup_test_doubles_with_one_published_and_one_visible_draft(tree_instance)
-    published_taxons = [TestTaxon.new]
-    draft_taxons = [VisibleDraftTaxon.new]
-    stub_test_adapter(published_taxons, draft_taxons, tree_instance)
-  end
-
-  def setup_test_doubles_including_one_visible_draft_taxon(tree_instance)
-    published_taxons = [TestTaxon.new, TestTaxon.new]
-    draft_taxons = [VisibleDraftTaxon.new, TestTaxon.new]
-    stub_test_adapter(published_taxons, draft_taxons, tree_instance)
-  end
-
-  def setup_test_doubles_for_two_published_taxons(tree_instance)
-    published_taxons = [TestTaxon.new, TestTaxon.new]
-    draft_taxons = []
-    stub_test_adapter(published_taxons, draft_taxons, tree_instance)
-  end
-
-  def stub_test_adapter(published_taxons, draft_taxons, tree_instance)
-    setup_draft_taxons(draft_taxons)
-    setup_published_taxons(published_taxons)
-
-    draft_taxons.each { |taxon| setup_tree_data(taxon) }
-    published_taxons.each { |taxon| setup_tree_data(taxon) }
-
-    (published_taxons + draft_taxons).each do |taxon|
-      @tree_builder_class.stubs(:new).with(taxon.expanded_links).returns(tree_instance)
-    end
-  end
-
-  def setup_published_taxons(root_taxons)
-    result = root_taxons.map(&:to_h)
-    @test_adapter.stubs(:published_taxon_data).returns(result)
-  end
-
-  def setup_draft_taxons(root_taxons)
-    result = root_taxons.map(&:to_h)
-    @test_adapter.stubs(:draft_taxon_data).returns(result)
-  end
-
-  def setup_tree_data(dummy_taxon)
-    @test_adapter.stubs(:tree_data).with(dummy_taxon.id).returns(dummy_taxon.tree)
+    assert_equal result, [:root_taxon, :root_taxon, :root_taxon, :root_taxon]
   end
 end

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -6,23 +6,33 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
   end
 
   test "#published_taxon_data" do
-    setup_published_taxons(["published_taxon"])
+    setup_published_taxons([published_taxon])
     result = subject.published_taxon_data
-    assert result == ["published_taxon"]
-  end
-
-  test "#tree_data" do
-    taxon_data = { "content_id" => "123" }
-    setup_expanded_taxon_data(taxon_data)
-    result = subject.tree_data("123")
-    assert_equal taxon_data, result
+    assert result == [published_taxon]
   end
 
   test "#draft_taxon_data" do
-    setup_published_taxons(["published"])
-    setup_draft_taxons(["draft"])
+    setup_published_taxons([published_taxon])
+    setup_draft_taxons([visible_draft_taxon, draft_taxon])
     result = subject.draft_taxon_data
-    assert_equal ["draft"], result
+    assert_equal [visible_draft_taxon], result
+  end
+
+  def published_taxon
+    { "content_id" => "published" }
+  end
+
+  def draft_taxon
+    { "content_id" => "draft" }
+  end
+
+  def visible_draft_taxon
+    {
+      "content_id" => "visible_and_draft",
+      "details" => {
+        "visible_to_departmental_editors" => true
+      }
+    }
   end
 
   def setup_published_taxons(root_taxons)
@@ -33,6 +43,10 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
       }
     }
     publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: false)
+
+    root_taxons.each do |taxon|
+      publishing_api_has_expanded_links(taxon, with_drafts: true)
+    end
   end
 
   def setup_draft_taxons(root_taxons)
@@ -43,9 +57,9 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
       }
     }
     publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: true)
-  end
 
-  def setup_expanded_taxon_data(taxon)
-    publishing_api_has_expanded_links(taxon, with_drafts: true)
+    root_taxons.each do |taxon|
+      publishing_api_has_expanded_links(taxon, with_drafts: true)
+    end
   end
 end

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -8,14 +8,20 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
   test "#published_taxon_data" do
     setup_published_taxons([published_taxon])
     result = subject.published_taxon_data
-    assert result == [published_taxon]
+    assert_equal result, [published_taxon_tree]
   end
 
   test "#draft_taxon_data" do
     setup_published_taxons([published_taxon])
     setup_draft_taxons([visible_draft_taxon, draft_taxon])
     result = subject.draft_taxon_data
-    assert_equal [visible_draft_taxon], result
+    assert_equal [visible_draft_taxon_tree], result
+  end
+
+  def published_taxon_tree
+    published_taxon.tap do |taxon|
+      taxon['expanded_links_hash'] = published_taxon
+    end
   end
 
   def published_taxon
@@ -24,6 +30,12 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
 
   def draft_taxon
     { "content_id" => "draft" }
+  end
+
+  def visible_draft_taxon_tree
+    visible_draft_taxon.tap do |taxon|
+      taxon['expanded_links_hash'] = visible_draft_taxon
+    end
   end
 
   def visible_draft_taxon

--- a/test/unit/taxonomy/redis_cache_adapter_test.rb
+++ b/test/unit/taxonomy/redis_cache_adapter_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class Taxonomy::RedisCacheAdapterTest < ActiveSupport::TestCase
+  def subject
+    Taxonomy::RedisCacheAdapter.new(redis_client, publishing_api_adapter)
+  end
+
+  def redis_client
+    @client ||= stub
+  end
+
+  def publishing_api_adapter
+    @adapter ||= stub
+  end
+
+  test "#rebuild_caches" do
+    draft_taxons = { 'foo' => 'bar' }
+    published_taxons = { 'baz' => 'qux' }
+    publishing_api_adapter.stubs(:draft_taxon_data).returns(draft_taxons)
+    publishing_api_adapter.stubs(:published_taxon_data).returns(published_taxons)
+    redis_client.expects(:set).with("govuk_taxonomy_draft_taxons", JSON.dump(draft_taxons))
+    redis_client.expects(:set).with("govuk_taxonomy_published_taxons", JSON.dump(published_taxons))
+    subject.rebuild_caches
+  end
+end


### PR DESCRIPTION
We've been seeing a lot of timeouts from the calls to `publishing_api#get_expanded_links` for `Taxon` types with a large number of recursively resolved sub-taxons. This is despite having the results of these calls stored in the Rails cache - a per-machine memcache instance in this case.

This change sets up a single shared cache in Redis, which is designed to never-expire. A background process which runs every hour will repopulate the cache.

A follow-up PR will change the GovukTaxonomy class to read from the api-compatible cache-backed adapter class.

[Trello](https://trello.com/c/fsehBQ7s/124-dealing-with-slowness-within-publishing-api)