### PR TITLE
Change govuk taxonomy to use redis cache

### DIFF
--- a/lib/taxonomy/govuk_taxonomy.rb
+++ b/lib/taxonomy/govuk_taxonomy.rb
@@ -1,6 +1,6 @@
 module Taxonomy
   class GovukTaxonomy
-    def initialize(adapter: PublishingApiAdapter.new, tree_builder_class: Tree)
+    def initialize(adapter: RedisCacheAdapter.new, tree_builder_class: Tree)
       @adapter = adapter
       @tree_builder_class = tree_builder_class
     end

--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -31,7 +31,7 @@ module Taxonomy
     end
 
     def tree_data(content_id)
-      get_expanded_links_hash(content_id, cache_expiry: 1.hour, with_drafts: true)
+      get_expanded_links_hash(content_id, with_drafts: true)
     end
 
     def all_taxon_data_including_draft
@@ -39,15 +39,13 @@ module Taxonomy
     end
 
     def get_root_taxons(with_drafts:)
-      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, cache_expiry: 24.hours, with_drafts: with_drafts)
+      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
         .fetch('expanded_links', {})
         .fetch('root_taxons', [])
     end
 
-    def get_expanded_links_hash(content_id, cache_expiry:, with_drafts:)
-      Rails.cache.fetch("#{self.class.name}_expanded_links_#{content_id}_#{with_drafts}", expires_in: cache_expiry) do
-        Services.publishing_api.get_expanded_links(content_id, with_drafts: with_drafts).to_h
-      end
+    def get_expanded_links_hash(content_id, with_drafts:)
+      Services.publishing_api.get_expanded_links(content_id, with_drafts: with_drafts).to_h
     end
   end
 end

--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -3,9 +3,17 @@ module Taxonomy
     DRAFT_TAXONS_CACHE_KEY = "govuk_taxonomy_draft_taxons".freeze
     PUBLISHED_TAXONS_CACHE_KEY = "govuk_taxonomy_published_taxons".freeze
 
-    def initialize(redis_client = Redis.new, adapter = PublishingApiAdapter.new)
+    def initialize(redis_client: Redis.current, adapter: PublishingApiAdapter.new)
       @redis_client = redis_client
       @adapter = adapter
+    end
+
+    def draft_taxon_data
+      JSON.parse redis_client.get(DRAFT_TAXONS_CACHE_KEY)
+    end
+
+    def published_taxon_data
+      JSON.parse redis_client.get(PUBLISHED_TAXONS_CACHE_KEY)
     end
 
     def rebuild_caches

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
     @edition = create(:publication, organisations: [organisation])
 
-    stub_taxonomy_with_draft_expanded_links
+    stub_taxonomy_with_all_taxons
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)

--- a/test/functional/admin/statistics_announcement_tags_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_tags_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::StatisticsAnnouncementTagsControllerTest < ActionController::TestCa
     organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
     @announcement = create(:statistics_announcement, organisations: [organisation])
 
-    stub_taxonomy_with_draft_expanded_links
+    stub_taxonomy_with_all_taxons
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)

--- a/test/unit/models/taxonomy_tag_form_test.rb
+++ b/test/unit/models/taxonomy_tag_form_test.rb
@@ -41,7 +41,7 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
   end
 
   test '#most_specific_taxons ignores taxons if there is a more specific one' do
-    stub_taxonomy_with_draft_expanded_links
+    stub_taxonomy_with_all_taxons
 
     selected_taxons = [
       grandparent_taxon_content_id,

--- a/test/unit/taxonomy/redis_cache_adapter_test.rb
+++ b/test/unit/taxonomy/redis_cache_adapter_test.rb
@@ -2,7 +2,10 @@ require 'test_helper'
 
 class Taxonomy::RedisCacheAdapterTest < ActiveSupport::TestCase
   def subject
-    Taxonomy::RedisCacheAdapter.new(redis_client, publishing_api_adapter)
+    Taxonomy::RedisCacheAdapter.new(
+      redis_client: redis_client,
+      adapter: publishing_api_adapter
+    )
   end
 
   def redis_client


### PR DESCRIPTION
This is the second part of https://github.com/alphagov/whitehall/pull/3298

It changes the gov.uk taxonomy implementation to rely solely on the contents of the Redis cache.

[Trello](https://trello.com/c/fsehBQ7s/124-dealing-with-slowness-within-publishing-api)