### PR TITLE
Move locking of taxonomy cache job to rake

### DIFF
--- a/app/workers/rebuild_taxonomy_cache_worker.rb
+++ b/app/workers/rebuild_taxonomy_cache_worker.rb
@@ -1,23 +1,7 @@
-require 'redis-lock'
-
 class RebuildTaxonomyCacheWorker
   include Sidekiq::Worker
 
   def perform
-    run_on_one_app_instance_only do
-      Taxonomy::RedisCacheAdapter.new.rebuild_caches
-    end
-  end
-
-private
-
-  def run_on_one_app_instance_only
-    Redis.current.lock(key, life: 600, acquire: 1) do
-      yield
-    end
-  end
-
-  def key
-    "rebuild_taxonomy_cache_worker_lock"
+    Taxonomy::RedisCacheAdapter.new.rebuild_caches
   end
 end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -1,5 +1,10 @@
+require 'redis-lock'
+
 namespace :taxonomy do
   task rebuild_cache: [:environment] do
-    RebuildTaxonomyCacheWorker.perform_async
+    Redis.current.lock("rebuild_taxonomy_cache_worker_lock", life: 10.minutes, acquire: 1) do
+      Rails.logger.info "Scheduling taxonomy cache rebuild"
+      RebuildTaxonomyCacheWorker.perform_async
+    end
   end
 end


### PR DESCRIPTION
Having this lock inside the worker means that we'll still execute multiple workers. Moving it to the cron job is better because the job will actually just be executed once.

https://trello.com/c/fsehBQ7s