### PR TITLE
Set 60 second timeout for taxonomy cache generation

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -45,7 +45,15 @@ module Taxonomy
     end
 
     def get_expanded_links_hash(content_id, with_drafts:)
-      Services.publishing_api.get_expanded_links(content_id, with_drafts: with_drafts).to_h
+      publishing_api_with_huge_timeout.get_expanded_links(content_id, with_drafts: with_drafts).to_h
+    end
+
+    def publishing_api_with_huge_timeout
+      @publishing_api_with_huge_timeout ||= begin
+        Services.publishing_api.dup.tap do |client|
+          client.options[:timeout] = 60
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We're still seeing publishing-api timeouts when populating the caches. The PublishingApiAdapter class is only used from a worker, which means that we can set an enormous timeout. Hopefully this increases the number of successful cache rebuilds.

https://trello.com/c/fsehBQ7s