### PR TITLE
Increase the number of cache refreshes for taxonomy

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,6 +12,6 @@ every :hour, roles: [:backend] do
   rake "rummager:index:consultations"
 end
 
-every :hour, roles: [:backend] do
+every 10.minutes, roles: [:backend] do
   rake "taxonomy:rebuild_cache"
 end


### PR DESCRIPTION
This will make it easier to observe the behaviour. Once we're confident this works we can dial down the frequency.

https://trello.com/c/fsehBQ7s