### PR TITLE
Make world location base_path less

### DIFF
--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -25,14 +25,22 @@ module PublishingApi
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
+        schema_name: "world_location",
       )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      if international_delegation?
+        content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      end
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
 
     def links
       {}
+    end
+
+  private
+
+    def international_delegation?
+      item.world_location_type_id == WorldLocationType::InternationalDelegation.id
     end
   end
 end

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -36,6 +36,8 @@ private
       PublishingApi::WorldLocationPresenter
     when ::MinisterialRole
       PublishingApi::MinisterialRolePresenter
+    when ::WorldLocation
+      PublishingApi::WorldLocationPresenter
     when ::WorldwideOrganisation
       PublishingApi::WorldwideOrganisationPresenter
     when ::Contact

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -7,19 +7,16 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
 
   test 'presents a World Location ready for adding to the publishing API' do
     world_location = create(:world_location, name: 'Locationia', analytics_identifier: 'WL123')
-    public_path = Whitehall.url_maker.world_location_path(world_location)
 
     expected_hash = {
-      base_path: public_path,
       title: "Locationia",
       description: nil,
-      schema_name: "placeholder",
+      schema_name: "world_location",
       document_type: "world_location",
       locale: 'en',
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',
       public_updated_at: world_location.updated_at,
-      routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       need_ids: [],
       details: {},
@@ -34,6 +31,6 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal world_location.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, 'placeholder')
+    assert_valid_against_schema(presented_item.content, 'world_location')
   end
 end


### PR DESCRIPTION
WorldLocation pages are being converted to worldwide taxonomy and will no longer be renderable. To facilitate this we will now consider them base_path-less content.

This commit updates the schema for this format and modifies the presenter to match.

WorldLocations of type InternationalDelegation will continue to be rendered by Whitehall so the presenter will still present a base_path for those to the publishing API.

The problem with this approach is that it will break pages that are using this link in the UI as it will no longer be usable to generate a URL. We are planning to implement an association between the world location and the taxon that can be expanded in the world location link and used for generating links in the UI. Removing the World Location link type altogether is not feasible currently as not all content will be tagged to the taxon (e.g. news). In the short term we will add a lookup based link helper to government-frontend.

[Trello](https://trello.com/c/6tio72jl/221-split-world-locations-from-international-delegations-in-whitehall)