### PR TITLE
Fix an over-specific scope joining StatisticsAnnouncements to Publications

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -113,7 +113,7 @@ class StatisticsAnnouncement < ApplicationRecord
   def self.without_published_publication
     includes(:publication).
       references(:editions).
-      where("publication_id IS NULL || editions.state NOT IN (?)", Edition::POST_PUBLICATION_STATES)
+      where("editions.id IS NULL || editions.state NOT IN (?)", Edition::POST_PUBLICATION_STATES)
   end
 
   def self.with_topics(topic_ids)


### PR DESCRIPTION
The `StatisticsAnnouncements.without_published_publication` scope was failing
to include announcements associated with deleted publications, because
the 'publication_id' referenced in the `where` clause is not NULL in that
case.

By changing the WHERE clause to reference the `id` field of the `included`
table, ActiveRecord builds a left-outer join which gives us the resultset
we expect.

[Fixes](https://govuk.zendesk.com/agent/tickets/2214782)