### PR TITLE
Remove worldwide organisations from tagging yml

### DIFF
--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -18,8 +18,3 @@ organisations_in_tagging_beta:
     - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
     - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
   worldwide_related:
-    - "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
-    - "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
-    - "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
-    - "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
-    - "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union


### PR DESCRIPTION
For https://trello.com/c/6MObnZSc/211-enable-the-whitehall-tagging-interface-for-worldwide-content

We are not ready to go live with tagging of documents to worldwide related
orgs yet. By removing the organisations from this yml file, we will be able
to deploy our code changes now.

We expect to revert this some time next week (26 - 30th of June)