### PR TITLE
Add description and summary to worldwide organisations

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -59,6 +59,7 @@ class WorldwideOrganisation < ApplicationRecord
 
   include Searchable
   searchable title: :name,
+             description: :summary,
              link: :search_link,
              content: :summary,
              format: 'worldwide_organisation'

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        description: nil,
+        description: description,
         details: {},
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
@@ -33,6 +33,10 @@ module PublishingApi
 
     def links
       {}
+    end
+
+    def description
+      item.summary
     end
   end
 end

--- a/db/data_migration/20170622082508_republish_all_worldwide_organisations.rb
+++ b/db/data_migration/20170622082508_republish_all_worldwide_organisations.rb
@@ -1,0 +1,5 @@
+all_worldwide_orgs = WorldwideOrganisation.all
+
+all_worldwide_orgs.each do |worldwide_org|
+  worldwide_org.save
+end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -213,7 +213,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
                   'link' => '/government/world/organisations/british-embassy-to-hat-land',
                   'indexable_content' => 'Providing assistance to uk residents in hat land',
                   'format' => 'worldwide_organisation',
-                  'description' => ''}, worldwide_organisation.search_index)
+                  'description' => 'Providing assistance to uk residents in hat land' }, worldwide_organisation.search_index)
   end
 
   test 'knows if a given office is on its home page' do


### PR DESCRIPTION
We want the Worldwide Organisation Summary to display under the title on the new taxon navigation pages.

To do this, we add the summary text to the `description` field in the schema when sending to Publishing Api and also include the `description` as a `searchable` field for Rummager.

Included is a data migration to republish all the Worldwide Organisations so we push the data through the pipes.

Part of https://trello.com/c/WAX1kJnP/222-ensure-worldwide-organisations-and-worldwide-news-pages-display-summary-text

This also relies [PR 350](https://github.com/alphagov/collections/pull/350) in Collections to bring back all tagged content for the pages rather than only `guidance`.

### Without summary (before):
<img width="619" alt="screen shot 2017-06-22 at 09 52 10" src="https://user-images.githubusercontent.com/647311/27425641-faacde18-5730-11e7-8f5e-bcb99cb86a00.png">

### With summary (after):
<img width="613" alt="screen shot 2017-06-22 at 09 52 24" src="https://user-images.githubusercontent.com/647311/27425591-cc63a8b6-5730-11e7-9bd2-be329b69ab98.png">

