### PR TITLE
Redirect /world to /government/world

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,11 @@ Whitehall::Application.routes.draw do
     ::Whitehall.admin_host == request.host
   }
 
+  # Redirect everything under /world to /government/world
+  # It may look like we're redirecting back to the same page but the
+  # destination is automatically prefixed with /government by Rails.
+  get '/world/*page' => redirect('/world/%{page}')
+
   get '/government/ministers/minister-of-state--11' => redirect('/government/people/kris-hopkins', prefix: '')
 
   namespace 'api' do


### PR DESCRIPTION
This commit adds a redirect from `/world` to `/government/world`. This is in preparation for the migration of all content from `/government/world` to `/world`. Before this migration, the existing router prefix redirect will be removed, therefore whitehall will handle redirecting from one prefix to the other.

Trello: https://trello.com/c/Sea8M6TG/243-add-whitehall-redirect-from-world-to-government-world