### PR TITLE
Add redirect checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'govuk_ab_testing', '~> 2.2.0'
 gem 'mlanett-redis-lock'
 gem 'deprecated_columns', '0.1.1'
+gem 'faraday'
 
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,6 +482,7 @@ DEPENDENCIES
   dotenv-rails
   equivalent-xml (~> 0.6.0)
   factory_girl
+  faraday
   friendly_id (~> 5.2.1)
   gds-api-adapters (~> 45.0.0)
   gds-sso (~> 13.2)

--- a/lib/tasks/worldwide_redirect_check.rake
+++ b/lib/tasks/worldwide_redirect_check.rake
@@ -1,0 +1,93 @@
+# require 'lib/worldwide_redirect_checker'
+
+desc "Check redirects for worldwide redirects from /government/world to /world"
+task worldwide_redirect_check: :environment do
+  # WORLD_LOCATIONS
+
+  # test_redirects = [
+  #   {
+  #     url: "/government/world/organisations/uk-trade-investment-russia",
+  #     redirect_url: "/government/world/organisations/department-for-international-trade-russia",
+  #   }
+  # ]
+
+  world_location_root_redirects = [
+    {
+      url: "/government/world",
+      redirect_url: "/world",
+    }
+  ]
+
+  world_location_redirects_for_en = WorldLocation.all.map do |wl|
+    {
+      url: "/government/world/#{wl.slug}",
+      redirect_url: "/world/#{wl.slug}",
+    }
+  end
+
+  world_location_redirects_for_other_locales = [
+    # TODO, will need to fetch the translations somehow
+  ]
+
+  world_location_news_redirects_for_en_locale = WorldLocation.all.map do |wl|
+    {
+      url: "/government/world/#{wl.slug}/news",
+      redirect_url: "/world/#{wl.slug}/news",
+    }
+  end
+
+  world_location_news_redirects_for_other_locales = [
+    # TODO, will need to fetch the translations somehow
+  ]
+
+
+  # WORLDWIDE_ORGANISATIONS
+
+  worldwide_organisations_root_redirect = [
+    {
+      url: "/government/world/organisations",
+      redirect_url: "/world/organisations",
+    }
+  ]
+  worldwide_organisations_redirects = [
+    # TODO
+  ]
+  worldwide_organisation_corporate_information_pages_redirects = [
+    # TODO
+  ]
+  worldwide_organisation_about_redirects = [
+    # TODO
+  ]
+  worldwide_organisation_offices_redirects = [
+    # TODO
+  ]
+
+
+  # EMBASSIES FINDER PAGE
+
+  worldwide_embassies_root_redirects = [
+    {
+      url: "/government/world/embassies",
+      redirect_url: "/world/embassies",
+    }
+  ]
+
+  redirects = [
+    # test_redirects,
+    world_location_root_redirects,
+    world_location_redirects_for_en,
+    world_location_redirects_for_other_locales,
+    world_location_news_redirects_for_en_locale,
+    world_location_news_redirects_for_other_locales,
+    worldwide_organisations_root_redirect,
+    worldwide_organisations_redirects,
+    worldwide_organisation_corporate_information_pages_redirects,
+    worldwide_organisation_about_redirects,
+    worldwide_organisation_offices_redirects,
+    worldwide_embassies_root_redirects,
+  ]
+
+  redirects.each do |r_list|
+    WorldwideRedirectChecker.new(r_list).call
+  end
+end

--- a/lib/tasks/worldwide_redirect_check.rake
+++ b/lib/tasks/worldwide_redirect_check.rake
@@ -1,93 +1,172 @@
-# require 'lib/worldwide_redirect_checker'
+namespace :worldwide_redirect_check do
+  desc "Check redirects for worldwide redirects from /government/world to /world"
+  task check_all: :environment do
+    Rake::Task["worldwide_redirect_check:check_world_root"].invoke
 
-desc "Check redirects for worldwide redirects from /government/world to /world"
-task worldwide_redirect_check: :environment do
-  # WORLD_LOCATIONS
+    Rake::Task["worldwide_redirect_check:check_embassies_root"].invoke
 
-  # test_redirects = [
-  #   {
-  #     url: "/government/world/organisations/uk-trade-investment-russia",
-  #     redirect_url: "/government/world/organisations/department-for-international-trade-russia",
-  #   }
-  # ]
+    Rake::Task["worldwide_redirect_check:check_world_locations"].invoke
+    Rake::Task["worldwide_redirect_check:check_non_english_world_locations"].invoke
+    Rake::Task["worldwide_redirect_check:check_world_location_news"].invoke
+    Rake::Task["worldwide_redirect_check:check_non_english_world_location_news"].invoke
 
-  world_location_root_redirects = [
-    {
-      url: "/government/world",
-      redirect_url: "/world",
-    }
-  ]
-
-  world_location_redirects_for_en = WorldLocation.all.map do |wl|
-    {
-      url: "/government/world/#{wl.slug}",
-      redirect_url: "/world/#{wl.slug}",
-    }
+    Rake::Task["worldwide_redirect_check:check_world_organisations_root"].invoke
+    Rake::Task["worldwide_redirect_check:check_world_organisations"].invoke
+    Rake::Task["worldwide_redirect_check:check_non_english_world_organisations"].invoke
+    Rake::Task["worldwide_redirect_check:check_world_organisation_corporate_information_pages"].invoke
+    Rake::Task["worldwide_redirect_check:check_non_english_world_organisation_corporate_information_pages"].invoke
   end
 
-  world_location_redirects_for_other_locales = [
-    # TODO, will need to fetch the translations somehow
-  ]
-
-  world_location_news_redirects_for_en_locale = WorldLocation.all.map do |wl|
-    {
-      url: "/government/world/#{wl.slug}/news",
-      redirect_url: "/world/#{wl.slug}/news",
-    }
+  # Only used for testing, not called in `check_all` rake task
+  task check_test_redirect: :environment do
+    test_redirects = [
+      {
+        url: "/government/world/organisations/uk-trade-investment-russia",
+        redirect_url: "/government/world/organisations/department-for-international-trade-russia",
+      }
+    ]
+    WorldwideRedirectChecker.new(test_redirects).call
   end
 
-  world_location_news_redirects_for_other_locales = [
-    # TODO, will need to fetch the translations somehow
-  ]
+  task check_world_root: :environment do
+    world_location_root_redirects = [
+      {
+        url: "/government/world",
+        redirect_url: "/world",
+      }
+    ]
+    WorldwideRedirectChecker.new(world_location_root_redirects).call
+  end
 
+  task check_embassies_root: :environment do
+    worldwide_embassies_root_redirects = [
+      {
+        url: "/government/world/embassies",
+        redirect_url: "/world/embassies",
+      }
+    ]
+    WorldwideRedirectChecker.new(worldwide_embassies_root_redirects).call
+  end
 
-  # WORLDWIDE_ORGANISATIONS
+  task check_world_locations: :environment do
+    # There are 238 WorldLocations
+    world_location_redirects_for_en_locale = WorldLocation.all.map do |wl|
+      {
+        url: "/government/world/#{wl.slug}",
+        redirect_url: "/world/#{wl.slug}",
+      }
+    end
+    WorldwideRedirectChecker.new(world_location_redirects_for_en_locale).call
+  end
 
-  worldwide_organisations_root_redirect = [
-    {
-      url: "/government/world/organisations",
-      redirect_url: "/world/organisations",
-    }
-  ]
-  worldwide_organisations_redirects = [
-    # TODO
-  ]
-  worldwide_organisation_corporate_information_pages_redirects = [
-    # TODO
-  ]
-  worldwide_organisation_about_redirects = [
-    # TODO
-  ]
-  worldwide_organisation_offices_redirects = [
-    # TODO
-  ]
+  task check_non_english_world_locations: :environment do
+    world_location_redirects_for_other_locales = []
+    WorldLocation.all.each do |wl|
+      wl.non_english_translated_locales.each do |twl|
+        expectation = {
+          url: "/government/world/#{wl.slug}.#{twl.code}",
+          redirect_url: "/world/#{wl.slug}",
+        }
+        world_location_redirects_for_other_locales.push(expectation)
+      end
+    end
+    WorldwideRedirectChecker.new(world_location_redirects_for_other_locales).call
+  end
 
+  task check_world_location_news: :environment do
+    world_location_news_redirects_for_en_locale = WorldLocation.all.map do |wl|
+      {
+        url: "/government/world/#{wl.slug}/news",
+        redirect_url: "/world/#{wl.slug}/news",
+      }
+    end
+    WorldwideRedirectChecker.new(world_location_news_redirects_for_en_locale).call
+  end
 
-  # EMBASSIES FINDER PAGE
+  task check_non_english_world_location_news: :environment do
+    world_location_news_redirects_for_other_locales = []
+    WorldLocation.all.each do |wl|
+      wl.non_english_translated_locales.each do |twl|
+        expectation = {
+          url: "/government/world/#{wl.slug}/news.#{twl.code}",
+          redirect_url: "/world/#{wl.slug}/news.#{twl.code}",
+        }
+        world_location_news_redirects_for_other_locales.push(expectation)
+      end
+    end
+    WorldwideRedirectChecker.new(world_location_news_redirects_for_other_locales).call
+  end
 
-  worldwide_embassies_root_redirects = [
-    {
-      url: "/government/world/embassies",
-      redirect_url: "/world/embassies",
-    }
-  ]
+  task check_world_organisations_root: :environment do
+    worldwide_organisations_root_redirect = [
+      {
+        url: "/government/world/organisations",
+        redirect_url: "/world/organisations",
+      }
+    ]
+    WorldwideRedirectChecker.new(worldwide_organisations_root_redirect).call
+  end
 
-  redirects = [
-    # test_redirects,
-    world_location_root_redirects,
-    world_location_redirects_for_en,
-    world_location_redirects_for_other_locales,
-    world_location_news_redirects_for_en_locale,
-    world_location_news_redirects_for_other_locales,
-    worldwide_organisations_root_redirect,
-    worldwide_organisations_redirects,
-    worldwide_organisation_corporate_information_pages_redirects,
-    worldwide_organisation_about_redirects,
-    worldwide_organisation_offices_redirects,
-    worldwide_embassies_root_redirects,
-  ]
+  task check_world_organisations: :environment do
+    # There are 444 WorldLocations
+    world_location_redirects_for_en_locale = WorldwideOrganisation.all.map do |wo|
+      {
+        url: "/government/world/organisations/#{wo.slug}",
+        redirect_url: "/world/organisations/#{wo.slug}",
+      }
+    end
+    WorldwideRedirectChecker.new(world_location_redirects_for_en_locale).call
+  end
 
-  redirects.each do |r_list|
-    WorldwideRedirectChecker.new(r_list).call
+  task check_non_english_world_organisations: :environment do
+    world_organisations_for_other_locales = []
+    WorldwideOrganisation.all.each do |wwo|
+      wwo.non_english_translated_locales.each do |wwo_locale|
+        expectation = {
+          url: "/government/world/organisations/#{wwo.slug}.#{wwo_locale.code}",
+          redirect_url: "/world/organisations/#{wwo.slug}.#{wwo_locale.code}",
+        }
+        world_organisations_for_other_locales.push(expectation)
+      end
+    end
+    WorldwideRedirectChecker.new(world_organisations_for_other_locales).call
+  end
+
+  task check_world_organisation_corporate_information_pages: :environment do
+    orgs_with_corporate_info_pages = WorldwideOrganisation.all.select { |wwo| wwo.corporate_information_pages.present? }
+    orgs_with_published_corporate_info_pages = orgs_with_corporate_info_pages.select { |wwo| wwo.corporate_information_pages.published.present? }
+
+    corporate_info_page_redirects = []
+    orgs_with_published_corporate_info_pages.each do |wwo|
+      corporate_info_pages = wwo.corporate_information_pages.published
+      corporate_info_pages.each do |cip|
+        expectation = {
+          url: Whitehall.url_maker.public_document_path(cip),
+          redirect_url: Whitehall.url_maker.public_document_path(cip).gsub('/government', ''),
+        }
+        corporate_info_page_redirects.push(expectation)
+      end
+    end
+    WorldwideRedirectChecker.new(corporate_info_page_redirects).call
+  end
+
+  task check_non_english_world_organisation_corporate_information_pages: :environment do
+    orgs_with_corporate_info_pages = WorldwideOrganisation.all.select { |wwo| wwo.corporate_information_pages.present? }
+    orgs_with_published_corporate_info_pages = orgs_with_corporate_info_pages.select { |wwo| wwo.corporate_information_pages.published.present? }
+
+    corporate_info_page_redirects = []
+    orgs_with_published_corporate_info_pages.each do |wwo|
+      corporate_info_pages = wwo.corporate_information_pages.published
+      corporate_info_pages.each do |cip|
+        cip.non_english_translated_locales.each do |cip_locale|
+          expectation = {
+            url: Whitehall.url_maker.public_document_path(cip, locale: cip_locale),
+            redirect_url: Whitehall.url_maker.public_document_path(cip, locale: cip_locale).gsub('/government', ''),
+          }
+          corporate_info_page_redirects.push(expectation)
+        end
+      end
+    end
+    WorldwideRedirectChecker.new(corporate_info_page_redirects).call
   end
 end

--- a/lib/tasks/worldwide_redirect_check.rake
+++ b/lib/tasks/worldwide_redirect_check.rake
@@ -62,12 +62,15 @@ namespace :worldwide_redirect_check do
   task check_non_english_world_locations: :environment do
     world_location_redirects_for_other_locales = []
     WorldLocation.all.each do |wl|
-      wl.non_english_translated_locales.each do |twl|
-        expectation = {
-          url: "/government/world/#{wl.slug}.#{twl.code}",
-          redirect_url: "/world/#{wl.slug}",
-        }
-        world_location_redirects_for_other_locales.push(expectation)
+      if wl.respond_to?(:original_available_locales)
+        translated_locales = wl.original_available_locales - [:en]
+        translated_locales.each do |twl_locale|
+          expectation = {
+            url: "/government/world/#{wl.slug}.#{twl_locale.code}",
+            redirect_url: "/world/#{wl.slug}",
+          }
+          world_location_redirects_for_other_locales.push(expectation)
+        end
       end
     end
     WorldwideRedirectChecker.new(world_location_redirects_for_other_locales).call

--- a/lib/worldwide_redirect_checker.rb
+++ b/lib/worldwide_redirect_checker.rb
@@ -61,6 +61,19 @@ private
   def connection
     @connection ||= Faraday.new(headers: { accept_encoding: 'none' }) do |faraday|
       faraday.adapter Faraday.default_adapter
+      faraday.basic_auth(user, password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
     end
+  end
+
+  def user
+    creds[0]
+  end
+
+  def password
+    creds[1]
+  end
+
+  def creds
+    ENV["BASIC_AUTH_CREDENTIALS"].split(":")
   end
 end

--- a/lib/worldwide_redirect_checker.rb
+++ b/lib/worldwide_redirect_checker.rb
@@ -1,0 +1,66 @@
+class WorldwideRedirectChecker
+  class Response
+    REDIRECT_CODE = 301
+
+    attr_reader :url, :expected_redirect_url, :connection
+
+    def initialize(url, expected_redirect_url, connection)
+      @url = url
+      @expected_redirect_url = expected_redirect_url
+      @connection = connection
+    end
+
+    def is_correct_redirect?
+      is_redirect? && redirect_url_matches_expected_url?
+    end
+
+    def error_message
+      return "not a redirect (Status: #{http_response.status})" unless is_redirect?
+      return "does not match expected_url (#{response_redirect_url} instead of #{expected_redirect_url})" unless redirect_url_matches_expected_url?
+    end
+
+  private
+
+    def is_redirect?
+      http_response.status == REDIRECT_CODE
+    end
+
+    def redirect_url_matches_expected_url?
+      response_redirect_url == expected_redirect_url
+    end
+
+    def http_response
+      @_response ||= connection.get(URI.parse(Plek.current.website_root + url))
+    end
+
+    def response_redirect_url
+      http_response.headers["location"]
+    end
+  end
+
+  attr_reader :redirects
+
+  def initialize(redirects)
+    @redirects = redirects
+  end
+
+  def call
+    redirects.each do |r|
+      response = Response.new(r[:url], r[:redirect_url], connection)
+
+      if response.is_correct_redirect?
+        puts "✅  Redirect successful: #{r[:url]} -> #{r[:redirect_url]}"
+      else
+        puts "❌  Redirect incorrect: #{r[:url]} - #{response.error_message}"
+      end
+    end
+  end
+
+private
+
+  def connection
+    @connection ||= Faraday.new(headers: { accept_encoding: 'none' }) do |faraday|
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/Rn6Z8W7d/227-add-automated-checks-for-world-redirects

We'll be redirecting all worldwide related content from `/government/world` to `/world`. This checker class will test that the redirects are correct, by making a http request through the whole stack. The idea is that you can add arrays of hashes with a `url` to check and the expected `redirect_url`.