### PR TITLE
Redirect /world to /government/world

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Whitehall::Application.routes.draw do
   # Redirect everything under /world to /government/world
   # It may look like we're redirecting back to the same page but the
   # destination is automatically prefixed with /government by Rails.
+  get '/world' => redirect('/world')
   get '/world/*page' => redirect('/world/%{page}')
 
   get '/government/ministers/minister-of-state--11' => redirect('/government/people/kris-hopkins', prefix: '')


### PR DESCRIPTION
This commit redirects the page at `/world` to `/government/world` (follow-up to https://github.com/alphagov/whitehall/pull/3307).

Trello: https://trello.com/c/Sea8M6TG/243-add-whitehall-redirect-from-world-to-government-world