### PR TITLE
Rake task to add /world prefix route to router

### DIFF
--- a/lib/tasks/add_world_prefix_route.rake
+++ b/lib/tasks/add_world_prefix_route.rake
@@ -1,0 +1,10 @@
+require 'gds_api/router'
+
+namespace :router do
+  desc 'Add the /world prefix route to the router to send all requests to whitehall'
+  task add_world_prefix_route: :environment do
+    router = GdsApi::Router.new(Plek.find('router-api'))
+    router.add_route('/world', 'prefix', 'whitehall-frontend')
+    router.commit_routes
+  end
+end


### PR DESCRIPTION
This commit adds a rake task, which adds a `/world` prefix route to the router. This route will overwrite the exising prefix route which initiates a redirect inside the router. This new prefix route tells the router to send all requests to `/world/*` to whitehall, which will then serve a redirect to `/government/world`.

This is in preparation for the move from `/government/world` to `/world`.

Trello: https://trello.com/c/BCk0rrZv/244-rake-task-to-publish-world-prefix-route-in-router