### PR TITLE
Fix bug with non-unique documents in collection groups

### DIFF
--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -40,7 +40,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
     params[:groups].values.each do |group_params|
       group = @collection.groups.find(group_params[:id])
       group.ordering = group_params[:order]
-      group.set_document_ids_in_order! group_params.fetch(:document_ids, []).map(&:to_i)
+      group.set_document_ids_in_order! group_params.fetch(:document_ids, []).map(&:to_i).uniq
     end
     respond_to do |format|
       format.html { render :index }

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -155,9 +155,27 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_equal [@group_2.id, @group_1.id], @collection.reload.groups.pluck(:id)
   end
 
-  test "POST #update_memberships should support moving memberships between groups" do
+  test "POST #update_memberships should cope with duplicate documents in group" do
     given_two_groups_with_documents
     post :update_memberships, {
+      document_collection_id: @collection.id,
+      groups: {
+        0 => {
+          id: @group_1.id,
+          document_ids: [
+            @doc_1_1.id,
+            @doc_1_1.id
+          ],
+          order: 0
+        }
+      }
+    }
+    assert_equal [@doc_1_1], @group_1.reload.documents
+  end
+
+  test "POST #update_memberships should support moving memberships between groups" do
+    given_two_groups_with_documents
+    post :update_memberships,
       document_collection_id: @collection.id,
       groups: {
         0 => {
@@ -177,7 +195,6 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
           order: 1
         }
       }
-    }
     assert @group_2.reload.documents.include?(@doc_1_2)
   end
 


### PR DESCRIPTION
Bug manifested when attempting to re-order document groups in the
Whitehall admin UI. It would appear to work, but not actually persist.

This fix prevents admin users from adding the same document to a group
twice. Groups that have previously been created with duplicate documents
have been made editable again and will silently discard the non-unique
elements nezt time they are edited.

[Fixes](https://govuk.zendesk.com/agent/tickets/2217107) [Fixes](https://govuk.zendesk.com/agent/tickets/2215130)