### PR TITLE
Enable tagging of DocumentCollections for worldwide organisations

### DIFF
--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -1,7 +1,7 @@
 module Edition::TaggableOrganisations
   extend ActiveSupport::Concern
 
-  WORLD_TAGGABLE_DOCUMENT_TYPES = %w(Publication DetailedGuide).freeze
+  WORLD_TAGGABLE_DOCUMENT_TYPES = %w(Publication DetailedGuide DocumentCollection).freeze
 
   WORLD_TAGGABLE_PUBLICATION_TYPES = [
     PublicationType::Guidance,

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -85,6 +85,12 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     assert edition.can_be_tagged_to_taxonomy?
   end
 
+  test '#can_be_tagged_to_taxonomy? is true for DocumentCollection' do
+    edition = create(:document_collection, organisations: [@lead_org])
+
+    assert edition.can_be_tagged_to_taxonomy?
+  end
+
   # method will return `false` for all other edition types, we choose NewsArticle as example
   test '#can_be_tagged_to_taxonomy? is false for NewsArticle' do
     edition = create(:news_article, organisations: [@lead_org])


### PR DESCRIPTION
For https://trello.com/c/nmzi76Me/247-enable-tagging-of-documentcollections-in-whitehall

This document type also needs to be able to be tagged in the Whitehall tagging interface, see https://github.com/alphagov/whitehall/pull/3297