### PR TITLE
Send world location news pages to publishing api as placeholders

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -23,6 +23,8 @@ class WorldLocation < ApplicationRecord
   accepts_nested_attributes_for :edition_world_locations
   accepts_nested_attributes_for :offsite_links
 
+  after_update :send_news_page_to_publishing_api_and_rummager
+
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = 'WL'
 
@@ -118,4 +120,8 @@ class WorldLocation < ApplicationRecord
 
   extend FriendlyId
   friendly_id
+
+  def send_news_page_to_publishing_api_and_rummager
+    WorldLocationNewsPageWorker.new.perform(self)
+  end
 end

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -1,0 +1,72 @@
+module PublishingApi
+  class WorldLocationNewsPagePresenter
+    attr_accessor :world_location
+    attr_accessor :update_type
+
+    def initialize(world_location, update_type: nil)
+      self.world_location = world_location
+      self.update_type = update_type || "major"
+    end
+
+    def content_id
+      find_or_create_content_id
+    end
+
+    def content
+      content = BaseItemPresenter.new(
+        world_location,
+        title: title,
+        need_ids: [],
+      ).base_attributes
+
+      content.merge!(
+        description: description,
+        details: {},
+        document_type: "placeholder_world_location_news_page",
+        public_updated_at: world_location.updated_at,
+        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        schema_name: "placeholder",
+        base_path: path_for_news_page,
+      )
+      content.merge!(PayloadBuilder::Routes.for(path_for_news_page))
+      content.merge!(PayloadBuilder::AnalyticsIdentifier.for(world_location))
+    end
+
+    def links
+      {}
+    end
+
+    def content_for_rummager
+      {
+        content_id: content_id,
+        link: path_for_news_page,
+        format: "world_location_news_page", # Used for the rummager document type
+        title: title,
+        description: description,
+        indexable_content: description,
+      }
+    end
+
+  private
+
+    def path_for_news_page
+      Whitehall.url_maker.polymorphic_path(world_location) + "/news"
+    end
+
+    def description
+      "Updates, news and events from the UK government in #{world_location.name}"
+    end
+
+    def title
+      world_location.title
+    end
+
+    def content_id_from_publishing_api
+      Services.publishing_api.lookup_content_ids(base_paths: path_for_news_page)[path_for_news_page]
+    end
+
+    def find_or_create_content_id
+      @content_id ||= (content_id_from_publishing_api || SecureRandom.uuid)
+    end
+  end
+end

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -1,0 +1,25 @@
+class WorldLocationNewsPageWorker
+  attr_accessor :world_location
+
+  def perform(world_location)
+    @world_location = world_location
+    send_news_page_to_publishing_api
+    send_news_page_to_rummager
+  end
+
+private
+
+  def news_page_presenter
+    @news_page_presenter ||= PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
+  end
+
+  def send_news_page_to_publishing_api
+    Services.publishing_api.put_content(news_page_presenter.content_id, news_page_presenter.content)
+    Services.publishing_api.publish(news_page_presenter.content_id, news_page_presenter.update_type, locale: "en")
+  end
+
+  def send_news_page_to_rummager
+    index = Whitehall::SearchIndex.for(:government)
+    index.add(news_page_presenter.content_for_rummager)
+  end
+end

--- a/db/data_migration/20170626140347_republish_world_locations_to_push_world_location_news_to_pub_api.rb
+++ b/db/data_migration/20170626140347_republish_world_locations_to_push_world_location_news_to_pub_api.rb
@@ -1,0 +1,5 @@
+all_world_locations = WorldLocation.all
+
+all_world_locations.each do |world_location|
+  world_location.save
+end

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -14,19 +14,23 @@ def add_translation_to_world_location(location, translation)
 end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists$/ do |world_location_type, name|
+  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   create(world_location_type.gsub(' ', '_').to_sym, name: name)
 end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists with the mission statement "([^"]*)"$/ do |world_location_type, name, mission_statement|
+  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   create(world_location_type.gsub(' ', '_').to_sym, name: name, mission_statement: mission_statement)
 end
 
 Given /^the (world location|international delegation) "([^"]*)" is inactive/ do |world_location_type, name|
+  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   world_location = WorldLocation.find_by(name: name) || create(world_location_type.gsub(' ', '_').to_sym, name: name)
   world_location.update_column(:active, false)
 end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |world_location_type, name, locale|
+  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   location = create(world_location_type.gsub(' ', '_').to_sym, name: name)
   locale = Locale.find_by_language_name(locale)
 
@@ -204,6 +208,7 @@ Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" world location 
 end
 
 Given /^a world location "([^"]*)" exists in both english and french$/ do |name|
+  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   location = create(:world_location, name: name)
   add_translation_to_world_location(location, locale: "French", name: 'Unimportant', mission_statement: 'Unimportant')
 end

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -9,6 +9,8 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
     Locale.stubs(:non_english).returns([
       Locale.new(:fr), Locale.new(:es)
     ])
+
+    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Admin::WorldLocationsControllerTest < ActionController::TestCase
   setup do
     login_as :writer
+    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
   end
 
   should_be_an_admin_controller

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -74,6 +74,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
   end
 
   test "shows featured items in defined order for locale" do
+    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
     LocalisedModel.new(@world_location, :fr).update_attributes(name: "Territoire antarctique britannique")
 
     less_recent_news_article = create(:published_news_article, first_published_at: 2.days.ago)

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -8,6 +8,10 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
   should_be_a_public_facing_controller
 
+  def setup
+    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  end
+
   def assert_featured_editions(editions)
     assert_equal editions, assigns(:feature_list).current_featured.map(&:edition)
   end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -207,6 +207,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "redirects out of the B cohort if the request for an embassy page is non en" do
     with_variant WorldwidePublishingTaxonomy: "B", assert_meta_tag: false do
+      WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
       worldwide_organisation = create(:worldwide_organisation)
       LocalisedModel.new(worldwide_organisation, "fr").update_attributes(name: "Le nom de Org")
       world_location = create(:world_location)

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCase
+  def present(model_instance)
+    PublishingApi::WorldLocationNewsPagePresenter.new(model_instance, {})
+  end
+
+  def world_location
+    @world_location ||= create(:world_location, name: "Aardistan", "title": "Aardistan and the Uk")
+  end
+
+  test 'presents an item for rummager' do
+    expected_hash = {
+      content_id: "a_guid",
+      link: "/government/world/aardistan/news",
+      format: "world_location_news_page",
+      title: "Aardistan and the Uk",
+      description: "Updates, news and events from the UK government in Aardistan",
+      indexable_content: "Updates, news and events from the UK government in Aardistan"
+    }
+
+    Services.publishing_api.stubs(:lookup_content_ids).returns({})
+
+    PublishingApi::WorldLocationNewsPagePresenter.any_instance.stubs(:content_id).returns("a_guid")
+
+    presented_item = present(world_location)
+
+    assert_equal expected_hash, presented_item.content_for_rummager
+  end
+
+  test 'with an item not yet in the publishing api, it presents a World Location News Page ready for publishing api' do
+    expected_hash = {
+      title: "Aardistan and the Uk",
+      locale: "en",
+      need_ids: [],
+      publishing_app: "whitehall",
+      redirects: [],
+      description: "Updates, news and events from the UK government in Aardistan",
+      details: {},
+      document_type: "placeholder_world_location_news_page",
+      public_updated_at: world_location.updated_at,
+      rendering_app: "whitehall-frontend",
+      schema_name: "placeholder",
+      base_path: "/government/world/aardistan/news",
+      routes: [{ path:  "/government/world/aardistan/news", type: "exact" }],
+      analytics_identifier: "WL1",
+    }
+
+    Services.publishing_api.stubs(:lookup_content_ids).returns({})
+
+    PublishingApi::WorldLocationNewsPagePresenter.any_instance.stubs(:content_id).returns("a_new_guid")
+
+    presented_item = present(world_location)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal "a_new_guid", presented_item.content_id
+  end
+
+  test 'with an item already in the publishing api, it presents a World Location News Page ready for publishing api' do
+    expected_hash = {
+      title: "Aardistan and the Uk",
+      locale: "en",
+      need_ids: [],
+      publishing_app: "whitehall",
+      redirects: [],
+      description: "Updates, news and events from the UK government in Aardistan",
+      details: {},
+      document_type: "placeholder_world_location_news_page",
+      public_updated_at: world_location.updated_at,
+      rendering_app: "whitehall-frontend",
+      schema_name: "placeholder",
+      base_path: "/government/world/aardistan/news",
+      routes: [{ path: "/government/world/aardistan/news", type: "exact" }],
+      analytics_identifier: "WL1",
+    }
+
+    Services.publishing_api.stubs(:lookup_content_ids).returns("/government/world/aardistan/news" => "aguid")
+
+    presented_item = present(world_location)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal "aguid", presented_item.content_id
+  end
+end

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
+  MockNewsPagePresenter = Struct.new("NewsPagePresenter") do
+    def content_id
+      "a_guid"
+    end
+
+    def content
+      Hash.new(title: "title", description: "description")
+    end
+
+    def update_type
+      "major"
+    end
+
+    def content_for_rummager
+      Hash.new(title: "title", link: "link")
+    end
+  end
+
+  test "sends to the publishing api and rummager" do
+    wl = create(:world_location, name: "Aardistan", title: "Aardistan and the Uk")
+
+    mock_news_page_presenter = MockNewsPagePresenter.new
+
+    WorldLocationNewsPageWorker.any_instance.stubs(:news_page_presenter).returns(mock_news_page_presenter)
+
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
+
+    Services.publishing_api.expects(:put_content)
+      .with(
+        "a_guid",
+        Hash.new(title: "title", description: "description")
+    )
+
+    Services.publishing_api.expects(:publish)
+      .with(
+        "a_guid",
+        "major",
+        locale: "en"
+    )
+
+    WorldLocationNewsPageWorker.new.perform(wl)
+  end
+end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class WorldLocationTest < ActiveSupport::TestCase
   should_protect_against_xss_and_content_attacks_on :name, :mission_statement
 
+  def setup
+    WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
+  end
+
   test 'should be invalid without a name' do
     world_location = build(:world_location, name: nil)
     refute world_location.valid?
@@ -271,5 +275,11 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert_raise ActiveRecord::RecordInvalid do
       FeatureList.create!(featurable: world_location2, locale: :en)
     end
+  end
+
+  test "should call perform on World Location News Page Worker when saving a World Location" do
+    world_location = create(:world_location, slug: 'india')
+    WorldLocationNewsPageWorker.any_instance.expects(:perform).at_least_once.with(world_location)
+    world_location.save
   end
 end


### PR DESCRIPTION
World Location News Pages need to be sent to the Publishing Api and also need to be indexable by Rummager so we can properly tag them in Content Tagger and also so that we display the summary/description when viewing the navigation pages in Collections.

[Trello](https://trello.com/c/WAX1kJnP/222-ensure-worldwide-organisations-and-worldwide-news-pages-display-summary-text)

In Collections, the news page will eventually be pulled in to the taxon navigation pages - an example screenshot, complete with "summary" is below:
<img width="613" alt="screen shot 2017-06-26 at 12 58 19" src="https://user-images.githubusercontent.com/647311/27538314-45120a64-5a6f-11e7-938c-1aa24e056ee9.png">

[Related PR in Collection](https://github.com/alphagov/collections/pull/352) (closed in favour of this one)

Relies on [GOV.UK Content Schemas PR 630](https://github.com/alphagov/govuk-content-schemas/pull/630)