### PR TITLE
[Do Not Merge]Republish World Locations to move them to /world

### DIFF
--- a/db/data_migration/20170626170840_republish_world_locations_to_move_to_slash_world.rb
+++ b/db/data_migration/20170626170840_republish_world_locations_to_move_to_slash_world.rb
@@ -1,0 +1,3 @@
+require 'data_hygiene/publishing_api_republisher'
+
+DataHygiene::PublishingApiRepublisher.new(WorldwideOrganisation.all).perform


### PR DESCRIPTION
Part of the deploy process of the new Worldwide taxonomy. This should address step 13 (Republish all worldwide content)