### PR TITLE
Add rake task for redirecting WorldLocations

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -40,6 +40,19 @@ class WorldLocation < ApplicationRecord
              slug: :slug
   include PublishesToPublishingApi
 
+  #TODO Remove this once all of the translated
+  #world locations have been redirected
+  original_available_locales = instance_method(:available_locales)
+  define_method(:original_available_locales) do
+    original_available_locales.bind(self).()
+  end
+
+  def available_locales
+    [:en]
+  end
+  alias_method :translated_locales, :available_locales
+  ######################################################
+
   def search_link
     Whitehall.url_maker.world_location_path(slug)
   end

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-Given /^I am viewing a world location that is translated$/ do
-  world_location = create(:world_location, translated_into: [:fr])
+Given /^a worldwide organisation that is translated exists$/ do
+  world_location = create(:world_location)
   worldwide_organisation = create(:worldwide_organisation,
     world_locations: [world_location],
     name: "en-organisation",
@@ -11,12 +11,10 @@ Given /^I am viewing a world location that is translated$/ do
          worldwide_organisation: worldwide_organisation,  summary: "en-summary",
          translated_into: {fr: {summary: "fr-summary"}}
   )
-  visit world_location_path(world_location)
-  click_link "Français"
 end
 
-When /^I visit a world organisation associated with that locale that is also translated$/ do
-  click_link "fr-organisation"
+When /^I visit the world organisation that is translated$/ do
+  visit worldwide_organisation_path(WorldwideOrganisation.last, locale: "fr")
 end
 
 Then /^I should see the translation of that world organisation$/ do

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -195,11 +195,6 @@ When(/^I stop featuring the offsite link "(.*?)" for the world location "(.*?)"$
   end
 end
 
-Then /^I should see no featured items on the french version of the "([^"]*)" page$/ do |world_location_name|
-  view_world_location_in_locale(world_location_name, "Français")
-  assert page.has_no_css?('.feature'), "Feature was unexpectedly present"
-end
-
 Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" world location page$/) do |title, world_location_name|
   world_location = WorldLocation.find_by!(name: world_location_name)
   offsite_link = OffsiteLink.find_by!(title: title)
@@ -207,48 +202,9 @@ Then(/^I should see the edit offsite link "(.*?)" on the "(.*?)" world location 
   page.has_link?(title, href: edit_admin_world_location_offsite_link_path(world_location.id, offsite_link.id))
 end
 
-Given /^a world location "([^"]*)" exists in both english and french$/ do |name|
-  WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
-  location = create(:world_location, name: name)
-  add_translation_to_world_location(location, locale: "French", name: 'Unimportant', mission_statement: 'Unimportant')
-end
-
-Given /^there is a news article "([^"]*)" in english \("([^"]*)" in french\) related to the world location$/ do |english_title, french_title|
-  world_location = WorldLocation.last
-  create(:published_news_article, title: english_title, world_locations: [world_location], translated_into: {
-    fr: {
-      title: french_title
-    }
-  })
-end
-
-When /^I feature "([^"]*)" on the french "([^"]*)" page$/ do |news_article_title, world_location_name|
-  feature_news_article_in_world_location(news_article_title, world_location_name, nil, "Français")
-end
-
-Then /^I should see "([^"]*)" as the title of the feature on the french "([^"]*)" page$/ do |expected_title, world_location_name|
-  view_world_location_in_locale(world_location_name, "Français")
-  assert page.has_css?('.feature h2', text: expected_title)
-end
-
 Then /^I should see "([^"]*)" featured on the public facing "([^"]*)" page$/ do |expected_title, name|
   visit world_location_path(WorldLocation.find_by!(name: name))
   assert page.has_css?('.feature h2', text: expected_title)
-end
-
-Then /^I should see "([^"]*)" as the title of the featured item on the french "([^"]*)" admin page$/ do |expected_title, world_location_name|
-  world_location = WorldLocation.find_by!(name: world_location_name)
-  visit admin_world_location_path(world_location)
-  click_link "Features (Français)"
-  assert has_css?('.title', text: expected_title)
-end
-
-Then /^I cannot feature "([^"]*)" on the french "([^"]*)" page due to the lack of a translation$/ do |title, world_location_name|
-  world_location = WorldLocation.find_by!(name: world_location_name)
-  visit admin_world_location_path(world_location)
-  click_link "Features (Français)"
-  fill_in 'title', with: title.split.first
-  assert page.has_no_css?("a.btn", text: "Feature")
 end
 
 Then(/^there should be nothing featured on the home page of world location "(.*?)"$/) do |name|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -260,14 +260,7 @@ Then /^when viewing the worldwide organisation "([^"]*)" with the locale "([^"]*
   worldwide_organisation = WorldwideOrganisation.find_by!(name: name)
   translation = table.rows_hash
 
-  visit world_location_path(worldwide_organisation.world_locations.first)
-  click_link locale
-
-  within record_css_selector(worldwide_organisation) do
-    assert page.has_css?('.name', text: translation["name"]), "Name wasn't present on associated world location page"
-  end
-
-  click_link translation["name"]
+  visit worldwide_organisation_path(worldwide_organisation, locale: locale)
 
   assert page.has_css?('.summary', text: translation["summary"]), "Summary wasn't present"
   assert page.has_css?('.description', text: translation["description"]), "Description wasn't present"
@@ -276,7 +269,7 @@ end
 
 Given /^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |name, native_locale_name|
   locale_code = Locale.find_by_language_name(native_locale_name).code
-  country = create(:world_location, world_location_type: WorldLocationType::WorldLocation, translated_into: [locale_code])
+  country = create(:world_location, world_location_type: WorldLocationType::WorldLocation)
   create(:worldwide_organisation, name: name, world_locations: [country], translated_into: [locale_code])
 end
 

--- a/features/translated-content.feature
+++ b/features/translated-content.feature
@@ -4,8 +4,8 @@ Feature: Providing translated content from gov.uk/government
   So that I can better understand it's relationship to the locales that I am interested in
 
   Scenario: Maintaining locale between pages
-    Given I am viewing a world location that is translated
-    When I visit a world organisation associated with that locale that is also translated
+    Given a worldwide organisation that is translated exists
+    Given I visit the world organisation that is translated
     Then I should see the translation of that world organisation
 
   Scenario: Adding a translation to a draft translatable document

--- a/features/world-locations.feature
+++ b/features/world-locations.feature
@@ -24,12 +24,6 @@ Feature: Administering world location information
       |You must buy the X-Factor single, says Queen|
       |Bringing back the Charleston|
 
-  Scenario: Featuring different things on different locale versions of a world location page
-    Given a world location "Jamestopia" exists in both english and french
-    And an english news article called "Beards" related to the world location
-    When I feature "Beards" on the english "Jamestopia" page
-    Then I should see no featured items on the french version of the "Jamestopia" page
-
   Scenario: Creating offsite content on a world location page
     Given a world location "Jamestopia" exists
     When I add the offsite link "Offsite Thing" of type "Alert" to the world location "Jamestopia"
@@ -43,44 +37,6 @@ Feature: Administering world location information
       | Offsite Thing | s300_minister-of-funk.960x640.jpg |
     When I stop featuring the offsite link "Offsite Thing" for the world location "Jamestopia"
     Then there should be nothing featured on the home page of world location "Jamestopia"
-
-  Scenario: Featuring shows the correct translation of the article on world location page
-    Given a world location "Jamestopia" exists in both english and french
-    And there is a news article "Beards" in english ("Barbes" in french) related to the world location
-    When I feature "Barbes" on the french "Jamestopia" page
-    Then I should see "Barbes" as the title of the featured item on the french "Jamestopia" admin page
-    And I should see "Barbes" as the title of the feature on the french "Jamestopia" page
-
-  Scenario: Featuring things that aren't associated with the world location
-    Given a world location "Jamestopia" exists in both english and french
-    And a published news article "Beards" which isn't explicitly associated with "Jamestopia"
-    When I feature "Beards" on the english "Jamestopia" page
-    Then I should see "Beards" featured on the public facing "Jamestopia" page
-    And I cannot feature "Beards" on the french "Jamestopia" page due to the lack of a translation
-
-  Scenario: Adding a new translation
-    Given a world location "Afrolasia" exists with the mission statement "The UK has a long-standing relationship with Afrolasia"
-    When I add a new translation to the world location "Afrolasia" with:
-      | locale            | Français                                                    |
-      | name              | Afrolasie                                                   |
-      | title             | UK en Afrolasia                                             |
-      | mission_statement | Le Royaume-Uni a une relation de longue date avec Afrolasie |
-    Then when viewing the world location "Afrolasia" with the locale "Français" I should see:
-      | name              | Afrolasie                                                   |
-      | title             | UK en Afrolasia                                             |
-      | mission_statement | Le Royaume-Uni a une relation de longue date avec Afrolasie |
-
-  Scenario: Editing an existing translation
-    Given a world location "Afrolasia" exists with a translation for the locale "Français"
-    When I edit the "Français" translation for "Afrolasia" setting:
-      | locale            | Français                                                    |
-      | name              | Afrolandie                                                  |
-      | title             | UK en Afrolandie                                            |
-      | mission_statement | Enseigner aux gens comment infuser le thé                   |
-    Then when viewing the world location "Afrolasia" with the locale "Français" I should see:
-      | name              | Afrolandie                                                  |
-      | title             | UK en Afrolandie                                            |
-      | mission_statement | Enseigner aux gens comment infuser le thé                   |
 
   Scenario: Viewing the list presents world locations in name order, ignoring "The" accents, grouped by first letter
     Given a world location "Special Republic" exists

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -87,18 +87,18 @@ Feature: Administering worldwide organisation
     Then I should see the corporate information on the public worldwide organisation page
 
   Scenario: Adding a new translation
-    Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "fr"
+    Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "Français"
     When I add a new translation to the worldwide organisation "Department of Beards in France" with:
       | locale      | Français                                          |
       | name        | Département des barbes en France                  |
-    Then when viewing the worldwide organisation "Department of Beards in France" with the locale "Français" I should see:
+    Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
       | name        | Département des barbes en France                  |
 
   Scenario: Editing an existing translation
     Given a worldwide organisation "Department of Beards in France" exists with a translation for the locale "Français"
     When I edit the "Français" translation for the worldwide organisation "Department of Beards in France" setting:
       | name        | Le super département des barbes en France         |
-    Then when viewing the worldwide organisation "Department of Beards in France" with the locale "Français" I should see:
+    Then when viewing the worldwide organisation "Department of Beards in France" with the locale "fr" I should see:
       | name        | Le super département des barbes en France         |
 
   Scenario: Translating a corporate information page for a worldwide organisation

--- a/lib/tasks/worldwide_taxonomy.rake
+++ b/lib/tasks/worldwide_taxonomy.rake
@@ -1,0 +1,22 @@
+namespace :worldwide_taxonomy do
+  task redirect_world_location_translations_to_en: :environment do
+    base_path_prefix = "/government/world"
+    world_locations = WorldLocation.all
+
+    world_locations.each do |world_location|
+      en_slug = world_location.slug
+      destination_base_path = File.join("", base_path_prefix, en_slug)
+      content_id = world_location.content_id
+      locales = world_location.original_available_locales - [:en]
+
+      locales.each do |locale|
+        PublishingApiRedirectWorker.perform_async_in_queue(
+          "bulk_republishing",
+          content_id,
+          destination_base_path,
+          locale
+        )
+      end
+    end
+  end
+end

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -28,41 +28,10 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
     end
   end
 
-  view_test 'index omits existing translations from create select' do
-    location = create(:world_location, translated_into: [:fr])
-    get :index, world_location_id: location
-    assert_select "select[name=translation_locale]" do
-      assert_select "option[value=fr]", count: 0
-    end
-  end
-
-  view_test 'index omits create form if no missing translations' do
-    location = create(:world_location, translated_into: [:fr, :es])
-    get :index, world_location_id: location
-    assert_select "select[name=translation_locale]", count: 0
-  end
-
-  view_test 'index lists existing translations' do
-    location = create(:world_location, translated_into: [:fr])
-    get :index, world_location_id: location
-    edit_translation_path = edit_admin_world_location_translation_path(location, 'fr')
-    view_location_path = world_location_path(location, locale: 'fr')
-    assert_select "a[href=?]", edit_translation_path, text: 'Français'
-    assert_select "a[href=?]", view_location_path, text: 'view'
-  end
-
   view_test 'index does not list the english translation' do
     get :index, world_location_id: @location
     edit_translation_path = edit_admin_world_location_translation_path(@location, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
-  end
-
-  view_test 'index displays delete button for a translation' do
-    location = create(:world_location, translated_into: [:fr])
-    get :index, world_location_id: location
-    assert_select "form[action=?]", admin_world_location_translation_path(location, :fr) do
-      assert_select "input[type='submit'][value=?]", "Delete"
-    end
   end
 
   test 'create redirects to edit for the chosen language' do

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -165,13 +165,19 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert_equal [link_6, link_2, link_1, link_4, link_3], world_location.featured_links.only_the_initial_set
   end
 
-  test "has removeable translations" do
-    stub_any_publishing_api_call
+  test "translated world locations appear to only have :en translated locales" do
+    world_location = create(:world_location, translated_into: [:fr, :en])
+    assert_equal [:en], world_location.translated_locales
+  end
 
-    world_location = create(:world_location, translated_into: [:fr, :es])
-    world_location.remove_translations_for(:fr)
-    refute world_location.translated_locales.include?(:fr)
-    assert world_location.translated_locales.include?(:es)
+  test "translated world locations appear to only have :en available locales" do
+    world_location = create(:world_location, translated_into: [:fr, :en])
+    assert_equal [:en], world_location.available_locales
+  end
+
+  test "translated world locations still have all locales exposed" do
+    world_location = create(:world_location, translated_into: [:fr, :en])
+    assert_equal [:en, :fr], world_location.original_available_locales
   end
 
   test 'we can find those that are countries' do


### PR DESCRIPTION
Redirect all the WorldLocation translations. They are no longer supported so are redirected to the non-translated taxon page. This will also cause them to appear unpublished to the publishing API which will remove them from the links of other content.

This also adds a patch to make all world locations appear untranslated. This will remove the translation link on the world location page until we remove the translations themselves.