### PR TITLE
Republish the world

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -135,6 +135,6 @@ class WorldLocation < ApplicationRecord
   friendly_id
 
   def send_news_page_to_publishing_api_and_rummager
-    WorldLocationNewsPageWorker.new.perform(self)
+    WorldLocationNewsPageWorker.new.perform(id)
   end
 end

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -1,8 +1,8 @@
 class WorldLocationNewsPageWorker < WorkerBase
   attr_accessor :world_location
 
-  def perform(world_location)
-    @world_location = world_location
+  def perform(world_location_id)
+    @world_location = WorldLocation.find(world_location_id)
     send_news_page_to_publishing_api
     send_news_page_to_rummager
   end

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -1,4 +1,4 @@
-class WorldLocationNewsPageWorker
+class WorldLocationNewsPageWorker < WorkerBase
   attr_accessor :world_location
 
   def perform(world_location)

--- a/lib/tasks/worldwide_taxonomy.rake
+++ b/lib/tasks/worldwide_taxonomy.rake
@@ -36,7 +36,7 @@ namespace :worldwide_taxonomy do
     world_locations = WorldLocation.all
 
     world_locations.each do |world_location|
-      WorldLocationNewsPageWorker.perform_async(world_location)
+      WorldLocationNewsPageWorker.perform_async(world_location.id)
     end
 
     [worldwide_organisations, world_locations].each do |collection|

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -41,6 +41,6 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
         locale: "en"
     )
 
-    WorldLocationNewsPageWorker.new.perform(wl)
+    WorldLocationNewsPageWorker.new.perform(wl.id)
   end
 end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -285,7 +285,7 @@ class WorldLocationTest < ActiveSupport::TestCase
 
   test "should call perform on World Location News Page Worker when saving a World Location" do
     world_location = create(:world_location, slug: 'india')
-    WorldLocationNewsPageWorker.any_instance.expects(:perform).at_least_once.with(world_location)
+    WorldLocationNewsPageWorker.any_instance.expects(:perform).at_least_once.with(world_location.id)
     world_location.save
   end
 end


### PR DESCRIPTION
This adds a rake task to republish all `/government/world` content to move it all to `/world` since the routes have been changed.

This PR is rebased on top of a few others while we test the deploy process. The only new commits are the last two e16cbbb and 1019473