### PR TITLE
Fix embassies and worldwide organisations finders

### DIFF
--- a/db/data_migration/20170628130725_redirect_organisations_to_slash_world.rb
+++ b/db/data_migration/20170628130725_redirect_organisations_to_slash_world.rb
@@ -1,0 +1,6 @@
+# Redirect the current finder sitting at /government/world/organisations to the new location
+
+content_id = "b8faa6b3-e9b0-41fb-a415-92af505277ca"
+destination = "/world/organisations"
+
+PublishingApiRedirectWorker.new.perform(content_id, destination, I18n.default_locale.to_s)

--- a/lib/finders/worldwide_organisations.json
+++ b/lib/finders/worldwide_organisations.json
@@ -1,5 +1,5 @@
 {
-  "base_path": "/government/world/organisations",
+  "base_path": "/world/organisations",
   "title": "Worldwide organisations",
   "description": "A list of British organisations worldwide.",
   "locale": "en",
@@ -19,11 +19,11 @@
   "routes": [
     {
       "type": "exact",
-      "path": "/government/world/organisations"
+      "path": "/world/organisations"
     },
     {
       "type": "exact",
-      "path": "/government/world/organisations.json"
+      "path": "/world/organisations.json"
     }
   ]
 }

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -111,7 +111,7 @@ class PublishStaticPages
       {
         content_id: "430df081-f28e-4a1f-b812-8977fdac6e9a",
         title: "Find a British embassy, high commission or consulate",
-        base_path: "/government/world/embassies",
+        base_path: "/world/embassies",
         document_type: "finder",
         description: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
         indexable_content: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",


### PR DESCRIPTION
This commit changes the base paths for the embassies and worldwide organisations finders to `/world/*`.

Also includes a data migration (as suggested by @gpeng) to republish the static pages and subsequently send a redirect to Publishing Api so that `/government/world/organisations` redirects to `/world/organisations`