### PR TITLE
Stop publishing headings in HTML publications

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -53,7 +53,6 @@ module PublishingApi
     def details
       {
         body: body,
-        headings: headings,
         public_timestamp: public_timestamp,
         first_published_version: first_published_version?
       }
@@ -61,10 +60,6 @@ module PublishingApi
 
     def body
       govspeak_content.try(:computed_body_html) || ""
-    end
-
-    def headings
-      govspeak_content.try(:computed_headers_html) || ""
     end
 
     def first_published_version?

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -32,7 +32,6 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       details: {
         body: Whitehall::GovspeakRenderer.new
           .govspeak_to_html(html_attachment.govspeak_content.body),
-        headings: html_attachment.govspeak_content.computed_headers_html,
         public_timestamp: edition.public_timestamp,
         first_published_version: html_attachment.attachable.first_published_version?,
       },
@@ -71,7 +70,6 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     html_attachment = HtmlAttachment.last
 
     assert_equal "", present(html_attachment).content[:details][:body]
-    assert_equal "", present(html_attachment).content[:details][:headings]
   end
 
   test "HtmlAttachment presentations sends the parent updated_at if it has no public_timestamp" do


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-content-schemas/pull/631 (tests will fail until this is merged/deployed)
Follow up to https://github.com/alphagov/government-frontend/pull/384

A follow-up PR should check whether the logic to calculate and store headers in Whitehall can be removed entirely.

@nickcolley @andysellick @rubenarakelyan 