### PR TITLE
[Do Not Merge]Remove World Location translation monkey patch

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -40,19 +40,6 @@ class WorldLocation < ApplicationRecord
              slug: :slug
   include PublishesToPublishingApi
 
-  #TODO Remove this once all of the translated
-  #world locations have been redirected
-  original_available_locales = instance_method(:available_locales)
-  define_method(:original_available_locales) do
-    original_available_locales.bind(self).()
-  end
-
-  def available_locales
-    [:en]
-  end
-  alias_method :translated_locales, :available_locales
-  ######################################################
-
   def search_link
     Whitehall.url_maker.world_location_path(slug)
   end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -40,6 +40,15 @@ class WorldLocation < ApplicationRecord
              slug: :slug
   include PublishesToPublishingApi
 
+  def publish_to_publishing_api
+    self.class.send(:define_method, "available_locales") { [:en] }
+    self.class.send(:define_method, "translated_locales") { [:en] }
+
+    run_callbacks :published do
+      Whitehall::PublishingApi.publish_async(self)
+    end
+  end
+
   def search_link
     Whitehall.url_maker.world_location_path(slug)
   end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -165,19 +165,12 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert_equal [link_6, link_2, link_1, link_4, link_3], world_location.featured_links.only_the_initial_set
   end
 
-  test "translated world locations appear to only have :en translated locales" do
-    world_location = create(:world_location, translated_into: [:fr, :en])
-    assert_equal [:en], world_location.translated_locales
-  end
-
-  test "translated world locations appear to only have :en available locales" do
-    world_location = create(:world_location, translated_into: [:fr, :en])
-    assert_equal [:en], world_location.available_locales
-  end
-
-  test "translated world locations still have all locales exposed" do
-    world_location = create(:world_location, translated_into: [:fr, :en])
-    assert_equal [:en, :fr], world_location.original_available_locales
+  test "has removeable translations" do
+    stub_any_publishing_api_call
+    world_location = create(:world_location, translated_into: [:fr, :es])
+    world_location.remove_translations_for(:fr)
+    refute world_location.translated_locales.include?(:fr)
+    assert world_location.translated_locales.include?(:es)
   end
 
   test 'we can find those that are countries' do


### PR DESCRIPTION
World Locations have now had all the translations redirected. We should
remove the monkey patch. We also need the available locales on World
Locations so that the World Location News pages are translated.