### PR TITLE
Allow uploads of shp_rxl files

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -130,7 +130,7 @@ class AttachmentUploader < WhitehallUploader
 
     class ArcGISShapefileExaminer < Examiner
       REQUIRED_EXTS = %w(shp shx dbf)
-      OPTIONAL_EXTS = %w(aih ain atx avl cpg fbn fbx ixs mxs prj sbn sbx shp.xml)
+      OPTIONAL_EXTS = %w(aih ain atx avl cpg fbn fbx ixs mxs prj sbn sbx shp.xml shp_rxl).freeze
       ALLOWED_EXTS = REQUIRED_EXTS + OPTIONAL_EXTS
       EXT_MATCHER = /\.(#{ALLOWED_EXTS.map { |e| Regexp.escape(e)}.join('|') })\Z/
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -150,6 +150,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
       london.sbn
       london.sbx
       london.shp.xml
+      london.shp_rxl
     )
   end
 


### PR DESCRIPTION
When uploading zip files containing shape files, a user reported the
system didn't allow. After looking, I realised one of the files with a
`.shp_rxl` extension isn't in our list of allowed extensions.

This commit adds it to the optional list of allowed extensions so that
we allow uploads.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2229208