### PR TITLE
Show translations on world location news pages

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -15,6 +15,7 @@ class WorldLocationNewsController < PublicFacingController
         @statistics_publications = latest_presenters(publications.statistics, translated: true, count: 2)
         @announcements = latest_presenters(Announcement.published.in_world_location(@world_location), translated: true, count: 2)
         @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
+        @world_location_news_translation = WorldLocationNewsTranslation.new(@world_location.original_available_locales)
       end
       format.json do
         redirect_to api_world_location_path(@world_location, format: :json)

--- a/app/models/world_location_news_translation.rb
+++ b/app/models/world_location_news_translation.rb
@@ -1,0 +1,11 @@
+class WorldLocationNewsTranslation
+  attr_accessor :translated_locales
+
+  def initialize(translated_locales = [])
+    @translated_locales = Array(translated_locales)
+  end
+
+  def available_in_multiple_languages?
+    translated_locales.count > 1
+  end
+end

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -11,7 +11,7 @@
                           extra: true, big: true } %>
       <aside class="heading-extra">
         <div class="inner-heading">
-          <%= render 'shared/available_languages', object: @world_location %>
+          <%= render 'shared/available_languages', object: @world_location_news_translation %>
           <%= render 'shared/featured_links', links: @world_location.featured_links.only_the_initial_set %>
         </div>
       </aside>

--- a/test/unit/models/world_location_news_translation_test.rb
+++ b/test/unit/models/world_location_news_translation_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class WorldLocationNewsTranslationTest < ActiveSupport::TestCase
+  test 'it is not available in multiple languages when initialised with nil' do
+    world_location_news_translation = WorldLocationNewsTranslation.new(nil)
+
+    refute world_location_news_translation.available_in_multiple_languages?
+  end
+
+  test 'it is not available in multiple languages when initialised with a single translated locale' do
+    locales = [:en]
+
+    world_location_news_translation = WorldLocationNewsTranslation.new(locales)
+
+    refute world_location_news_translation.available_in_multiple_languages?
+  end
+
+  test 'it is not available in multiple languages when initialised with a single locale that is not an array' do
+    locale = :en
+
+    world_location_news_translation = WorldLocationNewsTranslation.new(locale)
+
+    refute world_location_news_translation.available_in_multiple_languages?
+  end
+
+  test 'it is available in multiple languages when initialised with an array of translated locales' do
+    locales = [:en, :fr]
+
+    world_location_news_translation = WorldLocationNewsTranslation.new(locales)
+
+    assert world_location_news_translation.available_in_multiple_languages?
+  end
+
+  test 'it returns an empty array as translated_locales when initialised with nil' do
+    world_location_news_translation = WorldLocationNewsTranslation.new(nil)
+
+    assert [], world_location_news_translation.translated_locales
+  end
+
+  test 'it returns a single available language in an array as translated_locales when a single language is passed in' do
+    locale = :en
+    locale_as_array = [:en]
+
+    assert [:en], WorldLocationNewsTranslation.new(locale_as_array).translated_locales
+    assert [:en], WorldLocationNewsTranslation.new(locale).translated_locales
+  end
+
+  test 'it returns the available languages as translated_locales' do
+    locales = [:en, :fr]
+
+    world_location_news_translation = WorldLocationNewsTranslation.new(locales)
+
+    assert [:en, :fr], world_location_news_translation.translated_locales
+  end
+end


### PR DESCRIPTION
World Locations are now Taxonomies rendered by Collections. World Location News Pages are, however, still rendered by Whitehall. World Locations no longer require translations, but World Location News Pages do. The translations for World Location News is still retrieved from the available translations for World Locations. World Locations are sent to Publishing Api as base pathless and we do not want to send all the translations, so we have created a World Location News Translation model to proxy the information to the frontend.

[Trello](https://trello.com/c/HBCgTrfl/269-add-language-toggle-back-to-world-location-news-pages)

## Before
<img width="882" alt="screen shot 2017-07-03 at 09 49 15" src="https://user-images.githubusercontent.com/647311/27785315-1fd1a3a2-5fd5-11e7-8155-ab5a96796438.png">

## After

### Translated
<img width="974" alt="screen shot 2017-07-03 at 09 49 35" src="https://user-images.githubusercontent.com/647311/27785342-2e8b05be-5fd5-11e7-976c-6294a43fdf32.png">

### In English
<img width="983" alt="screen shot 2017-07-03 at 09 52 07" src="https://user-images.githubusercontent.com/647311/27785371-50ad1d8a-5fd5-11e7-87d9-857381967e72.png">

### Country with no translations
<img width="914" alt="screen shot 2017-07-03 at 09 50 18" src="https://user-images.githubusercontent.com/647311/27785407-78dc7c9c-5fd5-11e7-8ccd-ee251a0e174f.png">


