### PR TITLE
Correctly redirect world atom feeds

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,8 +156,9 @@ Whitehall::Application.routes.draw do
 
     # Redirect everything under /government/world to /world
     # It may look like we're redirecting back to the same page but the
-    # source is automatically prefixed with /government by Rails.
+    # source is prefixed with /government.
     get '/world' => redirect('/world', prefix: '')
+    get '/world/*page.:format' => redirect('/world/%{page}.%{format}', prefix: '')
     get '/world/*page' => redirect('/world/%{page}', prefix: '')
 
     constraints(AdminRequest) do


### PR DESCRIPTION
This commit adds a new redirect route to capture source URLs with format extensions (such as `.atom`) and redirect them correctly, keeping the format extension.