### PR TITLE
Redirect non-en world locations

### DIFF
--- a/app/workers/world_location_redirect_worker.rb
+++ b/app/workers/world_location_redirect_worker.rb
@@ -1,0 +1,37 @@
+class WorldLocationRedirectWorker < WorkerBase
+  def perform(world_location_id)
+    world_location = WorldLocation.find_by(id: world_location_id)
+    return if world_location.nil?
+
+    base_path_prefix = "/world"
+
+    en_slug = world_location.slug
+    destination_base_path = File.join("", base_path_prefix, en_slug)
+    content_id = world_location.content_id
+    locales = world_location.available_locales - [:en]
+
+    locales.each do |locale|
+      fix_base_path(world_location, locale, en_slug)
+
+      PublishingApiRedirectWorker.new.perform(
+        content_id,
+        destination_base_path,
+        locale
+      )
+    end
+  end
+
+  def fix_base_path(world_location, locale, en_slug)
+    presenter_class = PublishingApiPresenters.presenter_class_for(world_location)
+    presenter = presenter_class.new(world_location)
+    payload = presenter.content
+
+    new_base_path = "/world/#{en_slug}.#{locale}"
+    payload[:base_path] = new_base_path
+    payload[:routes] = [{ path: new_base_path, type: "exact" }]
+    payload[:locale] = locale
+
+    Services.publishing_api.put_content(world_location.content_id, payload)
+    Services.publishing_api.publish(world_location.content_id, "republish", locale: locale)
+  end
+end

--- a/lib/tasks/world_locations.rake
+++ b/lib/tasks/world_locations.rake
@@ -1,0 +1,9 @@
+namespace :world_locations do
+  task redirect_world_location_translations_to_en: :environment do
+    world_location_ids = WorldLocation.all.pluck(:id)
+
+    world_location_ids.each do |world_location_id|
+      WorldLocationRedirectWorker.perform_async(world_location_id)
+    end
+  end
+end


### PR DESCRIPTION
We no longer support translated world location pages. They were redirected but re-appeared when we moved them from `/government/world/<slug>` to `/world/<slug>`.

This PR adds a rake task to redirect them to their :en equivalent again. 

This happens in two steps. Firstly, we update the publishing API to change the base_path of the document to `/world/<slug>.<locale>`. Then we make the `unpublish` call with the redirect. We can't just redirect via publishing API as that would create a redirect from the original url
not the new `/world` one.

As the presenter no longer exposes a base path for WorldLocations we can't use the existing worker classes for publishing. This PR adds a worker which reinstates the base path by adding it to the payload from the presenter. This worker can be removed once this rake task has been run.

[Trello](https://trello.com/c/LqIOECF3/17-non-english-locale-worldlocation-pages-still-being-rendered-at-world-sluglocale)