### PR TITLE
Discard html attachment with edition

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -93,10 +93,6 @@ class HtmlAttachment < Attachment
     'HTML'
   end
 
-  def save_and_update_publishing_api
-    save && Whitehall.edition_services.draft_updater(attachable).perform!
-  end
-
   def translated_locales
     [locale || I18n.default_locale.to_s]
   end

--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -67,7 +67,7 @@ class PublishingApiHtmlAttachmentsWorker
   end
 
   def delete
-    discard_drafts(current_html_attachments)
+    discard_drafts(current_html_attachments + deleted_html_attachments)
   end
 
 private

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -120,31 +120,6 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert attachment.slug.blank?
   end
 
-  test "#save_and_update_publishing_api saves the attachment" do
-    publication = build(
-      :draft_publication,
-      html_attachments: [attachment = build(:html_attachment)]
-    )
-    attachment.attachable = publication
-    attachment.save_and_update_publishing_api
-    assert attachment.persisted?, "Attachment has not been saved"
-  end
-
-  test "#save_and_udpate_publishing_api sends the attachable to draft_updater" do
-    edition = create(
-      :draft_publication,
-      html_attachments: [attachment = build(:html_attachment)]
-    )
-
-    Whitehall.edition_services
-      .expects(:draft_updater)
-      .with(edition)
-      .returns(draft_updater = stub)
-    draft_updater.expects(:perform!)
-
-    attachment.save_and_update_publishing_api
-  end
-
   test "#translated_locales lists only the attachment's locale" do
     assert_equal ["en"], HtmlAttachment.new.translated_locales
     assert_equal ["cy"], HtmlAttachment.new(locale: "cy").translated_locales

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -283,6 +283,18 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
         )
         call(publication)
       end
+
+      test "for a draft publication with deleted html attachments discards the deleted attachment drafts" do
+        publication = create(:draft_publication)
+        attachment = publication.html_attachments.first
+        attachment.destroy
+
+        PublishingApiDiscardDraftWorker.expects(:perform_async).with(
+          attachment.content_id,
+          "en"
+        )
+        call(publication)
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a bug where if an HtmlAttachment is deleted and then the draft edition that it is attached to is discarded the publishing API was not being updated so the draft of the attachment would be left in the content store. This causes problems if the publisher then tries to recreate the document and attachment as the draft blocks the new attachment from being published and as it occupies the base_path the new edition will appear to be linking to the previous version.

Also removes a method that is no longer used since it stopped being called in b2781d0

[Trello](https://trello.com/c/Tv7sA09x/34-bug-republishing-attachments)