### PR TITLE
Fix duplicate content_id bug

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,6 +1,5 @@
 # Abstract base class for Attachments.
 class Attachment < ApplicationRecord
-  include HasContentId
   belongs_to :attachable, polymorphic: true
   has_one :attachment_source
 

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -1,4 +1,6 @@
 class ExternalAttachment < Attachment
+  include HasContentId
+
   validates :external_url, presence: true, uri: true, length: { maximum: 255 }
 
   def accessible?

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -1,4 +1,6 @@
 class FileAttachment < Attachment
+  include HasContentId
+
   delegate :url, :content_type, :pdf?, :csv?, :opendocument?,
     :file_extension, :file_size,
     :number_of_pages, :file, :filename, :filename_without_extension, :virus_status,

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -2,6 +2,8 @@ class HtmlAttachment < Attachment
   extend FriendlyId
   friendly_id :title, use: :scoped, scope: :attachable
 
+  include HasContentId
+
   has_one :govspeak_content,
     autosave: true, inverse_of: :html_attachment, dependent: :destroy
 
@@ -124,9 +126,18 @@ private
   def fetch_previously_published_content_ids
     document_id = attachable.document_id
     edition_ids = Edition.unscoped.where(document_id: document_id).pluck(:id)
-    HtmlAttachment.where(
+    params = {
       attachable_id: edition_ids,
-      title: title
+      slug: slug
+    }
+
+    if !sluggable_locale? #translations don't have slugs
+      params.delete(:slug)
+      params[:title] = title
+    end
+
+    HtmlAttachment.where(
+      params
     ).pluck(:content_id)
   end
 end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -147,6 +147,72 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal content_id, new_attachment.content_id
   end
 
+  test "attachment with the same title but different base_path does not retain
+    the content_id" do
+    deleted_attachment = create(
+      :html_attachment,
+      title: "original title",
+      attachable: build(:published_publication)
+    )
+    #this will have slug `original-title`
+    deleted_attachment.update_attributes(title: "new title")
+
+    first_edition = deleted_attachment.attachable
+    deleted_attachment.destroy
+
+    new_draft = first_edition.create_draft(first_edition.creator)
+    #this will have slug `new-title`
+    new_attachment = create(
+      :html_attachment,
+      title: "new title",
+      attachable: new_draft
+    )
+
+    assert_not_equal new_attachment.content_id, deleted_attachment.content_id
+  end
+
+  test "translations with the same title retain the same content_id" do
+    content_id = "97660b60-d4cd-4bfe-b9f5-d95d20e78449"
+    first_attachment = create(
+      :html_attachment,
+      title: "Le Boeuf",
+      locale: "fr",
+      content_id: content_id
+    )
+
+    edition = first_attachment.attachable
+    first_attachment.destroy
+    second_attachment = create(
+      :html_attachment,
+      title: "Le Boeuf",
+      locale: "fr",
+      attachable: edition
+    )
+
+    assert_equal content_id, second_attachment.content_id
+  end
+
+  test "translations with the different titles get different content_id" do
+    content_id = "97660b60-d4cd-4bfe-b9f5-d95d20e78449"
+    first_attachment = create(
+      :html_attachment,
+      title: "Le Boeuf",
+      locale: "fr",
+      content_id: content_id
+    )
+
+    edition = first_attachment.attachable
+    first_attachment.destroy
+    second_attachment = create(
+      :html_attachment,
+      title: "Les Oeufs",
+      locale: "fr",
+      attachable: edition
+    )
+
+    assert_not_equal content_id, second_attachment.content_id
+  end
+
   test "attachment with an unused base path gets a new content_id" do
     first_attachment = create(
       :html_attachment,


### PR DESCRIPTION
When an `HtmlAttachment` is created on an `Edition` we check previous
`Edition`s to see if an attachment with the same title (and
consequently the same `base_path`) has existed before and if it does we
reuse the `content_id` otherwise we get a conflict when the most recent
`HtmlAttachment` is sent to the publishing API. Previously deleted
`HtmlAttachment` are redirected to the parent document so they still
have a representation in the publishing API (albeit a redirect but it
still causes a conflict).

This was being done by comparing the title of the new attachment with
all titles of attachments that have been associated with editions of the
parent document.

It is possible to rename `HtmlAttachment`s though which means that the
objects `title` and `slug` aren't always related. This can cause very
weird redirecting behaviour.

e.g.

'Edition one' (slug `edition-one`) gets an attachment 'Attachment one'
(slug `attachment-one`). So the attachment base_path is
`/edition-one/attachment-one`.

The attachment is then renamed to 'Attachment one rename'. Its slug
stays the same.

We then add another attachment called 'Attachment one rename' which gets
the slug 'attachment-one-rename'. The current code compares the titles
and takes the `content_id` from the original attachment. We now have two
attachments with the same title, same content_id but different slugs.

Depending on which attachment makes it to publishing API first we get a
variety of different combinations of strange redirects from one to the
other.

This commit compares using the slug rather than the title. The problem
with this approach is that the slug and the content_id are both created
in callbacks so we now need to make sure the slug is created before the
content_id. This has involved taking the `HasContentId` module out of
the base class.

Unfortunately translated `HtmlAttachment`s don't have slugs
(agghhhhh) so this approach won't work for them. The previous bug ridden
title comparison has been maintained for them until inspiration strikes.

[Trello](https://trello.com/c/Tv7sA09x/34-bug-republishing-attachments)