### PR TITLE
Add summary field to CSV export

### DIFF
--- a/app/presenters/document_list_export_presenter.rb
+++ b/app/presenters/document_list_export_presenter.rb
@@ -31,6 +31,7 @@ class DocumentListExportPresenter
       'History-mode applied',
       'Primary language',
       'Translations available',
+      'Summary',
     ]
   end
 
@@ -56,6 +57,7 @@ class DocumentListExportPresenter
       edition.historic?,
       primary_language,
       translations_available,
+      edition.summary,
     ]
   end
 

--- a/test/unit/presenters/document_list_export_presenter_test.rb
+++ b/test/unit/presenters/document_list_export_presenter_test.rb
@@ -106,4 +106,10 @@ class DocumentListExportPresenterTest < ActiveSupport::TestCase
     presenter = DocumentListExportPresenter.new(edition_translated_many_times)
     assert_equal %w(Arabic Welsh Malay), presenter.translations_available
   end
+
+  test '#row returns a summary' do
+    edition = create(:detailed_guide)
+    presenter = DocumentListExportPresenter.new(edition)
+    assert presenter.row.include?(edition.summary)
+  end
 end


### PR DESCRIPTION
For: [Trello card](https://trello.com/c/s5lEAwdw/187-add-summary-field-to-whitehall-csv-export)

This will add the `edition.summary` field to the CSV export, which will enable people looking at the CSV export to check at a glance whether:
- the summary is less than 140 characters
- ends in a full stop
- compare summaries for similar pages