### PR TITLE
Track clicks on links in policy area pages

### DIFF
--- a/app/views/classifications/_document_list.html.erb
+++ b/app/views/classifications/_document_list.html.erb
@@ -5,9 +5,30 @@
 <section id="<%= heading.downcase %>" class="document-block documents-<%= document_block_counter %>">
   <h1 class="label"><%= heading %></h1>
   <div class="content">
-    <%= render partial: "shared/list_description", locals: { editions: documents } %>
+    <%= render partial: "shared/list_description", locals: { heading: heading, editions: documents } %>
     <p class="see-all">
-      <%= link_to "See all #{heading.downcase}", public_send("#{type}_filter_path", @classification, publication_filter_option: filter_option) %>
+    <%-
+      see_more_url = public_send(
+        "#{type}_filter_path",
+        @classification,
+        publication_filter_option: filter_option
+      )
+    %>
+    <%=
+      link_to(
+        "See all #{heading.downcase}",
+        see_more_url,
+        data: {
+          track_category: 'navPolicyAreaLinkClicked',
+          track_action: "#{heading}.#{documents.count + 1}",
+          track_label: see_more_url,
+          track_options: {
+            dimension28: documents.count.to_s,
+            dimension29: "See all #{heading.downcase}"
+          }
+        }
+      )
+    %>
     </p>
   </div>
 </section>

--- a/app/views/shared/_list_description.html.erb
+++ b/app/views/shared/_list_description.html.erb
@@ -1,7 +1,23 @@
 <ol class="document-list">
-  <% editions.each do |edition| %>
+  <% editions.each_with_index do |edition, edition_index| %>
     <%= content_tag_for(:li, edition, class: 'document-row') do %>
-      <h2><%= link_to edition.title, public_document_path(edition) %></h2>
+      <h2>
+        <%=
+          link_to(
+            edition.title,
+            public_document_path(edition),
+            data: {
+              track_category: 'navPolicyAreaLinkClicked',
+              track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",
+              track_label: public_document_path(edition),
+              track_options: {
+                dimension28: editions.count.to_s,
+                dimension29: edition.title
+              }
+            }
+          )
+        %>
+      </h2>
       <ul class="attributes">
         <li class="publication-date"><%= edition.display_date_microformat %></li>
         <li class="document-type"><%= t_display_type(edition) %></li>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -2,7 +2,14 @@
 <% page_class "topics-show" %>
 <% atom_discovery_link_tag atom_feed_url_for(@classification), "Latest activity on #{@classification.name}" %>
 
-<%= content_tag_for(:div, @classification, class: "classification #{@classification.class.name.underscore}") do %>
+<%= content_tag_for(
+  :div,
+  @classification,
+  class: "classification #{@classification.class.name.underscore}",
+  data: {
+    module: 'track-click'
+  }
+) do %>
 
   <header class="block headings-block">
     <div class="inner-block floated-children">
@@ -75,14 +82,44 @@
           <h1 class="label">Detailed guides</h1>
           <div class="content">
             <ol class="collection-list one-column">
-              <% @detailed_guides.each do |detailed_guide| %>
+              <% @detailed_guides.each_with_index do |detailed_guide, detailed_guide_index| %>
                 <%= content_tag_for(:li, detailed_guide, class: 'topic collection-item') do %>
                   <div class="container">
-                    <h2><%= link_to detailed_guide.title, public_document_path(detailed_guide) %></h2>
+                    <h2>
+                      <%=
+                        link_to(
+                          detailed_guide.title,
+                          public_document_path(detailed_guide) ,
+                          data: {
+                            track_category: 'navPolicyAreaLinkClicked',
+                            track_action: "DetailedGuides.#{detailed_guide_index + 1}",
+                            track_label: public_document_path(detailed_guide),
+                            track_options: {
+                              dimension28: @detailed_guides.count.to_s,
+                              dimension29: detailed_guide.title
+                            }
+                          }
+                        )
+                      %>
+                    </h2>
                     <div class="summary">
                       <p>
                         <%= detailed_guide.summary %>
-                        <%= link_to "Read more", public_document_path(detailed_guide) %>
+                        <%=
+                          link_to(
+                            "Read more",
+                            public_document_path(detailed_guide),
+                            data: {
+                            track_category: 'navPolicyAreaLinkClicked',
+                              track_action: "DetailedGuides.#{detailed_guide_index + 1}",
+                              track_label: public_document_path(detailed_guide),
+                              track_options: {
+                                dimension28: @detailed_guides.count.to_s,
+                                dimension29: detailed_guide.title
+                              }
+                            }
+                          )
+                        %>
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
This commit adds tracking attributes to all links in policy area pages.
Those links will be under:

- Annoucements
- Consultations
- Publications
- Statistics
- Detailed gudies

The data will help us understand how users use these pages.

An example click on a link to a detailed guide will generate the following event:

```
ga("send", {hitType: "event", eventCategory: "navPolicyAreaLinkClicked", eventAction: "DetailedGuides.1", eventLabel: "/guidance/how-to-challenge-our-decision-to-schedule-or-not-to-schedule-a-monument", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension2: "placeholder_policy_area", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension9: "<D5><PB571><PB1164>", dimension17: "placeholder_policy_area", dimension20: "whitehall", dimension32: "none", dimension33: "thing", dimension34: "other", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", transport: "beacon", dimension28: "5", dimension29: "How to challenge our decision to schedule or not to schedule a monument"})
```

The most important attributes here are:
- `eventCategory: "navPolicyAreaLinkClicked"`;
- `eventAction: "DetailedGuides.1"` - meaning it's the 1st link from the detailed guides' section;
- `eventLabel: "/guidance/how-to-challenge-our-decision-to-schedule-or-not-to-schedule-a-monument"` - the href of the link we clicked;
- `dimension28: "5"` - there were 5 links on the section;
- `dimension29: "How to challenge our decision to schedule or not to schedule a monument"` - the title of the detailed guide.

Trello: https://trello.com/c/1zi6Nr3B/31-add-link-position-tracking-to-whitehall-navigation