### PR TITLE
Track clicks on links in finder-type pages

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -8,10 +8,14 @@ class AnnouncementsController < DocumentsController
 
     respond_to do |format|
       format.html do
-        @filter = DocumentFilterPresenter.new(@filter, view_context, AnnouncementPresenter)
+        @filter = AnnouncementFilterJsonPresenter.new(
+          @filter, view_context, AnnouncementPresenter
+        )
       end
       format.json do
-        render json: AnnouncementFilterJsonPresenter.new(@filter, view_context, AnnouncementPresenter)
+        render json: AnnouncementFilterJsonPresenter.new(
+          @filter, view_context, AnnouncementPresenter
+        )
       end
       format.atom do
         documents = Announcement.published_with_eager_loading(@filter.documents.map(&:id))

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -10,7 +10,9 @@ class PublicationsController < DocumentsController
 
     respond_to do |format|
       format.html do
-        @filter = DocumentFilterPresenter.new(@filter, view_context, PublicationesquePresenter)
+        @filter = PublicationFilterJsonPresenter.new(
+          @filter, view_context, PublicationesquePresenter
+        )
       end
       format.json do
         render json: PublicationFilterJsonPresenter.new(@filter, view_context, PublicationesquePresenter)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -9,7 +9,9 @@ class StatisticsController < DocumentsController
 
     respond_to do |format|
       format.html do
-        @filter = DocumentFilterPresenter.new(@filter, view_context, PublicationesquePresenter)
+        @filter = StatisticsFilterJsonPresenter.new(
+          @filter, view_context, PublicationesquePresenter
+        )
       end
       format.json do
         render json: StatisticsFilterJsonPresenter.new(@filter, view_context, PublicationesquePresenter)

--- a/app/presenters/document_filter_presenter.rb
+++ b/app/presenters/document_filter_presenter.rb
@@ -12,13 +12,14 @@ class DocumentFilterPresenter < Struct.new(:filter, :context, :document_decorato
       current_page: documents.current_page,
       total_pages: documents.total_pages,
       total_count: documents.total_count,
-      results: documents.map { |d| d.as_hash },
+      results: documents.each_with_index.map { |d, i| { result: d.as_hash, index: i + 1 } },
       results_any?: documents.any?,
       result_type: result_type,
       no_results_title: context.t('document_filters.no_results.title'),
       no_results_description: context.t('document_filters.no_results.description'),
       no_results_tna_heading: context.t('document_filters.no_results.tna_heading'),
-      no_results_tna_link: context.t('document_filters.no_results.tna_link')
+      no_results_tna_link: context.t('document_filters.no_results.tna_link'),
+      category: result_type.capitalize,
     }
     if !documents.last_page? || !documents.first_page?
       data[:more_pages?] = true

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -1,29 +1,37 @@
 {{#results_any?}}
-  <ol class="js-document-list document-list">
+  <ol class="js-document-list document-list" data-module="track-click">
     {{#results}}
-      <li id="{{type}}_{{id}}" class="document-row">
-        <h3><a href="{{url}}">{{title}}</a></h3>
+      <li id="{{result.type}}_{{result.id}}" class="document-row">
+        <h3>
+          <a
+            href="{{result.url}}"
+            data-category="nav{{category}}LinkClicked"
+            data-action="{{index}}"
+            data-label="{{result.url}}"
+            data-options='{"dimension28":"{{count}}","dimension29":"{{result.title}}"}'
+            >{{result.title}}</a>
+        </h3>
         <ul class="attributes">
-          <li>{{{display_date_microformat}}}</li>
-          <li class="organisations">{{{organisations}}}</li>
-          <li class="display-type">{{display_type}}</li>
-          {{#field_of_operation}}
-            <li class="field-of-operation">{{{field_of_operation}}}</li>
-          {{/field_of_operation}}
-          {{#topics}}
-            <li class="topics">{{{topics}}}</li>
-          {{/topics}}
-          {{#publication_collections}}
-            <li class="document-collections">{{{publication_collections}}}</li>
-          {{/publication_collections}}
+          <li>{{{result.display_date_microformat}}}</li>
+          <li class="organisations">{{{result.organisations}}}</li>
+          <li class="display-type">{{result.display_type}}</li>
+          {{#result.field_of_operation}}
+            <li class="field-of-operation">{{{result.field_of_operation}}}</li>
+          {{/result.field_of_operation}}
+          {{#result.topics}}
+            <li class="topics">{{{result.topics}}}</li>
+          {{/result.topics}}
+          {{#result.publication_collections}}
+            <li class="document-collections">{{{result.publication_collections}}}</li>
+          {{/result.publication_collections}}
         </ul>
-        {{#historic?}}
-          {{#government_name}}
+        {{#result.historic?}}
+          {{#result.government_name}}
             <p class="historic">
-            First published during the {{government_name}}
+            First published during the {{result.government_name}}
             </p>
-          {{/government_name}}
-        {{/historic?}}
+          {{/result.government_name}}
+        {{/result.historic?}}
       </li>
     {{/results}}
   </ol>

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -262,4 +262,54 @@ class AnnouncementsControllerTest < ActionController::TestCase
     get :index, locale: 'fr'
     refute_select '.filter-results-summary'
   end
+
+  view_test 'index includes tracking details on all links' do
+    news_article = create(:published_news_article)
+
+    get :index
+
+    assert_select_object(news_article) do
+      results_list = css_select('ol.document-list').first
+
+      assert_equal(
+        'track-click',
+        results_list.attributes['data-module'].value,
+        "Expected the document list to have the 'track-click' module"
+      )
+
+      article_link = css_select('li.document-row a').first
+
+      assert_equal(
+        'navAnnouncementLinkClicked',
+        article_link.attributes['data-category'].value,
+        "Expected the data category attribute to be 'navAnnouncementLinkClicked'"
+      )
+
+      assert_equal(
+        '1',
+        article_link.attributes['data-action'].value,
+        "Expected the data action attribute to be the 1st position on the list"
+      )
+
+      assert_equal(
+        public_document_path(news_article),
+        article_link.attributes['data-label'].value,
+        "Expected the data label attribute to be the link of the news article"
+      )
+
+      options = JSON.parse(article_link.attributes['data-options'].value)
+
+      assert_equal(
+        '1',
+        options['dimension28'],
+        "Expected the custom dimension 28 to have the total number of articles"
+      )
+
+      assert_equal(
+        news_article.title,
+        options['dimension29'],
+        "Expected the custom dimension 29 to have the title of the article"
+      )
+    end
+  end
 end

--- a/test/javascripts/unit/document_filter_test.js
+++ b/test/javascripts/unit/document_filter_test.js
@@ -44,21 +44,27 @@ module("Document filter", {
       "result_type": "publication",
       "results": [
         {
-          "id": 1,
-          "type": "document-type",
-          "title": "document-title",
-          "url": "/document-path",
-          "organisations": "organisation-name-1, organisation-name-2",
-          "topics": "topic-name-1, topic-name-2",
-          "field_of_operation": "place-of-war"
+          "result": {
+            "id": 1,
+            "type": "document-type",
+            "title": "document-title",
+            "url": "/document-path",
+            "organisations": "organisation-name-1, organisation-name-2",
+            "topics": "topic-name-1, topic-name-2",
+            "field_of_operation": "place-of-war"
+          },
+          "index": 1
         },
         {
-          "id": 2,
-          "type": "document-type-2",
-          "title": "document-title-2",
-          "url": "/document-path-2",
-          "organisations": "organisation-name-2, organisation-name-3",
-          "publication_collections": "collection-1"
+          "result": {
+            "id": 2,
+            "type": "document-type-2",
+            "title": "document-title-2",
+            "url": "/document-path-2",
+            "organisations": "organisation-name-2, organisation-name-3",
+            "publication_collections": "collection-1"
+          },
+          "index": 2
         }
       ]
     };

--- a/test/unit/presenters/document_filter_presenter_test.rb
+++ b/test/unit/presenters/document_filter_presenter_test.rb
@@ -62,24 +62,29 @@ class DocumentFilterPresenterTest < PresenterTestCase
     refute json.has_key?("prev_page_url")
   end
 
-  test 'json provides a list of documents' do
+  test 'json provides a list of documents with their positions' do
     presenters = [PublicationesquePresenter.new(stub_publication, @view_context)]
     @filter.stubs(:documents).returns(Kaminari.paginate_array(presenters).page(1))
     json = JSON.parse(DocumentFilterPresenter.new(@filter, @view_context).to_json)
     assert_equal 1, json['results'].size
-    assert_equal({
-      "id" => stub_publication.id,
-      "type" => "publication",
-      "display_type" => "Policy paper",
-      "title" => stub_publication.title,
-      "url" => "/government/publications/some-doc",
-      "organisations" => "Ministry of Silly",
-      "display_date_microformat" => "<time class=\"public_timestamp\" datetime=\"2011-11-08T11:11:11+00:00\"> 8 November 2011</time>",
-      "public_timestamp" => 3.days.ago.as_json,
-      "historic?" => false,
-      "government_name" => nil,
-      "publication_collections" => nil,
-      }, json['results'].first)
+    expected_result = {
+      'result' => {
+        "id" => stub_publication.id,
+        "type" => "publication",
+        "display_type" => "Policy paper",
+        "title" => stub_publication.title,
+        "url" => "/government/publications/some-doc",
+        "organisations" => "Ministry of Silly",
+        "display_date_microformat" => "<time class=\"public_timestamp\" datetime=\"2011-11-08T11:11:11+00:00\"> 8 November 2011</time>",
+        "public_timestamp" => 3.days.ago.as_json,
+        "historic?" => false,
+        "government_name" => nil,
+        "publication_collections" => nil,
+      },
+      'index' => 1,
+    }
+
+    assert_equal(expected_result, json['results'].first)
   end
 
   test 'decorates each documents with the given decorator class' do
@@ -93,5 +98,15 @@ class DocumentFilterPresenterTest < PresenterTestCase
     assert_instance_of MyDecorator, presenter.documents.first
     assert_equal stub_document, presenter.documents.first.model
     assert_equal @view_context, presenter.documents.first.context
+  end
+
+  test 'includes the category of documents being presented' do
+    json = JSON.parse(DocumentFilterPresenter.new(@filter, @view_context).to_json)
+
+    assert_equal(
+      'Document',
+      json['category'],
+      'It should have a category attribute of "Document"'
+    )
   end
 end

--- a/test/unit/presenters/publication_filter_json_presenter_test.rb
+++ b/test/unit/presenters/publication_filter_json_presenter_test.rb
@@ -11,4 +11,18 @@ class PublicationFilterJsonPresenterTest < PresenterTestCase
     json = JSON.parse(PublicationFilterJsonPresenter.new(@filter, @view_context).to_json)
     assert_equal Whitehall.atom_feed_maker.publications_url, json['atom_feed_url']
   end
+
+  test 'includes the category of documents being presented' do
+    presenter = JSON.parse(
+      PublicationFilterJsonPresenter.new(
+        @filter, @view_context, PublicationesquePresenter
+      ).to_json
+    )
+
+    assert_equal(
+      'Publication',
+      presenter['category'],
+      'It should have a category attribute of "Publication"'
+    )
+  end
 end

--- a/test/unit/presenters/statistics_filter_json_presenter_test.rb
+++ b/test/unit/presenters/statistics_filter_json_presenter_test.rb
@@ -1,23 +1,23 @@
 require 'test_helper'
 
-class AnnouncementFilterJsonPresenterTest < PresenterTestCase
+class StatisticsFilterJsonPresenterTest < PresenterTestCase
   setup do
     @filter = Whitehall::DocumentFilter::FakeSearch.new
     @view_context.params[:action] = :index
-    @view_context.params[:controller] = :announcements
+    @view_context.params[:controller] = :statistics
   end
 
   test 'includes the category of documents being presented' do
     presenter = JSON.parse(
-      AnnouncementFilterJsonPresenter.new(
-        @filter, @view_context, AnnouncementPresenter
+      StatisticsFilterJsonPresenter.new(
+        @filter, @view_context, PublicationesquePresenter
       ).to_json
     )
 
     assert_equal(
-      'Announcement',
+      'Statistic',
       presenter['category'],
-      'It should have a category attribute of "Announcement"'
+      'It should have a category attribute of "Statistic"'
     )
   end
 end


### PR DESCRIPTION
This includes:

- Publications (and publication-like pages);
- Announcements;
- Statistics.

Every link will include the category name (as described above) and
information about the link being clicked and which position the link is
on.

Trello: https://trello.com/c/1zi6Nr3B/31-add-link-position-tracking-to-whitehall-navigation