### PR TITLE
Remove topic title from topical event pages

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -15,8 +15,7 @@
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
-                locals: { type: 'Topic',
-                          heading: "#{h(@classification.name)}#{' <span class="archived">(Archived)</span>' if @classification.archived?}".html_safe,
+                locals: { heading: "#{h(@classification.name)}#{' <span class="archived">(Archived)</span>' if @classification.archived?}".html_safe,
                           big: true, extra: true } %>
       <% if @classification.logo_url.present? %>
         <div class="heading-extra topical-event-logo">


### PR DESCRIPTION
This commit removes the “topic” title from topical event pages since it is redundant and not always appropriate.

Trello: https://trello.com/c/2HR2e1kq/39-remove-topic-from-topical-event-pages

Before:

![screen shot 2017-07-20 at 08 53 46](https://user-images.githubusercontent.com/444232/28406742-a14fb732-6d29-11e7-8c19-87fad9c1ec67.png)

After:

![screen shot 2017-07-20 at 08 58 18](https://user-images.githubusercontent.com/444232/28406749-a6374684-6d29-11e7-843c-4dacfbadb93f.png)
