### PR TITLE
Create JSON endpoint to show Policy Area

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -1,5 +1,12 @@
 class Admin::TopicsController < Admin::ClassificationsController
 
+  def show
+    respond_to do |format|
+      format.html
+      format.json { render json: @classification, include: :classification_policies }
+    end
+  end
+
   private
 
   def model_class

--- a/test/factories/topics.rb
+++ b/test/factories/topics.rb
@@ -2,5 +2,9 @@ FactoryGirl.define do
   factory :topic do
     sequence(:name) { |index| "topic-#{index}" }
     description 'Topic description'
+
+    trait :with_classification_policies do
+      classification_policies { create_list(:classification_policy, 1) }
+    end
   end
 end

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -30,6 +30,14 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     assert_select 'h1', topic.name
   end
 
+  view_test "GET :show as JSON lists the topic's classification policies" do
+    topic = create(:topic, :with_classification_policies)
+    get :show, id: topic, format: :json
+
+    assert_response :success
+    assert json_response['classification_policies']
+  end
+
   ### Describing :new ###
 
   view_test "GET :new displays topic form" do


### PR DESCRIPTION
Helps to build up the relationships between Policy Areas and Policies for the Q2 taxonomy work we are doing.

[Trello](https://github.com/alphagov/whitehall/pull/3346)