### PR TITLE
Remove the UK world location

### DIFF
--- a/db/data_migration/20170720144123_remove_united_kingdom_world_location_taggings.rb
+++ b/db/data_migration/20170720144123_remove_united_kingdom_world_location_taggings.rb
@@ -1,0 +1,8 @@
+# Remove all instances where editions have been tagged to "United Kingdom" as
+# a WorldLocation, before removing the WorldLocation itself.
+
+UK_WORLD_LOCATION_ID = 202
+
+EditionWorldLocation.where(world_location_id: UK_WORLD_LOCATION_ID).destroy
+
+WorldLocation.find(UK_WORLD_LOCATION_ID).destroy


### PR DESCRIPTION
This commit removes the UK world location and untags all editions that are tagged to it.

It doesn’t make sense to have a world location for the UK since all documents are assumed to be about the UK unless expressly tagged to another world location. This also causes confusion for users who sign up to email alerts for the UK world location but are not alerted to the majority of changes since tagging is inconsistent.

Trello: https://trello.com/c/FCbbsRLo/49-use-of-united-kingdom-as-a-world-location