### PR TITLE
Fix Uk world location data migration

### DIFF
--- a/db/data_migration/20170720144123_remove_united_kingdom_world_location_taggings.rb
+++ b/db/data_migration/20170720144123_remove_united_kingdom_world_location_taggings.rb
@@ -3,6 +3,6 @@
 
 UK_WORLD_LOCATION_ID = 202
 
-EditionWorldLocation.where(world_location_id: UK_WORLD_LOCATION_ID).destroy
+EditionWorldLocation.where(world_location_id: UK_WORLD_LOCATION_ID).destroy_all
 
 WorldLocation.find(UK_WORLD_LOCATION_ID).destroy


### PR DESCRIPTION
This commit fixes the data migration to change `destroy` to `destroy_all` since we are working with a collection of records.