### PR TITLE
Allow broken link reporting by organisation

### DIFF
--- a/lib/tasks/broken_link_reporting.rake
+++ b/lib/tasks/broken_link_reporting.rake
@@ -1,11 +1,12 @@
 desc "Generates and emails CSV reports of all public documents containing broken links."
-task :generate_broken_link_reports, [:reports_dir, :email_address] => [:environment] do |_, args|
+task :generate_broken_link_reports, [:reports_dir, :email_address, :organisation_slug] => [:environment] do |_, args|
   begin
-    reports_dir     = args[:reports_dir]
-    email_address   = args[:email_address]
-    report_zip_name = "broken-link-reports-#{Date.today.strftime}.zip"
-    report_zip_path = Pathname.new(reports_dir).join(report_zip_name)
-    logger          = Logger.new(Rails.root.join('log/broken_link_reporting.log'))
+    reports_dir       = args[:reports_dir]
+    email_address     = args[:email_address]
+    organisation_slug = args[:organisation_slug]
+    report_zip_name   = "broken-link-reports-#{Date.today.strftime}.zip"
+    report_zip_path   = Pathname.new(reports_dir).join(report_zip_name)
+    logger            = Logger.new(Rails.root.join('log/broken_link_reporting.log'))
 
     logger.info("Cleaning up any existing reports.")
     FileUtils.mkpath reports_dir
@@ -13,7 +14,8 @@ task :generate_broken_link_reports, [:reports_dir, :email_address] => [:environm
     FileUtils.rm(report_zip_path) if File.exists?(report_zip_path)
 
     logger.info("Generating broken link reports...")
-    Whitehall::BrokenLinkReporter.new(reports_dir, logger).generate_reports
+    organisation = Organisation.where(slug: organisation_slug).first if organisation_slug
+    Whitehall::BrokenLinkReporter.new(reports_dir, logger, organisation).generate_reports
 
     logger.info("Reports generated. Zipping...")
     system "zip #{report_zip_path} #{reports_dir}/*_broken_links.csv --junk-paths"

--- a/lib/whitehall/broken_link_reporter.rb
+++ b/lib/whitehall/broken_link_reporter.rb
@@ -1,12 +1,13 @@
 # Generates CSV reports of all public documents containing broken links.
 module Whitehall
   class BrokenLinkReporter
-    attr_reader :csv_reports, :logger
+    attr_reader :csv_reports, :logger, :organisation
 
-    def initialize(csv_reports_dir, logger = Rails.logger)
+    def initialize(csv_reports_dir, logger = Rails.logger, organisation = nil)
       @csv_reports_dir = csv_reports_dir
       @csv_reports = {}
       @logger = logger
+      @organisation = organisation
     end
 
     def generate_reports
@@ -27,7 +28,11 @@ module Whitehall
   private
 
     def public_editions
-      Edition.publicly_visible.with_translations
+      if organisation.nil?
+        Edition.publicly_visible.with_translations
+      else
+        Edition.publicly_visible.with_translations.in_organisation(organisation)
+      end
     end
 
     def csv_row_for(checker)
@@ -100,7 +105,7 @@ module Whitehall
 
     private
 
-      # These hosts are hardcoded because we run this on preview but want the
+      # These hosts are hardcoded because we run this on integration but want the
       # generated URLs to be production ones.
       def public_host
         "www.gov.uk"

--- a/test/integration/broken_link_reporter_test.rb
+++ b/test/integration/broken_link_reporter_test.rb
@@ -4,7 +4,7 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
 
   teardown do
     if File.directory?(reports_dir)
-      FileUtils.rm Dir.glob(reports_dir.join('*_bad_links.csv'))
+      FileUtils.rm Dir.glob(reports_dir.join('*_broken_links.csv'))
     end
   end
 
@@ -39,30 +39,73 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
     embassy_csv = CSV.read(reports_dir.join('british-embassy-paris_broken_links.csv'))
     assert_equal 2, embassy_csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], embassy_csv[0]
-    assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.world_location_news_article_path(news_article.slug)}",
-                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_world_location_news_article_path(news_article)}",
-                   news_article.public_timestamp.to_s,
-                   'WorldLocationNewsArticle',
-                   '1',
-                   'https://www.gov.uk/missing-link'], embassy_csv[1]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.world_location_news_article_path(news_article.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_world_location_news_article_path(news_article)}",
+                  news_article.public_timestamp.to_s,
+                  'WorldLocationNewsArticle',
+                  '1',
+                  'https://www.gov.uk/missing-link'], embassy_csv[1]
 
     hmrc_csv = CSV.read(reports_dir.join('hm-revenue-customs_broken_links.csv'))
     assert_equal 3, hmrc_csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], hmrc_csv[0]
-    assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
-                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
-                   publication.public_timestamp.to_s,
-                   'Publication',
-                   '1',
-                   "https://www.gov.uk/bad-link"], hmrc_csv[1]
-    assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
-                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
-                   detailed_guide.public_timestamp.to_s,
-                   'DetailedGuide',
-                   '2',
-                   "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"], hmrc_csv[2]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                  publication.public_timestamp.to_s,
+                  'Publication',
+                  '1',
+                  "https://www.gov.uk/bad-link"], hmrc_csv[1]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                  detailed_guide.public_timestamp.to_s,
+                  'DetailedGuide',
+                  '2',
+                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"], hmrc_csv[2]
   end
 
+  test 'generates CSV reports detailing broken links on public documents tagged to a defined organisation' do
+    stub_request(:any, 'https://www.gov.uk/good-link').to_return(status: 200)
+    stub_request(:any, 'https://www.gov.uk/another-good-link').to_return(status: 200)
+    stub_request(:any, 'https://www.gov.uk/bad-link').to_return(status: 500)
+    stub_request(:any, 'https://www.gov.uk/missing-link').to_return(status: 404)
+
+    hmrc = create(:organisation, name: 'HM Revenue & Customs')
+    embassy_paris = create(:worldwide_organisation, name: 'British Embassy Paris')
+
+    publication    = create(:published_publication,
+                            lead_organisations: [hmrc],
+                            body: "[A broken page](https://www.gov.uk/bad-link)\n[A good link](https://www.gov.uk/another-good-link)")
+
+    detailed_guide = create(:published_detailed_guide,
+                            lead_organisations: [hmrc],
+                            body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)")
+
+    create(:world_location_news_article,
+           :withdrawn,
+           worldwide_organisations: [embassy_paris],
+           body: "[Good link](https://www.gov.uk/good-link)\n[Missing page](https://www.gov.uk/missing-link)")
+
+    Dir.mkdir(reports_dir) unless File.directory?(reports_dir)
+    Whitehall::BrokenLinkReporter.new(reports_dir.to_s, NullLogger.instance, hmrc).generate_reports
+
+    refute File.file?(reports_dir.join('british-embassy-paris_broken_links.csv'))
+
+    hmrc_csv = CSV.read(reports_dir.join('hm-revenue-customs_broken_links.csv'))
+    assert_equal 3, hmrc_csv.size
+    assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], hmrc_csv[0]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                  publication.public_timestamp.to_s,
+                  'Publication',
+                  '1',
+                  "https://www.gov.uk/bad-link"], hmrc_csv[1]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                  detailed_guide.public_timestamp.to_s,
+                  'DetailedGuide',
+                  '2',
+                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"], hmrc_csv[2]
+  end
 
   test 'does not blow up if a document does not have any organisations' do
     stub_request(:any, 'https://www.gov.uk/good-link').to_return(status: 200)
@@ -80,13 +123,12 @@ class BrokenLinkReporterTest < ActiveSupport::TestCase
     csv = CSV.read(reports_dir.join('no-organisation_broken_links.csv'))
     assert_equal 2, csv.size
     assert_equal ['page', 'admin link', 'public timestamp', 'format', 'broken link count', 'broken links'], csv[0]
-    assert_equal [ "https://www.gov.uk#{Whitehall.url_maker.speech_path(speech.slug)}",
-                   "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
-                   speech.public_timestamp.to_s,
-                   'Speech',
-                   '1',
-                   'https://www.gov.uk/missing-link'], csv[1]
-
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.speech_path(speech.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_speech_path(speech)}",
+                  speech.public_timestamp.to_s,
+                  'Speech',
+                  '1',
+                  'https://www.gov.uk/missing-link'], csv[1]
   end
 
 private


### PR DESCRIPTION
This commit adds support to the broken link reporting feature to filter by organisation.