### PR TITLE
Catch JSON::ParserError

### DIFF
--- a/lib/sync_checker/checks/details_check.rb
+++ b/lib/sync_checker/checks/details_check.rb
@@ -7,11 +7,15 @@ module SyncChecker
       def call(response)
         failures = []
         if response.response_code == 200
-          @content_item = JSON.parse(response.body)
-          if run_check?
-            expected_details.each do |k, v|
-              failures << check_key(k, v)
+          begin
+            @content_item = JSON.parse(response.body)
+            if run_check?
+              expected_details.each do |k, v|
+                failures << check_key(k, v)
+              end
             end
+          rescue JSON::ParserError
+            failures << "response.body not valid JSON. Likely not present in the content store"
           end
         end
         failures.compact

--- a/lib/sync_checker/checks/html_attachment_unpublished_check.rb
+++ b/lib/sync_checker/checks/html_attachment_unpublished_check.rb
@@ -12,11 +12,15 @@ module SyncChecker
         return failures unless attachable.unpublishing.present?
 
         if there_is_an_item_in_the_content_store?
-          @content_item = JSON.parse(response.body)
-          if attachable_has_been_withdrawn?
-            failures << check_for_withdrawn_notice
-          elsif attachable_has_been_unpublished?
-            failures << check_redirected
+          begin
+            @content_item = JSON.parse(response.body)
+            if attachable_has_been_withdrawn?
+              failures << check_for_withdrawn_notice
+            elsif attachable_has_been_unpublished?
+              failures << check_redirected
+            end
+          rescue JSON::ParserError
+            failures << "response.body not valid JSON. Likely not present in the content store"
           end
         else
           failures << "attachable has been unpublished but the attachment has nothing in the content store"

--- a/lib/sync_checker/checks/links_check.rb
+++ b/lib/sync_checker/checks/links_check.rb
@@ -6,14 +6,18 @@ module SyncChecker
       def call(response)
         failures = []
         if response.response_code == 200
-          @content_item = JSON.parse(response.body)
-          if run_check?
-            if key_should_be_present? && object_at_key.nil?
-              failures << "the links key '#{links_key}' is not present"
-            else
-              failures += check_for_missing_content_ids
-              failures += check_for_unexpected_content_ids
+          begin
+            @content_item = JSON.parse(response.body)
+            if run_check?
+              if key_should_be_present? && object_at_key.nil?
+                failures << "the links key '#{links_key}' is not present"
+              else
+                failures += check_for_missing_content_ids
+                failures += check_for_unexpected_content_ids
+              end
             end
+          rescue
+            failures << "response.body not valid JSON. Likely not present in the content store"
           end
         end
         failures.flatten.compact

--- a/lib/sync_checker/checks/top_level_check.rb
+++ b/lib/sync_checker/checks/top_level_check.rb
@@ -5,13 +5,17 @@ module SyncChecker
       def call(response)
         failures = []
         if response.response_code == 200
-          @content_item = JSON.parse(response.body)
-          if run_check?
-            expected.each do |k, v|
-              if expected[k] != content_item[k.to_s]
-                failures << "expected #{k}: '#{v}', got '#{content_item[k.to_s]}'"
+          begin
+            @content_item = JSON.parse(response.body)
+            if run_check?
+              expected.each do |k, v|
+                if expected[k] != content_item[k.to_s]
+                  failures << "expected #{k}: '#{v}', got '#{content_item[k.to_s]}'"
+                end
               end
             end
+          rescue JSON::ParserError
+            failures << "response.body not valid JSON. Likely not present in the content store"
           end
         end
         failures

--- a/lib/sync_checker/checks/topics_check.rb
+++ b/lib/sync_checker/checks/topics_check.rb
@@ -11,10 +11,14 @@ module SyncChecker
       def call(response)
         failures = []
         if response.response_code == 200
-          @content_item = JSON.parse(response.body)
-          if run_check?
-            failures << check_parent
-            failures << check_topics
+          begin
+            @content_item = JSON.parse(response.body)
+            if run_check?
+              failures << check_parent
+              failures << check_topics
+            end
+          rescue JSON::ParserError
+            failures << "response.body not valid JSON. Likely not present in the content store"
           end
         end
         failures.flatten.compact


### PR DESCRIPTION
This commit adds error handling to the sync checks. They currently fail with a `JSON::ParserError` if the content store redirects to a `special_route` when the content item is not found. It still returns a 200 response but the body is HTML which causes the error.

Marked DNM until manually tested.

[Trello](https://trello.com/c/9odHKy0o/5-migrate-existing-wlna-to-newsarticle-format)