### PR TITLE
Make country optional for contacts

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -11,7 +11,7 @@ class Contact < ApplicationRecord
 
   validates :title, :contact_type, presence: true
   validates :contact_form_url, uri: true, allow_blank: true
-  validates :street_address, :country_id, presence: true, if: -> r { r.has_postal_address? }
+  validates :street_address, presence: true, if: -> (r) { r.has_postal_address? }
   accepts_nested_attributes_for :contact_numbers, allow_destroy: true, reject_if: :all_blank
 
   after_update :republish_dependent_editions

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -41,7 +41,7 @@ class ContactTest < ActiveSupport::TestCase
     assert_equal ["can't be blank"], contact.errors[:street_address]
   end
 
-  test "should be invalid with only street address but no country" do
+  test "should be valid with only street address" do
     contact = build(:contact,
       recipient: "",
       street_address: "123 Acacia Avenue",
@@ -49,8 +49,7 @@ class ContactTest < ActiveSupport::TestCase
       region: "",
       postal_code: "",
       country_id: "")
-    refute contact.valid?
-    assert_equal ["can't be blank"], contact.errors[:country_id]
+    assert contact.valid?
   end
 
   test "should be valid with only street address and country" do


### PR DESCRIPTION
This commit makes the country field optional for contacts. Since the UK was removed as a world location in https://github.com/alphagov/whitehall/pull/3347, addresses in the UK will not have an associated country.