### PR TITLE
Disallow tagging to inactive world locations

### DIFF
--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -101,7 +101,7 @@ module Admin::TaggableContentHelper
   # of the array consists of two values: the location name and its ID
   def taggable_world_locations_container
     Rails.cache.fetch(taggable_world_locations_cache_digest, expires_in: 1.day) do
-      WorldLocation.ordered_by_name.map {|w| [w.name, w.id] }
+      WorldLocation.ordered_by_name.where(active: true).map { |w| [w.name, w.id] }
     end
   end
 

--- a/db/data_migration/20170724124104_add_united_kingdom_world_location.rb
+++ b/db/data_migration/20170724124104_add_united_kingdom_world_location.rb
@@ -1,0 +1,10 @@
+WorldLocation.create!(
+  id: 202,
+  name: "United Kingdom",
+  title: "UK and United Kingdom",
+  world_location_type: WorldLocationType::WorldLocation,
+  active: false,
+  iso2: "GB",
+  analytics_identifier: "WL202",
+  content_id: "5e9f371a-7706-11e4-a3cb-005056011aef"
+)

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -33,7 +33,7 @@ end
 Given(/^there are some published publications$/) do
   topic = create :topic, name: "A Topic"
   department = create(:ministerial_department, name: "A Department")
-  world_location = create(:world_location, name: "A World Location")
+  world_location = create(:world_location, name: "A World Location", active: true)
 
   create :published_publication, title: "Publication with keyword"
   create :published_guidance, title: "Guidance publication"
@@ -132,7 +132,7 @@ end
 Given(/^there are some published announcements$/) do
   topic = create :topic, name: "A Topic"
   department = create(:ministerial_department, name: "A Department")
-  world_location = create(:world_location, name: "A World Location")
+  world_location = create(:world_location, name: "A World Location", active: true)
 
   create :published_news_story, title: "News Article with keyword, topic, department, world location published within date range",
          first_published_at: "2013-02-01",

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -149,7 +149,7 @@ end
 When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do |news_type, title|
   if news_type == "World news story"
     create(:worldwide_organisation, name: "Afghanistan embassy")
-    create(:world_location, name: "Afghanistan")
+    create(:world_location, name: "Afghanistan", active: true)
     begin_drafting_news_article(title: title, first_published: Date.today.to_s, announcement_type: news_type)
     select "Afghanistan embassy", from: "Select the worldwide organisations associated with this news article"
     select "Afghanistan", from: "Select the world locations this news article is about"

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 Given /^a worldwide organisation that is translated exists$/ do
-  world_location = create(:world_location)
+  world_location = create(:world_location, active: true)
   worldwide_organisation = create(:worldwide_organisation,
     world_locations: [world_location],
     name: "en-organisation",
@@ -44,7 +44,7 @@ end
 
 Given(/^the organisation "(.*?)" is translated into Welsh and has a contact "(.*?)"$/) do |organisation_name, contact_title|
   organisation = create(:organisation, name: organisation_name, translated_into: :cy)
-  contact = create(:contact, title: contact_title, country: create(:world_location),
+  contact = create(:contact, title: contact_title, country: create(:world_location, active: true),
                    street_address: '123 The Avenue', contactable: organisation)
   create(:contact_number, contact: contact,
          label: 'English phone', number: '0123456789')
@@ -73,7 +73,7 @@ end
 
 Given(/^the world organisation "(.*?)" is translated into French and has an office "(.*?)"$/) do |organisation_name, office_name|
   organisation = create(:worldwide_organisation, name: organisation_name, translated_into: :fr)
-  contact = create(:contact, title: office_name, country: create(:world_location),
+  contact = create(:contact, title: office_name, country: create(:world_location, active: true),
                    street_address: "123 The Avenue")
   create(:contact_number, contact: contact, label: "English phone", number: "0123456789")
   office = create(:worldwide_office, worldwide_organisation: organisation, contact: contact)

--- a/features/step_definitions/world_location_news_article_steps.rb
+++ b/features/step_definitions/world_location_news_article_steps.rb
@@ -25,7 +25,7 @@ Then /^I should only be able to view the world location news article article in 
 end
 
 When /^I draft a valid world location news article "([^"]*)"$/ do |title|
-  world_location = create(:world_location, name: "Afganistan")
+  world_location = create(:world_location, name: "Afganistan", active: true)
   worldwide_organisation = create(:worldwide_organisation, name: "Afganistan embassy")
 
   begin_drafting_world_location_news_article title: title, body: 'test-body', summary: 'test-summary'

--- a/features/step_definitions/world_location_steps.rb
+++ b/features/step_definitions/world_location_steps.rb
@@ -15,23 +15,23 @@ end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists$/ do |world_location_type, name|
   WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
-  create(world_location_type.gsub(' ', '_').to_sym, name: name)
+  create(world_location_type.gsub(' ', '_').to_sym, name: name, active: true)
 end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists with the mission statement "([^"]*)"$/ do |world_location_type, name, mission_statement|
   WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
-  create(world_location_type.gsub(' ', '_').to_sym, name: name, mission_statement: mission_statement)
+  create(world_location_type.gsub(' ', '_').to_sym, name: name, active: true, mission_statement: mission_statement)
 end
 
 Given /^the (world location|international delegation) "([^"]*)" is inactive/ do |world_location_type, name|
   WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
-  world_location = WorldLocation.find_by(name: name) || create(world_location_type.gsub(' ', '_').to_sym, name: name)
+  world_location = WorldLocation.find_by(name: name) || create(world_location_type.gsub(' ', '_').to_sym, name: name, active: true)
   world_location.update_column(:active, false)
 end
 
 Given /^an? (world location|international delegation) "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |world_location_type, name, locale|
   WorldLocationNewsPageWorker.any_instance.stubs(:perform).returns(true)
-  location = create(world_location_type.gsub(' ', '_').to_sym, name: name)
+  location = create(world_location_type.gsub(' ', '_').to_sym, name: name, active: true)
   locale = Locale.find_by_language_name(locale)
 
   translation = LocalisedModel.new(location, locale.code)

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -86,7 +86,7 @@ Given /^a worldwide organisation "([^"]*)"$/ do |name|
 end
 
 Given /^a worldwide organisation "([^"]*)" exists for the world location "([^"]*)" with translations into "([^"]*)"$/ do |name, country_name, translation|
-  country = create(:world_location, translated_into: [translation])
+  country = create(:world_location, active: true, translated_into: [translation])
   create(:worldwide_organisation, name: name, world_locations: [country])
 end
 
@@ -131,7 +131,7 @@ Then(/^I should be able to remove all services from the "(.*?)" office$/) do |de
 end
 
 Given /^that the world location "([^"]*)" exists$/ do |country_name|
-  create(:world_location, name: country_name)
+  create(:world_location, name: country_name, active: true)
 end
 
 Given /^the worldwide organisation "([^"]*)" exists$/ do |worldwide_organisation_name|
@@ -269,7 +269,7 @@ end
 
 Given /^a worldwide organisation "([^"]*)" exists with a translation for the locale "([^"]*)"$/ do |name, native_locale_name|
   locale_code = Locale.find_by_language_name(native_locale_name).code
-  country = create(:world_location, world_location_type: WorldLocationType::WorldLocation)
+  country = create(:world_location, active: true, world_location_type: WorldLocationType::WorldLocation)
   create(:worldwide_organisation, name: name, world_locations: [country], translated_into: [locale_code])
 end
 

--- a/test/unit/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/helpers/admin/taggable_content_helper_test.rb
@@ -147,13 +147,14 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     ], taggable_statistical_data_sets_container
   end
 
-  test '#taggable_world_locations_container returns an array of label/ID pairs for all world locations' do
-    location_a = create(:world_location, name: 'Andora')
-    location_c = create(:world_location, name: 'Croatia')
-    location_b = create(:world_location, name: 'Brazil')
+  test '#taggable_world_locations_container returns an array of label/ID pairs for all active world locations' do
+    location_a = create(:world_location, name: 'Andorra', active: true)
+    location_c = create(:world_location, name: 'Croatia', active: true)
+    location_b = create(:world_location, name: 'Brazil', active: true)
+    create(:world_location, name: 'United Kingdom', active: false)
 
     assert_equal [
-      ['Andora', location_a.id],
+      ['Andorra', location_a.id],
       ['Brazil', location_b.id],
       ['Croatia', location_c.id],
       ], taggable_world_locations_container


### PR DESCRIPTION
This commit changes the world location tagging logic to disallow tagging to inactive world locations. This allows us to re-add the United Kingdom to enable its use as a country for contacts without allow tagging to it.