### PR TITLE
[DO NOT MERGE] Add special route for /government/uploads

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -31,6 +31,26 @@ namespace :publishing_api do
         public_updated_at: Time.zone.now.iso8601,
       ))
     end
+
+    [
+      {
+        base_path: "/government/uploads",
+        content_id: "b12da705-0100-4e01-b79f-f5eed28caa1a",
+        title: "Government uploads",
+        description: "The prefix route under which government uploads are published.",
+      },
+    ].each do |route|
+      publisher.publish(
+        route.merge(
+          format: "special_route",
+          publishing_app: "whitehall",
+          rendering_app: Whitehall::RenderingApp::WHITEHALL_ADMIN,
+          update_type: "major",
+          type: "prefix",
+          public_updated_at: Time.zone.now.iso8601,
+        )
+      )
+    end
   end
 
   desc "Send published item links to Publishing API."

--- a/lib/whitehall/rendering_app.rb
+++ b/lib/whitehall/rendering_app.rb
@@ -1,7 +1,7 @@
 module Whitehall
   module RenderingApp
-    WHITEHALL_ADMIN = 'whitehall-admin'
-    WHITEHALL_FRONTEND = 'whitehall-frontend'
-    GOVERNMENT_FRONTEND = 'government-frontend'
+    WHITEHALL_ADMIN = 'whitehall-admin'.freeze
+    WHITEHALL_FRONTEND = 'whitehall-frontend'.freeze
+    GOVERNMENT_FRONTEND = 'government-frontend'.freeze
   end
 end

--- a/lib/whitehall/rendering_app.rb
+++ b/lib/whitehall/rendering_app.rb
@@ -1,5 +1,6 @@
 module Whitehall
   module RenderingApp
+    WHITEHALL_ADMIN = 'whitehall-admin'
     WHITEHALL_FRONTEND = 'whitehall-frontend'
     GOVERNMENT_FRONTEND = 'government-frontend'
   end


### PR DESCRIPTION
To route requests through to whitehall-admin. This is currently done
using NGinx configured through govuk-puppet.

Adding a specific route makes it clearer that these requests are
handled by whitehall-admin, rather than whitehall-frontend.

I haven't tested this locally, I first wanted to put this out there to see if anyone else through it was a good idea.