### PR TITLE
Add link to the content guidance to the dashboard

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -9,6 +9,7 @@
     <ul>
       <li><a href="https://www.gov.uk/guidance/style-guide">GOV.UK style guide</a></li>
       <li><a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk">How to publish content on GOV.UK</a></li>
+      <li><a href="https://www.gov.uk/guidance/content-design">Planning, writing and managing content</a></li>
     </ul>
   </div>
   <div class="col-md-4">


### PR DESCRIPTION
For: https://trello.com/c/NcPD97CB/198-update-guidance-links-on-whitehall-dashboard

The Whitehall dashboard has links to useful guidance for content designers
and there's a super useful content design guidance section that we could
include as well.  So we do that.

