### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'faraday'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 45.0.0'
+  gem 'gds-api-adapters', '~> 47.2'
 end
 
 if ENV['GLOBALIZE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (45.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -301,7 +301,7 @@ GEM
       pry (~> 0.10)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.6)
+    rack (1.6.8)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (2.0.0)
@@ -483,7 +483,7 @@ DEPENDENCIES
   factory_girl
   faraday
   friendly_id (~> 5.2.1)
-  gds-api-adapters (~> 45.0.0)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.2)
   globalize (~> 5.0.0)
   govspeak (~> 3.6.2)
@@ -552,4 +552,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/presenters/publishing_api/base_item_presenter.rb
+++ b/app/presenters/publishing_api/base_item_presenter.rb
@@ -1,12 +1,15 @@
 module PublishingApi
   class BaseItemPresenter
-    attr_accessor :item, :title, :need_ids, :locale
+    include UpdateTypeHelper
 
-    def initialize(item, title: nil, need_ids: nil, locale: I18n.locale.to_s)
+    attr_accessor :item, :title, :need_ids, :locale, :update_type
+
+    def initialize(item, title: nil, need_ids: nil, locale: I18n.locale.to_s, update_type: nil)
       self.item = item
       self.title = title || item.title
       self.need_ids = need_ids || item.need_ids
       self.locale = locale
+      self.update_type = update_type || default_update_type(item)
     end
 
     def base_attributes
@@ -16,6 +19,7 @@ module PublishingApi
         need_ids: need_ids,
         publishing_app: "whitehall",
         redirects: [],
+        update_type: update_type,
       }
     end
   end

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/coming_soon_presenter.rb
+++ b/app/presenters/publishing_api/coming_soon_presenter.rb
@@ -32,6 +32,7 @@ module PublishingApi
         item,
         title: 'Coming soon',
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
 
     def content
       BaseItemPresenter
-        .new(consultation)
+        .new(consultation, update_type: update_type)
         .base_attributes
         .merge(PayloadBuilder::AccessLimitation.for(consultation))
         .merge(PayloadBuilder::PublicDocumentPath.for(consultation))

--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -21,6 +21,7 @@ module PublishingApi
         publishing_app: "whitehall",
         details: details,
         phase: phase,
+        update_type: update_type,
       }
     end
 

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -17,7 +17,7 @@ module PublishingApi
 
     def content
       BaseItemPresenter
-        .new(corporate_information_page)
+        .new(corporate_information_page, update_type: update_type)
         .base_attributes
         .merge(PayloadBuilder::PublicDocumentPath.for(corporate_information_page))
         .merge(

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -14,7 +14,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
 
     def content
       {}.tap { |content|
-        content.merge!(BaseItemPresenter.new(item).base_attributes)
+        content.merge!(BaseItemPresenter.new(item, update_type: update_type).base_attributes)
         content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
         content.merge!(
           description: item.summary,

--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: PayloadBuilder::TagDetails.for(item),

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -18,6 +18,7 @@ module PublishingApi
         item,
         need_ids: [],
         locale: locale,
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/ministerial_role_presenter.rb
+++ b/app/presenters/publishing_api/ministerial_role_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -16,7 +16,7 @@ module PublishingApi
 
     def content
       BaseItemPresenter
-        .new(news_article)
+        .new(news_article, update_type: update_type)
         .base_attributes
         .merge(PayloadBuilder::AccessLimitation.for(news_article))
         .merge(PayloadBuilder::FirstPublishedAt.for(news_article))

--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -24,6 +24,7 @@ module PublishingApi
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           schema_name: "placeholder",
           title: operational_field.name,
+          update_type: update_type,
         )
       }
     end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -19,6 +19,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/policy_area_placeholder_presenter.rb
+++ b/app/presenters/publishing_api/policy_area_placeholder_presenter.rb
@@ -18,6 +18,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/services_and_information_presenter.rb
+++ b/app/presenters/publishing_api/services_and_information_presenter.rb
@@ -25,6 +25,7 @@ module PublishingApi
         organisation,
         title: "Services and information - #{organisation.name}",
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -14,7 +14,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/statistics_announcement_presenter.rb
+++ b/app/presenters/publishing_api/statistics_announcement_presenter.rb
@@ -16,6 +16,7 @@ module PublishingApi
       content = BaseItemPresenter.new(
         item,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -16,6 +16,7 @@ module PublishingApi
       content = BaseItemPresenter.new(
         item,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/topical_event_about_page_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_about_page_presenter.rb
@@ -16,7 +16,8 @@ module PublishingApi
       content = BaseItemPresenter.new(
         item,
         title: item.name,
-        need_ids: []
+        need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/working_group_presenter.rb
+++ b/app/presenters/publishing_api/working_group_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -14,7 +14,7 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(item).base_attributes
+      content = BaseItemPresenter.new(item, update_type: update_type).base_attributes
       content.merge!(
         description: item.summary,
         details: details,

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         world_location,
         title: title,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -17,6 +17,7 @@ module PublishingApi
         item,
         title: item.name,
         need_ids: [],
+        update_type: update_type,
       ).base_attributes
 
       content.merge!(

--- a/app/services/publish_finder.rb
+++ b/app/services/publish_finder.rb
@@ -21,7 +21,7 @@ private
       content_id,
       finder_content_item
     )
-    Services.publishing_api.publish(content_id, "major")
+    Services.publishing_api.publish(content_id)
   end
 
   def send_to_rummager

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -15,7 +15,7 @@ private
 
   def send_news_page_to_publishing_api
     Services.publishing_api.put_content(news_page_presenter.content_id, news_page_presenter.content)
-    Services.publishing_api.publish(news_page_presenter.content_id, news_page_presenter.update_type, locale: "en")
+    Services.publishing_api.publish(news_page_presenter.content_id, nil, locale: "en")
   end
 
   def send_news_page_to_rummager

--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -7,6 +7,7 @@
   "schema_name": "finder",
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
+  "update_type": "major",
   "details": {
     "document_noun": "case study",
     "default_order": "-public_timestamp",

--- a/lib/finders/groups.json
+++ b/lib/finders/groups.json
@@ -7,6 +7,7 @@
   "schema_name": "finder",
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
+  "update_type": "major",
   "details": {
     "document_noun": "group",
     "default_order": "title",

--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -7,6 +7,7 @@
   "schema_name": "finder",
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
+  "update_type": "major",
   "details": {
     "document_noun": "person",
     "default_order": "title",

--- a/lib/finders/policy_areas.json
+++ b/lib/finders/policy_areas.json
@@ -7,6 +7,7 @@
    "schema_name":"finder",
    "publishing_app":"whitehall",
    "rendering_app":"finder-frontend",
+   "update_type": "major",
    "details": {
       "document_noun": "policy area",
       "facets":[

--- a/lib/finders/statistical_data_sets.json
+++ b/lib/finders/statistical_data_sets.json
@@ -7,6 +7,7 @@
   "schema_name": "finder",
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
+  "update_type": "major",
   "details": {
     "document_noun": "data set",
     "facets": [

--- a/lib/finders/topical_events.json
+++ b/lib/finders/topical_events.json
@@ -7,6 +7,7 @@
    "locale":"en",
    "publishing_app":"whitehall",
    "rendering_app":"finder-frontend",
+   "update_type": "major",
    "details": {
      "document_noun": "topical event",
      "default_documents_per_page": 50,

--- a/lib/finders/worldwide_organisations.json
+++ b/lib/finders/worldwide_organisations.json
@@ -7,6 +7,7 @@
   "schema_name": "finder",
   "publishing_app": "whitehall",
   "rendering_app": "finder-frontend",
+  "update_type": "major",
   "details": {
     "document_noun": "organisation",
     "default_order": "title",

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -158,6 +158,7 @@ class PublishStaticPages
           },
         ],
         public_updated_at: Time.zone.now.iso8601,
+        update_type: "minor",
       }
     }
   end

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -6,7 +6,7 @@ class PublishStaticPages
 
       payload = present_for_publishing_api(page)
       Services.publishing_api.put_content(payload[:content_id], payload[:content])
-      Services.publishing_api.publish(payload[:content_id], "minor", locale: "en")
+      Services.publishing_api.publish(payload[:content_id], nil, locale: "en")
     end
   end
 

--- a/test/unit/presenters/publishing_api/base_item_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/base_item_presenter_test.rb
@@ -5,13 +5,14 @@ module PublishingApi
     test "it returns the base set of attributes needed by all documents sent to the publishing API" do
       stubbed_item = stub(need_ids: [1, 2], title: 'A title')
 
-      presenter = PublishingApi::BaseItemPresenter.new(stubbed_item, locale: "fr")
+      presenter = PublishingApi::BaseItemPresenter.new(stubbed_item, update_type: "major", locale: "fr")
       expected_hash = {
         title: stubbed_item.title,
         locale: "fr",
         need_ids: stubbed_item.need_ids,
         publishing_app: "whitehall",
         redirects: [],
+        update_type: "major",
       }
 
       assert_equal presenter.base_attributes, expected_hash

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -27,6 +27,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       routes: [
         { path: public_path, type: 'exact' }
       ],
+      update_type: "major",
       redirects: [],
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",

--- a/test/unit/presenters/publishing_api/classification_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/classification_presenter_test.rb
@@ -23,7 +23,8 @@ class PublishingApi::ClassificationTest < ActiveSupport::TestCase
       ],
       redirects: [],
       public_updated_at: topic.updated_at,
-      details: {}
+      update_type: "major",
+      details: {},
     }
 
     presenter = ::PublishingApiPresenters.presenter_for(topic)

--- a/test/unit/presenters/publishing_api/coming_soon_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/coming_soon_presenter_test.rb
@@ -30,6 +30,7 @@ class PublishingApi::ComingSoonPresenterTest < ActiveSupport::TestCase
       routes: [{ path: public_path, type: 'exact' }],
       redirects: [],
       public_updated_at: @edition.updated_at,
+      update_type: "major",
     }
 
     presenter = PublishingApi::ComingSoonPresenter.new(@edition)

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -67,7 +67,7 @@ module PublishingApi::ConsultationPresenterTest
 
       PublishingApi::BaseItemPresenter
         .expects(:new)
-        .with(consultation)
+        .with(consultation, update_type: "major")
         .returns(stub(base_attributes: attributes_double))
 
       actual_content = presented_content

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -35,6 +35,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
       phase: "live",
       public_updated_at: @updated_at,
       publishing_app: "whitehall",
+      update_type: "major",
       details: {
         description: nil,
         title: "Government Digital Service",

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -71,7 +71,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
 
       PublishingApi::BaseItemPresenter
         .expects(:new)
-        .with(corporate_information_page)
+        .with(corporate_information_page, update_type: "major")
         .returns(stub(base_attributes: attributes_double))
 
       actual_content = presented_content

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -50,6 +50,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       ],
       redirects: [],
       first_published_at: detailed_guide.created_at,
+      update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         first_public_at: detailed_guide.created_at,

--- a/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -34,6 +34,7 @@ module PublishingApi
           { path: public_path, type: 'exact' }
         ],
         redirects: [],
+        update_type: "major",
         details: {
           tags: {
             browse_pages: [],

--- a/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -29,6 +29,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
         { path: html_attachment.url, type: 'exact' }
       ],
       redirects: [],
+      update_type: "major",
       details: {
         body: Whitehall::GovspeakRenderer.new
           .govspeak_to_html(html_attachment.govspeak_content.body),

--- a/test/unit/presenters/publishing_api/ministerial_role_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/ministerial_role_presenter_test.rb
@@ -23,6 +23,7 @@ class PublishingApi::MinisterialRolePresenterTest < ActiveSupport::TestCase
       redirects: [],
       need_ids: [],
       details: {},
+      update_type: "major",
     }
     expected_links = {
       organisations: ministerial_role.organisations.map(&:content_id)

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -71,7 +71,7 @@ module PublishingApi::NewsArticlePresenterTest
 
       PublishingApi::BaseItemPresenter
         .expects(:new)
-        .with(news_article)
+        .with(news_article, update_type: 'major')
         .returns(stub(base_attributes: attributes_double))
 
       actual_content = presented_content

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -30,6 +30,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       need_ids: [],
+      update_type: "major",
       details: {
         brand: nil,
         logo: {

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -23,6 +23,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       redirects: [],
       need_ids: [],
       details: {},
+      update_type: "major",
     }
     expected_links = {}
 

--- a/test/unit/presenters/publishing_api/policy_area_placeholder_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/policy_area_placeholder_presenter_test.rb
@@ -23,6 +23,7 @@ class PublishingApi::PolicyAreaPlaceholderPresenterTest < ActionView::TestCase
       redirects: [],
       need_ids: [],
       details: {},
+      update_type: "major",
     }
     expected_links = {organisations: []}
 

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -31,6 +31,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       ],
       redirects: [],
       first_published_at: publication.first_public_at,
+      update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         tags: {

--- a/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/services_and_information_presenter_test.rb
@@ -23,6 +23,7 @@ class PublishingApi::ServicesAndInformationPresenterTest < ActionView::TestCase
       redirects: [],
       need_ids: [],
       details: {},
+      update_type: "minor",
     }
     expected_links = {
       parent: [

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -25,6 +25,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
+      update_type: "major",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,
@@ -70,6 +71,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
+      update_type: "major",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,
@@ -119,6 +121,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
+      update_type: "major",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         previous_display_date: 7.days.from_now.to_s(:date_with_time),

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -31,7 +31,8 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
           alt_text: "Image alt text"
         }
       },
-      need_ids: []
+      need_ids: [],
+      update_type: "major",
     }
 
     presented_item = present(take_part_page)

--- a/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_about_page_presenter_test.rb
@@ -23,6 +23,7 @@ class PublishingApi::TopicalEventAboutPagePresenterTest < ActiveSupport::TestCas
         { path: topical_event_about_page.search_link, type: 'exact' }
       ],
       redirects: [],
+      update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Body</p></div>",
         read_more: 'Read more'

--- a/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/topical_event_presenter_test.rb
@@ -21,6 +21,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
           type: 'exact'
         }
       ],
+      update_type: "major",
       redirects: [],
       public_updated_at: topical_event.updated_at,
       details: {
@@ -55,6 +56,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
           type: 'exact'
         }
       ],
+      update_type: "major",
       redirects: [],
       public_updated_at: topical_event.updated_at,
       details: {}

--- a/test/unit/presenters/publishing_api/working_group_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/working_group_presenter_test.rb
@@ -28,6 +28,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
       ],
       redirects: [],
       public_updated_at: group.updated_at,
+      update_type: "major",
       details: {
         email: "group-1@example.com",
         body: "<div class=\"govspeak\"><p>This is some <em>Govspeak</em> in the description field</p>\n</div>", # This is deliberately the 'wrong' way around

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -44,6 +44,7 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
       base_path: "/world/aardistan/news",
       routes: [{ path:  "/world/aardistan/news", type: "exact" }],
       analytics_identifier: "WL1",
+      update_type: "major",
     }
 
     Services.publishing_api.stubs(:lookup_content_ids).returns({})
@@ -72,6 +73,7 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
       base_path: "/world/aardistan/news",
       routes: [{ path: "/world/aardistan/news", type: "exact" }],
       analytics_identifier: "WL1",
+      update_type: "major",
     }
 
     Services.publishing_api.stubs(:lookup_content_ids).returns("/world/aardistan/news" => "aguid")

--- a/test/unit/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_presenter_test.rb
@@ -21,6 +21,7 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
       need_ids: [],
       details: {},
       analytics_identifier: "WL123",
+      update_type: "major",
     }
     expected_links = {}
 

--- a/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -24,6 +24,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       need_ids: [],
       details: {},
       analytics_identifier: "WO123",
+      update_type: "major",
     }
     expected_links = {}
 

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -27,12 +27,13 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
             document_type: page[:document_type],
             schema_name: "placeholder",
             base_path: page[:base_path],
-            title: page[:title]
+            title: page[:title],
+            update_type: "minor",
           )
         )
 
       Services.publishing_api.expects(:publish)
-        .with(page[:content_id], 'minor', locale: "en")
+        .with(page[:content_id], nil, locale: "en")
     end
   end
 

--- a/test/unit/services/publish_finder_test.rb
+++ b/test/unit/services/publish_finder_test.rb
@@ -11,7 +11,7 @@ class PublishFinderTest < ActiveSupport::TestCase
     PublishFinder.call(people_finder)
 
     assert_publishing_api_put_content('a-content-id', people_finder)
-    assert_publishing_api_publish('a-content-id', update_type: 'major')
+    assert_publishing_api_publish('a-content-id')
   end
 
   test 'it uses the existing content id when publishing' do
@@ -23,6 +23,6 @@ class PublishFinderTest < ActiveSupport::TestCase
     PublishFinder.call(people_finder)
 
     assert_publishing_api_put_content('existing-content-id', people_finder)
-    assert_publishing_api_publish('existing-content-id', update_type: 'major')
+    assert_publishing_api_publish('existing-content-id')
   end
 end

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -31,6 +31,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
       routes: [ { path: base_path, type: 'exact' } ],
       redirects: [],
       public_updated_at: edition.updated_at,
+      update_type: "major",
     }
 
     expected_links = PublishingApi::ComingSoonPresenter.new(edition).links

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -31,13 +31,13 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
     Services.publishing_api.expects(:put_content)
       .with(
         "a_guid",
-        Hash.new(title: "title", description: "description")
+        Hash.new(title: "title", description: "description", update_type: "major")
     )
 
     Services.publishing_api.expects(:publish)
       .with(
         "a_guid",
-        "major",
+        nil,
         locale: "en"
     )
 


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)