### PR TITLE
Populate the analytics meta tags for finders

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -8,6 +8,11 @@ class AnnouncementsController < DocumentsController
 
     respond_to do |format|
       format.html do
+        @content_item = Whitehall
+          .content_store
+          .content_item("/government/announcements")
+          .to_hash
+
         @filter = AnnouncementFilterJsonPresenter.new(
           @filter, view_context, AnnouncementPresenter
         )

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -10,6 +10,11 @@ class PublicationsController < DocumentsController
 
     respond_to do |format|
       format.html do
+        @content_item = Whitehall
+          .content_store
+          .content_item("/government/publications")
+          .to_hash
+
         @filter = PublicationFilterJsonPresenter.new(
           @filter, view_context, PublicationesquePresenter
         )

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -9,6 +9,11 @@ class StatisticsController < DocumentsController
 
     respond_to do |format|
       format.html do
+        @content_item = Whitehall
+          .content_store
+          .content_item("/government/statistics")
+          .to_hash
+
         @filter = StatisticsFilterJsonPresenter.new(
           @filter, view_context, PublicationesquePresenter
         )

--- a/features/step_definitions/announcement_steps.rb
+++ b/features/step_definitions/announcement_steps.rb
@@ -5,6 +5,7 @@ Given /^I can navigate to the list of announcements$/ do
 end
 
 When /^I visit the list of announcements$/ do
+  stub_content_item_from_content_store_for(announcements_path)
   visit homepage
   click_link "Announcements"
 end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -197,12 +197,16 @@ Then /^I should see (#{THE_DOCUMENT}) in the list of published documents$/ do |e
 end
 
 Then(/^(#{THE_DOCUMENT}) should no longer be listed on the public site$/) do |edition|
+  public_edition_path = public_path_for(edition)
+  stub_content_item_from_content_store_for(public_edition_path)
   visit_public_index_for(edition)
   css_selector = edition.is_a?(DetailedGuide) ? 'h1.page_title' : record_css_selector(edition)
   assert page.has_no_content?(edition.title)
 end
 
 Then /^(#{THE_DOCUMENT}) should be visible to the public$/ do |edition|
+  public_edition_path = public_path_for(edition)
+  stub_content_item_from_content_store_for(public_edition_path)
   visit_public_index_for(edition)
   assert page.has_css?(record_css_selector(edition), text: edition.title)
 end

--- a/features/step_definitions/fatalities_steps.rb
+++ b/features/step_definitions/fatalities_steps.rb
@@ -4,6 +4,7 @@ When /^I create a fatality notice titled "([^"]*)" in the field "([^"]*)"$/ do |
 end
 
 Then /^the fatality notice is shown on the Announcements page$/ do
+  stub_content_item_from_content_store_for(announcements_path)
   visit homepage
   click_link "Announcements"
   assert page.has_content?(FatalityNotice.last.title)

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -48,6 +48,7 @@ Given(/^there are some published publications$/) do
 end
 
 When(/^I visit the publications index page$/) do
+  stub_content_item_from_content_store_for(publications_path)
   visit publications_path
 end
 
@@ -169,6 +170,7 @@ Given(/^there are some published announcements$/) do
 end
 
 When(/^I visit the announcements index page$/) do
+  stub_content_item_from_content_store_for(announcements_path)
   visit announcements_path
 end
 
@@ -198,6 +200,7 @@ Given(/^there are some published announcments including a few in French$/) do
 end
 
 When(/^I visit the announcments index in French$/) do
+  stub_content_item_from_content_store_for(announcements_path)
   visit announcements_path + '.fr'
 end
 

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -91,6 +91,7 @@ Then(/^I should be informed I shouldn't use this image in the markdown$/) do
 end
 
 When(/^I browse to the announcements index$/) do
+  stub_content_item_from_content_store_for(announcements_path)
   visit announcements_path
 end
 
@@ -101,6 +102,7 @@ When(/^I publish a new news article of the type "(.*?)" called "(.*?)"$/) do |an
 end
 
 When(/^I filter the announcements list by "(.*?)"$/) do |announcement_type|
+  stub_content_item_from_content_store_for(announcements_path)
   visit announcements_path
   select announcement_type, from: "Announcement type"
   click_on "Refresh results"

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -50,6 +50,7 @@ When /^I draft a new publication "([^"]*)" that does not apply to the nations:$/
 end
 
 When /^I visit the list of publications$/ do
+  stub_content_item_from_content_store_for(publications_path)
   visit homepage
   click_link "Publications"
 end
@@ -159,6 +160,13 @@ Given /^a published publication "([^"]*)" with type "([^"]*)"$/ do |publication_
 end
 
 When /^I filter the publications list by "([^"]*)"$/ do |publication_filter|
+  stub_content_item_from_content_store_for(publications_path)
+  filter_path_name = (publication_filter.to_s.underscore + "_path").to_sym
+
+  if respond_to?(filter_path_name)
+    stub_content_item_from_content_store_for(send(filter_path_name))
+  end
+
   visit publications_path
   select publication_filter, from: "Publication type"
   click_on "Refresh results"

--- a/features/step_definitions/statistics_steps.rb
+++ b/features/step_definitions/statistics_steps.rb
@@ -17,6 +17,7 @@ Given(/^there are some statistics$/) do
 end
 
 When(/^I visit the statistics index page$/) do
+  stub_content_item_from_content_store_for(statistics_path)
   visit statistics_path
 end
 

--- a/features/support/finder_helpers.rb
+++ b/features/support/finder_helpers.rb
@@ -1,0 +1,9 @@
+module FinderHelpers
+  def stub_content_item_from_content_store_for(base_path)
+    @content_item = content_item_for_base_path(base_path)
+
+    content_store_has_item(base_path, @content_item)
+  end
+end
+
+World(FinderHelpers)

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -49,19 +49,23 @@ module NavigationHelpers
     visit topic_path(Topic.find_by!(name: name))
   end
 
-  def visit_public_index_for(edition)
+  def public_path_for(edition)
     case edition
     when Publication
-      visit publications_path
+      publications_path
     when Speech
-      visit announcements_path
+      announcements_path
     when Consultation
-      visit consultations_path
+      consultations_path
     when DetailedGuide
-      visit detailed_guide_path(edition.document)
+      detailed_guide_path(edition.document)
     else
       raise "Don't know where to go for #{edition.class.name}s"
     end
+  end
+
+  def visit_public_index_for(edition)
+    visit public_path_for(edition)
   end
 end
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 
 require "test_helper"
+require "gds_api/test_helpers/content_store"
 
 class PublicationsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
   with_not_quite_as_fake_search
   should_be_a_public_facing_controller
   should_display_attachments_for :publication
@@ -24,6 +27,14 @@ class PublicationsControllerTest < ActionController::TestCase
   def assert_publication_order(expected_order)
     actual_order = assigns(:publications).map(&:model).map(&:id)
     assert_equal expected_order.map(&:id), actual_order
+  end
+
+  setup do
+    @content_item = content_item_for_base_path(
+      '/government/publications'
+    )
+
+    content_store_has_item(@content_item['base_path'], @content_item)
   end
 
   test '#show displays published publications' do
@@ -792,5 +803,19 @@ class PublicationsControllerTest < ActionController::TestCase
         "Expected the custom dimension 29 to have the title of the publication"
       )
     end
+  end
+
+  view_test 'includes the analytics component' do
+    get :index
+
+    analytics_component = css_select(
+      'test-govuk-component[data-template=govuk_component-analytics_meta_tags]'
+    )
+
+    assert_match(
+      @content_item['title'],
+      analytics_component.text,
+      'Expected the analytics meta tag component to be initialized with the content item'
+    )
   end
 end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -1,12 +1,17 @@
 require 'test_helper'
+require "gds_api/test_helpers/content_store"
 
 class RoutingTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::ContentStore
+
   test "visiting #{Whitehall.router_prefix}/policy-topics redirects to #{Whitehall.router_prefix}/topics" do
     get "#{Whitehall.router_prefix}/policy-topics"
     assert_redirected_to "#{Whitehall.router_prefix}/topics"
   end
 
   test "assets are served under the #{Whitehall.router_prefix} prefix" do
+    content_store_has_item('/government/publications', {})
+
     get publications_path
     assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
   end


### PR DESCRIPTION
This commit makes sure we set the `@content_item` instance variable with
the content store response related to the finder the user is on, so that
the analytics meta tag component gets populated correctly and all
necessary meta tags added to the page.

This will allow us to identify what page we are on in static and
simplify the code that looks for the number of links and sections on the
page.

The logic to populate the component is already in the layout: https://github.com/alphagov/whitehall/blob/master/app/views/layouts/_frontend_base.html.erb#L13-L14