### PR TITLE
Rename Democratic Republic of Congo to Democratic Republic of the Congo

### DIFF
--- a/db/data_migration/20170727112620_rename_democratic_republic_of_congo.rb
+++ b/db/data_migration/20170727112620_rename_democratic_republic_of_congo.rb
@@ -1,0 +1,6 @@
+# Change country name from Democratic Republic of Congo to
+# Democratic Republic of the Congo
+WorldLocation
+  .find_by(slug: "democratic-republic-of-the-congo")
+  .translation
+  .update(name: "Democratic Republic of the Congo")


### PR DESCRIPTION
Continues from #2776 

[Trello card](https://trello.com/c/HDfCubtm/693-1-getting-married-in-italy-same-sex-marriage-content-change-request-content-change-request)

## Description 
As a result of the change in the name of Democratic Republic of Congo to
Democratic Republic of the Congo, this commit setups a migration to achieve
this. Previous attempt only changed the slug https://github.com/alphagov/whitehall/pull/2776.



## Expected change

- The former name ```Democratic Republic of Congo``` will now appear as ```Democratic Republic of the Congo```.