### PR TITLE
Link to news page from world locations translation page

### DIFF
--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -24,7 +24,7 @@
           <% @world_location.non_english_translated_locales.each do |locale| %>
             <tr>
               <td class="locale">
-                <%= link_to locale.native_language_name, edit_admin_world_location_translation_path(@world_location, locale.code) %> (<%= link_to "view", world_location_path(@world_location, locale: locale) %>)
+                <%= link_to locale.native_language_name, edit_admin_world_location_translation_path(@world_location, locale.code) %> (<%= link_to "view", world_location_news_index_path(@world_location, locale: locale) %>)
               </td>
               <td class="actions">
                 <%= button_to 'Delete',


### PR DESCRIPTION
This commit changes the URL of the “view” link that appears next to each translation of a world location in whitehall-admin to point to the world location news page rather than the world location, which is now rendered by `collections`.

<img width="1152" alt="screen shot 2017-07-27 at 15 59 43" src="https://user-images.githubusercontent.com/444232/28677220-baeebc90-72e4-11e7-91eb-e7bcf43c30f0.png">
