### PR TITLE
Create correct title for blank organisation acronyms

### DIFF
--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -16,7 +16,11 @@ class CorporateInformationPageType
   end
 
   def title(organisation)
-    organisation_name = (organisation.respond_to?(:acronym) && organisation.acronym || "#{organisation.name}")
+    organisation_name = if organisation.respond_to?(:acronym) && organisation.acronym.present?
+                          organisation.acronym
+                        else
+                          organisation.name
+                        end
     translation_key = slug.gsub('-', '_')
     I18n.t("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name)
   end

--- a/test/unit/models/corporate_information_page_type_test.rb
+++ b/test/unit/models/corporate_information_page_type_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class CorporateInformationPageTypeTest < ActiveSupport::TestCase
+  setup do
+    @organisation = create(:organisation, name: 'Department of Alphabet')
+    @corporate_information_page_type = CorporateInformationPageType.new(
+      id: 7, slug: "procurement", menu_heading: :jobs_and_contracts
+    )
+  end
+
+  test '.title uses the organisation\'s acronym when it exists' do
+    @organisation.acronym = 'ABC'
+    corporate_information_page = create(
+      :corporate_information_page,
+      corporate_information_page_type: @corporate_information_page_type,
+      organisation: @organisation
+    )
+
+    assert_equal "Procurement at ABC", corporate_information_page.title
+  end
+
+  test '.title uses the organisation\'s name when the acronym is nil' do
+    @organisation.acronym = nil
+    corporate_information_page = create(
+      :corporate_information_page,
+      corporate_information_page_type: @corporate_information_page_type,
+      organisation: @organisation
+    )
+
+    assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
+  end
+
+  test '.title uses the organisation\'s name when the acronym is empty' do
+    @organisation.acronym = ''
+    corporate_information_page = create(
+      :corporate_information_page,
+      corporate_information_page_type: @corporate_information_page_type,
+      organisation: @organisation
+    )
+
+    assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
+  end
+end


### PR DESCRIPTION
This commit fixes an issue where organisations with empty acronyms generate broken corporate information page titles. The fix now checks to ensure the acronym is present and if not, uses the organisation’s name instead.

Corporate information pages will need to be republished after this fix so the titles show up correctly in government-frontend.

Before:

<img width="316" alt="screen shot 2017-07-31 at 14 36 17" src="https://user-images.githubusercontent.com/444232/28780157-ac5fc93c-75fd-11e7-86cd-83d797ea04a9.png">

After:

<img width="312" alt="screen shot 2017-07-31 at 14 36 27" src="https://user-images.githubusercontent.com/444232/28780207-d5de5706-75fd-11e7-876b-c969225dde85.png">