### PR TITLE
Republish all published corporate information pages

### DIFF
--- a/db/data_migration/20170731135854_republish_corporate_information_pages_for_organisation_acronym_fix.rb
+++ b/db/data_migration/20170731135854_republish_corporate_information_pages_for_organisation_acronym_fix.rb
@@ -1,0 +1,5 @@
+CorporateInformationPage
+  .published
+  .includes(:document).each do |cip|
+  Whitehall::PublishingApi.republish_document_async(cip.document)
+end


### PR DESCRIPTION
This commit republishes all published corporate information pages to apply the change made in https://github.com/alphagov/whitehall/pull/3363.