### PR TITLE
Remove beta banner for courts and tribunals

### DIFF
--- a/app/views/organisations/courts_index.html.erb
+++ b/app/views/organisations/courts_index.html.erb
@@ -4,8 +4,6 @@
 <div class="organisations-index">
   <div class="block-1">
     <div class="inner-block">
-      <%= render partial: 'govuk_component/beta_label' , locals: {
-        message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals-service')}'>HM Courts and Tribunals Service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
       <header class="page-header">
         <h1 class="title">Courts and Tribunals</h1>
       </header>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -4,11 +4,6 @@
 <%= api_link_tag api_organisation_url(@organisation) %>
 
 <%= organisation_wrapper(@organisation) do %>
-<% if @organisation.court_or_hmcts_tribunal? %>
-  <%= render partial: 'govuk_component/beta_label' , locals: {
-    message: "This part of GOV.UK is still being built – find more information on the <a href='#{organisation_path('hm-courts-and-tribunals-service')}'>HM Courts and Tribunals Service</a> or the <a href='https://www.justice.gov.uk'>Justice website</a>."} %>
-<% end %>
-
   <div class="block-1 headings-block<%= " service-priority" if @organisation.service_priority_homepage? %>">
     <div class="inner-block<%= " floated-children" if @organisation.service_priority_homepage? %>">
       <%= render 'header', organisation: @organisation, show_featured_links: true, languages_available: true %>

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -84,18 +84,6 @@ class OrganisationsControllerTest < ActionController::TestCase
     refute_select "span.count.js-filter-count"
   end
 
-  view_test "does not show a beta banner on organisations index" do
-    get :index
-
-    refute_select "test-govuk-component[data-template=govuk_component-beta_label]"
-  end
-
-  view_test "shows a beta banner on courts index" do
-    get :index, courts_only: true
-
-    assert_select "test-govuk-component[data-template=govuk_component-beta_label]"
-  end
-
   ### Describing :show ###
 
   view_test "showing an organisation without a list of contacts doesn't try to create one" do
@@ -816,24 +804,6 @@ class OrganisationsControllerTest < ActionController::TestCase
       organisation = create_org_and_stub_content_store(:organisation)
       get :show, id: organisation, courts_only: true
     end
-  end
-
-  view_test "shows a beta banner for courts" do
-    court = create_org_and_stub_content_store(:court)
-    get :show, id: court, courts_only: true
-    assert_select "test-govuk-component[data-template=govuk_component-beta_label]"
-  end
-
-  view_test "shows a beta banner for HMCTS tribunals" do
-    hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
-    get :show, id: hmcts_tribunal, courts_only: true
-    assert_select "test-govuk-component[data-template=govuk_component-beta_label]"
-  end
-
-  view_test "does not show a beta banner for organisations" do
-    organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
-    refute_select "test-govuk-component[data-template=govuk_component-beta_label]"
   end
 
   view_test "organisations show the 'About Us' summary and link to page under 'What we do'" do


### PR DESCRIPTION
All 'Court' org types currently have a beta label at the top, for example:

https://www.gov.uk/courts-tribunals/bankruptcy-court
https://www.gov.uk/courts-tribunals/admiralty-court
https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court

This should be removed, as it is out of date (and the links send users on a circular journey).

Zendesk: https://govuk.zendesk.com/agent/tickets/2288368

## Before
<img width="891" alt="screen shot 2017-07-31 at 13 53 58" src="https://user-images.githubusercontent.com/87579/28781794-2f5362d6-7603-11e7-83ab-eff007baadc9.png">

## After
<img width="1006" alt="screen shot 2017-07-31 at 15 09 28" src="https://user-images.githubusercontent.com/87579/28781804-3bcfb7b2-7603-11e7-941f-958049341773.png">
<img width="1096" alt="screen shot 2017-07-31 at 15 09 45" src="https://user-images.githubusercontent.com/87579/28781813-43106a08-7603-11e7-9cfb-00e8fa8d9ab3.png">
