### PR TITLE
Fix Worldwide organisation default news article image uploads

### DIFF
--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -60,7 +60,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
       :name, :logo_formatted_name,
       world_location_ids: [],
       sponsoring_organisation_ids: [],
-      default_news_image_attributes: [:file_cache]
+      default_news_image_attributes: [:file, :file_cache]
     )
   end
 end

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -47,10 +47,14 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   test "updates an existing objects with new values" do
     organisation = create(:worldwide_organisation)
     put :update, id: organisation.id, worldwide_organisation: {
-      name: "New name"
+      name: "New name",
+      default_news_image_attributes: {
+        file: fixture_file_upload('minister-of-funk.960x640.jpg')
+      },
     }
     worldwide_organisation = WorldwideOrganisation.last
     assert_equal "New name", worldwide_organisation.name
+    assert_equal 'minister-of-funk.960x640.jpg', worldwide_organisation.default_news_image.file.file.filename
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
 


### PR DESCRIPTION
The file param was being excluded so admin changes were always ignored.

See https://govuk.zendesk.com/agent/tickets/2288494