### PR TITLE
Republish news articles when an organisation changes their default news image

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -30,6 +30,7 @@ class Edition < ApplicationRecord
   serialize :need_ids, Array
 
   extend Edition::FindableByOrganisation
+  extend Edition::FindableByWorldwideOrganisation
 
   include Searchable
 

--- a/app/models/edition/findable_by_worldwide_organisation.rb
+++ b/app/models/edition/findable_by_worldwide_organisation.rb
@@ -1,0 +1,10 @@
+module Edition::FindableByWorldwideOrganisation
+  def in_worldwide_organisation(worldwide_organisation)
+    worldwide_organisation_ids = Array(worldwide_organisation).map(&:id)
+
+    where('exists (SELECT * FROM edition_worldwide_organisations ewo_orgcheck
+                        WHERE ewo_orgcheck.edition_id = editions.id
+                        AND ewo_orgcheck.worldwide_organisation_id IN (:ids))',
+          ids: worldwide_organisation_ids)
+  end
+end

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -960,4 +960,23 @@ class OrganisationTest < ActiveSupport::TestCase
       'http://www.example.com/path/to/new_chart',
     )
   end
+
+  test "#save triggers organisation with a changed default news organisation image to republish news articles" do
+    organisation = create(:organisation)
+
+    DataHygiene::PublishingApiRepublisher
+      .expects(:new)
+      .with(
+        NewsArticle
+          .in_organisation(organisation)
+          .includes(:images)
+          .where(images: { id: nil })
+      )
+      .returns(stub(:perform))
+
+    organisation.update_attribute(
+      :default_news_image,
+      create(:default_news_organisation_image_data),
+    )
+  end
 end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -301,4 +301,23 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     world_organisation.destroy
     refute HomePageList.exists?(h.id)
   end
+
+  test "#save triggers organisation with a changed default news organisation image to republish news articles" do
+    world_organisation = create(:worldwide_organisation)
+
+    DataHygiene::PublishingApiRepublisher
+      .expects(:new)
+      .with(
+        NewsArticle
+          .in_worldwide_organisation(world_organisation)
+          .includes(:images)
+          .where(images: { id: nil })
+      )
+      .returns(stub(:perform))
+
+    world_organisation.update_attribute(
+      :default_news_image,
+      create(:default_news_organisation_image_data),
+    )
+  end
 end


### PR DESCRIPTION
The default image may be chosen when a news article is published from Whitehall.
That means all previously published news articles may continue to display an old default news image until they are republished. This adds a hook to ensure republishing happens.

See https://govuk.zendesk.com/agent/tickets/2288494