### PR TITLE
Remove old rake task

### DIFF
--- a/lib/tasks/world_locations.rake
+++ b/lib/tasks/world_locations.rake
@@ -1,9 +1,0 @@
-namespace :world_locations do
-  task redirect_world_location_translations_to_en: :environment do
-    world_location_ids = WorldLocation.all.pluck(:id)
-
-    world_location_ids.each do |world_location_id|
-      WorldLocationRedirectWorker.perform_async(world_location_id)
-    end
-  end
-end


### PR DESCRIPTION
This was a one off rake task relating to moving world pages into the taxonomy. It is no longer needed.