### PR TITLE
Fix from/to date filtering in whitehall-admin

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -74,18 +74,18 @@ module Admin
     end
 
     def from_date
-      @from_date ||= Chronic.parse(options[:from_date], endian_precedence: :little) if options[:from_date]
+      @from_date ||= Chronic.parse(options[:from_date], endian_precedence: :little, guess: :begin) if options[:from_date]
     end
 
     def to_date
-      @to_date ||= Chronic.parse(options[:to_date], endian_precedence: :little) if options[:to_date]
+      @to_date ||= Chronic.parse(options[:to_date], endian_precedence: :little, guess: :begin) if options[:to_date]
     end
 
     def date_range_string
       if from_date && to_date
         "from #{from_date.to_date.to_s(:uk_short)} to #{to_date.to_date.to_s(:uk_short)}"
       elsif from_date
-        "after #{from_date.to_date.to_s(:uk_short)}"
+        "from #{from_date.to_date.to_s(:uk_short)}"
       elsif to_date
         "before #{to_date.to_date.to_s(:uk_short)}"
       end

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -237,7 +237,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
 
   test "should generate page title for from date" do
     filter = Admin::EditionFilter.new(Edition, build(:user), from_date: '09/11/2011')
-    assert_equal "Everyone’s documents after 09/11/2011", filter.page_title
+    assert_equal "Everyone’s documents from 09/11/2011", filter.page_title
   end
 
   test "should generate page title for to date" do


### PR DESCRIPTION
This commit changes the from/to date filtering logic for whitehall-admin to correctly include the actual from date in the range when filtering documents, and not return some documents after the "to" date. This logic was previously only returning documents last updated after/before 12 noon. It also changes the heading that appears to make it clearer that the from date is included in the range.

```
irb(main):001:0> Chronic.parse("04/08/2017", endian_precedence: :little)
=> 2017-08-04 12:00:00 +0000
irb(main):002:0> Chronic.parse("04/08/2017", endian_precedence: :little, guess: :begin)
=> 2017-08-04 00:00:00 +0000
```

Trello: https://trello.com/c/NecdTxxq/63-amend-csv-export-copy