### PR TITLE
Link admin attachments partial to full url

### DIFF
--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -13,7 +13,7 @@
       <%= content_tag_for(:li, attachment.becomes(Attachment), class: "well") do %>
         <strong><%= attachment.title %></strong>
         <span class="file">
-          <%= attachment.is_a?(ExternalAttachment) ? 'Link' : 'File' %>: <%= link_to_attachment(attachment, preview: true) %>
+          <%= attachment.is_a?(ExternalAttachment) ? 'Link' : 'File' %>: <%= link_to_attachment(attachment, preview: true, full_url: true) %>
         </span>
         <%= attachment_virus_status(attachment) %>
         <%= attachment_metadata_tag(attachment) %>

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -22,6 +22,15 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
+  Scenario: Previewing HTML attachment
+    Given I am an writer
+    And I start drafting a new publication "Standard Beard Lengths"
+    When I start editing the attachments from the publication page
+    And I upload an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
+    When I visit the attachments page
+    Then I can see the attachment title "Beard Length Graphs 2012"
+    And I can see the preview link to the attachment "HTML attachment"
+
   Scenario: Replacing data on an attachment
     Given I am an editor
     And a published publication "Standard Beard Lengths" with a PDF attachment

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -1,37 +1,18 @@
-When(/^I make unsaved changes to the news article$/) do
-  @news_article = NewsArticle.last
-  visit edit_admin_news_article_path(@news_article)
-  fill_in 'Title', with: 'An unsaved change'
-end
-
-When(/^I attempt to visit the attachments page$/) do
+When(/^I visit the attachments page$/) do
   first(:link, 'Attachments').click
 end
 
-Then(/^I should stay on the edit screen for the news article$/) do
-  assert_path edit_admin_news_article_path(@news_article)
-end
-
-When(/^I save my changes$/) do
-  click_on 'Save and continue editing'
-end
-
-Then(/^I can visit the attachments page$/) do
-  first(:link, 'Attachments').click
-  assert_path admin_edition_attachments_path(@news_article)
-end
-
-When /^the (?:attachment|image)s? (?:has|have) been virus\-checked$/ do
+When(/^the (?:attachment|image)s? (?:has|have) been virus\-checked$/) do
   FileUtils.cp_r(Whitehall.incoming_uploads_root + '/.', Whitehall.clean_uploads_root + "/")
   FileUtils.rm_rf(Whitehall.incoming_uploads_root)
   FileUtils.mkdir(Whitehall.incoming_uploads_root)
 end
 
-Then /^the image will be quarantined for virus checking$/ do
+Then(/^the image will be quarantined for virus checking$/) do
   assert_final_path(person_image_path, "thumbnail-placeholder.png")
 end
 
-Then /^the virus checked image will be available for viewing$/ do
+Then(/^the virus checked image will be available for viewing$/) do
   assert_final_path(person_image_path, person_image_path)
 end
 
@@ -111,17 +92,12 @@ Then(/^the outcome for the consultation should have the attachment "(.*?)"$/) do
   assert page.has_content?(attachment_title)
 end
 
-Given(/^the publication "(.*?)" has an html attachment "(.*?)" with the body "(.*?)"$/) do |publication_title, attachment_title, attachment_body|
-  publication = Publication.find_by(title: publication_title)
-  create :html_attachment, attachable: publication, title: attachment_title, body: attachment_body
+Then(/^I can see the attachment title "([^"]*)"$/) do |text|
+  assert page.has_css?('li.attachment', text: text)
 end
 
 Then(/^I can see the preview link to the attachment "(.*?)"$/) do |attachment_title|
   assert page.has_link?("a", href: /draft-origin/, text: attachment_title)
-end
-
-Then(/^I should see the html attachment body "(.*?)"$/) do |attachment_body|
-  assert page.has_content?(attachment_body)
 end
 
 When(/^I upload an html attachment with the title "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)" and the contact address "(.*?)"$/) do |title, isbn, web_isbn, contact_address|
@@ -140,7 +116,7 @@ When(/^I publish the draft edition for publication "(.*?)"$/) do |publication_ti
   publication.update!(state: 'published', major_change_published_at: Date.today)
 end
 
-Then /^the html attachment "(.*?)" includes the contact address "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)"$/ do |attachment_title, contact_address, isbn, web_isbn|
+Then(/^the html attachment "(.*?)" includes the contact address "(.*?)" and the isbn "(.*?)" and the web isbn "(.*?)"$/) do |attachment_title, contact_address, isbn, web_isbn|
   html_attachment = HtmlAttachment.find_by title: attachment_title
 
   assert_equal attachment_title, html_attachment.title


### PR DESCRIPTION
This will link the document either to the draft stack or the live site. Without it, it would link to whitehall-frontend. Add a feature test for this and remove unused step definitions.

For https://trello.com/c/cLVn6spv/31-switch-html-publications-to-use-draft-stack-when-previewing-content