### PR TITLE
Add speech type explanation to payload

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -34,6 +34,7 @@ module PublishingApi
         body: body,
         political: item.political,
         delivered_on: item.delivered_on.iso8601,
+        speech_type_explanation: speech_type_explanation,
         change_history: item.change_history.as_json,
       }
       details.merge!(image_payload) if has_image?
@@ -125,6 +126,10 @@ module PublishingApi
       else
         speaker.name
       end
+    end
+
+    def speech_type_explanation
+      item.speech_type ? item.speech_type.explanation : nil
     end
   end
 end

--- a/db/data_migration/20170807145027_republish_speeches_with_speech_type_explanation.rb
+++ b/db/data_migration/20170807145027_republish_speeches_with_speech_type_explanation.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiDocumentRepublisher.new(Speech)
+republisher.perform

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -30,6 +30,7 @@ module SyncChecker
       def expected_details_hash(speech, _locale)
         super.tap do |details|
           details.merge!(expected_delivered_on(speech))
+          details.merge!(expected_speech_type_explanation(speech))
           details.merge!(expected_government(speech))
           details.merge!(expected_image(speech))
           details.merge!(expected_political(speech))
@@ -57,6 +58,10 @@ module SyncChecker
 
       def expected_delivered_on(speech)
         { "delivered_on" => speech.delivered_on.iso8601 }
+      end
+
+      def expected_speech_type_explanation(speech)
+        { "speech_type_explanation" => speech.speech_type.explanation }
       end
 
       def expected_government(speech)

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -66,6 +66,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       refute(details[:political])
       assert_equal(expected_body,     details[:body])
       assert_match(iso8601_regex,     details[:delivered_on])
+      assert_equal("Transcript of the speech, exactly as it was delivered", details[:speech_type_explanation])
 
       assert_equal("The Government",  details[:government][:title])
       assert_equal("the-government",  details[:government][:slug])


### PR DESCRIPTION
The content schema field `speech_type_explanation` for Speeches has not been populated from Whitehall. This commit updates the SpeechPresenter to send the relevant data to the Publishing Platform. With this fix, the speech pages will render the explanation as part of the 'Delivered on:' text:

<img width="677" alt="screen shot 2017-08-07 at 15 05 00" src="https://user-images.githubusercontent.com/5112255/29032316-d7e08818-7b88-11e7-9e99-2d488f9f1565.png">


For https://trello.com/c/fyS5Hct7/62-investigate-re-adding-speech-type-to-template