### PR TITLE
Change default_page_size to Kaminari default

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -38,7 +38,7 @@ module Admin
     end
 
     def default_page_size
-      50
+      Kaminari.config.default_per_page
     end
 
     def hide_type


### PR DESCRIPTION
The default `kaminari` page size is 25, but we were internally using 50 when fetching data before passing into `kaminari` for pagination. This resulted in some results not being displayed because we were paging in increments of 50 while `kaminari` was paging in increments of 25.

Trello: https://trello.com/c/RwjGDzxA/97-whitehall-admin-editions-list-missing-documents