### PR TITLE
Do not send empty speech type explanation

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -34,9 +34,9 @@ module PublishingApi
         body: body,
         political: item.political,
         delivered_on: item.delivered_on.iso8601,
-        speech_type_explanation: speech_type_explanation,
         change_history: item.change_history.as_json,
       }
+      details.merge!(speech_type_explanation)
       details.merge!(image_payload) if has_image?
       details.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details.merge!(PayloadBuilder::FirstPublicAt.for(item))
@@ -68,6 +68,13 @@ module PublishingApi
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+    end
+
+    def speech_type_explanation
+      return {} unless item.speech_type
+      return {} unless item.speech_type.explanation.present?
+
+      { speech_type_explanation: item.speech_type.explanation }
     end
 
     def image_payload
@@ -126,10 +133,6 @@ module PublishingApi
       else
         speaker.name
       end
-    end
-
-    def speech_type_explanation
-      item.speech_type ? item.speech_type.explanation : nil
     end
   end
 end

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -61,6 +61,8 @@ module SyncChecker
       end
 
       def expected_speech_type_explanation(speech)
+        return {} unless speech.speech_type.explanation.present?
+
         { "speech_type_explanation" => speech.speech_type.explanation }
       end
 


### PR DESCRIPTION
Of the seven SpeechTypes, only three of them have an explanation string set. For the speech types without an explanation, the presenter was sending speech_type_explanation as `nil` which failed against the content schemas (they expect a string). Also government frontend only checks for presence of the key, so sending an empty string would cause it to render an empty pair of parentheses. See code in government-frontend below:

```
  def speech_type_explanation
    explanation = content_item["details"]["speech_type_explanation"]
    " (#{explanation})" if explanation
  end
```

Therefore not sending the key for speech_type_explanation at all when empty seems like the easiest fix for this. This should also make the Speech sync checks perform better.