### PR TITLE
Rename world locations to world location news

### DIFF
--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -40,7 +40,7 @@ module Admin::UrlHelper
   end
 
   def admin_world_locations_header_menu_link
-    admin_header_menu_link "World locations", admin_world_locations_path
+    admin_header_menu_link "World location news", admin_world_locations_path
   end
 
   def admin_policy_groups_header_menu_link

--- a/app/models/world_location_type.rb
+++ b/app/models/world_location_type.rb
@@ -19,6 +19,6 @@ class WorldLocationType
     [WorldLocation]
   end
 
-  WorldLocation = create(id: 1, key: "world_location", name: "World location", sort_order: 0)
+  WorldLocation = create(id: 1, key: "world_location", name: "World location news", sort_order: 0)
   InternationalDelegation = create(id: 3, key: "international_delegation", name: "International delegation", sort_order: 2)
 end

--- a/app/views/admin/world_locations/index.html.erb
+++ b/app/views/admin/world_locations/index.html.erb
@@ -1,5 +1,5 @@
-<% page_title "World locations" %>
-<h1>World locations</h1>
+<% page_title "World location news" %>
+<h1>World location news</h1>
 
 <%= render partial: "world_location_table", locals: {title: "Active", world_locations: @active_world_locations } %>
 


### PR DESCRIPTION
World location pages have been changed, they are now auto-generated from other
content and they are no longer editable by content editors directly. The admin
views didn't reflect this however. The editable content the admin listed as "world location" was actually "world location news", and this change reflects it in the view.

https://govuk.zendesk.com/agent/tickets/2294928

**Before**
![before](https://user-images.githubusercontent.com/8225167/29068331-31af27b4-7c2e-11e7-91f6-421d93bcf0ae.png)

**After**
![after](https://user-images.githubusercontent.com/8225167/29068444-c7bfc786-7c2e-11e7-9405-a129be0ca9a7.png)
