### PR TITLE
Format advice updates

### DIFF
--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -6,7 +6,7 @@ class PublicationType
   include ActiveRecordLikeInterface
 
   FORMAT_ADVICE = {
-    1 => "<p>Publications that relate to the setting and delivery of government policy. Includes white papers, strategies, operational plans, action plans, implementation plans (excludes consultations, research and impact assessments, or internal procedural “policies”).</p>",
+    1 => "<p>A policy paper explains the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.</p><p>Read the <a href=\"https://www.gov.uk/guidance/content-design/content-types#policy-paper\" target=\"_blank\">policy papers guidance</a> in full.</p>",
     2 => "<p>Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.</p>",
     3 => "<p>Non-statutory guidance publications. Includes: manuals, handbooks and other documents that offer advice.</p><p>Do <em>not</em> use for: statutory guidance (use the “statutory guidance” publication type) or guidance about completing a form (attach to same publication as the form itself).</p>",
     4 => "<p>Pro-forma or form documents that need to be completed by the user. Can include guidance on how to fill in forms (ie no need to create a separate “guidance” publication for form instructions).</p>",

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="format-advice">
-  <p><strong>Use this format for:</strong> Guidance for professional or specialist users so that they can complete a defined task.</p>
+  <p>Detailed guides tell users the steps they need to take to complete a specific task. They are usually aimed at specialist or professional audiences.</p><p>Read the <a href="https://www.gov.uk/guidance/content-design/content-types#detailed-guide" target="_blank">detailed guides guidance</a> in full.</p>
 </div>
 
 <%= edition_editing_tabs(edition) do %>


### PR DESCRIPTION
Change to detailed guide and policy paper format advice. The need to make them clearer came from some firebreak work: [detailed guides](https://trello.com/c/GDDJPDrf/60-changing-the-detailed-guide-format-guidance), [policy papers](https://trello.com/c/aADBKCH0/59-changing-the-policy-paper-format-guidance).

## Screenshots:

Policy Paper Update:

<img width="772" alt="screen shot 2017-08-10 at 14 59 45" src="https://user-images.githubusercontent.com/5112255/29173952-c2b08c4e-7ddc-11e7-8bdf-43508a4cd89d.png">

-----------------------------------

Detailed Guide Update:

<img width="767" alt="screen shot 2017-08-10 at 15 00 39" src="https://user-images.githubusercontent.com/5112255/29173958-c77f2a14-7ddc-11e7-8f50-4eee1e4f585f.png">

