### PR TITLE
Make `EmailTopicChecker` more robust

### DIFF
--- a/lib/email_topic_checker.rb
+++ b/lib/email_topic_checker.rb
@@ -82,8 +82,8 @@ class EmailTopicChecker
     tags = details[:tags] if details
 
     params = {
-      links: strip_empty_arrays(links),
-      tags: strip_empty_arrays(tags),
+      links: strip_empty_arrays(links || {}),
+      tags: strip_empty_arrays(tags || {}),
       document_type: content[:document_type],
     }.merge(supertypes)
 


### PR DESCRIPTION
Handle missing `links` and `tags` arrays to stop the check falling over.