### PR TITLE
Alter title for world_location_news pages

### DIFF
--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -1,4 +1,4 @@
-<% page_title @world_location.title, "UK and the world" %>
+<% page_title @world_location.title %>
 <% page_class "world-locations-show" %>
 <% atom_discovery_link_tag atom_feed_url_for(@world_location), t("feeds.latest_activity") %>
 

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -21,6 +21,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
 
   view_test "index displays world location title and mission-statement" do
     get :index, world_location_id: @world_location
+    assert_select "title", text: "UK and India - GOV.UK"
     assert_select "p.type", text: "World location news"
     assert_select "h1", text: "UK and India"
     assert_select ".mission_statement", text: "country-mission-statement"


### PR DESCRIPTION
title change to 'UK and COUNTRY', and heading change to 'COUNTRY and the
UK'

For https://trello.com/c/aQPSDsVW/74-change-page-title-and-description-for-world-location-news-pages