### PR TITLE
[DO NOT MERGE] Fix "View on website" link for world location news

### DIFF
--- a/app/views/admin/world_locations/show.html.erb
+++ b/app/views/admin/world_locations/show.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= view_on_website_link_for @world_location %></p>
+    <p><%= link_to "View on website", "/world/#{@world_location.name}/news" %></p>
   </div>
 
   <section class="world-location-details">


### PR DESCRIPTION
The link in the admin was still pointing to the world location page
(www.gov.uk/world/country) instead of the world location article page
(www.gov.uk/world/country/news).

cc @gpeng 

https://govuk.zendesk.com/agent/tickets/2294928

