### PR TITLE
Fix name of world location model

### DIFF
--- a/app/models/world_location_type.rb
+++ b/app/models/world_location_type.rb
@@ -19,6 +19,6 @@ class WorldLocationType
     [WorldLocation]
   end
 
-  WorldLocation = create(id: 1, key: "world_location", name: "World location news", sort_order: 0)
+  WorldLocation = create(id: 1, key: "world_location", name: "World location", sort_order: 0)
   InternationalDelegation = create(id: 3, key: "international_delegation", name: "International delegation", sort_order: 2)
 end


### PR DESCRIPTION
This was changed in https://github.com/alphagov/whitehall/pull/3384 but the type should still be “world location” whereas whitehall-admin can refer to the pages as “world location news”.