### PR TITLE
Add named params to tests

### DIFF
--- a/test/functional/admin/about_pages_controller_test.rb
+++ b/test/functional/admin/about_pages_controller_test.rb
@@ -7,33 +7,33 @@ class Admin::AboutPagesControllerTest < ActionController::TestCase
   end
 
   view_test "GET show prompts user to create an about page" do
-    get :show, topical_event_id: @topical_event.to_param
+    get :show, params: { topical_event_id: @topical_event.to_param }
     assert_response :success
     assert_select 'h1', @topical_event.name
     assert_select 'p', /doesn’t yet have a page/
   end
 
   view_test "GET new allows user to enter copy for new about page" do
-    get :new, topical_event_id: @topical_event.to_param
+    get :new, params: { topical_event_id: @topical_event.to_param }
     assert_select 'textarea[name*="summary"]'
   end
 
   test "POST create saves a new about page" do
     assert_difference 'AboutPage.count' do
-      post :create, topical_event_id: @topical_event.to_param, about_page: attributes_for(:about_page)
+      post :create, params: { topical_event_id: @topical_event.to_param, about_page: attributes_for(:about_page) }
     end
     assert_not_nil @topical_event.about_page, "expected topical event to have an about page"
   end
 
   view_test "GET edit shows the form for editing an about page" do
     about = create(:about_page, topical_event: @topical_event)
-    get :edit, topical_event_id: @topical_event.to_param
+    get :edit, params: { topical_event_id: @topical_event.to_param }
     assert_select 'textarea[name*="summary"]', text: /#{about.summary}/
   end
 
   test "PUT update saves changes to the about page" do
     about = create(:about_page, topical_event: @topical_event)
-    put :update, topical_event_id: @topical_event.to_param, about_page: { name: 'New name' }
+    put :update, params: { topical_event_id: @topical_event.to_param, about_page: { name: 'New name' } }
     assert_equal 'New name', about.reload.name
   end
 end

--- a/test/functional/admin/access_and_opening_times_controller_test.rb
+++ b/test/functional/admin/access_and_opening_times_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
 
   test "GET on :edit assigns a new instance if one does not already exist" do
     worldwide_organisation = create(:worldwide_organisation)
-    get :edit, worldwide_organisation_id: worldwide_organisation
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation }
 
     assert_response :success
     assert_template :edit
@@ -22,7 +22,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   test "GET on :edit loads the access and opening times if one exists" do
     worldwide_organisation = create(:worldwide_organisation)
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation)
-    get :edit, worldwide_organisation_id: worldwide_organisation
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation }
 
     assert_response :success
     assert_template :edit
@@ -33,7 +33,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   test "GET on :edit loads the office as accessible if worldwide_office_id is supplied" do
     worldwide_organisation = create(:worldwide_organisation)
     worldwide_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
-    get :edit, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office }
 
     assert_response :success
     assert_template :edit
@@ -48,7 +48,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation, body: 'default from org')
     worldwide_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
-    get :edit, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office }
 
     assert_response :success
     assert_equal worldwide_office, assigns(:accessible)
@@ -61,7 +61,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation)
     worldwide_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
-    get :edit, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office }
 
     assert_response :success
     assert_template :edit
@@ -73,7 +73,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
 
   test "POST on :create saves the access and opening times details to the organisation" do
     worldwide_organisation = create(:worldwide_organisation)
-    post :create, worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: 'body text' }
+    post :create, params: { worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: 'body text' } }
 
     assert access_and_opening_times = worldwide_organisation.access_and_opening_times
     assert_equal 'body text', access_and_opening_times.body
@@ -83,7 +83,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   test "POST on :create saves access info to an office and redirects to the offices page for the organisation" do
     worldwide_organisation = create(:worldwide_organisation)
     worldwide_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
-    post :create, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office, access_and_opening_times: { body: 'custom body text' }
+    post :create, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office, access_and_opening_times: { body: 'custom body text' } }
 
     assert access_and_opening_times = worldwide_office.access_and_opening_times
     assert_equal 'custom body text', access_and_opening_times.body
@@ -92,7 +92,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
 
   view_test "POST on :create displays errors if access and opening times info is invalid" do
     worldwide_organisation = create(:worldwide_organisation)
-    post :create, worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: '' }
+    post :create, params: { worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: '' } }
 
     assert_nil worldwide_organisation.access_and_opening_times
     assert_template :edit
@@ -104,7 +104,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   test 'PUT on :update updates the access and opening times details' do
     worldwide_organisation = create(:worldwide_organisation)
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation)
-    put :update, worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: 'new body' }
+    put :update, params: { worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: 'new body' } }
 
     assert_equal 'new body', access_and_opening_times.reload.body
     assert_redirected_to access_info_admin_worldwide_organisation_path(worldwide_organisation)
@@ -115,7 +115,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
     worldwide_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
     default_access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation, body: 'default body')
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_office)
-    put :update, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office, access_and_opening_times: { body: 'custom new body' }
+    put :update, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: worldwide_office, access_and_opening_times: { body: 'custom new body' } }
 
     assert_equal 'custom new body', access_and_opening_times.reload.body
     assert_equal 'default body', default_access_and_opening_times.body
@@ -125,7 +125,7 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
   view_test "PUT on :update displays errors if access and opening times info is invalid" do
     worldwide_organisation = create(:worldwide_organisation)
     access_and_opening_times = create(:access_and_opening_times, accessible: worldwide_organisation, body: 'old body')
-    put :update, worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: '' }
+    put :update, params: { worldwide_organisation_id: worldwide_organisation, access_and_opening_times: { body: '' } }
 
     assert_equal 'old body', access_and_opening_times.reload.body
     assert_template :edit
@@ -139,15 +139,15 @@ class Admin::AccessAndOpeningTimesControllerTest < ActionController::TestCase
     office_for_other_org = create(:worldwide_office)
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :edit, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org
+      get :edit, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org }
     end
 
     assert_raise ActiveRecord::RecordNotFound do
-      post :create, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org, access_and_opening_times: { body: 'body' }
+      post :create, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org, access_and_opening_times: { body: 'body' } }
     end
 
     assert_raise ActiveRecord::RecordNotFound do
-      put :update, worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org, access_and_opening_times: { body: 'body' }
+      put :update, params: { worldwide_organisation_id: worldwide_organisation, worldwide_office_id: office_for_other_org, access_and_opening_times: { body: 'body' } }
     end
   end
 end

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -40,17 +40,17 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
         zip_file: fixture_file_upload(filename)
       }
     end
-    post :upload_zip, { edition_id: @edition }.merge(params)
+    post :upload_zip, params: { edition_id: @edition }.merge(params)
   end
 
   test 'Actions are unavailable on unmodifiable editions' do
     edition = create(:published_news_article)
-    get :new, edition_id: edition
+    get :new, params: { edition_id: edition }
     assert_response :redirect
   end
 
   view_test 'GET :new displays a bulk upload form' do
-    get :new, edition_id: @edition
+    get :new, params: { edition_id: @edition }
 
     assert_response :success
     assert_select 'input[type=file]'
@@ -58,7 +58,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
 
   test 'bulk upload access is forbidden for users without access to the edition' do
     login_as :world_editor
-    get :new, edition_id: @edition
+    get :new, params: { edition_id: @edition }
     assert_response :forbidden
   end
 
@@ -98,7 +98,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
   end
 
   view_test 'POST :create with attachment metadata saves attachments to edition' do
-    post :create, edition_id: @edition, bulk_upload: valid_create_params
+    post :create, params: { edition_id: @edition, bulk_upload: valid_create_params }
     assert_response :redirect
     assert_equal 2, @edition.reload.attachments.count
     assert_equal @titles[0], @edition.attachments[0].title
@@ -106,7 +106,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
   end
 
   view_test 'POST :create with invalid attachments re-renders the bulk upload form' do
-    post :create, edition_id: @edition, bulk_upload: invalid_create_params
+    post :create, params: { edition_id: @edition, bulk_upload: invalid_create_params }
 
     assert_response :success
     assert_select '.form-errors', text: /enter missing fields/

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -15,9 +15,11 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     role_2 = create(:ministerial_role, name: 'Non-Executive Director', cabinet_member: true, organisations: [organisation])
     role_1 = create(:ministerial_role, name: 'Prime Minister', cabinet_member: true, organisations: [organisation])
 
-    put :update, roles: {
-      "#{role_1.id}" => {ordering: 0},
-      "#{role_2.id}" => {ordering: 1},
+    put :update, params: {
+      roles: {
+        role_1.id.to_s => { ordering: 0 },
+        role_2.id.to_s => { ordering: 1 },
+      }
     }
 
     assert_equal MinisterialRole.cabinet.order(:seniority).to_a, [role_1, role_2]
@@ -27,9 +29,11 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     role_2 = create(:ministerial_role, name: 'Chief Whip and Parliamentary Secretary to the Treasury', attends_cabinet_type_id: 2, organisations: [organisation])
     role_1 = create(:ministerial_role, name: 'Minister without Portfolio', attends_cabinet_type_id: 1, organisations: [organisation])
 
-    put :update, roles: {
-      "#{role_1.id}" => {ordering: 0},
-      "#{role_2.id}" => {ordering: 1},
+    put :update, params: {
+      roles: {
+        role_1.id.to_s => { ordering: 0 },
+        role_2.id.to_s => { ordering: 1 },
+      }
     }
 
     assert_equal MinisterialRole.also_attends_cabinet.order(:seniority).to_a, [role_1, role_2]
@@ -39,9 +43,11 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     role_2 = create(:ministerial_role, name: 'Whip 1', whip_organisation_id: 2, organisations: [organisation])
     role_1 = create(:ministerial_role, name: 'Whip 2', whip_organisation_id: 2, organisations: [organisation])
 
-    put :update, whips: {
-      "#{role_1.id}" => {ordering: 0},
-      "#{role_2.id}" => {ordering: 1},
+    put :update, params: {
+      whips: {
+        role_1.id.to_s => { ordering: 0 },
+        role_2.id.to_s => { ordering: 1 },
+      }
     }
 
     assert_equal MinisterialRole.whip.order(:seniority).to_a, [role_2, role_1]
@@ -62,9 +68,11 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     org_2 = create(:organisation)
     org_1 = create(:organisation)
 
-    put :update, organisation: {
-      "#{org_1.id}" => {ordering: 0},
-      "#{org_2.id}" => {ordering: 1},
+    put :update, params: {
+      organisation: {
+        org_1.id.to_s => { ordering: 0 },
+        org_2.id.to_s => { ordering: 1 },
+      }
     }
 
     assert_equal Organisation.order(:ministerial_ordering), [org_1, org_2]

--- a/test/functional/admin/classification_featurings_controller_test.rb
+++ b/test/functional/admin/classification_featurings_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     draft_article     = create(:news_article, topics: [@topic])
     unrelated_article = create(:news_article, :with_topics)
 
-    get :index, topic_id: @topic, page: 1
+    get :index, params: { topic_id: @topic, page: 1 }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article_2, news_article_1], tagged_editions
@@ -28,7 +28,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     news_article      = create(:published_news_article, topics: [@topic], title: 'Specific title')
     unrelated_article = create(:published_news_article, :with_topics, title: 'Specific title')
 
-    get :index, topic_id: @topic, title: 'specific'
+    get :index, params: { topic_id: @topic, title: 'specific' }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
@@ -40,7 +40,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     news_article = create(:published_news_article, topics: [@topic])
     news_article.organisations << org
 
-    get :index, topic_id: @topic, organisation: org.id
+    get :index, params: { topic_id: @topic, organisation: org.id }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
@@ -52,7 +52,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     user = create(:user)
     create(:edition_author, edition: news_article, user: user)
 
-    get :index, topic_id: @topic, author: user.id
+    get :index, params: { topic_id: @topic, author: user.id }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
@@ -62,7 +62,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     create(:published_statistical_data_set, topics: [@topic])
     news_article = create(:published_news_article, topics: [@topic])
 
-    get :index, topic_id: @topic, type: news_article.display_type_key
+    get :index, params: { topic_id: @topic, type: news_article.display_type_key }
 
     tagged_editions = assigns(:tagged_editions)
     assert_equal [news_article], tagged_editions
@@ -72,7 +72,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     create(:published_news_article, topics: [@topic])
     news_article = create(:published_news_article, topics: [@topic])
 
-    get :index, topic_id: create(:topic)
+    get :index, params: { topic_id: create(:topic) }
 
     assert_equal 0, assigns(:tagged_editions).count
     assert_match 'No documents found', response.body
@@ -83,11 +83,11 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
     feature2 = create(:classification_featuring, classification: @topic)
     feature3 = create(:classification_featuring, classification: @topic)
 
-    put :order, topic_id: @topic, ordering: {
+    put :order, params: { topic_id: @topic, ordering: {
                                         feature1.id.to_s => '1',
                                         feature2.id.to_s => '2',
                                         feature3.id.to_s => '0'
-                                      }
+                                      } }
 
     assert_response :redirect
     assert_equal [feature3, feature1, feature2], @topic.reload.classification_featurings
@@ -95,7 +95,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
 
   view_test "GET :new renders only image fields if featuring an edition" do
     edition = create :edition
-    get :new, topic_id: @topic.id, edition_id: edition.id
+    get :new, params: { topic_id: @topic.id, edition_id: edition.id }
 
     assert_select "#classification_featuring_image_attributes_file"
     assert_select "#classification_featuring_alt_text"
@@ -103,7 +103,7 @@ class Admin::ClassificationFeaturingsControllerTest < ActionController::TestCase
 
   view_test "GET :new renders all fields if not featuring an edition" do
     offsite_link = create :offsite_link
-    get :new, topic_id: @topic.id, offsite_link_id: offsite_link.id
+    get :new, params: { topic_id: @topic.id, offsite_link_id: offsite_link.id }
 
     assert_select "#classification_featuring_image_attributes_file"
     assert_select "#classification_featuring_alt_text"

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -47,7 +47,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       }
     )
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     consultation = Consultation.last
     response_form = consultation.consultation_participation.consultation_response_form
@@ -76,7 +76,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       }
     )
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     consultation = Consultation.last
     assert_nil consultation.consultation_participation
@@ -96,7 +96,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
       }
     )
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     assert_select "form#new_edition" do
       assert_select "input[name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file_cache]'][value$='two-pages.pdf']"
@@ -106,7 +106,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
 
   view_test "show renders the summary" do
     draft_consultation = create(:draft_consultation, summary: "a-simple-summary")
-    get :show, id: draft_consultation
+    get :show, params: { id: draft_consultation }
     assert_select ".page-header .lead", text: "a-simple-summary"
   end
 
@@ -115,7 +115,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)
 
-    get :edit, id: consultation
+    get :edit, params: { id: consultation }
 
     assert_select "form#edit_edition" do
       assert_select "textarea[name='edition[summary]']"
@@ -134,7 +134,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   test "update should save modified consultation attributes" do
     consultation = create(:consultation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       summary: "new-summary",
       opening_at: 1.day.ago,
       closing_at: 50.days.from_now,
@@ -142,7 +142,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
         link_url: "http://consult.com",
         email: "tell-us-what-you-think@gov.uk"
       }
-    }
+    } }
 
     consultation.reload
     assert_equal "new-summary", consultation.summary
@@ -155,12 +155,12 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   test "update should save consultation without consultation participation if participation fields are all blank" do
     consultation = create(:consultation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       consultation_participation_attributes: {
         link_url: nil,
         email: nil
       }
-    }
+    } }
 
     consultation.reload
     assert_nil consultation.consultation_participation
@@ -171,7 +171,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       consultation_participation_attributes: {
         id: participation.id,
         consultation_response_form_attributes: {
@@ -179,7 +179,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
           _destroy: '1'
         }
       }
-    }
+    } }
 
     refute_select ".errors"
     consultation.reload
@@ -194,7 +194,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       consultation_participation_attributes: {
         id: participation.id,
         consultation_response_form_attributes: {
@@ -207,7 +207,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
           }
         }
       }
-    }
+    } }
 
     refute_select ".errors"
     consultation.reload
@@ -220,7 +220,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       consultation_participation_attributes: {
         id: participation.id,
         consultation_response_form_attributes: {
@@ -228,7 +228,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
           attachment_action: 'remove'
         }
       }
-    }
+    } }
 
     refute_select ".errors"
     consultation.reload
@@ -249,7 +249,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)
 
-    put :update, id: consultation, edition: {
+    put :update, params: { id: consultation, edition: {
       consultation_participation_attributes: {
         id: participation.id,
         consultation_response_form_attributes: {
@@ -262,7 +262,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
           }
         }
       }
-    }
+    } }
 
     refute_select ".errors"
     consultation.reload

--- a/test/functional/admin/contact_translations_controller_test.rb
+++ b/test/functional/admin/contact_translations_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = create(:contact, contactable: organisation)
 
-    post :create, organisation_id: organisation, contact_id: contact, translation_locale: "fr"
+    post :create, params: { organisation_id: organisation, contact_id: contact, translation_locale: "fr" }
 
     assert_redirected_to edit_admin_organisation_contact_translation_path(organisation, contact, id: "fr")
   end
@@ -21,7 +21,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = create(:contact, contactable: organisation, title: "english-title")
 
-    get :edit, organisation_id: organisation, contact_id: contact, id: "fr"
+    get :edit, params: { organisation_id: organisation, contact_id: contact, id: "fr" }
 
     assert_select "h1", text: "Edit ‘Français (French)’ translation for: english-title"
   end
@@ -31,7 +31,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
     contact = create(:contact, contactable: organisation, title: "english-title")
     contact_number = create(:contact_number, contact: contact, number: "123456789 english-number")
 
-    get :edit, organisation_id: organisation, contact_id: contact, id: "fr"
+    get :edit, params: { organisation_id: organisation, contact_id: contact, id: "fr" }
 
     assert_select "input", value: "123456789 english-number"
   end
@@ -40,11 +40,10 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = create(:contact, contactable: organisation, title: "english-title")
 
-    put :update, organisation_id: organisation, contact_id: contact, id: "fr",
-      contact: {
+    put :update, params: { organisation_id: organisation, contact_id: contact, id: "fr", contact: {
         title: "Afrolasie Bureau",
         comments: "Enseigner aux gens comment infuser le thé"
-      }
+      } }
 
     contact.reload
 
@@ -60,7 +59,7 @@ class Admin::ContactTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = create(:contact, contactable: organisation, translated_into: [:fr])
 
-    delete :destroy, organisation_id: organisation, contact_id: contact, id: "fr"
+    delete :destroy, params: { organisation_id: organisation, contact_id: contact, id: "fr" }
 
     contact.reload
     refute contact.translated_locales.include?(:fr)

--- a/test/functional/admin/contacts_controller_test.rb
+++ b/test/functional/admin/contacts_controller_test.rb
@@ -11,11 +11,13 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   test "POST on :create creates contact" do
     organisation = create(:organisation)
     post :create,
-      contact: {
-        title: "Main office",
-        contact_type_id: ContactType::General.id
-      },
-      organisation_id: organisation.id
+      params: {
+                contact: {
+              title: "Main office",
+              contact_type_id: ContactType::General.id
+            },
+            organisation_id: organisation.id
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert contact = organisation.contacts.last
@@ -27,14 +29,16 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
 
     post :create,
-      contact: {
-        title: "Head office",
-        contact_numbers_attributes: {
-          "0" => {label: "Main phone", number: "1234"}
-        },
-        contact_type_id: ContactType::General.id
-      },
-      organisation_id: organisation.id
+      params: {
+                contact: {
+              title: "Head office",
+              contact_numbers_attributes: {
+                "0" => { label: "Main phone", number: "1234" }
+              },
+              contact_type_id: ContactType::General.id
+            },
+            organisation_id: organisation.id
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert contact = organisation.contacts.last
@@ -45,12 +49,14 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   test "POST on :create creates contact on the home page of the organisation if told to" do
     organisation = create(:organisation)
     post :create,
-      contact: {
-        title: "Main office",
-        show_on_home_page: '1',
-        contact_type_id: ContactType::General.id
-      },
-      organisation_id: organisation.id
+      params: {
+                contact: {
+              title: "Main office",
+              show_on_home_page: '1',
+              contact_type_id: ContactType::General.id
+            },
+            organisation_id: organisation.id
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert contact = organisation.contacts.last
@@ -62,12 +68,14 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   test "POST on :create creates contact without adding to the home page of the organisation if told not to" do
     organisation = create(:organisation)
     post :create,
-      contact: {
-        title: "Main office",
-        show_on_home_page: '0',
-        contact_type_id: ContactType::General.id
-      },
-      organisation_id: organisation.id
+      params: {
+                contact: {
+              title: "Main office",
+              show_on_home_page: '0',
+              contact_type_id: ContactType::General.id
+            },
+            organisation_id: organisation.id
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert contact = organisation.contacts.last
@@ -79,11 +87,13 @@ class Admin::ContactsControllerTest < ActionController::TestCase
   test "POST on :create creates contact without adding to the home page of the organisation if no suggestion made" do
     organisation = create(:organisation)
     post :create,
-      contact: {
-        title: "Main office",
-        contact_type_id: ContactType::General.id
-      },
-      organisation_id: organisation.id
+      params: {
+                contact: {
+              title: "Main office",
+              contact_type_id: ContactType::General.id
+            },
+            organisation_id: organisation.id
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert contact = organisation.contacts.last
@@ -96,7 +106,7 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = organisation.contacts.create(title: "Main office", contact_type: ContactType::General)
 
-    put :update, contact: {title: "Head office"}, organisation_id: organisation, id: contact
+    put :update, params: { contact: { title: "Head office" }, organisation_id: organisation, id: contact }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %{"#{contact.reload.title}" updated successfully}, flash[:notice]
@@ -109,13 +119,16 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     contact_number = contact.contact_numbers.create(label: "Main phone", number: "1234")
 
     put :update,
-      contact: {
-        title: "Head office",
-        contact_numbers_attributes: {
-          "0" => {id: contact_number.id, label: "Main phone", number: "5678"}
-        }
-      },
-      organisation_id: organisation, id: contact
+      params: {
+                contact: {
+              title: "Head office",
+              contact_numbers_attributes: {
+                "0" => { id: contact_number.id, label: "Main phone", number: "5678" }
+              }
+            },
+            organisation_id: organisation,
+            id: contact
+    }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %{"#{contact.reload.title}" updated successfully}, flash[:notice]
@@ -127,11 +140,14 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     contact = organisation.contacts.create(title: "Main office", contact_type: ContactType::General)
 
     put :update,
-      contact: {
-        title: "Head office",
-        show_on_home_page: '1',
-      },
-      organisation_id: organisation, id: contact
+      params: {
+                contact: {
+              title: "Head office",
+              show_on_home_page: '1',
+            },
+            organisation_id: organisation,
+            id: contact
+    }
 
     contact.reload
     assert_redirected_to admin_organisation_contacts_url(organisation)
@@ -146,11 +162,14 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation.add_contact_to_home_page!(contact)
 
     put :update,
-      contact: {
-        title: "Head office",
-        show_on_home_page: '0',
-      },
-      organisation_id: organisation, id: contact
+      params: {
+                contact: {
+              title: "Head office",
+              show_on_home_page: '0',
+            },
+            organisation_id: organisation,
+            id: contact
+    }
 
     contact.reload
     assert_redirected_to admin_organisation_contacts_url(organisation)
@@ -165,10 +184,13 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation.add_contact_to_home_page!(contact)
 
     put :update,
-      contact: {
-        title: "Head office",
-      },
-      organisation_id: organisation, id: contact
+      params: {
+                contact: {
+              title: "Head office",
+            },
+            organisation_id: organisation,
+            id: contact
+    }
 
     contact.reload
     assert_redirected_to admin_organisation_contacts_url(organisation)
@@ -181,7 +203,7 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = organisation.contacts.create(title: "Main office", contact_type: ContactType::General)
 
-    delete :destroy, organisation_id: organisation, id: contact
+    delete :destroy, params: { organisation_id: organisation, id: contact }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %{"#{contact.title}" deleted successfully}, flash[:notice]
@@ -193,7 +215,7 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     contact = organisation.contacts.create(title: "Main office", contact_type: ContactType::General)
     organisation.add_contact_to_home_page!(contact)
 
-    post :remove_from_home_page, organisation_id: organisation, id: contact
+    post :remove_from_home_page, params: { organisation_id: organisation, id: contact }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %{"#{contact.title}" removed from home page successfully}, flash[:notice]
@@ -204,7 +226,7 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     contact = organisation.contacts.create(title: "Main office", contact_type: ContactType::General)
 
-    post :add_to_home_page, organisation_id: organisation, id: contact
+    post :add_to_home_page, params: { organisation_id: organisation, id: contact }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
     assert_equal %{"#{contact.title}" added to home page successfully}, flash[:notice]
@@ -220,11 +242,13 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     organisation.add_contact_to_home_page!(contact_2)
     organisation.add_contact_to_home_page!(contact_3)
 
-    post :reorder_for_home_page, organisation_id: organisation,
-      ordering: {
-        contact_1.id.to_s => '3',
-        contact_2.id.to_s => '1',
-        contact_3.id.to_s => '2'
+    post :reorder_for_home_page, params: {
+        organisation_id: organisation,
+        ordering: {
+          contact_1.id.to_s => '3',
+          contact_2.id.to_s => '1',
+          contact_3.id.to_s => '2'
+        }
       }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)
@@ -237,10 +261,12 @@ class Admin::ContactsControllerTest < ActionController::TestCase
     contact = organisation.contacts.create(title: "Head office", contact_type: ContactType::General)
     organisation.add_contact_to_home_page!(contact)
 
-    post :reorder_for_home_page, organisation_id: organisation,
-      ordering: {
-        contact.id.to_s => '2',
-        '1000000' => '1'
+    post :reorder_for_home_page, params: {
+        organisation_id: organisation,
+        ordering: {
+          contact.id.to_s => '2',
+          '1000000' => '1'
+        }
       }
 
     assert_redirected_to admin_organisation_contacts_url(organisation)

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
   test "GET :index" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
-    get :index, organisation_id: @organisation
+    get :index, params: { organisation_id: @organisation }
 
     assert_response :success
     assert_template :index
@@ -22,7 +22,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
   end
 
   view_test "GET :new should display form" do
-    get :new, organisation_id: @organisation
+    get :new, params: { organisation_id: @organisation }
 
     assert_select "form[action='#{admin_organisation_corporate_information_pages_path(@organisation)}']" do
       assert_select "textarea[name='edition[body]']"
@@ -33,7 +33,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
   end
 
   test "POST :create can create a corporate information page for an Organisation" do
-    post :create, organisation_id: @organisation, edition: corporate_information_page_attributes
+    post :create, params: { organisation_id: @organisation, edition: corporate_information_page_attributes }
 
     assert page = @organisation.corporate_information_pages.last
     assert_redirected_to [:admin, @organisation, page]
@@ -45,7 +45,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
   test "POST :create can create a corporation information page for a WorldwideOrganisation" do
     organisation = create(:worldwide_organisation)
-    post :create, worldwide_organisation_id: organisation, edition: corporate_information_page_attributes
+    post :create, params: { worldwide_organisation_id: organisation, edition: corporate_information_page_attributes }
 
     assert page = organisation.corporate_information_pages.last
     assert_redirected_to [:admin, organisation, page]
@@ -56,7 +56,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
   end
 
   view_test "POST :create should redisplay form with error message on fail" do
-    post :create, organisation_id: @organisation, edition: corporate_information_page_attributes(body: nil)
+    post :create, params: { organisation_id: @organisation, edition: corporate_information_page_attributes(body: nil) }
     @organisation.reload
     assert_select "form[action='#{admin_organisation_corporate_information_pages_path(@organisation)}']"
     assert_equal "There are some problems with the document", flash[:alert]
@@ -64,7 +64,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
   view_test "GET :edit should display form without type selector for existing corporate information page" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
-    get :edit, organisation_id: @organisation, id: corporate_information_page
+    get :edit, params: { organisation_id: @organisation, id: corporate_information_page }
 
     assert_select "form[action='#{admin_organisation_corporate_information_page_path(@organisation, corporate_information_page)}']" do
       assert_select "textarea[name='edition[body]']", corporate_information_page.body
@@ -77,7 +77,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
   test "PUT :update should update an existing corporate information page and redirect on success" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
     new_attributes = {body: "New body", summary: "New summary"}
-    put :update, organisation_id: @organisation, id: corporate_information_page, edition: new_attributes
+    put :update, params: { organisation_id: @organisation, id: corporate_information_page, edition: new_attributes }
     corporate_information_page.reload
     assert_equal new_attributes[:body], corporate_information_page.body
     assert_equal new_attributes[:summary], corporate_information_page.summary
@@ -88,7 +88,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
   view_test "PUT :update should redisplay form on failure" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
     new_attributes = {body: "", summary: "New summary"}
-    put :update, organisation_id: @organisation, id: corporate_information_page, edition: new_attributes
+    put :update, params: { organisation_id: @organisation, id: corporate_information_page, edition: new_attributes }
     assert_match /^There are some problems/, flash[:alert]
 
     assert_select "form[action='#{admin_organisation_corporate_information_page_path(@organisation, corporate_information_page)}']" do
@@ -101,7 +101,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
   test "PUT :delete should delete the page and redirect to the organisation" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
-    put :destroy, organisation_id: @organisation, id: corporate_information_page
+    put :destroy, params: { organisation_id: @organisation, id: corporate_information_page }
     assert_equal "The document '#{corporate_information_page.title}' has been deleted", flash[:notice]
     assert_redirected_to [:admin, @organisation, CorporateInformationPage]
   end

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -28,7 +28,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   test "associate user needs with a guide" do
     attributes = controller_attributes_for(:detailed_guide, need_ids: "123456, 789012")
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     assert_equal ["123456", "789012"], DetailedGuide.last.need_ids
   end
@@ -51,7 +51,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
 
     detailed_guide = create(:detailed_guide, need_ids: ["123456", "456789"])
 
-    get :show, id: detailed_guide.id
+    get :show, params: { id: detailed_guide.id }
 
     assert_select "#user-needs-section" do |section|
       assert_select "#user-need-id-123456" do

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -16,19 +16,19 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   test 'POST #create adds a document to a group and redirects' do
     document = create(:publication).document
     assert_difference '@group.reload.documents.size' do
-      post :create, id_params.merge(document_id: document.id)
+      post :create, params: id_params.merge(document_id: document.id)
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
   end
 
   test 'POST #create warns user when document not found' do
-    post :create, id_params.merge(document_id: 1234, title: 'blah')
+    post :create, params: id_params.merge(document_id: 1234, title: 'blah')
     assert_match /couldn't find.*blah/, flash[:alert]
   end
 
   test 'POST #create handles invalid DocumentCollectionGroupMemberships' do
     collection_document = create(:document, document_type: 'DocumentCollection')
-    post :create, id_params.merge(document_id: collection_document.id)
+    post :create, params: id_params.merge(document_id: collection_document.id)
     assert_match /Document cannot be a document collection/, flash[:alert]
   end
 
@@ -44,14 +44,14 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     documents = [create(:publication), create(:publication)].map(&:document)
     @group.documents << documents
     assert_difference '@group.reload.documents.size', -1 do
-      delete :destroy, remove_params.merge(documents: [documents.first.id])
+      delete :destroy, params: remove_params.merge(documents: [documents.first.id])
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
     assert_match /1 document removed/, flash[:notice]
   end
 
   test 'DELETE #destroy sets flash message if no documents selected' do
-    delete :destroy, remove_params
+    delete :destroy, params: remove_params
     assert_match /select one or more documents/i, flash[:alert]
   end
 
@@ -62,7 +62,7 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     @collection.groups << new_group
     assert_difference 'new_group.reload.documents.size', 1 do
       assert_difference '@group.reload.documents.size', -1 do
-        delete :destroy, move_params.merge(
+        delete :destroy, params: move_params.merge(
           documents: [documents.first.id],
           new_group_id: new_group.id
         )

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -12,13 +12,13 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   view_test 'GET #index lists the groups and documents in the collection' do
     publication = create(:publication)
     @group.documents = [publication.document]
-    get :index, document_collection_id: @collection
+    get :index, params: { document_collection_id: @collection }
     assert_select 'h2', Regexp.new(@group.heading)
     assert_select 'label', Regexp.new(publication.title)
   end
 
   view_test "GET #index shows helpful message when a group is empty" do
-    get :index, document_collection_id: @collection
+    get :index, params: { document_collection_id: @collection }
     assert_select 'section.group .no-content', /No documents in this group/
   end
 
@@ -26,7 +26,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     @group.documents << create(:publication).document
     @collection.groups << build(:document_collection_group)
     group1, group2 = @collection.groups
-    get :index, document_collection_id: @collection
+    get :index, params: { document_collection_id: @collection }
     assert_select 'section.group' do
       assert_select "option[value='#{group1.id}']", count: 0
       assert_select "option[value='#{group2.id}']", group2.heading
@@ -48,13 +48,13 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   view_test 'GET #new renders successfully' do
-    get :new, document_collection_id: @collection
+    get :new, params: { document_collection_id: @collection }
     assert_response :ok
   end
 
   def post_create(params = {})
     params.reverse_merge!(heading: 'Heading', body: '')
-    post :create, document_collection_id: @collection, document_collection_group: params
+    post :create, params: { document_collection_id: @collection, document_collection_group: params }
   end
 
   test 'POST #create creates a new group from valid data and redirects' do
@@ -74,13 +74,12 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   view_test 'GET #edit renders successfully' do
-    get :edit, document_collection_id: @collection, id: @group
+    get :edit, params: { document_collection_id: @collection, id: @group }
     assert_response :ok
   end
 
   def put_update(params)
-    put :update, document_collection_id: @collection, id: @group,
-                 document_collection_group: params
+    put :update, params: { document_collection_id: @collection, id: @group, document_collection_group: params }
   end
 
   test 'PUT #update modifies the group and redirects' do
@@ -100,33 +99,33 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   view_test "GET #delete explains you can't delete groups that have documents" do
     @group.documents = [create(:publication).document]
     @collection.groups << build(:document_collection_group)
-    get :delete, document_collection_id: @collection, id: @group
+    get :delete, params: { document_collection_id: @collection, id: @group }
     assert_select 'div.alert', /can’t delete a group.*documents/
     assert_select 'input[type="submit"]', count: 0
   end
 
   view_test "GET #delete explains you can't delete the last group" do
-    get :delete, document_collection_id: @collection, id: @group
+    get :delete, params: { document_collection_id: @collection, id: @group }
     assert_select 'div.alert', /can’t\s+delete the last/
     assert_select 'input[type="submit"]', count: 0
   end
 
   view_test 'GET #delete allows you to delete an empty group' do
     @collection.groups << build(:document_collection_group)
-    get :delete, document_collection_id: @collection, id: @group
+    get :delete, params: { document_collection_id: @collection, id: @group }
     assert_select 'input[type="submit"][value="Delete"]'
   end
 
   view_test 'DELETE #destroy deletes group and redirects' do
     assert_difference '@collection.groups.count', -1 do
-      delete :destroy, document_collection_id: @collection, id: @group
+      delete :destroy, params: { document_collection_id: @collection, id: @group }
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
   end
 
   test "POST #update_memberships saves the order of group members" do
     given_two_groups_with_documents
-    post :update_memberships, {
+    post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
@@ -144,7 +143,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
 
   test "POST #update_memberships saves the order of groups" do
     given_two_groups_with_documents
-    post :update_memberships, {
+    post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {
@@ -214,7 +213,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   test "POST #update_memberships should handle empty groups" do
     given_two_groups_with_documents
 
-    post :update_memberships, {
+    post :update_memberships, params: {
       document_collection_id: @collection.id,
       groups: {
         0 => {

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
       summary: "the summary"
     )
 
-    get :show, id: collection
+    get :show, params: { id: collection }
 
     assert_select "h1", "collection-title"
     assert_select ".page-header .lead", "the summary"
@@ -36,14 +36,16 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
   end
 
   test "POST #create saves the document collection" do
-    post :create, edition: {
-          title: "collection-title",
-          summary: "collection-summary",
-          body: "collection-body",
-          lead_organisation_ids: [@organisation.id],
-          topic_ids: [@topic.id],
-          previously_published: false
-        }
+    post :create, params: {
+          edition: {
+                title: "collection-title",
+                summary: "collection-summary",
+                body: "collection-body",
+                lead_organisation_ids: [@organisation.id],
+                topic_ids: [@topic.id],
+                previously_published: false
+              }
+    }
 
     assert_equal 1, DocumentCollection.count
     document_collection = DocumentCollection.first
@@ -54,7 +56,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
   end
 
   view_test "POST #create with invalid params re-renders form the with errors" do
-    post :create, edition: { title: "" }
+    post :create, params: { edition: { title: "" } }
 
     assert_response :success
     assert_equal 0, DocumentCollection.count
@@ -65,7 +67,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
   view_test "GET #edit renders the edit form for the document collection" do
     document_collection = create(:document_collection)
 
-    get :edit, id: document_collection
+    get :edit, params: { id: document_collection }
 
     assert_select "form[action=?]", admin_document_collection_path(document_collection) do
       assert_select "input[name='edition[slug]'][value=?]", document_collection.slug
@@ -78,7 +80,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
   test "PUT #update updates the document collection" do
     document_collection = create(:document_collection, title: "old-title")
 
-    put :update, id: document_collection, edition: { title: "new-title" }
+    put :update, params: { id: document_collection, edition: { title: "new-title" } }
 
     assert_equal "new-title", document_collection.reload.title
     assert_response :redirect
@@ -86,7 +88,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
 
   view_test "PUT #update with invalid params re-renders the form with errors" do
     document_collection = create(:document_collection, title: "old-title")
-    put :update, id: document_collection, edition: {title: ""}
+    put :update, params: { id: document_collection, edition: { title: "" } }
 
     assert_equal "old-title", document_collection.reload.title
 
@@ -97,7 +99,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
 
   test "DELETE #destroy deletes the document collection" do
     document_collection = create(:document_collection)
-    delete :destroy, id: document_collection
+    delete :destroy, params: { id: document_collection }
 
     refute DocumentCollection.exists?(document_collection.id)
     assert_response :redirect

--- a/test/functional/admin/document_searches_controller_test.rb
+++ b/test/functional/admin/document_searches_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::DocumentSearchesControllerTest < ActionController::TestCase
 
   view_test 'GET #show returns filter results as JSON' do
     publication = create(:publication, title: 'search term')
-    get :show, title: 'search term', format: :json
+    get :show, params: { title: 'search term' }, format: :json
     assert_response :success
     assert_equal true, json_response['results_any?']
     assert_equal 1, json_response['results'].size
@@ -30,7 +30,7 @@ class Admin::DocumentSearchesControllerTest < ActionController::TestCase
     guidance = create(:publication, title: 'search term', publication_type: PublicationType::Guidance)
     form = create(:publication, title: 'search term', publication_type: PublicationType::Form)
 
-    get :show, title: 'search term', type: 'publication', subtypes: [PublicationType::Guidance.id], format: :json
+    get :show, params: { title: 'search term', type: 'publication', subtypes: [PublicationType::Guidance.id] }, format: :json
 
     assert_response :success
     assert_equal true, json_response['results_any?']

--- a/test/functional/admin/document_sources_controller_test.rb
+++ b/test/functional/admin/document_sources_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::DocumentSourcesControllerTest < ActionController::TestCase
   test "update should add a document source" do
     edition = create(:draft_publication)
 
-    put :update, edition_id: edition, document_sources: "http://woo.example.com"
+    put :update, params: { edition_id: edition, document_sources: "http://woo.example.com" }
 
     refute edition.document.document_sources.empty?
     assert_equal 1, edition.document.document_sources.size
@@ -22,7 +22,7 @@ class Admin::DocumentSourcesControllerTest < ActionController::TestCase
     edition = create(:draft_publication)
     document_source = edition.document.document_sources.create(url: 'http://www.example.com/')
 
-    put :update, edition_id: edition, document_sources: ""
+    put :update, params: { edition_id: edition, document_sources: "" }
 
     edition.document.document_sources.reload
     assert edition.document.document_sources.empty?
@@ -36,8 +36,8 @@ class Admin::DocumentSourcesControllerTest < ActionController::TestCase
   test "update should add multiple document sources" do
     edition = create(:draft_publication)
 
-    put :update, edition_id: edition, document_sources: %Q{http://www.example.com
-http://woo.example.com}
+    put :update, params: { edition_id: edition, document_sources: %{http://www.example.com
+http://woo.example.com} }
 
     refute edition.document.document_sources.empty?
     assert_equal 2, edition.document.document_sources.size
@@ -49,8 +49,8 @@ http://woo.example.com}
     edition = create(:draft_publication)
     edition.document.document_sources.create(url: 'http://www.example.com/')
 
-    put :update, edition_id: edition, document_sources: %Q{http://www.example.com
-http://woo.example.com}
+    put :update, params: { edition_id: edition, document_sources: %{http://www.example.com
+http://woo.example.com} }
 
     edition.document.document_sources.reload
     refute edition.document.document_sources.empty?

--- a/test/functional/admin/documents_controller_test.rb
+++ b/test/functional/admin/documents_controller_test.rb
@@ -8,12 +8,12 @@ class Admin::DocumentsControllerTest < ActionController::TestCase
   end
 
   view_test 'GET by-content-id redirects to content by content_id' do
-    get :by_content_id, content_id: @document.content_id
+    get :by_content_id, params: { content_id: @document.content_id }
     assert_redirected_to @url_maker.admin_edition_path(@document.latest_edition)
   end
 
   view_test 'GET by-content-id redirects to a search if content_id is not found' do
-    get :by_content_id, content_id: @document.content_id + "wrong-id"
+    get :by_content_id, params: { content_id: @document.content_id + "wrong-id" }
     assert_redirected_to @url_maker.admin_editions_path
   end
 end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -61,7 +61,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   view_test 'should check a child taxon and its parents when only a child taxon is returned' do
     stub_publishing_api_links_with_taxons(@edition.content_id, [child_taxon_content_id])
 
-    get :edit, edition_id: @edition
+    get :edit, params: { edition_id: @edition }
 
     assert_select "input[value='#{parent_taxon_content_id}'][checked='checked']"
     assert_select "input[value='#{child_taxon_content_id}'][checked='checked']"
@@ -70,7 +70,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   view_test 'should check a parent taxon but not its children when only a parent taxon is returned' do
     stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
 
-    get :edit, edition_id: @edition
+    get :edit, params: { edition_id: @edition }
 
     assert_select "input[value='#{parent_taxon_content_id}'][checked='checked']"
     refute_select "input[value='#{child_taxon_content_id}'][checked='checked']"

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -10,14 +10,14 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
   test 'create redirects to edit for the chosen language' do
     edition = create(:edition)
-    post :create, edition_id: edition, translation_locale: 'fr'
+    post :create, params: { edition_id: edition, translation_locale: 'fr' }
     assert_redirected_to edit_admin_edition_translation_path(edition, id: 'fr')
   end
 
   view_test 'edit indicates which language we are adding a translation for' do
     edition = create(:edition, title: 'english-title')
 
-    get :edit, edition_id: edition, id: 'fr'
+    get :edit, params: { edition_id: edition, id: 'fr' }
 
     assert_select "h1", text: "Edit ‘Français (French)’ translation for: english-title"
   end
@@ -26,7 +26,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     edition = create(:edition)
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
 
-    get :edit, edition_id: edition, id: 'fr'
+    get :edit, params: { edition_id: edition, id: 'fr' }
 
     assert_select "form[action='#{admin_edition_translation_path(edition, 'fr')}']" do
       assert_select "input[type=text][name='edition[title]'][value='french-title']"
@@ -41,7 +41,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   view_test 'edit shows the english values underneath the associated form fields' do
     edition = create(:edition)
 
-    get :edit, edition_id: edition, id: 'fr'
+    get :edit, params: { edition_id: edition, id: 'fr' }
 
     assert_select '#english_title', text: "English: #{edition.title}"
     assert_select '#english_summary', text: "English: #{edition.summary}"
@@ -51,7 +51,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   view_test "edit shows the govspeak helper" do
     edition = create(:edition)
 
-    get :edit, edition_id: edition, id: 'fr'
+    get :edit, params: { edition_id: edition, id: 'fr' }
 
     assert_select '#govspeak_help'
   end
@@ -60,7 +60,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     edition = create(:edition)
     create(:editorial_remark, edition: edition)
 
-    get :edit, edition_id: edition, id: "fr"
+    get :edit, params: { edition_id: edition, id: "fr" }
 
     assert_select "#notes"
   end
@@ -68,7 +68,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   view_test "edit when translating corporate information pages does not allow title to be edited" do
     edition = create(:corporate_information_page)
 
-    get :edit, edition_id: edition, id: "cy"
+    get :edit, params: { edition_id: edition, id: "cy" }
 
     refute_select "input#edition_title"
   end
@@ -76,11 +76,11 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   test "update creates a translation for an edition that's yet to be published, and redirect back to the edition admin page" do
     edition = create(:draft_edition)
 
-    put :update, edition_id: edition, id: 'fr', edition: {
+    put :update, params: { edition_id: edition, id: 'fr', edition: {
       title: 'translated-title',
       summary: 'translated-summary',
       body: 'translated-body'
-    }
+    } }
 
     edition.reload
 
@@ -97,11 +97,11 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     published_edition = create(:published_edition)
     draft_edition = published_edition.create_draft(@writer)
 
-    put :update, edition_id: draft_edition, id: 'fr', edition: {
+    put :update, params: { edition_id: draft_edition, id: 'fr', edition: {
       title: 'translated-title',
       summary: 'translated-summary',
       body: 'translated-body'
-    }
+    } }
 
     draft_edition.reload
 
@@ -115,11 +115,11 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   test "update does not overwrite an existing manually added change note when adding a new translation" do
     edition = create(:draft_edition, change_note: 'manually-added-change-note')
 
-    put :update, edition_id: edition, id: 'fr', edition: {
+    put :update, params: { edition_id: edition, id: 'fr', edition: {
       title: 'translated-title',
       summary: 'translated-summary',
       body: 'translated-body'
-    }
+    } }
 
     edition.reload
 
@@ -129,9 +129,9 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   view_test 'update renders the form again, with errors, if the translation is invalid' do
     edition = create(:draft_edition)
 
-    put :update, edition_id: edition, id: 'fr', edition: {
+    put :update, params: { edition_id: edition, id: 'fr', edition: {
       title: ''
-    }
+    } }
 
     assert_select '.form-errors'
   end
@@ -139,11 +139,11 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   view_test "#update puts the translation to the publishing API" do
     edition = create(:draft_edition)
 
-    put :update, edition_id: edition, id: "fr", edition: {
+    put :update, params: { edition_id: edition, id: "fr", edition: {
       title: "translated-title",
       summary: "translated-summary",
       body: "translated-body",
-    }
+    } }
 
     assert_publishing_api_put_content(edition.content_id, request_json_includes({
       title: "translated-title",
@@ -155,13 +155,13 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   test "should limit access to translations of editions that aren't accessible to the current user" do
     protected_edition = create(:draft_publication, :access_limited)
 
-    post :create, edition_id: protected_edition.id, id: "en"
+    post :create, params: { edition_id: protected_edition.id, id: "en" }
     assert_response :forbidden
 
-    get :edit, edition_id: protected_edition.id, id: "en"
+    get :edit, params: { edition_id: protected_edition.id, id: "en" }
     assert_response :forbidden
 
-    put :update, edition_id: protected_edition.id, id: "en"
+    put :update, params: { edition_id: protected_edition.id, id: "en" }
     assert_response :forbidden
   end
 
@@ -169,7 +169,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     edition = create(:edition)
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
 
-    delete :destroy, edition_id: edition, id: 'fr'
+    delete :destroy, params: { edition_id: edition, id: 'fr' }
 
     edition.reload
     refute edition.translated_locales.include?(:fr)
@@ -180,7 +180,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     edition = create(:edition)
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
 
-    delete :destroy, edition_id: edition, id: 'fr'
+    delete :destroy, params: { edition_id: edition, id: 'fr' }
 
     assert_publishing_api_discard_draft(edition.content_id, locale: 'fr')
   end

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
 
   test "#edit loads the unpublishing and renders the unpublish edit template" do
     unpublishing = @edition.unpublishing
-    get :edit, edition_id: @edition.id
+    get :edit, params: { edition_id: @edition.id }
 
     assert_response :success
     assert_template :edit
@@ -27,7 +27,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     withdrawer.expects(:perform!)
 
 
-    put :update, edition_id: @edition.id, unpublishing: { explanation: "this used to say withdrawn" }
+    put :update, params: { edition_id: @edition.id, unpublishing: { explanation: "this used to say withdrawn" } }
 
     assert_redirected_to admin_edition_path(@edition)
     assert_equal "The public explanation was updated", flash[:notice]
@@ -44,7 +44,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
 
     unpublisher.expects(:perform!)
 
-    put :update, edition_id: @unpublished_edition.id, unpublishing: { explanation: "this used to say unpublished" }
+    put :update, params: { edition_id: @unpublished_edition.id, unpublishing: { explanation: "this used to say unpublished" } }
 
     assert_redirected_to admin_edition_path(@unpublished_edition)
     assert_equal "The public explanation was updated", flash[:notice]
@@ -54,7 +54,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   test "#update shows form with error if the update was not possible" do
     unpublishing = @edition.unpublishing
     original_explanation = unpublishing.explanation
-    put :update, edition_id: @edition, unpublishing: { explanation: nil }
+    put :update, params: { edition_id: @edition, unpublishing: { explanation: nil } }
 
     assert_template :edit
     assert_equal "The public explanation could not be updated", flash[:alert]

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -14,21 +14,21 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     stub_filter = stub_edition_filter
     Admin::EditionFilter.expects(:new).with(anything, anything, has_entries(state: "draft", type: "publication")).returns(stub_filter)
 
-    get :index, state: :draft, type: :publication
+    get :index, params: { state: :draft, type: :publication }
   end
 
   test "should not pass blank parameters to the edition filter" do
     stub_filter = stub_edition_filter
     Admin::EditionFilter.expects(:new).with(anything, anything, Not(has_key(:author))).returns(stub_filter)
 
-    get :index, state: :draft, author: ""
+    get :index, params: { state: :draft, author: "" }
   end
 
   test 'should add state param set to "active" if none is supplied' do
     stub_filter = stub_edition_filter
     Admin::EditionFilter.expects(:new).with(anything, anything, has_entry(state: "active")).returns(stub_filter)
 
-    get :index, type: :publication
+    get :index, params: { type: :publication }
   end
 
   view_test 'should distinguish between edition types when viewing the list of editions' do
@@ -38,14 +38,14 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     stub_filter.stubs(:show_stats)
     Admin::EditionFilter.stubs(:new).returns(stub_filter)
 
-    get :index, state: :draft
+    get :index, params: { state: :draft }
 
     assert_select_object(guide) { assert_select ".type", text: "Detailed guide" }
     assert_select_object(publication) { assert_select ".type", text: "Publication: Policy paper" }
   end
 
   view_test '#index should respond to xhr requests with only the filter results html' do
-    xhr :get, :index, state: :active
+    xhr :get, :index, params: { state: :active }
     response_html = Nokogiri::HTML::DocumentFragment.parse(response.body)
 
     assert_equal "h1", response_html.children[0].node_name()
@@ -54,7 +54,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test '#index should show unpublishing information' do
     edition = create(:unpublished_edition)
-    xhr :get, :index, state: :active
+    xhr :get, :index, params: { state: :active }
 
     assert_select 'td.title', text: /edition.title/
     assert_select 'td.title', text: /unpublished less than a minute ago/
@@ -71,7 +71,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
       publication.reload.create_draft(editor)
     end
 
-    get :diff, id: draft_publication, audit_trail_entry_id: draft_publication.document_version_trail.first.version.item_id
+    get :diff, params: { id: draft_publication, audit_trail_entry_id: draft_publication.document_version_trail.first.version.item_id }
 
     assert_response :success
     assert_template :diff
@@ -85,13 +85,13 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     draft_edition = create(:draft_publication)
     published_edition.expects(:create_draft).with(current_user).returns(draft_edition)
 
-    post :revise, id: published_edition
+    post :revise, params: { id: published_edition }
   end
 
   test "revising a published edition redirects to edit for the new draft" do
     published_edition = create(:published_publication)
 
-    post :revise, id: published_edition
+    post :revise, params: { id: published_edition }
 
     draft_edition = Edition.last
     assert_redirected_to edit_admin_publication_path(draft_edition.reload)
@@ -101,7 +101,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     published_edition = create(:published_publication)
     existing_draft = create(:draft_publication, document: published_edition.document)
 
-    post :revise, id: published_edition
+    post :revise, params: { id: published_edition }
 
     assert_redirected_to edit_admin_publication_path(existing_draft)
     assert_equal "There is already an active draft edition for this document", flash[:alert]
@@ -111,7 +111,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     published_edition = create(:published_publication)
     existing_submitted = create(:submitted_publication, document: published_edition.document)
 
-    post :revise, id: published_edition
+    post :revise, params: { id: published_edition }
 
     assert_redirected_to edit_admin_publication_path(existing_submitted)
     assert_equal "There is already an active submitted edition for this document", flash[:alert]
@@ -121,41 +121,41 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     published_edition = create(:published_publication)
     existing_rejected = create(:rejected_publication, document: published_edition.document)
 
-    post :revise, id: published_edition
+    post :revise, params: { id: published_edition }
 
     assert_redirected_to edit_admin_publication_path(existing_rejected)
     assert_equal "There is already an active rejected edition for this document", flash[:alert]
   end
 
   test "should remember standard filter options" do
-    get :index, state: :draft, type: 'consultation'
+    get :index, params: { state: :draft, type: 'consultation' }
     assert_equal 'consultation', session[:document_filters]['type']
   end
 
   test "should remember author filter options" do
-    get :index, state: :draft, author: current_user
+    get :index, params: { state: :draft, author: current_user }
     assert_equal current_user.to_param, session[:document_filters]['author']
   end
 
   test "should remember organisation filter options" do
     organisation = create(:organisation)
-    get :index, state: :draft, organisation: organisation
+    get :index, params: { state: :draft, organisation: organisation }
     assert_equal organisation.to_param, session[:document_filters]['organisation']
   end
 
   test "should remember state filter options" do
-    get :index, state: :draft
+    get :index, params: { state: :draft }
     assert_equal 'draft', session[:document_filters]['state']
   end
 
   test "should remember title filter options" do
-    get :index, title: "test"
+    get :index, params: { title: "test" }
     assert_equal "test", session[:document_filters]['title']
   end
 
   test "index should redirect to remembered filtered options if available" do
     organisation = create(:organisation)
-    get :index, organisation: organisation, state: :submitted
+    get :index, params: { organisation: organisation, state: :submitted }
 
     get :index
     assert_redirected_to admin_editions_path(state: :submitted, organisation: organisation)
@@ -164,7 +164,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   test "index should redirect to remembered filtered options if selected filter is invalid" do
     organisation = create(:organisation)
     session[:document_filters] = { 'state' => 'submitted', 'author' => current_user.to_param, 'organisation' => organisation.to_param }
-    get :index, author: 'invalid'
+    get :index, params: { author: 'invalid' }
     assert_redirected_to admin_editions_path(state: :submitted, author: current_user, organisation: organisation)
   end
 
@@ -177,7 +177,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "should not show published editions as force published" do
     publication = create(:published_publication)
-    get :index, state: :published, type: :publication
+    get :index, params: { state: :published, type: :publication }
 
     assert_select_object(publication)
     refute_select "tr.force_published"
@@ -185,7 +185,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "should show force published editions as force published" do
     publication = create(:published_publication, force_published: true)
-    get :index, state: :published, type: :publication
+    get :index, params: { state: :published, type: :publication }
 
     assert_select_object(publication)
     assert_select "tr.force_published"
@@ -193,7 +193,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "should show force published editions when the filter is active" do
     publication = create(:published_publication, force_published: true)
-    get :index, state: :force_published, type: :publication
+    get :index, params: { state: :force_published, type: :publication }
 
     assert_select_object(publication)
     assert_select "tr.force_published"
@@ -202,7 +202,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   view_test "should not display the featured column when viewing all active editions" do
     create(:published_news_article)
 
-    get :index, state: :active, type: 'news_article'
+    get :index, params: { state: :active, type: 'news_article' }
 
     refute_select "th", text: "Featured"
     refute_select "td.featured"
@@ -215,7 +215,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     rejected_edition = create(:rejected_news_article)
     published_edition = create(:published_consultation)
 
-    get :index, state: :active
+    get :index, params: { state: :active }
 
     assert_select_object(draft_edition) { assert_select ".state", "Draft" }
     assert_select_object(imported_edition) { assert_select ".state", "Imported" }
@@ -227,7 +227,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   view_test "should not display state information when viewing editions of a particular state" do
     draft_edition = create(:draft_publication)
 
-    get :index, state: :draft
+    get :index, params: { state: :draft }
 
     assert_select_object(draft_edition) { refute_select ".state" }
   end
@@ -242,7 +242,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     ]
     inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
 
-    get :index, state: :active
+    get :index, params: { state: :active }
 
     accessible.each do |edition|
       assert_select_object(edition)
@@ -255,7 +255,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as(create(:user, organisation: my_organisation))
     publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation])
 
-    get :index, state: :active
+    get :index, params: { state: :active }
 
     assert_select_object(publication) do
       assert_select "span", "limited access"
@@ -267,7 +267,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as(create(:user, organisation: my_organisation))
     inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
 
-    post :revise, id: inaccessible
+    post :revise, params: { id: inaccessible }
     assert_response :forbidden
   end
 

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
 
   view_test "should render the edition title and body to give context to the person rejecting" do
     edition = create(:submitted_publication, title: "edition-title", body: "edition-body")
-    get :new, edition_id: edition
+    get :new, params: { edition_id: edition }
 
     assert_select "#{record_css_selector(edition)} .title", text: "edition-title"
     assert_select "#{record_css_selector(edition)} .body", text: "edition-body"
@@ -18,25 +18,25 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   view_test "should render the editorial remark form for a statistical data set" do
     StatisticalDataSet.stubs(access_limited_by_default?: false)
     edition = create(:draft_statistical_data_set, title: "edition-title", body: "edition-body")
-    get :new, edition_id: edition
+    get :new, params: { edition_id: edition }
     assert_select "form#new_editorial_remark"
   end
 
   view_test "should render the editorial remark form for a document collection" do
     edition = create(:draft_document_collection, title: "collection-title", body: "collection-body")
-    get :new, edition_id: edition
+    get :new, params: { edition_id: edition }
     assert_select "form#new_editorial_remark"
   end
 
   test "should redirect to the edition" do
     edition = create(:submitted_speech)
-    post :create, edition_id: edition, editorial_remark: { body: "editorial-remark-body" }
+    post :create, params: { edition_id: edition, editorial_remark: { body: "editorial-remark-body" } }
     assert_redirected_to admin_speech_path(edition)
   end
 
   test "should create an editorial remark" do
     edition = create(:submitted_publication)
-    post :create, edition_id: edition, editorial_remark: { body: "editorial-remark-body" }
+    post :create, params: { edition_id: edition, editorial_remark: { body: "editorial-remark-body" } }
 
     edition.reload
     assert_equal 1, edition.editorial_remarks.length
@@ -46,7 +46,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
 
   view_test "should explain why the editorial remark could not be saved" do
     edition = create(:submitted_consultation)
-    post :create, edition_id: edition, editorial_remark: { body: "" }
+    post :create, params: { edition_id: edition, editorial_remark: { body: "" } }
     assert_template "new"
     assert_select ".form-errors"
   end
@@ -54,9 +54,9 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   test "should prevent access to inaccessible editions" do
     protected_edition = create(:submitted_publication, access_limited: true)
 
-    get :new, edition_id: protected_edition.id
+    get :new, params: { edition_id: protected_edition.id }
     assert_response :forbidden
-    get :create, edition_id: protected_edition.id
+    get :create, params: { edition_id: protected_edition.id }
     assert_response :forbidden
   end
 end

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     edition = create(:edition, body: "body-in-govspeak")
     fact_check_request = create(:fact_check_request, edition: edition, comments: "comment")
     govspeak_transformation_fixture "body-in-govspeak" => "body-in-html" do
-      get :show, id: fact_check_request
+      get :show, params: { id: fact_check_request }
     end
 
     assert_select ".body", text: "body-in-html"
@@ -21,7 +21,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     edition = create(:deleted_edition, title: "deleted-publication-title", body: "deleted-publication-body")
     fact_check_request = create(:fact_check_request, edition: edition)
 
-    get :show, id: fact_check_request
+    get :show, params: { id: fact_check_request }
 
     assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
     refute_select ".title", text: "deleted-publication-title"
@@ -31,14 +31,14 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
   test "users with a valid.to_param should be able to access the publication" do
     fact_check_request = create(:fact_check_request)
 
-    get :edit, id: fact_check_request
+    get :edit, params: { id: fact_check_request }
 
     assert_response :success
     assert_template "admin/fact_check_requests/edit"
   end
 
   test "users with invalid token should not be able to access the publication" do
-    get :edit, id: "invalid-token"
+    get :edit, params: { id: "invalid-token" }
 
     assert_response :not_found
   end
@@ -47,7 +47,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     edition = create(:deleted_edition, title: "deleted-publication-title", body: "deleted-publication-body")
     fact_check_request = create(:fact_check_request, edition: edition)
 
-    get :edit, id: fact_check_request
+    get :edit, params: { id: fact_check_request }
 
     assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
     refute_select ".document .title", text: "deleted-publication-title"
@@ -58,7 +58,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     edition = create(:edition, body: "body-in-govspeak")
     fact_check_request = create(:fact_check_request, edition: edition)
     govspeak_transformation_fixture "body-in-govspeak" => "body-in-html" do
-      get :edit, id: fact_check_request
+      get :edit, params: { id: fact_check_request }
     end
 
     assert_select ".body", text: "body-in-html"
@@ -68,7 +68,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     publication = create(:publication)
     fact_check_request = create(:fact_check_request, edition: publication)
 
-    get :edit, id: fact_check_request
+    get :edit, params: { id: fact_check_request }
 
     assert_response :success
   end
@@ -76,7 +76,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
   view_test "should display any additional instructions to the fact checker" do
     fact_check_request = create(:fact_check_request, instructions: "Please concentrate on the content")
 
-    get :edit, id: fact_check_request
+    get :edit, params: { id: fact_check_request }
 
     assert_select "#fact_check_request_instructions", text: /Please concentrate on the content/
   end
@@ -84,7 +84,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
   view_test "should not display the extra instructions section" do
     fact_check_request = create(:fact_check_request, instructions: "")
 
-    get :edit, id: fact_check_request
+    get :edit, params: { id: fact_check_request }
 
     refute_select "#fact_check_request_instructions"
   end
@@ -93,7 +93,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     fact_check_request = create(:fact_check_request)
     attributes = attributes_for(:fact_check_request, comments: "looks fine to me")
 
-    put :update, id: fact_check_request, fact_check_request: attributes
+    put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
     fact_check_request.reload
     assert_equal "looks fine to me", fact_check_request.comments
@@ -105,7 +105,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     attributes = attributes_for(:fact_check_request, comments: "looks fine to me")
     ActionMailer::Base.deliveries.clear
 
-    put :update, id: fact_check_request, fact_check_request: attributes
+    put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
     assert_equal 1, ActionMailer::Base.deliveries.length
   end
@@ -116,7 +116,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     attributes = attributes_for(:fact_check_request, comments: "looks fine to me")
     ActionMailer::Base.deliveries.clear
 
-    put :update, id: fact_check_request, fact_check_request: attributes
+    put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
     assert_equal 0, ActionMailer::Base.deliveries.length
   end
@@ -125,7 +125,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     fact_check_request = create(:fact_check_request)
     attributes = attributes_for(:fact_check_request, comments: "looks fine to me")
 
-    put :update, id: fact_check_request, fact_check_request: attributes
+    put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
     assert_redirected_to admin_fact_check_request_path(fact_check_request)
   end
@@ -135,7 +135,7 @@ class Admin::FactCheckRequestsControllerTest < ActionController::TestCase
     fact_check_request = create(:fact_check_request, edition: edition)
     attributes = attributes_for(:fact_check_request, comments: "looks fine to me")
 
-    put :update, id: fact_check_request, fact_check_request: attributes
+    put :update, params: { id: fact_check_request, fact_check_request: attributes }
 
     assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end
@@ -158,7 +158,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
 
   test "should create a fact check request" do
     @attributes.merge!(email_address: "fact-checker@example.com")
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert fact_check_request = @edition.fact_check_requests.last
     assert_equal "fact-checker@example.com", fact_check_request.email_address
@@ -167,20 +167,20 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
 
   test "should prevent creation of a fact check request if edition is not accessible to the current user" do
     protected_edition = create(:draft_publication, :access_limited)
-    post :create, edition_id: protected_edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: protected_edition.id, fact_check_request: @attributes }
 
     assert_response :forbidden
   end
 
   test "should send an email when a fact check has been requested" do
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_equal 1, ActionMailer::Base.deliveries.length
   end
 
   test "uses host from request in email urls" do
     request.host = "whitehall.example.com"
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_last_email_body_contains("http://whitehall.example.com/")
   end
@@ -188,61 +188,61 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
   test "uses protocol from request in email urls" do
     request.env["HTTPS"] = "on"
     request.host = "whitehall.example.com"
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_last_email_body_contains("https://whitehall.example.com/")
   end
 
   test "uses port from request in email urls" do
     request.host = "whitehall.example.com:8182"
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_last_email_body_contains("http://whitehall.example.com:8182/")
   end
 
   test "display an informational message when a fact check has been requested" do
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_equal "The document has been sent to fact-checker@example.com", flash[:notice]
   end
 
   test "redirect back to the edition preview when a fact check has been requested" do
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_redirected_to admin_publication_path(@edition)
   end
 
   test "should not send an email if the fact checker's email address is missing" do
     @attributes.merge!(email_address: "")
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_equal 0, ActionMailer::Base.deliveries.length
   end
 
   test "should display a warning if the fact checker's email address is missing" do
     @attributes.merge!(email_address: "")
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_equal "There was a problem: Email address can't be blank", flash[:alert]
   end
 
   test "redirect back to the edition preview if the fact checker's email address is missing" do
     @attributes.merge!(email_address: "")
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_redirected_to admin_publication_path(@edition)
   end
 
   test "should reject invalid email addresses" do
     @attributes.merge!(email_address: "not-an-email")
-    post :create, edition_id: @edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
     assert_match "There was a problem: Email address does not appear to be a valid e-mail address", flash[:alert]
   end
 
   view_test "should display an apology if requesting a fact check for an edition that has been deleted" do
     edition = create(:deleted_publication)
-    post :create, edition_id: edition.id, fact_check_request: @attributes
+    post :create, params: { edition_id: edition.id, fact_check_request: @attributes }
 
     assert_select ".fact_check_request .apology", text: "We’re sorry, but this document is no longer available for fact checking."
   end

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   view_test "show renders the summary" do
     draft_fatality_notice = create(:draft_fatality_notice, summary: "a-simple-summary")
 
-    get :show, id: draft_fatality_notice
+    get :show, params: { id: draft_fatality_notice }
 
     assert_select ".page-header .lead", text: "a-simple-summary"
   end
@@ -40,7 +40,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
     field = create(:operational_field)
     edition = create(:fatality_notice, operational_field: field)
 
-    get :edit, id: edition
+    get :edit, params: { id: edition }
 
     assert_select "form#edit_edition" do
       assert_select "select[name='edition[operational_field_id]']"
@@ -62,7 +62,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
       }}
     )
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
     assert fatality_notice = FatalityNotice.last
     assert fatality_notice_casuality = fatality_notice.fatality_notice_casualties.last
     assert_equal "Personal details", fatality_notice_casuality.personal_details

--- a/test/functional/admin/feature_lists_controller_test.rb
+++ b/test/functional/admin/feature_lists_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
     world_location = create(:world_location)
     feature_list = create(:feature_list, featurable: world_location, locale: :fr)
 
-    get :show, id: feature_list
+    get :show, params: { id: feature_list }
 
     assert_redirected_to features_admin_world_location_path(feature_list.featurable, locale: feature_list.locale)
   end
@@ -20,10 +20,10 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
     feature1 = create(:feature, feature_list: feature_list, ordering: 1)
     feature2 = create(:feature, feature_list: feature_list, ordering: 2)
 
-    post :reorder, id: feature_list, ordering: {
+    post :reorder, params: { id: feature_list, ordering: {
       feature2.id.to_s => "1",
       feature1.id.to_s => "2"
-    }
+    } }
 
     assert_equal [feature2, feature1], feature_list.reload.features
   end
@@ -32,7 +32,7 @@ class Admin::FeatureListsControllerTest < ActionController::TestCase
     world_location = create(:world_location)
     feature_list = create(:feature_list, featurable: world_location, locale: :fr)
 
-    post :reorder, id: feature_list
+    post :reorder, params: { id: feature_list }
 
     assert_redirected_to features_admin_world_location_path(feature_list.featurable, locale: feature_list.locale)
   end

--- a/test/functional/admin/features_controller_test.rb
+++ b/test/functional/admin/features_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
     feature_list = create(:feature_list, featurable: world_location, locale: :en)
     edition = create(:published_speech, world_locations: [world_location])
 
-    get :new, feature_list_id: feature_list, edition_id: edition.id
+    get :new, params: { feature_list_id: feature_list, edition_id: edition.id }
 
     assert_equal edition.document, assigns[:feature].document
   end
@@ -21,7 +21,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
     edition = create(:published_speech)
     feature = create(:feature, document: edition.document, feature_list: feature_list)
 
-    post :unfeature, feature_list_id: feature_list, id: feature
+    post :unfeature, params: { feature_list_id: feature_list, id: feature }
 
     feature.reload
 
@@ -41,7 +41,7 @@ class Admin::FeaturesControllerTest < ActionController::TestCase
 
     PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id)
 
-    post :create, feature_list_id: feature_list.id, feature: params
+    post :create, params: { feature_list_id: feature_list.id, feature: params }
 
     assert_equal edition.document_id, Feature.last.document_id
   end

--- a/test/functional/admin/financial_reports_controller_test.rb
+++ b/test/functional/admin/financial_reports_controller_test.rb
@@ -10,16 +10,16 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
 
   view_test "GET :index lists the organisation's reports" do
     report = create(:financial_report, funding: 20000)
-    get :index, organisation_id: report.organisation
+    get :index, params: { organisation_id: report.organisation }
     assert_select 'td', text: report.year.to_s
     assert_select 'td', /20,000/
   end
 
   test "POST to :create with valid data creates a new financial_report" do
     organisation = create(:organisation)
-    post :create, organisation_id: organisation, financial_report: {
+    post :create, params: { organisation_id: organisation, financial_report: {
       year: 2013, spending: 2400, funding: 2380
-    }
+    } }
 
     assert_redirected_to admin_organisation_financial_reports_url(organisation)
     assert_equal "Created Financial Report", flash[:notice]
@@ -29,9 +29,9 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
   test "PUT to :update with valid data updates the financial report" do
     financial_report = create(:financial_report)
     organisation = financial_report.organisation
-    put :update, organisation_id: organisation, id: financial_report, financial_report: {
+    put :update, params: { organisation_id: organisation, id: financial_report, financial_report: {
       year: financial_report.year, spending: 4096, funding: 0
-    }
+    } }
 
     assert_redirected_to admin_organisation_financial_reports_url(organisation)
     assert_equal "Updated Financial Report", flash[:notice]
@@ -41,9 +41,9 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
   view_test "PUT to :update with invalid data re-renders the form with code 400" do
     financial_report = create(:financial_report)
     organisation = financial_report.organisation
-    put :update, organisation_id: organisation, id: financial_report, financial_report: {
+    put :update, params: { organisation_id: organisation, id: financial_report, financial_report: {
       year: 'not-a-year', spending: 0, funding: 0
-    }
+    } }
     assert_select 'div.alert'
     assert_response :bad_request
   end
@@ -53,7 +53,7 @@ class Admin::FinancialReportsControllerTest < ActionController::TestCase
     organisation = financial_report.organisation
 
     assert_difference 'organisation.financial_reports.count', -1 do
-      delete :destroy, organisation_id: organisation, id: financial_report
+      delete :destroy, params: { organisation_id: organisation, id: financial_report }
     end
 
     assert_redirected_to admin_organisation_financial_reports_url(organisation)

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -10,14 +10,14 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
   test "POST :create redirects to edit page when 'Save and continue editing' button clicked" do
     params = attributes_for(:edition)
     assert_difference 'GenericEdition.count' do
-      post :create, edition: params, save_and_continue: 'Save and continue editing'
+      post :create, params: { edition: params, save_and_continue: 'Save and continue editing' }
     end
     assert_redirected_to edit_admin_generic_edition_url(GenericEdition.last)
   end
 
   test "PUT :update redirects to edit page when 'Save and continue' button clicked" do
     edition = create(:edition)
-    put :update, id: edition, edition: { title: 'New title' }, save_and_continue: 'Save and continue editing'
+    put :update, params: { id: edition, edition: { title: 'New title' }, save_and_continue: 'Save and continue editing' }
     assert_redirected_to edit_admin_generic_edition_url(GenericEdition.last)
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/attachments_workflow_test.rb
@@ -16,7 +16,7 @@ class AttachableEditionTest < ActionController::TestCase
 
   view_test 'GET :edit displays "Document" and "Attachments" tabs' do
     edition = create(:news_article)
-    get :edit, id: edition
+    get :edit, params: { id: edition }
     assert_tab 'Document', edit_admin_news_article_path(edition)
     assert_tab 'Attachments', admin_edition_attachments_path(edition)
   end
@@ -29,7 +29,7 @@ class AttachableEditionsWithInlineSupportTest < ActionController::TestCase
 
   view_test 'GET :edit lists the attachments with markdown hint for editions that support inline attachments' do
     edition = create(:news_article, :with_file_attachment)
-    get :edit, id: edition
+    get :edit, params: { id: edition }
     attachment = edition.attachments.first
 
     assert_select "#govspeak_help", text: /Attachments/
@@ -45,7 +45,7 @@ class AttachableEditionWithoutInlineSupportTest < ActionController::TestCase
 
   view_test 'GET :edit does not list the attachments for editions that do not support inline attachments' do
     edition = create(:publication, :with_file_attachment)
-    get :edit, id: edition
+    get :edit, params: { id: edition }
     attachment = edition.attachments.first
 
     assert_select 'li', text: %r(#{attachment.title}), count: 0

--- a/test/functional/admin/generic_editions_controller_tests/audit_trail_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/audit_trail_test.rb
@@ -9,7 +9,7 @@ class Admin::GenericEditionsController::AuditTrailTest < ActionController::TestC
       draft_edition = create(:draft_edition)
 
       request.env['HTTPS'] = 'on'
-      get action, id: draft_edition
+      get action, params: { id: draft_edition }
 
       assert_select "#history", text: /Created by Tom/ do
         assert_select "img[src^='https']"

--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -13,7 +13,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   view_test "show displays the delete button for draft editions" do
     draft_edition = create(:draft_edition)
 
-    get :show, id: draft_edition
+    get :show, params: { id: draft_edition }
 
     assert_select "form[action='#{admin_generic_edition_path(draft_edition)}']" do
       assert_select "input[name='_method'][type='hidden'][value='delete']"
@@ -24,7 +24,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   view_test "show displays the delete button for submitted editions" do
     submitted_edition = create(:submitted_edition)
 
-    get :show, id: submitted_edition
+    get :show, params: { id: submitted_edition }
 
     assert_select "form[action='#{admin_generic_edition_path(submitted_edition)}']" do
       assert_select "input[name='_method'][type='hidden'][value='delete']"
@@ -35,7 +35,7 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   view_test "show does not display the delete button for published editions" do
     published_edition = create(:published_edition)
 
-    get :show, id: published_edition
+    get :show, params: { id: published_edition }
 
     refute_select ".edition-sidebar input[name='_method'][type='hidden'][value='delete']"
   end
@@ -43,33 +43,33 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   view_test "show does not display the delete button for superseded editions" do
     superseded_edition = create(:superseded_edition)
 
-    get :show, id: superseded_edition
+    get :show, params: { id: superseded_edition }
 
     refute_select "form[action='#{admin_generic_edition_path(superseded_edition)}'] input[name='_method'][type='hidden'][value='delete']"
   end
 
   test "destroy marks the edition as deleted" do
     edition = create(:draft_edition)
-    delete :destroy, id: edition
+    delete :destroy, params: { id: edition }
     edition.reload
     assert edition.deleted?
   end
 
   test "destroying an edition redirects to the draft editions page" do
     draft_edition = create(:draft_edition)
-    delete :destroy, id: draft_edition
+    delete :destroy, params: { id: draft_edition }
     assert_redirected_to admin_editions_path
   end
 
   test "destroy displays a notice indicating the edition has been deleted" do
     draft_edition = create(:draft_edition, title: "edition-title")
-    delete :destroy, id: draft_edition
+    delete :destroy, params: { id: draft_edition }
     assert_equal "The document 'edition-title' has been deleted", flash[:notice]
   end
 
   test "destroy notifies the publishing API of the deleted document" do
     draft_edition = create(:draft_edition, translated_into: [:es, :fr])
-    delete :destroy, id: draft_edition
+    delete :destroy, params: { id: draft_edition }
 
     %w[en es fr].each do |locale|
       assert_publishing_api_discard_draft(draft_edition.content_id, locale: locale)

--- a/test/functional/admin/generic_editions_controller_tests/force_publishing_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/force_publishing_documents_test.rb
@@ -6,28 +6,28 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
   view_test "should not display the force publish form if edition is publishable" do
     login_as :departmental_editor
     edition = create(:submitted_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select force_publish_button_selector(edition)
   end
 
   view_test "should display the force publish form if edition is not publishable but is force-publishable" do
     login_as :departmental_editor
     edition = create(:draft_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select force_publish_button_selector(edition), count: 1
   end
 
   view_test "should not display the force publish form if edition is neither publishable nor force-publishable" do
     login_as :writer
     edition = create(:draft_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select force_publish_button_selector(edition)
   end
 
   view_test "show should indicate a force-published document" do
     login_as :writer
     edition = create(:published_edition, force_published: true)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select ".force_published"
   end
 
@@ -35,7 +35,7 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
     creator = create(:departmental_editor, name: "Fred")
     login_as(creator)
     edition = create(:published_edition, force_published: true, creator: creator)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select ".force_published form input"
   end
 
@@ -44,7 +44,7 @@ class Admin::GenericEditionsController::ForcePublishingDocumentsTest < ActionCon
     login_as(creator)
     edition = create(:published_edition, force_published: true, creator: creator)
     login_as(create(:departmental_editor, name: "Another Editor"))
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select ".force_published form input"
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_document_on_public_site_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_document_on_public_site_test.rb
@@ -9,13 +9,13 @@ class Admin::GenericEditionsController::LinkingToDocumentOnPublicSiteTest < Acti
 
   view_test "should link to public version when published" do
     published_edition = create(:published_edition)
-    get :show, id: published_edition
+    get :show, params: { id: published_edition }
     assert_select link_to_public_version_selector, count: 1
   end
 
   view_test "should not link to public version when not published" do
     draft_edition = create(:draft_edition)
-    get :show, id: draft_edition
+    get :show, params: { id: draft_edition }
     refute_select link_to_public_version_selector
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/linking_to_preview_of_document_on_public_site_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/linking_to_preview_of_document_on_public_site_test.rb
@@ -9,7 +9,7 @@ class Admin::GenericEditionsController::LinkingToPreviewOfDocumentOnPublicSiteTe
 
   view_test "should link to preview version when not published" do
     draft_edition = create(:draft_edition)
-    get :show, id: draft_edition
+    get :show, params: { id: draft_edition }
     assert_select link_to_preview_version_selector
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -12,14 +12,14 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     login_as :managing_editor
     published_edition = create(:published_news_article, first_published_at: 2.days.ago)
     new_draft = create(:news_article, document: published_edition.document, first_published_at: 2.days.ago)
-    get :edit, id: new_draft
+    get :edit, params: { id: new_draft }
     assert_select '.political-status', count: 1
   end
 
   view_test "doesn't display the political checkbox for non-privileged users " do
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
-    get :edit, id: new_draft
+    get :edit, params: { id: new_draft }
     assert_select '.political-status', count: 0
   end
 
@@ -38,7 +38,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     published_edition = create(:published_news_article, first_published_at: 3.years.ago)
     new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
 
-    get :edit, id: new_draft
+    get :edit, params: { id: new_draft }
 
     assert_response :redirect
   end
@@ -52,7 +52,7 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
 
-    get :edit, id: new_draft
+    get :edit, params: { id: new_draft }
 
     assert_response :success
   end

--- a/test/functional/admin/generic_editions_controller_tests/publishing_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/publishing_documents_test.rb
@@ -9,13 +9,13 @@ class Admin::GenericEditionsController::PublishingDocumentsTest < ActionControll
 
   view_test "should display the publish form if edition is publishable" do
     edition = create(:submitted_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select publish_form_selector(edition), count: 1
   end
 
   view_test "should not display the publish form if edition is not publishable" do
     edition = create(:draft_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select publish_form_selector(edition)
   end
 end

--- a/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/rejecting_documents_test.rb
@@ -11,34 +11,34 @@ class Admin::GenericEditionsController::RejectingDocumentsTest < ActionControlle
     login_as :departmental_editor
     edition = create(:submitted_edition)
     GenericEdition.stubs(:find).with(edition.to_param).returns(edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select reject_button_selector(edition), count: 1
   end
 
   view_test "doesn't display the 'Reject' button for unprivileged users" do
     edition = create(:edition)
     GenericEdition.stubs(:find).with(edition.to_param).returns(edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select reject_button_selector(edition)
   end
 
   view_test "should show who rejected the edition" do
     edition = create(:rejected_edition)
     edition.editorial_remarks.create!(body: "editorial-remark-body", author: current_user)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select ".rejected_by", text: current_user.name
   end
 
   view_test "should not show the editorial remarks section" do
     edition = create(:submitted_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
     refute_select "#editorial_remarks .editorial_remark"
   end
 
   view_test "should show the list of editorial remarks" do
     edition = create(:rejected_edition)
     remark = edition.editorial_remarks.create!(body: "editorial-remark-body", author: current_user)
-    get :show, id: edition
+    get :show, params: { id: edition }
     assert_select ".editorial_remark" do
       assert_select ".body", text: /editorial-remark-body/
       assert_select ".actor", text: current_user.name

--- a/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/revising_documents_test.rb
@@ -10,7 +10,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
   view_test "should be possible to revise a published edition" do
     published_edition = create(:published_edition)
 
-    get :show, id: published_edition
+    get :show, params: { id: published_edition }
 
     assert_select "form[action='#{revise_admin_edition_path(published_edition)}']"
   end
@@ -18,7 +18,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
   view_test "should not be possible to revise a draft edition" do
     draft_edition = create(:draft_edition)
 
-    get :show, id: draft_edition
+    get :show, params: { id: draft_edition }
 
     refute_select "form[action='#{revise_admin_edition_path(draft_edition)}']"
   end
@@ -26,7 +26,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
   view_test "should not be possible to revise an superseded edition" do
     superseded_edition = create(:superseded_edition)
 
-    get :show, id: superseded_edition
+    get :show, params: { id: superseded_edition }
 
     refute_select "form[action='#{revise_admin_edition_path(superseded_edition)}']"
   end
@@ -35,7 +35,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
     original_edition = create(:published_edition)
     new_draft = original_edition.create_draft(create(:writer))
 
-    get :show, id: new_draft
+    get :show, params: { id: new_draft }
 
     assert_select ".alert a", href: Whitehall.url_maker.admin_edition_path(original_edition)
   end
@@ -44,7 +44,7 @@ class Admin::GenericEditionsController::RevisingDocumentsTest < ActionController
     original_edition = create(:published_edition)
     new_draft = original_edition.create_draft(create(:writer))
 
-    get :show, id: original_edition
+    get :show, params: { id: original_edition }
 
     assert_select ".alert a", href: Whitehall.url_maker.admin_edition_path(new_draft)
   end

--- a/test/functional/admin/generic_editions_controller_tests/speed_tagging_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/speed_tagging_test.rb
@@ -8,10 +8,10 @@ class Admin::GenericEditionsController::SpeedTaggingTest < ActionController::Tes
   test "should show the document when 'Save' is clicked" do
     edition = create(:edition, :imported)
 
-    put :update, id: edition, speed_save: 1, edition: {
+    put :update, params: { id: edition, speed_save: 1, edition: {
       title: "new-title",
       body: "new-body"
-    }
+    } }
 
     assert edition.reload.imported?
     assert_redirected_to admin_edition_path(edition)
@@ -19,7 +19,7 @@ class Admin::GenericEditionsController::SpeedTaggingTest < ActionController::Tes
 
   test "re-renders the show page when there are errors during speed tagging update" do
     imported_edition = create(:edition, :imported, title: 'News article')
-    put :update, id: imported_edition, speed_save: 'Save', edition: { title: '' }
+    put :update, params: { id: imported_edition, speed_save: 'Save', edition: { title: '' } }
 
     assert_response :success
     assert_template :show

--- a/test/functional/admin/generic_editions_controller_tests/translation_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/translation_test.rb
@@ -15,7 +15,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
   view_test 'show displays a form to create missing translations' do
     edition = create(:draft_edition)
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "form[action=?]", admin_edition_translations_path(edition) do
       assert_select "select[name=translation_locale]"
@@ -27,7 +27,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     edition = create(:draft_edition)
     with_locale(:es) { edition.update_attributes!(attributes_for("draft_edition")) }
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "select[name=translation_locale]" do
       assert_select "option[value=es]", count: 0
@@ -39,7 +39,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     with_locale(:es) { edition.update_attributes!(attributes_for("draft_edition")) }
     Locale.stubs(:non_english).returns([Locale.new(:es)])
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "select[name=translation_locale]", count: 0
   end
@@ -48,7 +48,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     edition = create(:published_edition)
     refute edition.editable?
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "select[name=translation_locale]", count: 0
   end
@@ -57,7 +57,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     edition = create(:draft_edition, title: 'english-title', summary: 'english-summary', body: 'english-body')
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "a[href='#{edit_admin_edition_translation_path(edition, 'fr')}']", text: 'Edit'
   end
@@ -66,7 +66,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     edition = create(:draft_edition, title: 'english-title', summary: 'english-summary', body: 'english-body')
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "form[action=?]", admin_edition_translation_path(edition, 'fr') do
       assert_select "input[type='submit'][value=?]", "Delete"
@@ -80,7 +80,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     end
     edition.save!
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "#translations" do
       assert_select "td", text: 'French'
@@ -92,7 +92,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
     force_publish(edition)
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "#translations a[href='#{edit_admin_edition_translation_path(edition, 'fr')}']", count: 0
   end
@@ -102,7 +102,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
     with_locale(:fr) { edition.update_attributes!(title: 'french-title', summary: 'french-summary', body: 'french-body') }
     force_publish(edition)
 
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "#translations form[action=?]", admin_edition_translation_path(edition, 'fr'), count: 0
   end
@@ -116,7 +116,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
       "french-body-in-govspeak" => "french-body-in-html"
     }
     govspeak_transformation_fixture(transformation) do
-      get :show, id: edition
+      get :show, params: { id: edition }
     end
 
     assert_select "#translations" do

--- a/test/functional/admin/generic_editions_controller_tests/unpublishing_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/unpublishing_test.rb
@@ -7,7 +7,7 @@ class Admin::GenericEditionsController::UnpublishingTest < ActionController::Tes
 
   view_test "displays unpublish button for unpublishable editions" do
     edition = create(:published_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     assert_select "a", text: "Withdraw or unpublish"
   end
@@ -15,7 +15,7 @@ class Admin::GenericEditionsController::UnpublishingTest < ActionController::Tes
   view_test "does not display unpublish button if edition is not unpublishable" do
     login_as :managing_editor
     edition = create(:draft_edition)
-    get :show, id: edition
+    get :show, params: { id: edition }
 
     refute_select "a", text: "Withdraw or unpublish"
   end

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
   [:new, :edit, :prepare_to_close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
       login_as :gds_editor
-      get action_method, id: @government.id
+      get action_method, params: { id: @government.id }
       assert_response 403
     end
   end
@@ -18,7 +18,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
   [:create, :update, :close].each do |action_method|
     test "GDS admin permission required to access #{action_method}" do
       login_as :gds_editor
-      post action_method, id: @government.id
+      post action_method, params: { id: @government.id }
       assert_response 403
     end
   end
@@ -31,7 +31,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
 
   test "#close sets the end date to today" do
     login_as :gds_admin
-    post :close, id: @government.id
+    post :close, params: { id: @government.id }
     @government.reload
     assert_equal Date.today, @government.end_date
   end
@@ -39,7 +39,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
   test "#close doesn't overwrite an end date if there is one" do
     login_as :gds_admin
     @government.update(end_date: 10.days.ago.to_date)
-    post :close, id: @government.id
+    post :close, params: { id: @government.id }
     @government.reload
     assert_equal 10.days.ago.to_date, @government.end_date
   end
@@ -50,7 +50,7 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     ministerial = create(:ministerial_role_appointment)
     ambassadorial = create(:ambassador_role_appointment)
 
-    post :close, id: @government.id
+    post :close, params: { id: @government.id }
 
     assert_equal @government.end_date, ministerial.reload.ended_at
     assert_nil ambassadorial.ended_at

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "GET on :index assigns the person, their historical accounts and renders the :index template" do
-    get :index, person_id: @person
+    get :index, params: { person_id: @person }
 
     assert_response :success
     assert_template :index
@@ -18,7 +18,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "GET on :new assigns the person, a fresh historical account and renders the :new template" do
-    get :new, person_id: @person
+    get :new, params: { person_id: @person }
 
     assert_response :success
     assert_template :new
@@ -38,7 +38,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
     }
 
     assert_difference('@person.historical_accounts.count') do
-      post :create, person_id: @person, historical_account: historical_account_params
+      post :create, params: { person_id: @person, historical_account: historical_account_params }
     end
 
     assert_redirected_to admin_person_historical_accounts_path(@person)
@@ -54,14 +54,14 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
 
   test "POST on :create with invalid paramters re-renders :new template" do
     assert_no_difference('@person.historical_accounts.count') do
-      post :create, person_id: @person, historical_account: { summary: 'Only summary' }
+      post :create, params: { person_id: @person, historical_account: { summary: 'Only summary' } }
     end
     assert_template :new
     assert_equal 'Only summary', assigns(:historical_account).summary
   end
 
   test "GET on :edit loads the historical account and renders the :edit template" do
-    get :edit, person_id: @person, id: @historical_account
+    get :edit, params: { person_id: @person, id: @historical_account }
 
     assert_response :success
     assert_template :edit
@@ -70,7 +70,7 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "PUT on :update updates the details of the historical account" do
-    put :update, person_id: @person, id: @historical_account, historical_account: { summary: 'New summary' }
+    put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: 'New summary' } }
 
     assert_redirected_to admin_person_historical_accounts_path(@person)
     assert_equal 'New summary', @historical_account.reload.summary
@@ -78,14 +78,14 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
 
   test "PUT on :update with invalid paramters re-renders the :edit template" do
     summary_before = @historical_account.summary
-    put :update, person_id: @person, id: @historical_account, historical_account: { summary: '' }
+    put :update, params: { person_id: @person, id: @historical_account, historical_account: { summary: '' } }
     assert_template :edit
     assert_equal summary_before, @historical_account.reload.summary
     assert_equal '', assigns(:historical_account).summary
   end
 
   test "Delete on :destroy destroys the historical account" do
-    delete :destroy, person_id: @person, id: @historical_account
+    delete :destroy, params: { person_id: @person, id: @historical_account }
     refute HistoricalAccount.exists?(@historical_account.id)
     assert_redirected_to admin_person_historical_accounts_path(@person)
   end

--- a/test/functional/admin/links_reports_controller_test.rb
+++ b/test/functional/admin/links_reports_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
   test "AJAX POST :create saves a LinksReport and queues it for processing" do
     Sidekiq::Testing.fake! do
-      xhr :post, :create, links_report: {}, edition_id: @publication.id
+      xhr :post, :create, params: { links_report: {}, edition_id: @publication.id }
 
       assert_response :success
       assert_template :create
@@ -24,7 +24,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
   test "POST :create queues a LinksReport and redirects back to the edition" do
     Sidekiq::Testing.fake! do
-      post :create, edition_id: @publication.id
+      post :create, params: { edition_id: @publication.id }
 
       assert_redirected_to admin_publication_url(@publication)
 
@@ -36,7 +36,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
   test "AJAX GET :show renders assigns the LinksReport and renders the template" do
     links_report = create(:links_report, link_reportable: @publication)
-    xhr :get, :show, id: links_report, edition_id: @publication
+    xhr :get, :show, params: { id: links_report, edition_id: @publication }
 
     assert_response :success
     assert_template :show
@@ -46,7 +46,7 @@ class Admin::LinksReportsControllerTest < ActionController::TestCase
 
   test "GET :show redirects back to the edition" do
     links_report = create(:links_report, link_reportable: @publication)
-    get :show, id: links_report, edition_id: @publication
+    get :show, params: { id: links_report, edition_id: @publication }
 
     assert_redirected_to admin_publication_url(@publication)
   end

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -35,7 +35,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
   view_test "show renders the summary" do
     draft_news_article = create(:draft_news_article, summary: "a-simple-summary")
 
-    get :show, id: draft_news_article
+    get :show, params: { id: draft_news_article }
 
     assert_select ".page-header .lead", text: "a-simple-summary"
   end

--- a/test/functional/admin/operational_fields_controller_test.rb
+++ b/test/functional/admin/operational_fields_controller_test.rb
@@ -43,7 +43,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   end
 
   test "create should create a new operational field" do
-    post :create, operational_field: { name: "field-a", description: "desc" }
+    post :create, params: { operational_field: { name: "field-a", description: "desc" } }
 
     operational_field = OperationalField.last
     refute_nil operational_field
@@ -52,7 +52,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   end
 
   test "create should redirect to operational field list on success" do
-    post :create, operational_field: { name: "field-a" }
+    post :create, params: { operational_field: { name: "field-a" } }
 
     assert_redirected_to admin_operational_fields_path
   end
@@ -60,7 +60,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   view_test "create should re-render form with errors on failure" do
     create(:operational_field, name: "field-a")
 
-    post :create, operational_field: { name: "field-a" }
+    post :create, params: { operational_field: { name: "field-a" } }
 
     assert_template "new"
     assert_select ".errors"
@@ -69,7 +69,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   view_test "edit should display operational field form" do
     operational_field = create(:operational_field, name: "field-a", description: "description of field")
 
-    get :edit, id: operational_field
+    get :edit, params: { id: operational_field }
 
     assert_select "form[action=?]", admin_operational_field_path(operational_field) do
       assert_select "input[name='operational_field[name]'][value='field-a']"
@@ -80,7 +80,7 @@ class Admin::OperationalFieldsControllerTest < ActionController::TestCase
   test "udpate should modify operational field" do
     operational_field = create(:operational_field, name: "original")
 
-    put :update, id: operational_field, operational_field: { name: "new", description: "new desc" }
+    put :update, params: { id: operational_field, operational_field: { name: "new", description: "new desc" } }
 
     operational_field.reload
     assert_equal "new", operational_field.name

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   view_test 'index shows a form to create missing translations' do
-    get :index, organisation_id: @organisation
+    get :index, params: { organisation_id: @organisation }
     translations_path = admin_organisation_translations_path(@organisation)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
@@ -28,7 +28,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
 
   view_test 'index omits existing translations from create select' do
     organisation = create(:organisation, translated_into: [:fr])
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     assert_select "select[name=translation_locale]" do
       assert_select "option[value=fr]", count: 0
     end
@@ -36,13 +36,13 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
 
   view_test 'index omits create form if no missing translations' do
     organisation = create(:organisation, translated_into: [:fr, :es])
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     assert_select "select[name=translation_locale]", count: 0
   end
 
   view_test 'index lists existing translations' do
     organisation = create(:organisation, translated_into: [:fr])
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     edit_translation_path = edit_admin_organisation_translation_path(organisation, 'fr')
     view_organisation_path = organisation_path(organisation, locale: 'fr')
     assert_select "a[href=?]", edit_translation_path, text: 'Français'
@@ -50,27 +50,27 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'index does not list the english translation' do
-    get :index, organisation_id: @organisation
+    get :index, params: { organisation_id: @organisation }
     edit_translation_path = edit_admin_organisation_translation_path(@organisation, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
   end
 
   view_test 'index displays delete button for a translation' do
     organisation = create(:organisation, translated_into: [:fr])
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     assert_select "form[action=?]", admin_organisation_translation_path(organisation, :fr) do
       assert_select "input[type='submit'][value=?]", "Delete"
     end
   end
 
   test 'create redirects to edit for the chosen language' do
-    post :create, organisation_id: @organisation, translation_locale: 'fr'
+    post :create, params: { organisation_id: @organisation, translation_locale: 'fr' }
     assert_redirected_to edit_admin_organisation_translation_path(@organisation, id: 'fr')
   end
 
   view_test 'edit indicates which language is being translated to' do
     organisation = create(:organisation, translated_into: [:fr])
-    get :edit, organisation_id: @organisation, id: 'fr'
+    get :edit, params: { organisation_id: @organisation, id: 'fr' }
     assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
   end
 
@@ -82,7 +82,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
           }
     })
 
-    get :edit, organisation_id: organisation, id: 'fr'
+    get :edit, params: { organisation_id: organisation, id: 'fr' }
 
     translation_path = admin_organisation_translation_path(organisation, 'fr')
 
@@ -97,7 +97,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   view_test 'edit form adds right-to-left class and dir attribute for text field and areas in right-to-left languages' do
     organisation = create(:organisation, translated_into: {ar: {name: 'الناس'}})
 
-    get :edit, organisation_id: organisation, id: 'ar'
+    get :edit, params: { organisation_id: organisation, id: 'ar' }
 
     translation_path = admin_organisation_translation_path(organisation, 'ar')
 
@@ -110,12 +110,11 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   end
 
   test 'update updates translation and redirects back to the index' do
-    put :update, organisation_id: @organisation, id: 'fr',
-      organisation: {
+    put :update, params: { organisation_id: @organisation, id: 'fr', organisation: {
         name: 'Afrolasie Bureau',
         acronym: 'AFRO',
         logo_formatted_name: 'Afrolasie Bureau',
-      }
+      } }
 
     @organisation.reload
 
@@ -129,11 +128,10 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'update re-renders form if translation is invalid' do
-    put :update, organisation_id: @organisation, id: 'fr',
-      organisation: {
+    put :update, params: { organisation_id: @organisation, id: 'fr', organisation: {
         name: 'Afrolasie Bureau',
         logo_formatted_name: '',
-      }
+      } }
 
     refute @organisation.available_in_locale?('fr')
     translation_path = admin_organisation_translation_path(@organisation, 'fr')
@@ -143,7 +141,7 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
   test 'destroy removes translation and redirects to list of translations' do
     organisation = create(:organisation, translated_into: [:fr])
 
-    delete :destroy, organisation_id: organisation, id: 'fr'
+    delete :destroy, params: { organisation_id: organisation, id: 'fr' }
 
     organisation.reload
     refute organisation.translated_locales.include?(:fr)

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -29,7 +29,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
   test "POST on :create denied if not a gds admin" do
     login_as :writer
-    post :create, organisation: {}
+    post :create, params: { organisation: {} }
     assert_response :forbidden
   end
 
@@ -51,7 +51,8 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     parent_org_2 = create(:organisation)
     topic_ids = [create(:topic), create(:topic)].map(&:id)
 
-    post :create, organisation: attributes.merge(
+    post :create, params: {
+organisation: attributes.merge(
       organisation_classifications_attributes: [
         { classification_id: topic_ids[0], ordering: 1 },
         { classification_id: topic_ids[1], ordering: 2 }
@@ -66,6 +67,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
         }
       }
     )
+}
 
     assert_redirected_to admin_organisations_path
     assert organisation = Organisation.last
@@ -81,17 +83,21 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   end
 
   test 'POST :create can set a custom logo' do
-    post :create, organisation: example_organisation_attributes.merge(
+    post :create, params: {
+organisation: example_organisation_attributes.merge(
       organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
       logo: fixture_file_upload('logo.png', 'image/png')
     )
+}
     assert_match /logo.png/, Organisation.last.logo.file.filename
   end
 
   test 'POST create can set number of important board members' do
-    post :create, organisation: example_organisation_attributes.merge(
+    post :create, params: {
+organisation: example_organisation_attributes.merge(
       important_board_members: 1,
     )
+}
     assert_equal 1, Organisation.last.important_board_members
   end
 
@@ -99,7 +105,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     attributes = example_organisation_attributes
 
     assert_no_difference('Organisation.count') do
-      post :create, organisation: attributes.merge(name: '')
+      post :create, params: { organisation: attributes.merge(name: '') }
     end
     assert_response :success
     assert_template :new
@@ -107,7 +113,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
   test "GET on :show loads the organisation and renders the show template" do
     organisation = create(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_response :success
     assert_template :show
@@ -115,7 +121,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
   test "GET on :edit loads the organisation and renders the edit template" do
     organisation = create(:organisation)
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
 
     assert_response :success
     assert_template :edit
@@ -138,7 +144,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_chief_professional_officer_role = create(:organisation_role, organisation: organisation, role: chief_professional_officer_role)
     organisation_military_role = create(:organisation_role, organisation: organisation, role: military_role)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_select "#minister_ordering input[type='hidden'][name^='organisation[organisation_roles_attributes]'][value='#{organisation_ministerial_role.id}']"
     refute_select "#minister_ordering input[type='hidden'][name^='organisation[organisation_roles_attributes]'][value='#{organisation_board_member_role.id}']"
@@ -174,7 +180,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     create(:role_appointment, person: person, role: ministerial_role, started_at: 1.day.ago)
     organisation = create(:organisation, roles: [ministerial_role])
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_select "#minister_ordering label", text: /Prime Minister/i
     assert_select "#minister_ordering label", text: /John Doe/i
@@ -187,7 +193,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_junior_ministerial_role = create(:organisation_role, organisation: organisation, role: junior_ministerial_role, ordering: 2)
     organisation_senior_ministerial_role = create(:organisation_role, organisation: organisation, role: senior_ministerial_role, ordering: 1)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_equal [organisation_senior_ministerial_role, organisation_junior_ministerial_role], assigns(:ministerial_organisation_roles)
   end
@@ -202,7 +208,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_junior_board_member_role = create(:organisation_role, organisation: organisation, role: junior_board_member_role, ordering: 3)
     organisation_senior_board_member_role = create(:organisation_role, organisation: organisation, role: senior_board_member_role, ordering: 1)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_equal [
       organisation_senior_board_member_role,
@@ -218,7 +224,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_junior_traffic_commissioner_role = create(:organisation_role, organisation: organisation, role: junior_traffic_commissioner_role, ordering: 2)
     organisation_senior_traffic_commissioner_role = create(:organisation_role, organisation: organisation, role: senior_traffic_commissioner_role, ordering: 1)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_equal [organisation_senior_traffic_commissioner_role, organisation_junior_traffic_commissioner_role], assigns(:traffic_commissioner_organisation_roles)
   end
@@ -230,7 +236,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_junior_chief_professional_officer_role = create(:organisation_role, organisation: organisation, role: junior_chief_professional_officer_role, ordering: 2)
     organisation_senior_chief_professional_officer_role = create(:organisation_role, organisation: organisation, role: senior_chief_professional_officer_role, ordering: 1)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_equal [organisation_senior_chief_professional_officer_role, organisation_junior_chief_professional_officer_role], assigns(:chief_professional_officer_roles)
   end
@@ -242,20 +248,20 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_junior_representative_role = create(:organisation_role, organisation: organisation, role: junior_representative_role, ordering: 2)
     organisation_senior_representative_role = create(:organisation_role, organisation: organisation, role: senior_representative_role, ordering: 1)
 
-    get :people, id: organisation
+    get :people, params: { id: organisation }
 
     assert_equal [organisation_senior_representative_role, organisation_junior_representative_role], assigns(:special_representative_organisation_roles)
   end
 
   view_test "GET on :people does not display an empty ministerial roles section" do
     organisation = create(:organisation)
-    get :people, id: organisation
+    get :people, params: { id: organisation }
     refute_select "#minister_ordering"
   end
 
   view_test "GET on :people contains the relevant dom classes to facilitate the javascript ordering functionality" do
     organisation = create(:organisation, roles: [create(:ministerial_role)])
-    get :people, id: organisation
+    get :people, params: { id: organisation }
     assert_select "fieldset#minister_ordering.sortable input.ordering[name^='organisation[organisation_roles_attributes]']"
   end
 
@@ -269,7 +275,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation_senior_board_member_role = create(:organisation_role, organisation: organisation, role: senior_board_member_role)
     organisation_junior_board_member_role = create(:organisation_role, organisation: organisation, role: junior_board_member_role)
 
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
 
     assert_select 'select#organisation_important_board_members option', count: 2
   end
@@ -279,29 +285,29 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     ministerial_role = create(:ministerial_role)
     organisation_role = create(:organisation_role, organisation: organisation, role: ministerial_role, ordering: 1)
 
-    put :update, id: organisation.id, organisation: {organisation_roles_attributes: {
+    put :update, params: { id: organisation.id, organisation: { organisation_roles_attributes: {
       "0" => {id: organisation_role.id, ordering: "2"}
-    }}
+    } } }
 
     assert_equal 2, organisation_role.reload.ordering
   end
 
   test 'PUT :update can set a custom logo' do
     organisation = create(:organisation)
-    put :update, id: organisation, organisation: {
+    put :update, params: { id: organisation, organisation: {
       organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
       logo: fixture_file_upload('logo.png')
-    }
+    } }
     assert_match /logo.png/, organisation.reload.logo.file.filename
   end
 
   test 'PUT :update can set default news image' do
     organisation = create(:organisation)
-    put :update, id: organisation, organisation: {
+    put :update, params: { id: organisation, organisation: {
       default_news_image_attributes: {
         file: fixture_file_upload('minister-of-funk.960x640.jpg')
       }
-    }
+    } }
     assert_equal 'minister-of-funk.960x640.jpg', organisation.reload.default_news_image.file.file.filename
   end
 
@@ -310,7 +316,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation = create(:organisation, name: 'org name')
     create(:organisation_role, organisation: organisation, role: ministerial_role)
 
-    put :update, id: organisation, organisation: {name: ""}
+    put :update, params: { id: organisation, organisation: { name: "" } }
 
     assert_response :success
     assert_template :edit
@@ -324,7 +330,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
       name: "Ministry of Noise",
     }
 
-    put :update, id: organisation, organisation: organisation_attributes
+    put :update, params: { id: organisation, organisation: organisation_attributes }
 
     organisation.reload
     assert_equal "Ministry of Noise", organisation.name
@@ -333,12 +339,12 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
   test "PUT on :update handles non-departmental public body information" do
     organisation = create(:organisation)
 
-    put :update, id: organisation, organisation: {
+    put :update, params: { id: organisation, organisation: {
       ocpa_regulated: 'false',
       public_meetings: 'true',
       public_minutes: 'true',
       regulatory_function: 'false'
-    }
+    } }
 
     organisation.reload
 
@@ -353,12 +359,12 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     featured_link = create(:featured_link, linkable: organisation)
 
-    put :update, id: organisation, organisation: { featured_links_attributes: { '0' => {
+    put :update, params: { id: organisation, organisation: { featured_links_attributes: { '0' => {
       id: featured_link.id,
       title: 'New title',
       url: featured_link.url,
       _destroy: 'false'
-    } } }
+    } } } }
 
     assert_response :redirect
     assert_equal 'New title', featured_link.reload.title
@@ -369,17 +375,17 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     writer = create(:writer, organisation: organisation)
     login_as(writer)
 
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     refute_select ".homepage-priority"
 
     managing_editor = create(:managing_editor, organisation: organisation)
     login_as(managing_editor)
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     assert_select ".homepage-priority"
 
     gds_editor = create(:gds_editor, organisation: organisation)
     login_as(gds_editor)
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     assert_select ".homepage-priority"
   end
 
@@ -388,15 +394,15 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     gds_editor = create(:gds_editor, organisation: organisation)
     login_as(gds_editor)
 
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     assert_response :success
 
     organisation2 = create(:organisation)
-    get :edit, id: organisation2
+    get :edit, params: { id: organisation2 }
     assert_response 403
 
     organisation2.parent_organisations << organisation
-    get :edit, id: organisation2
+    get :edit, params: { id: organisation2 }
     assert_response :success
   end
 
@@ -409,14 +415,14 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
                                   alt_text: 'Image alternative text')
 
 
-    get :features, id: organisation, locale: 'en'
+    get :features, params: { id: organisation, locale: 'en' }
     assert_response :success
   end
 
   view_test "GET :features without an organisation defaults to the user organisation" do
     organisation = create(:organisation)
 
-    get :features, id: organisation, locale: 'en'
+    get :features, params: { id: organisation, locale: 'en' }
     assert_response :success
 
     selected_organisation = css_select('#organisation option[selected="selected"]')
@@ -428,17 +434,17 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     writer = create(:writer, organisation: organisation)
     login_as(writer)
 
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     refute_select ".political-status"
 
     managing_editor = create(:managing_editor, organisation: organisation)
     login_as(managing_editor)
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     refute_select ".political-status"
 
     gds_editor = create(:gds_editor, organisation: organisation)
     login_as(gds_editor)
-    get :edit, id: organisation
+    get :edit, params: { id: organisation }
     assert_select ".political-status"
   end
 end

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   view_test "creating with invalid data shows errors" do
-    post :create, person: {title: "", forename: "", surname: "", letters: ""}
+    post :create, params: { person: { title: "", forename: "", surname: "", letters: "" } }
 
     assert_select ".form-errors"
   end
@@ -31,7 +31,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   test "creating with valid data creates a new person" do
     attributes = attributes_for(:person, title: "person-title", forename: "person-forename", surname: "person-surname", letters: "person-letters", biography: "person-biography")
 
-    post :create, person: attributes
+    post :create, params: { person: attributes }
 
     refute_nil person = Person.last
     assert_equal attributes[:title], person.title
@@ -42,7 +42,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   end
 
   test "creating with valid data redirects to the index" do
-    post :create, person: attributes_for(:person)
+    post :create, params: { person: attributes_for(:person) }
 
     assert_redirected_to admin_person_url(Person.last)
   end
@@ -50,14 +50,14 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   test "creating allows attachment of an image" do
     attributes = attributes_for(:person)
     attributes[:image] = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
-    post :create, person: attributes
+    post :create, params: { person: attributes }
 
     refute_nil Person.last.image
   end
 
   test "GET on :show assigns the person and renders the show page" do
     person = create(:person)
-    get :show, id: person
+    get :show, params: { id: person }
 
     assert_equal person, assigns(:person)
     assert_response :success
@@ -66,7 +66,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
 
   view_test "editing shows form for editing a person" do
     person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
-    get :edit, id: person
+    get :edit, params: { id: person }
 
     assert_select "form[action='#{admin_person_path}']" do
       assert_select "input[name='person[title]'][type=text]"
@@ -80,7 +80,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
 
   view_test "editing shows existing image" do
     person = create(:person, image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
-    get :edit, id: person
+    get :edit, params: { id: person }
 
     assert_select "img[src='#{person.image_url}']"
   end
@@ -88,7 +88,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   view_test "updating with invalid data shows errors" do
     person = create(:person)
 
-    put :update, id: person.id, person: {title: "", forename: "", surname: "", letters: ""}
+    put :update, params: { id: person.id, person: { title: "", forename: "", surname: "", letters: "" } }
 
     assert_select ".form-errors"
   end
@@ -96,14 +96,14 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   test "updating with valid data redirects to the index" do
     person = create(:person)
 
-    put :update, id: person.id, person: attributes_for(:person)
+    put :update, params: { id: person.id, person: attributes_for(:person) }
 
     assert_redirected_to admin_person_url(person)
   end
 
   test "should be able to destroy a destroyable person" do
     person = create(:person, forename: "Dave")
-    delete :destroy, id: person.id
+    delete :destroy, params: { id: person.id }
 
     assert_response :redirect
     assert_equal %{"Dave" destroyed.}, flash[:notice]
@@ -113,7 +113,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     person = create(:person)
     create(:role_appointment, person: person)
 
-    delete :destroy, id: person.id
+    delete :destroy, params: { id: person.id }
     assert_equal "Cannot destroy a person with appointments", flash[:alert]
   end
 

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   view_test 'index shows a form to create missing translations' do
-    get :index, person_id: @person
+    get :index, params: { person_id: @person }
 
     translations_path = admin_person_translations_path(@person)
     assert_select "form[action=?]", translations_path do
@@ -35,7 +35,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       }
     )
 
-    get :index, person_id: person
+    get :index, params: { person_id: person }
 
     assert_select "select[name=translation_locale]" do
       assert_select "option[value=fr]", count: 0
@@ -51,7 +51,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       }
     )
 
-    get :index, person_id: person
+    get :index, params: { person_id: person }
 
     assert_select "select[name=translation_locale]", count: 0
   end
@@ -64,7 +64,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       }
     )
 
-    get :index, person_id: person
+    get :index, params: { person_id: person }
 
     edit_translation_path = edit_admin_person_translation_path(person, 'fr')
     view_person_path = person_path(person, locale: 'fr')
@@ -73,7 +73,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'index does not list the english translation' do
-    get :index, person_id: @person
+    get :index, params: { person_id: @person }
 
     edit_translation_path = edit_admin_person_translation_path(@person, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
@@ -87,7 +87,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       }
     )
 
-    get :index, person_id: person
+    get :index, params: { person_id: person }
 
     assert_select "form[action=?]", admin_person_translation_path(person, :fr) do
       assert_select "input[type='submit'][value=?]", "Delete"
@@ -95,14 +95,14 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
   end
 
   test 'create redirects to edit for the chosen language' do
-    post :create, person_id: @person, translation_locale: 'fr'
+    post :create, params: { person_id: @person, translation_locale: 'fr' }
 
     assert_redirected_to edit_admin_person_translation_path(@person, id: 'fr')
   end
 
   view_test 'edit indicates which language is being translated to' do
     person = create(:person, translated_into: [:fr])
-    get :edit, person_id: @person, id: 'fr'
+    get :edit, params: { person_id: @person, id: 'fr' }
     assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
   end
 
@@ -111,7 +111,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       fr: { biography: 'Elle est née. Elle a vécu. Elle est morte.' }
     })
 
-    get :edit, person_id: person, id: 'fr'
+    get :edit, params: { person_id: person, id: 'fr' }
 
     translation_path = admin_person_translation_path(person, 'fr')
     assert_select "form[action=?]", translation_path do
@@ -125,7 +125,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       ar: { biography: 'ولدت. عاشت. توفيت.' }}
     )
 
-    get :edit, person_id: person, id: 'ar'
+    get :edit, params: { person_id: person, id: 'ar' }
 
     translation_path = admin_person_translation_path(person, 'ar')
     assert_select "form[action=?]", translation_path do
@@ -137,9 +137,9 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'update updates translation and redirects back to the index' do
-    put :update, person_id: @person, id: 'fr', person: {
+    put :update, params: { person_id: @person, id: 'fr', person: {
       biography: 'Elle est née. Elle a vécu. Elle est morte.'
-    }
+    } }
 
     @person.reload
     with_locale :fr do
@@ -153,7 +153,7 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
       fr: { biography: 'Elle est née. Elle a vécu. Elle est morte.' }
     })
 
-    delete :destroy, person_id: person, id: 'fr'
+    delete :destroy, params: { person_id: person, id: 'fr' }
 
     person.reload
     refute person.translated_locales.include?(:fr)

--- a/test/functional/admin/policies_controller_test.rb
+++ b/test/functional/admin/policies_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::PoliciesControllerTest < ActionController::TestCase
     create(:classification_policy, policy_content_id: policy_content_id, classification: topics.first)
     create(:classification_policy, policy_content_id: policy_content_id, classification: topics.second)
 
-    get :topics, policy_id: policy_content_id, format: :json
+    get :topics, params: { policy_id: policy_content_id }, format: :json
     assert_equal topics.first.id, json_response['topics'].first
     assert_equal topics.second.id, json_response['topics'].second
   end

--- a/test/functional/admin/policy_groups_controller_test.rb
+++ b/test/functional/admin/policy_groups_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   end
 
   test "POST :create" do
-    post :create, policy_group: { name: 'Policy Forum' }
+    post :create, params: { policy_group: { name: 'Policy Forum' } }
 
     assert_response :redirect
     assert_redirected_to admin_policy_groups_path
@@ -33,7 +33,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   view_test "GET :edit" do
     group = create(:policy_group)
 
-    get :edit, id: group
+    get :edit, params: { id: group }
 
     assert_response :success
     assert_equal group, assigns(:policy_group)
@@ -42,7 +42,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   test "PUT :update" do
     group = create(:policy_group, name: 'Policy Forum')
 
-    put :update, id: group, policy_group: { name: 'Policy Board' }
+    put :update, params: { id: group, policy_group: { name: 'Policy Board' } }
 
     assert_response :redirect
     assert_redirected_to admin_policy_groups_path
@@ -52,7 +52,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
   test "DELETE :destroy is forbidden for writers" do
     group = create(:policy_group)
 
-    delete :destroy, id: group
+    delete :destroy, params: { id: group }
 
     assert_response :forbidden
     assert PolicyGroup.exists?(group.id)
@@ -62,7 +62,7 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
     group = create(:policy_group)
 
     login_as :gds_editor
-    delete :destroy, id: group
+    delete :destroy, params: { id: group }
 
     assert_response :redirect
     assert_redirected_to admin_policy_groups_path

--- a/test/functional/admin/preview_controller_test.rb
+++ b/test/functional/admin/preview_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::PreviewControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   view_test "renders the body param using govspeak into a document body template" do
-    post :preview, body: "# gov speak"
+    post :preview, params: { body: "# gov speak" }
     assert_select ".document .body h1", "gov speak"
   end
 
@@ -16,14 +16,14 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     edition = create(:publication, body: '!!1')
     image = create(:image, edition: edition)
 
-    post :preview, body: edition.body, image_ids: edition.images.map(&:id)
+    post :preview, params: { body: edition.body, image_ids: edition.images.map(&:id) }
     assert_select ".document .body figure.image.embedded img[src=?]", Whitehall.public_asset_host + image.url
   end
 
   view_test "renders attached files if attachment_ids provided" do
     edition = create(:published_detailed_guide, :with_file_attachment, body: '!@1')
 
-    post :preview, body: edition.body, attachment_ids: edition.attachments.map(&:id)
+    post :preview, params: { body: edition.body, attachment_ids: edition.attachments.map(&:id) }
     assert_select ".document .body" do
       assert_select_object edition.attachments.first
     end
@@ -33,7 +33,7 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     edition = create(:published_detailed_guide, :with_file_attachment, body: '!@1')
     alternative_format_provider = create(:organisation, alternative_format_contact_email: "alternative@example.com")
 
-    post :preview, body: edition.body, attachment_ids: edition.attachments.map(&:id), alternative_format_provider_id: alternative_format_provider.id
+    post :preview, params: { body: edition.body, attachment_ids: edition.attachments.map(&:id), alternative_format_provider_id: alternative_format_provider.id }
     assert_select ".document .body" do
       assert_select_object edition.attachments.first do
         assert_select "a[href^=\"mailto:alternative@example.com\"]"
@@ -44,12 +44,12 @@ class Admin::PreviewControllerTest < ActionController::TestCase
   test "preview succeeds if alternative_format_provider_id is blank" do
     edition = create(:published_detailed_guide, :with_file_attachment, body: '!@1')
 
-    post :preview, body: edition.body, attachment_ids: edition.attachments.map(&:id), alternative_format_provider_id: ""
+    post :preview, params: { body: edition.body, attachment_ids: edition.attachments.map(&:id), alternative_format_provider_id: "" }
     assert_response :success
   end
 
   test "preview returns a 403 if the content contains potential XSS exploits" do
-    post :preview, body: "<script>alert('woah');</script>"
+    post :preview, params: { body: "<script>alert('woah');</script>" }
     assert_response :forbidden
   end
 
@@ -57,7 +57,7 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     protected_edition = create(:draft_publication, :access_limited)
     attachment = create(:file_attachment, attachable: protected_edition)
 
-    post :preview, body: "blah", attachment_ids: [attachment.id]
+    post :preview, params: { body: "blah", attachment_ids: [attachment.id] }
     assert_response :forbidden
   end
 end

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   test 'GET :new loads the organisation and feature and instantiates a new item and link' do
-    get :new, organisation_id: @organisation, promotional_feature_id: @promotional_feature
+    get :new, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature }
 
     assert_response :success
     assert_template :new
@@ -22,12 +22,14 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
 
   test 'POST :create saves the new promotional item to the feature' do
     post :create,
-      organisation_id: @organisation,
-      promotional_feature_id: @promotional_feature,
-      promotional_feature_item: {
-        summary: 'Summary text',
-        image_alt_text: 'Alt text',
-        image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+      params: {
+        organisation_id: @organisation,
+        promotional_feature_id: @promotional_feature,
+        promotional_feature_item: {
+          summary: 'Summary text',
+          image_alt_text: 'Alt text',
+          image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+        }
       }
 
     assert promotional_feature_item = @promotional_feature.reload.promotional_feature_items.first
@@ -41,7 +43,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   test 'GET :edit loads the item and its links renders the template' do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
     link = create(:promotional_feature_link, promotional_feature_item: promotional_feature_item)
-    get :edit, organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item
+    get :edit, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 
     assert_response :success
     assert_template :edit
@@ -53,7 +55,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
 
   test 'GET :edit assigns a blank link if the item does not already have one' do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
-    get :edit, organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item
+    get :edit, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 
     assert_response :success
     assert_template :edit
@@ -66,11 +68,10 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
 
-    put :update, organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item,
-                  promotional_feature_item: {
+    put :update, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item, promotional_feature_item: {
                     summary: 'Updated summary',
                     links_attributes: { '0' => { url: link.url, text: link.text, id: link.id, _destroy: false } }
-                  }
+                  } }
 
     assert_equal 'Updated summary', promotional_feature_item.reload.summary
     assert_redirected_to admin_organisation_promotional_feature_url(@organisation, @promotional_feature)
@@ -79,8 +80,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
 
   test 'PUT :update re-renders edit if the feature item does not save' do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, summary: 'Old summary')
-    put :update, organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item,
-                  promotional_feature_item: { summary: ''}
+    put :update, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item, promotional_feature_item: { summary: '' } }
 
     assert_template :edit
     assert_equal 'Old summary', promotional_feature_item.reload.summary
@@ -88,7 +88,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
 
   test 'DELETE :destroy deletes the promotional item' do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
-    delete :destroy, organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item
+    delete :destroy, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 
     assert_redirected_to admin_organisation_promotional_feature_url(@organisation, @promotional_feature)
     refute PromotionalFeatureItem.exists?(promotional_feature_item.id)

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -12,13 +12,13 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     organisation = create(:ministerial_department)
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :index, organisation_id: organisation
+      get :index, params: { organisation_id: organisation }
     end
   end
 
   test "GET :index loads the promotional organisation and renders the index template" do
     create(:promotional_feature, organisation: @organisation)
-    get :index, organisation_id: @organisation
+    get :index, params: { organisation_id: @organisation }
 
     assert_response :success
     assert_equal @organisation, assigns(:organisation)
@@ -27,7 +27,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   test "GET :new prepares a promotional feature" do
-    get :new, organisation_id: @organisation
+    get :new, params: { organisation_id: @organisation }
 
     assert_response :success
     assert_equal @organisation, assigns(:organisation)
@@ -35,7 +35,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves the new promotional feature and redirects to the show page" do
-    post :create, organisation_id: @organisation, promotional_feature: { title: 'Promotional feature title'}
+    post :create, params: { organisation_id: @organisation, promotional_feature: { title: 'Promotional feature title' } }
 
     assert promotional_feature = @organisation.reload.promotional_features.last
     assert_equal 'Promotional feature title', promotional_feature.title
@@ -44,7 +44,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
   test "GET :show loads the promotional feature belonging to the organisation" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
-    get :show, organisation_id: @organisation, id: promotional_feature
+    get :show, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_response :success
     assert_template :show
@@ -53,7 +53,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
   test "GET :edit loads the promotional feature and renders the template" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
-    get :edit, organisation_id: @organisation, id: promotional_feature
+    get :edit, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_response :success
     assert_template :edit
@@ -62,7 +62,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
   test "PUT :update saves the promotional feature and redirects to the show page" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
-    put :update, organisation_id: @organisation, id: promotional_feature, promotional_feature: { title: 'New title' }
+    put :update, params: { organisation_id: @organisation, id: promotional_feature, promotional_feature: { title: 'New title' } }
 
     assert_redirected_to admin_organisation_promotional_feature_url(@organisation, promotional_feature)
     assert_equal 'New title', promotional_feature.reload.title
@@ -70,7 +70,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
   test "DELETE :destroy deletes the promotional feature" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
-    delete :destroy, organisation_id: @organisation, id: promotional_feature
+    delete :destroy, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_redirected_to admin_organisation_promotional_features_url(@organisation)
     refute PromotionalFeature.exists?(promotional_feature.id)

--- a/test/functional/admin/responses_controller_test.rb
+++ b/test/functional/admin/responses_controller_test.rb
@@ -11,25 +11,25 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
   test 'Actions are unavailable if consultation is unmodifiable' do
     edition = create(:published_consultation)
 
-    get :show, consultation_id: edition, type: 'ConsultationOutcome'
+    get :show, params: { consultation_id: edition, type: 'ConsultationOutcome' }
     assert_response :redirect
   end
 
   test 'Access is forbidden to users who do not have access to the consultation' do
     login_as :world_editor
-    get :show, consultation_id: @consultation, type: 'ConsultationOutcome'
+    get :show, params: { consultation_id: @consultation, type: 'ConsultationOutcome' }
     assert_response :forbidden
   end
 
   view_test "GET :show renders a form for outcome when one does not exist" do
-    get :show, consultation_id: @consultation, type: 'ConsultationOutcome'
+    get :show, params: { consultation_id: @consultation, type: 'ConsultationOutcome' }
 
     assert_response :success
     assert_select "textarea[name='consultation_outcome[summary]']"
   end
 
   view_test "GET :show renders a form for feedback when one does not exist" do
-    get :show, consultation_id: @consultation, type: 'ConsultationPublicFeedback'
+    get :show, params: { consultation_id: @consultation, type: 'ConsultationPublicFeedback' }
 
     assert_response :success
     assert_select "textarea[name='consultation_public_feedback[summary]']"
@@ -37,7 +37,7 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
 
   view_test "GET :show when consultation has an outcome shows the outcome details and includes an edit link" do
     outcome = create_outcome
-    get :show, consultation_id: @consultation, type: 'ConsultationOutcome'
+    get :show, params: { consultation_id: @consultation, type: 'ConsultationOutcome' }
 
     assert_response :success
     assert_select 'p', text: 'A summary of the outcome'
@@ -46,7 +46,7 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
 
   view_test "GET :show when consultation has public feedback shows the feedback details and includes an edit link" do
     feedback = create_feedback
-    get :show, consultation_id: @consultation, type: 'ConsultationPublicFeedback'
+    get :show, params: { consultation_id: @consultation, type: 'ConsultationPublicFeedback' }
 
     assert_response :success
     assert_select 'p', text: 'A summary of the public feedback'
@@ -54,7 +54,7 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
   end
 
   test "POST :create with valid outcome params saves the outcome and redirects" do
-    post :create, consultation_id: @consultation, consultation_outcome: { summary: 'Outcome summary', published_on: Date.today }, type: 'ConsultationOutcome'
+    post :create, params: { consultation_id: @consultation, consultation_outcome: { summary: 'Outcome summary', published_on: Date.today }, type: 'ConsultationOutcome' }
 
     assert_response :redirect
     assert outcome = @consultation.outcome
@@ -62,7 +62,7 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
   end
 
   test "POST :create with valid feedback params saves the feedback and redirects" do
-    post :create, consultation_id: @consultation, consultation_public_feedback: { summary: 'Feedback summary', published_on: Date.today }, type: 'ConsultationPublicFeedback'
+    post :create, params: { consultation_id: @consultation, consultation_public_feedback: { summary: 'Feedback summary', published_on: Date.today }, type: 'ConsultationPublicFeedback' }
 
     assert_response :redirect
     assert public_feedback = @consultation.public_feedback
@@ -70,7 +70,7 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
   end
 
   view_test "POST :create with invalid params re-renders the form" do
-    post :create, consultation_id: @consultation, consultation_outcome: { summary: '', published_on: Date.today }, type: 'ConsultationOutcome'
+    post :create, params: { consultation_id: @consultation, consultation_outcome: { summary: '', published_on: Date.today }, type: 'ConsultationOutcome' }
 
     assert_response :success
     assert_select "textarea[name='consultation_outcome[summary]']"
@@ -78,26 +78,26 @@ class Admin::ResponsesControllerTest < ActionController::TestCase
 
   view_test "GET :edit renders the edit form for an outcome" do
     outcome = create_outcome
-    get :edit, consultation_id: @consultation, type: 'ConsultationOutcome'
+    get :edit, params: { consultation_id: @consultation, type: 'ConsultationOutcome' }
     assert_select "textarea[name='consultation_outcome[summary]']", text: outcome.summary
   end
 
   view_test "GET :edit renders the edit form for public feedback" do
     feedback = create_feedback
-    get :edit, consultation_id: @consultation, type: 'ConsultationPublicFeedback'
+    get :edit, params: { consultation_id: @consultation, type: 'ConsultationPublicFeedback' }
     assert_select "textarea[name='consultation_public_feedback[summary]']", text: feedback.summary
   end
 
   test "PUT :update with valid outcome params saves the changes to the outcome" do
     outcome = create_outcome
-    put :update, consultation_id: @consultation, consultation_outcome: { summary: 'New summary', published_on: Date.today }, type: 'ConsultationOutcome'
+    put :update, params: { consultation_id: @consultation, consultation_outcome: { summary: 'New summary', published_on: Date.today }, type: 'ConsultationOutcome' }
     assert_response :redirect
     assert_equal 'New summary', outcome.reload.summary
   end
 
   test "PUT :update with valid feedback params saves the changes to the feedback" do
     feedback = create_feedback
-    put :update, consultation_id: @consultation, consultation_public_feedback: { summary: 'New summary', published_on: Date.today }, type: 'ConsultationPublicFeedback'
+    put :update, params: { consultation_id: @consultation, consultation_public_feedback: { summary: 'New summary', published_on: Date.today }, type: 'ConsultationPublicFeedback' }
     assert_response :redirect
     assert_equal 'New summary', feedback.reload.summary
   end

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -9,13 +9,13 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
 
   view_test "new should display a form for creating an appointment" do
     role = create(:role)
-    get :new, role_id: role.id
+    get :new, params: { role_id: role.id }
     assert_select 'form[action=?]', admin_role_role_appointments_path(role)
   end
 
   view_test "new should display a form for creating an appointment that will curtail the previous appointment if make_current is set" do
     role = create(:role)
-    get :new, role_id: role.id, make_current: true
+    get :new, params: { role_id: role.id, make_current: true }
     assert_select 'form[action=?]', admin_role_role_appointments_path(role) do
       assert_select "input[name='role_appointment[make_current]'][value=true]"
     end
@@ -23,7 +23,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
 
   view_test "new should display a form for creating new an appoint, with started_at set to today, if make_current is set" do
     role = create(:role)
-    get :new, role_id: role.id, make_current: true
+    get :new, params: { role_id: role.id, make_current: true }
     assert_select 'form[action=?]', admin_role_role_appointments_path(role) do
       assert_select "input[name='role_appointment[make_current]']"
       assert_select "select[name='role_appointment[started_at(1i)]'] option[value='#{Date.today.year}'][selected='selected']"
@@ -34,7 +34,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
 
   view_test "new should display a form for creating a historical appointment if make_current is not set" do
     role = create(:role)
-    get :new, role_id: role.id
+    get :new, params: { role_id: role.id }
     assert_select 'form[action=?]', admin_role_role_appointments_path(role) do
       assert_select "input[name='role_appointment[make_current]']", false
     end
@@ -43,7 +43,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   test "create should create a new appointment" do
     role = create(:role)
     person = create(:person)
-    post :create, role_id: role.id, role_appointment: {person_id: person.id, started_at: 3.days.ago}
+    post :create, params: { role_id: role.id, role_appointment: { person_id: person.id, started_at: 3.days.ago } }
     new_appointment = role.role_appointments.first
     assert_equal person, new_appointment.person
     assert_equal 3.days.ago, new_appointment.started_at
@@ -52,7 +52,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   test "create redirects to the role edit form on success with a flash message" do
     role = create(:role)
     person = create(:person)
-    post :create, role_id: role.id, role_appointment: {person_id: person.id, started_at: 3.days.ago}
+    post :create, params: { role_id: role.id, role_appointment: { person_id: person.id, started_at: 3.days.ago } }
     assert_redirected_to edit_admin_role_path(role)
     assert_equal "Appointment created", flash[:notice]
   end
@@ -60,7 +60,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   view_test "create should show any errors when creating the appointment" do
     role = create(:role)
     person = create(:person)
-    post :create, role_id: role.id, role_appointment: {started_at: 3.days.ago}
+    post :create, params: { role_id: role.id, role_appointment: { started_at: 3.days.ago } }
     assert role.role_appointments.empty?
     assert_select ".field_with_errors", text: "Person*"
   end
@@ -69,69 +69,69 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     role = create(:role)
     previous_appointment = create(:role_appointment, role: role, started_at: 10.days.ago)
     person = create(:person)
-    post :create, role_id: role.id, role_appointment: {person_id: person.id, started_at: 3.days.ago, make_current: true}
+    post :create, params: { role_id: role.id, role_appointment: { person_id: person.id, started_at: 3.days.ago, make_current: true } }
     assert_equal person, role.current_person
   end
 
   view_test "edit should display an editing form for an existing appointment" do
     appointment = create(:role_appointment)
-    get :edit, id: appointment.id
+    get :edit, params: { id: appointment.id }
     assert_select 'form[action=?]', admin_role_appointment_path(appointment)
   end
 
   view_test "edit should show a button to delete an appointment" do
     appointment = create(:role_appointment)
-    get :edit, id: appointment.id
+    get :edit, params: { id: appointment.id }
     assert_select 'form[action=?]', admin_role_appointment_path(appointment)
   end
 
   view_test "edit should not show a button to delete an undeleteable appointment" do
     appointment = create(:role_appointment)
-    get :edit, id: appointment.id
+    get :edit, params: { id: appointment.id }
     assert_select 'form[action=?]', admin_role_appointment_path(appointment)
   end
 
   view_test "edit should show speeches associated with this appointment" do
     appointment = create(:role_appointment)
     create(:speech, title: "Some Speech", role_appointment: appointment)
-    get :edit, id: appointment.id
+    get :edit, params: { id: appointment.id }
     assert_select '.speeches', text: /Some Speech/
   end
 
   view_test "edit should not allow the person to be changed" do
     appointment = create(:role_appointment)
-    get :edit, id: appointment.id
+    get :edit, params: { id: appointment.id }
     assert_select 'select#role_appointment_person_id[disabled=disabled]'
   end
 
   test "update should update an existing role appointment" do
     appointment = create(:role_appointment, started_at: 3.days.ago, ended_at: 2.days.ago)
-    put :update, id: appointment.id, role_appointment: {ended_at: 1.day.ago}
+    put :update, params: { id: appointment.id, role_appointment: { ended_at: 1.day.ago } }
     assert_equal 1.day.ago, appointment.reload.ended_at
   end
 
   test "update should redirect to role edit form on success with a flash message" do
     appointment = create(:role_appointment, started_at: 3.days.ago, ended_at: 2.days.ago)
-    put :update, id: appointment.id, role_appointment: {ended_at: 1.day.ago}
+    put :update, params: { id: appointment.id, role_appointment: { ended_at: 1.day.ago } }
     assert_redirected_to edit_admin_role_path(appointment.role)
     assert_equal "Appointment has been updated", flash[:notice]
   end
 
   view_test "update shows errors if validation failed" do
     appointment = create(:role_appointment, started_at: 3.days.ago, ended_at: 2.days.ago)
-    put :update, id: appointment.id, role_appointment: {started_at: 1.day.from_now}
+    put :update, params: { id: appointment.id, role_appointment: { started_at: 1.day.from_now } }
     assert_select ".field_with_errors", text: "Started at*"
   end
 
   test "delete removes an appointment" do
     appointment = create(:role_appointment)
-    delete :destroy, id: appointment.id
+    delete :destroy, params: { id: appointment.id }
     assert_nil RoleAppointment.find_by(id: appointment.id)
   end
 
   test "delete redirects to role edit form on success with a flash message" do
     appointment = create(:role_appointment)
-    delete :destroy, id: appointment.id
+    delete :destroy, params: { id: appointment.id }
     assert_redirected_to edit_admin_role_path(appointment.role)
     assert_equal "Appointment has been deleted", flash[:notice]
   end
@@ -139,7 +139,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
   test "delete refuses to remove an appointment that cannot be deleted" do
     appointment = create(:role_appointment)
     speech = create(:speech, role_appointment: appointment)
-    delete :destroy, id: appointment.id
+    delete :destroy, params: { id: appointment.id }
     assert_equal appointment, appointment.reload, "appointment should still be in the database"
     assert_equal "Appointment can not be deleted", flash[:alert]
   end

--- a/test/functional/admin/role_translations_controller_test.rb
+++ b/test/functional/admin/role_translations_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   view_test 'index shows a form to create missing translations' do
-    get :index, role_id: @role
+    get :index, params: { role_id: @role }
 
     translations_path = admin_role_translations_path(@role)
     assert_select "form[action=?]", translations_path do
@@ -30,7 +30,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   view_test 'index omits existing translations from create select' do
     role = create(:role, translated_into: [:fr])
 
-    get :index, role_id: role
+    get :index, params: { role_id: role }
 
     assert_select "select[name=translation_locale]" do
       assert_select "option[value=fr]", count: 0
@@ -40,7 +40,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   view_test 'index omits create form if no missing translations' do
     role = create(:role, translated_into: [:fr, :es])
 
-    get :index, role_id: role
+    get :index, params: { role_id: role }
 
     assert_select "select[name=translation_locale]", count: 0
   end
@@ -48,14 +48,14 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   view_test 'index lists existing translations' do
     role = create(:role, translated_into: [:fr])
 
-    get :index, role_id: role
+    get :index, params: { role_id: role }
 
     edit_translation_path = edit_admin_role_translation_path(role, 'fr')
     assert_select "a[href=?]", edit_translation_path, text: 'Français'
   end
 
   view_test 'index does not list the english translation' do
-    get :index, role_id: @role
+    get :index, params: { role_id: @role }
 
     edit_translation_path = edit_admin_role_translation_path(@role, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
@@ -64,7 +64,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   view_test 'index displays delete button for a translation' do
     role = create(:role, translated_into: [:fr])
 
-    get :index, role_id: role
+    get :index, params: { role_id: role }
 
     assert_select "form[action=?]", admin_role_translation_path(role, :fr) do
       assert_select "input[type='submit'][value=?]", "Delete"
@@ -72,14 +72,14 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   end
 
   test 'create redirects to edit for the chosen language' do
-    post :create, role_id: @role, translation_locale: 'fr'
+    post :create, params: { role_id: @role, translation_locale: 'fr' }
 
     assert_redirected_to edit_admin_role_translation_path(@role, id: 'fr')
   end
 
   view_test 'edit indicates which language is being translated to' do
     role = create(:role, translated_into: [:fr])
-    get :edit, role_id: @role, id: 'fr'
+    get :edit, params: { role_id: @role, id: 'fr' }
     assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
   end
 
@@ -88,7 +88,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
       fr: { name: 'nom de rôle', responsibilities: 'responsabilités' }
     })
 
-    get :edit, role_id: role, id: 'fr'
+    get :edit, params: { role_id: role, id: 'fr' }
 
     translation_path = admin_role_translation_path(role, 'fr')
     assert_select "form[action=?]", translation_path do
@@ -103,7 +103,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
       ar: { name: 'دور اسم', responsibilities: 'المسؤوليات' }}
     )
 
-    get :edit, role_id: role, id: 'ar'
+    get :edit, params: { role_id: role, id: 'ar' }
 
     translation_path = admin_role_translation_path(role, 'ar')
     assert_select "form[action=?]", translation_path do
@@ -116,9 +116,9 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'update updates translation and redirects back to the index' do
-    put :update, role_id: @role, id: 'fr', role: {
+    put :update, params: { role_id: @role, id: 'fr', role: {
       name: 'nom de rôle', responsibilities: 'responsabilités'
-    }
+    } }
 
     @role.reload
     with_locale :fr do
@@ -129,9 +129,9 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   end
 
   view_test 'update re-renders form if translation is invalid' do
-    put :update, role_id: @role, id: 'fr', role: {
+    put :update, params: { role_id: @role, id: 'fr', role: {
       name: '', responsibilities: 'responsabilités'
-    }
+    } }
 
     translation_path = admin_role_translation_path(@role, 'fr')
     assert_select "form[action=?]",  translation_path do
@@ -144,7 +144,7 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
   test 'destroy removes translation and redirects to list of translations' do
     role = create(:role, translated_into: [:fr])
 
-    delete :destroy, role_id: role, id: 'fr'
+    delete :destroy, params: { role_id: role, id: 'fr' }
 
     role.reload
     refute role.translated_locales.include?(:fr)

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -177,11 +177,13 @@ class Admin::RolesControllerTest < ActionController::TestCase
   test "create should create a new ministerial role with a content_id" do
     org_one, org_two = create(:organisation), create(:organisation)
 
-    post :create, role: attributes_for(:ministerial_role,
+    post :create, params: {
+role: attributes_for(:ministerial_role,
       name: "role-name",
       role_type: "minister",
       organisation_ids: [org_one.id, org_two.id]
     )
+}
 
     assert role = MinisterialRole.last
     assert_equal "role-name", role.name
@@ -190,51 +192,59 @@ class Admin::RolesControllerTest < ActionController::TestCase
   end
 
   test "create should create a new board level manager role" do
-    post :create, role: attributes_for(:board_member_role,
+    post :create, params: {
+role: attributes_for(:board_member_role,
       role_type: "board_level_manager",
     )
+}
 
     assert role = BoardMemberRole.last
   end
 
   test "create should create a new military role" do
-    post :create, role: attributes_for(:military_role,
+    post :create, params: {
+role: attributes_for(:military_role,
       role_type: "chief_of_staff",
     )
+}
 
     assert role = MilitaryRole.last
   end
 
   test "create should create a new special representative role" do
-    post :create, role: attributes_for(:special_representative_role,
+    post :create, params: {
+role: attributes_for(:special_representative_role,
       role_type: "special_representative",
     )
+}
 
     assert role = SpecialRepresentativeRole.last
   end
 
   test "create should create a new chief professional officer role" do
-    post :create, role: attributes_for(:chief_professional_officer_role,
+    post :create, params: {
+role: attributes_for(:chief_professional_officer_role,
       role_type: "chief_professional_officer",
     )
+}
 
     assert role = ChiefProfessionalOfficerRole.last
   end
 
   test "create redirects to the index on success" do
-    post :create, role: attributes_for(:role)
+    post :create, params: { role: attributes_for(:role) }
 
     assert_redirected_to admin_roles_path
   end
 
   test "create should inform the user when a role is created successfully" do
-    post :create, role: attributes_for(:role, name: "role-name")
+    post :create, params: { role: attributes_for(:role, name: "role-name") }
 
     assert_equal %{"role-name" created.}, flash[:notice]
   end
 
   view_test "create with invalid data should display errors" do
-    post :create, role: attributes_for(:role, name: nil)
+    post :create, params: { role: attributes_for(:role, name: nil) }
 
     assert_select ".form-errors"
   end
@@ -243,7 +253,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
     org = create(:organisation, name: "org-name")
     role = create(:board_member_role, name: "role-name", permanent_secretary: true, organisations: [org])
 
-    get :edit, id: role
+    get :edit, params: { id: role }
 
     assert_select "form[action='#{admin_role_path(role)}']" do
       assert_select "input[name='role[name]'][value='role-name']"
@@ -261,11 +271,11 @@ class Admin::RolesControllerTest < ActionController::TestCase
     org_one, org_two = create(:organisation), create(:organisation)
     role = create(:ministerial_role, name: "role-name", cabinet_member: false, permanent_secretary: false, organisations: [org_one])
 
-    put :update, id: role, role: {
+    put :update, params: { id: role, role: {
       name: "new-name",
       role_type: "permanent_secretary",
       organisation_ids: [org_two.id]
-    }
+    } }
 
     role = Role.find(role.id)
     assert_equal BoardMemberRole, role.class
@@ -277,7 +287,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
   test "update redirects to the index on success" do
     role = create(:role)
 
-    put :update, id: role, role: attributes_for(:role)
+    put :update, params: { id: role, role: attributes_for(:role) }
 
     assert_redirected_to admin_roles_path
   end
@@ -285,7 +295,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
   test "update should inform the user when a role is updated successfully" do
     role = create(:role)
 
-    put :update, id: role, role: attributes_for(:role, name: "role-name")
+    put :update, params: { id: role, role: attributes_for(:role, name: "role-name") }
 
     assert_equal %{"role-name" updated.}, flash[:notice]
   end
@@ -293,7 +303,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
   view_test "update with invalid data should display errors" do
     role = create(:role)
 
-    put :update, id: role, role: attributes_for(:role, name: nil)
+    put :update, params: { id: role, role: attributes_for(:role, name: nil) }
 
     assert_select ".form-errors"
   end
@@ -301,7 +311,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
   test "should be able to destroy a destroyable role" do
     role = create(:role_without_organisations, name: "Prime Minister")
 
-    delete :destroy, id: role.id
+    delete :destroy, params: { id: role.id }
 
     assert_redirected_to admin_roles_path
     refute Role.find_by(id: role.id)
@@ -312,7 +322,7 @@ class Admin::RolesControllerTest < ActionController::TestCase
     role = create(:role)
     create(:role_appointment, role: role)
 
-    delete :destroy, id: role.id
+    delete :destroy, params: { id: role.id }
 
     assert_redirected_to admin_roles_path
     assert Role.find_by(id: role.id)

--- a/test/functional/admin/sitewide_settings_controller_test.rb
+++ b/test/functional/admin/sitewide_settings_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::SitewideSettingsControllerTest < ActionController::TestCase
   [:edit, :update].each do |action_method|
     test "#{action_method} action is not permitted to non-GDS editors" do
       login_as :departmental_editor
-      get action_method, id: 1
+      get action_method, params: { id: 1 }
       assert_response :forbidden
     end
   end
@@ -23,7 +23,7 @@ class Admin::SitewideSettingsControllerTest < ActionController::TestCase
 
   test "PUT on :update updates the sitewide setting" do
     sitewide_setting = create(:sitewide_setting)
-    put :update, id: sitewide_setting, sitewide_setting: {on: true, govspeak: "govspeak text"}
+    put :update, params: { id: sitewide_setting, sitewide_setting: { on: true, govspeak: "govspeak text" } }
 
     assert_equal 'govspeak text', sitewide_setting.reload.govspeak
     assert_equal true, sitewide_setting.reload.on

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -11,11 +11,13 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
 
   test "POST on :create creates social media account" do
     worldwide_organisation = create(:worldwide_organisation)
-    post :create, social_media_account: {
-      social_media_service_id: @social_media_service.id,
-      url: "http://foo"
-      },
-      worldwide_organisation_id: worldwide_organisation
+    post :create, params: {
+              social_media_account: {
+          social_media_service_id: @social_media_service.id,
+          url: "http://foo"
+          },
+          worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_redirected_to admin_worldwide_organisation_social_media_accounts_url(worldwide_organisation)
     assert_equal "#{@social_media_service.name} account created successfully", flash[:notice]
@@ -28,11 +30,13 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     social_media_account = worldwide_organisation.social_media_accounts.create(social_media_service_id: @social_media_service.id, url: "http://foo")
 
     put :update,
-        id: social_media_account,
-        worldwide_organisation_id: worldwide_organisation,
-        social_media_account: {
-          social_media_service_id: @social_media_service.id,
-          url: "http://bar"
+        params: {
+          id: social_media_account,
+          worldwide_organisation_id: worldwide_organisation,
+          social_media_account: {
+            social_media_service_id: @social_media_service.id,
+            url: "http://bar"
+          }
         }
 
     assert_redirected_to admin_worldwide_organisation_social_media_accounts_url(worldwide_organisation)
@@ -42,15 +46,15 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
 
   test ":create and :update strip whitespace from urls" do
     worldwide_organisation = create(:worldwide_organisation)
-    post :create, worldwide_organisation_id: worldwide_organisation, social_media_account: {
+    post :create, params: { worldwide_organisation_id: worldwide_organisation, social_media_account: {
       social_media_service_id: @social_media_service.id,
       url: "http://foo "
-    }
+    } }
 
     social_media_account = worldwide_organisation.social_media_accounts.first
     assert_equal "http://foo", social_media_account.url
 
-    post :update, {
+    post :update, params: {
       id: social_media_account,
       worldwide_organisation_id: worldwide_organisation,
       social_media_account: {
@@ -65,7 +69,7 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     organisation = create(:worldwide_organisation)
     social_media_account = create(:social_media_account, socialable: organisation)
 
-    delete :destroy, worldwide_organisation_id: organisation, id: social_media_account
+    delete :destroy, params: { worldwide_organisation_id: organisation, id: social_media_account }
 
     assert_redirected_to admin_worldwide_organisation_social_media_accounts_url(organisation)
     assert_equal "#{social_media_account.service_name} account deleted successfully", flash[:notice]

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -35,7 +35,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     speech_type = SpeechType::Transcript
     attributes = controller_attributes_for(:speech, speech_type: speech_type, role_appointment_id: role_appointment.id)
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     assert speech = Speech.last
     assert_equal speech_type, speech.speech_type
@@ -48,7 +48,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     speech_type = SpeechType::Transcript
     attributes = controller_attributes_for(:speech, speech_type: speech_type, person_override: "The Queen")
 
-    post :create, edition: attributes
+    post :create, params: { edition: attributes }
 
     assert speech = Speech.last
     assert_equal speech_type, speech.speech_type
@@ -63,12 +63,12 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     new_delivered_on = speech.delivered_on + 1
     new_speech_type = SpeechType::Transcript
 
-    put :update, id: speech.id, edition: {
+    put :update, params: { id: speech.id, edition: {
       role_appointment_id: new_role_appointment.id,
       speech_type_id: new_speech_type.id,
       delivered_on: new_delivered_on,
       location: "new-location"
-    }
+    } }
 
     speech = Speech.last
     assert_equal new_speech_type, speech.speech_type

--- a/test/functional/admin/statistics_announcement_date_changes_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_date_changes_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::StatisticsAnnouncementDateChangesControllerTest < ActionController:
   end
 
   view_test "GET :new renders a pre-filled announcement form" do
-    get :new, statistics_announcement_id: @announcement
+    get :new, params: { statistics_announcement_id: @announcement }
 
     assert_response :success
     assert_select "input[name='statistics_announcement_date_change[precision]'][value='1']" do |element|
@@ -40,13 +40,13 @@ class Admin::StatisticsAnnouncementDateChangesControllerTest < ActionController:
   end
 
   view_test "GET :new only shows change notes field when the release date is confirmed" do
-    get :new, statistics_announcement_id: @announcement
+    get :new, params: { statistics_announcement_id: @announcement }
 
     assert_response :success
     refute_select('textarea#statistics_announcement_date_change_change_note')
 
     @announcement.current_release_date.update_attribute(:confirmed, true)
-    get :new, statistics_announcement_id: @announcement
+    get :new, params: { statistics_announcement_id: @announcement }
 
     assert_response :success
     assert_select('textarea#statistics_announcement_date_change_change_note')
@@ -54,11 +54,11 @@ class Admin::StatisticsAnnouncementDateChangesControllerTest < ActionController:
 
   test "POST :create with valid params saves the date change and redirects to the announcement" do
     new_date = Time.zone.local(2013, 05, 11, 9, 30)
-    post :create, statistics_announcement_id: @announcement, statistics_announcement_date_change: {
+    post :create, params: { statistics_announcement_id: @announcement, statistics_announcement_date_change: {
       release_date: new_date,
       confirmed: '1',
       precision: StatisticsAnnouncementDate::PRECISION[:exact]
-    }
+    } }
 
     @announcement.reload
     assert_redirected_to admin_statistics_announcement_url(@announcement)

--- a/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_unpublishings_controller_test.rb
@@ -12,21 +12,21 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
 
   test "GDS Editor permission required to unpublish" do
     login_as :departmental_editor
-    get :new, statistics_announcement_id: @announcement.id
+    get :new, params: { statistics_announcement_id: @announcement.id }
     assert_response 403
   end
 
   view_test "GET :new renders a form" do
-    get :new, statistics_announcement_id: @announcement
+    get :new, params: { statistics_announcement_id: @announcement }
 
     assert_response :success
     assert_select "input[name='statistics_announcement[redirect_url]']"
   end
 
   test "POST :create with invalid params rerenders the form" do
-    post :create, statistics_announcement_id: @announcement, statistics_announcement: {
+    post :create, params: { statistics_announcement_id: @announcement, statistics_announcement: {
       redirect_url: 'https://youtube.com'
-    }
+    } }
 
     assert_template :new
   end
@@ -36,9 +36,9 @@ class Admin::StatisticsAnnouncementUnpublishingsControllerTest < ActionControlle
 
     stub_publishing_api_destroy_intent(@announcement.base_path)
 
-    post :create, statistics_announcement_id: @announcement, statistics_announcement: {
+    post :create, params: { statistics_announcement_id: @announcement, statistics_announcement: {
       redirect_url: redirect_url
-    }
+    } }
 
     @announcement.reload
     assert_redirected_to admin_statistics_announcements_path

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -36,18 +36,20 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves the announcement to the database and redirects to the dashboard" do
-    post :create, statistics_announcement: {
-                    title: 'Beard stats 2014',
-                    summary: 'Summary text',
-                    publication_type_id: PublicationType::OfficialStatistics.id,
-                    organisation_ids: [@organisation.id],
-                    topic_ids: [@topic.id],
-                    current_release_date_attributes: {
-                      release_date: 1.year.from_now,
-                      precision: StatisticsAnnouncementDate::PRECISION[:one_month],
-                      confirmed: '0'
-                    }
-                  }
+    post :create, params: {
+                    statistics_announcement: {
+                                    title: 'Beard stats 2014',
+                                    summary: 'Summary text',
+                                    publication_type_id: PublicationType::OfficialStatistics.id,
+                                    organisation_ids: [@organisation.id],
+                                    topic_ids: [@topic.id],
+                                    current_release_date_attributes: {
+                                      release_date: 1.year.from_now,
+                                      precision: StatisticsAnnouncementDate::PRECISION[:one_month],
+                                      confirmed: '0'
+                                    }
+                                  }
+    }
 
     assert_response :redirect
     assert announcement = StatisticsAnnouncement.last
@@ -59,7 +61,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
   end
 
   view_test "POST :create re-renders the form if the announcement is invalid" do
-    post :create, statistics_announcement: { title: '', summary: 'Summary text' }
+    post :create, params: { statistics_announcement: { title: '', summary: 'Summary text' } }
 
     assert_response :success
     assert_select "ul.errors li", text: "Title can't be blank"
@@ -68,7 +70,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 
   view_test "GET :show renders the details of the announcement" do
     announcement = create(:statistics_announcement)
-    get :show, id: announcement
+    get :show, params: { id: announcement }
 
     assert_response :success
     assert_select 'h1 .stats-heading', text: announcement.title
@@ -76,7 +78,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 
   view_test "GET :edit renders the edit form for the  announcement" do
     announcement = create(:statistics_announcement)
-    get :edit, id: announcement.id
+    get :edit, params: { id: announcement.id }
 
     assert_response :success
     assert_select "input[name='statistics_announcement[title]'][value='#{announcement.title}']"
@@ -84,7 +86,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 
   test "PUT :update saves changes to the announcement" do
     announcement = create(:statistics_announcement)
-    put :update, id: announcement.id, statistics_announcement: { title: "New announcement title" }
+    put :update, params: { id: announcement.id, statistics_announcement: { title: "New announcement title" } }
 
     assert_response :redirect
     assert_equal 'New announcement title', announcement.reload.title
@@ -92,7 +94,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 
   view_test "PUT :update re-renders edit form if changes are not valid" do
     announcement = create(:statistics_announcement)
-    put :update, id: announcement.id, statistics_announcement: { title: '' }
+    put :update, params: { id: announcement.id, statistics_announcement: { title: '' } }
 
     assert_response :success
     assert_select "ul.errors li", text: "Title can't be blank"
@@ -101,8 +103,10 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
   test "POST :publish_cancellation cancels the announcement" do
     announcement = create(:statistics_announcement)
     post :publish_cancellation,
-          id: announcement.id,
-          statistics_announcement: { cancellation_reason: "Reason" }
+          params: {
+            id: announcement.id,
+            statistics_announcement: { cancellation_reason: "Reason" }
+          }
 
     assert_redirected_to [:admin, announcement]
     assert announcement.reload.cancelled?
@@ -113,12 +117,14 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
   test "cancelled announcements cannot be cancelled" do
     announcement = create(:cancelled_statistics_announcement)
 
-    get :cancel, id: announcement
+    get :cancel, params: { id: announcement }
     assert_redirected_to [:admin, announcement]
 
     post :publish_cancellation,
-          id: announcement.id,
-          statistics_announcement: { cancellation_reason: "Reason" }
+          params: {
+            id: announcement.id,
+            statistics_announcement: { cancellation_reason: "Reason" }
+          }
     assert_redirected_to [:admin, announcement]
   end
 

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -30,9 +30,11 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
 
   test 'POST :create saves a new instance with the supplied valid params' do
     attrs = attributes_for(:take_part_page, title: 'Wear a monocle!')
-    post :create, take_part_page: attrs.merge(
+    post :create, params: {
+take_part_page: attrs.merge(
       image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
     )
+}
 
     puts assigns(:take_part_page).errors.full_messages
     assert assigns(:take_part_page).persisted?
@@ -42,7 +44,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
 
   test 'POST :create doesn\'t save the new instance when the supplied params are invalid' do
     attrs = attributes_for(:take_part_page, title: '')
-    post :create, take_part_page: attrs
+    post :create, params: { take_part_page: attrs }
 
     refute assigns(:take_part_page).persisted?
     assert_response :success
@@ -52,7 +54,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test 'GET :edit fetches the supplied instance' do
     page = create(:take_part_page)
 
-    get :edit, id: page
+    get :edit, params: { id: page }
 
     assert_equal page, assigns(:take_part_page)
     assert_response :success
@@ -62,7 +64,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test 'PUT :update changes the supplied instance with the supplied params' do
     attrs = attributes_for(:take_part_page, title: 'Wear a monocle!')
     page = create(:take_part_page, title: 'Drink in a gin palace!')
-    post :update, id: page, take_part_page: attrs
+    post :update, params: { id: page, take_part_page: attrs }
 
     assert_equal page, assigns(:take_part_page)
     assert_equal 'Wear a monocle!', page.reload.title
@@ -72,7 +74,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test 'PUT :update doesn\'t save the new instance when the supplied params are invalid' do
     attrs = attributes_for(:take_part_page, title: '')
     page = create(:take_part_page, title: 'Drink in a gin palace!')
-    post :update, id: page, take_part_page: attrs
+    post :update, params: { id: page, take_part_page: attrs }
 
     assert_equal page, assigns(:take_part_page)
     refute_equal '', page.reload.title
@@ -84,7 +86,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test 'DELETE :destroy removes the suppliued instance' do
     page = create(:take_part_page)
 
-    delete :destroy, id: page
+    delete :destroy, params: { id: page }
 
     refute TakePartPage.exists?(page.id)
     assert_redirected_to admin_take_part_pages_path
@@ -93,7 +95,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test 'POST :reorder asks TakePartPage to reorder using the supplied ordering params' do
     TakePartPage.expects(:reorder!).with(['1', '5', '20', '9'])
 
-    post :reorder, ordering: { '1' => '1', '20' => '4', '9' => '12', '5' => '3'}
+    post :reorder, params: { ordering: { '1' => '1', '20' => '4', '9' => '12', '5' => '3' } }
 
     assert_redirected_to admin_take_part_pages_path
   end

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   view_test "GET :show lists the topical event details" do
     topical_event = create(:topical_event)
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
 
     assert_response :success
     assert_select 'h1', topical_event.name
@@ -24,7 +24,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   test 'POST :create saves the topical event' do
     assert_difference("TopicalEvent.count") do
-      post :create, topical_event: { name: 'Event', description: 'Event description' }
+      post :create, params: { topical_event: { name: 'Event', description: 'Event description' } }
     end
 
     assert_response :redirect
@@ -47,7 +47,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   view_test 'GET :edit renders the topical event form' do
     topical_event = create(:topical_event)
-    get :edit, id: topical_event
+    get :edit, params: { id: topical_event }
 
     assert_response :success
     assert_select "input[name='topical_event[name]'][value='#{topical_event.name}']"
@@ -55,7 +55,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   test 'PUT :update saves changes to the topical event' do
     topical_event = create(:topical_event)
-    put :update, id: topical_event, topical_event: { name: 'New name' }
+    put :update, params: { id: topical_event, topical_event: { name: 'New name' } }
 
     assert_response :redirect
     assert_equal 'New name', topical_event.reload.name
@@ -63,7 +63,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
   test 'DELETE :destroy deletes the topical event' do
     topical_event = create(:topical_event)
-    delete :destroy, id: topical_event
+    delete :destroy, params: { id: topical_event }
 
     assert_response :redirect
     assert topical_event.reload.deleted?

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -24,7 +24,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   view_test "GET :show lists the topic's details" do
     topic = create(:topic)
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_response :success
     assert_select 'h1', topic.name
@@ -52,9 +52,11 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     second_topic = create(:topic)
     attributes = attributes_for(:topic)
 
-    post :create, topic: attributes.merge(
+    post :create, params: {
+topic: attributes.merge(
       related_classification_ids: [first_topic.id]
     )
+}
 
     assert_response :redirect
 
@@ -65,7 +67,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   end
 
   view_test "POST :create with bad data shows errors" do
-    post :create, topic: attributes_for(:topic).merge(name: "")
+    post :create, params: { topic: attributes_for(:topic).merge(name: "") }
 
     assert_template :new
     assert_select ".form-errors"
@@ -75,7 +77,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   view_test "GET :edit renders the edit form" do
     topic = create(:topic)
-    get :edit, id: topic
+    get :edit, params: { id: topic }
 
     assert_response :success
     assert_select "input[name='topic[name]'][value='#{topic.name}']"
@@ -86,10 +88,10 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   test "PUT :update saves changes to the topic and redirects" do
     topic = create(:topic)
 
-    put :update, id: topic, topic: {
+    put :update, params: { id: topic, topic: {
       name: "new-name",
       description: "new-description"
-    }
+    } }
 
     assert_response :redirect
     assert_equal "new-name", topic.reload.name
@@ -98,7 +100,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   view_test "PUT :update with bad data renders errors" do
     topic = create(:topic, name: 'topic')
-    put :update, id: topic.id, topic: {name: "Blah", description: ""}
+    put :update, params: { id: topic.id, topic: { name: "Blah", description: "" } }
 
     assert_equal 'topic', topic.reload.name
     assert_select ".form-errors"
@@ -109,9 +111,9 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     publication = create(:publication, topics: [topic])
     association = topic.classification_memberships.first
 
-    put :update, id: topic.id, topic: {name: "Blah", description: "Blah", classification_memberships_attributes: {
+    put :update, params: { id: topic.id, topic: { name: "Blah", description: "Blah", classification_memberships_attributes: {
       "0" => {id: association.id, ordering: "4"}
-    }}
+    } } }
 
     assert_equal 4, association.reload.ordering
   end
@@ -120,7 +122,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
   test "DELETE :destroy deletes a deletable topic" do
     topic = create(:topic)
-    delete :destroy, id: topic.id
+    delete :destroy, params: { id: topic.id }
 
     assert_response :redirect
     assert topic.reload.deleted?
@@ -129,7 +131,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   test "DELETE :destroy does not delete topics with associated content" do
     topic = create(:topic, policy_content_ids: [policy_1["content_id"]])
 
-    delete :destroy, id: topic
+    delete :destroy, params: { id: topic }
     assert_equal "Cannot destroy Policy area with associated content", flash[:alert]
     refute topic.reload.deleted?
   end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   end
 
   view_test "show displays user name and email address" do
-    get :show, id: @user.id
+    get :show, params: { id: @user.id }
 
     assert_select ".user .settings" do
       assert_select ".name", "user-name"
@@ -28,23 +28,23 @@ class Admin::UsersControllerTest < ActionController::TestCase
   end
 
   view_test "show displays edit if you are able to edit the record" do
-    get :show, id: @user.id
+    get :show, params: { id: @user.id }
     refute_select "a[href='#{edit_admin_user_path(@user)}']"
 
     login_as create(:gds_editor)
-    get :show, id: @user.id
+    get :show, params: { id: @user.id }
     assert_select "a[href='#{edit_admin_user_path(@user)}']"
   end
 
   test "edit only works if you are a GDS editor" do
     another_user = create(:user, name: "other user")
-    get :edit, id: another_user.id
+    get :edit, params: { id: another_user.id }
     assert_response :forbidden
   end
 
   view_test "edit displays form" do
     login_as create(:gds_editor)
-    get :edit, id: @user.id
+    get :edit, params: { id: @user.id }
 
     assert_select "form[action='#{admin_user_path(@user)}']" do
       assert_select "input[type='submit'][value='Save']"
@@ -53,7 +53,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
   view_test "edit displays cancel link" do
     login_as create(:gds_editor)
-    get :edit, id: @user.id
+    get :edit, params: { id: @user.id }
 
     assert_select ".or_cancel a[href='#{admin_user_path(@user)}']"
   end
@@ -61,7 +61,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   test "update saves world location changes by gds editors and redirects to :show" do
     login_as create(:gds_editor)
     world_location = create(:world_location)
-    put :update, id: @user.id, user: { world_location_ids: [world_location.id] }
+    put :update, params: { id: @user.id, user: { world_location_ids: [world_location.id] } }
 
     assert_equal world_location, @user.reload.world_locations.first
     assert_redirected_to admin_user_path(@user)
@@ -70,7 +70,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   test "update does not allow world locations changes by just anyone" do
     login_as create(:user, name: "Another user")
     world_location = create(:world_location)
-    put :update, id: @user.id, user: { world_location_ids: [world_location.id] }
+    put :update, params: { id: @user.id, user: { world_location_ids: [world_location.id] } }
     assert_response :forbidden
   end
 end

--- a/test/functional/admin/world_location_news_articles_controller_test.rb
+++ b/test/functional/admin/world_location_news_articles_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::WorldLocationNewsArticlesControllerTest < ActionController::TestCas
   test 'PUT :update for non-English edition does not save any additional translations' do
     edition = I18n.with_locale(:fr) { create(:world_location_news_article, title: 'French Title', body: 'French Body', primary_locale: :fr) }
 
-    put :update, id: edition, edition: { title: 'New French title', world_location_ids: [@world_location.id], worldwide_organisation_ids: [@worldwide_organisation.id]}
+    put :update, params: { id: edition, edition: { title: 'New French title', world_location_ids: [@world_location.id], worldwide_organisation_ids: [@worldwide_organisation.id] } }
     assert_redirected_to admin_world_location_news_article_path(edition)
 
     assert_equal 'fr', edition.reload.primary_locale

--- a/test/functional/admin/world_location_translations_controller_test.rb
+++ b/test/functional/admin/world_location_translations_controller_test.rb
@@ -16,7 +16,7 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   should_be_an_admin_controller
 
   view_test 'index shows a form to create missing translations' do
-    get :index, world_location_id: @location
+    get :index, params: { world_location_id: @location }
     translations_path = admin_world_location_translations_path(@location)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
@@ -29,26 +29,26 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   end
 
   view_test 'index does not list the english translation' do
-    get :index, world_location_id: @location
+    get :index, params: { world_location_id: @location }
     edit_translation_path = edit_admin_world_location_translation_path(@location, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
   end
 
   test 'create redirects to edit for the chosen language' do
-    post :create, world_location_id: @location, translation_locale: 'fr'
+    post :create, params: { world_location_id: @location, translation_locale: 'fr' }
     assert_redirected_to edit_admin_world_location_translation_path(@location, id: 'fr')
   end
 
   view_test 'edit indicates which language is being translated to' do
     location = create(:world_location, translated_into: [:fr])
-    get :edit, world_location_id: @location, id: 'fr'
+    get :edit, params: { world_location_id: @location, id: 'fr' }
     assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
   end
 
   view_test 'edit presents a form to update an existing translation' do
     location = create(:world_location, translated_into: {fr: {name: 'Afrolasie', mission_statement: 'Enseigner aux gens comment infuser le thé'}})
 
-    get :edit, world_location_id: location, id: 'fr'
+    get :edit, params: { world_location_id: location, id: 'fr' }
 
     translation_path = admin_world_location_translation_path(location, 'fr')
 
@@ -62,7 +62,7 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   view_test 'edit form adds right-to-left class and dir attribute for text field and areas in right-to-left languages' do
     location = create(:world_location, translated_into: {ar: {name: 'الناس', mission_statement: 'تعليم الناس كيفية تحضير الشاي'}})
 
-    get :edit, world_location_id: location, id: 'ar'
+    get :edit, params: { world_location_id: location, id: 'ar' }
 
     translation_path = admin_world_location_translation_path(location, 'ar')
 
@@ -78,10 +78,10 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   end
 
   view_test 'update updates translation and redirects back to the index' do
-    put :update, world_location_id: @location, id: 'fr', world_location: {
+    put :update, params: { world_location_id: @location, id: 'fr', world_location: {
       name: 'Afrolasie',
       mission_statement: 'Enseigner aux gens comment infuser le thé'
-    }
+    } }
 
     @location.reload
 
@@ -94,10 +94,10 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   end
 
   view_test 'update re-renders form if translation is invalid' do
-    put :update, world_location_id: @location, id: 'fr', world_location: {
+    put :update, params: { world_location_id: @location, id: 'fr', world_location: {
       name: '',
       mission_statement: 'Enseigner aux gens comment infuser le thé'
-    }
+    } }
 
     translation_path = admin_world_location_translation_path(@location, 'fr')
 
@@ -109,7 +109,7 @@ class Admin::WorldLocationTranslationsControllerTest < ActionController::TestCas
   test 'destroy removes translation and redirects to list of translations' do
     location = create(:world_location, translated_into: [:fr])
 
-    delete :destroy, world_location_id: location, id: 'fr'
+    delete :destroy, params: { world_location_id: location, id: 'fr' }
 
     location.reload
     refute location.translated_locales.include?(:fr)

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -27,7 +27,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
   view_test 'should allow modification of existing world location data' do
     world_location = create(:world_location)
 
-    get :edit, id: world_location
+    get :edit, params: { id: world_location }
 
     assert_template 'world_locations/edit'
     assert_select "input[name='world_location[title]']"
@@ -37,7 +37,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
   test 'updating should modify the world location' do
     world_location = create(:world_location)
 
-    put :update, id: world_location, world_location: { mission_statement: 'country-mission-statement' }
+    put :update, params: { id: world_location, world_location: { mission_statement: 'country-mission-statement' } }
 
     world_location.reload
     assert_equal 'country-mission-statement', world_location.mission_statement
@@ -46,7 +46,7 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
   test 'after updating redirects to world location show page' do
     world_location = create(:world_location)
 
-    put :update, id: world_location, world_location: { mission_statement: 'country-mission-statement' }
+    put :update, params: { id: world_location, world_location: { mission_statement: 'country-mission-statement' } }
 
     assert_redirected_to [:admin, world_location]
   end
@@ -54,12 +54,12 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
   test "updating should be able to create a new featured link" do
     world_location = create(:world_location)
 
-    post :update, id: world_location, world_location: {
+    post :update, params: { id: world_location, world_location: {
       featured_links_attributes: {"0" => {
         url: "http://www.gov.uk/mainstream/something",
         title: "Something on mainstream"
       }}
-    }
+    } }
 
     assert world_location = WorldLocation.last
     assert featured_link = world_location.featured_links.last
@@ -71,12 +71,12 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
     world_location = create(:world_location)
     featured_link = create(:featured_link, linkable: world_location)
 
-    post :update, id: world_location, world_location: {
+    post :update, params: { id: world_location, world_location: {
       featured_links_attributes: {"0" => {
         id: featured_link.id,
         _destroy: "1"
       }}
-    }
+    } }
 
     refute FeaturedLink.exists?(featured_link.id)
   end

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -12,14 +12,16 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Main office",
-          contact_type_id: ContactType::General.id
-        }
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Main office",
+                contact_type_id: ContactType::General.id
+              }
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation)
     assert_equal 1, worldwide_organisation.offices.count
@@ -30,15 +32,17 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create_worldwide_organisation_with_main_office
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Main office",
-          contact_type_id: ContactType::General.id
-        },
-        show_on_home_page: '1'
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Main office",
+                contact_type_id: ContactType::General.id
+              },
+              show_on_home_page: '1'
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     new_office = worldwide_organisation.offices.last
     assert_equal 'Main office', new_office.contact.title
@@ -49,15 +53,17 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create_worldwide_organisation_with_main_office
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Main office",
-          contact_type_id: ContactType::General.id
-        },
-        show_on_home_page: '0'
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Main office",
+                contact_type_id: ContactType::General.id
+              },
+              show_on_home_page: '0'
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     new_office = worldwide_organisation.offices.last
     assert_equal 'Main office', new_office.contact.title
@@ -68,14 +74,16 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create_worldwide_organisation_with_main_office
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Main office",
-          contact_type_id: ContactType::General.id
-        }
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Main office",
+                contact_type_id: ContactType::General.id
+              }
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     new_office = worldwide_organisation.offices.last
     assert_equal 'Main office', new_office.contact.title
@@ -88,15 +96,17 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Main office",
-          contact_type_id: ContactType::General.id
-        },
-        service_ids: [service2.id, service1.id]
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Main office",
+                contact_type_id: ContactType::General.id
+              },
+              service_ids: [service2.id, service1.id]
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     assert_equal 1, worldwide_organisation.offices.count
     assert_equal [service1, service2], worldwide_organisation.offices.first.services.sort_by(&:id)
@@ -106,17 +116,19 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation)
 
     post :create,
-      worldwide_office: {
-        worldwide_office_type_id: WorldwideOfficeType::Other.id,
-        contact_attributes: {
-          title: "Head office",
-          contact_type_id: ContactType::General.id,
-          contact_numbers_attributes: {
-            "0" => {label: "Main phone", number: "1234"}
-          }
-        }
-      },
-      worldwide_organisation_id: worldwide_organisation.id
+      params: {
+                worldwide_office: {
+              worldwide_office_type_id: WorldwideOfficeType::Other.id,
+              contact_attributes: {
+                title: "Head office",
+                contact_type_id: ContactType::General.id,
+                contact_numbers_attributes: {
+                  "0" => { label: "Main phone", number: "1234" }
+                }
+              }
+            },
+            worldwide_organisation_id: worldwide_organisation.id
+    }
 
     assert_equal 1, worldwide_organisation.offices.count
     assert office = worldwide_organisation.offices.first
@@ -127,14 +139,16 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation, office = create_worldwide_organisation_and_office
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office"
-        }
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office"
+              }
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal "Head office", office.reload.contact.title
   end
@@ -143,15 +157,17 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation, office = create_worldwide_organisation_and_office
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office"
-        },
-        show_on_home_page: '1'
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office"
+              },
+              show_on_home_page: '1'
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal "Head office", office.reload.contact.title
     assert worldwide_organisation.office_shown_on_home_page?(office)
@@ -162,15 +178,17 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation.add_office_to_home_page!(office)
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office"
-        },
-        show_on_home_page: '0'
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office"
+              },
+              show_on_home_page: '0'
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal "Head office", office.reload.contact.title
     refute worldwide_organisation.office_shown_on_home_page?(office)
@@ -181,14 +199,16 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation.add_office_to_home_page!(office)
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office"
-        }
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office"
+              }
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal "Head office", office.reload.contact.title
     assert worldwide_organisation.office_shown_on_home_page?(office)
@@ -200,11 +220,13 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation, office = create_worldwide_organisation_and_office
 
     put :update,
-      worldwide_office: {
-        service_ids: [service3.id, service2.id]
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              service_ids: [service3.id, service2.id]
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal [service2, service3], office.reload.services.sort_by(&:id)
   end
@@ -214,17 +236,19 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     contact_number = office.contact.contact_numbers.create(label: "Main phone", number: "1234")
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office",
-          contact_numbers_attributes: {
-            "0" => {id: contact_number.id, label: "Main phone", number: "5678"}
-          }
-        },
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office",
+                contact_numbers_attributes: {
+                  "0" => { id: contact_number.id, label: "Main phone", number: "5678" }
+                }
+              },
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     assert_equal ["Main phone: 5678"], office.contact.reload.contact_numbers.reload.map { |cn| "#{cn.label}: #{cn.number}" }
   end
@@ -234,22 +258,24 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     contact_number = office.contact.contact_numbers.create(label: "Phone", number: "1234")
 
     put :update,
-      worldwide_office: {
-        contact_attributes: {
-          id: office.contact.id,
-          title: "Head office",
-          contact_numbers_attributes: {
-            "0" => {
-              id: contact_number.id,
-              label: contact_number.label,
-              number: contact_number.number,
-              _destroy: 'true'
-            }
-          }
-        },
-      },
-      id: office,
-      worldwide_organisation_id: worldwide_organisation
+      params: {
+                worldwide_office: {
+              contact_attributes: {
+                id: office.contact.id,
+                title: "Head office",
+                contact_numbers_attributes: {
+                  "0" => {
+                    id: contact_number.id,
+                    label: contact_number.label,
+                    number: contact_number.number,
+                    _destroy: 'true'
+                  }
+                }
+              },
+            },
+            id: office,
+            worldwide_organisation_id: worldwide_organisation
+    }
 
     refute ContactNumber.exists?(contact_number.id)
   end
@@ -258,7 +284,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation, office = create_worldwide_organisation_and_office
     worldwide_organisation.add_office_to_home_page!(office)
 
-    post :remove_from_home_page, worldwide_organisation_id: worldwide_organisation, id: office
+    post :remove_from_home_page, params: { worldwide_organisation_id: worldwide_organisation, id: office }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)
     assert_equal %{"#{office.title}" removed from home page successfully}, flash[:notice]
@@ -268,7 +294,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
   test "POST on :add_to_home_page adds office to the home page of the worldwide organisation" do
     worldwide_organisation, office = create_worldwide_organisation_and_office
 
-    post :add_to_home_page, worldwide_organisation_id: worldwide_organisation, id: office
+    post :add_to_home_page, params: { worldwide_organisation_id: worldwide_organisation, id: office }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)
     assert_equal %{"#{office.title}" added to home page successfully}, flash[:notice]
@@ -295,11 +321,13 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation.add_office_to_home_page!(office_2)
     worldwide_organisation.add_office_to_home_page!(office_3)
 
-    post :reorder_for_home_page, worldwide_organisation_id: worldwide_organisation,
-      ordering: {
-        office_1.id.to_s => '3',
-        office_2.id.to_s => '1',
-        office_3.id.to_s => '2'
+    post :reorder_for_home_page, params: {
+        worldwide_organisation_id: worldwide_organisation,
+        ordering: {
+          office_1.id.to_s => '3',
+          office_2.id.to_s => '1',
+          office_3.id.to_s => '2'
+        }
       }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)
@@ -311,10 +339,12 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation, office = create_worldwide_organisation_and_office
     worldwide_organisation.add_office_to_home_page!(office)
 
-    post :reorder_for_home_page, worldwide_organisation_id: worldwide_organisation,
-      ordering: {
-        office.id.to_s => '2',
-        '1000000' => '1'
+    post :reorder_for_home_page, params: {
+        worldwide_organisation_id: worldwide_organisation,
+        ordering: {
+          office.id.to_s => '2',
+          '1000000' => '1'
+        }
       }
 
     assert_redirected_to admin_worldwide_organisation_worldwide_offices_url(worldwide_organisation)

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -20,8 +20,10 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   test "creates a worldwide organisation" do
-    post :create, worldwide_organisation: {
-      name: "Organisation",
+    post :create, params: {
+      worldwide_organisation: {
+        name: "Organisation",
+      }
     }
 
     worldwide_organisation = WorldwideOrganisation.last
@@ -32,8 +34,10 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   end
 
   view_test "shows validation errors on invalid worldwide organisation" do
-    post :create, worldwide_organisation: {
-      name: "",
+    post :create, params: {
+      worldwide_organisation: {
+        name: "",
+      }
     }
 
     assert_select 'form#new_worldwide_organisation .errors'
@@ -41,16 +45,18 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "shows an edit page for an existing worldwide organisation" do
     organisation = create(:worldwide_organisation)
-    get :edit, id: organisation.id
+    get :edit, params: { id: organisation.id }
   end
 
   test "updates an existing objects with new values" do
     organisation = create(:worldwide_organisation)
-    put :update, id: organisation.id, worldwide_organisation: {
-      name: "New name",
-      default_news_image_attributes: {
-        file: fixture_file_upload('minister-of-funk.960x640.jpg')
-      },
+    put :update, params: {
+      id: organisation.id, worldwide_organisation: {
+        name: "New name",
+        default_news_image_attributes: {
+          file: fixture_file_upload('minister-of-funk.960x640.jpg')
+        },
+      }
     }
     worldwide_organisation = WorldwideOrganisation.last
     assert_equal "New name", worldwide_organisation.name
@@ -61,7 +67,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   test "setting the main office" do
     offices = [create(:worldwide_office), create(:worldwide_office)]
     worldwide_organisation = create(:worldwide_organisation, offices: offices)
-    put :set_main_office, id: worldwide_organisation.id, worldwide_organisation: { main_office_id: offices.last.id }
+    put :set_main_office, params: { id: worldwide_organisation.id, worldwide_organisation: { main_office_id: offices.last.id } }
 
     assert_equal offices.last, worldwide_organisation.reload.main_office
     assert_equal "Main office updated successfully", flash[:notice]
@@ -70,7 +76,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "viewing office access details with no default assigns a new one" do
     worldwide_organisation = create(:worldwide_organisation)
-    get :access_info, id: worldwide_organisation
+    get :access_info, params: { id: worldwide_organisation }
 
     assert_response :success
     assert_template :access_info
@@ -90,7 +96,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
            document: page.document)
 
     count = WorldwideOrganisation.count
-    delete :destroy, id: organisation.id
+    delete :destroy, params: { id: organisation.id }
     assert_equal count - 1, WorldwideOrganisation.count
   end
 
@@ -101,7 +107,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
                       summary: "We have a nice organisation in madrid",
                       body: "# Organisation\nOur organisation is on the main road\n")
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select_object organisation do
       assert_select "h1", organisation.name

--- a/test/functional/admin/worldwide_organisations_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_translations_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   should_be_an_admin_controller
 
   view_test 'index shows a form to create missing translations' do
-    get :index, worldwide_organisation_id: @worldwide_organisation
+    get :index, params: { worldwide_organisation_id: @worldwide_organisation }
     translations_path = admin_worldwide_organisation_translations_path(@worldwide_organisation)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
@@ -28,7 +28,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
 
   view_test 'index omits existing translations from create select' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
-    get :index, worldwide_organisation_id: worldwide_organisation
+    get :index, params: { worldwide_organisation_id: worldwide_organisation }
     assert_select "select[name=translation_locale]" do
       assert_select "option[value=fr]", count: 0
     end
@@ -36,13 +36,13 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
 
   view_test 'index omits create form if no missing translations' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr, :es])
-    get :index, worldwide_organisation_id: worldwide_organisation
+    get :index, params: { worldwide_organisation_id: worldwide_organisation }
     assert_select "select[name=translation_locale]", count: 0
   end
 
   view_test 'index lists existing translations' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
-    get :index, worldwide_organisation_id: worldwide_organisation
+    get :index, params: { worldwide_organisation_id: worldwide_organisation }
     edit_translation_path = edit_admin_worldwide_organisation_translation_path(worldwide_organisation, 'fr')
     view_worldwide_organisation_path = worldwide_organisation_path(worldwide_organisation, locale: 'fr')
     assert_select "a[href=?]", edit_translation_path, text: 'Français'
@@ -50,7 +50,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   view_test 'index does not list the english translation' do
-    get :index, worldwide_organisation_id: @worldwide_organisation
+    get :index, params: { worldwide_organisation_id: @worldwide_organisation }
     edit_translation_path = edit_admin_worldwide_organisation_translation_path(@worldwide_organisation, 'en')
     assert_select "a[href=?]", edit_translation_path, text: 'en', count: 0
   end
@@ -58,7 +58,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   view_test 'index displays delete button for a translation' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
 
-    get :index, worldwide_organisation_id: worldwide_organisation
+    get :index, params: { worldwide_organisation_id: worldwide_organisation }
 
     assert_select "form[action=?]", admin_worldwide_organisation_translation_path(worldwide_organisation, 'fr') do
       assert_select "input[type='submit'][value=?]", "Delete"
@@ -66,13 +66,13 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   test 'create redirects to edit for the chosen language' do
-    post :create, worldwide_organisation_id: @worldwide_organisation, translation_locale: 'fr'
+    post :create, params: { worldwide_organisation_id: @worldwide_organisation, translation_locale: 'fr' }
     assert_redirected_to edit_admin_worldwide_organisation_translation_path(@worldwide_organisation, id: 'fr')
   end
 
   view_test 'edit indicates which language is being translated to' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
-    get :edit, worldwide_organisation_id: @worldwide_organisation, id: 'fr'
+    get :edit, params: { worldwide_organisation_id: @worldwide_organisation, id: 'fr' }
     assert_select "h1", text: /Edit ‘Français \(French\)’ translation/
   end
 
@@ -83,7 +83,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
       }}
     )
 
-    get :edit, worldwide_organisation_id: worldwide_organisation, id: 'fr'
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation, id: 'fr' }
 
     translation_path = admin_worldwide_organisation_translation_path(worldwide_organisation, 'fr')
 
@@ -96,7 +96,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   view_test 'edit presents a form respecting the RTL value of the language' do
     worldwide_organisation = create(:worldwide_organisation)
 
-    get :edit, worldwide_organisation_id: worldwide_organisation, id: 'ar'
+    get :edit, params: { worldwide_organisation_id: worldwide_organisation, id: 'ar' }
 
     assert_select "form" do
       assert_select "fieldset.right-to-left input[type=text][name='worldwide_organisation[name]']"
@@ -104,9 +104,9 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   view_test 'update updates translation and redirects back to the index' do
-    put :update, worldwide_organisation_id: @worldwide_organisation, id: 'fr', worldwide_organisation: {
+    put :update, params: { worldwide_organisation_id: @worldwide_organisation, id: 'fr', worldwide_organisation: {
       name: 'Département des barbes en France',
-    }
+    } }
 
     @worldwide_organisation.reload
 
@@ -118,9 +118,9 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   end
 
   view_test 'update re-renders form if translation is invalid' do
-    put :update, worldwide_organisation_id: @worldwide_organisation, id: 'fr', worldwide_organisation: {
+    put :update, params: { worldwide_organisation_id: @worldwide_organisation, id: 'fr', worldwide_organisation: {
       name: '',
-    }
+    } }
 
     refute @worldwide_organisation.available_in_locale?('fr')
     translation_path = admin_worldwide_organisation_translation_path(@worldwide_organisation, 'fr')
@@ -130,7 +130,7 @@ class Admin::WorldwideOrganisationsTranslationsControllerTest < ActionController
   test 'destroy removes translation and redirects to list of translations' do
     worldwide_organisation = create(:worldwide_organisation, translated_into: [:fr])
 
-    delete :destroy, worldwide_organisation_id: worldwide_organisation, id: 'fr'
+    delete :destroy, params: { worldwide_organisation_id: worldwide_organisation, id: 'fr' }
 
     worldwide_organisation.reload
     refute worldwide_organisation.translated_locales.include?(:fr)

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -107,13 +107,13 @@ class AnnouncementsControllerTest < ActionController::TestCase
   end
 
   view_test "index shows selected announcement type filter option in the title" do
-    get :index, announcement_filter_option: 'news-stories'
+    get :index, params: { announcement_filter_option: 'news-stories' }
 
     assert_select 'h1 span', ': news stories'
   end
 
   view_test "index indicates selected announcement type filter option in the filter selector" do
-    get :index, announcement_filter_option: 'news-stories'
+    get :index, params: { announcement_filter_option: 'news-stories' }
 
     assert_select "select[name='announcement_filter_option']" do
       assert_select "option[selected='selected']", text: Whitehall::AnnouncementFilterOption::NewsStory.label
@@ -127,7 +127,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
 
     create(:published_news_article, world_locations: [wl1, wl2, wl3])
 
-    get :index, {world_locations: [wl1.slug, wl3.slug]}
+    get :index, params: { world_locations: [wl1.slug, wl3.slug] }
 
     assert_select "select[name='world_locations[]']" do
       assert_select "option[selected='selected']", count: 2
@@ -160,7 +160,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     speeches = (4..6).map { |n| create(:published_speech, first_published_at: n.days.ago) }
 
     with_number_of_documents_per_page(4) do
-      get :index, page: 2
+      get :index, params: { page: 2 }
     end
 
     assert_documents_appear_in_order_within(".filter-results", speeches[1..2])
@@ -178,7 +178,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, topics: [topic], departments: [organisation]
+    get :index, params: { topics: [topic], departments: [organisation] }
 
     assert_select_autodiscovery_link announcements_url(format: "atom", topics: [topic], departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
   end
@@ -186,7 +186,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
   view_test "index generates an atom feed for the current filter" do
     org = create(:organisation, name: "org-name")
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select 'feed > id', 1
@@ -205,7 +205,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     news = create(:published_news_article, organisations: [org], first_published_at: 1.week.ago)
     speech = create(:published_speech, organisations: [other_org], delivered_on: 3.days.ago)
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([news])
@@ -216,7 +216,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     news = create(:published_news_story, first_published_at: 1.week.ago)
     speech = create(:published_speech, delivered_on: 3.days.ago)
 
-    get :index, format: :atom, announcement_type_option: 'news-stories'
+    get :index, params: { announcement_type_option: 'news-stories' }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([news])
@@ -236,7 +236,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, format: :json, to_date: "2012-01-01", topics: [topic.slug], departments: [organisation.slug]
+    get :index, params: { to_date: "2012-01-01", topics: [topic.slug], departments: [organisation.slug] }, format: :json
 
     json = ActiveSupport::JSON.decode(response.body)
     atom_url = announcements_url(format: "atom", topics: [topic.slug], departments: [organisation.slug], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
@@ -247,7 +247,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
   view_test 'index only lists documents in the given locale' do
     english_article = create(:published_news_article)
     spanish_article = create(:published_news_article, translated_into: [:fr])
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     assert_select_object spanish_article
     refute_select_object english_article
@@ -256,20 +256,20 @@ class AnnouncementsControllerTest < ActionController::TestCase
   view_test 'index for non-english locale copes when a nil page is specified' do
     english_article = create(:published_news_article)
     spanish_article = create(:published_news_article, translated_into: [:fr])
-    get :index, locale: 'fr', page: nil
+    get :index, params: { locale: 'fr', page: nil }
 
     assert_response :success
   end
 
   view_test 'index for non-english locales only allows filtering by world location' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     assert_select '.filter', count: 1
     assert_select "select#world_locations"
   end
 
   view_test 'index for non-english locales skips results summary' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
     refute_select '.filter-results-summary'
   end
 

--- a/test/functional/api/governments_controller_test.rb
+++ b/test/functional/api/governments_controller_test.rb
@@ -36,7 +36,7 @@ class Api::GovernmentsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(foo: :bar)
     Api::GovernmentPresenter.stubs(:new).with(government, anything).returns(presenter)
 
-    get :show, id: government.slug, format: 'json'
+    get :show, params: { id: government.slug }, format: 'json'
     assert_equal 'bar', json_response['foo']
   end
 
@@ -48,13 +48,13 @@ class Api::GovernmentsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(foo: :bar)
     Api::GovernmentPresenter.stubs(:new).with(government, anything).returns(presenter)
 
-    get :show, id: government.slug, format: 'json'
+    get :show, params: { id: government.slug }, format: 'json'
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
   view_test "show responds with 404 if government is not found" do
     Government.stubs(:find_by).with(slug: 'unknown').returns nil
-    get :show, id: 'unknown', format: 'json'
+    get :show, params: { id: 'unknown' }, format: 'json'
     assert_response :not_found
     assert_equal 'not found', json_response['_response_info']['status']
   end

--- a/test/functional/api/organisations_controller_test.rb
+++ b/test/functional/api/organisations_controller_test.rb
@@ -16,7 +16,7 @@ class Api::OrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(foo: :bar)
     Api::OrganisationPresenter.stubs(:new).with(organisation, anything).returns(presenter)
 
-    get :show, id: organisation.slug, format: 'json'
+    get :show, params: { id: organisation.slug }, format: 'json'
     assert_equal 'bar', json_response['foo']
   end
 
@@ -30,7 +30,7 @@ class Api::OrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(foo: :bar)
     Api::OrganisationPresenter.stubs(:new).with(organisation, anything).returns(presenter)
 
-    get :show, id: organisation.slug, format: 'json'
+    get :show, params: { id: organisation.slug }, format: 'json'
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
@@ -38,7 +38,7 @@ class Api::OrganisationsControllerTest < ActionController::TestCase
     friendly = stub
     Organisation.stubs(:friendly).returns(friendly)
     friendly.stubs(:find).with('unknown').returns(nil)
-    get :show, id: 'unknown', format: 'json'
+    get :show, params: { id: 'unknown' }, format: 'json'
     assert_response :not_found
     assert_equal 'not found', json_response['_response_info']['status']
   end

--- a/test/functional/api/world_locations_controller_test.rb
+++ b/test/functional/api/world_locations_controller_test.rb
@@ -12,7 +12,7 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(location: :representation)
     Api::WorldLocationPresenter.stubs(:new).with(world_location, anything).returns(presenter)
 
-    get :show, id: world_location.slug, format: 'json'
+    get :show, params: { id: world_location.slug }, format: 'json'
     assert_equal 'representation', json_response['location']
   end
 
@@ -24,13 +24,13 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(location: :representation)
     Api::WorldLocationPresenter.stubs(:new).with(world_location, anything).returns(presenter)
 
-    get :show, id: world_location.slug, format: 'json'
+    get :show, params: { id: world_location.slug }, format: 'json'
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
   view_test "show responds with 404 if world location is not found" do
     WorldLocation.stubs(:find_by).with(slug: 'unknown').returns nil
-    get :show, id: 'unknown', format: 'json'
+    get :show, params: { id: 'unknown' }, format: 'json'
     assert_response :not_found
     assert_equal 'not found', json_response['_response_info']['status']
   end

--- a/test/functional/api/worldwide_organisations_controller_test.rb
+++ b/test/functional/api/worldwide_organisations_controller_test.rb
@@ -14,7 +14,7 @@ class Api::WorldwideOrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(worldwide_organisation: :representation)
     Api::WorldwideOrganisationPresenter.stubs(:new).with(worldwide_organisation, anything).returns(presenter)
 
-    get :show, id: worldwide_organisation.slug, format: 'json'
+    get :show, params: { id: worldwide_organisation.slug }, format: 'json'
     assert_equal 'representation', json_response['worldwide_organisation']
   end
 
@@ -29,7 +29,7 @@ class Api::WorldwideOrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(worldwide_organisation: :representation)
     Api::WorldwideOrganisationPresenter.stubs(:new).with(worldwide_organisation, anything).returns(presenter)
 
-    get :show, id: worldwide_organisation.slug, format: 'json'
+    get :show, params: { id: worldwide_organisation.slug }, format: 'json'
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
@@ -38,7 +38,7 @@ class Api::WorldwideOrganisationsControllerTest < ActionController::TestCase
     WorldwideOrganisation.stubs(:friendly).returns(friendly)
     friendly.stubs(:find).with('unknown').returns(nil)
 
-    get :show, id: 'unknown', format: 'json'
+    get :show, params: { id: 'unknown' }, format: 'json'
     assert_response :not_found
     assert_equal 'not found', json_response['_response_info']['status']
   end
@@ -52,7 +52,7 @@ class Api::WorldwideOrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(paged: :representation)
     Api::WorldwideOrganisationPresenter.stubs(:paginate).with(world_location.worldwide_organisations, anything).returns(presenter)
 
-    get :index, world_location_id: world_location.slug, format: 'json'
+    get :index, params: { world_location_id: world_location.slug }, format: 'json'
 
     assert_equal 'representation', json_response['paged']
   end
@@ -66,14 +66,14 @@ class Api::WorldwideOrganisationsControllerTest < ActionController::TestCase
     presenter.stubs(:as_json).returns(paged: :representation)
     Api::WorldwideOrganisationPresenter.stubs(:paginate).with(world_location.worldwide_organisations, anything).returns(presenter)
 
-    get :index, world_location_id: world_location.slug, format: 'json'
+    get :index, params: { world_location_id: world_location.slug }, format: 'json'
 
     assert_equal 'ok', json_response['_response_info']['status']
   end
 
   view_test "index responds with 404 if location not found" do
     WorldLocation.stubs(:find_by).with(slug: 'unknown').returns nil
-    get :index, world_location_id: 'unknown', format: 'json'
+    get :index, params: { world_location_id: 'unknown' }, format: 'json'
     assert_response :not_found
     assert_equal 'not found', json_response['_response_info']['status']
   end

--- a/test/functional/application_controller_analytics_test.rb
+++ b/test/functional/application_controller_analytics_test.rb
@@ -23,7 +23,7 @@ class ApplicationControllerAnalyticsTest < ActionController::TestCase
 
     with_routing do |map|
       map.draw do
-        get '/test_organisations', to: 'application_controller_analytics_test/test#test_organisations'
+        get '/test_organisations', params: { to: 'application_controller_analytics_test/test#test_organisations' }
       end
       get :test_organisations
     end
@@ -33,7 +33,7 @@ class ApplicationControllerAnalyticsTest < ActionController::TestCase
   test "sets format header for google analytics" do
     with_routing do |map|
       map.draw do
-        get '/test_format', to: 'application_controller_analytics_test/test#test_format'
+        get '/test_format', params: { to: 'application_controller_analytics_test/test#test_format' }
       end
       get :test_format
     end

--- a/test/functional/application_controller_search_parameters_test.rb
+++ b/test/functional/application_controller_search_parameters_test.rb
@@ -22,7 +22,7 @@ class ApplicationControllerSearchParametersTest < ActionController::TestCase
   test "sets filter_organisations search parameter header for orgs with scoped search" do
     with_routing do |map|
       map.draw do
-        get '/test_scoped', to: 'application_controller_search_parameters_test/test#test_scoped'
+        get '/test_scoped', params: { to: 'application_controller_search_parameters_test/test#test_scoped' }
       end
       get :test_scoped
     end
@@ -32,7 +32,7 @@ class ApplicationControllerSearchParametersTest < ActionController::TestCase
   test "doesn't set filter_organisations search parameter header for orgs without scoped search" do
     with_routing do |map|
       map.draw do
-        get '/test_unscoped', to: 'application_controller_search_parameters_test/test#test_unscoped'
+        get '/test_unscoped', params: { to: 'application_controller_search_parameters_test/test#test_unscoped' }
       end
       get :test_unscoped
     end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class AttachmentsControllerTest < ActionController::TestCase
   def get_show(attachment_data)
-    get :show, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :show, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
   end
 
   def basename(attachment_data)
@@ -95,7 +95,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     )
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
     create_thumbnail_for_upload(attachment_data.file)
-    get :show, id: attachment_data.to_param, file: attachment_data.filename, extension: 'png'
+    get :show, params: { id: attachment_data.to_param, file: attachment_data.filename, extension: 'png' }
 
     assert_response :success
     assert_match "#{attachment_data.filename}.png", response.headers['Content-Disposition']
@@ -125,7 +125,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
   test "an invalid filename returns a not found response" do
     attachment_data = create(:attachment_data)
-    get :show, id: attachment_data.to_param, file: basename(attachment_data), extension: "#{attachment_data.file_extension}missing"
+    get :show, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: "#{attachment_data.file_extension}missing" }
     assert_response :not_found
   end
 
@@ -136,7 +136,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
     login_as(:writer)
-    get :show, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :show, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :success
     assert_cache_control 'no-cache'
@@ -150,7 +150,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     ])
     attachment_data = attachment.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_equal visible_edition, assigns(:edition)
     assert_equal attachment, assigns(:attachment)
@@ -168,7 +168,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     ], organisations: [org_1, org_2, org_3])
     attachment_data = attachment.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_select 'a[href=?]', organisation_path(org_1)
     assert_select 'a[href=?]', organisation_path(org_2)
@@ -179,7 +179,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     unpublished_edition = create(:draft_publication, :with_file_attachment, attachments: [build(:csv_attachment)])
     attachment_data = unpublished_edition.attachments.first.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :not_found
   end
@@ -188,7 +188,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     visible_edition = create(:published_publication, :with_file_attachment, attachments: [build(:file_attachment)])
     attachment_data = visible_edition.attachments.first.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :not_found
   end
@@ -197,7 +197,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     unpublished_publication = create(:draft_publication, :unpublished, :with_file_attachment, attachments: [build(:csv_attachment)])
     attachment_data = unpublished_publication.attachments.first.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_redirected_to publication_url(unpublished_publication.unpublishing.slug)
   end
@@ -210,7 +210,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
     CsvPreview.expects(:new).raises(CsvPreview::FileEncodingError)
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_equal visible_edition, assigns(:edition)
     assert_equal attachment, assigns(:attachment)
@@ -224,7 +224,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     ])
     attachment_data = attachment.attachment_data
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :success
     assert_select 'p.preview-error', text: /This file could not be previewed/
@@ -235,7 +235,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :not_found
   end
@@ -246,7 +246,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
-    get :preview, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :preview, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :success
     assert_select 'div.csv-preview td', text: "Office for Facial Hair Studies"
@@ -263,7 +263,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
     attachment.update_column(:deleted, true)
 
-    get :show, id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension
+    get :show, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
     assert_response :not_found
   end

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -4,7 +4,7 @@ class ConsultationsControllerTest < ActionController::TestCase
   should_be_a_public_facing_controller
 
   test 'index redirects to the publications index filtering consultations, retaining any other filter params' do
-    get :index, topics: ["a-topic-slug"], departments: ['an-org-slug']
+    get :index, params: { topics: ["a-topic-slug"], departments: ['an-org-slug'] }
     assert_redirected_to publications_path(publication_filter_option: Whitehall::PublicationFilterOption::Consultation.slug, topics: ["a-topic-slug"], departments: ['an-org-slug'])
   end
 end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -5,14 +5,14 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
 
   view_test "show renders the summary as plain text" do
     @corporate_information_page = create(:corporate_information_page, :published, summary: "Just plain text")
-    get :show, organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug
+    get :show, params: { organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug }
 
     assert_select ".description", text: "Just plain text"
   end
 
   view_test "show renders the body as govspeak" do
     @corporate_information_page = create(:corporate_information_page, :published, body: "## Title\n\npara1\n\n")
-    get :show, organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug
+    get :show, params: { organisation_id: @corporate_information_page.organisation, id: @corporate_information_page.slug }
 
     assert_select ".body" do
       assert_select "h2", "Title"
@@ -25,7 +25,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:worldwide_organisation, world_locations: [world_location])
     corporate_information_page = create(:corporate_information_page, :published, worldwide_organisation: worldwide_organisation, organisation: nil)
 
-    get :show, organisation: nil, worldwide_organisation_id: worldwide_organisation, id: corporate_information_page.slug
+    get :show, params: { organisation: nil, worldwide_organisation_id: worldwide_organisation, id: corporate_information_page.slug }
 
     assert_select "a[href=?]", worldwide_organisation_path(worldwide_organisation)
     assert_select "a[href=?]", world_location_path(world_location)
@@ -34,14 +34,14 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
   view_test "should show description on organisation about subpage" do
     organisation = create(:organisation)
     create(:about_corporate_information_page, organisation: organisation, summary: "organisation-description")
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     assert_select ".description", text: "organisation-description"
   end
 
   view_test "should show links to the alternate languages for a translated organisation" do
     organisation = create(:organisation, translated_into: [:fr])
     create(:about_corporate_information_page, organisation: organisation, summary: "organisation-description")
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     expected_url = organisation_corporate_information_pages_path(organisation, locale: :fr)
     assert_select ".available-languages a[href='#{expected_url}']", text: Locale.new(:fr).native_language_name
   end
@@ -55,7 +55,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
       draft_corporate_publication
     ])
 
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
 
     assert_select_object(published_corporate_publication)
     refute_select_object(draft_corporate_publication)
@@ -72,7 +72,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
       middle_published_corporate_publication,
     ])
 
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
 
     assert_equal [
       new_published_corporate_publication,
@@ -85,14 +85,14 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     organisation = create(:organisation)
     corporate_information_page = create(:published_corporate_information_page, organisation: organisation)
     draft_corporate_information_page = create(:corporate_information_page, organisation: organisation, corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id)
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     assert_select "a[href='#{organisation_corporate_information_page_path(organisation, corporate_information_page.slug)}']"
     refute_select "a[href='#{organisation_corporate_information_page_path(organisation, draft_corporate_information_page.slug)}']"
   end
 
   view_test "should not display corporate information section on about-us page if there are no corporate publications" do
     organisation = create(:organisation)
-    get :index, organisation_id: organisation
+    get :index, params: { organisation_id: organisation }
     refute_select "#corporate-information"
   end
 
@@ -102,7 +102,7 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     alternative_url = Whitehall.url_maker.root_url
     cip.unpublishing.update_attributes!(redirect: true, slug: cip.slug, alternative_url: alternative_url)
 
-    get :show, organisation_id: cip.organisation, id: cip.slug
+    get :show, params: { organisation_id: cip.organisation, id: cip.slug }
     assert_response :redirect
     assert_redirected_to alternative_url
   end
@@ -119,10 +119,10 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
     # only find it for the unpublished one.
     assert_equal draft_cip.slug, cip.unpublishing.slug
 
-    get :show, organisation_id: organisation, id: cip.slug
+    get :show, params: { organisation_id: organisation, id: cip.slug }
     assert_response :redirect
 
-    get :show, organisation_id: organisation_2, id: cip.slug
+    get :show, params: { organisation_id: organisation_2, id: cip.slug }
     assert_response 404
   end
 

--- a/test/functional/documents_controller_worldwide_slimmer_headers_inclusion_test.rb
+++ b/test/functional/documents_controller_worldwide_slimmer_headers_inclusion_test.rb
@@ -7,7 +7,7 @@ class DocumentsControllerWorldwideSlimmerHeadersInclusionTest < ActionController
     edition = create(:world_location_news_article)
     force_publish(edition)
 
-    get :show, id: edition.document
+    get :show, params: { id: edition.document }
 
     assert_response :success
     expected_header_value = "<#{edition.world_locations.first.analytics_identifier}>"
@@ -18,7 +18,7 @@ class DocumentsControllerWorldwideSlimmerHeadersInclusionTest < ActionController
     edition = create(:world_location_news_article)
     force_publish(edition)
 
-    get :show, id: edition.document
+    get :show, params: { id: edition.document }
 
     assert_response :success
     expected_header_value = "<#{edition.worldwide_organisations.first.analytics_identifier}>"

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -5,14 +5,14 @@ class EmailSignupsControllerTest < ActionController::TestCase
 
   view_test 'GET :new with a valid field displays the subscription form' do
     topic = create(:topic)
-    get :new, email_signup: { feed: atom_feed_url_for(topic) }
+    get :new, params: { email_signup: { feed: atom_feed_url_for(topic) } }
 
     assert_response :success
     assert_select "input[name='email_signup[feed]'][value='#{atom_feed_url_for(topic)}']"
   end
 
   view_test 'GET :new with an invalid feed shows an error message' do
-    get :new, email_signup: { feed: 'http://nonse-feed.atom' }
+    get :new, params: { email_signup: { feed: 'http://nonse-feed.atom' } }
 
     assert_response :success
     refute_select "input[name='email_signup[feed]']"
@@ -26,7 +26,7 @@ class EmailSignupsControllerTest < ActionController::TestCase
     EmailAlertApiSignupWorker.stubs(:perform_async)
 
     topic = create(:topic)
-    post :create, email_signup: { feed: atom_feed_url_for(topic) }
+    post :create, params: { email_signup: { feed: atom_feed_url_for(topic) } }
 
     assert_response :redirect
     assert_redirected_to 'http://govdelivery_signup_url'
@@ -34,7 +34,7 @@ class EmailSignupsControllerTest < ActionController::TestCase
 
   view_test 'POST :create with an invalid email signup shows an error message' do
     Whitehall.govuk_delivery_client.expects(:topic).never
-    post :create, email_signup: { feed: 'http://gov.uk/invalid/feed.atom'}
+    post :create, params: { email_signup: { feed: 'http://gov.uk/invalid/feed.atom' } }
 
     assert_response :success
     assert_select "p", text: /we could not find a valid email alerts feed/

--- a/test/functional/historic_appointments_controller_test.rb
+++ b/test/functional/historic_appointments_controller_test.rb
@@ -29,7 +29,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     eighteenth_century_pm = create(:ministerial_role_appointment, role: pm_role, started_at: DateTime.civil(1701), ended_at: DateTime.civil(1704))
 
     chancellor_account =  create(:historical_account, roles: [chancellor_role])
-    get :index, role: 'past-prime-ministers'
+    get :index, params: { role: 'past-prime-ministers' }
 
     assert_response :success
     assert_template :index
@@ -50,7 +50,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Prime Ministers" do
     pm_account = create(:historical_account, roles: [pm_role])
     create(:role_appointment, person: pm_account.person, role: pm_role)
-    get :show, role: 'past-prime-ministers', person_id: pm_account.person.slug
+    get :show, params: { role: 'past-prime-ministers', person_id: pm_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -62,7 +62,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
   test "GET on :show loads the person, appointment and historical account for previous Chanellors" do
     chancellor_account = create(:historical_account, roles: [chancellor_role])
     create(:role_appointment, person: chancellor_account.person, role: chancellor_role)
-    get :show, role: 'past-chancellors', person_id: chancellor_account.person.slug
+    get :show, params: { role: 'past-chancellors', person_id: chancellor_account.person.slug }
 
     assert_response :success
     assert_template :show
@@ -75,7 +75,7 @@ class HistoricAppointmentsControllerTest < ActionController::TestCase
     chancellor_account = create(:historical_account, roles: [chancellor_role])
 
     assert_raise ActiveRecord::RecordNotFound do
-      get :show, role: 'past-prime-ministers', person_id: chancellor_account.person.slug
+      get :show, params: { role: 'past-prime-ministers', person_id: chancellor_account.person.slug }
     end
   end
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -50,7 +50,7 @@ class HomeControllerTest < ActionController::TestCase
     version_2.change_note = 'My new version'
     force_publish(version_2)
 
-    get :feed, format: :atom, govdelivery_version: 'yes'
+    get :feed, params: { govdelivery_version: 'yes' }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([version_2], true)

--- a/test/functional/latest_controller_test.rb
+++ b/test/functional/latest_controller_test.rb
@@ -6,7 +6,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should handle organisations' do
     organisation = create(:organisation)
 
-    get :index, departments: [organisation]
+    get :index, params: { departments: [organisation] }
 
     assert_equal organisation, @controller.send(:subject)
   end
@@ -14,7 +14,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should handle topics' do
     topic = create(:topic)
 
-    get :index, topics: [topic]
+    get :index, params: { topics: [topic] }
 
     assert_equal topic, @controller.send(:subject)
   end
@@ -22,7 +22,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should handle topical events' do
     topical_event = create(:topical_event)
 
-    get :index, topics: [topical_event]
+    get :index, params: { topics: [topical_event] }
 
     assert_equal topical_event, @controller.send(:subject)
   end
@@ -30,7 +30,7 @@ class LatestControllerTest < ActionController::TestCase
   test 'GET :index should handle world locations' do
     world_location = create(:world_location)
 
-    get :index, world_locations: [world_location]
+    get :index, params: { world_locations: [world_location] }
 
     assert_equal world_location, @controller.send(:subject)
   end
@@ -52,7 +52,7 @@ class LatestControllerTest < ActionController::TestCase
                             organisations: [organisation],
                             first_published_at: 2.days.ago)
 
-    get :index, departments: [organisation]
+    get :index, params: { departments: [organisation] }
 
     assert_equal [policy_paper, detailed_guide], @controller.send(:documents)
   end
@@ -67,7 +67,7 @@ class LatestControllerTest < ActionController::TestCase
                             organisations: [organisation],
                             first_published_at: 2.days.ago)
 
-    get :index, departments: [organisation], page: 2
+    get :index, params: { departments: [organisation], page: 2 }
 
     assert_equal [], @controller.send(:documents)
   end

--- a/test/functional/ministerial_roles_controller_test.rb
+++ b/test/functional/ministerial_roles_controller_test.rb
@@ -207,7 +207,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     published_news_article = create(:published_news_article, role_appointments: [role_appointment])
     draft_news_article = create(:draft_news_article, role_appointments: [role_appointment])
 
-    get :show, id: ministerial_role
+    get :show, params: { id: ministerial_role }
 
     assert_select_object(published_speech)
     refute_select_object(draft_speech)
@@ -226,7 +226,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     another_published_speech = create(:published_speech, role_appointment: another_role_appointment)
     another_published_news_article = create(:published_news_article, role_appointments: [another_role_appointment])
 
-    get :show, id: ministerial_role
+    get :show, params: { id: ministerial_role }
 
     assert_select ".announcements" do
       assert_select_object(published_speech)
@@ -238,7 +238,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
 
   view_test 'show has atom feed autodiscovery link' do
     ministerial_role = create(:ministerial_role)
-    get :show, id: ministerial_role
+    get :show, params: { id: ministerial_role }
     assert_select_autodiscovery_link atom_feed_url_for(ministerial_role)
   end
 
@@ -250,7 +250,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
       create(:published_speech, role_appointment: role_appointment, delivered_on: 2.days.ago.to_date)
     ]
 
-    get :show, format: :atom, id: ministerial_role
+    get :show, params: { id: ministerial_role }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries(expected_entries)
@@ -260,7 +260,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
   view_test "should not display an empty published speeches section" do
     ministerial_role = create(:ministerial_role)
 
-    get :show, id: ministerial_role
+    get :show, params: { id: ministerial_role }
 
     refute_select ".news_and_speeches"
   end
@@ -269,7 +269,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
     role = create(:ministerial_role)
     first_appointment = create(:role_appointment, role: role, started_at: 9.years.ago, ended_at: 4.years.ago)
     second_appointment = create(:role_appointment, role: role, started_at: 4.years.ago, ended_at: 5.days.ago)
-    get :show, id: role
+    get :show, params: { id: role }
 
     assert_select ".previous-roles" do
       assert_select_object first_appointment do
@@ -283,7 +283,7 @@ class MinisterialRolesControllerTest < ActionController::TestCase
 
   view_test "show links to historical appointments when the role is historic" do
     historic_role = create(:historic_role, name: 'Prime Minister')
-    get :show, id: historic_role
+    get :show, params: { id: historic_role }
 
     assert_select ".previous-roles" do
       assert_select "a[href=?]", historic_appointments_path('past-prime-ministers'), text: "past #{historic_role.name.pluralize}"

--- a/test/functional/operational_fields_controller_test.rb
+++ b/test/functional/operational_fields_controller_test.rb
@@ -10,7 +10,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
   view_test "show displays name" do
     operational_field = create(:operational_field)
 
-    get :show, id: operational_field
+    get :show, params: { id: operational_field }
 
     assert_select "h1", text: %r{#{operational_field.name}}
   end
@@ -18,7 +18,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
   view_test "shows description using govspeak" do
     operational_field = create(:operational_field, description: "description [with link](http://example.com).")
 
-    get :show, id: operational_field
+    get :show, params: { id: operational_field }
 
     assert_select ".description" do
       assert_select "a[href='http://example.com']", "with link"
@@ -26,7 +26,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
   end
 
   test "shows the first organisation found which handles fatalities" do
-    get :show, id: create(:operational_field)
+    get :show, params: { id: create(:operational_field) }
     assert_equal @organisation, assigns(:organisation)
   end
 
@@ -39,7 +39,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
 
     uk_fatality = create(:fatality_notice, operational_field: uk)
 
-    get :show, id: iraq
+    get :show, params: { id: iraq }
     assert_equal [FatalityNoticePresenter.new(iraq_fatality)], assigns(:fatality_notices)
   end
 
@@ -54,7 +54,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
     new_iraq_fatality.update_column(:first_published_at, 5.days.ago)
     new_iraq_fatality.update_column(:public_timestamp, 3.days.ago)
 
-    get :show, id: iraq
+    get :show, params: { id: iraq }
     assert_equal [
       FatalityNoticePresenter.new(new_iraq_fatality),
       FatalityNoticePresenter.new(old_iraq_fatality)
@@ -66,7 +66,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
     fatality_notice = create(:published_fatality_notice, operational_field: iraq)
     casualty = create(:fatality_notice_casualty, fatality_notice: fatality_notice)
 
-    get :show, id: iraq
+    get :show, params: { id: iraq }
 
     assert_select_object casualty
   end
@@ -93,7 +93,7 @@ class OperationalFieldsControllerTest < ActionController::TestCase
   test "should set Google Analytics organisation headers" do
     operational_field = create(:operational_field)
 
-    get :show, id: operational_field
+    get :show, params: { id: operational_field }
 
     assert_equal "<#{@organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
     assert_equal @organisation.acronym.downcase, response.headers["X-Slimmer-Page-Owner"]

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -35,7 +35,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     court = create(:court)
     hmcts_tribunal = create(:hmcts_tribunal)
 
-    get :index, courts_only: true
+    get :index, params: { courts_only: true }
 
     assert_template :courts_index
     assert_nil assigns(:organisations)
@@ -61,7 +61,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     court = create(:court)
     hmcts_tribunal = create(:hmcts_tribunal)
 
-    get :index, courts_only: true
+    get :index, params: { courts_only: true }
 
     assert_select "a[href='/courts-tribunals/#{court.slug}']", text: court.name
     assert_select "a[href='/courts-tribunals/#{hmcts_tribunal.slug}']", text: hmcts_tribunal.name
@@ -79,7 +79,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     court = create(:court)
     hmcts_tribunal = create(:hmcts_tribunal)
 
-    get :index, courts_only: true
+    get :index, params: { courts_only: true }
 
     refute_select "span.count.js-filter-count"
   end
@@ -89,7 +89,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "showing an organisation without a list of contacts doesn't try to create one" do
     # needs to be a view_test so the entire view is rendered
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     organisation.reload
     refute organisation.has_home_page_contacts_list?
@@ -109,7 +109,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     policy = publishing_api_has_policies(['test-title']).first
     create(:featured_policy, organisation: organisation, policy_content_id: policy["content_id"])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select '#corporate-info'
     assert_select '#high-profile-units'
@@ -133,7 +133,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       end
 
       Timecop.freeze(Time.zone.now + Whitehall.default_cache_max_age * 1.5) do
-        get :show, id: organisation
+        get :show, params: { id: organisation }
       end
 
       assert_cache_control("max-age=#{5.minutes}")
@@ -157,7 +157,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:role_appointment, role: chief_of_the_defence_staff, person: person)
     organisation = create_org_and_stub_content_store(:organisation, roles: [chief_of_the_defence_staff])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select_object person do
       assert_select "a[href=?]", person_path(person), text: person.name
@@ -166,7 +166,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "#show doesn't present expanded navigation for non-department organisations" do
     organisation = create_org_and_stub_content_store(:organisation, organisation_type: OrganisationType.other)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select "nav" do
       refute_select "a[href=?]", announcements_path(departments: [organisation])
       refute_select "a[href=?]", publications_path(departments: [organisation])
@@ -175,13 +175,13 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "#show uses the correct logo type branding" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select ".organisation-logo-stacked-single-identity"
   end
 
   view_test "#show indicates when an organisation is not part of the single identity branding" do
     organisation = create_org_and_stub_content_store(:organisation, organisation_logo_type_id: OrganisationLogoType::NoIdentity.id)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select ".organisation-logo-stacked-no-identity"
   end
 
@@ -192,7 +192,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       logo: fixture_file_upload('logo.png')
     )
     VirusScanHelpers.simulate_virus_scan(organisation.logo)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select %Q{img[alt="#{organisation.name}"][src*="logo.png"]}
   end
 
@@ -200,7 +200,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     organisation = create(:organisation, logo_formatted_name: "Ministry of Jam")
     sub_organisation = create_org_and_stub_content_store(:sub_organisation, name: "Marmalade Inspection Board", logo_formatted_name: "Marmalade Inspection Board", parent_organisations: [organisation])
 
-    get :show, id: sub_organisation.slug
+    get :show, params: { id: sub_organisation.slug }
 
     assert_select ".page-header" do
       assert_select "h1", text: sub_organisation.name
@@ -212,14 +212,14 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "#show uses the correct organisation brand colour" do
     organisation = create_org_and_stub_content_store(:organisation, organisation_brand_colour_id: OrganisationBrandColour::HMGovernment.id)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select ".hm-government-brand-colour"
   end
 
   test "showing a live organisation renders the show template" do
     organisation = create_org_and_stub_content_store(:organisation, govuk_status: 'live')
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'show'
   end
@@ -227,7 +227,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "showing a live promotional style organisation renders the show promotional template" do
     organisation = create_org_and_stub_content_store(:executive_office, govuk_status: 'live')
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'show-promotional'
   end
@@ -237,7 +237,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     policies = publishing_api_has_policies(['test-policy'])
     create(:featured_policy, organisation: organisation, policy_content_id: policies.first["content_id"])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#featured-policies"
   end
@@ -245,7 +245,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "showing a joining organisation renders the not live template" do
     organisation = create_org_and_stub_content_store(:organisation, govuk_status: 'joining')
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'not_live'
   end
@@ -253,7 +253,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "showing an exempt organisation renders the not live template" do
     organisation = create_org_and_stub_content_store(:organisation, govuk_status: 'exempt')
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'not_live'
   end
@@ -261,7 +261,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "showing an transitioning organisation renders the not live template" do
     organisation = create_org_and_stub_content_store(:organisation, govuk_status: 'transitioning')
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'not_live'
   end
@@ -269,7 +269,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   test "showing a closed organisation renders the not live template" do
     organisation = create_org_and_stub_content_store(:closed_organisation)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'not_live'
   end
@@ -277,7 +277,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "showing a closed organisation does not render the parent_organisations or the url" do
     organisation = create_org_and_stub_content_store(:closed_organisation)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_template 'not_live'
     refute_select ".parent_organisations"
@@ -287,7 +287,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "showing a transitioning court or tribunal does not render the parent_organisations or the url" do
     organisation = create_org_and_stub_content_store(:hmcts_tribunal, govuk_status: 'transitioning')
 
-    get :show, id: organisation, courts_only: true
+    get :show, params: { id: organisation, courts_only: true }
 
     assert_template 'not_live'
     refute_select ".parent_organisations"
@@ -298,7 +298,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     organisation = create_org_and_stub_content_store(:organisation, govuk_status: 'exempt', url: '')
     create(:published_corporate_information_page, organisation: organisation)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select ".description a[href=?]", organisation.url
     assert_select ".thumbnail", false
@@ -308,7 +308,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     organisation = create_org_and_stub_content_store(:closed_organisation, url: 'http://madeup-url.com')
     create(:published_corporate_information_page, organisation: organisation)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     refute_select ".description a[href=?]", organisation.url
     assert_select ".thumbnail", false
@@ -316,13 +316,13 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should not display an empty published policies section" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     refute_select "#policies"
   end
 
   view_test "should not display an empty published document sections" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     refute_select "#publications"
     refute_select "#consultations"
     refute_select "#announcements"
@@ -331,25 +331,25 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should not display the child organisations section" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     refute_select "#child_organisations"
   end
 
   view_test "should not display the parent organisations section" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     refute_select "#parent_organisations"
   end
 
   view_test "shows that courts are 'administered by' their parent organisation" do
     court = create_org_and_stub_content_store(:court)
-    get :show, id: court, courts_only: true
+    get :show, params: { id: court, courts_only: true }
     assert_select "p.parent-organisations", text: /Administered by\s+HMCTS/m
   end
 
   view_test "shows that HMCTS tribunals are 'administered by' HMCTS" do
     hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
-    get :show, id: hmcts_tribunal, courts_only: true
+    get :show, params: { id: hmcts_tribunal, courts_only: true }
     assert_select "p.parent-organisations", text: /Administered by\s+HMCTS/m
   end
 
@@ -358,7 +358,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     policy = publishing_api_has_policies(['Welfare reform']).first
     create(:featured_policy, organisation: organisation, policy_content_id: policy["content_id"])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#policies" do
       assert_select "a[href='#{policy["base_path"]}']", text: "Welfare reform"
@@ -380,7 +380,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:featured_policy, organisation: organisation, policy_content_id: policies[1]["content_id"])
     create(:featured_policy, organisation: organisation, policy_content_id: policies[2]["content_id"])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal first_three_policy_titles, assigns[:policies].map(&:title)
   end
@@ -393,7 +393,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     announcement_2 = create(:published_speech, role_appointment: role_appointment, first_published_at: 3.days.ago)
     announcement_3 = create(:published_news_article, organisations: [organisation], first_published_at: 1.days.ago)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [announcement_3, announcement_1], assigns[:announcements].object
   end
@@ -404,7 +404,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     announcement_2 = create(:published_speech, organisations: [organisation], first_published_at: 2.days.ago.to_date, speech_type: SpeechType::WrittenStatement)
     announcement_3 = create(:published_news_article, organisations: [organisation], first_published_at: 3.days.ago)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select '#announcements' do
       assert_select_object(announcement_1) do
@@ -426,7 +426,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     _consultation_3 = create(:published_consultation, organisations: [organisation], first_published_at: 3.days.ago)
     consultation_1 = create(:published_consultation, organisations: [organisation], first_published_at: 1.day.ago)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [consultation_1, consultation_2], assigns[:consultations].object
   end
@@ -440,7 +440,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       build(:file_attachment)
     ])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#consultations" do
       assert_select_object consultation_1 do
@@ -465,7 +465,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     consultation = create(:published_consultation, organisations: [organisation], opening_at: 1.days.ago)
     statistics_publication = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago, publication_type: PublicationType::OfficialStatistics)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [publication_1, publication_2], assigns[:non_statistics_publications].object
   end
@@ -476,7 +476,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     publication_3 = create(:published_publication, organisations: [organisation], first_published_at: 3.days.ago.to_date, publication_type: PublicationType::PolicyPaper)
     publication_1 = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago.to_date, publication_type: PublicationType::OfficialStatistics)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#publications" do
       assert_select_object publication_2 do
@@ -494,7 +494,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     publication_2 = create(:published_publication, organisations: [organisation], first_published_at: 2.days.ago, publication_type: PublicationType::OfficialStatistics)
     publication_3 = create(:published_publication, organisations: [organisation], first_published_at: 3.days.ago, publication_type: PublicationType::OfficialStatistics)
     publication_1 = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago, publication_type: PublicationType::NationalStatistics)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_equal [publication_1, publication_2], assigns[:statistics_publications].object
   end
 
@@ -504,7 +504,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     publication_3 = create(:published_publication, organisations: [organisation], first_published_at: 3.days.ago.to_date, publication_type: PublicationType::OfficialStatistics)
     publication_1 = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
@@ -523,7 +523,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     publication_1 = create(:published_publication, organisations: [organisation], first_published_at: 1.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
     publication_2 = create(:published_publication, organisations: [organisation], first_published_at: 2.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
     publication_3 = create(:published_publication, organisations: [organisation], first_published_at: 3.day.ago.to_date, publication_type: PublicationType::NationalStatistics)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_equal [publication_1, publication_2, publication_3], assigns[:recently_updated].take(3)
   end
 
@@ -531,7 +531,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     organisation = create_org_and_stub_content_store(:organisation)
     sub_organisation = create(:sub_organisation, parent_organisations: [organisation])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select ".sub_organisations" do
       assert_select_object(sub_organisation)
@@ -543,7 +543,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     pub = create(:published_publication, organisations: [organisation], first_published_at: 4.weeks.ago.to_date)
     news = create(:published_news_article, organisations: [organisation], first_published_at: 2.weeks.ago)
 
-    get :show, id: organisation, format: :atom
+    get :show, params: { id: organisation }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([news, pub])
@@ -553,7 +553,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "show should include a rel='alternate' link to the organisation's JSON representation" do
     organisation = create_org_and_stub_content_store(:organisation, name: "org-name")
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "link[rel=alternate][type='application/json'][href=?]", api_organisation_url(organisation)
   end
@@ -565,7 +565,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: junior_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: senior_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [senior_role, junior_role], assigns(:ministerial_roles).collect(&:model)
   end
@@ -577,7 +577,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: assigned_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: vacant_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [assigned_role], assigns(:ministerial_roles).collect(&:model)
   end
@@ -589,7 +589,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: junior_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: senior_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [senior_role, junior_role], assigns(:traffic_commissioner_roles).collect(&:model)
   end
@@ -601,7 +601,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: junior_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: senior_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [senior_role, junior_role], assigns(:chief_professional_officer_roles).collect(&:model)
   end
@@ -613,7 +613,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: junior_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: senior_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [senior_role, junior_role], assigns(:judge_roles).collect(&:model)
   end
@@ -625,7 +625,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:organisation_role, organisation: organisation, role: junior_role, ordering: 2)
     create(:organisation_role, organisation: organisation, role: senior_role, ordering: 1)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_equal [senior_role, junior_role], assigns(:military_roles).collect(&:model)
   end
@@ -636,7 +636,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:role_appointment, role: minister, person: person)
     organisation = create_org_and_stub_content_store(:organisation, ministerial_roles: [minister])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select_object person do
       assert_select "a[href=?]", person_path(person), text: person.name
@@ -653,7 +653,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     organisation = create_org_and_stub_content_store(:organisation, ministerial_roles: [ministerial_role_1, ministerial_role_2])
     minister_in_another_organisation = create(:ministerial_role)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select_object(person_1) do
       assert_select ".current-appointee a[href=?]", person_path(person_1), "Fred"
@@ -671,7 +671,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     person = create(:person, image: image_fixture_file)
     create(:role_appointment, person: person, role: ministerial_role)
     organisation = create_org_and_stub_content_store(:organisation, ministerial_roles: [ministerial_role])
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select "img[src*='minister-of-funk.960x640.jpg']"
   end
 
@@ -680,7 +680,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     person = create(:person)
     create(:role_appointment, person: person, role: ministerial_role)
     organisation = create_org_and_stub_content_store(:organisation, ministerial_roles: [ministerial_role])
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select "div.blank-person div.blank-person-inner"
   end
 
@@ -693,7 +693,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     create(:role_appointment, role: junior, person: junior_person)
     organisation = create_org_and_stub_content_store(:organisation, management_roles: [permanent_secretary, junior])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select management_selector do
       assert_select_object(senior_person) do
@@ -708,7 +708,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "should not display an empty management team section" do
     organisation = create_org_and_stub_content_store(:organisation, management_roles: [])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     refute_select management_selector
   end
@@ -720,7 +720,7 @@ class OrganisationsControllerTest < ActionController::TestCase
 
     organisation = create_org_and_stub_content_store(:organisation, special_representative_roles: [special_representative_role])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select special_representative_selector do
       assert_select_object(representative) do
@@ -732,7 +732,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "should not display an empty special representatives section" do
     organisation = create_org_and_stub_content_store(:organisation, special_representative_roles: [])
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     refute_select special_representative_selector
   end
@@ -740,14 +740,14 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "should place organisation brand colour css class on organisation pages" do
     organisation = create_org_and_stub_content_store(:organisation, organisation_type: OrganisationType.ministerial_department, organisation_brand_colour_id: OrganisationBrandColour::HMGovernment.id)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select "##{dom_id(organisation)}.#{organisation.organisation_brand_colour.class_name}-brand-colour.ministerial-department"
   end
 
   view_test "should show featured links if there are some" do
     organisation = create_org_and_stub_content_store(:organisation,)
     featured_link = create(:featured_link, linkable: organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select '.featured-links' do
       assert_select "a[href=?]", featured_link.url, text: featured_link.title
@@ -756,60 +756,60 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "should set slimmer analytics headers on organisation pages" do
     organisation = create_org_and_stub_content_store(:organisation, acronym: "ABC")
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_equal "<#{organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
     assert_equal organisation.acronym.downcase, response.headers["X-Slimmer-Page-Owner"]
   end
 
   view_test "should show FOI contact information if not exempt" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select '#freedom-of-information', /Make an FOI request/
   end
 
   view_test "should show FOI exemption notice if exempt" do
     organisation = create_org_and_stub_content_store(:organisation, foi_exempt: true)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select '#freedom-of-information', /not covered by the Freedom of Information Act/
   end
 
   view_test "should not show FOI for courts" do
     court = create_org_and_stub_content_store(:court)
-    get :show, id: court, courts_only: true
+    get :show, params: { id: court, courts_only: true }
     refute_select '#freedom-of-information'
   end
 
   view_test "should not show FOI for HMCTS tribunals" do
     hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
-    get :show, id: hmcts_tribunal, courts_only: true
+    get :show, params: { id: hmcts_tribunal, courts_only: true }
     refute_select '#freedom-of-information'
   end
 
   test "should not show Courts from the organisations namespace" do
     assert_raises(ActiveRecord::RecordNotFound) do
       court = create_org_and_stub_content_store(:court)
-      get :show, id: court
+      get :show, params: { id: court }
     end
   end
 
   test "should not show Tribunals from the organisations namespace" do
     assert_raises(ActiveRecord::RecordNotFound) do
       hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
-      get :show, id: hmcts_tribunal
+      get :show, params: { id: hmcts_tribunal }
     end
   end
 
   test "should not show Organisations from the courts-and-tribunals namespace" do
     assert_raises(ActiveRecord::RecordNotFound) do
       organisation = create_org_and_stub_content_store(:organisation)
-      get :show, id: organisation, courts_only: true
+      get :show, params: { id: organisation, courts_only: true }
     end
   end
 
   view_test "organisations show the 'About Us' summary and link to page under 'What we do'" do
     organisation = create_org_and_stub_content_store(:organisation, parent_organisations: [create_org_and_stub_content_store(:organisation)])
     create(:about_corporate_information_page, organisation: organisation, summary: "This is *what* we do")
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select "#what-we-do" do
       assert_select "h1", text: "What we do"
@@ -822,7 +822,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "courts show the 'About Us' body as govspeak under 'What we do', with no link to the page" do
     court = create_org_and_stub_content_store(:court)
     create(:about_corporate_information_page, organisation: court, body: "This is *who* we are")
-    get :show, id: court, courts_only: true
+    get :show, params: { id: court, courts_only: true }
 
     assert_select "#what-we-do" do
       assert_select "h1", text: "What we do"
@@ -835,7 +835,7 @@ class OrganisationsControllerTest < ActionController::TestCase
   view_test "HMCTS tribunals show the 'About Us' body as govspeak under 'Who we are', with no link to the page" do
     hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
     create(:about_corporate_information_page, organisation: hmcts_tribunal, body: "This is *who* we are")
-    get :show, id: hmcts_tribunal, courts_only: true
+    get :show, params: { id: hmcts_tribunal, courts_only: true }
 
     assert_select "#what-we-do" do
       assert_select "h1", text: "What we do"
@@ -850,7 +850,7 @@ class OrganisationsControllerTest < ActionController::TestCase
     contact = create(:contact, comments: "This is a link: http://www.example.com")
     organisation.add_contact_to_home_page!(contact)
 
-    get :show, id: organisation
+    get :show, params: { id: organisation }
 
     assert_select ".comments", text: "This is a link: http://www.example.com" do
       assert_select "a[href='http://www.example.com']", text: "http://www.example.com"
@@ -859,19 +859,19 @@ class OrganisationsControllerTest < ActionController::TestCase
 
   view_test "organisations shows the default Jobs link" do
     organisation = create_org_and_stub_content_store(:organisation)
-    get :show, id: organisation
+    get :show, params: { id: organisation }
     assert_select "a", text: "Jobs"
   end
 
   view_test "courts don't show a Jobs link" do
     court = create_org_and_stub_content_store(:court)
-    get :show, id: court, courts_only: true
+    get :show, params: { id: court, courts_only: true }
     refute_select "a", text: "Jobs"
   end
 
   view_test "HMCTS tribunals don't show a Jobs link" do
     hmcts_tribunal = create_org_and_stub_content_store(:hmcts_tribunal)
-    get :show, id: hmcts_tribunal, courts_only: true
+    get :show, params: { id: hmcts_tribunal, courts_only: true }
     refute_select "a", text: "Jobs"
   end
 

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -25,7 +25,7 @@ class PeopleControllerTest < ActionController::TestCase
   view_test "#show displays the details of the person and their roles" do
     first_appointment = create(:ministerial_role_appointment, person: @person)
     second_appointment = create(:ministerial_role_appointment, person: @person)
-    get :show, id: @person
+    get :show, params: { id: @person }
 
     assert_select "h1", text: @person.name
     assert_select ".biography", text: @person.biography
@@ -41,20 +41,20 @@ class PeopleControllerTest < ActionController::TestCase
   end
 
   view_test 'show has atom feed autodiscovery link' do
-    get :show, id: @person
+    get :show, params: { id: @person }
     assert_select_autodiscovery_link atom_feed_url_for(@person)
   end
 
   test "GET :show sets the slimmer header for the person's organisation" do
     role_appointment = create(:role_appointment, person: @person)
     organisation = role_appointment.organisations.first
-    get :show, id: @person
+    get :show, params: { id: @person }
 
     assert_equal "<#{organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
   end
 
   test 'GET :show does not set the organisations slimmer header if the person is not associated with one' do
-    get :show, id: @person
+    get :show, params: { id: @person }
 
     assert_nil response.headers["X-Slimmer-Organisations"]
   end
@@ -67,7 +67,7 @@ class PeopleControllerTest < ActionController::TestCase
       create(:published_speech, role_appointment: role_appointment, delivered_on: 2.day.ago.to_date)
     ]
 
-    get :show, format: :atom, id: person
+    get :show, params: { id: person }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries(expected_entries)
@@ -78,7 +78,7 @@ class PeopleControllerTest < ActionController::TestCase
     create(:ministerial_role_appointment, person: @person)
     rummager_has_policies_for_every_type
 
-    get :show, id: @person
+    get :show, params: { id: @person }
 
     assert_select "#policy" do
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"

--- a/test/functional/policy_groups_controller_test.rb
+++ b/test/functional/policy_groups_controller_test.rb
@@ -4,7 +4,7 @@ class PolicyGroupsControllerTest < ActionController::TestCase
   test "should redirect to the slug URL if a policy id is provided" do
     policy_group = create(:policy_group)
 
-    get :show, id: policy_group.id
+    get :show, params: { id: policy_group.id }
 
     assert_redirected_to policy_group
   end

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -73,7 +73,7 @@ class PublicFacingControllerTest < ActionController::TestCase
         @request.env['HTTP_ACCEPT'] = type
         get :test
         assert_equal 200, response.status, "mime type #{type} should be acceptable"
-        assert_equal Mime::HTML, response.content_type
+        assert_equal Mime[:html], response.content_type
       end
     end
   end
@@ -92,12 +92,12 @@ class PublicFacingControllerTest < ActionController::TestCase
     with_routing_for_test_controller do
       get :json
       assert_response :success
-      assert_equal Mime::HTML, response.content_type
+      assert_equal Mime[:html], response.content_type
       assert_equal 'html', response.body
 
       get :json, format: :json
       assert_response :success
-      assert_equal Mime::JSON, response.content_type
+      assert_equal Mime[:json], response.content_type
       assert_equal '{}', response.body
 
       get :json, format: :atom
@@ -109,7 +109,7 @@ class PublicFacingControllerTest < ActionController::TestCase
     with_routing_for_test_controller do
       get :js_or_atom
       assert_response :success
-      assert_equal Mime::HTML, response.content_type
+      assert_equal Mime[:html], response.content_type
       assert_equal 'html', response.body
 
       xhr :get, :js_or_atom
@@ -145,7 +145,7 @@ class PublicFacingControllerTest < ActionController::TestCase
   test "all public facing requests with a locale should use the given locale" do
     with_routing_for_test_controller do
       I18n.default_locale = :tr
-      get :locale, locale: 'fr'
+      get :locale, params: { locale: 'fr' }
       assert_equal 'fr', response.body
     end
   end
@@ -153,7 +153,7 @@ class PublicFacingControllerTest < ActionController::TestCase
   test "all public facing requests with a locale should reset locale back to its original value after completion" do
     with_routing_for_test_controller do
       I18n.locale = :dr
-      get :locale, locale: 'fr'
+      get :locale, params: { locale: 'fr' }
       assert_equal :dr, I18n.locale
     end
   end
@@ -190,7 +190,7 @@ class PublicFacingControllerTest < ActionController::TestCase
   def with_routing_for_test_controller(&block)
     with_routing do |map|
       map.draw do
-        get '/test/:action(.:format)', controller: 'public_facing_controller_test/test'
+        get '/test/:action(.:format)', params: { controller: 'public_facing_controller_test/test' }
       end
       yield
     end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -60,7 +60,7 @@ class PublicationsControllerTest < ActionController::TestCase
     create(:published_publication, world_locations: [@world_location_1])
     create(:published_publication, world_locations: [@world_location_2])
 
-    get :index, world_locations: [@world_location_1, @world_location_2]
+    get :index, params: { world_locations: [@world_location_1, @world_location_2] }
 
     assert_select "select#world_locations[name='world_locations[]']" do
       assert_select "option[selected='selected']", text: @world_location_1.name
@@ -71,7 +71,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index highlights selected topic filter options" do
     given_two_documents_in_two_topics
 
-    get :index, topics: [@topic_1, @topic_2]
+    get :index, params: { topics: [@topic_1, @topic_2] }
 
     assert_select "select#topics[name='topics[]']" do
       assert_select "option[selected='selected']", text: @topic_1.name
@@ -82,7 +82,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index highlights selected organisation filter options" do
     given_two_documents_in_two_organisations
 
-    get :index, departments: [@organisation_1, @organisation_2]
+    get :index, params: { departments: [@organisation_1, @organisation_2] }
 
     assert_select "select#departments[name='departments[]']" do
       assert_select "option[selected]", text: @organisation_1.name
@@ -91,19 +91,19 @@ class PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "#index shows selected publication_filter_option in the title " do
-    get :index, publication_filter_option: 'consultations'
+    get :index, params: { publication_filter_option: 'consultations' }
 
     assert_select 'h1 span', ': all consultations'
   end
 
   view_test "#index capitalises FOI in the title correctly" do
-    get :index, publication_filter_option: 'foi-releases'
+    get :index, params: { publication_filter_option: 'foi-releases' }
 
     assert_select 'h1', html: 'Publications<span>: FOI releases</span>'
   end
 
   view_test "#index highlights selected publication type filter options" do
-    get :index, publication_filter_option: "forms"
+    get :index, params: { publication_filter_option: "forms" }
 
     assert_select "select[name='publication_filter_option']" do
       assert_select "option[selected='selected']", text: Whitehall::PublicationFilterOption::Form.label
@@ -111,13 +111,13 @@ class PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "#index displays filter keywords" do
-    get :index, keywords: "olympics 2012"
+    get :index, params: { keywords: "olympics 2012" }
 
     assert_select "input[name='keywords'][value=?]", "olympics 2012"
   end
 
   view_test "#index displays date filter" do
-    get :index, from_date: "01/01/2011", to_date: "01/02/2012"
+    get :index, params: { from_date: "01/01/2011", to_date: "01/02/2012" }
 
     assert_select "input#from_date[name='from_date'][value='01/01/2011']"
     assert_select "input#to_date[name='to_date'][value='01/02/2012']"
@@ -196,26 +196,26 @@ class PublicationsControllerTest < ActionController::TestCase
     english_publication = create(:published_publication)
     french_publication = create(:published_publication, translated_into: [:fr])
 
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     assert_select_object french_publication
     refute_select_object english_publication
   end
 
   view_test '#index for non-english locales only allows filtering by world location' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     assert_select '.filter', count: 1
     assert_select '.filter #world_locations'
   end
 
   view_test '#index for non-english locales skips results summary' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
     refute_select '.filter-results-summary'
   end
 
   test '#index for statistics document type redirect to statistics index' do
-    get :index, publication_filter_option: 'statistics', keywords: 'wombles'
+    get :index, params: { publication_filter_option: 'statistics', keywords: 'wombles' }
     assert_redirected_to statistics_path(keywords: 'wombles')
   end
 
@@ -223,7 +223,7 @@ class PublicationsControllerTest < ActionController::TestCase
     regulation = create(:published_publication, publication_type_id: PublicationType::Regulation.id)
     guidance = create(:published_publication, publication_type_id: PublicationType::Guidance.id)
 
-    get :index, publication_filter_option: 'regulations'
+    get :index, params: { publication_filter_option: 'regulations' }
 
     assert_select_object(regulation)
     refute_select_object(guidance)
@@ -278,7 +278,7 @@ class PublicationsControllerTest < ActionController::TestCase
     create(:topic, name: "topic-1")
     create(:organisation, name: "organisation-1")
 
-    get :index, format: :json, topics: ["topic-1"], departments: ["organisation-1"]
+    get :index, params: { topics: ["topic-1"], departments: ["organisation-1"] }, format: :json
 
     json = ActiveSupport::JSON.decode(response.body)
 
@@ -288,7 +288,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index requested as JSON includes atom feed URL without date parameters" do
     create(:topic, name: "topic-1")
 
-    get :index, format: :json, from_date: "2012-01-01", topics: ["topic-1"]
+    get :index, params: { from_date: "2012-01-01", topics: ["topic-1"] }, format: :json
 
     json = ActiveSupport::JSON.decode(response.body)
 
@@ -296,7 +296,7 @@ class PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "#index requested as JSON includes email signup path without date parameters" do
-    get :index, format: :json, to_date: "2012-01-01"
+    get :index, params: { to_date: "2012-01-01" }, format: :json
 
     json = ActiveSupport::JSON.decode(response.body)
 
@@ -309,7 +309,7 @@ class PublicationsControllerTest < ActionController::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, format: :json, from_date: "2012-01-01", topics: [topic.slug], departments: [organisation.slug]
+    get :index, params: { from_date: "2012-01-01", topics: [topic.slug], departments: [organisation.slug] }, format: :json
 
     json = ActiveSupport::JSON.decode(response.body)
     atom_url = publications_url(format: "atom", topics: [topic.slug], departments: [organisation.slug], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
@@ -326,7 +326,7 @@ class PublicationsControllerTest < ActionController::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, topics: [topic], departments: [organisation]
+    get :index, params: { topics: [topic], departments: [organisation] }
 
     assert_select_autodiscovery_link publications_url(format: "atom", topics: [topic], departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
   end
@@ -334,7 +334,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test '#index atom feed autodiscovery link does not include date filter' do
     topic = create(:topic)
 
-    get :index, topics: [topic], to_date: "2012-01-01"
+    get :index, params: { topics: [topic], to_date: "2012-01-01" }
 
     assert_select_autodiscovery_link publications_url(format: "atom", topics: [topic], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
   end
@@ -343,7 +343,7 @@ class PublicationsControllerTest < ActionController::TestCase
     topic = create(:topic)
     organisation = create(:organisation)
 
-    get :index, topics: [topic], departments: [organisation]
+    get :index, params: { topics: [topic], departments: [organisation] }
 
     feed_url = publications_url(format: "atom", topics: [topic], departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
     assert_select "a.feed[href=?]", feed_url
@@ -352,7 +352,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test '#index shows a link to the atom feed without any date filters' do
     organisation = create(:organisation)
 
-    get :index, from_date: "2012-01-01", departments: [organisation]
+    get :index, params: { from_date: "2012-01-01", departments: [organisation] }
 
     feed_url = publications_url(format: "atom", departments: [organisation], host: Whitehall.public_host, protocol: Whitehall.public_protocol)
     assert_select "a.feed[href=?]", feed_url
@@ -361,7 +361,7 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index generates an atom feed for the current filter" do
     org = create(:organisation, name: "org-name")
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select 'feed > id', 1
@@ -381,7 +381,7 @@ class PublicationsControllerTest < ActionController::TestCase
     c1 = create(:published_consultation, organisations: [org], opening_at: 1.day.ago)
     p2 = create(:published_publication, organisations: [other_org])
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([c1, p1])
@@ -394,7 +394,7 @@ class PublicationsControllerTest < ActionController::TestCase
     document = create(:published_consultation, organisations: [org], opening_at: Date.parse('2001-12-12'))
     create(:published_consultation, organisations: [other_org])
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([document])

--- a/test/functional/statistics_announcements_controller_test.rb
+++ b/test/functional/statistics_announcements_controller_test.rb
@@ -7,11 +7,13 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
     organisation = create :organisation
     topic = create :topic
 
-    get :index, keywords: "wombats",
-                from_date: "2050-02-02",
-                to_date: "2055-01-01",
-                organisations: [organisation.slug],
-                topics: [topic.slug]
+    get :index, params: {
+                  keywords: "wombats",
+                  from_date: "2050-02-02",
+                  to_date: "2055-01-01",
+                  organisations: [organisation.slug],
+                  topics: [topic.slug]
+                }
 
     assert assigns(:filter).is_a? Frontend::StatisticsAnnouncementsFilter
     assert_equal "wombats", assigns(:filter).keywords
@@ -61,7 +63,7 @@ class StatisticsAnnouncementsControllerTest < ActionController::TestCase
   end
 
   test "#index with dodgy params" do
-    get :index, topics: [{ hax: 1 }]
+    get :index, params: { topics: [{ hax: 1 }] }
     assert_response :success
   end
 

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -47,7 +47,7 @@ class StatisticsControllerTest < ActionController::TestCase
   view_test "#index highlights selected topic filter options" do
     given_two_statistics_publications_in_two_topics
 
-    get :index, topics: [@topic_1, @topic_2]
+    get :index, params: { topics: [@topic_1, @topic_2] }
 
     assert_select "select#topics[name='topics[]']" do
       assert_select "option[selected='selected']", text: @topic_1.name
@@ -58,7 +58,7 @@ class StatisticsControllerTest < ActionController::TestCase
   view_test "#index highlights selected organisation filter options" do
     given_two_statistics_publications_in_two_organisations
 
-    get :index, departments: [@organisation_1, @organisation_2]
+    get :index, params: { departments: [@organisation_1, @organisation_2] }
 
     assert_select "select#departments[name='departments[]']" do
       assert_select "option[selected]", text: @organisation_1.name
@@ -79,13 +79,13 @@ class StatisticsControllerTest < ActionController::TestCase
   end
 
   view_test "#index displays filter keywords" do
-    get :index, keywords: "olympics 2012"
+    get :index, params: { keywords: "olympics 2012" }
 
     assert_select "input[name='keywords'][value=?]", "olympics 2012"
   end
 
   view_test "#index displays date filter" do
-    get :index, from_date: "01/01/2011", to_date: "01/02/2012"
+    get :index, params: { from_date: "01/01/2011", to_date: "01/02/2012" }
 
     assert_select "input#from_date[name='from_date'][value='01/01/2011']"
     assert_select "input#to_date[name='to_date'][value='01/02/2012']"
@@ -110,20 +110,20 @@ class StatisticsControllerTest < ActionController::TestCase
     english_publication = create(:published_statistics)
     french_publication = create(:published_statistics, translated_into: [:fr])
 
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     assert_select_object french_publication
     refute_select_object english_publication
   end
 
   view_test '#index for non-english locales does not allow any filtering' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
 
     refute_select '.filter'
   end
 
   view_test '#index for non-english locales skips results summary' do
-    get :index, locale: 'fr'
+    get :index, params: { locale: 'fr' }
     refute_select '.filter-results-summary'
   end
 
@@ -189,7 +189,7 @@ class StatisticsControllerTest < ActionController::TestCase
                                                            organisations: [org, org2],
                                                            first_published_at: Date.parse("2012-03-14"))
 
-    get :index, format: :atom, departments: [org.to_param]
+    get :index, params: { departments: [org.to_param] }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([statistics_publication])

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -14,7 +14,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
     news_article_featuring = create(:classification_featuring, classification: topical_event, edition: news_article, ordering: 0)
     publication_featuring = create(:classification_featuring, classification: topical_event, edition: publication, ordering: 1)
 
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
 
     assert_equal [news_article_featuring, publication_featuring], assigns(:featurings)
   end
@@ -27,7 +27,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
       editions << create(:classification_featuring, edition: edition, classification: topical_event, ordering: i)
     end
 
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
     parsed_response = Nokogiri::HTML::Document.parse(response.body)
     assert_equal 5, parsed_response.css('.featured-news .feature').length
   end
@@ -35,7 +35,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
   view_test 'show has a link to the atom feed' do
     event = create_topical_event_and_stub_in_content_store
 
-    get :show, id: event
+    get :show, params: { id: event }
 
     assert_select "a.feed[href=?]", atom_feed_url_for(event)
   end
@@ -43,7 +43,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
   view_test 'show has a link to email signup page' do
     event = create_topical_event_and_stub_in_content_store
 
-    get :show, id: event
+    get :show, params: { id: event }
 
     assert_select ".govdelivery[href='#{new_email_signups_path(email_signup: { feed: atom_feed_url_for(event) })}']"
   end
@@ -52,7 +52,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
     topical_event = create_topical_event_and_stub_in_content_store(name: 'First World War Centenary')
     create(:organisation_classification, lead: true, classification: topical_event)
 
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
 
     assert_select '.arts-council-england'
     assert_select '.bbc'
@@ -68,7 +68,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
     topical_event = create_topical_event_and_stub_in_content_store(name: 'Something exciting')
     create(:organisation_classification, lead: true, classification: topical_event)
 
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
 
     refute_select '.arts-council-england'
     refute_select '.bbc'
@@ -83,7 +83,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
   test "sets a meta description" do
     topical_event = create_topical_event_and_stub_in_content_store(description: 'my description')
 
-    get :show, id: topical_event
+    get :show, params: { id: topical_event }
 
     assert_equal 'my description', assigns(:meta_description)
   end
@@ -92,7 +92,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
     topical_event = create_topical_event_and_stub_in_content_store
     publication = create(:published_publication, topical_events: [topical_event])
 
-    get :show, id: topical_event, format: :atom
+    get :show, params: { id: topical_event }, format: :atom
 
     assert_select_atom_feed do
       assert_select 'feed > id', 1

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -17,7 +17,7 @@ class TopicsControllerTest < ActionController::TestCase
 
     controller.expects(:expire_on_next_scheduled_publication).with(topic.scheduled_editions)
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "h1", text: topic.name
     assert_select ".govspeak", text: topic.description
@@ -28,7 +28,7 @@ class TopicsControllerTest < ActionController::TestCase
 
   view_test "GET :show includes the data tracking module" do
     topic = create_topic_and_stub_content_store
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select(".topic[data-module='track-click']")
   end
@@ -42,7 +42,7 @@ class TopicsControllerTest < ActionController::TestCase
       })
     end
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "#publications" do
       published.take(3).each_with_index do |edition, edition_index|
@@ -75,7 +75,7 @@ class TopicsControllerTest < ActionController::TestCase
       })
     end
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "#consultations" do
       published.take(3).each_with_index do |edition, edition_index|
@@ -104,7 +104,7 @@ class TopicsControllerTest < ActionController::TestCase
       })
     end
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "#statistics" do
       published.take(3).each_with_index do |edition, edition_index|
@@ -133,7 +133,7 @@ class TopicsControllerTest < ActionController::TestCase
       })
     end
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "#announcements" do
       published.take(3).each_with_index do |edition, edition_index|
@@ -164,7 +164,7 @@ class TopicsControllerTest < ActionController::TestCase
     end
     topic = create_topic_and_stub_content_store(editions: published_detailed_guides)
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select ".detailed-guidance" do
       published_detailed_guides.take(5).each_with_index do |guide, guide_index|
@@ -196,7 +196,7 @@ class TopicsControllerTest < ActionController::TestCase
     publication_2 = create(:published_publication, topics: [topic])
     create(:classification_featuring, classification: topic, edition: publication_1)
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_select "#recently-updated" do
       assert_select_prefix_object publication_1, prefix = "recent"
@@ -212,7 +212,7 @@ class TopicsControllerTest < ActionController::TestCase
     topic = create_topic_and_stub_content_store
     publication = create(:published_publication, topics: [topic])
 
-    get :show, id: topic, format: :atom
+    get :show, params: { id: topic }, format: :atom
 
     assert_select_atom_feed do
       assert_select 'feed > id', 1
@@ -228,7 +228,7 @@ class TopicsControllerTest < ActionController::TestCase
 
   test 'GET :show has a 5 minute expiry time' do
     topic = create_topic_and_stub_content_store
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_cache_control("max-age=#{5.minutes}")
   end
@@ -237,7 +237,7 @@ class TopicsControllerTest < ActionController::TestCase
     topic = create_topic_and_stub_content_store
     create(:scheduled_publication, scheduled_publication: 1.day.from_now, topics: [topic])
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_cache_control("max-age=#{5.minutes}")
   end
@@ -247,7 +247,7 @@ class TopicsControllerTest < ActionController::TestCase
     topic = create_topic_and_stub_content_store
     topic.organisations << organisation
 
-    get :show, id: topic
+    get :show, params: { id: topic }
 
     assert_equal "<#{organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
   end

--- a/test/functional/world_location_news_articles_controller_test.rb
+++ b/test/functional/world_location_news_articles_controller_test.rb
@@ -10,7 +10,7 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
 
   test "shows published world location news article" do
     world_news_article = create(:published_world_location_news_article)
-    get :show, id: world_news_article.document
+    get :show, params: { id: world_news_article.document }
     assert_response :success
   end
 
@@ -21,7 +21,7 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
 
   view_test "renders the world location news article summary from plain text" do
     world_news_article = create(:published_world_location_news_article, summary: 'plain *text* & so on')
-    get :show, id: world_news_article.document
+    get :show, params: { id: world_news_article.document }
 
     assert_select ".summary", text: "plain *text* & so on"
   end
@@ -29,7 +29,7 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
   view_test "renders the world location news article body using govspeak" do
     world_news_article = create(:published_world_location_news_article, body: "body-in-govspeak")
     govspeak_transformation_fixture "body-in-govspeak" => "body-in-html" do
-      get :show, id: world_news_article.document
+      get :show, params: { id: world_news_article.document }
     end
 
     assert_select ".body", text: "body-in-html"
@@ -43,7 +43,7 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
     updated_world_news_article.change_note = "change-note"
     force_publish(updated_world_news_article)
 
-    get :show, id: updated_world_news_article.document
+    get :show, params: { id: updated_world_news_article.document }
 
     assert_select ".meta" do
       assert_select ".date[datetime='#{world_news_article.first_published_at.iso8601}']"
@@ -54,7 +54,7 @@ class WorldLocationNewsArticlesControllerTest < ActionController::TestCase
   test "the format name is being set to news" do
     world_news_article = create(:published_world_location_news_article)
 
-    get :show, id: world_news_article.document
+    get :show, params: { id: world_news_article.document }
 
     assert_equal "news", response.headers["X-Slimmer-Format"]
   end

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -28,23 +28,23 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
 
   test "index responds with not found if appropriate translation doesn't exist" do
     assert_raise(ActiveRecord::RecordNotFound) do
-      get :index, world_location_id: @world_location, locale: 'fr'
+      get :index, params: { world_location_id: @world_location, locale: 'fr' }
     end
   end
 
   test "index when asked for json should redirect to the api controller" do
-    get :index, world_location_id: @world_location, format: :json
+    get :index, params: { world_location_id: @world_location }, format: :json
     assert_redirected_to api_world_location_path(@world_location, format: :json)
   end
 
   view_test 'index has atom feed autodiscovery link' do
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
 
     assert_select_autodiscovery_link atom_feed_url_for(@world_location)
   end
 
   view_test 'index includes a link to the atom feed' do
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
 
     assert_select "a.feed[href=?]", atom_feed_url_for(@world_location)
   end
@@ -53,7 +53,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     pub = create(:published_publication, world_locations: [@world_location], first_published_at: 1.week.ago.to_date)
     news = create(:published_news_article, world_locations: [@world_location], first_published_at: 1.day.ago)
 
-    get :index, world_location_id: @world_location, format: :atom
+    get :index, params: { world_location_id: @world_location }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([news, pub])
@@ -68,7 +68,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     feature_list = create(:feature_list, featurable: @world_location, locale: :en)
     create(:feature, feature_list: feature_list, document: news.document)
 
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
 
     assert_featured_editions [news]
   end
@@ -98,7 +98,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     feature_list = create(:feature_list, featurable: @world_location, locale: :en)
     create(:feature, feature_list: feature_list, document: news.document, started_at: 2.days.ago, ended_at: 1.day.ago)
 
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
     assert_featured_editions []
   end
 
@@ -109,7 +109,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
       create(:feature, feature_list: english, document: news_article.document)
     end
 
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
 
     assert_equal 5, assigns(:feature_list).current_feature_count
   end
@@ -125,7 +125,7 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     announcement1 = create(:published_news_article, world_locations: [@world_location], first_published_at: 1.day.ago)
     create(:published_speech, world_locations: [@world_location], first_published_at: 3.days.ago)
 
-    get :index, world_location_id: @world_location
+    get :index, params: { world_location_id: @world_location }
 
     assert_equal [announcement1, announcement2], assigns[:announcements].object
   end

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -37,14 +37,14 @@ class WorldLocationsControllerTest < ActionController::TestCase
       title: "UK in country-name",
       mission_statement: "country-mission-statement"
     )
-    get :show, id: world_location
+    get :show, params: { id: world_location }
     assert_select "h1", text: "UK in country-name"
     assert_select ".mission_statement", text: "country-mission-statement"
   end
 
   view_test "should use govspeak when displaying the mission_statement" do
     world_location = create(:world_location, mission_statement: "Line 1\n\nLine 2")
-    get :show, id: world_location
+    get :show, params: { id: world_location }
     assert_select ".mission_statement p", /Line 1/
     assert_select ".mission_statement p", /Line 2/
     assert_select ".mission_statement p", count: 2
@@ -53,20 +53,20 @@ class WorldLocationsControllerTest < ActionController::TestCase
   test "show responds with not found if appropriate translation doesn't exist" do
     world_location = create(:world_location)
     assert_raise(ActiveRecord::RecordNotFound) do
-      get :show, id: world_location, locale: 'fr'
+      get :show, params: { id: world_location, locale: 'fr' }
     end
   end
 
   test "show when asked for json should redirect to the api controller" do
     world_location = create(:world_location)
-    get :show, id: world_location, format: :json
+    get :show, params: { id: world_location }, format: :json
     assert_redirected_to api_world_location_path(world_location, format: :json)
   end
 
   view_test 'show has atom feed autodiscovery link' do
     world_location = create(:world_location)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select_autodiscovery_link atom_feed_url_for(world_location)
   end
@@ -74,7 +74,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   view_test 'show includes a link to the atom feed' do
     world_location = create(:world_location)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select "a.feed[href=?]", atom_feed_url_for(world_location)
   end
@@ -84,7 +84,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     pub = create(:published_publication, world_locations: [world_location], first_published_at: 1.week.ago.to_date)
     news = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
 
-    get :show, id: world_location, format: :atom
+    get :show, params: { id: world_location }, format: :atom
 
     assert_select_atom_feed do
       assert_select_atom_entries([news, pub])
@@ -101,7 +101,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     feature_list = create(:feature_list, featurable: world_location, locale: :en)
     create(:feature, feature_list: feature_list, document: news.document)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_featured_editions [news]
   end
@@ -119,10 +119,10 @@ class WorldLocationsControllerTest < ActionController::TestCase
     create(:feature, feature_list: french, ordering: 1, document: less_recent_news_article.document)
     create(:feature, feature_list: french, ordering: 2, document: more_recent_news_article.document)
 
-    get :show, id: world_location, locale: :fr
+    get :show, params: { id: world_location, locale: :fr }
     assert_featured_editions [less_recent_news_article, more_recent_news_article]
 
-    get :show, id: world_location, locale: :en
+    get :show, params: { id: world_location, locale: :en }
     assert_featured_editions [less_recent_news_article]
   end
 
@@ -133,7 +133,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     feature_list = create(:feature_list, featurable: world_location, locale: :en)
     create(:feature, feature_list: feature_list, document: news.document, started_at: 2.days.ago, ended_at: 1.day.ago)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
     assert_featured_editions []
   end
 
@@ -145,7 +145,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
       create(:feature, feature_list: english, document: news_article.document)
     end
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_equal 5, assigns(:feature_list).current_feature_count
   end
@@ -153,7 +153,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   test "show should set world location slimmer headers" do
     world_location = create(:world_location)
 
-    get :show, id: world_location.id
+    get :show, params: { id: world_location.id }
 
     assert_equal "<#{world_location.analytics_identifier}>", response.headers["X-Slimmer-World-Locations"]
   end
@@ -161,7 +161,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
   test "show should set organisations slimmer headers" do
     world_location = create(:world_location, :with_worldwide_organisations)
 
-    get :show, id: world_location.id
+    get :show, params: { id: world_location.id }
 
     related_organisations = world_location.worldwide_organisations_with_sponsoring_organisations
     assert_equal "<#{related_organisations.map(&:analytics_identifier).join('><')}>", response.headers["X-Slimmer-Organisations"]
@@ -169,7 +169,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
   test "GET :show does not set empty slimmer header for locations without an org" do
     world_location = create(:world_location)
-    get :show, id: world_location.id
+    get :show, params: { id: world_location.id }
 
     assert_nil response.headers["X-Slimmer-Organisations"]
   end
@@ -180,7 +180,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     announcement_3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
     announcement_1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_equal [announcement_1, announcement_2], assigns[:announcements].object
   end
@@ -191,7 +191,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     announcement_3 = create(:published_speech, world_locations: [world_location], first_published_at: 3.days.ago)
     announcement_1 = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select "#announcements" do
       assert_select_object announcement_1 do
@@ -214,7 +214,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
 
     statistics_publication = create(:published_statistics, world_locations: [world_location], first_published_at: 1.day.ago)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_equal [publication_1, publication_2], assigns[:non_statistics_publications].object
   end
@@ -225,7 +225,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     publication_3 = create(:published_policy_paper, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
     publication_1 = create(:published_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select "#publications" do
       assert_select_object publication_2 do
@@ -243,7 +243,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     publication_2 = create(:published_statistics, world_locations: [world_location], first_published_at: 2.days.ago)
     publication_3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago)
     publication_1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago)
-    get :show, id: world_location
+    get :show, params: { id: world_location }
     assert_equal [publication_1, publication_2], assigns[:statistics_publications].object
   end
 
@@ -253,7 +253,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     publication_3 = create(:published_statistics, world_locations: [world_location], first_published_at: 3.days.ago.to_date)
     publication_1 = create(:published_national_statistics, world_locations: [world_location], first_published_at: 1.day.ago.to_date)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select "#statistics-publications" do
       assert_select_object publication_1 do
@@ -272,7 +272,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     create(:published_news_article, world_locations: [world_location], translated_into: [:fr])
 
-    get :show, id: world_location, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }
 
     assert_select ".type", "Localisation"
     assert_select "#publications .see-all a", /Voir toutes nos publications/
@@ -284,7 +284,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     translated_speech = create(:published_speech, world_locations: [world_location], translated_into: [:fr])
     untranslated_speech = create(:published_speech, world_locations: [world_location])
 
-    get :show, id: world_location, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }
 
     assert_equal [translated_speech], assigns(:announcements).object
   end
@@ -295,7 +295,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     translated_publication = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     untranslated_publication = create(:published_publication, world_locations: [world_location])
 
-    get :show, id: world_location, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }
 
     assert_equal [translated_publication], assigns(:non_statistics_publications).object
   end
@@ -306,7 +306,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     translated_statistics = create(:published_statistics, world_locations: [world_location], translated_into: [:fr])
     untranslated_statistics = create(:published_statistics, world_locations: [world_location])
 
-    get :show, id: world_location, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }
 
     assert_equal [translated_statistics], assigns(:statistics_publications).object
   end
@@ -317,7 +317,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     translated_publication = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     untranslated_publication = create(:published_publication, world_locations: [world_location])
 
-    get :show, id: world_location, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }
 
     assert_equal [translated_publication], assigns(:recently_updated)
   end
@@ -328,7 +328,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     translated_edition = create(:published_publication, world_locations: [world_location], translated_into: [:fr])
     untranslated_edition = create(:published_publication, world_locations: [world_location])
 
-    get :show, id: world_location, format: :atom, locale: 'fr'
+    get :show, params: { id: world_location, locale: 'fr' }, format: :atom
 
     assert_select_atom_feed do
       with_locale :fr do
@@ -341,7 +341,7 @@ class WorldLocationsControllerTest < ActionController::TestCase
     world_location = create(:world_location)
     featured_link = create(:featured_link, linkable: world_location)
 
-    get :show, id: world_location
+    get :show, params: { id: world_location }
 
     assert_select '.featured-links' do
       assert_select "a[href='#{featured_link.url}']", text: featured_link.title

--- a/test/functional/worldwide_offices_controller_test.rb
+++ b/test/functional/worldwide_offices_controller_test.rb
@@ -6,7 +6,7 @@ class WorldwideOfficesControllerTest < ActionController::TestCase
   end
 
   test "get #show loads the office and renders the show template" do
-    get :show, worldwide_organisation_id: @worldwide_office.worldwide_organisation_id, id: @worldwide_office
+    get :show, params: { worldwide_organisation_id: @worldwide_office.worldwide_organisation_id, id: @worldwide_office }
 
     assert_response :success
     assert_template :show
@@ -16,7 +16,7 @@ class WorldwideOfficesControllerTest < ActionController::TestCase
 
   test "does not load offices from other organisation as there may be slug clashes" do
     assert_raise ActiveRecord::RecordNotFound do
-      get :show, worldwide_organisation_id: create(:worldwide_organisation), id: @worldwide_office
+      get :show, params: { worldwide_organisation_id: create(:worldwide_organisation), id: @worldwide_office }
     end
   end
 end

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -5,7 +5,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "shows worldwide organisation information" do
     organisation = create(:worldwide_organisation)
-    get :show, id: organisation.id
+    get :show, params: { id: organisation.id }
     assert_equal organisation, assigns(:worldwide_organisation)
   end
 
@@ -13,7 +13,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     organisation = create(:worldwide_organisation)
     create(:about_corporate_information_page, organisation: nil, worldwide_organisation: organisation, summary: 'my summary')
 
-    get :show, id: organisation.id
+    get :show, params: { id: organisation.id }
 
     assert_equal 'my summary', assigns(:meta_description)
   end
@@ -22,7 +22,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     organisation = create(:worldwide_organisation, :translated, :with_sponsorships)
     sponsoring_organisation = organisation.sponsoring_organisations.first
 
-    get :show, id: organisation.id
+    get :show, params: { id: organisation.id }
 
     expected_header_value = "<#{organisation.analytics_identifier}><#{sponsoring_organisation.analytics_identifier}>"
     assert_equal expected_header_value, response.headers["X-Slimmer-Organisations"]
@@ -32,7 +32,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     world_location = create(:world_location)
     organisation = create(:worldwide_organisation, world_locations: [world_location])
 
-    get :show, id: organisation.id
+    get :show, params: { id: organisation.id }
 
     assert_equal "<#{world_location.analytics_identifier}>", response.headers["X-Slimmer-World-Locations"]
   end
@@ -42,7 +42,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     location_2 = create(:world_location)
     organisation = create(:worldwide_organisation, world_locations: [location_1, location_2])
 
-    get :show, id: organisation.id
+    get :show, params: { id: organisation.id }
 
     assert_select "a[href='#{world_location_path(location_1)}']"
     assert_select "a[href='#{world_location_path(location_2)}']"
@@ -50,7 +50,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   test "show redirects to the api worldwide organisation endpoint when json is requested" do
     organisation = create(:worldwide_organisation)
-    get :show, id: organisation.id, format: :json
+    get :show, params: { id: organisation.id }, format: :json
     assert_redirected_to api_worldwide_organisation_path(organisation, format: :json)
   end
 
@@ -58,7 +58,7 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     # needs to be a view_test so the entire view is rendered
     worldwide_organisation = create(:worldwide_organisation)
     worldwide_organisation.main_office = create(:worldwide_office, worldwide_organisation: worldwide_organisation)
-    get :show, id: worldwide_organisation
+    get :show, params: { id: worldwide_organisation }
 
     worldwide_organisation.reload
     refute worldwide_organisation.has_home_page_offices_list?

--- a/test/integration/csrf_test.rb
+++ b/test/integration/csrf_test.rb
@@ -28,14 +28,14 @@ class CsrfTest < ActionController::TestCase
   test "does not raise an exception with a valid CSRF token" do
     with_test_routes do
       session["_csrf_token"] = SecureRandom.base64(32)
-      post :create, authenticity_token: session["_csrf_token"]
+      post :create, params: { authenticity_token: session["_csrf_token"] }
     end
   end
 
   def with_test_routes(&block)
     with_routing do |map|
       map.draw do
-        post '/post_csrf', to: 'csrf_test/test_admin#create'
+        post '/post_csrf', params: { to: 'csrf_test/test_admin#create' }
       end
       yield block
     end

--- a/test/integration/upload_access_test.rb
+++ b/test/integration/upload_access_test.rb
@@ -19,7 +19,7 @@ class UploadAccessTest < ActionDispatch::IntegrationTest
   end
 
   def get_via_nginx(path)
-    get path, {}, {
+    get path, params: {}, headers: {
       "HTTP_X_SENDFILE_TYPE" => "X-Accel-Redirect",
       "HTTP_X_ACCEL_MAPPING" => "#{Whitehall.clean_uploads_root}/=/clean-uploads/"
     }

--- a/test/support/admin_controller_test_helpers.rb
+++ b/test/support/admin_controller_test_helpers.rb
@@ -13,12 +13,17 @@ module AdminControllerTestHelpers
       test "creating should be able to create a new social media account for the #{type}" do
         social_media_service = create(:social_media_service)
 
-        post :create, type => attributes_for(type).merge(
-          social_media_accounts_attributes: {"0" => {
-          social_media_service_id: social_media_service.id,
-          url: "https://twitter.com/#!/bisgovuk"
-        }}
-        )
+        post :create, params: {
+          type => attributes_for(type).merge(
+            social_media_accounts_attributes: {
+              "0" =>
+              {
+                social_media_service_id: social_media_service.id,
+                url: "https://twitter.com/#!/bisgovuk"
+              }
+            }
+          )
+        }
 
         assert object = target_class.last
         assert social_media_account = object.social_media_accounts.last
@@ -27,14 +32,20 @@ module AdminControllerTestHelpers
       end
 
       test "creating with invalid data should build another social media account" do
-        post :create, type => attributes_for(type).merge(name: '')
+        post :create, params: { type => attributes_for(type).merge(name: '') }
         assert_kind_of SocialMediaAccount, assigns(type).social_media_accounts.first
       end
 
       test "creating ignores blank social media accounts" do
-        post :create, type => attributes_for(type).merge(
-          social_media_accounts_attributes: {"0" => {social_media_service_id: "", url: "" }}
-        )
+        post :create, params: {
+          type => attributes_for(type).merge(
+            social_media_accounts_attributes: {
+              "0" => {
+                social_media_service_id: "", url: ""
+              }
+            }
+          )
+        }
 
         assert created_object = target_class.last
         assert_equal 0, created_object.social_media_accounts.size
@@ -45,7 +56,7 @@ module AdminControllerTestHelpers
         account = create(:social_media_account, social_media_service: twitter, url: "http://twitter.com/foo")
         object = create(type, social_media_accounts: [account])
 
-        get :edit, id: object
+        get :edit, params: { id: object }
 
         assert assigns(type).social_media_accounts.all? { |o| o.kind_of? SocialMediaAccount }
         assert assigns(type).social_media_accounts.last.new_record?
@@ -55,12 +66,12 @@ module AdminControllerTestHelpers
         object = create(type)
         social_media_service = create(:social_media_service)
 
-        put :update, id: object, type => object.attributes.merge(
+        put :update, params: { id: object, type => object.attributes.merge(
           social_media_accounts_attributes: {"0" => {
           social_media_service_id: social_media_service.id,
           url: "https://twitter.com/#!/bisgovuk"
         }}
-        )
+        ) }
 
         assert social_media_account = object.social_media_accounts.last
         assert_equal social_media_service, social_media_account.social_media_service
@@ -72,13 +83,13 @@ module AdminControllerTestHelpers
         object = create(type, attributes)
         account = create(:social_media_account, socialable: object)
 
-        put :update, id: object, type => attributes.merge(
+        put :update, params: { id: object, type => attributes.merge(
           social_media_accounts_attributes: {"0" => {
           id: account.id,
           social_media_service_id: "",
           url: ""
         }}
-        )
+        ) }
 
         assert_equal 0, object.social_media_accounts.count
       end
@@ -86,12 +97,12 @@ module AdminControllerTestHelpers
       test "updating with blank social media account fields should not create new account" do
         object = create(type)
 
-        put :update, id: object, type => object.attributes.merge(
+        put :update, params: { id: object, type => object.attributes.merge(
           social_media_accounts_attributes: {"0" => {
           social_media_service_id: "",
           url: ""
         }}
-        )
+        ) }
 
         assert object.social_media_accounts.empty?
       end
@@ -99,7 +110,7 @@ module AdminControllerTestHelpers
       test "updating with invalid data should still display blank social media account fields" do
         object = create(type)
 
-        put :update, id: object, type => object.attributes.merge(name: "")
+        put :update, params: { id: object, type => object.attributes.merge(name: "") }
 
         assert_select "select[name='#{type}[social_media_accounts_attributes][0][social_media_service_id]']" do
           refute_select "option[selected='selected']"
@@ -117,9 +128,21 @@ module AdminControllerTestHelpers
 
         topic = create(:topic)
 
-        post :create, type => attributes.merge(
-          contacts_attributes: [{description: "Enquiries", contact_numbers_attributes: [{label: "Fax", number: "020712435678"}]}],
-        )
+        post :create, params: {
+          type => attributes.merge(
+            contacts_attributes: [
+              {
+                description: "Enquiries",
+                contact_numbers_attributes: [
+                  {
+                    label: "Fax",
+                    number: "020712435678"
+                  }
+                ]
+              }
+            ],
+          )
+        }
 
         assert object = target_class.last
         assert_equal 1, object.contacts.count
@@ -130,15 +153,19 @@ module AdminControllerTestHelpers
       end
 
       test "creating with blank numbers ignores blank numbers" do
-        post :create, type => attributes_for(type).merge(
-          contacts_attributes: {"0" => {
-          description: "Enquiries",
-          contact_numbers_attributes: {
-            "0" => { label: " ", number: " " },
-            "1" => { label: " ", number: " " }
-          }
-        }}
-        )
+        post :create, params: {
+          type => attributes_for(type).merge(
+            contacts_attributes: {
+              "0" => {
+                description: "Enquiries",
+                contact_numbers_attributes: {
+                  "0" => { label: " ", number: " " },
+                  "1" => { label: " ", number: " " },
+                }
+              }
+            }
+          )
+        }
 
         created_object = target_class.last
         assert_not_nil created_object
@@ -151,7 +178,7 @@ module AdminControllerTestHelpers
           contacts_attributes: [{description: "", number: ""}]
         }
 
-        put :update, id: object, type => attributes
+        put :update, params: { id: object, type => attributes }
 
         assert_equal 0, object.contacts.count
       end
@@ -161,12 +188,12 @@ module AdminControllerTestHelpers
         contact = create(:contact, contactable: object)
         contact_number = create(:contact_number, contact: contact)
 
-        put :update, id: object, type => { contacts_attributes: { 0 => {
+        put :update, params: { id: object, type => { contacts_attributes: { 0 => {
           id: contact,
           contact_numbers_attributes: {
           0 => { label: " ", number: " ", id: contact_number }
         }
-        }}}
+        } } } }
 
         contact.reload
         assert_equal 0, contact.contact_numbers.count

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -8,9 +8,11 @@ module AdminEditionControllerTestHelpers
       test "create should create a new #{edition_type} with summary" do
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
+        post :create, params: {
+          edition: attributes.merge(
           summary: "my summary",
-        )
+          )
+        }
 
         created_edition = edition_class.last
         assert_equal "my summary", created_edition.summary
@@ -19,7 +21,12 @@ module AdminEditionControllerTestHelpers
       test "update should save modified news article summary" do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {summary: "new-summary"}
+        put :update, params: {
+          id: edition,
+          edition: {
+            summary: "new-summary"
+          }
+        }
 
         saved_edition = edition.reload
         assert_equal "new-summary", edition.summary
@@ -54,7 +61,9 @@ module AdminEditionControllerTestHelpers
       test "create should create a new edition" do
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         edition = edition_class.last
         assert_equal attributes[:title], edition.title
@@ -62,7 +71,9 @@ module AdminEditionControllerTestHelpers
       end
 
       test "create should take the writer to the edition page" do
-        post :create, edition: controller_attributes_for(edition_type)
+        post :create, params: {
+          edition: controller_attributes_for(edition_type)
+        }
 
         admin_edition_path = send("admin_#{edition_type}_path", edition_class.last)
         assert_redirected_to admin_edition_path
@@ -71,7 +82,9 @@ module AdminEditionControllerTestHelpers
 
       test "create with invalid data should leave the writer in the document editor" do
         attributes = controller_attributes_for(edition_type)
-        post :create, edition: attributes.merge(title: '')
+        post :create, params: {
+          edition: attributes.merge(title: '')
+        }
 
         assert_equal attributes[:body], assigns(:edition).body, "the valid data should not have been lost"
         assert_template "editions/new"
@@ -79,7 +92,9 @@ module AdminEditionControllerTestHelpers
 
       view_test "create with invalid data should indicate there was an error" do
         attributes = controller_attributes_for(edition_type)
-        post :create, edition: attributes.merge(title: '')
+        post :create, params: {
+          edition: attributes.merge(title: '')
+        }
 
         assert_select ".field_with_errors input[name='edition[title]']"
         assert_equal attributes[:body], assigns(:edition).body, "the valid data should not have been lost"
@@ -89,7 +104,9 @@ module AdminEditionControllerTestHelpers
       test "removes blank space from titles for new editions" do
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(title: '   my title   ')
+        post :create, params: {
+          edition: attributes.merge(title: '   my title   ')
+        }
 
         edition = edition_class.last
         assert_equal 'my title', edition.title
@@ -102,7 +119,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit displays edition form" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         admin_edition_path = send("admin_#{edition_type}_path", edition)
         assert_select "form#edit_edition[action='#{admin_edition_path}']" do
@@ -115,7 +132,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit form has previewable body" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "textarea[name='edition[body]'].previewable"
       end
@@ -123,7 +140,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit form has cancel link which takes the user back to edition" do
         draft_edition = create("draft_#{edition_type}")
 
-        get :edit, id: draft_edition
+        get :edit, params: { id: draft_edition }
 
         admin_edition_path = send("admin_#{edition_type}_path", draft_edition)
         assert_select "a[href=?]", admin_edition_path, text: /cancel/i
@@ -132,7 +149,13 @@ module AdminEditionControllerTestHelpers
       test "update should save modified edition attributes" do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {title: "new-title", body: "new-body"}
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: "new-title",
+            body: "new-body"
+          }
+        }
 
         edition.reload
         assert_equal "new-title", edition.title
@@ -142,7 +165,13 @@ module AdminEditionControllerTestHelpers
       test "update should take the writer to the edition page" do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {title: 'new-title', body: 'new-body'}
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: 'new-title',
+            body: 'new-body'
+          }
+        }
 
         admin_edition_path = send("admin_#{edition_type}_path", edition)
         assert_redirected_to admin_edition_path
@@ -152,7 +181,13 @@ module AdminEditionControllerTestHelpers
       test "update records the user who changed the edition" do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {title: 'new-title', body: 'new-body'}
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: 'new-title',
+            body: 'new-body'
+          }
+        }
 
         assert_equal current_user, edition.edition_authors(true).last.user
       end
@@ -160,7 +195,12 @@ module AdminEditionControllerTestHelpers
       test "update with invalid data should not save the edition" do
         edition = create(edition_type, title: "A Title")
 
-        put :update, id: edition, edition: {title: ''}
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: ''
+          }
+        }
 
         assert_equal "A Title", edition.reload.title
         assert_template "editions/edit"
@@ -172,7 +212,12 @@ module AdminEditionControllerTestHelpers
         lock_version = edition.lock_version
         edition.touch
 
-        put :update, id: edition, edition: {lock_version: lock_version}
+        put :update, params: {
+          id: edition,
+          edition: {
+            lock_version: lock_version
+          }
+        }
 
         assert_template 'edit'
         conflicting_edition = edition.reload
@@ -184,7 +229,12 @@ module AdminEditionControllerTestHelpers
       test "removes blank space from titles for updated editions" do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: { title: '   my title    ' }
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: '   my title    '
+          }
+        }
 
         assert_equal 'my title', edition.reload.title
       end
@@ -201,7 +251,7 @@ module AdminEditionControllerTestHelpers
           )
         )
 
-        put :update, id: edition, edition: { title: 'updated title' }
+        put :update, params: { id: edition, edition: { title: 'updated title' } }
       end
 
       test "updating a submitted edition sends the draft to the content preview environment" do
@@ -214,7 +264,12 @@ module AdminEditionControllerTestHelpers
           )
         )
 
-        put :update, id: edition, edition: { title: 'updated title' }
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: 'updated title'
+          }
+        }
       end
 
       test "updating a rejected edition sends the draft to the content preview environment" do
@@ -227,7 +282,12 @@ module AdminEditionControllerTestHelpers
           )
         )
 
-        put :update, id: edition, edition: { title: 'updated title' }
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: 'updated title'
+          }
+        }
       end
 
       view_test "reports an error if the updater has an error on create" do
@@ -242,9 +302,11 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type)
 
         assert_difference "Edition.count", 0 do
-          post :create, edition: attributes.merge(
-            summary: "my summary",
-          )
+          post :create, params: {
+            edition: attributes.merge(
+              summary: "my summary",
+            )
+          }
         end
 
         assert_template "editions/new"
@@ -263,7 +325,12 @@ module AdminEditionControllerTestHelpers
 
         Whitehall.edition_services.stubs(:draft_updater).returns(draft_updater)
 
-        put :update, id: edition, edition: { title: 'updated title' }
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: 'updated title'
+          }
+        }
 
         assert_equal "Original title", edition.reload.title
         assert_template "editions/edit"
@@ -276,9 +343,13 @@ module AdminEditionControllerTestHelpers
       test "update should convert #{edition_type} to draft when speed tagging" do
         edition = create("imported_#{edition_type}")
 
-        put :update, id: edition, speed_save_convert: 1, edition: {
-          title: "new-title",
-          body: "new-body"
+        put :update, params: {
+          id: edition,
+          speed_save_convert: 1,
+          edition: {
+            title: "new-title",
+            body: "new-body"
+          }
         }
 
         edition.reload
@@ -308,7 +379,9 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         assert edition = edition_class.last
         assert_equal 1, edition.images.length
@@ -327,11 +400,15 @@ module AdminEditionControllerTestHelpers
 
         ImageData.any_instance.expects(:file=).once
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
       end
 
       view_test "creating an edition with invalid data should still show image fields" do
-        post :create, edition: controller_attributes_for(edition_type, title: "")
+        post :create, params: {
+          edition: controller_attributes_for(edition_type, title: "")
+        }
 
         assert_select "form#new_edition" do
           assert_select "input[name='edition[images_attributes][0][alt_text]'][type='text']"
@@ -348,7 +425,9 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         assert_select "form#new_edition" do
           assert_select "input[name*='edition[images_attributes]'][type='file']", count: 1
@@ -363,7 +442,9 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         assert_select "form#new_edition" do
           assert_select "input[name='edition[images_attributes][0][alt_text]'][type='text'][value='some-alt-text']"
@@ -380,7 +461,9 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         refute_select "p.image"
       end
@@ -395,7 +478,9 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image)}
         }
 
-        post :create, edition: attributes
+        post :create, params: {
+          edition: attributes
+        }
 
         assert edition = edition_class.last
         assert_equal 2, edition.images.length
@@ -409,11 +494,13 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type)
         invalid_image = fixture_file_upload('horrible-image.64x96.jpg', 'image/jpg')
 
-        post :create, edition: attributes.merge(
-          images_attributes: {
-            "0" => { alt_text: "alt-text", image_data_attributes: attributes_for(:image_data, file: invalid_image) }
-          }
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            images_attributes: {
+              "0" => { alt_text: "alt-text", image_data_attributes: attributes_for(:image_data, file: invalid_image) }
+            }
+          )
+        }
 
         assert_select ".errors", text: "Images image data file must be 960px wide and 640px tall, but is 64px wide and 96px tall"
       end
@@ -424,7 +511,7 @@ module AdminEditionControllerTestHelpers
         image = create(:image, alt_text: "blah", edition: edition,
                        image_data_attributes: attributes_for(:image_data, file: image))
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[images_attributes][0][alt_text]'][type='text'][value='blah']"
@@ -441,9 +528,11 @@ module AdminEditionControllerTestHelpers
         image = fixture_file_upload('minister-of-funk.960x640.jpg')
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {
-          images_attributes: {
-            "0" => { alt_text: "alt-text", image_data_attributes: attributes_for(:image_data, file: image) }
+        put :update, params: {
+          id: edition, edition: {
+            images_attributes: {
+              "0" => { alt_text: "alt-text", image_data_attributes: attributes_for(:image_data, file: image) }
+            }
           }
         }
 
@@ -456,11 +545,18 @@ module AdminEditionControllerTestHelpers
       view_test 'updating an edition with image alt text but no file attachment should show a validation error' do
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {
-          images_attributes: { "0" => {
-            alt_text: "alt-text",
-            image_data_attributes: { file_cache: "" }
-          } }
+        put :update, params: {
+          id: edition,
+          edition: {
+            images_attributes: {
+              "0" => {
+                alt_text: "alt-text",
+                image_data_attributes: {
+                  file_cache: ""
+                }
+              }
+            }
+          }
         }
 
         assert_select ".errors", text: "Images image data file can't be blank"
@@ -474,12 +570,17 @@ module AdminEditionControllerTestHelpers
         image = create(:image, edition: edition, alt_text: "old-alt-text", caption: 'old-caption')
         VirusScanHelpers.simulate_virus_scan
 
-        put :update, id: edition, edition: {
-          images_attributes: { "0" => {
-            id: image.id,
-            alt_text: "new-alt-text",
-            caption: 'new-caption'
-          } }
+        put :update, params: {
+          id: edition,
+          edition: {
+            images_attributes: {
+              "0" => {
+                id: image.id,
+                alt_text: "new-alt-text",
+                caption: 'new-caption'
+              }
+            }
+          }
         }
 
         assert_response :redirect
@@ -498,7 +599,7 @@ module AdminEditionControllerTestHelpers
                   image_data_attributes: attributes_for(:image_data, file: image)}
         } }
 
-        put :update, id: edition, edition: attributes
+        put :update, params: { id: edition, edition: attributes }
 
         edition.reload
         assert_equal 2, edition.images.length
@@ -510,7 +611,12 @@ module AdminEditionControllerTestHelpers
 
       view_test "updating an edition with invalid data should still allow image to be selected for upload" do
         edition = create(edition_type)
-        put :update, id: edition, edition: {title: ""}
+        put :update, params: {
+          id: edition,
+          edition: {
+            title: ""
+          }
+        }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[images_attributes][0][image_data_attributes][file]'][type='file']"
@@ -527,7 +633,7 @@ module AdminEditionControllerTestHelpers
             image_data_attributes: attributes_for(:image_data, file: image) } }
         }
 
-        put :update, id: edition, edition: attributes
+        put :update, params: { id: edition, edition: attributes }
 
         assert_select "form#edit_edition" do
           assert_select "input[name*='edition[images_attributes]'][type='file']", count: 1
@@ -544,7 +650,7 @@ module AdminEditionControllerTestHelpers
             image_data_attributes: attributes_for(:image_data, file: image) } }
         }
 
-        put :update, id: edition, edition: attributes
+        put :update, params: { id: edition, edition: attributes }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[images_attributes][0][alt_text]'][value='some-alt-text']"
@@ -558,7 +664,12 @@ module AdminEditionControllerTestHelpers
         lock_version = edition.lock_version
         edition.touch
 
-        put :update, id: edition, edition: {lock_version: lock_version}
+        put :update, params: {
+          id: edition,
+          edition: {
+            lock_version: lock_version
+          }
+        }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[images_attributes][0][alt_text]'][type='text']"
@@ -581,7 +692,7 @@ module AdminEditionControllerTestHelpers
           } }
         }
 
-        put :update, id: edition, edition: attributes
+        put :update, params: { id: edition, edition: attributes }
 
         assert_select "form#edit_edition" do
           assert_select "input[name*='edition[images_attributes]'][type='file']", count: 1
@@ -600,7 +711,7 @@ module AdminEditionControllerTestHelpers
             "2" => { image_data_attributes: { file_cache: "" } }
           }
         }
-        put :update, id: edition, edition: attributes
+        put :update, params: { id: edition, edition: attributes }
 
         refute_select ".errors"
         edition.reload
@@ -625,9 +736,11 @@ module AdminEditionControllerTestHelpers
       test "creating should create a new document with related policies" do
         attributes = controller_attributes_for(document_type)
 
-        post :create, edition: attributes.merge(
-          policy_content_ids: [policy_1['content_id'], policy_2['content_id']]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            policy_content_ids: [policy_1['content_id'], policy_2['content_id']]
+          )
+        }
 
         assert document = edition_class.last
         assert_equal [
@@ -641,7 +754,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit displays document form with related policies field" do
         document = create(document_type)
 
-        get :edit, id: document
+        get :edit, params: { id: document }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[policy_content_ids]']"
@@ -651,7 +764,12 @@ module AdminEditionControllerTestHelpers
       test "updating should save modified edition attributes with related policies" do
         edition = create(document_type, policy_content_ids: [policy_1['content_id']])
 
-        put :update, id: edition, edition: {policy_content_ids: [policy_2['content_id']]}
+        put :update, params: {
+          id: edition,
+          edition: {
+            policy_content_ids: [policy_2['content_id']]
+          }
+        }
 
         assert_equal [
           policy_area_1['content_id'],
@@ -665,8 +783,11 @@ module AdminEditionControllerTestHelpers
         lock_version = edition.lock_version
         edition.touch
 
-        put :update, id: edition, edition: {
-          lock_version: lock_version,
+        put :update, params: {
+          id: edition,
+          edition: {
+            lock_version: lock_version,
+          }
         }
 
         assert_select ".document.conflict"
@@ -689,9 +810,11 @@ module AdminEditionControllerTestHelpers
         second_data_set = create(:statistical_data_set, document: create(:document))
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          statistical_data_set_document_ids: [first_data_set.document.id, second_data_set.document.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            statistical_data_set_document_ids: [first_data_set.document.id, second_data_set.document.id]
+          )
+        }
 
         edition = edition_class.last
         assert_equal [first_data_set, second_data_set], edition.statistical_data_sets
@@ -700,7 +823,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display edition statistical data sets field" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[statistical_data_set_document_ids]']"
@@ -713,8 +836,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create(edition_type, statistical_data_sets: [first_data_set])
 
-        put :update, id: edition, edition: {
-          statistical_data_set_document_ids: [second_data_set.document.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            statistical_data_set_document_ids: [second_data_set.document.id]
+          }
         }
 
         edition.reload
@@ -750,9 +876,11 @@ module AdminEditionControllerTestHelpers
         second_organisation = create(:organisation)
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          lead_organisation_ids: [second_organisation.id, first_organisation.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            lead_organisation_ids: [second_organisation.id, first_organisation.id]
+          )
+        }
 
         edition = edition_class.last
         assert_equal [second_organisation, first_organisation], edition.lead_organisations
@@ -761,7 +889,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display edition organisations field" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[lead_organisation_ids][]']"
@@ -775,8 +903,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create(edition_type, organisations: [first_organisation])
 
-        put :update, id: edition, edition: {
-          lead_organisation_ids: [second_organisation.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [second_organisation.id]
+          }
         }
 
         edition.reload
@@ -789,8 +920,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create(edition_type, organisations: [organisation_1, organisation_2])
 
-        put :update, id: edition, edition: {
-          lead_organisation_ids: [organisation_2.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation_2.id]
+          }
         }
 
         edition.reload
@@ -805,9 +939,12 @@ module AdminEditionControllerTestHelpers
         edition = create(edition_type, organisations: [organisation_1, organisation_2])
         edition.organisations << organisation_3
 
-        put :update, id: edition, edition: {
-          lead_organisation_ids: [organisation_2.id, organisation_3.id],
-          supporting_organisation_ids: [organisation_1.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation_2.id, organisation_3.id],
+            supporting_organisation_ids: [organisation_1.id]
+          }
         }
 
         edition.reload
@@ -832,9 +969,11 @@ module AdminEditionControllerTestHelpers
         second_topic = create(:topic)
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          topic_ids: [first_topic.id, second_topic.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            topic_ids: [first_topic.id, second_topic.id]
+          )
+        }
 
         assert edition = edition_class.last
         assert_equal [first_topic, second_topic], edition.topics
@@ -843,7 +982,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display topics field" do
         edition = create("draft_#{edition_type}")
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[topic_ids]']"
@@ -856,8 +995,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create("draft_#{edition_type}", topics: [first_topic])
 
-        put :update, id: edition, edition: {
-          topic_ids: [second_topic.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            topic_ids: [second_topic.id]
+          }
         }
 
         edition.reload
@@ -870,8 +1012,12 @@ module AdminEditionControllerTestHelpers
         lock_version = edition.lock_version
         edition.touch
 
-        put :update, id: edition, edition: {
-          lock_version: lock_version, topic_ids: edition.topic_ids
+        put :update, params: {
+          id: edition,
+          edition: {
+            lock_version: lock_version,
+            topic_ids: edition.topic_ids
+          }
         }
 
         assert_select ".document.conflict" do
@@ -897,9 +1043,11 @@ module AdminEditionControllerTestHelpers
         second_appointment = create(:role_appointment)
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          role_appointment_ids: [first_appointment.id, second_appointment.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            role_appointment_ids: [first_appointment.id, second_appointment.id]
+          )
+        }
 
         edition = edition_class.last
         assert_equal [first_appointment, second_appointment], edition.role_appointments
@@ -908,7 +1056,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display edition role appointments field" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[role_appointment_ids]']"
@@ -921,8 +1069,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create(edition_type, role_appointments: [first_appointment])
 
-        put :update, id: edition, edition: {
-          role_appointment_ids: [second_appointment.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            role_appointment_ids: [second_appointment.id]
+          }
         }
 
         edition.reload
@@ -935,7 +1086,7 @@ module AdminEditionControllerTestHelpers
         test "edit not allowed for #{state} #{edition_type}" do
           edition = create("#{state}_#{edition_type}")
 
-          get :edit, id: edition
+          get :edit, params: { id: edition }
 
           assert_redirected_to send("admin_#{edition_type}_path", edition)
         end
@@ -943,7 +1094,12 @@ module AdminEditionControllerTestHelpers
         test "update not allowed for #{state} #{edition_type}" do
           edition = create("#{state}_#{edition_type}")
 
-          put :update, id: edition, edition: {title: 'new-title'}
+          put :update, params: {
+            id: edition,
+            edition: {
+              title: 'new-title'
+            }
+          }
 
           assert_redirected_to send("admin_#{edition_type}_path", edition)
         end
@@ -966,7 +1122,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display first_published_at fields" do
         edition = create(edition_type)
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         admin_edition_path = send("admin_#{edition_type}_path", edition)
         assert_select "form#edit_edition[action='#{admin_edition_path}']" do
@@ -977,7 +1133,9 @@ module AdminEditionControllerTestHelpers
 
       test "create should save overridden first_published_at attribute" do
         first_published_at = 3.months.ago
-        post :create, edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago)
+        post :create, params: {
+          edition: controller_attributes_for(edition_type).merge(first_published_at: 3.months.ago)
+        }
 
         edition = edition_class.last
         assert_equal first_published_at, edition.first_published_at
@@ -987,8 +1145,11 @@ module AdminEditionControllerTestHelpers
         edition = create(edition_type)
         first_published_at = 3.months.ago
 
-        put :update, id: edition, edition: {
-          first_published_at: first_published_at
+        put :update, params: {
+          id: edition,
+          edition: {
+            first_published_at: first_published_at
+          }
         }
 
         edition.reload
@@ -1000,7 +1161,7 @@ module AdminEditionControllerTestHelpers
       view_test "show should display first_published_at fields when speed tagging" do
         edition = create("imported_#{edition_type}")
 
-        get :show, id: edition
+        get :show, params: { id: edition }
 
         assert_select "label[for=edition_first_published_at]", text: "First published *"
         assert_select "select[name*='edition[first_published_at']", count: 5
@@ -1010,14 +1171,14 @@ module AdminEditionControllerTestHelpers
     def should_report_editing_conflicts_of(edition_type)
       test "editing an existing #{edition_type} should record a RecentEditionOpening" do
         edition = create(edition_type)
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_equal [current_user], edition.reload.recent_edition_openings.map(&:editor)
       end
 
       view_test "should not see a warning when editing an edition that nobody has recently edited" do
         edition = create(edition_type)
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         refute_select ".editing_conflict"
       end
@@ -1029,7 +1190,7 @@ module AdminEditionControllerTestHelpers
         Timecop.travel 1.hour.from_now
 
         request.env['HTTPS'] = 'on'
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select ".editing_conflict", /Joe Bloggs/ do
           assert_select "img[src^='https']"
@@ -1042,7 +1203,12 @@ module AdminEditionControllerTestHelpers
         edition.open_for_editing_as(@current_user)
 
         assert_difference "edition.reload.recent_edition_openings.count", -1 do
-          put :update, id: edition, edition: {summary: "A summary"}
+          put :update, params: {
+            id: edition,
+            edition: {
+              summary: "A summary"
+            }
+          }
         end
       end
     end
@@ -1062,7 +1228,7 @@ module AdminEditionControllerTestHelpers
 
       view_test "edit should display fields for related mainstream content" do
         edition = create(edition_type)
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         admin_editions_path = send("admin_#{edition_type}_path", edition)
         assert_select "form#edit_edition[action='#{admin_editions_path}']" do
@@ -1074,10 +1240,12 @@ module AdminEditionControllerTestHelpers
       test "create should allow setting of related mainstream content urls" do
         Services.publishing_api.stubs(:lookup_content_ids).with(base_paths: ["/starting-to-export", "/vat-rates"]).returns({"/starting-to-export" => "af70706d-1286-49a8-a597-b3715f29edb5", "/vat-rates" => "c621b246-aa0e-44ad-b320-5a9c16c1123b"})
 
-        post :create, edition: controller_attributes_for(edition_type).merge(
-          related_mainstream_content_url: "https://www.gov.uk/starting-to-export",
-          additional_related_mainstream_content_url: "https://www.gov.uk/vat-rates"
-        )
+        post :create, params: {
+          edition: controller_attributes_for(edition_type).merge(
+            related_mainstream_content_url: "https://www.gov.uk/starting-to-export",
+            additional_related_mainstream_content_url: "https://www.gov.uk/vat-rates"
+          )
+        }
 
         edition = edition_class.last
         assert_equal "https://www.gov.uk/starting-to-export", edition.related_mainstream_content_url
@@ -1093,9 +1261,12 @@ module AdminEditionControllerTestHelpers
         )
         Services.publishing_api.stubs(:lookup_content_ids).with(base_paths: ["/fishing-licences", "/set-up-business-uk"]).returns({"/fishing-licences" => "bc46370c-2f2b-4db7-bf23-ace64b465eca", "/set-up-business-uk" => "5e5bb54d-e471-4d07-977b-291168569f26"})
 
-        put :update, id: edition, edition: {
-          related_mainstream_content_url: "https://www.gov.uk/fishing-licences",
-          additional_related_mainstream_content_url: "https://www.gov.uk/set-up-business-uk"
+        put :update, params: {
+          id: edition,
+          edition: {
+            related_mainstream_content_url: "https://www.gov.uk/fishing-licences",
+            additional_related_mainstream_content_url: "https://www.gov.uk/set-up-business-uk"
+          }
         }
 
         edition.reload
@@ -1116,7 +1287,7 @@ module AdminEditionControllerTestHelpers
       view_test "when editing allow selection of alternative format provider for #{edition_type}" do
         draft = create("draft_#{edition_type}")
 
-        get :edit, id: draft
+        get :edit, params: { id: draft }
 
         assert_select "form#edit_edition" do
           assert_select "select[name='edition[alternative_format_provider_id]']"
@@ -1127,8 +1298,11 @@ module AdminEditionControllerTestHelpers
         organisation = create(:organisation_with_alternative_format_contact_email)
         edition = create(edition_type)
 
-        put :update, id: edition, edition: {
-          alternative_format_provider_id: organisation.id
+        put :update, params: {
+          id: edition,
+          edition: {
+            alternative_format_provider_id: organisation.id
+          }
         }
 
         saved_edition = edition.reload
@@ -1144,11 +1318,13 @@ module AdminEditionControllerTestHelpers
         controller.current_user.organisation = organisation
         controller.current_user.save!
 
-        post :create, edition: controller_attributes_for(edition_type).merge(
-          first_published_at: Date.parse("2010-10-21"),
-          access_limited: '1',
-          lead_organisation_ids: [organisation.id]
-        )
+        post :create, params: {
+          edition: controller_attributes_for(edition_type).merge(
+            first_published_at: Date.parse("2010-10-21"),
+            access_limited: '1',
+            lead_organisation_ids: [organisation.id]
+          )
+        }
 
         created_publication = edition_class.last
         refute created_publication.nil?
@@ -1158,7 +1334,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit displays persisted access_limited flag" do
         publication = create(edition_type, access_limited: false)
 
-        get :edit, id: publication
+        get :edit, params: { id: publication }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[access_limited]'][type=checkbox]"
@@ -1170,7 +1346,12 @@ module AdminEditionControllerTestHelpers
         controller.current_user.organisation = create(:organisation); controller.current_user.save!
         publication = create(edition_type, access_limited: false, organisations: [controller.current_user.organisation])
 
-        put :update, id: publication, edition: {access_limited: '1'}
+        put :update, params: {
+          id: publication,
+          edition: {
+            access_limited: '1'
+          }
+        }
 
         assert publication.reload.access_limited?
       end
@@ -1180,10 +1361,13 @@ module AdminEditionControllerTestHelpers
       edition_class = class_for(edition_type)
 
       test "create should record the relevant_to_local_government flag" do
-        post :create, edition: controller_attributes_for(edition_type,
-          first_published_at: Date.parse("2010-10-21"),
-          relevant_to_local_government: '1'
-        )
+        post :create, params: {
+          edition: controller_attributes_for(
+            edition_type,
+            first_published_at: Date.parse("2010-10-21"),
+            relevant_to_local_government: '1'
+          )
+        }
 
         assert created_publication = edition_class.last
         assert created_publication.relevant_to_local_government?
@@ -1192,7 +1376,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit displays persisted relevant_to_local_government flag" do
         publication = create(edition_type, relevant_to_local_government: false)
 
-        get :edit, id: publication
+        get :edit, params: { id: publication }
 
         assert_select "form#edit_edition" do
           assert_select "input[name='edition[relevant_to_local_government]'][type=checkbox]"
@@ -1203,7 +1387,12 @@ module AdminEditionControllerTestHelpers
       test "update records new value of relevant_to_local_government flag" do
         publication = create(edition_type, relevant_to_local_government: false)
 
-        put :update, id: publication, edition: {relevant_to_local_government: '1'}
+        put :update, params: {
+          id: publication,
+          edition: {
+            relevant_to_local_government: '1'
+          }
+        }
 
         assert publication.reload.relevant_to_local_government?
       end
@@ -1225,9 +1414,11 @@ module AdminEditionControllerTestHelpers
         second_topical_event = create(:topical_event)
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          topical_event_ids: [first_topical_event.id, second_topical_event.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            topical_event_ids: [first_topical_event.id, second_topical_event.id]
+          )
+        }
 
         assert edition = edition_class.last
         assert_equal [first_topical_event, second_topical_event], edition.topical_events
@@ -1236,7 +1427,7 @@ module AdminEditionControllerTestHelpers
       view_test "edit should display topical events field" do
         edition = create("draft_#{edition_type}")
 
-        get :edit, id: edition
+        get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[topical_event_ids]']"
@@ -1249,8 +1440,11 @@ module AdminEditionControllerTestHelpers
 
         edition = create("draft_#{edition_type}", topical_events: [first_topical_event])
 
-        put :update, id: edition, edition: {
-          topical_event_ids: [second_topical_event.id]
+        put :update, params: {
+          id: edition,
+          edition: {
+            topical_event_ids: [second_topical_event.id]
+          }
         }
 
         edition.reload
@@ -1290,9 +1484,11 @@ module AdminEditionControllerTestHelpers
         second_world_organisation = create(:worldwide_organisation)
         attributes = controller_attributes_for(edition_type)
 
-        post :create, edition: attributes.merge(
-          worldwide_organisation_ids: [first_world_organisation.id, second_world_organisation.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            worldwide_organisation_ids: [first_world_organisation.id, second_world_organisation.id]
+          )
+        }
 
         assert edition = edition_class.last
         assert_equal [first_world_organisation, second_world_organisation], edition.worldwide_organisations

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -18,9 +18,11 @@ module AdminEditionWorldLocationsBehaviour
         world_location2 = create(:world_location)
         attributes = controller_attributes_for(document_type)
 
-        post :create, edition: attributes.merge(
-          world_location_ids: [world_location.id, world_location2.id]
-        )
+        post :create, params: {
+          edition: attributes.merge(
+            world_location_ids: [world_location.id, world_location2.id]
+          )
+        }
 
         assert document = edition_class.last
         assert_equal [world_location, world_location2], document.world_locations
@@ -31,9 +33,9 @@ module AdminEditionWorldLocationsBehaviour
         world_location2 = create(:world_location)
         document = create(document_type, world_locations: [world_location2])
 
-        put :update, id: document, edition: {
+        put :update, params: { id: document, edition: {
           world_location_ids: [world_location.id]
-        }
+        } }
 
         document = document.reload
         assert_equal [world_location], document.world_locations
@@ -44,7 +46,7 @@ module AdminEditionWorldLocationsBehaviour
         lock_version = document.lock_version
         document.touch
 
-        put :update, id: document, edition: {lock_version: lock_version}
+        put :update, params: { id: document, edition: { lock_version: lock_version } }
 
         assert_select ".document.conflict" do
           assert_select "h1", "World locations"

--- a/test/support/controller_test_helpers.rb
+++ b/test/support/controller_test_helpers.rb
@@ -19,7 +19,7 @@ module ControllerTestHelpers
         edition = create(edition_type)
         login_as :writer
         actions.each do |action|
-          get action, id: edition.id
+          get action, params: { id: edition.id }
           assert_response 403
         end
       end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -10,12 +10,12 @@ module DocumentControllerTestHelpers
         english_attachment = create(:file_attachment, locale: :en, attachable: edition)
         french_attachment = create(:file_attachment, locale: :fr, attachable: edition)
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select_object(attachment)
         assert_select_object(english_attachment)
         refute_select_object(french_attachment)
 
-        get :show, id: edition.document, locale: :fr
+        get :show, params: { id: edition.document, locale: :fr }
         assert_select_object(attachment)
         refute_select_object(english_attachment)
         assert_select_object(french_attachment)
@@ -28,12 +28,12 @@ module DocumentControllerTestHelpers
         english_attachment = create(:html_attachment, locale: :en, attachable: edition)
         french_attachment = create(:html_attachment, locale: :fr, attachable: edition)
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select_object(attachment)
         assert_select_object(english_attachment)
         refute_select_object(french_attachment)
 
-        get :show, id: edition.document, locale: :fr
+        get :show, params: { id: edition.document, locale: :fr }
         assert_select_object(attachment)
         refute_select_object(english_attachment)
         assert_select_object(french_attachment)
@@ -47,7 +47,7 @@ module DocumentControllerTestHelpers
           attachment_2 = build(:file_attachment, file: fixture_file_upload('sample.rtf', 'text/rtf'))
         ])
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select_object(attachment_1) do
           assert_select '.title', text: attachment_1.title
@@ -62,7 +62,7 @@ module DocumentControllerTestHelpers
       view_test 'show displays HTML attachments' do
         edition = create("published_#{document_type}", :with_alternative_format_provider, :with_html_attachment, body: '!@1')
         attachment = edition.attachments.first
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select_object(attachment) do
           assert_select '.title', text: attachment.title
           assert_select 'img[src$=?]', 'pub-cover-html.png', message: 'should use HTML thumbnail for HTML attachments'
@@ -75,7 +75,7 @@ module DocumentControllerTestHelpers
           attachment_2 = build(:file_attachment, file: fixture_file_upload('sample.rtf', 'text/rtf'))
         ])
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select_object(attachment_1) do
           refute_select '.accessibility-warning'
@@ -93,7 +93,7 @@ module DocumentControllerTestHelpers
           attachment_1 = build(:file_attachment, file: fixture_file_upload('greenpaper.pdf', 'application/pdf'), accessible: false)
         ], alternative_format_provider: organisation)
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select_object(attachment_1) do
           assert_select '.accessibility-warning' do
@@ -108,7 +108,7 @@ module DocumentControllerTestHelpers
           attachment = build(:file_attachment, file: greenpaper_pdf)
         ])
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select_object(attachment) do
           assert_select ".type", /PDF/
@@ -123,7 +123,7 @@ module DocumentControllerTestHelpers
           attachment = build(:file_attachment, file: csv)
         ])
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select_object(attachment) do
           assert_select ".type", /RTF/
@@ -138,7 +138,7 @@ module DocumentControllerTestHelpers
         images = [create(:image), create(:image)]
         edition = create("published_#{document_type}", body: "!!2", images: images)
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select 'article figure.image.embedded img'
       end
@@ -147,26 +147,26 @@ module DocumentControllerTestHelpers
     def should_show_related_policies_for(document_type)
       view_test "show displays related published policies for #{document_type}" do
         edition = create("published_#{document_type}", policy_content_ids: [policy_1['content_id'], policy_2['content_id']])
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select '.meta a', text: "Policy 1"
       end
 
       view_test "should not display an empty list of related policies for #{document_type}" do
         edition = create("published_#{document_type}", policy_content_ids: [])
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         refute_select "#related-policies"
       end
 
       view_test "should render related policies on #{document_type} pages" do
         edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select ".meta a", text: policy_1["title"]
       end
 
       view_test "shows no policies if publishing api is unavailable" do
         edition = create("published_#{document_type}", policy_content_ids: [policy_1["content_id"]])
         publishing_api_isnt_available
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         refute_select ".meta a", text: policy_1["title"]
       end
     end
@@ -178,7 +178,7 @@ module DocumentControllerTestHelpers
         third_location = create(:international_delegation)
         edition = create("published_#{document_type}", world_locations: [first_location, second_location])
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select "a", text: first_location.name
         assert_select "a", text: second_location.name
@@ -193,7 +193,7 @@ module DocumentControllerTestHelpers
         draft_edition = create("draft_#{singular}")
         model = create(model_name, editions: [published_edition, draft_edition])
 
-        get :show, id: model
+        get :show, params: { id: model }
 
         assert_select "##{has_many_association.to_s.gsub('_', '-')}" do
           assert_select_object(published_edition)
@@ -206,7 +206,7 @@ module DocumentControllerTestHelpers
         another_published_edition = create("published_#{singular}")
         model = create(model_name, editions: [published_edition])
 
-        get :show, id: model
+        get :show, params: { id: model }
 
         assert_select "##{has_many_association.to_s.gsub('_', '-')}" do
           assert_select_object(published_edition)
@@ -219,7 +219,7 @@ module DocumentControllerTestHelpers
         earlier_edition = create("published_#{singular}", timestamp_key => 2.hours.ago)
         model = create(model_name, editions: [earlier_edition, later_edition])
 
-        get :show, id: model
+        get :show, params: { id: model }
 
         assert_equal [later_edition, earlier_edition], assigns(has_many_association).object
       end
@@ -227,7 +227,7 @@ module DocumentControllerTestHelpers
       view_test "should not display an empty published #{has_many_association.to_s.humanize.downcase} section" do
         model = create(model_name, editions: [])
 
-        get :show, id: model
+        get :show, params: { id: model }
 
         refute_select "##{has_many_association.to_s.gsub('_', '-')}"
       end
@@ -236,7 +236,7 @@ module DocumentControllerTestHelpers
     def should_set_expiry_headers(document_type)
       test "#{document_type} should set an expiry of 30 minutes" do
         edition = create("published_#{document_type}")
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         Whitehall.stubs(:default_cache_max_age).returns(30.minutes)
         assert_equal 'max-age=1800, public', response.headers['Cache-Control']
       end
@@ -252,7 +252,7 @@ module DocumentControllerTestHelpers
                                access_limited: false)
 
         login_as create(:departmental_editor)
-        get :show, id: document.id, preview: draft_edition.id
+        get :show, params: { id: document.id, preview: draft_edition.id }
         assert_response 200
         assert_cache_control 'no-cache'
       end
@@ -265,7 +265,7 @@ module DocumentControllerTestHelpers
                                body: "Draft information",
                                access_limited: false)
 
-        get :show, id: document.id, preview: draft_edition.id
+        get :show, params: { id: document.id, preview: draft_edition.id }
         assert_response 404
       end
 
@@ -273,7 +273,7 @@ module DocumentControllerTestHelpers
         draft = create(document_type, :published, access_limited: true)
 
         login_as(create(:departmental_editor, organisation: draft.organisations.first))
-        get :show, id: draft.document.id, preview: draft.id
+        get :show, params: { id: draft.document.id, preview: draft.id }
 
         assert_response 200
         assert_cache_control 'no-cache'
@@ -283,7 +283,7 @@ module DocumentControllerTestHelpers
         draft = create(document_type, :published, access_limited: true)
 
         login_as(create(:departmental_editor))
-        get :show, id: draft.document.id, preview: draft.id
+        get :show, params: { id: draft.document.id, preview: draft.id }
 
         assert_response 404
       end
@@ -295,7 +295,7 @@ module DocumentControllerTestHelpers
         northern_ireland_inapplicability = published_document.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://northern-ireland.com/")
         scotland_inapplicability = published_document.nation_inapplicabilities.create!(nation: Nation.scotland)
 
-        get :show, id: published_document.document
+        get :show, params: { id: published_document.document }
 
         assert_select inapplicable_nations_selector, "England and Wales (see #{published_document.format_name} for Northern Ireland)" do
           assert_select_object northern_ireland_inapplicability do
@@ -327,7 +327,7 @@ module DocumentControllerTestHelpers
         documents.sort_by!(&options[:sort_by]) if options[:sort_by]
 
         with_number_of_documents_per_page(3) do
-          get :index, page: 2
+          get :index, params: { page: 2 }
         end
 
         (0..2).to_a.each { |i| refute_filtered_documents_include documents[i] }
@@ -358,7 +358,7 @@ module DocumentControllerTestHelpers
         documents = (1..4).to_a.map { |i| create("published_#{edition_type}", title: "keyword-#{i}") }
 
         with_number_of_documents_per_page(3) do
-          get :index, page: 2
+          get :index, params: { page: 2 }
         end
 
         assert_select "#show-more-documents" do
@@ -371,7 +371,7 @@ module DocumentControllerTestHelpers
         documents = (1..7).to_a.map { |i| create("published_#{edition_type}", title: "keyword-#{i}") }
 
         with_number_of_documents_per_page(3) do
-          get :index, page: 2
+          get :index, params: { page: 2 }
         end
 
         assert_select "#show-more-documents" do
@@ -414,7 +414,7 @@ module DocumentControllerTestHelpers
       test "#{document_type} should set a meaningful meta description" do
         edition = create("published_#{document_type}", summary: "My **first** #{document_type}")
 
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_equal "My first #{document_type}", assigns(:meta_description)
       end
@@ -425,7 +425,7 @@ module DocumentControllerTestHelpers
         organisation = create(:organisation)
         lead_organisation = create(:organisation, acronym: "ABC")
         edition = create("published_#{document_type}", supporting_organisations: [organisation], lead_organisations: [lead_organisation])
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_equal "<#{lead_organisation.analytics_identifier}><#{organisation.analytics_identifier}>", response.headers["X-Slimmer-Organisations"]
         assert_equal lead_organisation.acronym.downcase, response.headers["X-Slimmer-Page-Owner"]
@@ -435,7 +435,7 @@ module DocumentControllerTestHelpers
     def should_set_the_article_id_for_the_edition_for(document_type)
       view_test "#{document_type} should set the article ID to the edition type/ID" do
         edition = create("published_#{document_type}")
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
 
         assert_select "article##{document_type}_#{edition.id}"
       end
@@ -444,7 +444,7 @@ module DocumentControllerTestHelpers
     def should_show_share_links_for(document_type)
       view_test "#{document_type} should show share links" do
         edition = create("published_#{document_type}")
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         assert_select ".document-share-links"
       end
     end
@@ -452,7 +452,7 @@ module DocumentControllerTestHelpers
     def should_not_show_share_links_for(document_type)
       view_test "#{document_type} should not show share links" do
         edition = create("published_#{document_type}")
-        get :show, id: edition.document
+        get :show, params: { id: edition.document }
         refute_select ".document-share-links"
       end
     end

--- a/test/support/organisation_controller_test_helpers.rb
+++ b/test/support/organisation_controller_test_helpers.rb
@@ -10,7 +10,7 @@ module OrganisationControllerTestHelpers
         organisation = create_org_and_stub_content_store(org_type)
         create(:about_corporate_information_page, organisation: organisation, summary: 'my org description')
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_equal 'my org description', assigns(:meta_description)
       end
@@ -19,7 +19,7 @@ module OrganisationControllerTestHelpers
         organisation = create_org_and_stub_content_store(org_type,
           logo_formatted_name: "unformatted name"
         )
-        get :show, id: organisation
+        get :show, params: { id: organisation }
         assert_select ".organisation h1", text: "unformatted name"
       end
 
@@ -32,7 +32,7 @@ module OrganisationControllerTestHelpers
           features << create(:feature, document: edition.document, feature_list: feature_list, ordering: i)
         end
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select_object features[0] do
           assert_select "img[src$='#{features[0].image.url(:s630)}'][alt=?]", features[0].alt_text
@@ -47,7 +47,7 @@ module OrganisationControllerTestHelpers
 
       view_test "#{org_type}:should not display an empty featured editions section" do
         organisation = create_org_and_stub_content_store(org_type)
-        get :show, id: organisation
+        get :show, params: { id: organisation }
         refute_select "#featured-documents article"
       end
 
@@ -67,7 +67,7 @@ module OrganisationControllerTestHelpers
           country: create(:world_location, iso2: 'GB')
         )
         organisation.add_contact_to_home_page!(organisation.contacts.first)
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select ".vcard" do
           assert_select ".fn", "Ministry of Pomp"
@@ -90,7 +90,7 @@ module OrganisationControllerTestHelpers
       view_test "#{org_type}:show has atom feed autodiscovery link" do
         organisation = create_org_and_stub_content_store(org_type)
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select_autodiscovery_link atom_feed_url_for(organisation)
       end
@@ -100,7 +100,7 @@ module OrganisationControllerTestHelpers
         feature_list = organisation.load_or_create_feature_list(:en)
         edition = create(:published_news_article, first_published_at: 1.days.ago)
         create(:feature, document: edition.document, feature_list: feature_list, ordering: 1)
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select "a.feed[href=?]", atom_feed_url_for(organisation)
       end
@@ -117,7 +117,7 @@ module OrganisationControllerTestHelpers
         feature_list = create(:feature_list, featurable: organisation, locale: :en)
         create(:feature, feature_list: feature_list, document: editions[0].document)
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         editions[0, 3].each do |edition|
           assert_select_prefix_object edition, :recent
@@ -127,7 +127,7 @@ module OrganisationControllerTestHelpers
 
       view_test "#{org_type}:should not show most recently published editions when there are none" do
         organisation = create_org_and_stub_content_store(org_type, editions: [])
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         refute_select "h1", text: "Recently updated"
       end
@@ -139,7 +139,7 @@ module OrganisationControllerTestHelpers
         flickr_account = create(:social_media_account, social_media_service: flickr, url: "http://www.flickr.com/photos/bisgovuk")
         organisation = create_org_and_stub_content_store(org_type, social_media_accounts: [twitter_account, flickr_account])
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select_object twitter_account
         assert_select_object flickr_account
@@ -148,7 +148,7 @@ module OrganisationControllerTestHelpers
       view_test "#{org_type}:should not show list of links to social media accounts if there are none" do
         organisation = create_org_and_stub_content_store(org_type, social_media_accounts: [])
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         refute_select ".social-media-accounts"
       end
@@ -159,7 +159,7 @@ module OrganisationControllerTestHelpers
         edition = create(:published_news_article, first_published_at: 1.days.ago)
         create(:feature, document: edition.document, feature_list: feature_list, ordering: 1)
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select ".govdelivery[href='#{new_email_signups_path(email_signup: { feed: atom_feed_url_for(organisation) })}']"
       end
@@ -169,7 +169,7 @@ module OrganisationControllerTestHelpers
         corporate_information_page = create(:published_corporate_information_page, organisation: organisation, corporate_information_page_type_id: CorporateInformationPageType::TermsOfReference.id)
         draft_corporate_information_page = create(:corporate_information_page, organisation: organisation, corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id)
 
-        get :show, id: organisation
+        get :show, params: { id: organisation }
 
         assert_select ".corporate-information a[href='#{organisation_corporate_information_page_path(organisation, corporate_information_page.slug)}']"
         refute_select ".corporate-information a[href='#{organisation_corporate_information_page_path(organisation, draft_corporate_information_page.slug)}']"

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -14,7 +14,7 @@ module TestsForNationalApplicability
       create(:government)
       attributes = attributes_for_edition
 
-      post :create, edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/"))
+      post :create, params: { edition: attributes.merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/")) }
 
       assert edition = Edition.last
       assert scotland_inapplicability = edition.nation_inapplicabilities.for_nation(Nation.scotland).first
@@ -59,9 +59,11 @@ module TestsForNationalApplicability
 
     view_test 'creating with invalid edition data should not lose the nation inapplicability fields or values' do
       attributes = attributes_for_edition
-      post :create, edition: attributes.merge(
-        title: ''
-      ).merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/"))
+      post :create, params: {
+        edition: attributes.merge(
+          title: ''
+        ).merge(nation_inapplicabilities_attributes_for(Nation.scotland => "http://www.scotland.com/"))
+      }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: true, alternative_url: "http://www.scotland.com/")
@@ -71,9 +73,11 @@ module TestsForNationalApplicability
 
     view_test 'creating with invalid nation inapplicability data should not lose the nation inapplicability fields or values' do
       attributes = attributes_for_edition
-      post :create, edition: attributes.merge(
-        nation_inapplicabilities_attributes_for(Nation.scotland => "invalid-url")
-      )
+      post :create, params: {
+        edition: attributes.merge(
+          nation_inapplicabilities_attributes_for(Nation.scotland => "invalid-url")
+        )
+      }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: true, alternative_url: "invalid-url")
@@ -85,7 +89,7 @@ module TestsForNationalApplicability
       edition = create_edition
       northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")
 
-      get :edit, id: edition
+      get :edit, params: { id: edition }
 
       assert_select "form#edit_edition" do
         assert_nation_inapplicability_fields_exist
@@ -101,7 +105,7 @@ module TestsForNationalApplicability
       edition = create_edition(attributes)
       northern_ireland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.northern_ireland, alternative_url: "http://www.discovernorthernireland.com/")
 
-      put :update, id: edition, edition: nation_inapplicabilities_attributes_for({Nation.scotland => "http://www.visitscotland.com/"}, northern_ireland_inapplicability)
+      put :update, params: { id: edition, edition: nation_inapplicabilities_attributes_for({ Nation.scotland => "http://www.visitscotland.com/" }, northern_ireland_inapplicability) }
 
       edition.reload
       assert_equal [Nation.scotland], edition.inapplicable_nations
@@ -116,7 +120,7 @@ module TestsForNationalApplicability
 
       attributes = nation_inapplicabilities_attributes_for({Nation.northern_ireland => "http://www.northernireland.com/"}, scotland_inapplicability, wales_inapplicability).merge(title: '')
 
-      put :update, id: edition, edition: attributes
+      put :update, params: { id: edition, edition: attributes }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")
@@ -130,11 +134,11 @@ module TestsForNationalApplicability
       scotland_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.scotland, alternative_url: "http://www.scotland.com/")
       wales_inapplicability = edition.nation_inapplicabilities.create!(nation: Nation.wales, alternative_url: "http://www.wales.com/")
 
-      put :update, id: edition, edition: nation_inapplicabilities_attributes_for(
+      put :update, params: { id: edition, edition: nation_inapplicabilities_attributes_for(
         {Nation.northern_ireland => "invalid-url"},
         scotland_inapplicability,
         wales_inapplicability
-      )
+      ) }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")
@@ -151,7 +155,7 @@ module TestsForNationalApplicability
 
       attributes = nation_inapplicabilities_attributes_for({Nation.northern_ireland => "http://www.northernireland.com/"}, scotland_inapplicability, wales_inapplicability).merge(lock_version: lock_version)
 
-      put :update, id: edition, edition: attributes
+      put :update, params: { id: edition, edition: attributes }
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")


### PR DESCRIPTION
This commit adds named params to all the tests that are missing them as part of the upgrade to Rails 5.

Trello: https://trello.com/c/eg61wStW/4-upgrade-whitehall-to-a-supported-version-of-rails