### PR TITLE
Add SRI attributes to JS and CSS assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ end
 gem 'sass', '~> 3.4.23'
 gem 'sassc-rails', '~> 1.3.0'
 gem 'uglifier'
+gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 group :development, :test do
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,9 @@ GEM
       builder
       multi_json
     arel (6.0.4)
+    asset_bom_removal-rails (1.0.2)
+      rails (>= 4.2)
+      sass (> 3.4)
     ast (2.3.0)
     autoprefixer-rails (7.1.1.2)
       execjs
@@ -470,6 +473,7 @@ PLATFORMS
 DEPENDENCIES
   addressable (>= 2.3.7)
   airbrake (= 4.1.0)
+  asset_bom_removal-rails (~> 1.0.0)
   babosa (= 1.0.2)
   better_errors
   binding_of_caller

--- a/app/views/histories/10_downing_street.html.erb
+++ b/app/views/histories/10_downing_street.html.erb
@@ -323,4 +323,4 @@
 
   </div>
 </div>
-<%= javascript_include_tag 'tour/tour_pano.js' %>
+<%= javascript_include_tag 'tour/tour_pano.js', integrity: true, crossorigin: 'anonymous' %>

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -18,12 +18,12 @@
       stylesheet_base = local_assigns[:stylesheet] || "base"
       stylesheet_base += "-rtl" if right_to_left?
     -%>
-    <!--[if gt IE 9]><!--><%= stylesheet_link_tag "frontend/#{stylesheet_base}.css" %><!--<![endif]-->
+    <!--[if gt IE 9]><!--><%= stylesheet_link_tag "frontend/#{stylesheet_base}.css", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
     <!--[if IE 6]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie6.css" %><script>var ieVersion = 6;</script><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie7.css" %><script>var ieVersion = 7;</script><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie8.css" %><script>var ieVersion = 8;</script><![endif]-->
     <!--[if IE 9]><%= stylesheet_link_tag "frontend/#{stylesheet_base}-ie9.css" %><script>var ieVersion = 9;</script><![endif]-->
-    <%= stylesheet_link_tag "frontend/print.css", media: "print" %>
+    <%= stylesheet_link_tag "frontend/print.css", media: "print", integrity: true, crossorigin: 'anonymous' %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
   </head>
@@ -32,7 +32,7 @@
     <div id="whitehall-wrapper">
       <%= yield %>
     </div>
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "application", integrity: true, crossorigin: 'anonymous' %>
     <%= javascript_tag(yield :javascript_initialisers) %>
   </body>
 </html>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :head do %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "admin.css" %><!--<![endif]-->
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "admin.css", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "admin-ie7.css" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "admin-ie8.css" %><script>var ieVersion = 8;</script><![endif]-->
   <%= csrf_meta_tags %>
@@ -109,7 +109,7 @@
 <% end %>
 
 <% content_for :body_end do %>
-  <%= javascript_include_tag "admin" %>
+  <%= javascript_include_tag "admin", integrity: true, crossorigin: 'anonymous' %>
   <%= render_mustache_templates if Rails.env.development? %>
   <% initialise_script "GOVUK.adminGlobalInitialiser" %>
   <%= javascript_tag(yield :javascript_initialisers) %>


### PR DESCRIPTION
For: https://trello.com/c/8o2zFPsC/147-enable-subresource-integrity-sri-on-whitehall-s

Many of the other assets used by whitehall come from static, so this only
gives us SRI on the assets actually delivered by whitehall.  The rest will
come when we add SRI to static.  We don't add these attributes to any of
the IE stylesheets because no version of IE currently supports SRI so
there's no point spending the time to calculate the values.