### PR TITLE
Update rummager with world news stories

### DIFF
--- a/db/data_migration/20170810111203_update_world_news_stories_in_rummager.rb
+++ b/db/data_migration/20170810111203_update_world_news_stories_in_rummager.rb
@@ -1,0 +1,21 @@
+world_news_story_type_id = 4
+
+editions = Edition
+  .where(state: ["withdrawn", "published"])
+  .where(news_article_type_id: world_news_story_type_id)
+
+puts "Updating #{editions.count} editions"
+
+editions.each do |edition|
+  print "."
+  SearchIndexAddWorker.perform_async_in_queue(
+    "bulk_republishing",
+    edition.class.name,
+    edition.id
+  )
+  SearchIndexDeleteWorker.perform_async_in_queue(
+    "bulk_republishing",
+    "/government/world-location-news/#{edition.slug}",
+    edition.rummager_index
+  )
+end


### PR DESCRIPTION
This PR adds a data migration that sends all of the `NewsArticle` of type `WorldNewsStory` to rummager and removes the entries for their previous base path (these were recently migrated from
`WorldLocationNewsArticle` so their path has changed).