### PR TITLE
Add `rake email_topics:check_all_documents`

### DIFF
--- a/lib/tasks/email_topics.rake
+++ b/lib/tasks/email_topics.rake
@@ -1,29 +1,26 @@
 namespace :email_topics do
   task :check, [:content_id] => :environment do |_task, args|
-    content_id = args.content_id
-    document = Document.find_by(content_id: content_id)
-    puts EmailTopicChecker.check(document)
+    document = Document.find_by!(content_id: args.content_id)
+    EmailTopicChecker.new(document).check
   end
 
   task check_all_documents: :environment do
-    Document.published.find_in_batches(batch_size: 20) do |documents|
-      presenters = documents.map do |document|
-        PublishingApiPresenters.presenter_for(document.published_edition)
-      end
-      presenters.each(&:content)
+    Document.published.find_in_batches(batch_size: 20).each do |documents|
+      threads = documents.map do |document|
+        checker = EmailTopicChecker.new(document, verbose: false)
 
-      threads = presenters.map do |presented_edition|
         Thread.new do
           begin
-            failed_content_id = EmailTopicChecker.check(presented_edition, false)
+            failed_content_id = checker.check
             puts failed_content_id if failed_content_id
             print "."
           rescue StandardError => ex
-            puts "#{presented_edition.content_id} raised #{ex.message}"
+            puts "#{document.content_id} raised #{ex.message}"
           end
         end
       end
-      threads.map(&:join)
+
+      threads.each(&:join)
     end
   end
 end

--- a/lib/tasks/email_topics.rake
+++ b/lib/tasks/email_topics.rake
@@ -3,4 +3,21 @@ namespace :email_topics do
     content_id = args.content_id
     EmailTopicChecker.check(content_id)
   end
+
+  task check_all_documents: :environment do
+    Document.published.find_in_batches(batch_size: 4) do |documents|
+      threads = documents.map do |document|
+        Thread.new do
+          begin
+            failed_content_id = EmailTopicChecker.check_and_return_failed_content_ids(document.content_id)
+            puts failed_content_id if failed_content_id
+            print "."
+          rescue StandardError => ex
+            puts "#{document.content_id} raised #{ex.message}"
+          end
+        end
+      end
+      threads.map(&:join)
+    end
+  end
 end

--- a/lib/tasks/email_topics.rake
+++ b/lib/tasks/email_topics.rake
@@ -1,19 +1,25 @@
 namespace :email_topics do
   task :check, [:content_id] => :environment do |_task, args|
     content_id = args.content_id
-    EmailTopicChecker.check(content_id)
+    document = Document.find_by(content_id: content_id)
+    puts EmailTopicChecker.check(document)
   end
 
   task check_all_documents: :environment do
-    Document.published.find_in_batches(batch_size: 4) do |documents|
-      threads = documents.map do |document|
+    Document.published.find_in_batches(batch_size: 20) do |documents|
+      presenters = documents.map do |document|
+        PublishingApiPresenters.presenter_for(document.published_edition)
+      end
+      presenters.each(&:content)
+
+      threads = presenters.map do |presented_edition|
         Thread.new do
           begin
-            failed_content_id = EmailTopicChecker.check_and_return_failed_content_ids(document.content_id)
+            failed_content_id = EmailTopicChecker.check(presented_edition, false)
             puts failed_content_id if failed_content_id
             print "."
           rescue StandardError => ex
-            puts "#{document.content_id} raised #{ex.message}"
+            puts "#{presented_edition.content_id} raised #{ex.message}"
           end
         end
       end

--- a/test/unit/email_topic_checker_test.rb
+++ b/test/unit/email_topic_checker_test.rb
@@ -2,41 +2,49 @@ require "test_helper"
 
 class EmailTopicCheckerTest < ActiveSupport::TestCase
   setup do
-    response = mock("Response", to_str: "http://example.com?topic_id=TOPIC_123")
+    response = stub("Response", to_str: "http://example.com?topic_id=TOPIC_123")
     Whitehall.govuk_delivery_client.stubs(:signup_url).returns(response)
 
-    mock_client = mock("EmailAlertApi", topic_matches: { "topics" => ["TOPIC_456"] })
+    mock_client = stub("EmailAlertApi", topic_matches: { "topics" => ["TOPIC_456"] })
     EmailTopicChecker.any_instance.stubs(email_alert_api: mock_client)
 
-    content_item = { "email_document_supertype" => "foo", "government_document_supertype" => "bar" }
-    Whitehall.content_store.stubs(content_item: content_item)
-
     edition = create(:edition, :published)
-    @content_id = edition.document.content_id
+    @document = edition.document
+
+    content_item = {
+      "content_id" => @document.content_id,
+      "email_document_supertype" => "foo",
+      "government_document_supertype" => "bar"
+    }
+    Whitehall.content_store.stubs(content_item: content_item)
   end
 
   test "lists govuk-delivery topics" do
-    assert_output(/^govuk-delivery topics:\nTOPIC_123/m) do
-      EmailTopicChecker.check(@content_id)
-    end
+    assert_match(
+      /^govuk-delivery topics:\nTOPIC_123/,
+      EmailTopicChecker.check(@document)
+    )
   end
 
   test "lists email-alert-api topics" do
-    assert_output(/^email-alert-api topics:\nTOPIC_456/m) do
-      EmailTopicChecker.check(@content_id)
-    end
+    assert_match(
+      /^email-alert-api topics:\nTOPIC_456/,
+      EmailTopicChecker.check(@document)
+    )
   end
 
   test "lists additional govuk-delivery topics" do
-    assert_output(/additional govuk-delivery topics:\nTOPIC_123/m) do
-      EmailTopicChecker.check(@content_id)
-    end
+    assert_match(
+      /additional govuk-delivery topics:\nTOPIC_123/,
+      EmailTopicChecker.check(@document)
+    )
   end
 
   test "lists additional email-alert-api topics" do
-    assert_output(/additional email-alert-api topics:\nTOPIC_456/m) do
-      EmailTopicChecker.check(@content_id)
-    end
+    assert_match(
+      /additional email-alert-api topics:\nTOPIC_456/,
+      EmailTopicChecker.check(@document)
+    )
   end
 
   test "lists email-alert-api params" do
@@ -48,15 +56,24 @@ class EmailTopicCheckerTest < ActiveSupport::TestCase
       government_document_supertype: "bar",
     }
 
-    assert_output(/^email-alert-api params:\n#{expected.to_s}/m) do
-      EmailTopicChecker.check(@content_id)
-    end
+    assert_match(
+      /^email-alert-api params:\n#{expected.to_s}/m,
+      EmailTopicChecker.check(@document)
+    )
   end
 
   test "lists govuk-delivery feed urls" do
     expected = "https://www.test.gov.uk/government/feed"
-    assert_output(/^govuk-delivery feed urls:\n#{expected}/m) do
-      EmailTopicChecker.check(@content_id)
+    assert_match(
+      /^govuk-delivery feed urls:\n#{expected}/m,
+      EmailTopicChecker.check(@document)
+    )
+  end
+
+  test "raises if content store returns an item with a different content id" do
+    @document.content_id = SecureRandom.uuid
+    assert_raises do
+      EmailTopicChecker.check(@document)
     end
   end
 end

--- a/test/unit/email_topic_checker_test.rb
+++ b/test/unit/email_topic_checker_test.rb
@@ -22,28 +22,28 @@ class EmailTopicCheckerTest < ActiveSupport::TestCase
   test "lists govuk-delivery topics" do
     assert_match(
       /^govuk-delivery topics:\nTOPIC_123/,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
   test "lists email-alert-api topics" do
     assert_match(
       /^email-alert-api topics:\nTOPIC_456/,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
   test "lists additional govuk-delivery topics" do
     assert_match(
       /additional govuk-delivery topics:\nTOPIC_123/,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
   test "lists additional email-alert-api topics" do
     assert_match(
       /additional email-alert-api topics:\nTOPIC_456/,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
@@ -58,7 +58,7 @@ class EmailTopicCheckerTest < ActiveSupport::TestCase
 
     assert_match(
       /^email-alert-api params:\n#{expected.to_s}/m,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
@@ -66,14 +66,14 @@ class EmailTopicCheckerTest < ActiveSupport::TestCase
     expected = "https://www.test.gov.uk/government/feed"
     assert_match(
       /^govuk-delivery feed urls:\n#{expected}/m,
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     )
   end
 
   test "raises if content store returns an item with a different content id" do
     @document.content_id = SecureRandom.uuid
     assert_raises do
-      EmailTopicChecker.check(@document)
+      EmailTopicChecker.new(@document).check
     end
   end
 end


### PR DESCRIPTION
This is an extension of: https://trello.com/c/kp8QW6i1/91-create-a-rake-task-to-be-able-to-see-which-topics-an-update-would-be-sent-to