### PR TITLE
Fix email_topics:check

### DIFF
--- a/lib/tasks/email_topics.rake
+++ b/lib/tasks/email_topics.rake
@@ -1,7 +1,7 @@
 namespace :email_topics do
   task :check, [:content_id] => :environment do |_task, args|
     document = Document.find_by!(content_id: args.content_id)
-    EmailTopicChecker.new(document).check
+    puts EmailTopicChecker.new(document).check
   end
 
   task check_all_documents: :environment do


### PR DESCRIPTION
`EmailTopicChecker` has been updated and returns a string now rather than writing to STDOUT. This commit adds a `puts` into the task to restore the output.