### PR TITLE
Use correct republish method

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -41,15 +41,13 @@ class WorldwideOrganisation < ApplicationRecord
     # If the default news organisation image changes we need to republish all
     # news articles belonging to the worldwide organisation
     if default_news_organisation_image_data_id_changed?
-      document_ids = NewsArticle
+      documents = NewsArticle
         .in_worldwide_organisation(self)
         .includes(:images)
         .where(images: { id: nil })
-        .map(&:document_id)
+        .map(&:document)
 
-      DataHygiene::PublishingApiRepublisher
-        .new(Document.where(id: document_ids))
-        .perform
+      documents.each { |d| Whitehall::PublishingApi.republish_document_async(d) }
     end
   end
 


### PR DESCRIPTION
We can't use `DataHygiene::PublishingApiRepublisher` on news articles as they are editions. I thought this meant you would have to pass the documents, but this is not the case. Actually this method is designed for models which have not yet transitions to being editions.

Instead, the correct method to use is `Whitehall::PublishingApi.republish_document_async`, an example of which is used in the `Dependable` class.

Ideally, world location news articles should be dependencies of world locations, but this feels like a much larger change, whereas this PR is just to fix an issue where the default image of world locations is not updated in news articles if it changes.