### PR TITLE
Add rake email_topics:check_file[path]

### DIFF
--- a/lib/tasks/email_topics.rake
+++ b/lib/tasks/email_topics.rake
@@ -1,9 +1,11 @@
 namespace :email_topics do
+  desc "check the email topics for a single document"
   task :check, [:content_id] => :environment do |_task, args|
     document = Document.find_by!(content_id: args.content_id)
     puts EmailTopicChecker.new(document).check
   end
 
+  desc "check the email topics for all documents"
   task check_all_documents: :environment do
     Document.published.find_in_batches(batch_size: 20).each do |documents|
       threads = documents.map do |document|
@@ -21,6 +23,20 @@ namespace :email_topics do
       end
 
       threads.each(&:join)
+    end
+  end
+
+  desc "check the email topics for documents listed in a file (one content_id per line)"
+  task :check_file, [:path] => :environment do |_task, args|
+    content_ids = File.read(File.expand_path(args.path)).split
+    documents = Document.where(content_id: content_ids)
+
+    documents.find_each do |document|
+      begin
+        puts EmailTopicChecker.new(document).check
+      rescue StandardError => ex
+        puts "#{document.content_id} raised #{ex.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
This is an extension of: https://trello.com/c/kp8QW6i1/91-create-a-rake-task-to-be-able-to-see-which-topics-an-update-would-be-sent-to

Add a rake task so we can rapidly get verbose output
for groups of content_ids produced by the
check_all_documents rake task.