### PR TITLE
Add an env var to ignore an issue with consultations

### DIFF
--- a/lib/email_topic_checker.rb
+++ b/lib/email_topic_checker.rb
@@ -114,7 +114,16 @@ class EmailTopicChecker
 
   def generate_feed_urls(edition)
     generator = Whitehall::GovUkDelivery::SubscriptionUrlGenerator.new(edition)
-    generator.subscription_urls
+    urls = generator.subscription_urls
+
+    # Ignore an issue with consultations that we've already captured:
+    # https://trello.com/c/CF0yJf2F
+    # https://trello.com/c/qv1l3WBy
+    if ENV["IGNORE_CONSULTATIONS_ISSUE"]
+      urls = urls.reject { |url| url.include?("publication_filter_option=consultations") }
+    end
+
+    urls
   end
 
   def strip_empty_arrays(hash)


### PR DESCRIPTION
Re-opened https://github.com/alphagov/whitehall/pull/3401 after fixing a problem with Jenkins. Will merge when green as already approved.