### PR TITLE
Improve search results for world locations

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -32,9 +32,9 @@ class WorldLocation < ApplicationRecord
   translates :name, :title, :mission_statement
 
   include Searchable
-  searchable title: :name,
+  searchable title: :title,
              link: :search_link,
-             content: :mission_statement,
+             description: :search_description,
              only: :active,
              format: 'world_location',
              slug: :slug
@@ -57,6 +57,10 @@ class WorldLocation < ApplicationRecord
 
   def search_link
     Whitehall.url_maker.world_location_path(slug)
+  end
+
+  def search_description
+    "Services if you're visiting, studying, working or living in #{name}. Includes information about trading with and doing business in the UK and #{name}."
   end
 
   after_update :remove_from_index_if_became_inactive

--- a/db/data_migration/20170811151325_rename_world_location_titles.rb
+++ b/db/data_migration/20170811151325_rename_world_location_titles.rb
@@ -1,0 +1,6 @@
+WorldLocation.where(world_location_type_id: 1).each do |world_location|
+  new_title = "#{world_location.name} and the UK"
+  puts "Update title for #{world_location.name} to '#{new_title}'"
+  world_location.title = new_title
+  world_location.save!
+end

--- a/db/data_migration/20170814083356_republish_world_location_news_pages.rb
+++ b/db/data_migration/20170814083356_republish_world_location_news_pages.rb
@@ -1,0 +1,4 @@
+WorldLocation.where(world_location_type_id: 1).each do |world_location|
+  puts "Republishing news page for #{world_location.name}"
+  WorldLocationNewsPageWorker.new.perform(world_location.id)
+end

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -238,15 +238,14 @@ class WorldLocationTest < ActiveSupport::TestCase
     inactive_location.destroy
   end
 
-  test 'search index data for a world location includes name, mission statement, the correct link and format' do
-    location = build(:world_location, name: 'hat land', slug: 'hat-land', mission_statement: 'helping people in hat land find out about other clothing')
+  test 'search index data for a world location includes name, description, the correct link and format' do
+    location = build(:world_location, name: 'hat land', title: 'hat land and the UK', slug: 'hat-land')
 
-    assert_equal({'title' => 'hat land',
-                  'link' => '/world/hat-land',
-                  'indexable_content' => 'helping people in hat land find out about other clothing',
-                  'format' => 'world_location',
-                  'description' => '',
-                  'slug' => 'hat-land'}, location.search_index)
+    assert_equal({ 'title' => 'hat land and the UK',
+                   'link' => '/world/hat-land',
+                   'description' => "Services if you're visiting, studying, working or living in hat land. Includes information about trading with and doing business in the UK and hat land.",
+                   'format' => 'world_location',
+                   'slug' => 'hat-land' }, location.search_index)
   end
 
   test 'search index includes data for all active locations' do


### PR DESCRIPTION
This commit:

* Changes the title of world locations in whitehall to match the format on the navigation pages (“UK and Country” -> “Country and the UK”) (international delegations are not changed) and republishes them
* Republishes all world location news pages to also pick up the change of title
* Sends the new titles to rummager as well as a new description that matches those on the navigation pages