### PR TITLE
Make sure attachments always use the public asset host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,17 @@ Whitehall::Application.configure do
   config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
-  config.action_controller.asset_host = Whitehall.asset_root
+  # Make sure we always use the public_asest_host for uploads as these are
+  # currently served by the whitehall backend machines so any asset urls need
+  # to use the public asset host because our CORS settings disallow the admin
+  # asset host from serve assets to the public pages
+  config.action_controller.asset_host = proc do |_source, request|
+    if request && request.path =~ %r{system/uploads}
+      Whitehall.public_asset_host
+    else
+      Whitehall.asset_root
+    end
+  end
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Attachments are always served by the whitehall-backend machines because
the NFS mount they are stored on is not available to the
whitehall-frontend machines.  This means any rendered page (such as CSV
previews) is rendered with by that rails app, and gets the admin assets
host.  The CORS settings for the admin asset hosts means that the browser
will reject those assets as not being available to pages on the public
site and so styling and functionality breaks.  We change the asset_host
for production.rb to use a proc that makes sure to always use the public
asset host for any attachments paths (those with system/uploads in the
path) and this should fix the problem.