### PR TITLE
Remove Speech type ‘ImportedAwaitingType’

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -98,12 +98,13 @@ module Admin::EditionsHelper
       })
     end
 
-    imported_type = SpeechType.find_by_name('Imported - Awaiting Type')
+    # copy default values from Transcript SpeechType for '' select option
+    default_type = SpeechType.find_by_name('Transcript')
     label_data.merge('' => {
-        ownerGroup: I18n.t("document.speech.#{imported_type.owner_key_group}"),
-        publishedExternallyLabel: t_delivered_on(imported_type),
-        locationRelevant: imported_type.location_relevant
-      })
+      ownerGroup: I18n.t("document.speech.#{default_type.owner_key_group}"),
+      publishedExternallyLabel: t_delivered_on(default_type),
+      locationRelevant: default_type.location_relevant
+    })
   end
 
   # Because of the unusual way lead organisations and supporting organisations

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -7,7 +7,6 @@ class Speech < Announcement
   validates :delivered_on, presence: true, unless: ->(speech) { speech.can_have_some_invalid_data? }
 
   delegate :display_type_key, :explanation, to: :speech_type
-  validate :only_speeches_allowed_invalid_data_can_be_awaiting_type
 
   def self.subtypes
     SpeechType.all
@@ -65,11 +64,5 @@ private
 
   def skip_organisation_validation?
     can_have_some_invalid_data? || person_override.present?
-  end
-
-  def only_speeches_allowed_invalid_data_can_be_awaiting_type
-    unless self.can_have_some_invalid_data?
-      errors.add(:speech_type, 'must be changed') if SpeechType::ImportedAwaitingType == self.speech_type
-    end
   end
 end

--- a/app/models/speech_type.rb
+++ b/app/models/speech_type.rb
@@ -8,7 +8,6 @@ class SpeechType
     4 => "<p>Very significant written statements given to Parliament by a minister.</p>",
     5 => "<p>Very significant oral statements given to Parliament by a minister.</p>",
     6 => "<p>Bylined articles written in the name of a minister or official (usually re-published from elsewhere).</p>",
-    1000 => "<p>DO NOT USE. This is a holding category for content that has been imported automatically.</p>"
   }.to_json.freeze
 
   attr_accessor :id, :singular_name, :plural_name, :explanation, :key, :owner_key_group, :published_externally_key, :location_relevant, :prevalence, :use_key_as_display_key
@@ -38,11 +37,7 @@ class SpeechType
   end
 
   def self.primary
-    all - use_discouraged
-  end
-
-  def self.use_discouraged
-    [ImportedAwaitingType]
+    all
   end
 
   def statement_to_parliament?
@@ -103,9 +98,5 @@ class SpeechType
     id: 6, key: "authored_article", singular_name: "Authored article",
     owner_key_group: "author_title", published_externally_key: "written_on", location_relevant: false,
     plural_name: "Authored article", use_key_as_display_key: true
-  )
-
-  ImportedAwaitingType = create(
-    id: 1000, key: "imported", singular_name: "Imported - Awaiting Type", plural_name: "Imported"
   )
 end

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -18,10 +18,6 @@
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>
-      <% if edition.imported? %>
-        <p>This document contains temporary organisation associations to allow for import. These fields will be overwritten once the deliverer of the speech is chosen.</p>
-        <hr>
-      <% end %>
       <%= render 'specialist_sector_fields', form: form, edition: edition %>
     </fieldset>
   <% end %>

--- a/features/speed-tagging-editions.feature
+++ b/features/speed-tagging-editions.feature
@@ -27,15 +27,9 @@ Feature: Speed tagging editions
     And I should be able to tag the publication with "Joe Bloggs"
     And I should not be able to tag the publication with "Jane Smith"
 
-  Scenario: Speed tagging shows speech required fields
-    When I go to speed tag a newly imported speech "Written statement on Beards"
-    Then I should have to select the speech type
-    And I should have to select the deliverer of the speech
-    And I should be able to set the delivered date of the speech
-
   Scenario: Speed tagging shows world locations when relevant
     Given a world location "Uganda" exists
-    When I go to speed tag a newly imported speech "Speech about Uganda"
+    When I go to speed tag a newly imported news article "News article about Uganda"
     Then I should be able to select the world location "Uganda"
 
   Scenario: Speed tagging news articles allows relevant appointments to be set
@@ -54,7 +48,7 @@ Feature: Speed tagging editions
     When I go to speed tag a newly imported news article "Beards are more costly this year"
     Then I should be able to set the first published date
 
-  Scenario: Speed tagging a consulation shows the required fields
+  Scenario: Speed tagging a consultation shows the required fields
     When I go to speed tag a newly imported consultation "Review of the Ministry of Beards 2012"
     Then I should be able to set the consultation dates
 

--- a/test/factories/speeches.rb
+++ b/test/factories/speeches.rb
@@ -17,7 +17,6 @@ FactoryGirl.define do
     end
   end
 
-  factory :imported_speech, parent: :speech, traits: [:imported]
   factory :draft_speech, parent: :speech, traits: [:draft]
   factory :submitted_speech, parent: :speech, traits: [:submitted]
   factory :rejected_speech, parent: :speech, traits: [:rejected]

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -10,7 +10,6 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
   should_allow_creating_of :speech
   should_allow_editing_of :speech
 
-  should_allow_speed_tagging_of :speech
   should_allow_related_policies_for :speech
   should_allow_association_between_world_locations_and :speech
   should_allow_attached_images_for :speech

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -623,14 +623,6 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
-  test "errors_as_draft does not have a side effect on the editions errors object" do
-    edition = build("imported_publication", publication_type: PublicationType::ImportedAwaitingType)
-    edition.valid?
-    assert_equal({}, edition.errors.messages)
-    edition.errors_as_draft
-    assert_equal({}, edition.errors.messages)
-  end
-
   test "should store title in multiple languages" do
     edition = build(:edition)
     with_locale(:en) { edition.title = 'english-title' }

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -15,12 +15,7 @@ class SpeechTest < ActiveSupport::TestCase
     refute speech.valid?
   end
 
-  [:imported, :deleted].each do |state|
-    test "#{state} editions are valid when the type is 'imported-awaiting-type'" do
-      speech = build(:speech, state: state, speech_type: SpeechType.find_by_slug('imported-awaiting-type'))
-      assert speech.valid?
-    end
-
+  [:deleted, :superseded].each do |state|
     test "#{state} editions are valid without a delivered on date" do
       speech = build(:speech, state: state, delivered_on: nil)
       assert speech.valid?
@@ -33,11 +28,6 @@ class SpeechTest < ActiveSupport::TestCase
   end
 
   [:draft, :scheduled, :published, :submitted, :rejected].each do |state|
-    test "#{state} editions are not valid when the publication type is 'imported-awaiting-type'" do
-      edition = build(:speech, state: state, speech_type: SpeechType.find_by_slug('imported-awaiting-type'))
-      refute edition.valid?
-    end
-
     test "#{state} editions are not valid without a delivered on date" do
       edition = build(:speech, state: state, delivered_on: nil)
       refute edition.valid?
@@ -180,13 +170,13 @@ class SpeechTest < ActiveSupport::TestCase
 
   test '#government returns the current government for an speech delivered at an unspecified time' do
     current_government = create(:current_government)
-    speech = create(:imported_speech, delivered_on: nil)
+    speech = create(:deleted_speech, delivered_on: nil)
     assert_equal current_government, speech.government
   end
 
   test '#government returns the current government for an speech in the future' do
     current_government = create(:current_government)
-    speech = create(:imported_speech, delivered_on: 2.weeks.from_now)
+    speech = create(:speech, delivered_on: 2.weeks.from_now)
     assert_equal current_government, speech.government
   end
 


### PR DESCRIPTION
This SpeechType was added in 2012 (https://github.com/alphagov/whitehall/commit/bdbc7ac299cc5b73924c235b8f13bcb814b61345) and is fine to remove now. As far as I know we do not ‘import’ Speeches anymore and there are no Speeches left in the production db with this SpeechType, so all of this is redundant code.

Checked the db with:

```
Speech.all.map { |s| s.speech_type.singular_name }.uniq.sort
=> [
"Authored article", 
"Draft text",
"Oral statement to Parliament",
"Speaking notes",
"Transcript",
"Written statement to Parliament"
]
```

Note: I came across this when we found a similar type for NewsArticles. This seems to fit into the context of when documents were being imported from an outside source into Whitehall a few years back (which admittedly I lack context on.. the term 'SpeedTagging' pops up throughout the code base). So NewsArticles have an `Unknown` NewsArticleType and Publications have `Unknown` and `ImportedAwaitingType` PublicationTypes. Removing this legacy code for Speeches was fairly quick but I'm wondering whether it's valuable to remove this individual legacy type or whether it should be done as a larger piece of work to clean up all code related to importing documents.