### PR TITLE
Add data migration to convert unknown news articles

### DIFF
--- a/db/data_migration/20170818104227_convert_unknown_news_articles_to_valid_news_articles.rb
+++ b/db/data_migration/20170818104227_convert_unknown_news_articles_to_valid_news_articles.rb
@@ -1,0 +1,21 @@
+begin
+  # Update NewsArticles in Whitehall
+  unknown_news_articles = NewsArticle.by_subtype(NewsArticleType::Unknown)
+  document_ids = unknown_news_articles.map { |n| n.document_id }.uniq
+  press_releases = unknown_news_articles.includes(:document).select { |n| n.slug.include?("press-release") }
+  news_stories = unknown_news_articles - press_releases
+
+  press_releases.update_all(news_article_type_id: NewsArticleType::PressRelease.id)
+  press_releases.where(minor_change: false, change_note: nil).update_all(change_note: "This news article was converted to a press release")
+
+  news_stories.update_all(news_article_type_id: NewsArticleType::NewsStory.id)
+  news_stories.where(minor_change: false, change_note: nil).update_all(change_note: "This news article was converted to a news story")
+
+  # Republish updated NewsArticles to PublishingAPI
+  document_ids.each do |id|
+    PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+    print "."
+  end
+rescue NameError => e
+  puts "Can't apply data migration: #{e.message}"
+end


### PR DESCRIPTION
The NewsArticleType Unknown is a legacy concept. These are NewsArticles that were never categorised into one of the other NewsArticleTypes. It's not possible to create one or even edit existing ones without choosing another NewsArticleType. These are surfaced on the frontend via the [Announcements page](www.gov.uk/government/announcements) and do get shown when filtering by PressRelease or NewsStory. Therefore it seems acceptable to convert these into those two types. This will enable us to remove the ‘Unknown’ NewsArticleType as well as some code that goes with this special case (in a future PR).

Related to https://trello.com/c/K1OAcdZ1/118-documents-with-an-unknown-newsarticletype-are-interfering-with-matching
