### PR TITLE
Add migration to send missing people to rummager

### DIFF
--- a/db/data_migration/20170818102913_send_missing_people_to_rummager.rb
+++ b/db/data_migration/20170818102913_send_missing_people_to_rummager.rb
@@ -1,0 +1,32 @@
+slugs = %w(
+  nick-hurd
+  nick-gibb
+  damian-green
+  brandon-lewis
+  elizabeth-truss
+  greg-hands
+  claire-perry
+  andrea-leadsom
+  lord-ashton-of-hyde
+  rory-stewart
+  stephen-barclay
+  richard-harrington
+  caroline-nokes
+  lord-oshaughnessy
+  david-rutley
+  rebecca-harris
+  mike-freer
+  nigel-adams
+  stuart-andrew
+  craig-whittaker
+  ian-duncan
+  david-hall--2
+  david-reid
+  duncan-thompson--2
+  david-reed
+  ben-merrick
+)
+
+missing_people = Person.where(slug: slugs)
+
+missing_people.map(&:update_in_search_index)


### PR DESCRIPTION
Some people listed in Whitehall have not been indexed in rummager. This manifests in some finder screens as rows in the people multi select that have no description. For example, the drop down on https://www.gov.uk/government/policies/2012-olympic-and-paralympic-legacy currently looks like this: 

<img width="321" alt="screen shot 2017-08-18 at 15 40 40" src="https://user-images.githubusercontent.com/647311/29463761-a64bbc72-842b-11e7-881c-4d2666f4e879.png">

The Html produced for the first three items in the list is:
```
<label for="people-brandon-lewis">
    <input name="people[]" value="brandon-lewis" id="people-brandon-lewis" type="checkbox" aria-controls="js-search-results-info">
        
</label>
<label for="people-lord-ashton-of-hyde">
    <input name="people[]" value="lord-ashton-of-hyde" id="people-lord-ashton-of-hyde" type="checkbox" aria-controls="js-search-results-info">
        
</label>
<label for="people-baroness-neville-rolfe-dbe">
    <input name="people[]" value="baroness-neville-rolfe-dbe" id="people-baroness-neville-rolfe-dbe" type="checkbox" aria-controls="js-search-results-info">
        Baroness Neville-Rolfe DBE CMG
</label>
```

Brandon Lewis and Lord Ashton have entries in the list, but are missing the inner Html which would display their names on screen.

A further manifestation is that searching for one of these missing people at `/government/people` does not return them in the list of results. For example, Andrea Leadsom has a profile page at https://www.gov.uk/government/people/andrea-leadsom, but searching for her by surname yields no results:

<img width="592" alt="screen shot 2017-08-18 at 15 48 06" src="https://user-images.githubusercontent.com/647311/29464102-ba821672-842c-11e7-83fa-06a2725425cc.png">

This migration updates these missing people in the search index.