### PR TITLE
Remove references to Unknown NewsArticleType

### DIFF
--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -133,7 +133,7 @@ ActiveModel::Name
   def edition_sub_type_options_for_select(selected)
     subtype_options_hash = {
       'Publication sub-types' => PublicationType.ordered_by_prevalence.map { |sub_type| [sub_type.plural_name, "publication_#{sub_type.id}"] },
-      'News article sub-types' => NewsArticleType.ordered_by_prevalence.map { |sub_type| [sub_type.plural_name, "news_article_#{sub_type.id}"] },
+      'News article sub-types' => NewsArticleType.all.map { |sub_type| [sub_type.plural_name, "news_article_#{sub_type.id}"] },
       'Speech sub-types' => SpeechType.all.map { |sub_type| [sub_type.plural_name, "speech_#{sub_type.id}"] }
     }
     grouped_options_for_select(subtype_options_hash, selected)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,7 +86,7 @@ module ApplicationHelper
   def news_article_type_options
     [
       ["", [""]],
-      ["Common types", NewsArticleType.primary.map { |type|
+      ["Common types", NewsArticleType.all.map { |type|
         [type.singular_name, type.id]
       }]
     ]

--- a/app/models/news_article_type.rb
+++ b/app/models/news_article_type.rb
@@ -10,10 +10,9 @@ class NewsArticleType
     2 => "<p>Unedited press releases as sent to the media, and official statements from the organisation or a minister.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>",
     3 => "<p>Government statements in response to media coverage, such as rebuttals and ‘myth busters’.</p><p>Do <em>not</em> use for: statements to Parliament. Use the “Speech” format for those.</p>",
     4 => "<p>Announcements specific to one or more world location. Don’t duplicate news published by another department.</p>",
-    999 => "<p>DO NOT USE. This is a legacy category for content created before sub-types existed.</p>",
   }.to_json.freeze
 
-  attr_accessor :id, :singular_name, :plural_name, :prevalence, :key
+  attr_accessor :id, :singular_name, :plural_name, :key
 
   def slug
     plural_name.downcase.gsub(/[^a-z]+/, "-")
@@ -25,22 +24,6 @@ class NewsArticleType
 
   def self.all_slugs
     all.map(&:slug).to_sentence
-  end
-
-  def self.by_prevalence
-    all.group_by { |type| type.prevalence }
-  end
-
-  def self.ordered_by_prevalence
-    primary + migration
-  end
-
-  def self.primary
-    by_prevalence[:primary]
-  end
-
-  def self.migration
-    by_prevalence[:migration]
   end
 
   def self.search_format_types
@@ -60,34 +43,23 @@ class NewsArticleType
     key: "news_story",
     singular_name: "News story",
     plural_name: "News stories",
-    prevalence: :primary
   )
   PressRelease = create(
     id: 2,
     key: "press_release",
     singular_name: "Press release",
     plural_name: "Press releases",
-    prevalence: :primary
   )
   GovernmentResponse = create(
     id: 3,
     key: "government_response",
     singular_name: "Government response",
     plural_name: "Government responses",
-    prevalence: :primary
   )
   WorldNewsStory = create(
     id: 4,
     key: "world_news_story",
     singular_name: "World news story",
     plural_name: "World news stories",
-    prevalence: :primary
-  )
-  Unknown = create(
-    id: 999,
-    key: "announcement",
-    singular_name: "Announcement",
-    plural_name: "Announcements",
-    prevalence: :migration
   )
 end

--- a/lib/email_topic_checker.rb
+++ b/lib/email_topic_checker.rb
@@ -123,12 +123,6 @@ class EmailTopicChecker
       urls = urls.reject { |url| url.include?("publication_filter_option=consultations") }
     end
 
-    # Ignore an issue with documents that have an 'unknown' news article type:
-    # https://trello.com/c/K1OAcdZ1
-    if ENV["IGNORE_UNKNOWN_ISSUE"]
-      urls = urls.reject { |url| url.include?("announcement_filter_option=press-releases") }
-    end
-
     urls
   end
 

--- a/lib/whitehall/announcement_filter_option.rb
+++ b/lib/whitehall/announcement_filter_option.rb
@@ -2,8 +2,8 @@ module Whitehall
   class AnnouncementFilterOption < FilterOption
     attr_accessor :speech_types, :news_article_types
 
-    PressRelease = create(id: 1, label: "Press releases", search_format_types: [NewsArticleType::PressRelease.search_format_types, NewsArticleType::Unknown.search_format_types].flatten, edition_types: ["NewsArticle"], news_article_types: [NewsArticleType::PressRelease, NewsArticleType::Unknown])
-    NewsStory = create(id: 2, label: "News stories", search_format_types: [NewsArticleType::NewsStory.search_format_types, NewsArticleType::Unknown.search_format_types].flatten, edition_types: ["NewsArticle"], news_article_types: [NewsArticleType::NewsStory, NewsArticleType::Unknown])
+    PressRelease = create(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: ["NewsArticle"], news_article_types: [NewsArticleType::PressRelease])
+    NewsStory = create(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: ["NewsArticle"], news_article_types: [NewsArticleType::NewsStory])
     FatalityNotice = create(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: ["FatalityNotice"])
     Speech = create(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: ["Speech"], speech_types: SpeechType.non_statements)
     Statement = create(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: ["Speech"], speech_types: SpeechType.statements)

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -29,11 +29,6 @@ class NewsArticleTest < ActiveSupport::TestCase
     refute news_article.valid?
   end
 
-  test "superseded news articles are valid with the 'unknown' news_article_type" do
-    news_article = build(:superseded_news_article, news_article_type: NewsArticleType::Unknown)
-    assert news_article.valid?
-  end
-
   test "non-English locale is invalid for non-world-news-story types" do
     non_foreign_language_news_types = [
       NewsArticleType::NewsStory,

--- a/test/unit/news_article_type_test.rb
+++ b/test/unit/news_article_type_test.rb
@@ -12,7 +12,7 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
   end
 
   test "should list all slugs" do
-    assert_equal "news-stories, press-releases, government-responses, world-news-stories and announcements", NewsArticleType.all_slugs
+    assert_equal "news-stories, press-releases, government-responses and world-news-stories", NewsArticleType.all_slugs
   end
 
   test 'search_format_types tags the type with the key, prefixed with news-article-' do
@@ -27,7 +27,6 @@ class NewsArticleTypeTest < ActiveSupport::TestCase
       "news-article-press-release",
       "news-article-government-response",
       "news-article-world-news-story",
-      "news-article-announcement",
     ]
     assert_equal expected, NewsArticleType.search_format_types
   end

--- a/test/unit/whitehall/document_filter/rummager_test.rb
+++ b/test/unit/whitehall/document_filter/rummager_test.rb
@@ -16,7 +16,7 @@ module Whitehall::DocumentFilter
           has_entry({ search_format_types: format_types }))
     end
 
-    test 'announcements_search looks for all announcements exluding world types by default' do
+    test 'announcements_search looks for all announcements excluding world types by default' do
       rummager = Rummager.new({})
       expected_types = [
         "fatality-notice",
@@ -24,7 +24,6 @@ module Whitehall::DocumentFilter
         "news-article-news-story",
         "news-article-press-release",
         "news-article-government-response",
-        "news-article-announcement"
       ]
       expect_search_by_format_types(expected_types)
       rummager.announcements_search


### PR DESCRIPTION
Now that we've [converted all NewsArticles away from the Unknown type](https://github.com/alphagov/whitehall/pull/3412), we can remove any code that refers to it.

For https://trello.com/c/K1OAcdZ1/118-documents-with-an-unknown-newsarticletype-are-interfering-with-matching