### PR TITLE
Document Smart Answers dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ API](https://github.com/alphagov/publishing-api) and
 * xpdf (first download [XQuartz](http://www.xquartz.org/))
 * PhantomJS (for running the Javascript tests)
 
+## Dependencies on Whitehall
+
+The following applications have dependencies on Whitehall APIs:
+
+* [alphagov/smart-answers](https://github.com/alphagov/smart-answers) uses the Worldwide
+  Locations and Worldwide Organisations endpoints
+
 ## Running the application
 
 The application can be started with


### PR DESCRIPTION
We recently had an incident where the Worldwide API was updated in such
a way that its contract with the Smart Answers application was broken.

This change adds a couple of comments documenting this dependency in the
README.