### PR TITLE
Removed deprecated need_ids column from Editions

### DIFF
--- a/db/migrate/20170821152429_remove_need_ids_from_editions.rb
+++ b/db/migrate/20170821152429_remove_need_ids_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveNeedIdsFromEditions < ActiveRecord::Migration
+  def change
+    remove_column :editions, :need_ids, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170411161614) do
+ActiveRecord::Schema.define(version: 20170821152429) do
 
   create_table "about_pages", force: :cascade do |t|
     t.integer  "topical_event_id",    limit: 4
@@ -432,7 +432,6 @@ ActiveRecord::Schema.define(version: 20170411161614) do
     t.datetime "opening_at"
     t.datetime "closing_at"
     t.integer  "corporate_information_page_type_id",          limit: 4
-    t.string   "need_ids",                                    limit: 255
     t.string   "primary_locale",                              limit: 255,   default: "en",    null: false
     t.boolean  "political",                                                 default: false
     t.string   "logo_url",                                    limit: 255


### PR DESCRIPTION
This is the final step in removing any reference to using the Needs API in `whitehall`. The actual work of disconnecting Needs API and converting needs into content items that can be fetched from the Publishing API was done in a previous PR: https://github.com/alphagov/whitehall/pull/3071.

This commit is only concerned with dropping the now unused `need_ids` column from the `Editions` table.