### PR TITLE
Republish world news stories

### DIFF
--- a/db/data_migration/20170824112024_republish_world_news_stories.rb
+++ b/db/data_migration/20170824112024_republish_world_news_stories.rb
@@ -1,0 +1,13 @@
+# Republishes documents for world news stories.
+
+document_ids = NewsArticle
+  .where(news_article_type_id: NewsArticleType::WorldNewsStory.id)
+  .pluck(:document_id)
+  .uniq
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+  print "."
+end
+
+puts


### PR DESCRIPTION
This is so that these editions receive the correct
email_document_supertype which affects the subscriber
lists that are matched in email-alert-api.

See: https://github.com/alphagov/govuk_document_types/pull/17