### PR TITLE
Update world location news view link

### DIFF
--- a/app/views/admin/world_locations/show.html.erb
+++ b/app/views/admin/world_locations/show.html.erb
@@ -7,7 +7,8 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= view_on_website_link_for @world_location %></p>
+    <p>
+    <%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %>
   </div>
 
   <section class="world-location-details">


### PR DESCRIPTION
`WorldLocation`s are no longer rendered explicitly and are now represented as world location news pages. This commit updates the 'View on website' link to point to this URL.

[Trello](https://trello.com/c/bkdPtKOI/129-link-to-world-location-news-page-from-whitehall-admin-ui)