### PR TITLE
Fix world news page url in tabs

### DIFF
--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -7,7 +7,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= view_on_website_link_for @world_location %></p>
+    <p><%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_location_translations/index.html.erb
+++ b/app/views/admin/world_location_translations/index.html.erb
@@ -5,7 +5,6 @@
   <div class="world-location-header">
     <h1>
       <span class="name"><%= @world_location.name %></span>
-      &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
     <p><%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %></p>
   </div>

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -6,7 +6,7 @@
       <span class="name"><%= @world_location.name %></span>
       &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
-    <p><%= view_on_website_link_for @world_location, url: { locale: I18n.default_locale } %></p>
+    <p><%= link_to "View on website", world_location_news_index_path(@world_location, {locale: params[:locale]}.merge(cachebust_url_options)) %></p>
   </div>
   <section class="world-location-details">
     <%= tab_navigation_for(@world_location) %>

--- a/app/views/admin/world_locations/features.html.erb
+++ b/app/views/admin/world_locations/features.html.erb
@@ -4,7 +4,6 @@
   <div class="world-location-header">
     <h1>
       <span class="name"><%= @world_location.name %></span>
-      &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
     <p><%= link_to "View on website", world_location_news_index_path(@world_location, {locale: params[:locale]}.merge(cachebust_url_options)) %></p>
   </div>

--- a/app/views/admin/world_locations/show.html.erb
+++ b/app/views/admin/world_locations/show.html.erb
@@ -5,7 +5,6 @@
   <div class="world-location-header">
     <h1>
       <span class="name"><%= @world_location.name %></span>
-      &ldquo;<span class="title"><%= @world_location.title %></span>&rdquo;
     </h1>
     <p>
     <%= link_to "View on website", world_location_news_index_path(@world_location, cachebust_url_options) %>

--- a/test/functional/admin/world_locations_controller_test.rb
+++ b/test/functional/admin/world_locations_controller_test.rb
@@ -81,11 +81,32 @@ class Admin::WorldLocationsControllerTest < ActionController::TestCase
     refute FeaturedLink.exists?(featured_link.id)
   end
 
-  view_test "the 'View on website' link on /features goes to the English world location page" do
+  view_test "the 'View on website' link on the show page goes to the news page" do
+    world_location = create(:world_location, slug: "germany")
+    get :show, id: world_location
+    assert_select 'a' do |links|
+      view_links = links.select { |link| link.text =~ /View on website/ }
+      assert_match(/\/world\/germany\/news/, view_links.first["href"])
+    end
+  end
+
+  view_test "the 'View on website' link on /features goes to the English France news page" do
+    world_location = create(:world_location, slug: "france", translated_into: [:fr])
+    get :features, id: world_location
+
+    assert_select 'a' do |links|
+      view_links = links.select { |link| link.text =~ /View on website/ }
+      assert_match(/\/world\/france\/news/, view_links.first["href"])
+    end
+  end
+
+  view_test "the 'View on website' link on /features.fr goes to the French world location page" do
     world_location = create(:world_location, slug: "france", translated_into: [:fr])
     get :features, id: world_location, locale: "fr"
 
-    assert response.body.include?("gov.uk/world/france")
-    refute response.body.include?("gov.uk/world/france.fr")
+    assert_select 'a' do |links|
+      view_links = links.select { |link| link.text =~ /View on website/ }
+      assert_match(/\/world\/france\/news\.fr/, view_links.first["href"])
+    end
   end
 end


### PR DESCRIPTION
This PR updates other instances of the 'View on website' link around the World Location admin interface following up from https://github.com/alphagov/whitehall/pull/3425

Also changes the page title to remove the "UK and... " bit.

[Trello](https://trello.com/c/bkdPtKOI/129-link-to-world-location-news-page-from-whitehall-admin-ui)