### PR TITLE
Push html attachments on save

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -16,7 +16,7 @@ class Admin::AttachmentsController < Admin::BaseController
   def new; end
 
   def create
-    if attachment.save
+    if save_attachment
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       render :new
@@ -25,7 +25,7 @@ class Admin::AttachmentsController < Admin::BaseController
 
   def update
     attachment.attributes = attachment_params
-    if attachment.save
+    if save_attachment
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
     else
@@ -172,6 +172,14 @@ private
       redirect_to attachable_attachments_path(attachable), notice: "Attachment '#{attachment.title}' uploaded"
     else
       raise
+    end
+  end
+
+  def save_attachment
+    if attachable_is_an_edition?
+      attachment.save && Whitehall.edition_services.draft_updater(attachable).perform!
+    else
+      attachment.save
     end
   end
 end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -118,6 +118,19 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     refute_nil(Attachment.find_by title: attachment[:title])
   end
 
+  test 'POST :create updates the edition of the attachment' do
+    attachment = valid_html_attachment_params
+
+    Whitehall.edition_services
+      .expects(:draft_updater)
+      .with(@edition)
+      .returns(updater = stub)
+
+    updater.expects(:perform!)
+
+    post :create, edition_id: @edition.id, type: 'html', attachment: attachment
+  end
+
   test 'POST :create ignores html attachments when attachable does not allow them' do
     attachable = create(:statistical_data_set, access_limited: false)
 


### PR DESCRIPTION
Save the edition upon adding/updating an HTML attachment which will trigger it updating the PublishingAPI. This should enable users to preview an attachment after adding it (previously a user would have to save the edition first before being able to preview the attachment).

Effectively reverts https://github.com/alphagov/whitehall/pull/3157 but it's not entirely clear to me why this functionality (of pushing to the publishing api after adding an attachment) was removed in the first place. I tried doing a straight revert but other parts of the code have changed too much since. 

For https://trello.com/c/7SU9Uf54/130-html-attachment-previewing-problems