### PR TITLE
Rescue from PublishingAPI get links 404 response

### DIFF
--- a/app/models/document/needs.rb
+++ b/app/models/document/needs.rb
@@ -15,6 +15,11 @@ module Document::Needs
     return unless response
 
     response["links"]["meets_user_needs"]
+  rescue GdsApi::HTTPNotFound
+    # This defends against a race condition where this query is made before the
+    # Document exists in the PublishingAPI (for example after creating a new
+    # edition)
+    []
   end
 
   def patch_meets_user_needs_links

--- a/test/unit/document/needs_test.rb
+++ b/test/unit/document/needs_test.rb
@@ -63,4 +63,14 @@ class Document::NeedsTest < ActiveSupport::TestCase
 
     assert_equal document.patch_meets_user_needs_links, "Links updated"
   end
+
+  test "#get_user_needs_from_publishing_api returns an empty array for a 404 response" do
+    document = create(:document)
+
+    Services.publishing_api.expects(:get_links)
+    .with(document.content_id)
+    .raises(GdsApi::HTTPNotFound.new(404))
+
+    assert_equal document.get_user_needs_from_publishing_api, []
+  end
 end


### PR DESCRIPTION
There is a race condition in the WhitehallAdmin UI when creating
new editions. When a new edition is saved for the first time, it's
sent to the PublishingAPI asynchronously. At the same time, the
save operation is considered successful by the
`Admin:EditionsController` and redirects to the show page for that
edition. The show page aims to displays needs information which
it gets from a `get_links` query to the PublishingAPI. It's possible
(I ran into this in my dev environment) that this query is made
before the Document exists in the PublishingAPI and would
therefore return a 404. This results in an error screen being shown
in the AdminUI.

We add a rescue statement to guard against this, prefering to
return an empty needs response as a way of failing gracefully.
A refresh of the show page should render all the correct data at a
later point...