### PR TITLE
Update HtmlAttachment -> publishing API

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -176,10 +176,10 @@ private
   end
 
   def save_attachment
-    if attachable_is_an_edition?
-      attachment.save && Whitehall.edition_services.draft_updater(attachable).perform!
-    else
-      attachment.save
+    attachment.save.tap do |result|
+      if result && attachment.is_a?(HtmlAttachment)
+        Whitehall::PublishingApi.save_draft_async(attachment)
+      end
     end
   end
 end


### PR DESCRIPTION
When an `HtmlAttachment` is saved it is possible to preview it in the UI but since we now preview via the draft stack and publishing API we need to ensure that it is sent on save. HtmlAttachment are persisted to publishing API when the parent addition is saved but if the user previews prior to that the get a 404.

This issue was fixed in an earlier commit but using the `edition_services` method doesn't always work as `.perform!` returns false if the edition is invalid which it may be.

This commit sends the attachment directly independently of the edition and returns just the result of `Attachment#save` to the controller action rather than including the result of the publishing API call.

[Trello](https://trello.com/c/7SU9Uf54/130-html-attachment-previewing-problems)