### PR TITLE
Fix a worldwide corporate info page 'about/about' issue

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -90,7 +90,12 @@ module PublicDocumentRoutesHelper
 
     # About pages are actually shown on the CIP index for an Organisation.
     # We generate a unique path for them anyway, but this is always redirected.
-    org.is_a?(Organisation) ? url.gsub("about/about", "about") : url
+    case org
+    when Organisation
+      url.gsub("/about/about", "/about")
+    when WorldwideOrganisation
+      url.gsub("/about/about", "")
+    end
   end
 
   def best_locale_for_edition(edition)

--- a/test/unit/helpers/public_document_routes_helper_test.rb
+++ b/test/unit/helpers/public_document_routes_helper_test.rb
@@ -69,8 +69,8 @@ class PublicDocumentRoutesHelperTest < LocalisedUrlTestCase
     assert_equal "/world/organisations/#{org.slug}/about/research.fr", public_document_path(cip, locale: :fr)
 
     cip.corporate_information_page_type = CorporateInformationPageType::AboutUs
-    assert_equal "/world/organisations/#{org.slug}/about/about", public_document_path(cip)
-    assert_equal "/world/organisations/#{org.slug}/about/about.fr", public_document_path(cip, locale: :fr)
+    assert_equal "/world/organisations/#{org.slug}", public_document_path(cip)
+    assert_equal "/world/organisations/#{org.slug}.fr", public_document_path(cip, locale: :fr)
   end
 
   test 'returns the document URL using Whitehall public_host and protocol' do


### PR DESCRIPTION
https://trello.com/c/XuduNMOa/132-unexpected-country-page-content-change-on-preview

We should link to the top-level worldwide organisation
rather than the /about/about subpath. This keeps the
preview urls consistent with the live urls for these
pages which means the rendering templates match.