### PR TITLE
Fix redirect schema validity

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,4 +1,4 @@
-# Whitehall Testing Guidlines
+# Whitehall Testing Guidelines
 
 All contributions to the Whitehall codebase should have appropriate tests. We
 have a pragmatic approach to testing:- every test should pull its weight.

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -1,4 +1,4 @@
-#Testing Guide
+# Testing Guide
 
 ## Running tests locally
 

--- a/lib/whitehall/publishing_api/redirect.rb
+++ b/lib/whitehall/publishing_api/redirect.rb
@@ -12,7 +12,6 @@ module Whitehall
 
       def as_json
         {
-          content_id: SecureRandom.uuid,
           base_path: base_path,
           document_type: "redirect",
           schema_name: "redirect",


### PR DESCRIPTION
It included a content_id when these are no longer allowed in payload.

Also has a couple of documentation fixes.