### PR TITLE
Generalise consultation subscription urls

### DIFF
--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -1,14 +1,22 @@
 module EmailSignupHelper
 
   def email_signup_path(atom_feed_url)
-    if EmailSignupPagesFinder.exists_for_atom_feed?(atom_feed_url)
-      organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
+    url = generalise_consultations(atom_feed_url)
+
+    if EmailSignupPagesFinder.exists_for_atom_feed?(url)
+      organisation_email_signup_information_path_from_atom_feed(url)
     else
-      new_email_signups_path(email_signup: {feed: atom_feed_url})
+      new_email_signups_path(email_signup: { feed: url })
     end
   end
 
 private
+
+  def generalise_consultations(atom_feed_url)
+    atom_feed_url
+      .gsub("open-consultations", "consultations")
+      .gsub("closed-consultations", "consultations")
+  end
 
   def organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
     organisation_email_signup_information_path extract_slug_from_atom_feed(atom_feed_url)

--- a/test/unit/helpers/email_signup_helper_test.rb
+++ b/test/unit/helpers/email_signup_helper_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class EmailSignupHelperTest < ActionView::TestCase
+  def base_url
+    "https://www.gov.uk/government/publications.atom"
+  end
+
+  test "#email_signup_path returns an email signup with the feed url" do
+    result = email_signup_path(base_url)
+    expected = "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications.atom"
+
+    assert_equal expected, result
+  end
+
+  test "#email_signup_path for 'open-consultations' returns the path with 'consultations'" do
+    result = email_signup_path("#{base_url}?publication_filter_option=open-consultations")
+    expected = "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications.atom%3Fpublication_filter_option%3Dconsultations"
+
+    assert_equal expected, result
+  end
+
+  test "#email_signup_path for 'closed-consultations' returns the path with 'consultations'" do
+    result = email_signup_path("#{base_url}?publication_filter_option=closed-consultations")
+    expected = "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications.atom%3Fpublication_filter_option%3Dconsultations"
+
+    assert_equal expected, result
+  end
+
+  test "#email_signup_path for 'consultations' returns the path with 'consultations'" do
+    result = email_signup_path("#{base_url}?publication_filter_option=consultations")
+    expected = "/government/email-signup/new?email_signup%5Bfeed%5D=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications.atom%3Fpublication_filter_option%3Dconsultations"
+
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
We’re changing consultation subscriptions to only
allow subscriptions to all consultations rather
than open/closed being separated. This was
previously broken.

https://trello.com/c/qv1l3WBy/119-documents-that-are-open-or-closed-consultations-dont-match-all-consultations-topics-in-email-alert-api