### PR TITLE
Redirect routes for duplicate 'About us' corporate info pages

### DIFF
--- a/db/data_migration/20170906102634_redirect_cips.rb
+++ b/db/data_migration/20170906102634_redirect_cips.rb
@@ -1,0 +1,63 @@
+class RedirectCIPs
+  def redirect_all
+    about_us = ::CorporateInformationPageType::AboutUs
+
+    about_pages = ::CorporateInformationPage
+      .where(corporate_information_page_type_id: about_us.id)
+
+    about_pages.find_each do |page|
+      page.available_locales.each do |locale|
+        redirect_one(page, locale)
+      end
+    end
+  end
+
+  def redirect_one(page, locale)
+    source = localised_path(page, locale, subpath: "/about")
+    destination = localised_path(page, locale, subpath: "")
+    redirect(source, destination, locale)
+
+    if page.worldwide_organisation
+      source = localised_path(page, locale, subpath: "/about/about")
+      redirect(source, destination, locale)
+    end
+  end
+
+private
+
+  def localised_path(page, locale, subpath:)
+    suffix = locale == :en ? "" : ".#{locale}"
+    Whitehall.url_maker.document_path(page) + subpath + suffix
+  end
+
+  def redirect(source, destination, locale)
+    content_id = lookup_content_id(source)
+
+    if content_id
+      puts "updated: #{source} --> #{destination}"
+      PublishingApiRedirectWorker.new.perform(content_id, destination, locale)
+    else
+      puts "    new: #{source} --> #{destination}"
+      content_id = SecureRandom.uuid
+
+      new_redirect = Whitehall::PublishingApi::Redirect.new(source, [{
+        path: source,
+        type: "exact",
+        destination: destination,
+      }])
+
+      Services.publishing_api.put_content(content_id, new_redirect.as_json)
+      Services.publishing_api.publish(content_id)
+    end
+  end
+
+  def lookup_content_id(base_path)
+    Services.publishing_api.lookup_content_id(
+      base_path: base_path,
+      exclude_unpublishing_types: [],
+      exclude_document_types: [],
+    )
+  end
+end
+
+RedirectCIPs.new.redirect_all


### PR DESCRIPTION
https://trello.com/c/9JFXOc5y/145-worldwide-organisations-are-not-updated-when-their-about-us-summary-is-changed-added?menu=filter&filter=label:Support

Whitehall has some special redirect logic around
the `/about` corporate info pages for organisations
and worldwide organisations. These pages are now
served by government-frontend and so we can't
rely on this redirect logic any more and need to
set up these routes in a more conventional way.

These `/about` pages are a bit of a mess. Some
orgs. have redirects that go to `/about/about`
which then falls through to Whitehall which then
serves duplicate content at this path. Many of
them have no content at the `/about` paths.

We can sort out this mess by updating or creating
redirects via Publishing API for these `/about` and
`/about/about` paths that redirect to the canonical
'About us' paths. This is much more conventional
approach that gives visibility of these redirects
to Publishing API, Content Store and Router.