### PR TITLE
Add world locations to speech presenter

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -47,7 +47,8 @@ module PublishingApi
         [
           :organisations,
           :policy_areas,
-          :related_policies
+          :related_policies,
+          :world_locations,
         ]
       )
       links.merge!(links_for_speaker)

--- a/lib/sync_checker/formats/speech_check.rb
+++ b/lib/sync_checker/formats/speech_check.rb
@@ -12,7 +12,11 @@ module SyncChecker
               .joins(:classification_memberships)
               .where(classification_memberships: {edition_id: edition_expected_in_live.id})
               .pluck(:content_id)
-          )
+          ),
+          Checks::LinksCheck.new(
+            "world_locations",
+            expected_world_location_content_ids,
+          ),
         ]
 
         if edition_expected_in_live.role_appointment
@@ -88,6 +92,10 @@ module SyncChecker
             "url" => speaker.image.url,
           }
         }
+      end
+
+      def expected_world_location_content_ids
+        edition_expected_in_live.world_locations.map(&:content_id)
       end
     end
   end

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -80,10 +80,12 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
   describe "links" do
     let(:policy_content_id) { SecureRandom.uuid }
     let(:topical_event) { create(:topical_event) }
+    let(:world_location) { create(:world_location) }
 
     before do
       speech.add_policy(policy_content_id)
       speech.topical_events << topical_event
+      speech.world_locations << world_location
     end
 
     it "contains the expected keys and values" do
@@ -93,6 +95,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       assert_includes(presented.links.keys, :topical_events)
       assert_includes(presented.links.keys, :people)
       assert_includes(presented.links.keys, :roles)
+      assert_includes(presented.links.keys, :world_locations)
 
       assert_includes(presented.links[:organisations], speech.organisations.first.content_id)
       assert_includes(presented.links[:related_policies], policy_content_id)
@@ -100,6 +103,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       assert_includes(presented.links[:topical_events], topical_event.content_id)
       assert_includes(presented.links[:roles], speech.role_appointment.role.content_id)
       assert_includes(presented.links[:people], person.content_id)
+      assert_includes(presented.links[:world_locations], world_location.content_id)
     end
 
     context "no role appointment (no speaker)" do


### PR DESCRIPTION
World Locations should be sent to the PublishingAPI for the Speech
format. Among others, this will ensure that the email subscriber
lists are matched correctly in the email-alert-api. We also update
the sync check for the format.