### PR TITLE
Republish speeches with world locations

### DIFF
--- a/db/data_migration/20170907105726_republish_speeches_with_world_locations.rb
+++ b/db/data_migration/20170907105726_republish_speeches_with_world_locations.rb
@@ -1,0 +1,6 @@
+document_ids = Speech.find_each.map { |s| s.document_id if s.world_locations.present? }.compact
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+  print "."
+end


### PR DESCRIPTION
We weren't sending world locations through for speeches.
We fixed in this #3438.