### PR TITLE
Add more cases to ignore for consultations issue topic checking

### DIFF
--- a/lib/email_topic_checker.rb
+++ b/lib/email_topic_checker.rb
@@ -121,6 +121,8 @@ class EmailTopicChecker
     # https://trello.com/c/qv1l3WBy
     if ENV["IGNORE_CONSULTATIONS_ISSUE"]
       urls = urls.reject { |url| url.include?("publication_filter_option=consultations") }
+      urls = urls.reject { |url| url.include?("publication_filter_option=open-consultations") }
+      urls = urls.reject { |url| url.include?("publication_filter_option=closed-consultations") }
     end
 
     urls


### PR DESCRIPTION
We've removed these topics from email-alert-api so more
things are being flagged as inconsistent. This is fine
because we've emailed those people and retired these
lists.