### PR TITLE
Republish authored article speeches

### DIFF
--- a/db/data_migration/20170907145709_republish_authored_articles.rb
+++ b/db/data_migration/20170907145709_republish_authored_articles.rb
@@ -1,0 +1,12 @@
+type = SpeechType.all.detect { |t| t.key == "authored_article" }
+
+document_ids = Speech
+  .published
+  .where(speech_type_id: type.id)
+  .pluck(:document_id)
+  .uniq
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+  print "."
+end


### PR DESCRIPTION
We've set the government_document_supertype to fix
some subscriber list matching problems. See:
https://github.com/alphagov/govuk_document_types/pull/20