### PR TITLE
Send topical_events in the links hash for consultations

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -37,6 +37,7 @@ module PublishingApi
         .merge(PayloadBuilder::People.for(consultation, :ministers))
         .merge(PayloadBuilder::People.for(consultation, :people))
         .merge(PayloadBuilder::Roles.for(consultation))
+        .merge(PayloadBuilder::TopicalEvents.for(consultation))
     end
 
   private

--- a/db/data_migration/20170908110927_republish_consultations_with_topical_events.rb
+++ b/db/data_migration/20170908110927_republish_consultations_with_topical_events.rb
@@ -1,0 +1,10 @@
+document_ids = Consultation
+  .find_each
+  .map { |c| c.document_id if c.topical_events.present? }
+  .compact
+  .uniq
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+  print "."
+end

--- a/lib/sync_checker/formats/consultation_check.rb
+++ b/lib/sync_checker/formats/consultation_check.rb
@@ -25,17 +25,31 @@ module SyncChecker
       end
 
       def checks_for_draft(_locale)
-        super << Checks::LinksCheck.new(
-          "ministers",
-          expected_minister_content_ids(edition_expected_in_draft)
-        )
+        super.tap do |checks|
+          checks << Checks::LinksCheck.new(
+            "ministers",
+            expected_minister_content_ids(edition_expected_in_draft)
+          )
+
+          checks << Checks::LinksCheck.new(
+            "topical_events",
+            expected_topical_event_content_ids(edition_expected_in_draft)
+          )
+        end
       end
 
       def checks_for_live(_locale)
-        super << Checks::LinksCheck.new(
-          "ministers",
-          expected_minister_content_ids(edition_expected_in_live)
-        )
+        super.tap do |checks|
+          checks << Checks::LinksCheck.new(
+            "ministers",
+            expected_minister_content_ids(edition_expected_in_live)
+          )
+
+          checks << Checks::LinksCheck.new(
+            "topical_events",
+            expected_topical_event_content_ids(edition_expected_in_live)
+          )
+        end
       end
 
     private
@@ -210,6 +224,11 @@ module SyncChecker
           .role_appointments
           .try(:collect, &:person)
           .try(:collect, &:content_id)
+      end
+
+
+      def expected_topical_event_content_ids(edition)
+        edition.topical_events.pluck(:content_id)
       end
     end
   end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -617,7 +617,8 @@ module PublishingApi::ConsultationPresenterTest
     setup do
       self.consultation = create(
         :consultation,
-        role_appointments: create_list(:ministerial_role_appointment, 2)
+        role_appointments: create_list(:ministerial_role_appointment, 2),
+        topical_events: create_list(:topical_event, 2),
       )
     end
 
@@ -627,6 +628,7 @@ module PublishingApi::ConsultationPresenterTest
         .map(&:person)
         .map(&:content_id)
 
+      assert expected_content_ids.present?
       assert_equal expected_content_ids, presented_links[:ministers]
     end
 
@@ -636,6 +638,7 @@ module PublishingApi::ConsultationPresenterTest
         .map(&:person)
         .map(&:content_id)
 
+      assert expected_content_ids.present?
       assert_equal expected_content_ids, presented_links[:people]
     end
 
@@ -645,7 +648,17 @@ module PublishingApi::ConsultationPresenterTest
         .map(&:role)
         .map(&:content_id)
 
+      assert expected_content_ids.present?
       assert_equal expected_content_ids, presented_links[:roles]
+    end
+
+    test "topical events" do
+      expected_content_ids = consultation
+        .topical_events
+        .map(&:content_id)
+
+      assert expected_content_ids.present?
+      assert_equal expected_content_ids, presented_links[:topical_events]
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/4y8S9j1S/85-transition-whitehalls-email-sending-to-use-email-alert-api

Otherwise we don’t trigger email alerts when a
consultation tagged to a topical event is
published.