### PR TITLE
Enable Niger link on world home page

### DIFF
--- a/db/data_migration/20170912122522_enable_niger_link_on_world_page.rb
+++ b/db/data_migration/20170912122522_enable_niger_link_on_world_page.rb
@@ -1,0 +1,3 @@
+world_location = WorldLocation.where(slug: "niger").first
+world_location.active = true
+world_location.save!


### PR DESCRIPTION
This commit enables the link to the Niger navigation page from the world home page at `/world`.

Zendesk: https://govuk.zendesk.com/agent/tickets/2394743