### PR TITLE
Add people drop down to announcements

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -203,7 +203,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
       $filterSummary.mustache('documents/_filter_selections', context);
     },
     removeFilters: function(field, removed){
-      var selects = ['topics', 'departments', 'world_locations', 'official_document_status'],
+      var selects = ['topics', 'departments', 'world_locations', 'official_document_status', 'people_ids'],
           inputs = ['keywords', 'from_date', 'to_date'];
 
       if($.inArray(field, selects) > -1){

--- a/app/helpers/document_filter_helper.rb
+++ b/app/helpers/document_filter_helper.rb
@@ -11,6 +11,11 @@ module DocumentFilterHelper
     unsorted_grouped_options_for_select(filter_options.for(:organisations).grouped, selected_values)
   end
 
+  def people_filter_options(selected_person = [])
+    selected_value = selected_person ? selected_person.map(&:slug) : ["all"]
+    filter_option_html(filter_options.for(:people), selected_value)
+  end
+
   def publication_type_filter_options(selected_publication_filter_option = nil)
     selected_value = selected_publication_filter_option ? selected_publication_filter_option.slug : "all"
     filter_option_html(filter_options.for(:publication_type), selected_value)

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -22,7 +22,7 @@
                           [
                             :keyword, :date, :announcement_type,
                             :locations, :department, :topic,
-                            :include_world_location_news
+                            :include_world_location_news, :people_ids
                           ]
                         else
                           [ :locations ]

--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -42,6 +42,13 @@
           </div>
         <% end %>
 
+        <% if filters.include? :people_ids %>
+          <div class="filter">
+            <%= label_tag "people_ids", "Person" %>
+            <%= select_tag "people_ids[]", people_filter_options(@filter.selected_people_option), class: "single-row-select", id: "people_ids" %>
+          </div>
+        <% end %>
+
         <% if filters.include? :official_document_status %>
           <div class="filter">
             <%= label_tag :official_document_status, "Official document status" %>

--- a/app/views/documents/_filter_results.html.erb
+++ b/app/views/documents/_filter_results.html.erb
@@ -4,6 +4,7 @@
     pluralized_result_type: result_type.pluralize(filter.documents.total_count),
     departments: filter_results_selections(filter.selected_organisations, 'departments'),
     topics: filter_results_selections(filter.selected_topics, 'topics'),
+    people_ids: filter_results_selections(filter.selected_people_option, 'people_ids'),
     world_locations_any?: filter.selected_locations.any?,
     world_locations: filter_results_selections(filter.selected_locations, 'world_locations'),
     keywords: filter_results_keywords(filter.keywords),

--- a/app/views/documents/_filter_selections.mustache
+++ b/app/views/documents/_filter_selections.mustache
@@ -9,6 +9,11 @@
     by <strong>{{name}}</strong> <a href="{{url}}" data-field="departments" data-val="{{value}}" title="Remove {{name}} filter">&times;</a> {{joining}}
   {{/departments}}
 </span>
+<span class="people-selections">
+  {{#people_ids}}
+  by <strong>{{name}}</strong> <a href="{{url}}" data-field="people_ids" data-val="{{value}}" title="Remove {{name}} filter">&times;</a> {{joining}}
+  {{/people_ids}}
+</span>
 {{#world_locations_any?}}
 from
 <span class="locations-selections">

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -19,7 +19,7 @@ module Whitehall::DocumentFilter
 
       @topics          = Array(@params[:topics])
       @departments     = Array(@params[:departments])
-      @people_ids      = Array(@params[:people_id])
+      @people_ids      = Array(@params[:people_ids])
       @world_locations = Array(@params[:world_locations])
 
       @official_document_status = @params[:official_document_status]

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -62,7 +62,7 @@ module Whitehall::DocumentFilter
 
     def selected_people_option
       @people_ids.reject! { |l| l == "all" }
-      People.where(id: @people_ids)
+      Person.where(slug: @people_ids)
     end
 
     def selected_locations

--- a/lib/whitehall/document_filter/options.rb
+++ b/lib/whitehall/document_filter/options.rb
@@ -30,7 +30,7 @@ module Whitehall
         announcement_type: 'announcement_filter_option',
         official_documents: 'official_document_status',
         locations: 'world_locations',
-        people: 'person',
+        people: 'people_ids',
       }.freeze
 
       def valid_option_name?(option_name)

--- a/lib/whitehall/document_filter/options.rb
+++ b/lib/whitehall/document_filter/options.rb
@@ -30,6 +30,7 @@ module Whitehall
         announcement_type: 'announcement_filter_option',
         official_documents: 'official_document_status',
         locations: 'world_locations',
+        people: 'person',
       }.freeze
 
       def valid_option_name?(option_name)
@@ -74,6 +75,13 @@ module Whitehall
 
       def options_for_topics
         @options_for_topics ||= StructuredOptions.new(all_label: "All policy areas", grouped: Classification.grouped_by_type)
+      end
+
+      def options_for_people
+        @options_for_people ||= StructuredOptions.new(
+          all_label: "All people",
+          ungrouped: Person.all.sort_by(&:name).map { |o| [o.name, o.slug] }
+        )
       end
 
       def options_for_document_type

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -41,7 +41,7 @@ module Whitehall::DocumentFilter
 
     def filter_by_people
       if @people_ids.present? && @people_ids != ["all"]
-        {people: @people.map(&:slug)}
+        { people: @people_ids }
       else
         {}
       end

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -134,6 +134,16 @@ class AnnouncementsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "index indicates selected people in the filter selector" do
+    a_person = create(:person, forename: "Jane", surname: "Doe")
+
+    get :index, params: { people_ids: [a_person.slug] }
+
+    assert_select "select[name='people_ids[]']" do
+      assert_select "option[selected='selected']", text: "Jane Doe"
+    end
+  end
+
   def assert_documents_appear_in_order_within(containing_selector, expected_documents)
     articles = css_select "#{containing_selector} li.document-row"
     expected_document_ids = expected_documents.map { |doc| dom_id(doc) }

--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -60,6 +60,7 @@ module Whitehall
           announcement_type
           official_documents
           locations
+          people
         }
 
         valid_option_names.each do |option_name|
@@ -77,6 +78,7 @@ module Whitehall
           announcement_filter_option
           official_document_status
           world_locations
+          people_ids
         }
 
         valid_filter_keys.each do |filter_key|
@@ -151,6 +153,20 @@ module Whitehall
         assert_equal ["All policy areas", "all"], options.all
         assert_equal expected_grouped_options, options.grouped
         assert_equal [], options.ungrouped
+      end
+
+      test "can get a list of options for people" do
+        one = create(:person)
+        another = create(:person)
+        options = filter_options.for(:people)
+
+        expected_ungrouped_options = [
+          [one.name, one.slug],
+          [another.name, another.slug],
+        ]
+
+        assert_equal ["All people", "all"], options.all
+        assert_equal expected_ungrouped_options, options.ungrouped
       end
 
       test "can get the list of options for official documents" do

--- a/test/unit/whitehall/document_filter/rummager_test.rb
+++ b/test/unit/whitehall/document_filter/rummager_test.rb
@@ -16,6 +16,11 @@ module Whitehall::DocumentFilter
           has_entry({ search_format_types: format_types }))
     end
 
+    def expect_search_by_people(people_ids)
+      Whitehall.government_search_client.expects(:advanced_search).with(
+        has_entry(people: people_ids))
+    end
+
     test 'announcements_search looks for all announcements excluding world types by default' do
       rummager = Rummager.new({})
       expected_types = [
@@ -41,6 +46,12 @@ module Whitehall::DocumentFilter
     test 'announcements_search looks for a specific announcement sub type if we use the announcement_type option' do
       rummager = Rummager.new({announcement_type: 'government-responses'})
       expect_search_by_format_types(NewsArticleType::GovernmentResponse.search_format_types)
+      rummager.announcements_search
+    end
+
+    test 'announcements_search looks for announcements that are associated with a person if we use the people_ids option' do
+      rummager = Rummager.new(people_ids: 'jane-doe')
+      expect_search_by_people(["jane-doe"])
       rummager.announcements_search
     end
 

--- a/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
+++ b/test/unit/whitehall/gov_uk_delivery/feed_url_validator_test.rb
@@ -39,17 +39,19 @@ class Whitehall::GovUkDelivery::FeedUrlValidatorTest < ActiveSupport::TestCase
     create(:topic, slug: 'arts-and-culture', name: 'Arts and culture')
     create(:ministerial_department, :with_published_edition, name: 'The Cabinet Office')
     create(:world_location, slug: 'afghanistan', name: 'Afghanistan')
+    create(:person, slug: 'jane-doe', forename: 'Jane', surname: 'Doe')
 
     feed_url = feed_url_for(
       document_type: "announcements",
       topics: ["arts-and-culture"],
       departments: ["the-cabinet-office"],
-      world_locations: ["afghanistan"]
+      world_locations: ["afghanistan"],
+      people_ids: ["jane-doe"]
     )
     validator = FeedUrlValidator.new(feed_url)
 
     assert validator.valid?
-    assert_equal "announcements related to The Cabinet Office, Arts and culture and Afghanistan", validator.description
+    assert_equal "announcements related to The Cabinet Office, Jane Doe, Arts and culture and Afghanistan", validator.description
   end
 
   test 'validates and describes a statistics filter feed url with filter options' do


### PR DESCRIPTION
Adds an extra filter to the `/government/announcements` search criteria.

* Adds the drop down to the frontend
* Sends the param through to the rummager search
* Update the atom and email urls to include the new param
* Adds some methods to filter by people against Whitehall database for cases when locale is not `en`

This PR does **not** address the actual creation of the email topics in the email alert service.

[Trello](https://trello.com/c/VvCBrEUe/57-5-add-drop-down-people-filter-to-announcements)

## Before screenshot
<img width="379" alt="announcements_without_people" src="https://user-images.githubusercontent.com/647311/30365947-596caa34-9861-11e7-82ea-605569d07f9d.png">

## After screenshot
<img width="362" alt="announcements_with_people" src="https://user-images.githubusercontent.com/647311/30366241-5bf3f43c-9862-11e7-9cab-1f51717f61f1.png">

