### PR TITLE
[DEPLOY ON FRIDAY] Changed char limit from 140 to 160

### DIFF
--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -10,8 +10,8 @@
     </div>
   <% end %>
 
-  <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' }, required: false %>
-  <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
+  <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' }, required: false %>
+  <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
   <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: true %>
 

--- a/app/views/admin/editions/_speed_tagging.html.erb
+++ b/app/views/admin/editions/_speed_tagging.html.erb
@@ -26,8 +26,8 @@
     <%= form.text_field :title %>
     <div class="title-length-info">Title text should be 65 characters or fewer and the slug will be truncated past 150. <span class="count"></span></div>
 
-    <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
-    <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
+    <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
+    <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
     <%= form.text_area :body, rows: 20, class: "previewable" %>
 

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -9,8 +9,8 @@
   <%= form.text_field :title, required: true %>
   <div class="title-length-info">Title text should be 65 characters or fewer and the slug will be truncated past 150. <span class="count"></span></div>
 
-  <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' }, required: form.object.summary_required? %>
-  <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
+  <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' }, required: form.object.summary_required? %>
+  <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
   <%= form.text_area :body, class: "previewable", rows: 20, cols: 9000, required: form.object.body_required? %>
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -13,7 +13,7 @@
                         data: { placeholder: "Role(s) this account is for…"} %>
         </div>
         <%= form.text_area :summary , rows: 2 %>
-        <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
+        <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
 
         <div class="form-group">
           <%= form.label :political_party_ids, 'Political parties' %>

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -7,8 +7,8 @@
     <%= form_for take_part_page, url: [:admin, take_part_page] do |form| %>
       <%= form.errors %>
       <%= form.text_field :title %>
-      <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 140, 'count-message-selector' => '.summary-length-info' } %>
-      <div class="summary-length-info">Summary text should be 140 characters or fewer. <span class="count"></span></div>
+      <%= form.text_area :summary, rows: 2, class: 'js-summary-length-counting', data: { 'count-message-threshold' => 160, 'count-message-selector' => '.summary-length-info' } %>
+      <div class="summary-length-info">Summary text should be 160 characters or fewer. <span class="count"></span></div>
       <%= form.text_area :body, rows: 20, class: "previewable", required: true %>
       <%= form.upload :image %>
       <%= form.text_field :image_alt_text, label_text: "Image description (alt text)" %>


### PR DESCRIPTION
Optimum summary length should be 160 characters, not 140.
https://trello.com/c/iBVy0LA1/56-guidance-on-summaries-in-writing-for-govuk

I've increased the count threshold to 160 and changed the warning message to reflect that.