### PR TITLE
Fix text direction in previous next

### DIFF
--- a/app/assets/stylesheets/frontend/helpers/_pagination.scss
+++ b/app/assets/stylesheets/frontend/helpers/_pagination.scss
@@ -14,6 +14,7 @@
 
     &.next {
       float: right;
+      direction: ltr;
       text-align: right;
 
       a {
@@ -30,6 +31,9 @@
       }
     }
     &.previous {
+      direction: ltr;
+      text-align: left;
+
       a {
           padding: $gutter-half 0 $gutter-half $gutter+5px;
       }


### PR DESCRIPTION
- on some pages where rtl is set for the whole page this breaks the layout of the next/previous controls
- see https://github.com/alphagov/whitehall/issues/2903#issuecomment-323762305 and https://www.gov.uk/government/announcements.ar?page=2

![screen shot 2017-09-14 at 09 30 30](https://user-images.githubusercontent.com/861310/30419753-629bca9e-992f-11e7-9880-bcf363e29f08.png)

https://trello.com/c/fXldccdQ/143-2-pagination-broken-on-translation-pages-rtl