### PR TITLE
Redirect seed-enterprise-investment-scheme-procedures

### DIFF
--- a/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
+++ b/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
@@ -1,0 +1,18 @@
+# Unpublish guidance/seed-enterprise-investment-scheme-procedures and redirect to guidance/venture-capital-schemes-apply-to-use-the-seed-enterprise-investment-scheme
+document_id = 272247
+detailed_guide = Document.find(document_id)
+
+if detailed_guide.published_edition
+  unpublisher = EditionUnpublisher.new(
+    detailed_guide.published_edition,
+    unpublishing: {
+      unpublishing_reason_id: UnpublishingReason::Consolidated.id,
+      explanation: "Unpublished as consolidated into another GOV.UK page. Editorial Board approval received. Redirected.",
+      alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/guidance/venture-capital-schemes-apply-to-use-the-seed-enterprise-investment-scheme"
+    }
+  )
+
+  unpublisher.perform!
+
+  PublishingApiDocumentRepublishingWorker.new.perform(document_id)
+)


### PR DESCRIPTION
Migration to unpublish /guidance/seed-enterprise-investment-scheme-procedures
and provide an alternate url of /guidance/venture-capital-schemes-apply-to-use-the-seed-enterprise-investment-scheme
as per request in zendesk ticket https://govuk.zendesk.com/agent/tickets/2406584

The publisher cannot currently edit this document themselves because of a bug which is documented in https://github.com/alphagov/whitehall/pull/3457