### PR TITLE
Generalise consultation subscription URLs in JSON responses

### DIFF
--- a/app/helpers/email_signup_helper.rb
+++ b/app/helpers/email_signup_helper.rb
@@ -10,13 +10,13 @@ module EmailSignupHelper
     end
   end
 
-private
-
-  def generalise_consultations(atom_feed_url)
-    atom_feed_url
+  def generalise_consultations(url)
+    url
       .gsub("open-consultations", "consultations")
       .gsub("closed-consultations", "consultations")
   end
+
+private
 
   def organisation_email_signup_information_path_from_atom_feed(atom_feed_url)
     organisation_email_signup_information_path extract_slug_from_atom_feed(atom_feed_url)

--- a/app/presenters/publication_filter_json_presenter.rb
+++ b/app/presenters/publication_filter_json_presenter.rb
@@ -1,10 +1,22 @@
 class PublicationFilterJsonPresenter < DocumentFilterPresenter
+  include EmailSignupHelper
+
   def as_json(options = nil)
-    super.merge atom_feed_url: context.filter_atom_feed_url,
-                email_signup_url: context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
+    super.merge(
+      atom_feed_url: context.filter_atom_feed_url,
+      email_signup_url: email_signup_url,
+    )
   end
 
   def result_type
     "publication"
+  end
+
+  def email_signup_url
+    generalise_consultations(
+      context.new_email_signups_path(
+        email_signup: { feed: context.filter_atom_feed_url },
+      ),
+    )
   end
 end

--- a/test/unit/presenters/publication_filter_json_presenter_test.rb
+++ b/test/unit/presenters/publication_filter_json_presenter_test.rb
@@ -25,4 +25,24 @@ class PublicationFilterJsonPresenterTest < PresenterTestCase
       'It should have a category attribute of "Publication"'
     )
   end
+
+  test "an atom feed containing 'open-consultations' returns the path with 'consultations'" do
+    @view_context.stubs(:filter_atom_feed_url).returns("open-consultations")
+
+    presenter = PublicationFilterJsonPresenter.new(@filter, @view_context)
+    email_signup_url = JSON.parse(presenter.to_json)["email_signup_url"]
+
+    refute email_signup_url.include?("open-consultations")
+    assert email_signup_url.include?("consultations")
+  end
+
+  test "an atom feed containing 'closed-consultations' returns the path with 'consultations'" do
+    @view_context.stubs(:filter_atom_feed_url).returns("closed-consultations")
+
+    presenter = PublicationFilterJsonPresenter.new(@filter, @view_context)
+    email_signup_url = JSON.parse(presenter.to_json)["email_signup_url"]
+
+    refute email_signup_url.include?("closed-consultations")
+    assert email_signup_url.include?("consultations")
+  end
 end


### PR DESCRIPTION
Commit 15a982a09b894143d8eac34618d1f999753972fb generalised
'open-' and 'closed-' consultations so that subscribers to
those lists receive all consultation notifications, but that
behaviour wasn't influencing responses from the JSON endpoint
the JavaScript-enabled form uses.

https://trello.com/c/qv1l3WBy/119-documents-that-are-open-or-closed-consultations-dont-match-all-consultations-topics-in-email-alert-api