### PR TITLE
[DO NOT MERGE] Republish orgs. when CIPs change

### DIFF
--- a/app/workers/publishing_api_corporate_information_pages_worker.rb
+++ b/app/workers/publishing_api_corporate_information_pages_worker.rb
@@ -15,6 +15,8 @@ class PublishingApiCorporateInformationPagesWorker
     PublishingApiDocumentRepublishingWorker.perform_async(
       about_us_page.document_id,
     )
+
+    organisation.save! if organisation
   end
 
   alias :delete :publish

--- a/test/unit/workers/publishing_api_corporate_information_pages_worker_test.rb
+++ b/test/unit/workers/publishing_api_corporate_information_pages_worker_test.rb
@@ -1,10 +1,14 @@
 require 'test_helper'
 
 class PublishingApiCorporateInformationPagesWorkerTest < ActiveSupport::TestCase
-  def assert_document_republished(document_id)
+  def assert_document_and_organisation_republished(document_id)
     PublishingApiDocumentRepublishingWorker
       .expects(:perform_async)
       .with(document_id)
+
+    Whitehall::PublishingApi
+      .expects(:publish_async)
+      .with(organisation)
 
     event = self.class.name.demodulize.underscore
 
@@ -32,56 +36,56 @@ class PublishingApiCorporateInformationPagesWorkerTest < ActiveSupport::TestCase
   end
 
   class Delete < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class ForcePublish < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class Publish < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class Republish < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class Unpublish < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class Unwithdraw < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class UpdateDraft < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class UpdateDraftTranslation < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 
   class Withdraw < PublishingApiCorporateInformationPagesWorkerTest
-    test 'it republishes the corresponding about page' do
-      assert_document_republished about_page.document_id
+    test 'it republishes the corresponding about page and organisation' do
+      assert_document_and_organisation_republished(about_page.document_id)
     end
   end
 end


### PR DESCRIPTION
We embed information from the 'About us' corporate information page
under the organisation listing on pages like this:

https://www.gov.uk/world/spain#/world/trade-and-invest-spain

This change makes it so we republish the corresponding organisation
for a corporate information page whenever that page changes, e.g.
it is published, withdrawn, etc.

This might be a bit heavy-handed, but it's 'cheap' to republish a
document to the Publishing API, so this might help keep things in
sync if things change in the future, e.g. we embed content from
other CIPs on the org. page.

https://trello.com/c/9JFXOc5y/145-worldwide-organisations-are-not-updated-when-their-about-us-summary-is-changed-added