### PR TITLE
Re-index org. when the ’About Us’ page is updated

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -2,6 +2,8 @@ class CorporateInformationPage < Edition
   include ::Attachable
   include Searchable
 
+  after_save :reindex_organisation_in_search_index, if: :about_page?
+
   has_one :edition_organisation, foreign_key: :edition_id, dependent: :destroy
   has_one :organisation, -> { includes(:translations) }, through: :edition_organisation, autosave: false
   has_one :edition_worldwide_organisation, foreign_key: :edition_id, inverse_of: :edition, dependent: :destroy
@@ -23,6 +25,10 @@ class CorporateInformationPage < Edition
 
   validates :corporate_information_page_type_id, presence: true
   validate :only_one_organisation_or_worldwide_organisation
+
+  def reindex_organisation_in_search_index
+    owning_organisation.update_in_search_index
+  end
 
   def body_required?
     !about_page?

--- a/test/unit/corporate_information_page_test.rb
+++ b/test/unit/corporate_information_page_test.rb
@@ -200,4 +200,50 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     Whitehall::SearchIndex.expects(:add).with(corp_page).never
     corp_page.update_in_search_index
   end
+
+  test "re-indexes the organisation after the 'About Us' CIP is saved" do
+    org = create(:organisation, govuk_status: 'live')
+    corp_page = create(
+      :corporate_information_page,
+      :published,
+      organisation: org,
+      corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
+    )
+
+    Whitehall::SearchIndex.expects(:add).with(org).once
+    corp_page.save!
+  end
+
+  test "re-indexes the worldwide organisation after the 'About Us' CIP is saved" do
+    worldwide_org = create(:worldwide_organisation)
+    about_us = create(
+      :corporate_information_page,
+      :published,
+      organisation: nil,
+      worldwide_organisation: worldwide_org,
+      corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
+    )
+
+    Whitehall::SearchIndex.expects(:add).with(worldwide_org).once
+    about_us.save!
+  end
+
+  test "does not re-index organisation for other types of corporate info page" do
+    org = create(:organisation, govuk_status: 'live')
+    other_page = create(:corporate_information_page, :published, organisation: org)
+    Whitehall::SearchIndex.expects(:add).with(org).never
+    other_page.save!
+  end
+
+  test "does not re-index worldwide organisation for other types of corporate info page" do
+    worldwide_org = create(:worldwide_organisation)
+    other_page = create(
+      :corporate_information_page,
+      :published,
+      organisation: nil,
+      worldwide_organisation: worldwide_org,
+    )
+    Whitehall::SearchIndex.expects(:add).with(worldwide_org).never
+    other_page.save!
+  end
 end


### PR DESCRIPTION
https://trello.com/c/9JFXOc5y/145-worldwide-organisations-are-not-updated-when-their-about-us-summary-is-changed-added

https://trello.com/c/HB9DM6zN/147-summaries-not-updating-on-help-and-services-page

The world taxon pages list worldwide organisations, e.g.
https://www.gov.uk/world/spain#/world/trade-and-invest-spain

These organisations are served from rummager and
the ‘summary’ underneath the worldwide org. is
derived from the ‘About Us’ corporate information
page for the organisation. Therefore, we need to
re-index the organisation when the ‘About Us’ page
changes.

**Update:** tested on integration and this successfully updated the worldwide org. summary on the country taxon page.