### PR TITLE
Return empty array when need ids are nil

### DIFF
--- a/app/models/document/needs.rb
+++ b/app/models/document/needs.rb
@@ -36,6 +36,6 @@ module Document::Needs
       content_id
     )
 
-    response["expanded_links"]["meets_user_needs"]
+    response["expanded_links"]["meets_user_needs"] || Array.new
   end
 end

--- a/test/unit/document/needs_test.rb
+++ b/test/unit/document/needs_test.rb
@@ -73,4 +73,26 @@ class Document::NeedsTest < ActiveSupport::TestCase
 
     assert_equal document.get_user_needs_from_publishing_api, []
   end
+
+  # This can happen when a document is associated with a need_id that is unpublished.
+  # Then publishing_ap.get_links will have ["links"]["meets_user_needs"], but
+  # publishing_api.get_expanded_links will not have ["expanded_links"]["meets_user_needs"]
+  test "#associated_needs returns empty array when ['expanded_links']['meets_user_needs'] is nil" do
+    document = create(:document)
+
+    document.stubs(:get_user_needs_from_publishing_api)
+      .returns(["f5f42227-b7c6-4543-bb30-68379f29aa40"])
+
+    Services.publishing_api.stubs(:get_expanded_links)
+      .with(document.content_id)
+      .returns(
+        "expanded_links" =>
+          { "an_expanded_link" =>
+            [{ "key" => "value" }]
+          }
+      )
+
+    expected_array = Array.new
+    assert_equal expected_array, document.associated_needs
+  end
 end


### PR DESCRIPTION
When editing a document, we display information about any associated user needs. The code in the view expects a document's `associated_needs` to respond to `any?`. If a document's `associated_needs` method returns a `nil`, it errors and the document cannot be edited from
whitehall-admin.

This commit ensures an empty array is returned in this instance.

## Why this happens:
Needs ids are exposed through a call to publishing_api's `get_links` and also through `get_expanded_links`. Our method to return the `associated_needs` first checks that `get_links` returns the user needs ids and if so, it then call `get_expanded_links` and uses the response
to display the user needs in whitehall-admin.

When a document is associated with a need that is unpublished, `get_links` will still return the need id, but `get_expanded_links` will return a nil. When this happens, our `associated_needs` currently returns `nil` instead of a duck that responds to `any?`.

Associated PR that unpublishes an edition according to a zendesk request that pointed us to this bug: https://github.com/alphagov/whitehall/pull/3450