### PR TITLE
Fix missing `end` in data migration

### DIFF
--- a/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
+++ b/db/data_migration/20170914142009_unpublish_seed_enterprise_investment_scheme.rb
@@ -15,4 +15,4 @@ if detailed_guide.published_edition
   unpublisher.perform!
 
   PublishingApiDocumentRepublishingWorker.new.perform(document_id)
-)
+end


### PR DESCRIPTION
A syntax error is preventing the data migration from running.
Fix this by adding the missing `end` for the `if` construct and removing the spurious `)`