### PR TITLE
Fix localised world location news paths

### DIFF
--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -50,7 +50,7 @@ module PublishingApi
   private
 
     def path_for_news_page
-      Whitehall.url_maker.polymorphic_path(world_location) + "/news"
+      Whitehall.url_maker.world_location_news_index_path(world_location)
     end
 
     def description

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -81,4 +81,13 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
     assert_equal expected_hash, presented_item.content
     assert_equal "aguid", presented_item.content_id
   end
+
+  test 'it builds localised base paths correctly' do
+    I18n.with_locale(:fr) do
+      presented_item = present(world_location)
+      base_path = presented_item.content[:base_path]
+
+      assert_equal "/world/aardistan/news.fr", base_path
+    end
+  end
 end


### PR DESCRIPTION
When creating a translation for a world location, we send the
news page downstream at the same time (there's a callback in
the WorldLocation model). We need to make sure we construct
the correct localised path when this happens.

Previously:
`/world/france.fr/news`

After this:
`/world/france/news.fr`

https://trello.com/c/XuS51W3b/143-unable-to-create-spanish-translation-for-dominican-republic-mission-statement-world-location-news-page