### PR TITLE
Upgrade gds-api-adaters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'govuk_ab_testing', '~> 2.4x'
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 47.9'
+  gem 'gds-api-adapters'
 end
 
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (47.9.1)
+    gds-api-adapters (49.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -327,7 +327,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     rack (2.0.3)
-    rack-cache (1.7.0)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-protection (2.0.0)
       rack
@@ -528,7 +528,7 @@ DEPENDENCIES
   factory_girl
   faraday
   friendly_id (~> 5.2.1)
-  gds-api-adapters (~> 47.9)
+  gds-api-adapters
   gds-sso (~> 13.2)
   globalize (= 5.1.0.beta2)
   govspeak (~> 5.0.3)


### PR DESCRIPTION
So that we can use the recently added
`GdsApi::AssetManager#create_whitehall_asset` method to enable us to
store assets using Asset Manager.

Upgraded using `bundle update --conservative gds-api-adapters`.