### PR TITLE
Save non-attachment assets in asset manager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (49.2.0)
+    gds-api-adapters (49.3.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger

--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class ConsultationResponseFormUploader < WhitehallUploader
+  storage :asset_manager_and_file_system
+
   def extension_whitelist
     %w(pdf csv rtf doc docx xls xlsx odt ods)
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,8 @@
 class ImageUploader < WhitehallUploader
   include CarrierWave::MiniMagick
 
+  storage :asset_manager_and_file_system
+
   configure do |config|
     config.remove_previously_stored_files_after_update = false
   end

--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -1,4 +1,6 @@
 class LogoUploader < WhitehallUploader
+  storage :asset_manager_and_file_system
+
   def extension_whitelist
     %w(jpg jpeg gif png)
   end

--- a/config/initializers/asset_manager.rb
+++ b/config/initializers/asset_manager.rb
@@ -1,0 +1,1 @@
+Whitehall.use_asset_manager = ENV['USE_ASSET_MANAGER'].present?

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,6 +3,7 @@ require 'whitehall/quarantined_file_storage'
 CarrierWave.configure do |config|
   config.storage_engines[:quarantined_file] = 'Whitehall::QuarantinedFileStorage'
   config.storage_engines[:asset_manager] = 'Whitehall::AssetManagerStorage'
+  config.storage_engines[:asset_manager_and_file_system] = 'Whitehall::AssetManagerAndQuarantinedFileStorage'
   config.storage Whitehall::QuarantinedFileStorage
   config.enable_processing = false if Rails.env.test?
   config.cache_dir = Rails.root.join "carrierwave-tmp"

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -2,6 +2,7 @@ require 'whitehall/quarantined_file_storage'
 
 CarrierWave.configure do |config|
   config.storage_engines[:quarantined_file] = 'Whitehall::QuarantinedFileStorage'
+  config.storage_engines[:asset_manager] = 'Whitehall::AssetManagerStorage'
   config.storage Whitehall::QuarantinedFileStorage
   config.enable_processing = false if Rails.env.test?
   config.cache_dir = Rails.root.join "carrierwave-tmp"

--- a/features/support/asset_manager_helper.rb
+++ b/features/support/asset_manager_helper.rb
@@ -1,0 +1,3 @@
+Before do
+  Services.stubs(:asset_manager).returns(stub_everything('asset-manager'))
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/asset_manager'
 
 module Services
   def self.publishing_api
@@ -15,5 +16,12 @@ module Services
         client.options[:timeout] = 1
       end
     end
+  end
+
+  def self.asset_manager
+    @asset_manager ||= GdsApi::AssetManager.new(
+      Plek.find("asset-manager"),
+      bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || '12345678',
+    )
   end
 end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -18,6 +18,7 @@ module Whitehall
   mattr_accessor :skip_safe_html_validation
   mattr_accessor :statistics_announcement_search_client
   mattr_accessor :uploads_cache_max_age
+  mattr_accessor :use_asset_manager
 
   asset_host_override = Rails.root.join("config/initializers/asset_host.rb")
   if File.exist?(asset_host_override)

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -1,6 +1,6 @@
 class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    Whitehall::AssetManagerStorage.new(uploader).store!(file)
+    Whitehall::AssetManagerStorage.new(uploader).store!(file) if Whitehall.use_asset_manager
     Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
   end
 

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -1,0 +1,10 @@
+class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::Abstract
+  def store!(file)
+    Whitehall::AssetManagerStorage.new(uploader).store!(file)
+    Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
+  end
+
+  def retrieve!(identifier)
+    Whitehall::QuarantinedFileStorage.new(uploader).retrieve!(identifier)
+  end
+end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,0 +1,11 @@
+class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
+  def store!(file)
+    path = File.join('/government/uploads', uploader.store_path)
+    Services.asset_manager.create_whitehall_asset(file: file.to_file, legacy_url_path: path)
+    file
+  end
+
+  def retrieve!(_identifier)
+    raise "We're not currently reading assets from Asset Manager so this shouldn't be called."
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,6 +55,7 @@ class ActiveSupport::TestCase
     stub_publishing_api_policies
     SyncCheckWorker.stubs(:enqueue)
     stub_static_locales
+    Services.stubs(:asset_manager).returns(stub_everything('asset-manager'))
   end
 
   teardown do

--- a/test/unit/consultation_response_form_uploader_test.rb
+++ b/test/unit/consultation_response_form_uploader_test.rb
@@ -11,4 +11,8 @@ class ConsultationResponseFormUploaderTest < ActiveSupport::TestCase
     uploader = ConsultationResponseFormUploader.new(model, "mounted-as")
     assert_match /^system/, uploader.store_dir
   end
+
+  test 'uses the asset manager and file system storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ConsultationResponseFormUploader.storage
+  end
 end

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -11,6 +11,10 @@ class ImageUploaderTest < ActiveSupport::TestCase
     ImageUploader.enable_processing = false
   end
 
+  test 'uses the asset manager and file system storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ImageUploader.storage
+  end
+
   test "should only allow JPG, GIF, PNG or SVG images" do
     uploader = ImageUploader.new
     assert_equal %w(jpg jpeg gif png svg), uploader.extension_whitelist

--- a/test/unit/logo_uploader_test.rb
+++ b/test/unit/logo_uploader_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LogoUploaderTest < ActiveSupport::TestCase
+  test 'uses the asset manager storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, LogoUploader.storage
+  end
+end

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'whitehall/asset_manager_storage'
+
+class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::TestCase
+  setup do
+    uploader = CarrierWave::Uploader::Base.new
+    @storage = Whitehall::AssetManagerAndQuarantinedFileStorage.new(uploader)
+    @file = CarrierWave::SanitizedFile.new(Tempfile.new('asset'))
+
+    @asset_manager_storage = stub('asset-manager-storage', store!: nil)
+    Whitehall::AssetManagerStorage.stubs(:new).returns(@asset_manager_storage)
+    @quarantined_file_storage = stub('quarantined-file-storage', store!: nil)
+    Whitehall::QuarantinedFileStorage.stubs(:new).returns(@quarantined_file_storage)
+  end
+
+  test 'stores the file using the asset manager storage engine' do
+    @asset_manager_storage.expects(:store!).with(@file)
+
+    @storage.store!(@file)
+  end
+
+  test 'stores the file using the quarantined file storage engine' do
+    @quarantined_file_storage.expects(:store!).with(@file)
+
+    @storage.store!(@file)
+  end
+
+  test 'returns the value returned from the quarantined file store' do
+    @quarantined_file_storage.stubs(:store!).with(@file).returns('stored-file')
+
+    assert_equal 'stored-file', @storage.store!(@file)
+  end
+
+  test 'retrieves the file from the quarantined file store' do
+    @quarantined_file_storage.stubs(:retrieve!).with('identifier').returns('retrieved-file')
+
+    assert_equal 'retrieved-file', @storage.retrieve!('identifier')
+  end
+end

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -11,10 +11,21 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     Whitehall::AssetManagerStorage.stubs(:new).returns(@asset_manager_storage)
     @quarantined_file_storage = stub('quarantined-file-storage')
     Whitehall::QuarantinedFileStorage.stubs(:new).returns(@quarantined_file_storage)
+
+    Whitehall.use_asset_manager = true
   end
 
   test 'stores the file using the asset manager storage engine' do
     @asset_manager_storage.expects(:store!).with(@file)
+    @quarantined_file_storage.stubs(:store!)
+
+    @storage.store!(@file)
+  end
+
+  test 'does not store the file using the asset manager storage engine when feature flag is off' do
+    Whitehall.use_asset_manager = false
+
+    @asset_manager_storage.expects(:store!).never
     @quarantined_file_storage.stubs(:store!)
 
     @storage.store!(@file)

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -7,31 +7,35 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     @storage = Whitehall::AssetManagerAndQuarantinedFileStorage.new(uploader)
     @file = CarrierWave::SanitizedFile.new(Tempfile.new('asset'))
 
-    @asset_manager_storage = stub('asset-manager-storage', store!: nil)
+    @asset_manager_storage = stub('asset-manager-storage')
     Whitehall::AssetManagerStorage.stubs(:new).returns(@asset_manager_storage)
-    @quarantined_file_storage = stub('quarantined-file-storage', store!: nil)
+    @quarantined_file_storage = stub('quarantined-file-storage')
     Whitehall::QuarantinedFileStorage.stubs(:new).returns(@quarantined_file_storage)
   end
 
   test 'stores the file using the asset manager storage engine' do
     @asset_manager_storage.expects(:store!).with(@file)
+    @quarantined_file_storage.stubs(:store!)
 
     @storage.store!(@file)
   end
 
   test 'stores the file using the quarantined file storage engine' do
+    @asset_manager_storage.stubs(:store!)
     @quarantined_file_storage.expects(:store!).with(@file)
 
     @storage.store!(@file)
   end
 
   test 'returns the value returned from the quarantined file store' do
+    @asset_manager_storage.stubs(:store!)
     @quarantined_file_storage.stubs(:store!).with(@file).returns('stored-file')
 
     assert_equal 'stored-file', @storage.store!(@file)
   end
 
   test 'retrieves the file from the quarantined file store' do
+    @asset_manager_storage.stubs(:store!)
     @quarantined_file_storage.stubs(:retrieve!).with('identifier').returns('retrieved-file')
 
     assert_equal 'retrieved-file', @storage.retrieve!('identifier')

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require 'whitehall/asset_manager_storage'
+
+class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
+  class AssetManagerUploader < CarrierWave::Uploader::Base
+    storage :asset_manager
+  end
+
+  setup do
+    @file = Tempfile.new('asset')
+    @uploader = AssetManagerUploader.new
+  end
+
+  test 'creates a whitehall asset using the file passed to the uploader' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(&same_content_as(@file))
+
+    @uploader.store!(@file)
+  end
+
+  test 'creates a whitehall asset using an instance of a file object' do
+    Services.asset_manager.expects(:create_whitehall_asset).with do |args|
+      args[:file].is_a?(File)
+    end
+
+    @uploader.store!(@file)
+  end
+
+  test 'creates a whitehall asset and sets the legacy url path to the location that it would have been stored on disk' do
+    @uploader.store_dir = 'store-dir'
+
+    expected_filename = File.basename(@file.path)
+    expected_path = File.join('/government/uploads/store-dir', expected_filename)
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(legacy_url_path: expected_path))
+
+    @uploader.store!(@file)
+  end
+
+  test 'returns the sanitized file' do
+    Services.asset_manager.stubs(:create_whitehall_asset)
+
+    storage = Whitehall::AssetManagerStorage.new(@uploader)
+    file = CarrierWave::SanitizedFile.new(@file)
+    assert_equal file, storage.store!(file)
+  end
+
+  test 'fails fast when trying to retrieve an existing file' do
+    storage = Whitehall::AssetManagerStorage.new(@uploader)
+    assert_raises RuntimeError do
+      storage.retrieve!('identifier')
+    end
+  end
+
+private
+
+  def same_content_as(file)
+    -> (args) {
+      args[:file].read == file.read
+    }
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/alphagov/asset-manager/issues/212.

This PR enables the saving of non-attachment Whitehall assets to Asset Manager behind the `USE_ASSET_MANAGER` environment variable feature flag. The functionality defaults to OFF on all environments. We have introduced a new storage engine which will continue to add assets to the "quarantined file store" as before (as well as send them to asset manager when enabled). In this way the current behaviour of non-attachment asset uploads is unaffected by this change.

This PR does not address
  - Updating existing assets (see issue https://github.com/alphagov/asset-manager/issues/245)
  - Removing assets (see issue https://github.com/alphagov/asset-manager/issues/244)
  - Making calls to the Asset Manager in a background process (see issue https://github.com/alphagov/asset-manager/issues/248)

Merging this PR allows us to continue to work on these issues against master and keeps the scope of this PR smaller. We are also able to enable this feature in integration to ensure it integrates correctly and in a performant way with Asset Manager. 