### PR TITLE
Remove specific whitehall admin asset host in dev config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,15 +84,15 @@ Whitehall::Application.configure do
   config.assets.cache_store = :null_store
   config.sass.cache = false
   config.slimmer.asset_host = ENV['STATIC_DEV'] || Plek.find('static')
-  config.asset_host = Whitehall.admin_root
 
   if ENV['SHOW_PRODUCTION_IMAGES']
+    orig_host = config.asset_host
     config.asset_host = Proc.new do |source|
       local_file = File.join(Whitehall.clean_uploads_root, source.sub('/government/uploads', ''))
       if !File.exist?(local_file) && source =~ %r{system/uploads}
         "https://assets.publishing.service.gov.uk"
       else
-        Whitehall.admin_root
+        orig_host
       end
     end
   end


### PR DESCRIPTION
Forcing the asset host to `Whitehall.admin_root` in development config
causes CORS errors when browsing pages rendered by whitehall-frontend.
The affects loading of assets - so requests for images and javascript
resources are not honoured.

For example, on `/government/announcements`:

<img width="1386" alt="screen shot 2017-10-02 at 09 27 04" src="https://user-images.githubusercontent.com/647311/31116893-a59236d6-a81f-11e7-92ae-81d1ce404bf8.png">

Removing the specific setting of the asset_host to
"http://whitehall-admin.dev.gov.uk" means that assets will, by default,
be referenced with relative paths which will allow them to load.