### PR TITLE
Add report of content by organisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   gem 'test-queue', '~> 0.2.13'
   gem 'ruby-prof'
   gem 'pry-byebug'
+  gem 'pry-rails'
   gem 'govuk-lint'
   gem 'dotenv-rails'
   gem 'teaspoon-qunit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
     pry-byebug (3.5.0)
       byebug (~> 9.1)
       pry (~> 0.10)
+    pry-rails (0.3.5)
+      pry (>= 0.9.10)
     rack (2.0.3)
     rack-cache (1.7.1)
       rack (>= 0.4)
@@ -563,6 +565,7 @@ DEPENDENCIES
   plek (~> 2.0)
   poltergeist
   pry-byebug
+  pry-rails
   rack (~> 2.0)
   rack-test
   rack_strip_client_ip (~> 0.0.2)

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -26,4 +26,50 @@ namespace :reporting  do
   task pdf_attachments_report: :environment do
     PDFAttachmentReporter.new(opts_from_environment(:data_path, :first_period_start_date, :last_time_period_days)).pdfs_by_organisation
   end
+
+  desc "A CSV report of organisation Edition publishing by month. Splits by freshly created and updated content"
+  task organisation_publishing_by_month: :environment do
+    options = opts_from_environment(:start_date, :end_date)
+
+    date_range = Date.parse(options[:start_date])...Date.parse(options[:end_date])
+    months = date_range.select { |d| d.day == 1 }.map { |m| "#{m.year}-#{m.month.to_s.rjust(2, '0')}" }
+
+    csv = CSV.open("organisation_publishing_by_month-#{options[:start_date]}-#{options[:end_date]}.csv", 'w')
+    csv << ([''] + months.map { |m| [m, m] }.flatten)
+    csv << (['Organisation'] + months.size.times.map { |_| %w{Published Updates} }.flatten)
+
+    first_editions = Edition.
+      order(:id).
+      group(:document_id).
+      pluck(:id).to_set
+
+    # So we have the organisation association for all edition types
+    Edition.include(Edition::Organisations)
+
+    EditionRecord = Struct.new(:id, :updated_at, :name)
+
+    all_editions = Edition.
+      joins(organisations: :translations).
+      where(
+        updated_at: date_range,
+        edition_organisations: { lead: 1 },
+        state: %w{published superseded},
+        organisation_translations: { locale: 'en' }
+      ).
+      pluck(*EditionRecord.members).
+      map { |r| EditionRecord.new(*r).tap { |er| er.name.strip! } } # One organisation has a leading space
+
+    by_org = all_editions.group_by(&:name).sort
+
+    by_org.each do |(org, records)|
+      row = [org]
+      by_month = records.group_by { |r| "#{r.updated_at.year}-#{r.updated_at.month.to_s.rjust(2, '0')}" }
+
+      months.each do |month|
+        created, updated = (by_month[month] || []).partition { |r| first_editions.include?(r.id) }
+        row += [created.size, updated.size]
+      end
+      csv << row
+    end
+  end
 end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -1,4 +1,4 @@
-namespace :reporting  do
+namespace :reporting do
   def opts_from_environment(*option_keys)
     {}.tap do |option_hash|
       option_keys.each do |key|
@@ -8,17 +8,17 @@ namespace :reporting  do
   end
 
   desc "An overview of attachment statistics by organisation as CSV"
-  task :attachments_overview => :environment do
+  task attachments_overview: :environment do
     AttachmentDataReporter.new(opts_from_environment(:data_path, :start_date, :end_date)).overview
   end
 
   desc "A report of attachments statistics with related document slugs as CSV"
-  task :attachments_report => :environment do
+  task attachments_report: :environment do
     AttachmentDataReporter.new(opts_from_environment(:data_path, :start_date, :end_date)).report
   end
 
   desc "A report of collection statistics by organisation as CSV"
-  task :collections_report => :environment do
+  task collections_report: :environment do
     CollectionDataReporter.new(ENV.fetch('OUTPUT_DIR', './tmp')).report
   end
 


### PR DESCRIPTION
Produces a CSV report of all Documents created or updated within a
supplied date range, and splits them by Organisation. The CSV has 2
columns per month - one for documents initially created that month and
one for the number of updates to documents.