### PR TITLE
Remove redundant asset override

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -19,11 +19,6 @@ module Whitehall
   mattr_accessor :statistics_announcement_search_client
   mattr_accessor :uploads_cache_max_age
 
-  asset_host_override = Rails.root.join("config/initializers/asset_host.rb")
-  if File.exist?(asset_host_override)
-    load asset_host_override
-  end
-
   class NoConfigurationError < StandardError; end
 
   def self.public_protocol


### PR DESCRIPTION
Commit 7736faa5fe3c6d091a2779efd1073a7a8508157d removed `config/initializers/asset_host.rb`. As such, we no longer need the code to selectively load this file.

[Trello](https://trello.com/c/sC9B896K/178-remove-redundant-asset-override-condition)