### PR TITLE
Fix colour contrast in publication headers

### DIFF
--- a/app/assets/stylesheets/frontend/views/_html-publications.scss
+++ b/app/assets/stylesheets/frontend/views/_html-publications.scss
@@ -38,7 +38,7 @@
   .publication-header {
     @extend %contain-floats;
     @include white-links;
-    background: $light-blue;
+    background: $govuk-blue;
     padding: $gutter-one-third $gutter-half;
     margin: 0 (-$gutter-half);
     @include media(tablet) {


### PR DESCRIPTION
Publication headers do not meet WCAG AA when using $light-blue. Changing to $govuk-blue improves the contrast ratio to meet AA standards.


