### PR TITLE
Send world location news article translations to Publishing API

### DIFF
--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -8,10 +8,6 @@ module PublishingApi
       self.update_type = update_type || "major"
     end
 
-    def content_id
-      find_or_create_content_id
-    end
-
     def content
       content = BaseItemPresenter.new(
         world_location,
@@ -36,7 +32,7 @@ module PublishingApi
       {}
     end
 
-    def content_for_rummager
+    def content_for_rummager(content_id)
       {
         content_id: content_id,
         link: path_for_news_page,
@@ -59,14 +55,6 @@ module PublishingApi
 
     def title
       world_location.title
-    end
-
-    def content_id_from_publishing_api
-      Services.publishing_api.lookup_content_ids(base_paths: path_for_news_page)[path_for_news_page]
-    end
-
-    def find_or_create_content_id
-      @content_id ||= (content_id_from_publishing_api || SecureRandom.uuid)
     end
   end
 end

--- a/app/presenters/publishing_api/world_location_news_page_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_page_presenter.rb
@@ -33,14 +33,16 @@ module PublishingApi
     end
 
     def content_for_rummager(content_id)
-      {
-        content_id: content_id,
-        link: path_for_news_page,
-        format: "world_location_news_page", # Used for the rummager document type
-        title: title,
-        description: description,
-        indexable_content: description,
-      }
+      I18n.with_locale(:en) do
+        {
+          content_id: content_id,
+          link: path_for_news_page,
+          format: "world_location_news_page", # Used for the rummager document type
+          title: title,
+          description: description,
+          indexable_content: description,
+        }
+      end
     end
 
   private

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -2,24 +2,52 @@ class WorldLocationNewsPageWorker < WorkerBase
   attr_accessor :world_location
 
   def perform(world_location_id)
-    @world_location = WorldLocation.find(world_location_id)
-    send_news_page_to_publishing_api
+    self.world_location = WorldLocation.find(world_location_id)
+
+    each_locale do
+      send_news_page_to_publishing_api
+    end
+
     send_news_page_to_rummager
   end
 
 private
 
-  def news_page_presenter
-    @news_page_presenter ||= PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
+  def each_locale
+    world_location.available_locales.each do |locale|
+      I18n.with_locale(locale) { yield }
+    end
   end
 
   def send_news_page_to_publishing_api
-    Services.publishing_api.put_content(news_page_presenter.content_id, news_page_presenter.content)
-    Services.publishing_api.publish(news_page_presenter.content_id, nil, locale: "en")
+    Services.publishing_api.put_content(content_id, presenter.content)
+    Services.publishing_api.publish(content_id, nil, locale: I18n.locale)
+  end
+
+  def presenter
+    PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
   end
 
   def send_news_page_to_rummager
-    index = Whitehall::SearchIndex.for(:government)
-    index.add(news_page_presenter.content_for_rummager)
+    document = presenter.content_for_rummager(content_id)
+    search_index.add(document)
+  end
+
+  def search_index
+    Whitehall::SearchIndex.for(:government)
+  end
+
+  # We use the same content_id for all locales so that Publishing API knows
+  # these are translations, rather than separate documents.
+  def content_id
+    @content_id ||= (content_id_from_publishing_api || SecureRandom.uuid)
+  end
+
+  def content_id_from_publishing_api
+    Services.publishing_api.lookup_content_ids(base_paths: english_base_path)[english_base_path]
+  end
+
+  def english_base_path
+    Whitehall.url_maker.world_location_news_index_path(world_location, locale: "en")
   end
 end

--- a/db/data_migration/20171003133232_discard_non_english_wl_news.rb
+++ b/db/data_migration/20171003133232_discard_non_english_wl_news.rb
@@ -1,0 +1,9 @@
+# These drafts were created with an incorrect base path structure:
+
+Services.publishing_api.discard_draft("d4515402-9704-4240-a0c5-38455521f3b5", locale: "zh-tw")
+Services.publishing_api.discard_draft("e35a3088-da23-4720-9ffa-87ea93b31880", locale: "ru")
+Services.publishing_api.discard_draft("414cba63-2bae-40ab-8441-4a1f242b1b00", locale: "ar")
+Services.publishing_api.discard_draft("6e751743-5e4c-4964-a318-61d97db76faa", locale: "zh")
+Services.publishing_api.discard_draft("3fb57d53-8f3d-4392-8e19-4a0534c29db5", locale: "ar")
+Services.publishing_api.discard_draft("aa347cd1-2e6c-4557-8c6a-85cd1f4f3090", locale: "it")
+Services.publishing_api.discard_draft("fbbb4746-b26e-4fff-af39-0955a8457926", locale: "es-419")

--- a/db/data_migration/20171003143628_republish_world_location_news_pages.rb
+++ b/db/data_migration/20171003143628_republish_world_location_news_pages.rb
@@ -1,0 +1,4 @@
+WorldLocation.pluck(:id).each do |id|
+  print "."
+  WorldLocationNewsPageWorker.perform_async_in_queue("bulk_republishing", id)
+end

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -51,4 +51,13 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
       assert_equal "/world/aardistan/news.fr", base_path
     end
   end
+
+  test "it doesn't localise the rummager payload" do
+    I18n.with_locale(:fr) do
+      presented_item = present(world_location)
+      base_path = presented_item.content_for_rummager("id-123")[:link]
+
+      assert_equal "/world/aardistan/news", base_path
+    end
+  end
 end

--- a/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_page_presenter_test.rb
@@ -9,27 +9,8 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
     @world_location ||= create(:world_location, name: "Aardistan", "title": "Aardistan and the Uk")
   end
 
-  test 'presents an item for rummager' do
-    expected_hash = {
-      content_id: "a_guid",
-      link: "/world/aardistan/news",
-      format: "world_location_news_page",
-      title: "Aardistan and the Uk",
-      description: "Updates, news and events from the UK government in Aardistan",
-      indexable_content: "Updates, news and events from the UK government in Aardistan"
-    }
-
-    Services.publishing_api.stubs(:lookup_content_ids).returns({})
-
-    PublishingApi::WorldLocationNewsPagePresenter.any_instance.stubs(:content_id).returns("a_guid")
-
-    presented_item = present(world_location)
-
-    assert_equal expected_hash, presented_item.content_for_rummager
-  end
-
-  test 'with an item not yet in the publishing api, it presents a World Location News Page ready for publishing api' do
-    expected_hash = {
+  test 'presents an item for publishing api' do
+    expected = {
       title: "Aardistan and the Uk",
       locale: "en",
       publishing_app: "whitehall",
@@ -46,40 +27,20 @@ class PublishingApi::WorldLocationNewsPagePresenterTest < ActiveSupport::TestCas
       update_type: "major",
     }
 
-    Services.publishing_api.stubs(:lookup_content_ids).returns({})
-
-    PublishingApi::WorldLocationNewsPagePresenter.any_instance.stubs(:content_id).returns("a_new_guid")
-
-    presented_item = present(world_location)
-
-    assert_equal expected_hash, presented_item.content
-    assert_equal "a_new_guid", presented_item.content_id
+    assert_equal expected, present(world_location).content
   end
 
-  test 'with an item already in the publishing api, it presents a World Location News Page ready for publishing api' do
-    expected_hash = {
+  test 'presents an item for rummager' do
+    expected = {
+      content_id: "id-123",
+      link: "/world/aardistan/news",
+      format: "world_location_news_page",
       title: "Aardistan and the Uk",
-      locale: "en",
-      publishing_app: "whitehall",
-      redirects: [],
       description: "Updates, news and events from the UK government in Aardistan",
-      details: {},
-      document_type: "placeholder_world_location_news_page",
-      public_updated_at: world_location.updated_at,
-      rendering_app: "whitehall-frontend",
-      schema_name: "placeholder",
-      base_path: "/world/aardistan/news",
-      routes: [{ path: "/world/aardistan/news", type: "exact" }],
-      analytics_identifier: "WL1",
-      update_type: "major",
+      indexable_content: "Updates, news and events from the UK government in Aardistan"
     }
 
-    Services.publishing_api.stubs(:lookup_content_ids).returns("/world/aardistan/news" => "aguid")
-
-    presented_item = present(world_location)
-
-    assert_equal expected_hash, presented_item.content
-    assert_equal "aguid", presented_item.content_id
+    assert_equal expected, present(world_location).content_for_rummager("id-123")
   end
 
   test 'it builds localised base paths correctly' do

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -1,46 +1,48 @@
 require "test_helper"
 
 class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
-  MockNewsPagePresenter = Struct.new("NewsPagePresenter") do
-    def content_id
-      "a_guid"
-    end
-
-    def content
-      Hash.new(title: "title", description: "description")
-    end
-
-    def update_type
-      "major"
-    end
-
-    def content_for_rummager
-      Hash.new(title: "title", link: "link")
-    end
+  setup do
+    hash = { "/world/france/news" => "id-123" }
+    Services.publishing_api.stubs(:lookup_content_ids).returns(hash)
   end
 
-  test "sends to the publishing api and rummager" do
-    wl = create(:world_location, name: "Aardistan", title: "Aardistan and the Uk")
+  test "sends to the publishing api" do
+    world_location = FactoryGirl.create(:world_location, name: "France")
+    presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
 
-    mock_news_page_presenter = MockNewsPagePresenter.new
+    Services.publishing_api.expects(:put_content).with("id-123", presenter.content)
+    Services.publishing_api.expects(:publish).with("id-123", nil, locale: :en)
 
-    WorldLocationNewsPageWorker.any_instance.stubs(:news_page_presenter).returns(mock_news_page_presenter)
+    WorldLocationNewsPageWorker.new.perform(world_location.id)
+  end
 
-    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
+  test "sends to rummager" do
+    world_location = FactoryGirl.create(:world_location, name: "France")
+    presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
 
-    Services.publishing_api.expects(:put_content)
-      .with(
-        "a_guid",
-        Hash.new(title: "title", description: "description", update_type: "major")
-    )
+    Whitehall::FakeRummageableIndex.any_instance.expects(:add)
+      .with(presenter.content_for_rummager("id-123"))
 
-    Services.publishing_api.expects(:publish)
-      .with(
-        "a_guid",
-        nil,
-        locale: "en"
-    )
+    WorldLocationNewsPageWorker.new.perform(world_location.id)
+  end
 
-    WorldLocationNewsPageWorker.new.perform(wl.id)
+  test "sends translations to the publishing api under the same content_id" do
+    world_location = FactoryGirl.create(:world_location, name: "France", translated_into: [:fr])
+
+    I18n.with_locale(:en) do
+      @english = PublishingApi::WorldLocationNewsPagePresenter.new(world_location).content
+    end
+
+    I18n.with_locale(:fr) do
+      @french = PublishingApi::WorldLocationNewsPagePresenter.new(world_location).content
+    end
+
+    Services.publishing_api.expects(:put_content).with("id-123", @english)
+    Services.publishing_api.expects(:publish).with("id-123", nil, locale: :en)
+
+    Services.publishing_api.expects(:put_content).with("id-123", @french)
+    Services.publishing_api.expects(:publish).with("id-123", nil, locale: :fr)
+
+    WorldLocationNewsPageWorker.new.perform(world_location.id)
   end
 end


### PR DESCRIPTION
https://trello.com/c/XuS51W3b/143-unable-to-create-spanish-translation-for-dominican-republic-mission-statement-world-location-news-page

After running the data migrations on integration, these `published` editions are in Publishing API:

```
["/world/armenia/news.hy", "/world/azerbaijan/news.az", "/world/afghanistan/news.dr", "/world/austria/news.de", "/world/algeria/news.ar", "/world/argentina/news.es-419", "/world/belarus/news.be", "/world/bolivia/news.es-419", "/world/democratic-republic-of-the-congo/news.fr", "/world/albania/news.sq", "/world/angola/news.pt", "/world/brazil/news.pt", "/world/china/news.zh", "/world/costa-rica/news.es-419", "/world/bulgaria/news.bg", "/world/colombia/news.es-419", "/world/egypt/news.ar", "/world/chile/news.es-419", "/world/cuba/news.es-419", "/world/czech-republic/news.cs", "/world/ecuador/news.es-419", "/world/estonia/news.et", "/world/france/news.fr", "/world/greece/news.el", "/world/guatemala/news.es-419", "/world/estonia/news.ru", "/world/germany/news.de", "/world/honduras/news.es-419", "/world/india/news.hi", "/world/italy/news.it", "/world/lebanon/news.ar", "/world/indonesia/news.id", "/world/iran/news.fa", "/world/jordan/news.ar", "/world/kazakhstan/news.ru", "/world/libya/news.ar", "/world/iraq/news.ar", "/world/israel/news.he", "/world/japan/news.ja", "/world/kuwait/news.ar", "/world/latvia/news.lv", "/world/moldova/news.ro", "/world/mexico/news.es-419", "/world/panama/news.es-419", "/world/peru/news.es-419", "/world/portugal/news.pt", "/world/romania/news.ro", "/world/senegal/news.fr", "/world/morocco/news.ar", "/world/mozambique/news.pt", "/world/pakistan/news.ur", "/world/poland/news.pl", "/world/russia/news.ru", "/world/oman/news.ar", "/world/qatar/news.ar", "/world/saudi-arabia/news.ar", "/world/south-korea/news.ko", "/world/spain/news.es", "/world/sri-lanka/news.si", "/world/thailand/news.th", "/world/serbia/news.sr", "/world/somalia/news.so", "/world/sri-lanka/news.ta", "/world/united-arab-emirates/news.ar", "/world/turkey/news.tr", "/world/ukraine/news.uk", "/world/yemen/news.ar", "/world/uzbekistan/news.uz", "/world/taiwan/news.zh-tw", "/world/tunisia/news.ar", "/world/uruguay/news.es-419", "/world/uzbekistan/news.ru", "/world/venezuela/news.es-419", "/world/congo/news.fr", "/world/cote-d-ivoire/news.fr", "/world/kyrgyzstan/news.ru", "/world/the-occupied-palestinian-territories/news.ar", "/world/guinea/news.fr", "/world/el-salvador/news.es-419"]
```

In production, these pages 200, e.g. https://www.gov.uk/world/thailand/news.th
But their content pages 404, e.g. https://www.gov.uk/api/content/world/thailand/news.th
Whereas on integration, they now 200, e.g. https://www-origin.integration.publishing.service.gov.uk/api/content/world/thailand/news.th

The `available_translations` property also looks correct.