### PR TITLE
Publish statistics announcements with a ‘minor’ update_type

### DIFF
--- a/app/presenters/publishing_api/statistics_announcement_presenter.rb
+++ b/app/presenters/publishing_api/statistics_announcement_presenter.rb
@@ -5,7 +5,7 @@ module PublishingApi
 
     def initialize(item, update_type: nil)
       self.item = item
-      self.update_type = update_type || "major"
+      self.update_type = "minor"
     end
 
     def content_id

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -43,7 +43,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_publishing_api_put_content(statistics_announcement.content_id,
                                       expected)
     assert_publishing_api_publish(statistics_announcement.content_id,
-                                  { update_type: "major", locale: "en" }, 1)
+                                  { update_type: "minor", locale: "en" }, 1)
     assert_publishing_api_put_intent(
       statistics_announcement.base_path,
       expected_intent.as_json
@@ -83,7 +83,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_publishing_api_put_content(statistics_announcement.content_id,
                                       expected)
     assert_publishing_api_publish(statistics_announcement.content_id,
-                                  { update_type: "major", locale: "en" }, 2)
+                                  { update_type: "minor", locale: "en" }, 2)
     assert_publishing_api_put_intent(
       statistics_announcement.base_path,
       expected_intent.as_json,
@@ -160,7 +160,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_publishing_api_put_content(statistics_announcement.content_id,
                                       request_json_includes(expected))
     assert_publishing_api_publish(statistics_announcement.content_id,
-                                  { update_type: "major", locale: "en" }, 2)
+                                  { update_type: "minor", locale: "en" }, 2)
     assert_publishing_api_put_intent(
       statistics_announcement.base_path,
       expected_intent.as_json,

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -24,7 +24,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: "major",
+      update_type: "minor",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,
@@ -69,7 +69,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: "major",
+      update_type: "minor",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         state: statistics_announcement.state,
@@ -118,7 +118,7 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
         { path: public_path, type: 'exact' }
       ],
       redirects: [],
-      update_type: "major",
+      update_type: "minor",
       details: {
         display_date: statistics_announcement.current_release_date.display_date,
         previous_display_date: 7.days.from_now.to_s(:date_with_time),

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -272,6 +272,19 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     refute statistics_announcement.requires_redirect?
   end
 
+  test 'publishes to publishing api with a minor update type' do
+    edition = create(:statistics_announcement)
+
+    presenter = PublishingApiPresenters.presenter_for(edition)
+    requests = [
+      stub_publishing_api_put_content(presenter.content_id, presenter.content),
+      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
+      stub_publishing_api_publish(presenter.content_id, update_type: "minor", locale: "en")
+    ]
+
+    requests.each { |request| assert_requested request }
+  end
+
 private
 
   def create_announcement_with_changes


### PR DESCRIPTION
https://trello.com/c/TzosJcjb/184-publication-and-its-pre-publication-both-shown-in-email-digest

We don’t provide workflow on these editing pages.
As soon as the editor saves, the page is
published. If we send ‘major’ update_types it
means email subscribers get spammed and those
pages appear in digests multiple times.

We could prevent emails for
statistics_announcements in email-alert-service,
but that would mean hardcoding a rule for that
document_type. I think this is a better solution
as it keeps this knowledge inside Whitehall.