### PR TITLE
Stop leaking `use_asset_manager` feature flag state in tests

### DIFF
--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -12,7 +12,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     @quarantined_file_storage = stub('quarantined-file-storage')
     Whitehall::QuarantinedFileStorage.stubs(:new).returns(@quarantined_file_storage)
 
-    Whitehall.use_asset_manager = true
+    Whitehall.stubs(:use_asset_manager).returns(true)
   end
 
   test 'stores the file using the asset manager storage engine' do
@@ -23,7 +23,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
   end
 
   test 'does not store the file using the asset manager storage engine when feature flag is off' do
-    Whitehall.use_asset_manager = false
+    Whitehall.stubs(:use_asset_manager).returns(false)
 
     @asset_manager_storage.expects(:store!).never
     @quarantined_file_storage.stubs(:store!)


### PR DESCRIPTION
Setting the feature flag `Whitehall.use_asset_manager` (introduced in
16c48785) to `true` in the test setup of
AssetManagerAndQuarantinedFileStorageTest without un-setting it in a
`teardown` block could cause issues with state leaking into other
tests. This commit replaces it with a stub to avoid any potential
problems.