### PR TITLE
Use sidekiq for asset manager storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .rbenv-version
 /coverage
 /test/reports
+/asset-manager-tmp
 /incoming-uploads
 /infected-uploads
 /carrierwave-tmp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ node {
       sh ("mkdir -p ./clean-uploads")
       sh ("mkdir -p ./infected-uploads")
       sh ("mkdir -p ./attachment-cache")
+      sh ("mkdir -p ./asset-manager-tmp")
     }
 
     stage("Set up content schema dependency") {

--- a/app/workers/asset_manager_worker.rb
+++ b/app/workers/asset_manager_worker.rb
@@ -2,5 +2,6 @@ class AssetManagerWorker < WorkerBase
   def perform(file_path, legacy_url_path)
     file = File.open(file_path)
     Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)
+    FileUtils.rm(file)
   end
 end

--- a/app/workers/asset_manager_worker.rb
+++ b/app/workers/asset_manager_worker.rb
@@ -1,5 +1,6 @@
 class AssetManagerWorker < WorkerBase
-  def perform(file, legacy_url_path)
+  def perform(file_path, legacy_url_path)
+    file = File.open(file_path)
     Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)
   end
 end

--- a/app/workers/asset_manager_worker.rb
+++ b/app/workers/asset_manager_worker.rb
@@ -1,0 +1,5 @@
+class AssetManagerWorker < WorkerBase
+  def perform(file, legacy_url_path)
+    Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)
+  end
+end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -106,6 +106,10 @@ module Whitehall
     File.join(uploads_root, 'infected-uploads')
   end
 
+  def self.asset_manager_tmp_dir
+    File.join(uploads_root, 'asset-manager-tmp')
+  end
+
   def self.edition_classes
     [
       CaseStudy,

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,7 +1,8 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
+    carrrierwave_file = file.to_file
     path = File.join('/government/uploads', uploader.store_path)
-    Services.asset_manager.create_whitehall_asset(file: file.to_file, legacy_url_path: path)
+    Services.asset_manager.create_whitehall_asset(file: carrrierwave_file, legacy_url_path: path)
     file
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,8 +1,8 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
     carrrierwave_file = file.to_file
-    path = File.join('/government/uploads', uploader.store_path)
-    Services.asset_manager.create_whitehall_asset(file: carrrierwave_file, legacy_url_path: path)
+    legacy_url_path = File.join('/government/uploads', uploader.store_path)
+    Services.asset_manager.create_whitehall_asset(file: carrrierwave_file, legacy_url_path: legacy_url_path)
     file
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,7 +1,13 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
     original_file = file.to_file
-    temporary_location = File.join(Whitehall.asset_manager_tmp_dir, File.basename(original_file))
+    temporary_location = File.join(
+      Whitehall.asset_manager_tmp_dir,
+      SecureRandom.uuid,
+      File.basename(original_file)
+    )
+
+    FileUtils.mkdir_p(File.dirname(temporary_location))
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
     AssetManagerWorker.new.perform(temporary_location, legacy_url_path)

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -2,7 +2,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
     carrrierwave_file = file.to_file
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
-    Services.asset_manager.create_whitehall_asset(file: carrrierwave_file, legacy_url_path: legacy_url_path)
+    AssetManagerWorker.new.perform(carrrierwave_file, legacy_url_path)
     file
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -10,7 +10,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.mkdir_p(File.dirname(temporary_location))
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
-    AssetManagerWorker.new.perform(temporary_location, legacy_url_path)
+    AssetManagerWorker.perform_async(temporary_location, legacy_url_path)
     file
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,8 +1,8 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    carrrierwave_file = file.to_file
+    carrrierwave_file_path = file.to_file.path
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
-    AssetManagerWorker.new.perform(carrrierwave_file, legacy_url_path)
+    AssetManagerWorker.new.perform(carrrierwave_file_path, legacy_url_path)
     file
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,8 +1,10 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    carrrierwave_file_path = file.to_file.path
+    original_file = file.to_file
+    temporary_location = File.join(Whitehall.asset_manager_tmp_dir, File.basename(original_file))
+    FileUtils.cp(original_file, temporary_location)
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
-    AssetManagerWorker.new.perform(carrrierwave_file_path, legacy_url_path)
+    AssetManagerWorker.new.perform(temporary_location, legacy_url_path)
     file
   end
 

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -21,7 +21,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
     @worker.expects(:perform).with do |actual_path, _|
       uploaded_file_name = File.basename(@file.path)
-      expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/#{uploaded_file_name}}
+      expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9\-]+/#{uploaded_file_name}}
       actual_path =~ expected_path
     end
 

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -11,12 +11,17 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     @uploader = AssetManagerUploader.new
     @worker = mock('asset-manager-worker')
     AssetManagerWorker.stubs(:new).returns(@worker)
+    FileUtils.mkdir_p(Whitehall.asset_manager_tmp_dir)
   end
 
-  test "creates a sidekiq job using the location of the file in the uploader's cache directory" do
+  teardown do
+    FileUtils.remove_dir(Whitehall.asset_manager_tmp_dir, true)
+  end
+
+  test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
     @worker.expects(:perform).with do |actual_path, _|
       uploaded_file_name = File.basename(@file.path)
-      expected_path = %r{#{@uploader.cache_dir}/[0-9\-]+/#{uploaded_file_name}}
+      expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/#{uploaded_file_name}}
       actual_path =~ expected_path
     end
 

--- a/test/unit/workers/asset_manager_worker_test.rb
+++ b/test/unit/workers/asset_manager_worker_test.rb
@@ -20,4 +20,9 @@ class AssetManagerWorkerTest < ActiveSupport::TestCase
 
     @worker.perform(@file.path, @legacy_url_path)
   end
+
+  test 'removes the file after it has been successfully uploaded' do
+    @worker.perform(@file.path, @legacy_url_path)
+    refute File.exist?(@file.path)
+  end
 end

--- a/test/unit/workers/asset_manager_worker_test.rb
+++ b/test/unit/workers/asset_manager_worker_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class AssetManagerWorkerTest < ActiveSupport::TestCase
+  setup do
+    @file = Tempfile.new('asset')
+    @legacy_url_path = 'legacy-url-path'
+    @worker = AssetManagerWorker.new
+  end
+
+  test 'creates a whitehall asset using the file passed to the worker' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(file: @file))
+
+    @worker.perform(@file, @legacy_url_path)
+  end
+
+  test 'creates a whitehall asset using the legacy_url_path passed to the worker' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(legacy_url_path: @legacy_url_path))
+
+    @worker.perform(@file, @legacy_url_path)
+  end
+end

--- a/test/unit/workers/asset_manager_worker_test.rb
+++ b/test/unit/workers/asset_manager_worker_test.rb
@@ -7,15 +7,17 @@ class AssetManagerWorkerTest < ActiveSupport::TestCase
     @worker = AssetManagerWorker.new
   end
 
-  test 'creates a whitehall asset using the file passed to the worker' do
-    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(file: @file))
+  test 'creates a whitehall asset using a file object at the correct path' do
+    Services.asset_manager.expects(:create_whitehall_asset).with do |args|
+      args[:file].path == @file.path
+    end
 
-    @worker.perform(@file, @legacy_url_path)
+    @worker.perform(@file.path, @legacy_url_path)
   end
 
   test 'creates a whitehall asset using the legacy_url_path passed to the worker' do
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(legacy_url_path: @legacy_url_path))
 
-    @worker.perform(@file, @legacy_url_path)
+    @worker.perform(@file.path, @legacy_url_path)
   end
 end


### PR DESCRIPTION
Do not merge: requires https://github.com/alphagov/govuk-puppet/pull/6636 to be deployed. 

When an image is uploaded there are several thumbnail versions created. If the `USE_ASSET_MANAGER` feature flag is turned on, this means several requests to the asset manager API have to happen in-request. This will make the uploading of images slower and more error prone (as any API request failure will impact all of the requests). 

This PR moves the Asset Manager API requests to a Sidekiq worker. In the commits I've taken the approach of introducing the worker synchronously at first (using `perform`)  to preserve current behaviour before switching to asynchronous work (using `perform_async`). 

Fixes: #248