### PR TITLE
Support uploading of .xsd files

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -12,7 +12,10 @@ class AttachmentUploader < WhitehallUploader
 
   process :set_content_type
   def set_content_type
-    content_type = MIME::Types.type_for(full_filename(file.file)).first.content_type
+    filename = full_filename(file.file)
+    types = MIME::Types.type_for(filename)
+    content_type = types.first.content_type if types.any?
+    content_type = "text/xml" if filename.end_with?(".xsd")
     content_type = "text/csv" if content_type == "text/comma-separated-values"
     content_type = "application/pdf" if content_type == "application/octet-stream"
     file.content_type = content_type

--- a/test/fixtures/sample.xsd
+++ b/test/fixtures/sample.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="department">
+  <xs:complexType>
+    <xs:element name="name" type="xs:string"/>
+    <xs:element name="budget" type="xs:positiveInteger" />
+  </xs:complexType>
+</xs:element>
+
+</xs:schema>

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -43,6 +43,16 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
     AttachmentUploader.enable_processing = false
   end
 
+  test "should be able to attach a xsd file" do
+    AttachmentUploader.enable_processing = true
+
+    uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
+    uploader.store!(fixture_file_upload("sample.xsd"))
+    assert uploader.file.present?
+
+    AttachmentUploader.enable_processing = false
+  end
+
   test "should be able to attach a zip file" do
     uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
     uploader.store!(fixture_file_upload('sample_attachment.zip'))


### PR DESCRIPTION
Currently this fails because `mime-type` doesn't recognise .xsd files.