### PR TITLE
Add withdrawer to authors

### DIFF
--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -6,7 +6,7 @@ class Admin::EditionUnpublishingController < Admin::BaseController
     services = Whitehall.edition_services
     if @unpublishing.update_attributes(explanation: params[:unpublishing][:explanation])
       if withdrawing?
-        services.withdrawer(@unpublishing.edition).perform!
+        services.withdrawer(@unpublishing.edition, user: current_user).perform!
       else
         services.unpublisher(@unpublishing.edition).perform!
       end

--- a/app/services/edition_withdrawer.rb
+++ b/app/services/edition_withdrawer.rb
@@ -1,4 +1,11 @@
 class EditionWithdrawer < EditionUnpublisher
+  attr_reader :user
+
+  def initialize(edition, options = {})
+    super
+    @user = options[:user]
+  end
+
   def verb
     'withdraw'
   end
@@ -8,6 +15,11 @@ class EditionWithdrawer < EditionUnpublisher
   end
 
 private
+
+  def fire_transition!
+    edition.authors << user if user
+    super
+  end
 
   def prepare_edition
     edition.force_published = false

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -5,7 +5,8 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   def setup
-    login_as(create(:managing_editor))
+    @user = create(:managing_editor)
+    login_as(@user)
     @edition = create(:withdrawn_edition)
   end
 
@@ -21,7 +22,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
   test "#update updates the withdrawal and redirects to admin policy page" do
     Whitehall.edition_services
       .expects(:withdrawer)
-      .with(@edition)
+      .with(@edition, user: @user)
       .returns(withdrawer = stub)
 
     withdrawer.expects(:perform!)
@@ -60,5 +61,4 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_equal "The public explanation could not be updated", flash[:alert]
     assert_equal original_explanation, unpublishing.reload.explanation
   end
-
 end

--- a/test/unit/services/edition_withdrawer_test.rb
+++ b/test/unit/services/edition_withdrawer_test.rb
@@ -54,6 +54,16 @@ class EditionWithdrawerTest < ActiveSupport::TestCase
     assert edition.reload.withdrawn?
   end
 
+  test 'adds user to authors if passed' do
+    edition = create(:published_edition)
+    edition.build_unpublishing(unpublishing_params)
+    user = create(:user)
+
+    unpublisher = EditionWithdrawer.new(edition, user: user)
+    unpublisher.perform!
+    assert_includes edition.authors, user
+  end
+
   test 'cannot withdraw a published editions if a newer draft exists' do
     edition = create(:published_edition)
     edition.create_draft(create(:writer))


### PR DESCRIPTION
Currently a user that withdraws a document is not considered to have been involved in the authoring of that document. Only users that have made an edit to the draft of the document are added to the `authors` collection.

The result of this is that a user that makes a small typo correction is considered an author but a user that withdraws it, which is a much more significant change to the document is not.

When an editor searches for documents that they have authored that are in a withdrawn state the search results are then inconsistent as some documents that they withdrew (and also 'authored' by the current definition) will be returned but those that they only withdrew but didn't 'author' are not.

This PR adds support for a `user` option when instantiating the `EditionWithdrawer` class. This argument, when passed, is added to the `authors` collection of the `Edition` that is being withdrawn. The `EditionUnpublishingController` now passes the current user to `EditionWithdrawer`. 

[Trello](https://trello.com/c/3gew8mhv/194-problem-with-withdrawn-state-filter)