### PR TITLE
Remove SRI from admin JS

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -109,7 +109,7 @@
 <% end %>
 
 <% content_for :body_end do %>
-  <%= javascript_include_tag "admin", integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag "admin" %>
   <%= render_mustache_templates if Rails.env.development? %>
   <% initialise_script "GOVUK.adminGlobalInitialiser" %>
   <%= javascript_tag(yield :javascript_initialisers) %>


### PR DESCRIPTION
We've received a number of support tickets relating to issues with the pop-up menus in Whitehall admin not popping up. These seem to be caused by the admin JS not loading for some users since we added the SRI attributes.

We need to make the JS dependent functionality more resilient but in the short term this commit removes the attributes from the JS. 

A ticket will be added to the Whitehall support backlog to review the use of JS in the Whitehall admin interface and make changes where necessary before reverting this commit.

[Trello](https://trello.com/c/2wYn3eJi/202-new-document-tab-does-not-display-dropdown)

cc: @fofr 