### PR TITLE
Fix flakey test

### DIFF
--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -156,8 +156,8 @@ module Whitehall
       end
 
       test "can get a list of options for people" do
-        one = create(:person)
-        another = create(:person)
+        one = create(:person, forename: "Dave")
+        another = create(:person, forename: "Elouise")
         options = filter_options.for(:people)
 
         expected_ungrouped_options = [


### PR DESCRIPTION
Whitehall master has started failing CI on occasion due to a couple of flakey tests. This PR fixes one of 'em.

This test tests a list of users that are ordered by name. Relying on `FactoryGirl` to generate the user's names causes inconsistencies in the results due to the use of sequences within the names.

e.g.

```
user_1 = <User forename:'George 8'>
user_2 = <User forename:'George 9'>
```

These users ordered by name [user_1, user_2]

```
user_1 = <User forename:'George 9'>
user_2 = <User forename:'George 10'>
```

These users ordered by name [user_2, user_1]

So depending on where in the FactoryGirl sequence this test is run the results differ.

This commit explicitly sets the forename to avoid this condition.