### PR TITLE
Reslug DCMS

### DIFF
--- a/db/data_migration/20171012084849_reslug_dcms.rb
+++ b/db/data_migration/20171012084849_reslug_dcms.rb
@@ -1,0 +1,5 @@
+require "data_hygiene/organisation_reslugger"
+
+organisation = Organisation.find_by(slug: "department-for-culture-media-sport")
+
+DataHygiene::OrganisationReslugger.new(organisation, "department-for-digital-culture-media-sport").run!


### PR DESCRIPTION
This commit changes the slug of the DCMS organisation page to reflect a change in name.

Trello: https://trello.com/c/kdJhnipT/212-change-slug-for-dcms-org-page