### PR TITLE
Fix broken URL link when showing an organisation

### DIFF
--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -9,7 +9,7 @@
     <table class="table">
       <tr><th>Type</th><td><%= @organisation.organisation_type.name %></td></tr>
       <tr><th>Acronym</th><td><%= @organisation.acronym %></td></tr>
-      <tr><th>URL</th><td><%= link_to @organisation.url %></td></tr>
+      <tr><th>URL</th><td><%= link_to @organisation.url, @organisation.url %></td></tr>
       <tr><th>Status on GOV.UK</th><td><%= @organisation.govuk_status.titleize %></td></tr>
       <% if @organisation.closed? %>
         <% if @organisation.closed_at.present? %>


### PR DESCRIPTION
By only having one argument passed to the link_to helper we are ending
up with a link to the current page (which is presumably due to some
Rails magic about current context:
https://github.com/rails/rails/blob/a217fd0d1392e2ab53d86682a52cc40330e6089f/actionpack/lib/action_dispatch/routing/url_for.rb#L109-L114

This specifies the url as both arguments which creates a link to the
appropriate resource.

Before:

```
<tr><th>URL</th><td><a href="/government/admin/organisations/scotland-office">http://www.scotlandoffice.gov.uk/</a></td></tr>
```

After:

```
<tr><th>URL</th><td><a href="http://www.scotlandoffice.gov.uk/">http://www.scotlandoffice.gov.uk/</a></td></tr>
```