### PR TITLE
Link from people page to filtered announcements

### DIFF
--- a/app/views/shared/_announcement_list.html.erb
+++ b/app/views/shared/_announcement_list.html.erb
@@ -19,7 +19,7 @@
     </ol>
 
     <div class="read-more">
-      <%= link_to t('announcements.view_all'), :announcements %>
+      <%= link_to t('announcements.view_all'), announcements_path("people[]": announcer.slug) %>
     </div>
   </section>
 <% end %>

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -84,4 +84,18 @@ class PeopleControllerTest < ActionController::TestCase
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
     end
   end
+
+  view_test "should display a link to view all announcements for a person" do
+    organisation = create(:organisation)
+    ministerial_role = create(:ministerial_role, organisations: [organisation])
+    person = create(:person)
+    role_appointment = create(:role_appointment, role: ministerial_role, person: person)
+    create(:published_speech, role_appointment: role_appointment)
+
+    get :show, params: { id: person }
+
+    assert_select "#announcements" do
+      assert_select "a[href='/government/announcements?people%5B%5D=#{person.slug}']", text: "View all announcements"
+    end
+  end
 end


### PR DESCRIPTION
Alter link on people pages to link to filtered announcements rather than all announcements.

Example page: [whitehall-frontend.dev.gov.uk/government/people/david-davis](gov.uk/government/people/david-davis)