### PR TITLE
Fix jQuery UI after upgrading the Rails version

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,5 +1,21 @@
 @import 'govuk_admin_template';
-@import 'jquery.ui.all';
+
+@import 'jquery.ui.core';
+@import 'jquery.ui.accordion';
+@import 'jquery.ui.autocomplete';
+@import 'jquery.ui.button';
+@import 'jquery.ui.datepicker';
+@import 'jquery.ui.dialog';
+@import 'jquery.ui.menu';
+@import 'jquery.ui.progressbar';
+@import 'jquery.ui.resizable';
+@import 'jquery.ui.selectable';
+@import 'jquery.ui.slider';
+@import 'jquery.ui.spinner';
+@import 'jquery.ui.tabs';
+@import 'jquery.ui.tooltip';
+@import 'jquery.ui.theme';
+
 @import 'vendor/chosen-bootstrap';
 @import 'vendor/jquery.highlighttextarea';
 @import 'shared/helpers/_magna-charta';


### PR DESCRIPTION
https://trello.com/c/cDOjXWjP/231-editor-view-for-adding-items-to-collection-has-bad-formatting-post-rails-5-upgrade

Previously, the 'jquery.ui.all' module loaded
these modules recursively. This doesn't seem to
work anymore so require them explicitly.

Longer term, we shouild try upgrading jQuery UI
to the latest version:
https://trello.com/c/je5OJmaY/1113-upgrade-jquery-ui-in-whitehall-admin

**Before:**
![screen shot 2017-10-16 at 12 29 12](https://user-images.githubusercontent.com/892251/31609837-a3e8b424-b26d-11e7-9ac9-048657a51198.png)

**After:**
![screen shot 2017-10-16 at 12 29 53](https://user-images.githubusercontent.com/892251/31609865-bf237f30-b26d-11e7-9f5a-0ae5f1dd27c4.png)
