### PR TITLE
Clarify whether email alerts go out when unwithdrawing

### DIFF
--- a/app/views/admin/edition_workflow/_unwithdraw_modal.html.erb
+++ b/app/views/admin/edition_workflow/_unwithdraw_modal.html.erb
@@ -9,7 +9,7 @@
           <h3 class="modal-title">Are you sure you want to unwithdraw this?</h3>
         </div>
         <div class="modal-body">
-          <p>This will create a new edition and immediately publish it.</p>
+          <p>This will create a new edition and immediately publish it. This will not trigger email alerts.</p>
         </div>
         <%= form_tag unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version), class: 'unwithdraw-form' do %>
           <div class="modal-footer">
@@ -22,7 +22,7 @@
 <% else %>
   <h1>Are you sure you want to unwithdraw this?</h1>
   <%= form_tag unwithdraw_admin_edition_path(@edition, lock_version: @edition.lock_version), class: 'unwithdraw-form' do %>
-    <p>This will create a new edition and immediately publish it.</p>
+    <p>This will create a new edition and immediately publish it. This will not trigger email alerts.</p>
     <%= submit_tag 'Unwithdraw', class: "btn btn-danger" %> <%= link_to 'Cancel', [:admin, @edition], class: 'btn btn-default add-left-margin' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
We've had a couple of Zendesk tickets asking about this.

https://trello.com/c/nUE37uD0/230-user-query-does-whether-unwithdrawing-trigger-an-email