### PR TITLE
Delete incorrectly published VOSA groups and redirect

### DIFF
--- a/db/data_migration/20171016161012_redirect_vosa.rb
+++ b/db/data_migration/20171016161012_redirect_vosa.rb
@@ -1,0 +1,19 @@
+slugs = %w(
+  vosa-directing-board
+  vosa-business-performance-board
+  vosa-investment-and-change-board
+)
+
+redirect_path = "/government/organisations/vehicle-and-operator-services-agency/about/our-governance"
+
+slugs.each do |slug|
+  group = PolicyGroup.find_by(slug: slug)
+  next unless group
+
+  content_id = group.content_id
+
+  group.delete
+  PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en")
+
+  puts "#{slug} -> #{redirect_path}"
+end


### PR DESCRIPTION
https://trello.com/c/Miu2R7ug/234-unpublish-group-pages-and-redirect-to-new-url