### PR TITLE
Delete duplicate role for Minister of State for Employment

### DIFF
--- a/db/data_migration/20171017100215_delete_duplicate_role.rb
+++ b/db/data_migration/20171017100215_delete_duplicate_role.rb
@@ -1,0 +1,17 @@
+role_to_delete = "minister-of-state--41"
+redirect_path = "/government/ministers/minister-of-state-employment"
+
+role = Role.find_by!(slug: role_to_delete)
+
+role.role_appointments = []
+role.organisations = []
+role.worldwide_organisations = []
+role.save!
+role.destroy
+
+raise "Failed to delete role" if Role.find_by(slug: role_to_delete)
+
+Whitehall::SearchIndex.delete(role)
+
+PublishingApiRedirectWorker.new.perform(role.content_id, redirect_path, "en")
+PublishingApiRedirectWorker.new.perform(role.content_id, "#{redirect_path}.cy", "cy")


### PR DESCRIPTION
https://trello.com/c/5PxaqxeE/236-delete-duplicate-ministerial-role
https://govuk.zendesk.com/agent/tickets/2398578

This is actually sending an unpublish event via the
`PublishingApiRedirectWorker` which is the right
thing to do.