### PR TITLE
Add a migration to fix GOV.UK Pay URL

### DIFF
--- a/db/data_migration/20171018095703_fix_govuk_pay_url.rb
+++ b/db/data_migration/20171018095703_fix_govuk_pay_url.rb
@@ -1,0 +1,20 @@
+slug = "govuk-pay"
+redirect_path = "https://www.payments.service.gov.uk"
+
+document = Document.find_by(slug: slug)
+exit unless document
+
+attachment_content_ids = document.editions.flat_map do |edition|
+  edition.attachments.map(&:content_id)
+end.uniq
+
+content_ids = [document.content_id] + attachment_content_ids
+
+document.delete
+
+puts "#{slug} -> #{redirect_path}"
+
+content_ids.each do |content_id|
+  puts "- #{content_id}"
+  PublishingApiRedirectWorker.new.perform(content_id, redirect_path, "en")
+end


### PR DESCRIPTION
The URL for GOV.UK Pay is https://www.payments.service.gov.uk but there currently exists old guidance in Whitehall about Pay which can be found from Google. This commit adds a migration which removes the old guidance pages and redirects them to the URL for GOV.UK Pay instead.

[Trello Card](https://trello.com/c/933P4qhQ/240-redirect-url-and-remove-original-page-from-whitehall-govuk-pay)