### PR TITLE
Scope worldwide organisation roles by ‘occupied’ only

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -37,6 +37,7 @@ class Role < ApplicationRecord
   scope :military,                   -> { where(type: 'MilitaryRole') }
   scope :special_representative,     -> { where(type: 'SpecialRepresentativeRole') }
   scope :chief_professional_officer, -> { where(type: 'ChiefProfessionalOfficerRole') }
+  scope :occupied,                   -> { where(id: RoleAppointment.current.pluck(:role_id)) }
 
   validates :name, presence: true
   validates :type, presence: true

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -2,6 +2,8 @@ class WorldwideOrganisation < ApplicationRecord
   include HasCorporateInformationPages
 
   PRIMARY_ROLES = [AmbassadorRole, HighCommissionerRole, GovernorRole]
+  SECONDARY_ROLES = [DeputyHeadOfMissionRole]
+  OFFICE_ROLES = [WorldwideOfficeStaffRole]
 
   has_many :worldwide_organisation_world_locations, dependent: :destroy
   has_many :world_locations, through: :worldwide_organisation_world_locations
@@ -103,15 +105,14 @@ class WorldwideOrganisation < ApplicationRecord
   end
 
   def primary_role
-    roles.where(type: PRIMARY_ROLES.map(&:name)).first
+    roles.occupied.where(type: PRIMARY_ROLES.map(&:name)).first
   end
 
   def secondary_role
-    roles.where(type: DeputyHeadOfMissionRole.name).first
+    roles.occupied.where(type: SECONDARY_ROLES.map(&:name)).first
   end
 
   def office_staff_roles
-    roles.where(type: WorldwideOfficeStaffRole.name)
+    roles.occupied.where(type: OFFICE_ROLES.map(&:name))
   end
-
 end

--- a/test/factories/role_appointments.rb
+++ b/test/factories/role_appointments.rb
@@ -36,4 +36,8 @@ FactoryGirl.define do
   factory :judge_role_appointment, parent: :role_appointment do
     association :role, factory: :judge_role
   end
+
+  trait :ended do
+    ended_at { 1.day.ago }
+  end
 end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -13,4 +13,16 @@ FactoryGirl.define do
   factory :historic_role, parent: :ministerial_role do
     supports_historical_accounts true
   end
+
+  trait :occupied do
+    after :build do |role, _|
+      role.role_appointments = [FactoryGirl.build(:role_appointment)]
+    end
+  end
+
+  trait :vacant do
+    after :build do |role, _|
+      role.role_appointments = [FactoryGirl.build(:role_appointment, :ended)]
+    end
+  end
 end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -179,6 +179,14 @@ class RoleTest < ActiveSupport::TestCase
     assert_equal [role], Role.also_attends_cabinet
   end
 
+  test "should be able to scope roles by whether they are occupied" do
+    occupied = create(:role, :occupied)
+    vacant = create(:role, :vacant)
+
+    assert_includes Role.occupied, occupied
+    refute_includes Role.occupied, vacant
+  end
+
   test "has removeable translations" do
     stub_any_publishing_api_call
 

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -112,7 +112,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_nil worldwide_organisation.primary_role
 
-    ambassador_role = create(:ambassador_role, worldwide_organisations: [worldwide_organisation])
+    ambassador_role = create(:ambassador_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
     assert_equal ambassador_role, worldwide_organisation.primary_role
     assert_nil worldwide_organisation.secondary_role
@@ -123,7 +123,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_nil worldwide_organisation.primary_role
 
-    high_commissioner_role = create(:high_commissioner_role, worldwide_organisations: [worldwide_organisation])
+    high_commissioner_role = create(:high_commissioner_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
     assert_equal high_commissioner_role, worldwide_organisation.primary_role
     assert_nil worldwide_organisation.secondary_role
@@ -134,7 +134,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_nil worldwide_organisation.primary_role
 
-    governor_role = create(:governor_role, worldwide_organisations: [worldwide_organisation])
+    governor_role = create(:governor_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
     assert_equal governor_role, worldwide_organisation.primary_role
     assert_nil worldwide_organisation.secondary_role
@@ -145,7 +145,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_nil worldwide_organisation.secondary_role
 
-    deputy_role = create(:deputy_head_of_mission_role, worldwide_organisations: [worldwide_organisation])
+    deputy_role = create(:deputy_head_of_mission_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
     assert_equal deputy_role, worldwide_organisation.secondary_role
     assert_nil worldwide_organisation.primary_role
@@ -156,12 +156,32 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_equal [], worldwide_organisation.office_staff_roles
 
-    staff_role1 = create(:worldwide_office_staff_role, worldwide_organisations: [worldwide_organisation])
-    staff_role2 = create(:worldwide_office_staff_role, worldwide_organisations: [worldwide_organisation])
+    staff_role1 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
+    staff_role2 = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [worldwide_organisation])
 
     assert_equal [staff_role1, staff_role2], worldwide_organisation.office_staff_roles
     assert_nil worldwide_organisation.primary_role
     assert_nil worldwide_organisation.secondary_role
+  end
+
+  test "primary, secondary and office staff roles return occupied roles only" do
+    org = create(:worldwide_organisation)
+
+    create(:ambassador_role, :vacant, worldwide_organisations: [org])
+    create(:deputy_head_of_mission_role, :vacant, worldwide_organisations: [org])
+    create(:worldwide_office_staff_role, :vacant, worldwide_organisations: [org])
+
+    assert_nil org.primary_role
+    assert_nil org.secondary_role
+    assert_equal [], org.office_staff_roles
+
+    a = create(:ambassador_role, :occupied, worldwide_organisations: [org])
+    b = create(:deputy_head_of_mission_role, :occupied, worldwide_organisations: [org])
+    c = create(:worldwide_office_staff_role, :occupied, worldwide_organisations: [org])
+
+    assert_equal a, org.primary_role
+    assert_equal b, org.secondary_role
+    assert_equal [c], org.office_staff_roles
   end
 
   test "has removeable translations" do


### PR DESCRIPTION
https://trello.com/c/n19MlHrj/239-user-trying-to-add-a-role-to-embassy-page

There’s currently a bug where we’re not showing a
person assigned to a role because a role
appointment that has ended is being picked out
instead which is then being hidden by the view.

This is the problematic page:
https://www.gov.uk/world/organisations/british-embassy-managua

We also wrote a script to check the correctness of
the results returned from the primary/secondary
methods. Its output is now showing no errors:
https://gist.github.com/tuzz/a4923f4248547d7f6b809f2b9dc6fce4

### Before:
![screen shot 2017-10-18 at 13 39 47](https://user-images.githubusercontent.com/892251/31718988-dbaf9240-b409-11e7-9dea-5041cd835a99.png)

### After:
![screen shot 2017-10-18 at 13 39 57](https://user-images.githubusercontent.com/892251/31718991-de76914a-b409-11e7-8f82-9472949b92a6.png)