### PR TITLE
Remove Organisation logos from Asset Manager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
-    gds-api-adapters (49.3.1)
+    gds-api-adapters (49.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger

--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class ConsultationResponseFormUploader < WhitehallUploader
-  storage :asset_manager_and_file_system
+  storage :asset_manager_and_quarantined_file_storage
 
   def extension_whitelist
     %w(pdf csv rtf doc docx xls xlsx odt ods)

--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class ConsultationResponseFormUploader < WhitehallUploader
-  storage :asset_manager_and_quarantined_file_storage
-
   def extension_whitelist
     %w(pdf csv rtf doc docx xls xlsx odt ods)
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,8 +1,6 @@
 class ImageUploader < WhitehallUploader
   include CarrierWave::MiniMagick
 
-  storage :asset_manager_and_quarantined_file_storage
-
   configure do |config|
     config.remove_previously_stored_files_after_update = false
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,7 @@
 class ImageUploader < WhitehallUploader
   include CarrierWave::MiniMagick
 
-  storage :asset_manager_and_file_system
+  storage :asset_manager_and_quarantined_file_storage
 
   configure do |config|
     config.remove_previously_stored_files_after_update = false

--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -1,5 +1,5 @@
 class LogoUploader < WhitehallUploader
-  storage :asset_manager_and_file_system
+  storage :asset_manager_and_quarantined_file_storage
 
   def extension_whitelist
     %w(jpg jpeg gif png)

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,4 +1,4 @@
-class AssetManagerWorker < WorkerBase
+class AssetManagerCreateWhitehallAssetWorker < WorkerBase
   def perform(file_path, legacy_url_path)
     file = File.open(file_path)
     Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -3,5 +3,6 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     file = File.open(file_path)
     Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)
     FileUtils.rm(file)
+    FileUtils.rmdir(File.dirname(file))
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,0 +1,9 @@
+class AssetManagerDeleteAssetWorker < WorkerBase
+  def perform(legacy_url_path)
+    gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
+    asset_url = gds_api_response['id']
+    asset_id = asset_url[/\/assets\/(.*)/, 1]
+
+    Services.asset_manager.delete_asset(asset_id)
+  end
+end

--- a/config/initializers/asset_manager.rb
+++ b/config/initializers/asset_manager.rb
@@ -1,1 +1,0 @@
-Whitehall.use_asset_manager = ENV['USE_ASSET_MANAGER'].present?

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,7 +3,7 @@ require 'whitehall/quarantined_file_storage'
 CarrierWave.configure do |config|
   config.storage_engines[:quarantined_file] = 'Whitehall::QuarantinedFileStorage'
   config.storage_engines[:asset_manager] = 'Whitehall::AssetManagerStorage'
-  config.storage_engines[:asset_manager_and_file_system] = 'Whitehall::AssetManagerAndQuarantinedFileStorage'
+  config.storage_engines[:asset_manager_and_quarantined_file_storage] = 'Whitehall::AssetManagerAndQuarantinedFileStorage'
   config.storage Whitehall::QuarantinedFileStorage
   config.enable_processing = false if Rails.env.test?
   config.cache_dir = Rails.root.join "carrierwave-tmp"

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -18,7 +18,6 @@ module Whitehall
   mattr_accessor :skip_safe_html_validation
   mattr_accessor :statistics_announcement_search_client
   mattr_accessor :uploads_cache_max_age
-  mattr_accessor :use_asset_manager
 
   class NoConfigurationError < StandardError; end
 

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -5,6 +5,27 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   def retrieve!(identifier)
-    Whitehall::QuarantinedFileStorage.new(uploader).retrieve!(identifier)
+    asset_manager_file = Whitehall::AssetManagerStorage.new(uploader).retrieve!(identifier)
+    quarantined_file = Whitehall::QuarantinedFileStorage.new(uploader).retrieve!(identifier)
+
+    File.new(asset_manager_file, quarantined_file)
+  end
+
+  class File
+    delegate :empty?, :path, :content_type, :filename, to: :@quarantined_file
+
+    def initialize(asset_manager_file, quarantined_file)
+      @asset_manager_file = asset_manager_file
+      @quarantined_file = quarantined_file
+    end
+
+    def url
+      @quarantined_file.url
+    end
+
+    def delete
+      @quarantined_file.delete
+      @asset_manager_file.delete
+    end
   end
 end

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -1,6 +1,6 @@
 class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    Whitehall::AssetManagerStorage.new(uploader).store!(file) if Whitehall.use_asset_manager
+    Whitehall::AssetManagerStorage.new(uploader).store!(file)
     Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -1,20 +1,35 @@
 class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def store!(file)
     original_file = file.to_file
-    temporary_location = File.join(
+    temporary_location = ::File.join(
       Whitehall.asset_manager_tmp_dir,
       SecureRandom.uuid,
-      File.basename(original_file)
+      ::File.basename(original_file)
     )
 
-    FileUtils.mkdir_p(File.dirname(temporary_location))
+    FileUtils.mkdir_p(::File.dirname(temporary_location))
     FileUtils.cp(original_file, temporary_location)
-    legacy_url_path = File.join('/government/uploads', uploader.store_path)
+    legacy_url_path = ::File.join('/government/uploads', uploader.store_path)
     AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path)
     file
   end
 
-  def retrieve!(_identifier)
-    raise "We're not currently reading assets from Asset Manager so this shouldn't be called."
+  def retrieve!(identifier)
+    asset_path = uploader.store_path(identifier)
+    File.new(asset_path)
+  end
+
+  class File
+    def initialize(asset_path)
+      @legacy_url_path = ::File.join('/government', 'uploads', asset_path)
+    end
+
+    def delete
+      gds_api_response = Services.asset_manager.whitehall_asset(@legacy_url_path)
+      asset_url = gds_api_response['id']
+      asset_id = asset_url[/\/assets\/(.*)/, 1]
+
+      Services.asset_manager.delete_asset(asset_id)
+    end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -25,11 +25,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def delete
-      gds_api_response = Services.asset_manager.whitehall_asset(@legacy_url_path)
-      asset_url = gds_api_response['id']
-      asset_id = asset_url[/\/assets\/(.*)/, 1]
-
-      Services.asset_manager.delete_asset(asset_id)
+      AssetManagerDeleteAssetWorker.perform_async(@legacy_url_path)
     end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -10,7 +10,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.mkdir_p(File.dirname(temporary_location))
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = File.join('/government/uploads', uploader.store_path)
-    AssetManagerWorker.perform_async(temporary_location, legacy_url_path)
+    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path)
     file
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class AssetManagerIntegrationTest
+  class CreatingAnOrganisationLogo < ActiveSupport::TestCase
+    setup do
+      Whitehall.stubs(:use_asset_manager).returns(true)
+
+      @filename = '960x640_jpeg.jpg'
+      @organisation = FactoryGirl.build(
+        :organisation,
+        organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', @filename))
+      )
+    end
+
+    test 'sends the logo to Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
+        args[:file].is_a?(File) &&
+          args[:legacy_url_path] =~ /#{@filename}/
+      end
+
+      @organisation.save!
+    end
+
+    test 'saves the logo to the file system' do
+      @organisation.save!
+
+      assert File.exist?(@organisation.logo.path)
+    end
+  end
+end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -3,8 +3,6 @@ require 'test_helper'
 class AssetManagerIntegrationTest
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
     setup do
-      Whitehall.stubs(:use_asset_manager).returns(true)
-
       @filename = '960x640_jpeg.jpg'
       @organisation = FactoryGirl.build(
         :organisation,
@@ -31,8 +29,6 @@ class AssetManagerIntegrationTest
 
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     setup do
-      Whitehall.stubs(:use_asset_manager).returns(true)
-
       @organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -28,4 +28,36 @@ class AssetManagerIntegrationTest
       assert File.exist?(@organisation.logo.path)
     end
   end
+
+  class RemovingAnOrganisationLogo < ActiveSupport::TestCase
+    setup do
+      Whitehall.stubs(:use_asset_manager).returns(true)
+
+      @organisation = FactoryGirl.create(
+        :organisation,
+        organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg'))
+      )
+      VirusScanHelpers.simulate_virus_scan(@organisation.logo)
+      @organisation.reload
+
+      Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+      Services.asset_manager.stubs(:delete_asset)
+    end
+
+    test 'removing an organisation logo removes it from the file system' do
+      logo_path = @organisation.logo.path
+
+      @organisation.remove_logo!
+      @organisation.reload
+
+      refute File.exist?(logo_path)
+    end
+
+    test 'removing an organisation logo removes it from asset manager' do
+      Services.asset_manager.expects(:delete_asset)
+
+      @organisation.remove_logo!
+    end
+  end
 end

--- a/test/unit/consultation_response_form_uploader_test.rb
+++ b/test/unit/consultation_response_form_uploader_test.rb
@@ -11,8 +11,4 @@ class ConsultationResponseFormUploaderTest < ActiveSupport::TestCase
     uploader = ConsultationResponseFormUploader.new(model, "mounted-as")
     assert_match /^system/, uploader.store_dir
   end
-
-  test 'uses the asset manager and file system storage engine' do
-    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ConsultationResponseFormUploader.storage
-  end
 end

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -11,10 +11,6 @@ class ImageUploaderTest < ActiveSupport::TestCase
     ImageUploader.enable_processing = false
   end
 
-  test 'uses the asset manager and file system storage engine' do
-    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ImageUploader.storage
-  end
-
   test "should only allow JPG, GIF, PNG or SVG images" do
     uploader = ImageUploader.new
     assert_equal %w(jpg jpeg gif png svg), uploader.extension_whitelist

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -11,21 +11,10 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     Whitehall::AssetManagerStorage.stubs(:new).returns(@asset_manager_storage)
     @quarantined_file_storage = stub('quarantined-file-storage')
     Whitehall::QuarantinedFileStorage.stubs(:new).returns(@quarantined_file_storage)
-
-    Whitehall.stubs(:use_asset_manager).returns(true)
   end
 
   test 'stores the file using the asset manager storage engine' do
     @asset_manager_storage.expects(:store!).with(@file)
-    @quarantined_file_storage.stubs(:store!)
-
-    @storage.store!(@file)
-  end
-
-  test 'does not store the file using the asset manager storage engine when feature flag is off' do
-    Whitehall.stubs(:use_asset_manager).returns(false)
-
-    @asset_manager_storage.expects(:store!).never
     @quarantined_file_storage.stubs(:store!)
 
     @storage.store!(@file)

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -45,10 +45,62 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     assert_equal 'stored-file', @storage.store!(@file)
   end
 
-  test 'retrieves the file from the quarantined file store' do
-    @asset_manager_storage.stubs(:store!)
-    @quarantined_file_storage.stubs(:retrieve!).with('identifier').returns('retrieved-file')
+  test 'returns the composite asset manager and quarantined file' do
+    @quarantined_file_storage.stubs(:retrieve!).with('identifier').returns('retrieved-quarantined-file')
+    @asset_manager_storage.stubs(:retrieve!).with('identifier').returns('retrieved-asset-manager-file')
 
-    assert_equal 'retrieved-file', @storage.retrieve!('identifier')
+    composite_file = stub(:composite_file)
+    Whitehall::AssetManagerAndQuarantinedFileStorage::File.stubs(:new).with('retrieved-asset-manager-file', 'retrieved-quarantined-file').returns(composite_file)
+
+    assert_equal composite_file, @storage.retrieve!('identifier')
+  end
+end
+
+class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport::TestCase
+  setup do
+    @asset_manager_file = stub(:asset_manager_file)
+    @quarantined_file = stub(:quarantined_file)
+    @file = Whitehall::AssetManagerAndQuarantinedFileStorage::File.new(@asset_manager_file, @quarantined_file)
+  end
+
+  test '#url has an arity of 0 ' do
+    assert_equal 0, @file.method(:url).arity
+  end
+
+  test '#url delegates to the quarantined file' do
+    @quarantined_file.stubs(:url).returns('quarantined-file-url')
+
+    assert_equal 'quarantined-file-url', @file.url
+  end
+
+  test '#path delegates to the quarantined file' do
+    @quarantined_file.stubs(:path).returns('quarantined-file-path')
+
+    assert_equal 'quarantined-file-path', @file.path
+  end
+
+  test '#filename delegates to the quarantined file' do
+    @quarantined_file.stubs(:filename).returns('quarantined-file-filename')
+
+    assert_equal 'quarantined-file-filename', @file.filename
+  end
+
+  test '#content_type delegates to the quarantined file' do
+    @quarantined_file.stubs(:content_type).returns('quarantined-file-content-type')
+
+    assert_equal 'quarantined-file-content-type', @file.content_type
+  end
+
+  test '#empty? delegates to the quarantined file' do
+    @quarantined_file.stubs(:empty?).returns('quarantined-file-empty?')
+
+    assert_equal 'quarantined-file-empty?', @file.empty?
+  end
+
+  test '#delete calls delete on both asset manager file and quarantined file' do
+    @asset_manager_file.expects(:delete)
+    @quarantined_file.expects(:delete)
+
+    @file.delete
   end
 end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -63,16 +63,10 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 end
 
 class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
-  test 'deletes file from asset manager' do
+  test 'queues the call to delete the asset from asset manager' do
     file = Whitehall::AssetManagerStorage::File.new('path/to/asset.png')
 
-    json_response = {
-      id: 'http://asset-manager/assets/asset-id'
-    }.to_json
-    http_response = stub('http_response', body: json_response)
-    gds_api_response = GdsApi::Response.new(http_response)
-    Services.asset_manager.stubs(:whitehall_asset).with('/government/uploads/path/to/asset.png').returns(gds_api_response)
-    Services.asset_manager.expects(:delete_asset).with('asset-id')
+    AssetManagerDeleteAssetWorker.expects(:perform_async).with('/government/uploads/path/to/asset.png')
 
     file.delete
   end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -17,7 +17,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   end
 
   test "creates a sidekiq job using the location of the file in the asset manager tmp directory" do
-    AssetManagerWorker.expects(:perform_async).with do |actual_path, _|
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with do |actual_path, _|
       uploaded_file_name = File.basename(@file.path)
       expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9\-]+/#{uploaded_file_name}}
       actual_path =~ expected_path
@@ -31,13 +31,13 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
     expected_filename = File.basename(@file.path)
     expected_path = File.join('/government/uploads/store-dir', expected_filename)
-    AssetManagerWorker.expects(:perform_async).with(anything, expected_path)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path)
 
     @uploader.store!(@file)
   end
 
   test 'returns the sanitized file' do
-    AssetManagerWorker.stubs(:perform_async)
+    AssetManagerCreateWhitehallAssetWorker.stubs(:perform_async)
 
     storage = Whitehall::AssetManagerStorage.new(@uploader)
     file = CarrierWave::SanitizedFile.new(@file)

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
-class AssetManagerWorkerTest < ActiveSupport::TestCase
+class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
   setup do
     @file = Tempfile.new('asset')
     @legacy_url_path = 'legacy-url-path'
-    @worker = AssetManagerWorker.new
+    @worker = AssetManagerCreateWhitehallAssetWorker.new
   end
 
   test 'creates a whitehall asset using a file object at the correct path' do

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
   setup do
-    @file = Tempfile.new('asset')
+    @file = Tempfile.new('asset', Dir.mktmpdir)
     @legacy_url_path = 'legacy-url-path'
     @worker = AssetManagerCreateWhitehallAssetWorker.new
   end
@@ -24,5 +24,10 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
   test 'removes the file after it has been successfully uploaded' do
     @worker.perform(@file.path, @legacy_url_path)
     refute File.exist?(@file.path)
+  end
+
+  test 'removes the directory after it has been successfully uploaded' do
+    @worker.perform(@file.path, @legacy_url_path)
+    refute Dir.exist?(File.dirname(@file))
   end
 end

--- a/test/unit/workers/asset_manager_delete_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_delete_asset_worker_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class AssetManagerDeleteAssetWorkerTest < ActiveSupport::TestCase
+  test 'deletes file from asset manager' do
+    json_response = {
+      id: 'http://asset-manager/assets/asset-id'
+    }.to_json
+    http_response = stub('http_response', body: json_response)
+    gds_api_response = GdsApi::Response.new(http_response)
+    Services.asset_manager.stubs(:whitehall_asset).with('/government/uploads/path/to/asset.png').returns(gds_api_response)
+    Services.asset_manager.expects(:delete_asset).with('asset-id')
+
+    worker = AssetManagerDeleteAssetWorker.new
+    worker.perform('/government/uploads/path/to/asset.png')
+  end
+end


### PR DESCRIPTION
Removing assets from Asset Manager when they're removed from Whitehall should allow us to keep the assets in the two systems synchronised while we're running them in parallel.

The requests to remove assets from Asset Manager are placed on a queue to allow us to retry jobs that fail due to network problems.

We've started by removing Organisation logos to reduce the scope of this change.
