### PR TITLE
Vanish coming soon pages for unscheduled editions

### DIFF
--- a/app/workers/publishing_api_vanish_worker.rb
+++ b/app/workers/publishing_api_vanish_worker.rb
@@ -1,0 +1,12 @@
+class PublishingApiVanishWorker < PublishingApiWorker
+  def perform(content_id, locale)
+    Services.publishing_api.unpublish(
+      content_id,
+      type: "vanish",
+      locale: locale
+    )
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+    # nothing to do here as we can't unpublish something that doesn't exist
+    nil
+  end
+end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -63,7 +63,7 @@ module Whitehall
       locales_for(edition).each do |locale|
         base_path = Whitehall.url_maker.public_document_path(edition, locale: locale)
         PublishingApiUnscheduleWorker.perform_async(base_path)
-        self.publish_gone_async(edition.content_id, nil, nil, locale) unless edition.document.published?
+        self.publish_vanish_async(edition.content_id, locale) unless edition.document.published?
       end
     end
 
@@ -73,6 +73,10 @@ module Whitehall
 
     def self.publish_gone_async(content_id, alternative_path, explanation, locale = I18n.default_locale.to_s)
       PublishingApiGoneWorker.perform_async(content_id, alternative_path, explanation, locale)
+    end
+
+    def self.publish_vanish_async(document_content_id, locale = I18n.default_locale.to_s)
+      PublishingApiVanishWorker.perform_async(document_content_id, locale)
     end
 
     def self.publish_withdrawal_async(document_content_id, explanation, locale = I18n.default_locale.to_s)

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -63,7 +63,7 @@ class SchedulingTest < ActiveSupport::TestCase
     assert_publishing_api_put_intent(french_path, publish_time: publish_time)
   end
 
-  test "unscheduling a scheduled first-edition removes the publish intent and replaces the 'coming_soon' with a 'gone' item" do
+  test "unscheduling a scheduled first-edition removes the publish intent and deletes the 'coming_soon' item" do
     gone_uuid = SecureRandom.uuid
     SecureRandom.stubs(uuid: gone_uuid)
     scheduled_edition = create(:scheduled_case_study)
@@ -74,9 +74,8 @@ class SchedulingTest < ActiveSupport::TestCase
     gone_request = stub_publishing_api_unpublish(
       scheduled_edition.content_id,
       body: {
-        type: "gone",
+        type: "vanish",
         locale: "en",
-        discard_drafts: true,
       }
     )
 
@@ -86,7 +85,7 @@ class SchedulingTest < ActiveSupport::TestCase
     assert_requested gone_request
   end
 
-  test "unscheduling a scheduled subsequent edition removes the publish intent but doesn't publish a 'gone' item" do
+  test "unscheduling a scheduled subsequent edition removes the publish intent but doesn't delete the original item" do
     published_edition = create(:published_case_study)
     scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
 

--- a/test/unit/workers/publishing_api_vanish_worker_test.rb
+++ b/test/unit/workers/publishing_api_vanish_worker_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
+
+class PublishingApiVanishWorkerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  test "publishes a 'vanish' item for the supplied content id" do
+    publication = create(:withdrawn_publication)
+
+    request = stub_publishing_api_unpublish(
+      publication.document.content_id,
+      body: {
+        type: "vanish",
+        locale: "en"
+      }
+    )
+
+    PublishingApiVanishWorker.new.perform(
+      publication.document.content_id, "en"
+    )
+
+    assert_requested request
+  end
+end


### PR DESCRIPTION
This commit changes the current behaviour of publishing a “410 Gone” item for a “coming soon” when its associated scheduled publication is unscheduled. Now it will remove the item completely which will result in a “404 Not Found” error.

404 is correct here since nothing has been published yet, and so nothing has “gone”.

Trello: https://trello.com/c/BinSjhTs/261-update-logic-for-removing-coming-soon-pages