### PR TITLE
Use most recent feature for speech image

### DIFF
--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -117,7 +117,7 @@ module PublishingApi
     end
 
     def feature
-      @feature ||= Feature.find_by(document_id: item.document_id)
+      @feature ||= Feature.where(document_id: item.document_id).last
     end
 
     def image

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -185,9 +185,20 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         )
       end
 
-      it "presents the featured image" do
+      let!(:feature_two) do
+        create(
+          :feature,
+          document: speech.document,
+          image: File.open(
+            Rails.root.join("test", "fixtures", "images", "960x640_gif.gif")
+          ),
+          alt_text: "featured image two"
+        )
+      end
+
+      it "presents the most recent featured image" do
         details = presented.content[:details]
-        assert_equal("featured image", details[:image][:alt_text])
+        assert_equal("featured image two", details[:image][:alt_text])
         assert_match(/960x640_gif.gif$/, details[:image][:url])
       end
     end


### PR DESCRIPTION
Speeches use the image of the speaker in the sidebar unless the speech has been featured. If it has then the speech will use the image from the feature. This isn't particularly obvious but users get further confused when they feature a speech for a second time in an attempt to change the
image and it doesn't update.

This is because once it has been featured we were always using the image from the first feature. This commit updates that functionality to use the most recent feature which gives users the ability to update the image albeit by a somewhat circuitous route.