### PR TITLE
Upgrade govspeak to 5.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '~> 5.0.3'
+  gem 'govspeak', '~> 5.1.0'
 end
 
 if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,13 +169,13 @@ GEM
       activemodel (>= 4.2, < 5.2)
       activerecord (>= 4.2, < 5.2)
       request_store (~> 1.0)
-    govspeak (5.0.3)
+    govspeak (5.1.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
       htmlentities (~> 4)
       i18n (~> 0.7)
-      kramdown (~> 1.12.0)
+      kramdown (~> 1.15.0)
       money (~> 6.7)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
@@ -240,7 +240,7 @@ GEM
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
     kgio (2.11.0)
-    kramdown (1.12.0)
+    kramdown (1.15.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
@@ -533,7 +533,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso (~> 13.2)
   globalize (= 5.1.0.beta2)
-  govspeak (~> 5.0.3)
+  govspeak (~> 5.1.0)
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.4x)


### PR DESCRIPTION
This fixes https://github.com/gettalong/kramdown/issues/440.

Trello: https://trello.com/c/opqJylTJ/290-fix-acronym-markdown-in-html-attachment-footnotes