### PR TITLE
Update Rummager rake task name

### DIFF
--- a/docs/search_setup_guide.md
+++ b/docs/search_setup_guide.md
@@ -36,7 +36,7 @@ Steps:
 following task from the rummager repo:
 
     ```
-    RUMMAGER_INDEX=government bundle exec rake rummager:migrate_index
+    RUMMAGER_INDEX=government bundle exec rake rummager:migrate_schema
     ```
 
 2. Run the bulk export and load:


### PR DESCRIPTION
`migrate_index` is now `migrate_schema`