### PR TITLE
Migrate organisation logos to asset manager

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,3 +11,4 @@
   - email_alert_api_signup
   - bulk_republishing
   - sync_checks
+  - asset_migration

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -8,7 +8,8 @@ class MigrateAssetsToAssetManager
       Services.asset_manager.create_whitehall_asset(
         file: file,
         legacy_url_path: file.legacy_url_path,
-        legacy_last_modified: file.legacy_last_modified
+        legacy_last_modified: file.legacy_last_modified,
+        legacy_etag: file.legacy_etag
       )
     end
   end
@@ -42,6 +43,10 @@ class MigrateAssetsToAssetManager
 
     def legacy_last_modified
       File.stat(path).mtime
+    end
+
+    def legacy_etag
+      Digest::MD5.hexdigest(read)
     end
   end
 end

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -5,7 +5,10 @@ class MigrateAssetsToAssetManager
 
   def perform
     @files.each do |file|
-      Services.asset_manager.create_whitehall_asset(file: file)
+      Services.asset_manager.create_whitehall_asset(
+        file: file,
+        legacy_url_path: file.path.gsub(Whitehall.clean_uploads_root, '/government/uploads')
+      )
     end
   end
 

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -5,13 +5,19 @@ class MigrateAssetsToAssetManager
 
   def perform
     @files.each do |file|
-      Services.asset_manager.create_whitehall_asset(
-        file: file,
-        legacy_url_path: file.legacy_url_path,
-        legacy_last_modified: file.legacy_last_modified,
-        legacy_etag: file.legacy_etag
-      )
+      create_whitehall_asset(file)
     end
+  end
+
+  private
+
+  def create_whitehall_asset(file)
+    Services.asset_manager.create_whitehall_asset(
+      file: file,
+      legacy_url_path: file.legacy_url_path,
+      legacy_last_modified: file.legacy_last_modified,
+      legacy_etag: file.legacy_etag
+    )
   end
 
   class OrganisationLogoFiles

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -7,7 +7,8 @@ class MigrateAssetsToAssetManager
     @files.each do |file|
       Services.asset_manager.create_whitehall_asset(
         file: file,
-        legacy_url_path: file.legacy_url_path
+        legacy_url_path: file.legacy_url_path,
+        legacy_last_modified: file.legacy_last_modified
       )
     end
   end
@@ -37,6 +38,10 @@ class MigrateAssetsToAssetManager
   class OrganisationLogoFile < File
     def legacy_url_path
       path.gsub(Whitehall.clean_uploads_root, '/government/uploads')
+    end
+
+    def legacy_last_modified
+      File.stat(path).mtime
     end
   end
 end

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,10 +1,11 @@
 class MigrateAssetsToAssetManager
-  def initialize(files = OrganisationLogoFiles.new)
-    @files = files
+  def initialize(file_paths = OrganisationLogoFilePaths.new)
+    @file_paths = file_paths
   end
 
   def perform
-    @files.each do |file|
+    @file_paths.each do |file_path|
+      file = OrganisationLogoFile.open(file_path)
       create_whitehall_asset(file) unless asset_exists?(file)
     end
   end
@@ -26,18 +27,14 @@ class MigrateAssetsToAssetManager
     false
   end
 
-  class OrganisationLogoFiles
-    delegate :each, to: :files
-
-    def files
-      file_paths.map { |f| OrganisationLogoFile.open(f) }
-    end
-
-    private
+  class OrganisationLogoFilePaths
+    delegate :each, to: :file_paths
 
     def file_paths
       all_paths_under_target_directory.reject { |f| File.directory?(f) }
     end
+
+  private
 
     def all_paths_under_target_directory
       Dir.glob(File.join(target_dir, '**', '*'))

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -7,7 +7,7 @@ class MigrateAssetsToAssetManager
     @files.each do |file|
       Services.asset_manager.create_whitehall_asset(
         file: file,
-        legacy_url_path: file.path.gsub(Whitehall.clean_uploads_root, '/government/uploads')
+        legacy_url_path: file.legacy_url_path
       )
     end
   end
@@ -16,7 +16,7 @@ class MigrateAssetsToAssetManager
     delegate :each, to: :files
 
     def files
-      file_paths.map { |f| File.open(f) }
+      file_paths.map { |f| OrganisationLogoFile.open(f) }
     end
 
     private
@@ -31,6 +31,12 @@ class MigrateAssetsToAssetManager
 
     def target_dir
       File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    end
+  end
+
+  class OrganisationLogoFile < File
+    def legacy_url_path
+      path.gsub(Whitehall.clean_uploads_root, '/government/uploads')
     end
   end
 end

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -5,7 +5,7 @@ class MigrateAssetsToAssetManager
 
   def perform
     @files.each do |file|
-      create_whitehall_asset(file)
+      create_whitehall_asset(file) unless asset_exists?(file)
     end
   end
 
@@ -18,6 +18,12 @@ class MigrateAssetsToAssetManager
       legacy_last_modified: file.legacy_last_modified,
       legacy_etag: file.legacy_etag
     )
+  end
+
+  def asset_exists?(file)
+    Services.asset_manager.whitehall_asset(file.legacy_url_path)
+  rescue GdsApi::HTTPNotFound
+    false
   end
 
   class OrganisationLogoFiles

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,0 +1,33 @@
+class MigrateAssetsToAssetManager
+  def initialize(files = OrganisationLogoFiles.new)
+    @files = files
+  end
+
+  def perform
+    @files.each do |file|
+      Services.asset_manager.create_whitehall_asset(file: file)
+    end
+  end
+
+  class OrganisationLogoFiles
+    delegate :each, to: :files
+
+    def files
+      file_paths.map { |f| File.open(f) }
+    end
+
+    private
+
+    def file_paths
+      all_paths_under_target_directory.reject { |f| File.directory?(f) }
+    end
+
+    def all_paths_under_target_directory
+      Dir.glob(File.join(target_dir, '**', '*'))
+    end
+
+    def target_dir
+      File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    end
+  end
+end

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -1,0 +1,6 @@
+namespace :asset_manager do
+  desc "Migrates Organisation logos to Asset Manager."
+  task migrate_organisation_logos: :environment do
+    MigrateAssetsToAssetManager.new.perform
+  end
+end

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -17,6 +17,14 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
     @subject.perform
   end
+
+  test 'it calls create_whitehall_asset with the legacy file path' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(
+      has_entry(:legacy_url_path, '/government/uploads/system/uploads/organisation/logo/1/logo.jpg')
+    )
+
+    @subject.perform
+  end
 end
 
 class OrganisationLogoFilesTest < ActiveSupport::TestCase

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
+  setup do
+    organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
+    FileUtils.mkdir_p(organisation_logo_dir)
+
+    @organisation_logo_path = File.join(organisation_logo_dir, 'logo.jpg')
+    dummy_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
+    FileUtils.cp(dummy_asset_path, @organisation_logo_path)
+
+    @subject = MigrateAssetsToAssetManager.new
+  end
+
+  test 'it calls create_whitehall_asset for each file in the list' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(:file, responds_with(:path, @organisation_logo_path)))
+
+    @subject.perform
+  end
+end
+
+class OrganisationLogoFilesTest < ActiveSupport::TestCase
+  setup do
+    organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
+    other_asset_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'other')
+
+    FileUtils.mkdir_p(organisation_logo_dir)
+    FileUtils.mkdir_p(other_asset_dir)
+
+    organisation_logo_path = File.join(organisation_logo_dir, 'logo.jpg')
+    other_asset_path = File.join(other_asset_dir, 'other_asset.png')
+    dummy_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
+
+    FileUtils.cp(dummy_asset_path, organisation_logo_path)
+    FileUtils.cp(dummy_asset_path, other_asset_path)
+
+    @organisation_logo = File.open(organisation_logo_path)
+    @other_asset = File.open(other_asset_path)
+
+    @subject = MigrateAssetsToAssetManager::OrganisationLogoFiles.new
+  end
+
+  test 'delegates each to files' do
+    assert @subject.respond_to?(:each)
+  end
+
+  test '#files includes only organistation logos' do
+    assert_equal 1, @subject.files.size
+  end
+
+  test '#files does not includes directories' do
+    @subject.files.each do |file|
+      refute File.directory?(file)
+    end
+  end
+end

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -37,6 +37,16 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
     @subject.perform
   end
+
+  test 'it calls create_whitehall_asset with the legacy etag' do
+    expected_etag = Digest::MD5.hexdigest(@organisation_logo_file.read)
+
+    Services.asset_manager.expects(:create_whitehall_asset).with(
+      has_entry(:legacy_etag, expected_etag)
+    )
+
+    @subject.perform
+  end
 end
 
 class OrganisationLogoFilesTest < ActiveSupport::TestCase

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -9,6 +9,8 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     dummy_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
     FileUtils.cp(dummy_asset_path, @organisation_logo_path)
 
+    @organisation_logo_file = File.open(@organisation_logo_path)
+
     @subject = MigrateAssetsToAssetManager.new
   end
 
@@ -21,6 +23,16 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   test 'it calls create_whitehall_asset with the legacy file path' do
     Services.asset_manager.expects(:create_whitehall_asset).with(
       has_entry(:legacy_url_path, '/government/uploads/system/uploads/organisation/logo/1/logo.jpg')
+    )
+
+    @subject.perform
+  end
+
+  test 'it calls create_whitehall_asset with the legacy last modified time' do
+    expected_last_modified = File.stat(@organisation_logo_file.path).mtime
+
+    Services.asset_manager.expects(:create_whitehall_asset).with(
+      has_entry(:legacy_last_modified, expected_last_modified)
     )
 
     @subject.perform

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   setup do
+    Services.asset_manager.stubs(:whitehall_asset).raises(GdsApi::HTTPNotFound.new(404))
+
     organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
     FileUtils.mkdir_p(organisation_logo_dir)
 
@@ -44,6 +46,13 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_whitehall_asset).with(
       has_entry(:legacy_etag, expected_etag)
     )
+
+    @subject.perform
+  end
+
+  test 'it does not call create_whitehall_asset if the asset already exists in asset manager' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+    Services.asset_manager.expects(:create_whitehall_asset).never
 
     @subject.perform
   end

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -58,7 +58,7 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   end
 end
 
-class OrganisationLogoFilesTest < ActiveSupport::TestCase
+class OrganisationLogoFilePathsTest < ActiveSupport::TestCase
   setup do
     organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
     other_asset_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'other')
@@ -76,20 +76,20 @@ class OrganisationLogoFilesTest < ActiveSupport::TestCase
     @organisation_logo = File.open(organisation_logo_path)
     @other_asset = File.open(other_asset_path)
 
-    @subject = MigrateAssetsToAssetManager::OrganisationLogoFiles.new
+    @subject = MigrateAssetsToAssetManager::OrganisationLogoFilePaths.new
   end
 
-  test 'delegates each to files' do
+  test 'delegates each to file_paths' do
     assert @subject.respond_to?(:each)
   end
 
   test '#files includes only organistation logos' do
-    assert_equal 1, @subject.files.size
+    assert_equal 1, @subject.file_paths.size
   end
 
   test '#files does not includes directories' do
-    @subject.files.each do |file|
-      refute File.directory?(file)
+    @subject.file_paths.each do |file_path|
+      refute File.directory?(file_path)
     end
   end
 end


### PR DESCRIPTION
This PR introduces a rake task `asset_manager:migrate_organisation_logos` which creates a sidekiq job for each file under `system/uploads/organisation/logo/` (organisation logos) to create an asset in the Asset Manager API (if one doesn't already exist for this logo).

There are around 60 such files in production in the moment and the jobs will be created on a low-priority queue when this rake task is run.

Fixes: https://github.com/alphagov/asset-manager/issues/276