### PR TITLE
Use Asset Manager to get URL of asset

### DIFF
--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -27,5 +27,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     def delete
       AssetManagerDeleteAssetWorker.perform_async(@legacy_url_path)
     end
+
+    def url
+      asset = Services.asset_manager.whitehall_asset(@legacy_url_path)
+      asset['file_url']
+    end
   end
 end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -70,4 +70,12 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
 
     file.delete
   end
+
+  test 'uses the asset-manager api to return the url of the file' do
+    asset_url = 'http://asset-host/asset.png'
+    Services.asset_manager.stubs(:whitehall_asset).with('/government/uploads/path/to/asset.png').returns('file_url' => asset_url)
+
+    file = Whitehall::AssetManagerStorage::File.new('path/to/asset.png')
+    assert_equal asset_url, file.url
+  end
 end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -63,19 +63,22 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 end
 
 class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
+  setup do
+    asset_path = 'path/to/asset.png'
+    @asset_url_path = "/government/uploads/#{asset_path}"
+    @file = Whitehall::AssetManagerStorage::File.new(asset_path)
+  end
+
   test 'queues the call to delete the asset from asset manager' do
-    file = Whitehall::AssetManagerStorage::File.new('path/to/asset.png')
+    AssetManagerDeleteAssetWorker.expects(:perform_async).with(@asset_url_path)
 
-    AssetManagerDeleteAssetWorker.expects(:perform_async).with('/government/uploads/path/to/asset.png')
-
-    file.delete
+    @file.delete
   end
 
   test 'uses the asset-manager api to return the url of the file' do
     asset_url = 'http://asset-host/asset.png'
-    Services.asset_manager.stubs(:whitehall_asset).with('/government/uploads/path/to/asset.png').returns('file_url' => asset_url)
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns('file_url' => asset_url)
 
-    file = Whitehall::AssetManagerStorage::File.new('path/to/asset.png')
-    assert_equal asset_url, file.url
+    assert_equal asset_url, @file.url
   end
 end


### PR DESCRIPTION
This will ensure that once we switch an uploader from using `AssetManagerAndQuarantinedFileStorage` to `AssetManagerStorage` we'll start rendering the assets in whitehall-admin from Asset Manager instead of the file system.

I'm not entirely sure about making this request to the Asset Manager API to get the URL. It feels correct to do this because it means that Whitehall doesn't need to know anything about how the URLs are created. On the other hand, I wonder whether the additional network request is overkill given that we know the path (which is `/government/uploads/ + @legacy_url_path`) and all we need to prepend is the assets host (e.g. assets-origin.)