### PR TITLE
Fix migration of organisation logos to Asset Manager

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -63,9 +63,7 @@ class MigrateAssetsToAssetManager
     end
 
     def legacy_etag
-      etag = Digest::MD5.hexdigest(read)
-      rewind
-      etag
+      '%x-%x' % [legacy_last_modified, size]
     end
   end
 end

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -63,7 +63,9 @@ class MigrateAssetsToAssetManager
     end
 
     def legacy_etag
-      Digest::MD5.hexdigest(read)
+      etag = Digest::MD5.hexdigest(read)
+      rewind
+      etag
     end
   end
 end

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -17,7 +17,8 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   end
 
   test 'it calls create_whitehall_asset for each file in the list' do
-    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(:file, responds_with(:path, @organisation_logo_path)))
+    Services.asset_manager.expects(:create_whitehall_asset)
+      .with(has_entry(:file, responds_with(:read, File.read(@organisation_logo_path))))
 
     @subject.perform
   end


### PR DESCRIPTION
This builds on the changes made in PR #3513 by:

* ensuring we send the file content to Asset Manager
* setting the legacy etag to a value that matches the value generated by Nginx
