### PR TITLE
Only touch a statistics_announcement when published

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -27,7 +27,7 @@ class Publication < Publicationesque
 
   after_save :touch_statistics_announcement
   def touch_statistics_announcement
-    unless draft?
+    if published?
       statistics_announcement.touch unless statistics_announcement.nil?
     end
   end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -87,6 +87,8 @@ FactoryGirl.define do
   factory :draft_statistics, parent: :publication, traits: [:draft, :statistics]
   factory :submitted_statistics, parent: :publication, traits: [:submitted, :statistics]
   factory :published_statistics, parent: :publication, traits: [:published, :statistics]
+  factory :superseded_statistics, parent: :publication, traits: [:superseded, :statistics]
+
   factory :published_guidance, parent: :publication, traits: [:published, :guidance]
 
   factory :draft_national_statistics, parent: :publication, traits: [:draft, :national_statistics]

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -229,4 +229,11 @@ class PublicationsInTopicsTest < ActiveSupport::TestCase
     statistics_announcement.expects(:touch).never
     publication.save!
   end
+
+  test "it doesn't touch the statistics_announcement if it's superseded" do
+    statistics_announcement = create(:statistics_announcement)
+    publication = build(:superseded_statistics, statistics_announcement: statistics_announcement)
+    statistics_announcement.expects(:touch).never
+    publication.save!
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/IVGRQBoB/213-investigate-statistics-announcements-not-being-redirected-when-the-statistics-are-published

Touching a statistics announcement when superseded seems to trigger a republishing of the announcement. Only doing this on published items will stop this happening when they are superseded.

Looks like this is a side effect of callback hell 😢 

The other thing that could really help this but seems quite a big behavioural change is changing the state of statistic announcements to be unpublished after the associated publication has been published. One of the problems with this is that there seems to be no state held on a StatisticsAnnouncement once they've been redirected.
