### PR TITLE
Add a 'url' class to contact vcards

### DIFF
--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -45,7 +45,7 @@
       <% end %>
 
       <% if contact.is_a?(WorldwideOffice) && contact.access_and_opening_times_body.present? %>
-        <%= link_to'Access and opening times', [contact.worldwide_organisation, contact] %>
+        <%= link_to 'Access and opening times', [contact.worldwide_organisation, contact], class: "url" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
This should enable search engines to correctly index the card and provide a button which links to this page.

[Trello Card](https://trello.com/c/Z6rvpaGN/297-change-google-card-url-to-point-to-embassy-page)