### PR TITLE
Skip auth for show method on Admin Topics Controller

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -1,4 +1,6 @@
 class Admin::TopicsController < Admin::ClassificationsController
+  skip_before_action :authenticate_user!, only: [:show]
+  skip_before_action :require_signin_permission!, only: [:show]
 
   def show
     respond_to do |format|


### PR DESCRIPTION
We want to access this endpoint from ContentTagger, but it being
an AdminController forces Signon permissions. Disabling auth here
should be fine as it's only the show method and it's not giving
away sensitive information.

Original PR for this endpoint: https://github.com/alphagov/whitehall/pull/3346