### PR TITLE
Allow other assets to be migrated using a rake task

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -9,6 +9,10 @@ class MigrateAssetsToAssetManager
     end
   end
 
+  def to_s
+    @file_paths.join("\n")
+  end
+
   class Worker < WorkerBase
     sidekiq_options queue: :asset_migration
 
@@ -36,7 +40,7 @@ class MigrateAssetsToAssetManager
   end
 
   class AssetFilePaths
-    delegate :each, to: :file_paths
+    delegate :each, :join, to: :file_paths
 
     def initialize(target_dir)
       @target_dir = target_dir

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,6 +1,6 @@
 class MigrateAssetsToAssetManager
-  def initialize(file_paths = AssetFilePaths.new)
-    @file_paths = file_paths
+  def initialize(target_dir)
+    @file_paths = AssetFilePaths.new(target_dir)
   end
 
   def perform

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -13,7 +13,7 @@ class MigrateAssetsToAssetManager
     sidekiq_options queue: :asset_migration
 
     def perform(file_path)
-      file = OrganisationLogoFile.open(file_path)
+      file = AssetFile.open(file_path)
       create_whitehall_asset(file) unless asset_exists?(file)
     end
 
@@ -53,7 +53,7 @@ class MigrateAssetsToAssetManager
     end
   end
 
-  class OrganisationLogoFile < File
+  class AssetFile < File
     def legacy_url_path
       path.gsub(Whitehall.clean_uploads_root, '/government/uploads')
     end

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -38,6 +38,10 @@ class MigrateAssetsToAssetManager
   class AssetFilePaths
     delegate :each, to: :file_paths
 
+    def initialize(target_dir)
+      @target_dir = target_dir
+    end
+
     def file_paths
       all_paths_under_target_directory.reject { |f| File.directory?(f) }
     end
@@ -45,11 +49,11 @@ class MigrateAssetsToAssetManager
   private
 
     def all_paths_under_target_directory
-      Dir.glob(File.join(target_dir, '**', '*'))
+      Dir.glob(File.join(full_target_dir, '**', '*'))
     end
 
-    def target_dir
-      File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    def full_target_dir
+      File.join(Whitehall.clean_uploads_root, @target_dir)
     end
   end
 

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,5 +1,5 @@
 class MigrateAssetsToAssetManager
-  def initialize(file_paths = OrganisationLogoFilePaths.new)
+  def initialize(file_paths = AssetFilePaths.new)
     @file_paths = file_paths
   end
 
@@ -35,7 +35,7 @@ class MigrateAssetsToAssetManager
     end
   end
 
-  class OrganisationLogoFilePaths
+  class AssetFilePaths
     delegate :each, to: :file_paths
 
     def file_paths

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -1,6 +1,16 @@
 namespace :asset_manager do
   desc "Migrates Assets to Asset Manager."
-  task migrate_assets: :environment do
-    MigrateAssetsToAssetManager.new.perform
+  task :migrate_assets, [:target_dir] => :environment do |_, args|
+    abort(usage_string) unless args[:target_dir]
+    MigrateAssetsToAssetManager.new(args[:target_dir]).perform
+  end
+
+  private
+
+  def usage_string
+    %{Usage: asset_manager:migrate_assets[<path>]
+
+      Where <path> is a subdirectory under Whitehall.clean_uploads_root e.g. `system/uploads/organisation/logo`
+    }
   end
 end

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -1,6 +1,6 @@
 namespace :asset_manager do
-  desc "Migrates Organisation logos to Asset Manager."
-  task migrate_organisation_logos: :environment do
+  desc "Migrates Assets to Asset Manager."
+  task migrate_assets: :environment do
     MigrateAssetsToAssetManager.new.perform
   end
 end

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -2,7 +2,9 @@ namespace :asset_manager do
   desc "Migrates Assets to Asset Manager."
   task :migrate_assets, [:target_dir] => :environment do |_, args|
     abort(usage_string) unless args[:target_dir]
-    MigrateAssetsToAssetManager.new(args[:target_dir]).perform
+    migrator = MigrateAssetsToAssetManager.new(args[:target_dir])
+    puts migrator
+    migrator.perform
   end
 
   private

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -13,7 +13,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
     @organisation_logo_file = File.open(@organisation_logo_path)
 
-    @subject = MigrateAssetsToAssetManager.new
+    @subject = MigrateAssetsToAssetManager.new(
+      MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads/organisation/logo')
+    )
   end
 
   test 'it calls create_whitehall_asset for each file in the list' do
@@ -80,14 +82,14 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     @organisation_logo = File.open(organisation_logo_path)
     @other_asset = File.open(other_asset_path)
 
-    @subject = MigrateAssetsToAssetManager::AssetFilePaths.new
+    @subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads/organisation/logo')
   end
 
   test 'delegates each to file_paths' do
     assert @subject.respond_to?(:each)
   end
 
-  test '#files includes only organistation logos' do
+  test '#files includes only organisation logos' do
     assert_equal 1, @subject.file_paths.size
   end
 
@@ -95,6 +97,11 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     @subject.file_paths.each do |file_path|
       refute File.directory?(file_path)
     end
+  end
+
+  test '#files includes all files when initialised with a top level target directory' do
+    subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads')
+    assert_equal 2, subject.file_paths.size
   end
 end
 

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -98,10 +98,10 @@ class AssetFilePathsTest < ActiveSupport::TestCase
   end
 end
 
-class OrganisationLogoFileTest < ActiveSupport::TestCase
+class AssetFileTest < ActiveSupport::TestCase
   setup do
     @path = Rails.root.join('test/fixtures/logo.png')
-    file = MigrateAssetsToAssetManager::OrganisationLogoFile.open(@path)
+    file = MigrateAssetsToAssetManager::AssetFile.open(@path)
     @parts = file.legacy_etag.split('-')
   end
 

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -13,9 +13,7 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
     @organisation_logo_file = File.open(@organisation_logo_path)
 
-    @subject = MigrateAssetsToAssetManager.new(
-      MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads/organisation/logo')
-    )
+    @subject = MigrateAssetsToAssetManager.new('system/uploads/organisation/logo')
   end
 
   test 'it calls create_whitehall_asset for each file in the list' do

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -62,7 +62,7 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   end
 end
 
-class OrganisationLogoFilePathsTest < ActiveSupport::TestCase
+class AssetFilePathsTest < ActiveSupport::TestCase
   setup do
     organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
     other_asset_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'other')
@@ -80,7 +80,7 @@ class OrganisationLogoFilePathsTest < ActiveSupport::TestCase
     @organisation_logo = File.open(organisation_logo_path)
     @other_asset = File.open(other_asset_path)
 
-    @subject = MigrateAssetsToAssetManager::OrganisationLogoFilePaths.new
+    @subject = MigrateAssetsToAssetManager::AssetFilePaths.new
   end
 
   test 'delegates each to file_paths' do

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -60,6 +60,10 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
     @subject.perform
   end
+
+  test 'to_s is a string of asset file paths to be migrated' do
+    assert_equal @organisation_logo_path, @subject.to_s
+  end
 end
 
 class AssetFilePathsTest < ActiveSupport::TestCase
@@ -85,6 +89,10 @@ class AssetFilePathsTest < ActiveSupport::TestCase
 
   test 'delegates each to file_paths' do
     assert @subject.respond_to?(:each)
+  end
+
+  test 'delegates join to file_paths' do
+    assert @subject.respond_to?(:join)
   end
 
   test '#files includes only organisation logos' do


### PR DESCRIPTION
This PR makes the specific organisation logo migration rake task introduced in db3a6e9de2a general by allowing it to take a directory as a parameter. For example:

    rake asset_manager:migrate_assets[system/uploads/image_data]

will migrate all assets under `Whitehall.clean_uploads_root + system/uploads/image_data`. 