### PR TITLE
Use Asset Manager for ConsultationResponseFormUploader

### DIFF
--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class ConsultationResponseFormUploader < WhitehallUploader
+  storage :asset_manager_and_quarantined_file_storage
+
   def extension_whitelist
     %w(pdf csv rtf doc docx xls xlsx odt ods)
   end

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -242,6 +242,9 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'updating should respect the attachment_action for response forms to replace it' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+    Services.asset_manager.stubs(:delete_asset)
+
     two_pages_pdf = fixture_file_upload('two-pages.pdf')
     greenpaper_pdf = fixture_file_upload('greenpaper.pdf')
 

--- a/test/unit/consultation_response_form_uploader_test.rb
+++ b/test/unit/consultation_response_form_uploader_test.rb
@@ -11,4 +11,8 @@ class ConsultationResponseFormUploaderTest < ActiveSupport::TestCase
     uploader = ConsultationResponseFormUploader.new(model, "mounted-as")
     assert_match /^system/, uploader.store_dir
   end
+
+  test 'uses the asset manager storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ConsultationResponseFormUploader.storage
+  end
 end


### PR DESCRIPTION
This commit switches the ConsultationResponseFormUploader to use the
`asset_manager_and_quarantined_file_storage` engine for storage -
meaning that assets will be stored on disk as before, but also sent to
Asset Manager.

We made a similar change to the LogoUploader in 794542b1.

We have to stub calls to the Asset Manager API in the
ConsultationsControllerTest but otherwise no changes to the tests are
required.

We've verified in development that:
 - adding an attachement to a Consultation
 - removing an attachment from a Consultation
 - replacing an attachment on a Consultation

all result in the correct calls being made to Asset Manager. The
existing behaviour when a draft consultation is discarded is to not
remove the associated asset from disk. It is not clear whether this is
intended behaviour, but switching the storage engine preserves this
behaviour (that is, no DELETE call is made to the Asset Manager for
the associated asset).