### PR TITLE
Catch all kinds of 500 errors from GDS API

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -11,12 +11,8 @@ class PublicFacingController < ApplicationController
     log_error_and_render_500 exception
   end
 
-  rescue_from GdsApi::HTTPErrorResponse do |exception|
-    if exception.code == 502
-      log_error_and_render_500 exception
-    else
-      raise
-    end
+  rescue_from GdsApi::HTTPServerError do |exception|
+    log_error_and_render_500 exception
   end
 
   # Allows additional request formats to be enabled.

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -32,11 +32,11 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
 
     def api_bad_gateway
-      raise GdsApi::HTTPErrorResponse.new(502, 'Bad Gateway')
+      raise GdsApi::HTTPBadGateway.new('Bad Gateway')
     end
 
-    def api_error
-      raise GdsApi::HTTPErrorResponse.new(500, 'Something went wrong')
+    def api_not_found
+      raise GdsApi::HTTPNotFound.new('Not found')
     end
   end
 
@@ -165,17 +165,17 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
   end
 
-  test "public facing controllers catch 502 errors from GDS API and renders a 500 response" do
+  test "public facing controllers catch server errors from GDS API and renders a 500 response" do
     with_routing_for_test_controller do
       get :api_bad_gateway
       assert_response :internal_server_error
     end
   end
 
-  test "public facing controllers do not catch other GDS API errors" do
+  test "public facing controllers do not catch client GDS API errors" do
     with_routing_for_test_controller do
       assert_raise GdsApi::HTTPErrorResponse do
-        get :api_error
+        get :api_not_found
       end
     end
   end
@@ -190,7 +190,7 @@ class PublicFacingControllerTest < ActionController::TestCase
   def with_routing_for_test_controller(&block)
     with_routing do |map|
       map.draw do
-        %w(test json js_or_atom locale api_timeout api_bad_gateway api_error).each do |action|
+        %w(test json js_or_atom locale api_timeout api_bad_gateway api_not_found).each do |action|
           get "/test/#{action}.{.:format}", to: "public_facing_controller_test/test##{action}"
         end
       end


### PR DESCRIPTION
Currently we only catch 502 errors, and all others get sent
through to Sentry. Looking at the history of why we picked only
502 it seems to be because this is the code we get when Rummager
times out.

Since then we've integrated with Publishing API which will often
time out and come through to us as a 504 error. It doesn't seem
useful to log this as an exception since there is nothing we can
do about it in Whitehall.

It seems to me that not reporting any kind of external server error
seems like the right thing to do since it's not in our control and
increases the noise when looking through the exception log. Instead
this commit will mean that we only see client errors which is more
likely to expose a problem on our side.