### PR TITLE
Allow RIS files to be uploaded

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -6,7 +6,7 @@ class AttachmentUploader < WhitehallUploader
 
   THUMBNAIL_GENERATION_TIMEOUT = 10.seconds
   FALLBACK_PDF_THUMBNAIL = File.expand_path("../../assets/images/pub-cover.png", __FILE__)
-  EXTENSION_WHITELIST = %w(chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf rtf sch txt wsdl xls xlsm xlsx xlt xml xsd xslt zip).freeze
+  EXTENSION_WHITELIST = %w(chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt wsdl xls xlsm xlsx xlt xml xsd xslt zip).freeze
 
   before :cache, :validate_zipfile_contents!
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -6,12 +6,13 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   test 'should allow whitelisted file extensions' do
     graphics = %w(dxf eps gif jpg png ps)
     documents = %w(chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt)
+    document_support = %w(ris)
     spreadsheets = %w(csv ods xls xlsm xlsx)
     markup = %w(gml kml sch wsdl xml xsd)
     containers = %w(zip)
     templates = %w(dot xlt xslt)
 
-    allowed_attachments = graphics + documents + spreadsheets + markup + containers + templates
+    allowed_attachments = graphics + documents + document_support + spreadsheets + markup + containers + templates
     assert_equal allowed_attachments.sort, AttachmentUploader.new.extension_whitelist.sort
   end
 


### PR DESCRIPTION
This commit whitelists `.ris` files for uploading as attachments. These are text files that contain bibliographical citations in an industry-recognised format.

Trello: https://trello.com/c/wI76F5mI/313-add-citations-file-to-reports