### PR TITLE
Correct note on admin consultation attachment view

### DIFF
--- a/app/helpers/admin/attachable_helper.rb
+++ b/app/helpers/admin/attachable_helper.rb
@@ -65,4 +65,17 @@ module Admin::AttachableHelper
       contents.join.html_safe
     end
   end
+
+  def is_publication?(model_name)
+    model_name == "publication"
+  end
+
+  def is_consultation?(model_name)
+    model_name == "consultation"
+  end
+
+  def attachment_note(model_name)
+    return "Attachments added to a #{model_name} will appear automatically." if is_publication?(model_name) || is_consultation?(model_name)
+    "Attachments need to be referenced in the body markdown to appear in your document."
+  end
 end

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -1,6 +1,5 @@
 <% page_title "Attachments for #{attachment.attachable_model_name}" %>
 <% page_class "attachments index" %>
-<% is_publication = attachment.attachable_model_name == 'publication' %>
 
 <div class="row">
   <section class="col-md-8">
@@ -9,11 +8,7 @@
     <%= attachable_editing_tabs(attachable) do %>
       <p class="qa-helper-copy">
         <strong>Note:</strong>
-        <% if is_publication %>
-          Attachments added to a publication will appear automatically.
-        <% else %>
-          Attachments need to be referenced in the body markdown to appear in your document.
-        <% end %>
+        <%= attachment_note(attachment.attachable_model_name) %>
       <p>
       <ul class="actions list-unstyled">
         <li>

--- a/test/integration/attachments_test.rb
+++ b/test/integration/attachments_test.rb
@@ -22,7 +22,17 @@ class AttachmentsTest < ActionDispatch::IntegrationTest
     visit "/government/admin/editions/#{publication.id}/attachments"
 
     within ".qa-helper-copy" do
-      assert_text "will appear automatically"
+      assert_text "publication will appear automatically"
+    end
+  end
+
+  test 'displays "will appear automatically" for consultations' do
+    consultation = create(:consultation)
+    visit "/government/admin/editions/#{consultation.id}/attachments"
+
+    within ".qa-helper-copy" do
+      assert_text "consultation will appear automatically"
+      assert_no_text "need to be referenced"
     end
   end
 end


### PR DESCRIPTION
Attachments on `consultations` do not need to be referenced in the body markdown to appear in the document, instead, like `publications` they appear automatically.

* Refactor the logic to decide which note to display in to the `attachable_helper`.
* Add logic to display the correct the "note" on the attachments tab when editing an edition.

## Old and inferior
<img width="597" alt="screen shot 2017-11-10 at 10 03 12" src="https://user-images.githubusercontent.com/647311/32653071-6f22c4f6-c5fe-11e7-95f4-1b3b645a2363.png">

## New and improved
<img width="499" alt="screen shot 2017-11-10 at 10 02 46" src="https://user-images.githubusercontent.com/647311/32653079-76e5ce90-c5fe-11e7-93c7-a44b105fc835.png">

[Trello](https://trello.com/c/NnMkSIZX/315-whitehall-publisher-consultation-attachments-misleading-note)