### PR TITLE
Use asset manager store for organisation logos

### DIFF
--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -1,5 +1,5 @@
 class LogoUploader < WhitehallUploader
-  storage :asset_manager_and_quarantined_file_storage
+  storage :asset_manager
 
   def extension_whitelist
     %w(jpg jpeg gif png)

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -11,7 +11,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = ::File.join('/government/uploads', uploader.store_path)
     AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path)
-    file
+    File.new(uploader.store_path)
   end
 
   def retrieve!(identifier)
@@ -30,6 +30,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
 
     def url
       URI.join(Plek.new.public_asset_host, @legacy_url_path).to_s
+    end
+
+    def filename
+      @legacy_url_path
     end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -29,8 +29,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def url
-      asset = Services.asset_manager.whitehall_asset(@legacy_url_path)
-      asset['file_url']
+      URI.join(Plek.new.public_asset_host, @legacy_url_path).to_s
     end
   end
 end

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -191,7 +191,7 @@ class OrganisationsControllerTest < ActionController::TestCase
       organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
       logo: fixture_file_upload('logo.png')
     )
-    VirusScanHelpers.simulate_virus_scan(organisation.logo)
+
     get :show, params: { id: organisation }
     assert_select %Q{img[alt="#{organisation.name}"][src*="logo.png"]}
   end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -27,6 +27,31 @@ class AssetManagerIntegrationTest
     end
   end
 
+  class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
+    setup do
+      @filename = 'greenpaper.pdf'
+      @consultation_response_form_data = FactoryGirl.build(
+        :consultation_response_form_data,
+        file: File.open(Rails.root.join('test', 'fixtures', @filename))
+      )
+    end
+
+    test 'sends the consultation response form data file to Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
+        args[:file].is_a?(File) &&
+          args[:legacy_url_path] =~ /#{@filename}/
+      end
+
+      @consultation_response_form_data.save!
+    end
+
+    test 'saves the consultation response form data file to the file system' do
+      @consultation_response_form_data.save!
+
+      assert File.exist?(@consultation_response_form_data.file.path)
+    end
+  end
+
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     setup do
       @organisation = FactoryGirl.create(
@@ -54,6 +79,35 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset)
 
       @organisation.remove_logo!
+    end
+  end
+
+  class RemovingAConsultationResponseFormData < ActiveSupport::TestCase
+    setup do
+      @consultation_response_form_data = FactoryGirl.create(
+        :consultation_response_form_data,
+        file: File.open(Rails.root.join('test', 'fixtures', 'greenpaper.pdf'))
+      )
+      VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
+      @consultation_response_form_data.reload
+      @file_path = @consultation_response_form_data.file.path
+
+      Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+      Services.asset_manager.stubs(:delete_asset)
+    end
+
+    test 'removing a consultation response form data file removes it from the file system' do
+      assert File.exist?(@file_path)
+
+      @consultation_response_form_data.remove_file!
+
+      refute File.exist?(@file_path)
+    end
+
+    test 'removing a consultation response form data file removes it from asset manager' do
+      Services.asset_manager.expects(:delete_asset)
+
+      @consultation_response_form_data.remove_file!
     end
   end
 end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -16,14 +16,7 @@ class AssetManagerIntegrationTest
         args[:file].is_a?(File) &&
           args[:legacy_url_path] =~ /#{@filename}/
       end
-
       @organisation.save!
-    end
-
-    test 'saves the logo to the file system' do
-      @organisation.save!
-
-      assert File.exist?(@organisation.logo.path)
     end
   end
 
@@ -59,20 +52,11 @@ class AssetManagerIntegrationTest
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg'))
       )
-      VirusScanHelpers.simulate_virus_scan(@organisation.logo)
+
       @organisation.reload
 
       Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
       Services.asset_manager.stubs(:delete_asset)
-    end
-
-    test 'removing an organisation logo removes it from the file system' do
-      logo_path = @organisation.logo.path
-
-      @organisation.remove_logo!
-      @organisation.reload
-
-      refute File.exist?(logo_path)
     end
 
     test 'removing an organisation logo removes it from asset manager' do

--- a/test/unit/logo_uploader_test.rb
+++ b/test/unit/logo_uploader_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class LogoUploaderTest < ActiveSupport::TestCase
   test 'uses the asset manager storage engine' do
-    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, LogoUploader.storage
+    assert_equal Whitehall::AssetManagerStorage, LogoUploader.storage
   end
 end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -64,11 +64,11 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       '/government/uploads/system/uploads/organisation/logo/1/960x640_jpeg.jpg'
 
     assert_equal(
-      presented_item.content[:details][:logo][:image],
       {
         url: expected_image_url,
         alt_text: 'Organisation of Things',
-      }
+      },
+      presented_item.content[:details][:logo][:image]
     )
   end
 

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -53,7 +53,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     storage.retrieve!('identifier')
   end
 
-  test 'returns an asset manager file' do
+  test 'retrieve! returns an asset manager file' do
     file = stub(:asset_manager_file)
     Whitehall::AssetManagerStorage::File.stubs(:new).returns(file)
 

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -75,10 +75,11 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     @file.delete
   end
 
-  test 'uses the asset-manager api to return the url of the file' do
-    asset_url = 'http://asset-host/asset.png'
-    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns('file_url' => asset_url)
+  test 'constructs the url of the file using the public asset host and legacy url path' do
+    Plek.stubs(:new).returns(stub('plek', public_asset_host: 'http://assets-host'))
 
-    assert_equal asset_url, @file.url
+    expected_asset_url = URI.join('http://assets-host', @asset_url_path).to_s
+
+    assert_equal expected_asset_url, @file.url
   end
 end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -36,12 +36,13 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     @uploader.store!(@file)
   end
 
-  test 'returns the sanitized file' do
+  test 'store! returns an asset manager file' do
     AssetManagerCreateWhitehallAssetWorker.stubs(:perform_async)
 
     storage = Whitehall::AssetManagerStorage.new(@uploader)
     file = CarrierWave::SanitizedFile.new(@file)
-    assert_equal file, storage.store!(file)
+
+    assert_equal Whitehall::AssetManagerStorage::File, storage.store!(file).class
   end
 
   test 'instantiates an asset manager file with the location of the file on disk' do


### PR DESCRIPTION
Organisation logos are now being stored in and served from Asset
Manager, so there is no longer any need to store them on the local,
NFS filesystem. This PR switches the storage engine for
`LogoUploader` to `AssetManagerStorage`.