### PR TITLE
Redirect deleted teacher supply stats announcement

### DIFF
--- a/db/data_migration/20171114113603_redirect_deleted_teacher_supply_stats_announcement.rb
+++ b/db/data_migration/20171114113603_redirect_deleted_teacher_supply_stats_announcement.rb
@@ -1,0 +1,3 @@
+content_id = "4a98c69d-5fd2-483e-8edc-f60b630e46b0"
+redirect_to_url = "/government/statistics/tsm-and-initial-teacher-training-allocations-2018-to-2019"
+PublishingApiRedirectWorker.new.perform(content_id, redirect_to_url, :en)


### PR DESCRIPTION
The statistics announcement originally published at
/government/statistics/announcements/teacher-supply-model-2018-to-2019
was cancelled because the data was combined with the published statistics at
/government/statistics/tsm-and-initial-teacher-training-allocations-2018-to-2019.

The publishers subsequently wanted
/government/statistics/announcements/teacher-supply-model-2018-to-2019
to redirect to
/government/statistics/announcements/tsm-and-initial-teacher-training-allocations-2018-to-2019.

The content team attempted to unpublish and redirect the cancelled
announcement but for some reason that failed. It looked, upon initial
investigation, like the announcement was hard deleted from whitehall's
database. On further investigation, however, this was not actually the
case, it was just that the `default_scope` on the model was hiding the
data.

This migration creates a redirect for the content id of the statistics announcement.

[Trello](https://trello.com/c/mWovovcS/341-spike-duplicated-stats-announcement-on-whitehall)
[Zendesk](https://govuk.zendesk.com/agent/tickets/2490196)