### PR TITLE
Alert on publishing by CO NSS Watchkeeper account

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -42,6 +42,12 @@ class Notifications < ActionMailer::Base
     mail from: no_reply_email_address, to: @author.email, subject: subject
   end
 
+  def edition_published_by_monitored_user(user)
+    @user = user
+    subject = "Account holder #{@user.name} (#{user.email}) has published to live"
+    mail from: no_reply_email_address, to: content_second_line_email_address, subject: subject
+  end
+
   def broken_link_reports(zip_path, recipient_address)
     filename = File.basename(zip_path)
     attachments[filename] = File.read(zip_path)
@@ -66,5 +72,9 @@ class Notifications < ActionMailer::Base
     address = Mail::Address.new("inside-government@digital.cabinet-office.gov.uk")
     address.display_name = name
     address.format
+  end
+
+  def content_second_line_email_address
+    "second-line-content@digital.cabinet-office.gov.uk"
   end
 end

--- a/app/views/notifications/edition_published_by_monitored_user.text.erb
+++ b/app/views/notifications/edition_published_by_monitored_user.text.erb
@@ -1,0 +1,5 @@
+Account holder <%= @user.name %> (<%= @user.email %>) has published to live.
+
+This account was set up for Catastrophic Emergency Planning, part of the Civil Contingencies Secretariat in the Cabinet Office. Cabinet Office made a commitment that it would not be used for regular publishing. There should only be activity on the account in a Catastrophic Emergency.
+
+Please alert the GOV.UK Policy & Engagement team and Head of Content.

--- a/test/functional/notifications_edition_published_by_monitored_user_test.rb
+++ b/test/functional/notifications_edition_published_by_monitored_user_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class NotificationsEditionPublishedByMonitoredUserTest < ActionMailer::TestCase
+  enable_url_helpers
+
+  setup do
+    @user = build(:user, name: "Jim Jimson", email: "jim@example.com")
+    @mail = Notifications.edition_published_by_monitored_user(@user)
+  end
+
+  test "email should be sent to the content second line email address" do
+    assert_equal [Notifications.new.send(:content_second_line_email_address)], @mail.to
+  end
+
+  test "email subject should include the name and email address of the user" do
+    assert_equal "Account holder Jim Jimson (jim@example.com) has published to live", @mail.subject
+  end
+
+  test "email body should include the name and email address of the user" do
+    assert_match Regexp.new("Jim Jimson"), @mail.body.to_s
+    assert_match Regexp.new("jim@example.com"), @mail.body.to_s
+  end
+end

--- a/test/functional/notifications_fact_check_request_response_test.rb
+++ b/test/functional/notifications_fact_check_request_response_test.rb
@@ -6,7 +6,8 @@ class NotificationsFactCheckRequestTest < ActionMailer::TestCase
   setup do
     @publication = build(:publication, title: "<publication-title>")
     @requestor = build(:fact_check_requestor, name: "<requestor-name>")
-    @request = build(:fact_check_request,
+    @request = build(
+      :fact_check_request,
       email_address: 'fact-checker@example.com',
       edition: @publication,
       requestor: @requestor
@@ -59,11 +60,13 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
 
   setup do
     @publication = build(:publication, title: "<publication-title>")
-    @requestor = build(:fact_check_requestor,
+    @requestor = build(
+      :fact_check_requestor,
       name: "<requestor-name>",
       email: "fact-check-requestor@example.com"
     )
-    @request = build(:fact_check_request,
+    @request = build(
+      :fact_check_request,
       email_address: 'fact-checker@example.com',
       edition: @publication,
       requestor: @requestor


### PR DESCRIPTION
This commit adds an email alert to content second line if the CO NSS Watchkeeper account publishes anything. This account is not meant to publish anything except in emergencies.

Trello: https://trello.com/c/lDbWmnE0/333-set-up-alerts-if-co-nss-watchkeepers-account-publishes-anything