### PR TITLE
Update meta description and text on embassy finder

### DIFF
--- a/app/controllers/embassies_controller.rb
+++ b/app/controllers/embassies_controller.rb
@@ -7,5 +7,7 @@ class EmbassiesController < ApplicationController
 
         EmbassyPresenter.new(Embassy.new(location))
       }.reject(&:blank?)
+
+    set_meta_description("Contact details of British embassies, consulates, and high commissions around the world.")
   end
 end

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -6,11 +6,11 @@ class EmbassyPresenter < SimpleDelegator
 
   def text
     if SPECIAL_CASES.keys.include?(name)
-      "There are no consular services available in #{name}. British nationals should contact the #{SPECIAL_CASES[name][:building]} in #{SPECIAL_CASES[name][:location]}."
+      "British nationals should contact the #{SPECIAL_CASES[name][:building]} in #{SPECIAL_CASES[name][:location]}."
     elsif offices.empty?
-      "There are no consular services available in #{name}. British nationals should contact the local authorities."
+      "British nationals should contact the local authorities."
     elsif has_remote_service?
-      "There are no consular services available in #{name}. British nationals should contact the #{organisation.name} in #{remote_services_country}."
+      "British nationals should contact the #{organisation.name} in #{remote_services_country}."
     end
   end
 

--- a/test/functional/embassies_controller_test.rb
+++ b/test/functional/embassies_controller_test.rb
@@ -31,8 +31,8 @@ class EmbassiesControllerTest < ActionController::TestCase
     assert_select "ol[class='locations'] h2", "Aruba"
     assert_select "ol[class='locations'] h2", "Sealand"
     assert_select "ol[class='locations'] ul a", /The British Embassy Kabul/
-    assert_select "ol[class='locations'] li p", /There are no consular services available in Aruba. British nationals should contact the British Consulate General Amsterdam in Netherlands/
-    assert_select "ol[class='locations'] li p", /There are no consular services available in Sealand. British nationals should contact the local authorities/
+    assert_select "ol[class='locations'] li p", /British nationals should contact the British Consulate General Amsterdam in Netherlands/
+    assert_select "ol[class='locations'] li p", /British nationals should contact the local authorities/
   end
 
   view_test "UK doesn't appear in the page" do
@@ -54,7 +54,6 @@ class EmbassiesControllerTest < ActionController::TestCase
       get :index
 
       assert_select "ol[class='locations'] h2", name
-      assert_select "ol[class='locations'] li p", /^There are no consular services available in #{name}/
       assert_select "ol[class='locations'] li p", /British nationals should contact the #{building} in #{building_location}/
       assert_select "ol[class='locations'] li a", building
     end


### PR DESCRIPTION
This commit updates the embassy finder with a meta description and removes the text “There are no consular services available in XYZ” for countries/territories that don’t have consular services.

Trello: https://trello.com/c/pnyIwHMg/318-embassy-finder-content-work