### PR TITLE
Ensure env var is present for user alerting

### DIFF
--- a/app/models/edition/audit_trail.rb
+++ b/app/models/edition/audit_trail.rb
@@ -51,7 +51,8 @@ module Edition::AuditTrail
   private :alert!
 
   def should_alert_for?(user)
-    user.email == ENV['CO_NSS_WATCHKEEPER_EMAIL_ADDRESS']
+    ENV['CO_NSS_WATCHKEEPER_EMAIL_ADDRESS'].present? &&
+      user.email == ENV['CO_NSS_WATCHKEEPER_EMAIL_ADDRESS']
   end
   private :should_alert_for?
 


### PR DESCRIPTION
This commit checks to make sure the env var that defines which users to alert about it present before alerting, so that alerts are not sent out in non-production environments that don’t have this env var set.

Trello: https://trello.com/c/lDbWmnE0/333-set-up-alerts-if-co-nss-watchkeepers-account-publishes-anything