### PR TITLE
Remove Taiwain from the list of consular special cases

### DIFF
--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -102,11 +102,6 @@ private
       location: "Lebanon",
       base_path: "/government/world/organisations/british-embassy-beirut",
     },
-    "Taiwan" => {
-      building: "British Office Taipei",
-      location: "Taiwan",
-      base_path: "/government/world/organisations/british-office-taipei",
-    },
     "Timor Leste" => {
       building: "British Embassy Jakarta",
       location: "Indonesia",


### PR DESCRIPTION
This commit removes Taiwan from the list of consular special cases since the special case no longer applies.

Trello: https://trello.com/c/pnyIwHMg/318-embassy-finder-content-work