### PR TITLE
Correct Spanish translation for announcement

### DIFF
--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -381,7 +381,7 @@ es-419:
       detail: Detalle
   read_more: Lea más
   see_all:
-    announcement: Vea todos nuestros novedades
+    announcement: Vea todas nuestras novedades
     authored_article: Vea todos nuestros artículos con autor
     case_study: Vea todos nuestros casos de estudio
     closed_consultation: Vea todos nuestros consultas cerradas


### PR DESCRIPTION
Change translation for "announcement" from
`Vea todos nuestros novedades` to `Vea todas nuestras novedades`

[Trello](https://trello.com/c/OoM8zDQ1/1194-incorrect-spelling-on-translated-fco-page-spanish)
