### PR TITLE
Remove Taiwain from the list of consular special cases

### DIFF
--- a/app/models/embassy.rb
+++ b/app/models/embassy.rb
@@ -9,7 +9,7 @@ class Embassy
   def_delegator :@world_location, :name
 
   def self.filter_offices(worldwide_organisation)
-    worldwide_organisation.offices.select { |o| embassy_high_commission_or_consulate?(o) }
+    worldwide_organisation.offices.select { |o| embassy_office?(o) }
   end
 
   def offices
@@ -30,9 +30,7 @@ class Embassy
     end
   end
 
-  private
-
-  def self.embassy_high_commission_or_consulate?(office)
+  def self.embassy_office?(office)
     [
       "British Trade and Cultural Office",
       "Consulate",

--- a/app/models/embassy.rb
+++ b/app/models/embassy.rb
@@ -33,6 +33,11 @@ class Embassy
   private
 
   def self.embassy_high_commission_or_consulate?(office)
-    ["Embassy", "Consulate", "High Commission"].include?(office.worldwide_office_type.name)
+    [
+      "British Trade and Cultural Office",
+      "Consulate",
+      "Embassy",
+      "High Commission",
+    ].include?(office.worldwide_office_type.name)
   end
 end

--- a/app/presenters/embassy_presenter.rb
+++ b/app/presenters/embassy_presenter.rb
@@ -102,11 +102,6 @@ private
       location: "Lebanon",
       base_path: "/government/world/organisations/british-embassy-beirut",
     },
-    "Taiwan" => {
-      building: "British Office Taipei",
-      location: "Taiwan",
-      base_path: "/government/world/organisations/british-office-taipei",
-    },
     "Timor Leste" => {
       building: "British Embassy Jakarta",
       location: "Indonesia",


### PR DESCRIPTION
https://trello.com/c/pnyIwHMg/318-embassy-finder-content-work

This was attempted previously in #3538 but this also removed the link to the office on the embassy index page because it wasn't of a specific type. After discussing, we've decided to add the type of this office to the list of hard-coded types. Currently, this is the only office with this type.

Taiwan now looks like the others:

<img width="536" alt="screen shot 2017-11-16 at 13 49 13" src="https://user-images.githubusercontent.com/892251/32894538-ff1a9220-cad4-11e7-96b5-7e0b084ebf46.png">
