### PR TITLE
Fix problem with replacing assets in asset manager store

### DIFF
--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -35,5 +35,9 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     def filename
       @legacy_url_path
     end
+
+    def path
+      @legacy_url_path
+    end
   end
 end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -85,15 +85,19 @@ class AssetManagerIntegrationTest
 
   class RemovingAConsultationResponseFormData < ActiveSupport::TestCase
     setup do
+      filename = 'greenpaper.pdf'
+      @consultation_response_form_asset_id = 'asset-id'
       @consultation_response_form_data = FactoryGirl.create(
         :consultation_response_form_data,
-        file: File.open(Rails.root.join('test', 'fixtures', 'greenpaper.pdf'))
+        file: File.open(Rails.root.join('test', 'fixtures', filename))
       )
       VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
       @consultation_response_form_data.reload
       @file_path = @consultation_response_form_data.file.path
 
-      Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(/#{filename}/))
+        .returns('id' => "http://asset-manager/assets/#{@consultation_response_form_asset_id}")
       Services.asset_manager.stubs(:delete_asset)
     end
 
@@ -107,6 +111,7 @@ class AssetManagerIntegrationTest
 
     test 'removing a consultation response form data file removes it from asset manager' do
       Services.asset_manager.expects(:delete_asset)
+        .with(@consultation_response_form_asset_id)
 
       @consultation_response_form_data.remove_file!
     end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -7,7 +7,7 @@ class AssetManagerIntegrationTest
       organisation = FactoryGirl.build(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', filename))
+        logo: File.open(fixture_path.join('images', filename))
       )
 
       Services.asset_manager.expects(:create_whitehall_asset).with do |args|
@@ -25,7 +25,7 @@ class AssetManagerIntegrationTest
       organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', logo_filename))
+        logo: File.open(fixture_path.join('images', logo_filename))
       )
       logo_asset_id = 'asset-id'
       Services.asset_manager.stubs(:whitehall_asset)
@@ -44,7 +44,7 @@ class AssetManagerIntegrationTest
       organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', old_logo_filename))
+        logo: File.open(fixture_path.join('images', old_logo_filename))
       )
       old_logo_asset_id = 'asset-id'
       Services.asset_manager.stubs(:whitehall_asset)
@@ -53,7 +53,7 @@ class AssetManagerIntegrationTest
 
       Services.asset_manager.expects(:delete_asset).with(old_logo_asset_id)
 
-      organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))
+      organisation.logo = File.open(fixture_path.join('images', '960x640_gif.gif'))
       organisation.save!
     end
   end
@@ -63,7 +63,7 @@ class AssetManagerIntegrationTest
       @filename = 'greenpaper.pdf'
       @consultation_response_form_data = FactoryGirl.build(
         :consultation_response_form_data,
-        file: File.open(Rails.root.join('test', 'fixtures', @filename))
+        file: File.open(fixture_path.join(@filename))
       )
     end
 
@@ -89,7 +89,7 @@ class AssetManagerIntegrationTest
       @consultation_response_form_asset_id = 'asset-id'
       @consultation_response_form_data = FactoryGirl.create(
         :consultation_response_form_data,
-        file: File.open(Rails.root.join('test', 'fixtures', filename))
+        file: File.open(fixture_path.join(filename))
       )
       VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
       @consultation_response_form_data.reload
@@ -123,7 +123,7 @@ class AssetManagerIntegrationTest
       @consultation_response_form_asset_id = 'asset-id'
       @consultation_response_form_data = FactoryGirl.create(
         :consultation_response_form_data,
-        file: File.open(Rails.root.join('test', 'fixtures', filename))
+        file: File.open(fixture_path.join(filename))
       )
       VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
       @consultation_response_form_data.reload
@@ -138,7 +138,7 @@ class AssetManagerIntegrationTest
     test 'replacing a consultation response form data file removes the old file from the file system' do
       assert File.exist?(@file_path)
 
-      @consultation_response_form_data.file = File.open(Rails.root.join('test', 'fixtures', 'whitepaper.pdf'))
+      @consultation_response_form_data.file = File.open(fixture_path.join('whitepaper.pdf'))
       @consultation_response_form_data.save!
 
       refute File.exist?(@file_path)
@@ -148,7 +148,7 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset)
         .with(@consultation_response_form_asset_id)
 
-      @consultation_response_form_data.file = File.open(Rails.root.join('test', 'fixtures', 'whitepaper.pdf'))
+      @consultation_response_form_data.file = File.open(fixture_path.join('whitepaper.pdf'))
       @consultation_response_form_data.save!
     end
   end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -3,18 +3,18 @@ require 'test_helper'
 class AssetManagerIntegrationTest
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
     test 'sends the logo to Asset Manager' do
-      @filename = '960x640_jpeg.jpg'
-      @organisation = FactoryGirl.build(
+      filename = '960x640_jpeg.jpg'
+      organisation = FactoryGirl.build(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', @filename))
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', filename))
       )
 
       Services.asset_manager.expects(:create_whitehall_asset).with do |args|
         args[:file].is_a?(File) &&
-          args[:legacy_url_path] =~ /#{@filename}/
+          args[:legacy_url_path] =~ /#{filename}/
       end
-      @organisation.save!
+      organisation.save!
     end
   end
 
@@ -45,42 +45,42 @@ class AssetManagerIntegrationTest
 
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     test 'removing an organisation logo removes it from asset manager' do
-      @organisation = FactoryGirl.create(
+      organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg'))
       )
 
-      @organisation.reload
+      organisation.reload
 
       Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
       Services.asset_manager.stubs(:delete_asset)
 
       Services.asset_manager.expects(:delete_asset)
 
-      @organisation.remove_logo!
+      organisation.remove_logo!
     end
   end
 
   class ReplacingAnOrganisationLogo < ActiveSupport::TestCase
     test 'replacing an organisation logo removes the old logo from asset manager' do
-      @old_logo_filename = '960x640_jpeg.jpg'
-      @organisation = FactoryGirl.create(
+      old_logo_filename = '960x640_jpeg.jpg'
+      organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', @old_logo_filename))
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', old_logo_filename))
       )
 
-      @organisation.reload
+      organisation.reload
 
       old_logo_asset_id = 'asset-id'
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(/#{@old_logo_filename}/))
+        .with(regexp_matches(/#{old_logo_filename}/))
         .returns('id' => "http://asset-manager/assets/#{old_logo_asset_id}")
       Services.asset_manager.expects(:delete_asset).with(old_logo_asset_id)
 
-      @organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))
-      @organisation.save!
+      organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))
+      organisation.save!
     end
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -46,14 +46,18 @@ class AssetManagerIntegrationTest
 
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     test 'removing an organisation logo removes it from asset manager' do
+      logo_filename = '960x640_jpeg.jpg'
       organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg'))
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', logo_filename))
       )
-      Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+      logo_asset_id = 'asset-id'
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(/#{logo_filename}/))
+        .returns('id' => "http://asset-manager/assets/#{logo_asset_id}")
 
-      Services.asset_manager.expects(:delete_asset)
+      Services.asset_manager.expects(:delete_asset).with(logo_asset_id)
 
       organisation.remove_logo!
     end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -19,31 +19,6 @@ class AssetManagerIntegrationTest
     end
   end
 
-  class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
-    setup do
-      @filename = 'greenpaper.pdf'
-      @consultation_response_form_data = FactoryGirl.build(
-        :consultation_response_form_data,
-        file: File.open(Rails.root.join('test', 'fixtures', @filename))
-      )
-    end
-
-    test 'sends the consultation response form data file to Asset Manager' do
-      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
-        args[:file].is_a?(File) &&
-          args[:legacy_url_path] =~ /#{@filename}/
-      end
-
-      @consultation_response_form_data.save!
-    end
-
-    test 'saves the consultation response form data file to the file system' do
-      @consultation_response_form_data.save!
-
-      assert File.exist?(@consultation_response_form_data.file.path)
-    end
-  end
-
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     test 'removing an organisation logo removes it from asset manager' do
       logo_filename = '960x640_jpeg.jpg'
@@ -80,6 +55,31 @@ class AssetManagerIntegrationTest
 
       organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))
       organisation.save!
+    end
+  end
+
+  class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
+    setup do
+      @filename = 'greenpaper.pdf'
+      @consultation_response_form_data = FactoryGirl.build(
+        :consultation_response_form_data,
+        file: File.open(Rails.root.join('test', 'fixtures', @filename))
+      )
+    end
+
+    test 'sends the consultation response form data file to Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
+        args[:file].is_a?(File) &&
+          args[:legacy_url_path] =~ /#{@filename}/
+      end
+
+      @consultation_response_form_data.save!
+    end
+
+    test 'saves the consultation response form data file to the file system' do
+      @consultation_response_form_data.save!
+
+      assert File.exist?(@consultation_response_form_data.file.path)
     end
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -14,6 +14,7 @@ class AssetManagerIntegrationTest
         args[:file].is_a?(File) &&
           args[:legacy_url_path] =~ /#{filename}/
       end
+
       organisation.save!
     end
   end
@@ -50,11 +51,7 @@ class AssetManagerIntegrationTest
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg'))
       )
-
-      organisation.reload
-
       Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-      Services.asset_manager.stubs(:delete_asset)
 
       Services.asset_manager.expects(:delete_asset)
 
@@ -70,13 +67,11 @@ class AssetManagerIntegrationTest
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(Rails.root.join('test', 'fixtures', 'images', old_logo_filename))
       )
-
-      organisation.reload
-
       old_logo_asset_id = 'asset-id'
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(/#{old_logo_filename}/))
         .returns('id' => "http://asset-manager/assets/#{old_logo_asset_id}")
+
       Services.asset_manager.expects(:delete_asset).with(old_logo_asset_id)
 
       organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -2,16 +2,14 @@ require 'test_helper'
 
 class AssetManagerIntegrationTest
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
-    setup do
+    test 'sends the logo to Asset Manager' do
       @filename = '960x640_jpeg.jpg'
       @organisation = FactoryGirl.build(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(Rails.root.join('test', 'fixtures', 'images', @filename))
       )
-    end
 
-    test 'sends the logo to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with do |args|
         args[:file].is_a?(File) &&
           args[:legacy_url_path] =~ /#{@filename}/
@@ -46,7 +44,7 @@ class AssetManagerIntegrationTest
   end
 
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
-    setup do
+    test 'removing an organisation logo removes it from asset manager' do
       @organisation = FactoryGirl.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
@@ -57,9 +55,7 @@ class AssetManagerIntegrationTest
 
       Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
       Services.asset_manager.stubs(:delete_asset)
-    end
 
-    test 'removing an organisation logo removes it from asset manager' do
       Services.asset_manager.expects(:delete_asset)
 
       @organisation.remove_logo!
@@ -67,7 +63,7 @@ class AssetManagerIntegrationTest
   end
 
   class ReplacingAnOrganisationLogo < ActiveSupport::TestCase
-    setup do
+    test 'replacing an organisation logo removes the old logo from asset manager' do
       @old_logo_filename = '960x640_jpeg.jpg'
       @organisation = FactoryGirl.create(
         :organisation,
@@ -76,9 +72,7 @@ class AssetManagerIntegrationTest
       )
 
       @organisation.reload
-    end
 
-    test 'replacing an organisation logo removes the old logo from asset manager' do
       old_logo_asset_id = 'asset-id'
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(/#{@old_logo_filename}/))

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -66,6 +66,30 @@ class AssetManagerIntegrationTest
     end
   end
 
+  class ReplacingAnOrganisationLogo < ActiveSupport::TestCase
+    setup do
+      @old_logo_filename = '960x640_jpeg.jpg'
+      @organisation = FactoryGirl.create(
+        :organisation,
+        organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+        logo: File.open(Rails.root.join('test', 'fixtures', 'images', @old_logo_filename))
+      )
+
+      @organisation.reload
+    end
+
+    test 'replacing an organisation logo removes the old logo from asset manager' do
+      old_logo_asset_id = 'asset-id'
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(/#{@old_logo_filename}/))
+        .returns('id' => "http://asset-manager/assets/#{old_logo_asset_id}")
+      Services.asset_manager.expects(:delete_asset).with(old_logo_asset_id)
+
+      @organisation.logo = File.open(Rails.root.join('test', 'fixtures', 'images', '960x640_gif.gif'))
+      @organisation.save!
+    end
+  end
+
   class RemovingAConsultationResponseFormData < ActiveSupport::TestCase
     setup do
       @consultation_response_form_data = FactoryGirl.create(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -163,6 +163,10 @@ class ActiveSupport::TestCase
       raise "Could not force publish edition: #{publisher.failure_reason}"
     end
   end
+
+  def fixture_path
+    Pathname.new(Rails.root.join('test', 'fixtures'))
+  end
 end
 
 class ActionController::TestCase

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -83,4 +83,8 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
 
     assert_equal expected_asset_url, @file.url
   end
+
+  test 'returns the legacy filename as the path' do
+    assert_equal @asset_url_path, @file.path
+  end
 end


### PR DESCRIPTION
We've seen [an exception in production](https://sentry.io/govuk/app-whitehall/issues/391658602/events/9208224189/) when someone tried to replace an organisation logo with a file of the same name. The file wasn't removed from Asset Manager and so the replacement couldn't be uploaded.

I've replicated the problem in the AssetManagerIntegrationTest and fixed it by adding the `AssetManagerStorage::File#path` method. I'm assuming that CarrierWave checks whether the path has changed when deciding whether it needs to upload a new file during replacement.

The fix is in the first commit in the branch. The subsequent commits all contain small improvements to the Asset Manager integration tests.
