### PR TITLE
Explicitly set text directions for all locales

### DIFF
--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -322,7 +322,7 @@ el:
     get_updates_to_this_list:
     latest_activity: "Πρόσφατες ενημερώσεις"
   i18n:
-    direction:
+    direction: ltr
   language_names:
     el: "Ελληνικά "
   latest_feed:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -321,7 +321,7 @@ it:
     get_updates_to_this_list:
     latest_activity: Attività recente
   i18n:
-    direction: Itr
+    direction: ltr
   language_names:
     it: Italiano
   latest_feed:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -321,7 +321,7 @@ pt:
     get_updates_to_this_list:
     latest_activity: "Últimas atividades"
   i18n:
-    direction: Itr
+    direction: ltr
   language_names:
     pt: Português
   latest_feed:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -371,7 +371,7 @@ ro:
     get_updates_to_this_list:
     latest_activity: Activiţăti recente
   i18n:
-    direction:
+    direction: ltr
   language_names:
     ro: Română
   latest_feed:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -422,7 +422,7 @@ ru:
     get_updates_to_this_list:
     latest_activity: "Реестр активности"
   i18n:
-    direction: "письмо"
+    direction: ltr
   language_names:
     ru: "Русский"
   latest_feed:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -323,7 +323,7 @@ so:
     get_updates_to_this_list:
     latest_activity: Waxqabadkii ugu dambeeyey
   i18n:
-    direction: litir
+    direction: ltr
   language_names:
     so: Soomaaliga
   latest_feed:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -282,7 +282,7 @@ tr:
     get_updates_to_this_list:
     latest_activity: Son etkinlik
   i18n:
-    direction: Itr
+    direction: ltr
   language_names:
     tr: Türkçe
   latest_feed:

--- a/test/unit/text_direction_test.rb
+++ b/test/unit/text_direction_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class TextDirectionTest < ActiveSupport::TestCase
+  paths = Dir[File.join(__dir__, "..", "..", "config", "locales", "*.yml")]
+
+  paths.each do |path|
+    test "explicitly sets text direction for #{File.basename(path)}" do
+      data = YAML.load(File.read(path))
+      locale = data.keys.first
+
+      i18n = data[locale]["i18n"]
+      direction = i18n["direction"] if i18n
+
+      assert_includes %w(ltr rtl), direction
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/RadCqvjL/360-spike-if-any-right-left-content-that-should-be-right-aligned-currently-isnt

Adds a test that checks all text directions have
been set to either left-to-right or right-to-left.

As part of this work, I audited all locales to
check they’d been set correctly. I
cross-referenced them against these two resources:

https://www.w3.org/International/questions/qa-scripts#directions

https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes