### PR TITLE
Remove organisation logos from NFS

### DIFF
--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,6 +1,8 @@
 class AssetRemover
   def remove_organisation_logos
     target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    files = Dir.glob(File.join(target_dir, '**', '*'))
     FileUtils.remove_dir(target_dir)
+    files
   end
 end

--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,0 +1,6 @@
+class AssetRemover
+  def remove_organisation_logos
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    FileUtils.remove_dir(target_dir)
+  end
+end

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -9,7 +9,8 @@ namespace :asset_manager do
 
   desc "Removes all organisation logos."
   task remove_organisation_logos: :environment do
-    AssetRemover.new.remove_organisation_logos
+    files = AssetRemover.new.remove_organisation_logos
+    puts files
   end
 
   private

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,6 +7,11 @@ namespace :asset_manager do
     migrator.perform
   end
 
+  desc "Removes all organisation logos."
+  task remove_organisation_logos: :environment do
+    AssetRemover.new.remove_organisation_logos
+  end
+
   private
 
   def usage_string

--- a/test/unit/asset_remover_test.rb
+++ b/test/unit/asset_remover_test.rb
@@ -31,4 +31,10 @@ class AssetRemoverTest < ActiveSupport::TestCase
 
     refute Dir.exist?(@logo_dir)
   end
+
+  test '#remove_organisation_logos returns an array of the files removed' do
+    files = @subject.remove_organisation_logos
+
+    assert_equal [@logo_path], files
+  end
 end

--- a/test/unit/asset_remover_test.rb
+++ b/test/unit/asset_remover_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class AssetRemoverTest < ActiveSupport::TestCase
+  setup do
+    @logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    @logo_path = File.join(@logo_dir, '960x640_jpeg.jpg')
+    fixture_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
+
+    FileUtils.mkdir_p(@logo_dir)
+    FileUtils.cp(fixture_asset_path, @logo_path)
+
+    @subject = AssetRemover.new
+  end
+
+  teardown do
+    FileUtils.remove_dir(@logo_dir, true)
+  end
+
+  test '#remove_organisation_logos removes all logos' do
+    assert File.exist?(@logo_path)
+
+    @subject.remove_organisation_logos
+
+    refute File.exist?(@logo_path)
+  end
+
+  test '#remove_organisation_logos removes the containing directory' do
+    assert Dir.exist?(@logo_dir)
+
+    @subject.remove_organisation_logos
+
+    refute Dir.exist?(@logo_dir)
+  end
+end


### PR DESCRIPTION
See: alphagov/asset-manager#272

Organisation logos are now being saved to, and served from[1], Asset
Manager. Any new logos are not being saved to NFS[2]. Existing logos
have been migrated to Asset Manager[3]. This means we can remove these
assets from the file system.

This PR adds `AssetRemover#remove_organisation_logos` to remove
the directory that "clean" organisation logos were moved to after
virus scanning, and all of its contents. We also add a Rake task `asset_manager:remove_organisation_logos` to allow this code to be run via Jenkins. 

[1] alphagov/asset-manager#283
[2] alphagov/asset-manager#274
[2] alphagov/asset-manager#276