### PR TITLE
Improve rendering on developer docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,20 +1,8 @@
 # Whitehall API
 
-Whitehall is primarily a publishing application but it also provides an API used
-by some applications. This API is public and is served under
-[https://www.gov.uk/api/](https://www.gov.uk/api/governments).
+Whitehall is primarily a publishing application but it also provides an API used by some applications. This API is public and is served under [https://www.gov.uk/api/](https://www.gov.uk/api/governments).
 
-Whitehall is not the only application to provide APIs under this path. For
-example,
-[/api/content](https://www.gov.uk/api/content/government)
-is served by
-[Content API](https://content-api.publishing.service.gov.uk)
-and
-[/api/search.json](https://www.gov.uk/api/search.json) is
-served by
-[Rummager](https://docs.publishing.service.gov.uk/apps/rummager.html).
-[This Nginx file](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/templates/publicapi_nginx_extra_config.erb)
-configures this behaviour.
+Whitehall is not the only application to provide APIs under this path. For example, [/api/content](https://www.gov.uk/api/content/government) is served by [Content API](https://content-api.publishing.service.gov.uk) and [/api/search.json](https://www.gov.uk/api/search.json) is served by [Rummager](https://docs.publishing.service.gov.uk/apps/rummager.html). [This Nginx file](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/templates/publicapi_nginx_extra_config.erb) configures this behaviour.
 
 ## Endpoints
 
@@ -44,9 +32,7 @@ Shows the details for a single world location.
 
 [`/api/world-locations/:slug/organisations`](https://www.gov.uk/api/world-locations/afghanistan/organisations) ([client](https://github.com/alphagov/gds-api-adapters/blob/0f24f4bc94ed1f8713c894b854c10ea867e6cf25/lib/gds_api/worldwide.rb#L12-L14))
 
-Lists worldwide organisations relating to a world location. Includes embassies,
-departments, sponsor organisations and details for offices such as addresses,
-telephone numbers and email addresses.
+Lists worldwide organisations relating to a world location. Includes embassies, departments, sponsor organisations and details for offices such as addresses, telephone numbers and email addresses.
 
 [`/api/worldwide-organisations/:slug`](https://www.gov.uk/api/worldwide-organisations/department-for-international-trade-afghanistan) (no client available)
 
@@ -54,13 +40,9 @@ Shows the details for a single worldwide organisation.
 
 ## Consumers
 
-Please
-[add your application to this list](https://github.com/alphagov/whitehall/edit/master/docs/api.md)
-if you're using the API.
+Please [add your application to this list](https://github.com/alphagov/whitehall/edit/master/docs/api.md) if you're using the API.
 
-There was
-[an incident](https://insidegovuk.blog.gov.uk/2017/09/27/incident-report-broken-smart-answers/)
-where some code was removed because these dependencies weren't known.
+There was [an incident](https://insidegovuk.blog.gov.uk/2017/09/27/incident-report-broken-smart-answers/) where some code was removed because these dependencies weren't known.
 
 `/api/governments`
 - [Smokey](https://github.com/alphagov/smokey/blob/f8678c4fe4805334b0ace8ddf5133be99094fc04/features/publicapi.feature#L22)


### PR DESCRIPTION
GitHub treats newlines within paragraphs as spaces
whereas developer docs preserves the newlines.