### PR TITLE
Fix issue with duplicate roles.

### DIFF
--- a/app/presenters/publishing_api/payload_builder/roles.rb
+++ b/app/presenters/publishing_api/payload_builder/roles.rb
@@ -24,6 +24,7 @@ module PublishingApi
           roles: role_appointments
             .map(&:role)
             .collect(&:content_id)
+            .uniq
         }
       end
 


### PR DESCRIPTION
If a document's Ministers field contains both former and current holders
of a role, the publishing-api presenter will contain a duplicate
reference to the Role content-item, which publishing-api will reject.

Fix this by calling `uniq` on the roles.

Quick fix because this is blocking publication: test to come.