### PR TITLE
Report errors in Publishing API workers

### DIFF
--- a/app/workers/publishing_api_gone_worker.rb
+++ b/app/workers/publishing_api_gone_worker.rb
@@ -16,8 +16,11 @@ class PublishingApiGoneWorker < PublishingApiWorker
       allow_draft: allow_draft,
       discard_drafts: !allow_draft
     )
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+  rescue GdsApi::HTTPNotFound
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
+  rescue GdsApi::HTTPUnprocessableEntity => e
+    # retrying is unlikely to fix the problem, we can send the error straight to Sentry
+    GovukError.notify(e)
   end
 end

--- a/app/workers/publishing_api_redirect_worker.rb
+++ b/app/workers/publishing_api_redirect_worker.rb
@@ -8,8 +8,11 @@ class PublishingApiRedirectWorker < PublishingApiWorker
       allow_draft: allow_draft,
       discard_drafts: !allow_draft,
     )
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPUnprocessableEntity
+  rescue GdsApi::HTTPNotFound
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
+  rescue GdsApi::HTTPUnprocessableEntity => e
+    # retrying is unlikely to fix the problem, we can send the error straight to Sentry
+    GovukError.notify(e)
   end
 end

--- a/test/unit/workers/publishing_api_gone_worker_test.rb
+++ b/test/unit/workers/publishing_api_gone_worker_test.rb
@@ -59,4 +59,21 @@ class PublishingApiGoneWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "sends an error to sentry if there is a problem with the request" do
+    govukerror_notify = MiniTest::Mock.new
+    govukerror_notify.expect :call, nil, [GdsApi::HTTPUnprocessableEntity]
+
+    publishing_api = MiniTest::Mock.new
+    def publishing_api.unpublish(_content_id, _options)
+      raise GdsApi::HTTPUnprocessableEntity, "test"
+    end
+
+    Services.stub :publishing_api, publishing_api do
+      GovukError.stub :notify, govukerror_notify do
+        PublishingApiGoneWorker.new.perform(@uuid, "alternative_path", "*why?*", "de")
+        assert_mock govukerror_notify
+      end
+    end
+  end
 end

--- a/test/unit/workers/publishing_api_redirect_worker_test.rb
+++ b/test/unit/workers/publishing_api_redirect_worker_test.rb
@@ -59,4 +59,21 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
 
     assert_requested request
   end
+
+  test "sends an error to sentry if there is a problem with the request" do
+    govukerror_notify = MiniTest::Mock.new
+    govukerror_notify.expect :call, nil, [GdsApi::HTTPUnprocessableEntity]
+
+    publishing_api = MiniTest::Mock.new
+    def publishing_api.unpublish(_content_id, _options)
+      raise GdsApi::HTTPUnprocessableEntity, "test"
+    end
+
+    Services.stub :publishing_api, publishing_api do
+      GovukError.stub :notify, govukerror_notify do
+        PublishingApiRedirectWorker.new.perform(@uuid, @destination, "fr", true)
+        assert_mock govukerror_notify
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently we're ignoring errors here which can mask problems. It's unlikely that retrying the worker will fix the problem, but it seems useful to still send the error through to Sentry so we have better visbility on it.

[Trello Card](https://trello.com/c/D8YUGjbN/388-unpublishing-statisticsannouncements-does-not-fully-work)