### PR TITLE
Replace factory_girl gem with factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ end
 
 group :test do
   gem 'rack-test'
-  gem 'factory_girl'
+  gem 'factory_bot'
   gem 'mocha', require: false
   gem 'timecop'
   gem 'webmock', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -534,7 +534,7 @@ DEPENDENCIES
   deprecated_columns (~> 0.1.1)
   dotenv-rails
   equivalent-xml (~> 0.6.0)
-  factory_girl
+  factory_bot
   faraday
   friendly_id (~> 5.2.1)
   gds-api-adapters

--- a/features/step_definitions/government_steps.rb
+++ b/features/step_definitions/government_steps.rb
@@ -19,11 +19,11 @@ Then(/^there should be a government called "(.*?)" between dates "(.*?)" and "(.
 end
 
 Given(/^a government exists called "(.*?)" between dates "(.*?)" and "(.*?)"$/) do |government_name, start_date, end_date|
-  FactoryGirl.create(:government, name: government_name, start_date: start_date, end_date: end_date)
+  FactoryBot.create(:government, name: government_name, start_date: start_date, end_date: end_date)
 end
 
 Given(/^a government exists called "(.*?)" starting on "(.*?)"$/) do |government_name, start_date|
-  FactoryGirl.create(:government, name: government_name, start_date: start_date)
+  FactoryBot.create(:government, name: government_name, start_date: start_date)
 end
 
 When(/^I edit the government called "(.*?)" to have dates "(.*?)" and "(.*?)"$/) do |government_name, start_date, end_date|
@@ -34,7 +34,7 @@ When(/^I edit the government called "(.*?)" to have dates "(.*?)" and "(.*?)"$/)
 end
 
 Given(/^there is a current government$/) do
-  FactoryGirl.create(:current_government)
+  FactoryBot.create(:current_government)
 end
 
 When(/^I close the current government$/) do

--- a/features/support/factory_girl.rb
+++ b/features/support/factory_girl.rb
@@ -1,3 +1,3 @@
 require File.expand_path("../../../test/factories", __FILE__)
 
-World(FactoryGirl::Syntax::Methods)
+World(FactoryBot::Syntax::Methods)

--- a/test/factories/about_page.rb
+++ b/test/factories/about_page.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :about_page do
     sequence(:name) { |index| "about-page-#{index}" }
     read_more_link_text 'Read more'

--- a/test/factories/access_and_opening_times.rb
+++ b/test/factories/access_and_opening_times.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :access_and_opening_times do
     body "Access body"
   end

--- a/test/factories/ambassador_roles.rb
+++ b/test/factories/ambassador_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :ambassador_role do
     name "Her Majesty's Ambassador to Spain"
   end

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :attachment_data do
     file { File.open(File.join(Rails.root, 'test', 'fixtures', 'greenpaper.pdf')) }
   end

--- a/test/factories/attachment_source.rb
+++ b/test/factories/attachment_source.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :attachment_source do
     sequence(:url) { |index| "http://example.com/attachment-#{index}.pdf" }
 

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:attachment_ordering)
 
   trait :abstract_attachment do

--- a/test/factories/board_member_roles.rb
+++ b/test/factories/board_member_roles.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :board_member_role do
     name "Permanent Secretary"
 
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:ministerial_department)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:ministerial_department)] unless evaluator.organisations.any?
     end
   end
 end

--- a/test/factories/case_studies.rb
+++ b/test/factories/case_studies.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :case_study, class: CaseStudy, parent: :edition_with_organisations do
     title "case-study-title"
     summary "case-study-summary"

--- a/test/factories/chief_professional_officers.rb
+++ b/test/factories/chief_professional_officers.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :chief_professional_officer_role do
     name "Chief Medical Officer"
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:organisation)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:organisation)] unless evaluator.organisations.any?
     end
   end
 end

--- a/test/factories/chief_scientific_advisor_roles.rb
+++ b/test/factories/chief_scientific_advisor_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :chief_scientific_advisor_role do
     name "Chief Scientific Advisor"
   end

--- a/test/factories/classification_featuring_image_data.rb
+++ b/test/factories/classification_featuring_image_data.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_featuring_image_data do
     file { image_fixture_file }
   end

--- a/test/factories/classification_featurings.rb
+++ b/test/factories/classification_featurings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_featuring do
     association :edition, factory: :published_edition
     classification

--- a/test/factories/classification_memberships.rb
+++ b/test/factories/classification_memberships.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_membership do
     publication
     classification factory: :topic

--- a/test/factories/classification_policy.rb
+++ b/test/factories/classification_policy.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_policy do
     association :classification, factory: :topic
   end

--- a/test/factories/classification_relations.rb
+++ b/test/factories/classification_relations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_relation do
     association :classification, factory: :topic
     association :related_classification, factory: :topic

--- a/test/factories/classifications.rb
+++ b/test/factories/classifications.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification do
     sequence(:name) { |index| "classification-#{index}" }
     description 'Classification description'

--- a/test/factories/consultation_participations.rb
+++ b/test/factories/consultation_participations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :consultation_participation do
   end
 end

--- a/test/factories/consultation_response_form_data.rb
+++ b/test/factories/consultation_response_form_data.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :consultation_response_form_data do
     file { File.open(File.join(Rails.root, 'test', 'fixtures', 'two-pages.pdf')) }
   end

--- a/test/factories/consultation_response_forms.rb
+++ b/test/factories/consultation_response_forms.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :consultation_response_form do
     transient do
       file { File.open(File.join(Rails.root, 'test', 'fixtures', 'two-pages.pdf')) }

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :consultation, class: Consultation, parent: :edition, traits: [:with_organisations, :with_topics] do
     title "consultation-title"
     body  "consultation-body"

--- a/test/factories/contact_numbers.rb
+++ b/test/factories/contact_numbers.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :contact_number do
     contact
     label "fax"

--- a/test/factories/contacts.rb
+++ b/test/factories/contacts.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :contact, traits: [:translated] do
     title "Contact description"
     contact_type { ContactType::General }

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :corporate_information_page, class: CorporateInformationPage, parent: :edition, traits: [:translated] do
     corporate_information_page_type_id CorporateInformationPageType::PublicationScheme.id
     body "Some stuff"

--- a/test/factories/default_news_organisation_image_data.rb
+++ b/test/factories/default_news_organisation_image_data.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :default_news_organisation_image_data do
     file { File.open(File.join(Rails.root, 'test', 'fixtures', 'minister-of-funk.960x640.jpg')) }
   end

--- a/test/factories/deputy_head_of_mission_roles.rb
+++ b/test/factories/deputy_head_of_mission_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :deputy_head_of_mission_role do
     name "Deputy head of mission in the British Virgin Islands"
   end

--- a/test/factories/detailed_guides.rb
+++ b/test/factories/detailed_guides.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :detailed_guide, class: DetailedGuide, parent: :edition, traits: [:with_organisations, :with_topics] do
     sequence(:title) { |index| "detailed-guide-title-#{index}" }
     body  "detailed-guide-body"

--- a/test/factories/document_collection.rb
+++ b/test/factories/document_collection.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :document_collection, class: DocumentCollection, parent: :edition, traits: [:with_organisations, :with_topics] do
     trait(:with_group) do
-      groups { FactoryGirl.build_list :document_collection_group, 1 }
+      groups { FactoryBot.build_list :document_collection_group, 1 }
     end
 
     trait(:with_groups) do
-      groups { FactoryGirl.build_list :document_collection_group, 2 }
+      groups { FactoryBot.build_list :document_collection_group, 2 }
     end
   end
 

--- a/test/factories/document_collection_group.rb
+++ b/test/factories/document_collection_group.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :document_collection_group do
     sequence(:heading) { |i| "Group #{i}" }
     body 'Group body text'

--- a/test/factories/document_collection_group_membership.rb
+++ b/test/factories/document_collection_group_membership.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :document_collection_group_membership do
     document { build :document }
     document_collection_group { build :document_collection_group }

--- a/test/factories/document_sources.rb
+++ b/test/factories/document_sources.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :document_source do
     sequence(:url) { |n| "http://ww#{n}.examaple.com/fancy-document-#{n}.aspx" }
   end

--- a/test/factories/documents.rb
+++ b/test/factories/documents.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :document do
     sequence(:content_id) { SecureRandom.uuid }
     sequence(:slug) { |index| "slug-#{index}" }

--- a/test/factories/edition_authors.rb
+++ b/test/factories/edition_authors.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition_author do
     edition
     user

--- a/test/factories/edition_organisations.rb
+++ b/test/factories/edition_organisations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition_organisation do
     edition
     organisation

--- a/test/factories/edition_relations.rb
+++ b/test/factories/edition_relations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition_relation do
     association :edition
     association :document, factory: :document

--- a/test/factories/edition_world_locations.rb
+++ b/test/factories/edition_world_locations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition_world_location do
     edition
     world_location

--- a/test/factories/edition_worldwide_organisations.rb
+++ b/test/factories/edition_worldwide_organisations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition_worldwide_organisation do
     edition
     worldwide_organisation

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -1,6 +1,6 @@
 require_relative '../support/generic_edition'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :edition, class: GenericEdition, traits: [:translated] do
     creator
     sequence(:title) { |index| "edition-title-#{index}" }
@@ -23,7 +23,7 @@ FactoryGirl.define do
       after :build do |edition, evaluator|
         if evaluator.lead_organisations.empty? && evaluator.create_default_organisation
           edition.edition_organisations.build(edition: edition,
-                                              organisation: FactoryGirl.build(:organisation),
+                                              organisation: FactoryBot.build(:organisation),
                                               lead_ordering: 1,
                                               lead: true)
         end
@@ -111,7 +111,7 @@ FactoryGirl.define do
 
     trait(:with_file_attachment) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email
-      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      attachments { FactoryBot.build_list :file_attachment, 1 }
       after :create do |edition, evaluator|
         VirusScanHelpers.simulate_virus_scan(edition.attachments.first.attachment_data.file)
       end
@@ -119,12 +119,12 @@ FactoryGirl.define do
 
     trait(:with_html_attachment) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email
-      attachments { FactoryGirl.build_list :html_attachment, 1 }
+      attachments { FactoryBot.build_list :html_attachment, 1 }
     end
 
     trait(:with_file_attachment_not_scanned) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email
-      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      attachments { FactoryBot.build_list :file_attachment, 1 }
     end
 
     trait(:with_document) do

--- a/test/factories/editorial_remarks.rb
+++ b/test/factories/editorial_remarks.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :editorial_remark do
     edition
     author

--- a/test/factories/fact_check_requests.rb
+++ b/test/factories/fact_check_requests.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fact_check_request do
     association :edition, factory: :publication
     association :requestor, factory: :fact_check_requestor

--- a/test/factories/fatality_notice_casualties.rb
+++ b/test/factories/fatality_notice_casualties.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fatality_notice_casualty, class: FatalityNoticeCasualty do
     personal_details "personal-details"
   end

--- a/test/factories/fatality_notices.rb
+++ b/test/factories/fatality_notices.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :fatality_notice, class: FatalityNotice, parent: :edition, traits: [:with_organisations, :with_topics] do
     title "fatality-title"
     summary "fatality-summary"

--- a/test/factories/feature_list.rb
+++ b/test/factories/feature_list.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :feature_list do
     locale :en
   end

--- a/test/factories/featured_link.rb
+++ b/test/factories/featured_link.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :featured_link do |link|
     link.url "https://www.gov.uk/example/service"
     link.title "An example service"

--- a/test/factories/featured_policies.rb
+++ b/test/factories/featured_policies.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :featured_policy do
     organisation
   end

--- a/test/factories/features.rb
+++ b/test/factories/features.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :feature do
     document
     image { image_fixture_file }

--- a/test/factories/financial_reports.rb
+++ b/test/factories/financial_reports.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :year do |n|
     Time.zone.now.year + n
   end

--- a/test/factories/governments.rb
+++ b/test/factories/governments.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :government do
     sequence(:name) { |index| "Government #{index}" }
     start_date "2010-05-06"

--- a/test/factories/governor_roles.rb
+++ b/test/factories/governor_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :governor_role do
     name "HM Governor in the British Virgin Islands"
   end

--- a/test/factories/high_commissioner_roles.rb
+++ b/test/factories/high_commissioner_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :high_commissioner_role do
     name "High Commissioner of India"
   end

--- a/test/factories/historical_accounts.rb
+++ b/test/factories/historical_accounts.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :historical_account do
     association :person
     summary "Some summary text"

--- a/test/factories/home_page_list_items.rb
+++ b/test/factories/home_page_list_items.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :home_page_list_item do
     item { create(:contact) }
     home_page_list

--- a/test/factories/home_page_lists.rb
+++ b/test/factories/home_page_lists.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :home_page_list do
     owner { create(:organisation) }
     name { 'contacts' }

--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :image_data do
     file { image_fixture_file }
   end

--- a/test/factories/images.rb
+++ b/test/factories/images.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :image do
     alt_text "An accessible description of the image"
     image_data

--- a/test/factories/judge_roles.rb
+++ b/test/factories/judge_roles.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :judge_role do
     sequence(:name) { |n| "Chief Justice ##{n}" }
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:court)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:court)] unless evaluator.organisations.any?
     end
   end
 end

--- a/test/factories/links_reports.rb
+++ b/test/factories/links_reports.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :links_report do
     links %w(http://link1.com http://link1.com)
     link_reportable { create(:draft_edition) }

--- a/test/factories/military_roles.rb
+++ b/test/factories/military_roles.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :military_role do
     name "Chief of the Air Staff"
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:organisation)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:organisation)] unless evaluator.organisations.any?
     end
   end
 end

--- a/test/factories/ministerial_roles.rb
+++ b/test/factories/ministerial_roles.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :ministerial_role, parent: :ministerial_role_without_organisation do
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:ministerial_department)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:ministerial_department)] unless evaluator.organisations.any?
     end
   end
 

--- a/test/factories/nation_inapplicabilities.rb
+++ b/test/factories/nation_inapplicabilities.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :nation_inapplicability do
     nation_id Nation::Scotland.id
   end

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :news_article, class: NewsArticle, parent: :edition, traits: [:with_organisations, :with_topics] do
     title "news-title"
     summary "news-summary"

--- a/test/factories/offsite_links.rb
+++ b/test/factories/offsite_links.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :offsite_link do
     title 'Summary text'
     link_type 'alert'

--- a/test/factories/operational_fields.rb
+++ b/test/factories/operational_fields.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :operational_field do
     sequence(:name) { |index| "field-#{index}" }
     description "description of field"

--- a/test/factories/organisation_classification.rb
+++ b/test/factories/organisation_classification.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :organisation_classification do
-    organisation { FactoryGirl.build(:organisation) }
-    classification { FactoryGirl.build(:topic) }
+    organisation { FactoryBot.build(:organisation) }
+    classification { FactoryBot.build(:topic) }
     lead false
   end
 end

--- a/test/factories/organisation_roles.rb
+++ b/test/factories/organisation_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :organisation_role do
     organisation
     role

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :organisation, traits: [:translated] do
     sequence(:name) { |index| "organisation-#{index}" }
     logo_formatted_name { name.to_s.split.join("\n") }
@@ -13,7 +13,7 @@ FactoryGirl.define do
 
     trait(:with_published_edition) {
       after :create do |organisation, evaluator|
-        FactoryGirl.create(:published_publication, lead_organisations: [organisation])
+        FactoryBot.create(:published_publication, lead_organisations: [organisation])
       end
     }
 

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :person, traits: [:translated] do
     sequence(:forename) { |index| "George #{index}" }
   end

--- a/test/factories/policy_groups.rb
+++ b/test/factories/policy_groups.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :policy_group do
     sequence(:email) { |n| "policy-group-#{n}@example.com" }
     name 'policy-group-name'
     description ''
 
     trait(:with_file_attachment) do
-      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      attachments { FactoryBot.build_list :file_attachment, 1 }
       after :create do |edition, _evaluator|
         VirusScanHelpers.simulate_virus_scan(edition.attachments.first.attachment_data.file)
       end

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotional_feature_item do
     association :promotional_feature
     summary 'Summary text'

--- a/test/factories/promotional_feature_links.rb
+++ b/test/factories/promotional_feature_links.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotional_feature_link do
     association :promotional_feature_item
     url         'http://example.com'

--- a/test/factories/promotional_features.rb
+++ b/test/factories/promotional_features.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotional_feature do
     association :organisation, factory: :executive_office
     title 'Feature title'

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -1,10 +1,10 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :publication, class: Publication, parent: :edition, traits: [:with_organisations, :with_topics] do
     sequence(:title) { |index| "publication-title-#{index}" }
     body  "publication-body"
     summary "publication-summary"
     publication_type_id { PublicationType::PolicyPaper.id }
-    attachments { FactoryGirl.build_list :html_attachment, 1 }
+    attachments { FactoryBot.build_list :html_attachment, 1 }
 
     trait(:corporate) do
       publication_type_id { PublicationType::CorporateReport.id }

--- a/test/factories/recent_edition_openings.rb
+++ b/test/factories/recent_edition_openings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :recent_edition_opening do
   end
 end

--- a/test/factories/responses.rb
+++ b/test/factories/responses.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   trait :response do
     consultation
     published_on { Date.today }
@@ -10,7 +10,7 @@ FactoryGirl.define do
     end
 
     trait(:with_file_attachment) do
-      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      attachments { FactoryBot.build_list :file_attachment, 1 }
 
       after :create do |consultation_outcome, _|
         VirusScanHelpers.simulate_virus_scan(
@@ -26,7 +26,7 @@ FactoryGirl.define do
     end
 
     trait(:with_file_attachment) do
-      attachments { FactoryGirl.build_list :file_attachment, 1 }
+      attachments { FactoryBot.build_list :file_attachment, 1 }
 
       after :create do |consultation_outcome, _|
         VirusScanHelpers.simulate_virus_scan(

--- a/test/factories/role_appointments.rb
+++ b/test/factories/role_appointments.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :role_appointment do
     role
     person

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :role, parent: :role_without_organisations do
     after :build do |role, evaluator|
-      role.organisations = [FactoryGirl.build(:organisation)] unless evaluator.organisations.any?
+      role.organisations = [FactoryBot.build(:organisation)] unless evaluator.organisations.any?
     end
   end
 
@@ -16,13 +16,13 @@ FactoryGirl.define do
 
   trait :occupied do
     after :build do |role, _|
-      role.role_appointments = [FactoryGirl.build(:role_appointment)]
+      role.role_appointments = [FactoryBot.build(:role_appointment)]
     end
   end
 
   trait :vacant do
     after :build do |role, _|
-      role.role_appointments = [FactoryGirl.build(:role_appointment, :ended)]
+      role.role_appointments = [FactoryBot.build(:role_appointment, :ended)]
     end
   end
 end

--- a/test/factories/sitewide_settings.rb
+++ b/test/factories/sitewide_settings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :sitewide_setting do
     sequence(:key) { |index| "sitewide_setting_key-#{index}" }
     description "Sitewide setting description"

--- a/test/factories/social_media_accounts.rb
+++ b/test/factories/social_media_accounts.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :social_media_account do
     social_media_service
     url "http://example.com"

--- a/test/factories/social_media_services.rb
+++ b/test/factories/social_media_services.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :social_media_service do
     sequence(:name) { |n| "Social Media Service #{n}" }
   end

--- a/test/factories/special_representative_roles.rb
+++ b/test/factories/special_representative_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :special_representative_role do
     name "United Kingdom Envoy to the Isles of Wonder"
   end

--- a/test/factories/specialist_sector.rb
+++ b/test/factories/specialist_sector.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :specialist_sector do
   end
 end

--- a/test/factories/speeches.rb
+++ b/test/factories/speeches.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :speech, class: Speech, parent: :edition, traits: [:with_organisations, :with_topics] do
     title "speech-title"
     body  "speech-body"
@@ -12,7 +12,7 @@ FactoryGirl.define do
 
     after(:build) do |object, evaluator|
       if evaluator.relevant_to_local_government
-        object.related_policy_ids = [FactoryGirl.create(:published_policy, relevant_to_local_government: true)].map(&:id)
+        object.related_policy_ids = [FactoryBot.create(:published_policy, relevant_to_local_government: true)].map(&:id)
       end
     end
   end

--- a/test/factories/sponsorship.rb
+++ b/test/factories/sponsorship.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :sponsorship do
     organisation
     worldwide_organisation

--- a/test/factories/statistical_data_sets.rb
+++ b/test/factories/statistical_data_sets.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :statistical_data_set, class: StatisticalDataSet, parent: :edition, traits: [:with_organisations, :with_topics] do
     title   "statistical-data-set-title"
     body    "statistical-data-set-body"

--- a/test/factories/statistics_announcement_dates.rb
+++ b/test/factories/statistics_announcement_dates.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :statistics_announcement_date do
     release_date { Time.zone.today + 1.month + 9.hours + 30.minutes }
     precision    StatisticsAnnouncementDate::PRECISION[:one_month]

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :statistics_announcement do
     transient do
       release_date nil
@@ -9,9 +9,9 @@ FactoryGirl.define do
     sequence(:title) { |index| "Stats announcement #{index}" }
     summary "Summary of announcement"
     publication_type_id PublicationType::OfficialStatistics.id
-    organisations { FactoryGirl.build_list :organisation, 1 }
+    organisations { FactoryBot.build_list :organisation, 1 }
 
-    topics { FactoryGirl.build_list :topic, 1 }
+    topics { FactoryBot.build_list :topic, 1 }
     association :creator, factory: :writer
     association :current_release_date, factory: :statistics_announcement_date
 

--- a/test/factories/take_part_pages.rb
+++ b/test/factories/take_part_pages.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :take_part_page do
     title 'A take part page title'
     summary 'Summary text'

--- a/test/factories/topical_events.rb
+++ b/test/factories/topical_events.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :topical_event do
     sequence(:name) { |index| "topical-event-#{index}" }
     description 'Topical event description'

--- a/test/factories/topics.rb
+++ b/test/factories/topics.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :topic do
     sequence(:name) { |index| "topic-#{index}" }
     description 'Topic description'

--- a/test/factories/traffic_commissioner_roles.rb
+++ b/test/factories/traffic_commissioner_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :traffic_commissioner_role do
     name "Traffic Commissioner for Scotland"
   end

--- a/test/factories/translated_trait.rb
+++ b/test/factories/translated_trait.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   trait :translated do
     transient do
       translated_into nil

--- a/test/factories/unpublishings.rb
+++ b/test/factories/unpublishings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :unpublishing do
     unpublishing_reason_id UnpublishingReason::PUBLISHED_IN_ERROR_ID
     edition { create(:published_case_study, state: 'draft', first_published_at: 2.days.ago) }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :name do |n|
     "user-#{n}"
   end

--- a/test/factories/world_location_news_articles.rb
+++ b/test/factories/world_location_news_articles.rb
@@ -1,12 +1,12 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :world_location_news_article, class: WorldLocationNewsArticle, parent: :edition, traits: [:with_topics] do
     title "world-location-news-title"
     summary "world-location-news-summary"
     body  "world-location-news-body"
 
     after :build do |news, evaluator|
-      news.world_locations = [FactoryGirl.build(:world_location)] unless evaluator.world_locations.any?
-      news.worldwide_organisations = [FactoryGirl.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
+      news.world_locations = [FactoryBot.build(:world_location)] unless evaluator.world_locations.any?
+      news.worldwide_organisations = [FactoryBot.build(:worldwide_organisation)] unless evaluator.worldwide_organisations.any?
     end
 
   end

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -1,11 +1,11 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :world_location, traits: [:translated] do
     name 'British Antarctic Territory'
     world_location_type WorldLocationType::WorldLocation
 
     trait(:with_worldwide_organisations) {
       after :create do |world_location, evaluator|
-        world_location.worldwide_organisations << FactoryGirl.create(:worldwide_organisation, :with_sponsorships)
+        world_location.worldwide_organisations << FactoryBot.create(:worldwide_organisation, :with_sponsorships)
       end
     }
   end

--- a/test/factories/worldwide_office_staff_roles.rb
+++ b/test/factories/worldwide_office_staff_roles.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_office_staff_role do
     name "Defence Attaché"
   end

--- a/test/factories/worldwide_office_staff_roles.rb
+++ b/test/factories/worldwide_office_staff_roles.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 FactoryBot.define do
   factory :worldwide_office_staff_role do
     name "Defence Attaché"

--- a/test/factories/worldwide_office_worldwide_services.rb
+++ b/test/factories/worldwide_office_worldwide_services.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_office_worldwide_service do
     worldwide_office
     worldwide_service

--- a/test/factories/worldwide_offices.rb
+++ b/test/factories/worldwide_offices.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_office do
     transient do
       title { 'Contact title' }

--- a/test/factories/worldwide_organisation_roles.rb
+++ b/test/factories/worldwide_organisation_roles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_organisation_role do
     worldwide_organisation
     role

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -1,10 +1,10 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_organisation, traits: [:translated] do
     sequence(:name) { |index| "worldwide-organisation-#{index}" }
 
     trait(:with_sponsorships) {
       after :create do |organisation, evaluator|
-        FactoryGirl.create(:sponsorship, worldwide_organisation: organisation)
+        FactoryBot.create(:sponsorship, worldwide_organisation: organisation)
       end
     }
   end

--- a/test/factories/worldwide_services.rb
+++ b/test/factories/worldwide_services.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :worldwide_service do
     name { 'worldwide-service-name' }
     service_type_id { WorldwideServiceType::DocumentaryServices.id }

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Admin::GovernmentsControllerTest < ActionController::TestCase
   setup do
-    @government = FactoryGirl.create(:government)
+    @government = FactoryBot.create(:government)
   end
 
   should_be_an_admin_controller

--- a/test/functional/organisations_controller_test.rb
+++ b/test/functional/organisations_controller_test.rb
@@ -143,9 +143,9 @@ class OrganisationsControllerTest < ActionController::TestCase
   sets_cache_control_max_age_to_time_of_next_scheduled(:publication)
   sets_cache_control_max_age_to_time_of_next_scheduled(:consultation)
   sets_cache_control_max_age_to_time_of_next_scheduled(:speech) do |organisation|
-    ministerial_role = FactoryGirl.create(:ministerial_role, organisations: [organisation])
-    role_appointment = FactoryGirl.create(:role_appointment, role: ministerial_role)
-    FactoryGirl.create(:speech, :draft,
+    ministerial_role = FactoryBot.create(:ministerial_role, organisations: [organisation])
+    role_appointment = FactoryBot.create(:role_appointment, role: ministerial_role)
+    FactoryBot.create(:speech, :draft,
       scheduled_publication: Time.zone.now + Whitehall.default_cache_max_age * 2,
       role_appointment: role_appointment)
   end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -4,7 +4,7 @@ class AssetManagerIntegrationTest
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
     test 'sends the logo to Asset Manager' do
       filename = '960x640_jpeg.jpg'
-      organisation = FactoryGirl.build(
+      organisation = FactoryBot.build(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(fixture_path.join('images', filename))
@@ -22,7 +22,7 @@ class AssetManagerIntegrationTest
   class RemovingAnOrganisationLogo < ActiveSupport::TestCase
     test 'removing an organisation logo removes it from asset manager' do
       logo_filename = '960x640_jpeg.jpg'
-      organisation = FactoryGirl.create(
+      organisation = FactoryBot.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(fixture_path.join('images', logo_filename))
@@ -41,7 +41,7 @@ class AssetManagerIntegrationTest
   class ReplacingAnOrganisationLogo < ActiveSupport::TestCase
     test 'replacing an organisation logo removes the old logo from asset manager' do
       old_logo_filename = '960x640_jpeg.jpg'
-      organisation = FactoryGirl.create(
+      organisation = FactoryBot.create(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
         logo: File.open(fixture_path.join('images', old_logo_filename))
@@ -61,7 +61,7 @@ class AssetManagerIntegrationTest
   class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
     setup do
       @filename = 'greenpaper.pdf'
-      @consultation_response_form_data = FactoryGirl.build(
+      @consultation_response_form_data = FactoryBot.build(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(@filename))
       )
@@ -87,7 +87,7 @@ class AssetManagerIntegrationTest
     setup do
       filename = 'greenpaper.pdf'
       @consultation_response_form_asset_id = 'asset-id'
-      @consultation_response_form_data = FactoryGirl.create(
+      @consultation_response_form_data = FactoryBot.create(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename))
       )
@@ -121,7 +121,7 @@ class AssetManagerIntegrationTest
     setup do
       filename = 'greenpaper.pdf'
       @consultation_response_form_asset_id = 'asset-id'
-      @consultation_response_form_data = FactoryGirl.create(
+      @consultation_response_form_data = FactoryBot.create(
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename))
       )

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -9,11 +9,11 @@ class ContactTest < ActiveSupport::TestCase
     @organisation_content_id = SecureRandom.uuid
     @world_location_content_id = SecureRandom.uuid
 
-    world_location = FactoryGirl.create(:world_location,
+    world_location = FactoryBot.create(:world_location,
                                         content_id: @world_location_content_id,
                                         title: "United Kingdom")
 
-    @contact = FactoryGirl.build(:contact,
+    @contact = FactoryBot.build(:contact,
                                  title: "Government Digital Service",
                                  recipient: "GDS mail room",
                                  street_address: "Aviation House, 125 Kingsway",
@@ -21,7 +21,7 @@ class ContactTest < ActiveSupport::TestCase
                                  country: world_location,
                                  email: "gds-mailroom@digital.cabinet-office.gov.uk")
 
-    @contact.contactable = FactoryGirl.create(:organisation, content_id: @organisation_content_id)
+    @contact.contactable = FactoryBot.create(:organisation, content_id: @organisation_content_id)
   end
 
   test "When a contact is saved, a 'contact' content item is published to the Publishing API" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ GovukContentSchemaTestHelpers.configure do |config|
 end
 
 class ActiveSupport::TestCase
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
   include ModelHelpers
   include ModelStubbingHelpers
   include HtmlAssertions
@@ -46,7 +46,7 @@ class ActiveSupport::TestCase
     Whitehall.search_backend = Whitehall::DocumentFilter::FakeSearch
     VirusScanHelpers.erase_test_files
     Sidekiq::Worker.clear_all
-    fake_whodunnit = FactoryGirl.build(:user)
+    fake_whodunnit = FactoryBot.build(:user)
     fake_whodunnit.stubs(:id).returns(1000)
     fake_whodunnit.stubs(:persisted?).returns(true)
     Edition::AuditTrail.whodunnit = fake_whodunnit

--- a/test/unit/edition/limited_access_test.rb
+++ b/test/unit/edition/limited_access_test.rb
@@ -13,7 +13,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     end
   end
 
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :limited_access_edition, class: LimitedAccessEdition, parent: :edition_with_organisations do
     end
     factory :limited_by_default_edition, class: LimitedByDefaultEdition, parent: :limited_access_edition do

--- a/test/unit/helpers/admin/edition_routes_helper_test.rb
+++ b/test/unit/helpers/admin/edition_routes_helper_test.rb
@@ -3,24 +3,24 @@ require 'test_helper'
 class Admin::EditionRoutesHelperTest < ActionView::TestCase
 
   test 'admin_edition_path take an edition instance and uses polymorphic routes to generate the correct path' do
-    p = FactoryGirl.create(:publication)
+    p = FactoryBot.create(:publication)
     assert_equal "/government/admin/publications/#{p.id}", admin_edition_path(p)
   end
 
   test 'admin_edition_url takes an edition instance and uses polymorphic routes to generate the correct whitehall-admin url by default' do
     admin_host = 'whitehall-admin.production.alphagov.co.uk'
     Whitehall.stubs(:admin_host).returns(admin_host)
-    s = FactoryGirl.create(:speech)
+    s = FactoryBot.create(:speech)
     assert_equal "http://#{admin_host}/government/admin/speeches/#{s.id}", admin_edition_url(s)
   end
 
   test 'admin_edition_url takes an edition instance and uses polymorphic routes to generate the correct url for the specified hostname' do
-    s = FactoryGirl.create(:speech)
+    s = FactoryBot.create(:speech)
     assert_equal "http://www.gov.uk/government/admin/speeches/#{s.id}", admin_edition_url(s, host: "www.gov.uk")
   end
 
   test 'edit_admin_edition_path take an edition instance and uses polymorphic routes to generate the correct path' do
-    s = FactoryGirl.create(:speech)
+    s = FactoryBot.create(:speech)
     assert_equal "/government/admin/speeches/#{s.id}/edit", edit_admin_edition_path(s)
   end
 
@@ -31,7 +31,7 @@ class Admin::EditionRoutesHelperTest < ActionView::TestCase
   end
 
   test 'editorial_remarks path helper generates a generic path regardless of edition subtype' do
-    c = FactoryGirl.create(:consultation)
+    c = FactoryBot.create(:consultation)
     assert_equal "/government/admin/editions/#{c.id}/editorial_remarks", admin_consultation_editorial_remarks_path(c)
   end
 
@@ -42,7 +42,7 @@ class Admin::EditionRoutesHelperTest < ActionView::TestCase
   end
 
   test 'fact_check_requests path helper generates a generic path regardless of edition subtype' do
-    p = FactoryGirl.create(:publication)
+    p = FactoryBot.create(:publication)
     assert_equal "/government/admin/editions/#{p.id}/fact_check_requests", admin_publication_fact_check_requests_path(p)
   end
 

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -156,7 +156,7 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
 
   test "is invalid when associating an organisation" do
     news_article = build(:news_article_world_news_story)
-    news_article.edition_organisations.build(organisation: FactoryGirl.build(:organisation))
+    news_article.edition_organisations.build(organisation: FactoryBot.build(:organisation))
 
     refute news_article.valid?
     assert_equal ["You can't tag a world news story to organisations, please remove organisation"],

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -5,11 +5,11 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
     @organisation_content_id = SecureRandom.uuid
     @world_location_content_id = SecureRandom.uuid
 
-    world_location = FactoryGirl.build(:world_location,
+    world_location = FactoryBot.build(:world_location,
                                        content_id: @world_location_content_id,
                                        title: "United Kingdom")
 
-    @contact = FactoryGirl.build(:contact,
+    @contact = FactoryBot.build(:contact,
                                  title: "Government Digital Service",
                                  recipient: "GDS mail room",
                                  street_address: "Aviation House, 125 Kingsway",
@@ -22,7 +22,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
 
     @updated_at = Time.zone.parse("2016-06-23 10:32:00")
     @contact.translation.updated_at = @updated_at
-    @contact.contactable = FactoryGirl.build(:organisation, content_id: @organisation_content_id)
+    @contact.contactable = FactoryBot.build(:organisation, content_id: @organisation_content_id)
     @presented = PublishingApi::ContactPresenter.new(@contact, {})
   end
 

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -131,11 +131,11 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       Speech.any_instance.stubs(:document).returns(document)
     end
 
-    let(:document) { FactoryGirl.build(:document) }
+    let(:document) { FactoryBot.build(:document) }
 
     [SpeechType::DraftText, SpeechType::SpeakingNotes, SpeechType::Transcript].each do |speech_type|
       context "for #{speech_type.plural_name}" do
-        let(:speech) { FactoryGirl.build(:speech, speech_type: speech_type) }
+        let(:speech) { FactoryBot.build(:speech, speech_type: speech_type) }
         it "is 'speech' for draft text" do
           assert_equal(presented.content[:document_type], "speech")
         end
@@ -144,7 +144,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
 
     [SpeechType::AuthoredArticle, SpeechType::OralStatement, SpeechType::WrittenStatement].each do |speech_type|
       context "for #{speech_type.plural_name}" do
-        let(:speech) { FactoryGirl.build(:speech, speech_type: speech_type) }
+        let(:speech) { FactoryBot.build(:speech, speech_type: speech_type) }
         it "is '#{speech_type.key}'" do
           assert_equal(presented.content[:document_type], speech_type.key)
         end

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class EditionUnwithdrawerTest < ActiveSupport::TestCase
   setup do
-    @edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
-    @user = FactoryGirl.create(:user)
+    @edition = FactoryBot.create(:published_edition, state: 'withdrawn')
+    @user = FactoryBot.create(:user)
     stub_any_publishing_api_call
   end
 
@@ -41,7 +41,7 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
   end
 
   test "unwithdraw handles legacy withdrawn editions" do
-    edition = FactoryGirl.create(:published_edition, state: 'withdrawn')
+    edition = FactoryBot.create(:published_edition, state: 'withdrawn')
 
     unwithdrawn_edition = unwithdraw(edition)
 

--- a/test/unit/whitehall/authority/authority_test_helper.rb
+++ b/test/unit/whitehall/authority/authority_test_helper.rb
@@ -15,37 +15,37 @@ require 'test_helper'
 module AuthorityTestHelper
   def self.define_edition_factory_methods(edition_type)
     define_method("normal_#{edition_type}") do |user = nil|
-      ne = FactoryGirl.build(edition_type)
+      ne = FactoryBot.build(edition_type)
       ne.stubs(:creator).returns(user)
       ne
     end
     define_method("submitted_#{edition_type}") do |user = nil|
-      ne = FactoryGirl.build(:"submitted_#{edition_type}")
+      ne = FactoryBot.build(:"submitted_#{edition_type}")
       ne.stubs(:submitted_by).returns(user)
       ne
     end
     define_method("force_published_#{edition_type}") do |user|
-      fpe = FactoryGirl.build(:"published_#{edition_type}", force_published: true)
+      fpe = FactoryBot.build(:"published_#{edition_type}", force_published: true)
       fpe.stubs(:published_by).returns(user)
       fpe
     end
     define_method("limited_#{edition_type}") do |orgs|
-      le = FactoryGirl.build(edition_type, access_limited: true)
+      le = FactoryBot.build(edition_type, access_limited: true)
       le.stubs(:organisations).returns(orgs)
       le
     end
     define_method("scheduled_#{edition_type}") do
-      FactoryGirl.build(:"scheduled_#{edition_type}").tap do |scheduled_edition|
+      FactoryBot.build(:"scheduled_#{edition_type}").tap do |scheduled_edition|
         scheduled_edition.stubs(:scheduled?).returns(true)
       end
     end
     define_method("force_scheduled_#{edition_type}") do |user|
-      fse = FactoryGirl.build(:"scheduled_#{edition_type}", force_published: true)
+      fse = FactoryBot.build(:"scheduled_#{edition_type}", force_published: true)
       fse.stubs(:scheduled_by).returns(user)
       fse
     end
     define_method("historic_#{edition_type}") do
-      he = FactoryGirl.build(:"published_#{edition_type}", force_published: true)
+      he = FactoryBot.build(:"published_#{edition_type}", force_published: true)
       he.stubs(:historic?).returns(true)
       he
     end

--- a/test/unit/workers/world_location_news_page_worker_test.rb
+++ b/test/unit/workers/world_location_news_page_worker_test.rb
@@ -7,7 +7,7 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
   end
 
   test "sends to the publishing api" do
-    world_location = FactoryGirl.create(:world_location, name: "France")
+    world_location = FactoryBot.create(:world_location, name: "France")
     presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
 
     Services.publishing_api.expects(:put_content).with("id-123", presenter.content)
@@ -17,7 +17,7 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
   end
 
   test "sends to rummager" do
-    world_location = FactoryGirl.create(:world_location, name: "France")
+    world_location = FactoryBot.create(:world_location, name: "France")
     presenter = PublishingApi::WorldLocationNewsPagePresenter.new(world_location)
 
     Whitehall::FakeRummageableIndex.any_instance.expects(:add)
@@ -27,7 +27,7 @@ class WorldLocationNewsPageWorkerTest < ActiveSupport::TestCase
   end
 
   test "sends translations to the publishing api under the same content_id" do
-    world_location = FactoryGirl.create(:world_location, name: "France", translated_into: [:fr])
+    world_location = FactoryBot.create(:world_location, name: "France", translated_into: [:fr])
 
     I18n.with_locale(:en) do
       @english = PublishingApi::WorldLocationNewsPagePresenter.new(world_location).content


### PR DESCRIPTION
Following the bulk gem update in 17fb7883a the `factory_girl` gem was upgraded to `4.9.0`. This introduced a deprecation warning

> DEPRECATION WARNING: The factory_girl gem is deprecated. Please
> upgrade to factory_bot.

This commit replaces the `factory_girl` gem with the `factory_bot`
gem.

The change in version number in Gemfile.lock is slightly
confusing (from `4.9.0` to `4.8.2`) - this isn't a downgrade. `4.9.0`
of `factory_girl` was released with this deprecation warning as
the only change[1]. `4.8.2` of `factory_bot` is the latest version of
the new gem.

I've renamed the constants `FactoryGirl` to `FactoryBot` as per the
update instructions[2].

I've also had to fix a rubocop exception triggered in CI as updating this file triggered the linting on these files (which already had an error). 

[1] https://github.com/thoughtbot/factory_bot/pull/1061
[2] https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md