### PR TITLE
Add seeds to allow for use within end-to-end testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
 ENV PORT 3020
 ENV REDIS_HOST redis
 ENV RAILS_ENV development
-ENV DATABASE_URL: mysql2://root:root@mysql/whitehall_development
-ENV TEST_DATABASE_URL: mysql2://root:root@mysql/whitehall_test
+ENV DATABASE_URL mysql2://root:root@mysql/whitehall_development
+ENV TEST_DATABASE_URL mysql2://root:root@mysql/whitehall_test
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,22 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+if User.where(name: "Test user").present?
+  puts "Skipping because user already exists"
+else
+  gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  User.create!(
+    name: "Test user",
+    permissions: ["signin", "GDS Admin"],
+    organisation_content_id: gds_organisation_id,
+  )
+end
+
+if Organisation.where(name: "Test Organisation").present?
+  puts "Skipping because organisation already exists"
+else
+  Organisation.create!(
+    name: "Test Organisation",
+    slug: "test-organisation",
+    acronym: "TO",
+    organisation_type_key: :other,
+    logo_formatted_name: "Test"
+  )
+end


### PR DESCRIPTION
We require a user to satisfy mocked GDS-SSO and an organisation for use as part of the manuals publishing flow. The manuals publisher fetches the organisation for the publishing user based on the slug assigned to them (we mirror this organisation slug in the manuals publisher)