### PR TITLE
Do not overwrite invisible draft taxons

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -12,6 +12,7 @@ class Admin::EditionTagsController < Admin::BaseController
     @tag_form = TaxonomyTagForm.new(
       content_id: @edition.content_id,
       selected_taxons: selected_taxons,
+      invisible_taxons: invisible_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
       all_taxons: Taxonomy::GovukTaxonomy.new.all_taxons
     )
@@ -41,5 +42,9 @@ private
 
   def selected_taxons
     params["taxonomy_tag_form"].fetch("taxons", []).reject(&:blank?)
+  end
+
+  def invisible_taxons
+    params["taxonomy_tag_form"].fetch("invisible_draft_taxons", "").split(",")
   end
 end

--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -9,15 +9,13 @@ class Admin::EditionTagsController < Admin::BaseController
   end
 
   def update
-    @tag_form = TaxonomyTagForm.new(
+    EditionTaxonLinkPatcher.new.call(
       content_id: @edition.content_id,
       selected_taxons: selected_taxons,
       invisible_taxons: invisible_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
-      all_taxons: Taxonomy::GovukTaxonomy.new.all_taxons
     )
 
-    @tag_form.publish!
     redirect_to admin_edition_path(@edition),
       notice: "The tags have been updated."
   rescue GdsApi::HTTPConflict

--- a/app/controllers/admin/statistics_announcement_tags_controller.rb
+++ b/app/controllers/admin/statistics_announcement_tags_controller.rb
@@ -8,14 +8,13 @@ class Admin::StatisticsAnnouncementTagsController < Admin::BaseController
   end
 
   def update
-    @tag_form = TaxonomyTagForm.new(
+    EditionTaxonLinkPatcher.new.call(
       content_id: @statistics_announcement.content_id,
       selected_taxons: selected_taxons,
+      invisible_taxons: invisible_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
-      all_taxons: Taxonomy::GovukTaxonomy.new.all_taxons
     )
 
-    @tag_form.publish!
     redirect_to admin_statistics_announcement_path(@statistics_announcement),
       notice: "The tags have been updated."
   rescue GdsApi::HTTPConflict
@@ -39,5 +38,9 @@ private
 
   def selected_taxons
     params["taxonomy_tag_form"].fetch("taxons", []).reject(&:blank?)
+  end
+
+  def invisible_taxons
+    params["taxonomy_tag_form"].fetch("invisible_draft_taxons", "").split(",")
   end
 end

--- a/app/models/taxonomy_tag_form.rb
+++ b/app/models/taxonomy_tag_form.rb
@@ -1,7 +1,7 @@
 class TaxonomyTagForm
   include ActiveModel::Model
 
-  attr_accessor :selected_taxons, :all_taxons, :content_id, :previous_version
+  attr_accessor :selected_taxons, :invisible_taxons, :all_taxons, :content_id, :previous_version
 
   def self.load(content_id)
     begin
@@ -41,7 +41,7 @@ class TaxonomyTagForm
       .publishing_api
       .patch_links(
         content_id,
-        links: { taxons: most_specific_taxons },
+        links: { taxons: most_specific_taxons + invisible_taxons },
         previous_version: previous_version
       )
   end

--- a/app/models/taxonomy_tag_form.rb
+++ b/app/models/taxonomy_tag_form.rb
@@ -36,32 +36,6 @@ class TaxonomyTagForm
     selected_taxons - (published_taxons + visible_draft_taxons)
   end
 
-  def publish!
-    Services
-      .publishing_api
-      .patch_links(
-        content_id,
-        links: { taxons: most_specific_taxons + invisible_taxons },
-        previous_version: previous_version
-      )
-  end
-
-  # Ignore any taxons that already have a more specific taxon selected
-  def most_specific_taxons
-    all_taxons.each_with_object([]) do |taxon, list_of_taxons|
-      content_ids = taxon.descendants.map(&:content_id)
-
-      any_descendants_selected = selected_taxons.any? do |selected_taxon|
-        content_ids.include?(selected_taxon)
-      end
-
-      unless any_descendants_selected
-        content_id = taxon.content_id
-        list_of_taxons << content_id if selected_taxons.include?(content_id)
-      end
-    end
-  end
-
 private
 
   def govuk_taxonomy

--- a/app/models/taxonomy_tag_form.rb
+++ b/app/models/taxonomy_tag_form.rb
@@ -24,6 +24,18 @@ class TaxonomyTagForm
     )
   end
 
+  def published_taxons
+    govuk_taxonomy.matching_against_published_taxons(selected_taxons)
+  end
+
+  def visible_draft_taxons
+    govuk_taxonomy.matching_against_visible_draft_taxons(selected_taxons)
+  end
+
+  def invisible_draft_taxons
+    selected_taxons - (published_taxons + visible_draft_taxons)
+  end
+
   def publish!
     Services
       .publishing_api
@@ -48,5 +60,11 @@ class TaxonomyTagForm
         list_of_taxons << content_id if selected_taxons.include?(content_id)
       end
     end
+  end
+
+private
+
+  def govuk_taxonomy
+    @_taxonomy ||= Taxonomy::GovukTaxonomy.new
   end
 end

--- a/app/services/edition_taxon_link_patcher.rb
+++ b/app/services/edition_taxon_link_patcher.rb
@@ -1,0 +1,32 @@
+class EditionTaxonLinkPatcher
+  def call(content_id:, previous_version:, selected_taxons:, invisible_taxons:)
+    Services
+      .publishing_api
+      .patch_links(
+        content_id,
+        links: { taxons: most_specific_taxons(selected_taxons) + invisible_taxons },
+        previous_version: previous_version
+      )
+  end
+
+private
+
+  def most_specific_taxons(selected_taxons)
+    all_taxons.each_with_object([]) do |taxon, list_of_taxons|
+      content_ids = taxon.descendants.map(&:content_id)
+
+      any_descendants_selected = selected_taxons.any? do |selected_taxon|
+        content_ids.include?(selected_taxon)
+      end
+
+      unless any_descendants_selected
+        content_id = taxon.content_id
+        list_of_taxons << content_id if selected_taxons.include?(content_id)
+      end
+    end
+  end
+
+  def all_taxons
+    Taxonomy::GovukTaxonomy.new.all_taxons
+  end
+end

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -20,13 +20,13 @@
         data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { form: @tag_form, root_taxons: @govuk_taxonomy.children } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.children } %>
 
         <h2>Draft topics</h2>
 
         <p>These topic pages are in development, and are not shown on GOV.UK</p>
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { form: @tag_form, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
       </div>
 
       <p>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -29,6 +29,7 @@
         <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
       </div>
 
+      <%= form.hidden_field "invisible_draft_taxons", value: @tag_form.invisible_draft_taxons.join(",") %>
       <p>
         <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
       </p>

--- a/app/views/admin/shared/tagging/_sub_taxons.html.erb
+++ b/app/views/admin/shared/tagging/_sub_taxons.html.erb
@@ -2,14 +2,14 @@
 <% taxons.each do |taxon| %>
   <p>
     <label>
-      <%= checkbox_for_taxonomy(@tag_form.selected_taxons, taxon) %>
+      <%= checkbox_for_taxonomy(selected_taxons, taxon) %>
       <span><%= taxon.name %></span>
     </label>
   </p>
 
   <% if taxon.children.present? %>
     <%= render partial: "/admin/shared/tagging/sub_taxons",
-          locals: { form: form, taxons: taxon.children } %>
+          locals: { selected_taxons: selected_taxons, taxons: taxon.children } %>
   <% end %>
 <% end %>
 </div>

--- a/app/views/admin/shared/tagging/_taxonomy.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy.html.erb
@@ -2,13 +2,13 @@
   <% root_taxon = TopicTreePresenter.new(root_taxon, collapsed: root_taxons.size > 1) %>
 
   <% if root_taxon.children.empty? %>
-    <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { form: @tag_form, taxons: [root_taxon] } %>
+    <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: [root_taxon] } %>
   <% else %>
     <div class="topic-tree">
       <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'></span><%= root_taxon.name %></a>
 
       <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
-        <%= render partial: "/admin/shared/tagging/sub_taxons", locals: {form: @tag_form, taxons: root_taxon.children } %>
+        <%= render partial: "/admin/shared/tagging/sub_taxons", locals: {selected_taxons: selected_taxons, taxons: root_taxon.children } %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -20,13 +20,13 @@
         data-content-format="statistics_announcement"
         data-content-public-path="<%= @statistics_announcement.public_path %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { form: @tag_form, root_taxons: @govuk_taxonomy.children } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.children } %>
 
         <h2>Draft topics</h2>
 
         <p>These topic pages are in development, and are not shown on GOV.UK</p>
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { form: @tag_form, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
       </div>
 
       <p>

--- a/lib/taxonomy/govuk_taxonomy.rb
+++ b/lib/taxonomy/govuk_taxonomy.rb
@@ -21,10 +21,38 @@ module Taxonomy
       @_all_taxons ||= children.flat_map(&:tree) + draft_child_taxons.flat_map(&:tree)
     end
 
+    def matching_against_published_taxons(taxons)
+      @_published_taxons ||= matching_against_taxonomy_branches(taxons, children)
+    end
+
+    def matching_against_visible_draft_taxons(taxons)
+      @_draft_visible_taxons ||= matching_against_taxonomy_branches(taxons, draft_child_taxons)
+    end
+
   private
 
     def build_tree(taxon_hash)
       @tree_builder_class.new(taxon_hash).root_taxon
+    end
+
+    def matching_against_taxonomy_branches(taxons, taxonomy_branches)
+      taxonomy_branches.flat_map do |branch|
+        filter_against_taxonomy_branch(taxons, branch)
+      end
+    end
+
+    def filter_against_taxonomy_branch(selected_taxons_content_ids, taxon)
+      matched_taxons = []
+
+      if selected_taxons_content_ids.include?(taxon.content_id)
+        matched_taxons << taxon.content_id
+      end
+
+      taxon.children.each do |child_taxon_branch|
+        matched_taxons.concat(filter_against_taxonomy_branch(selected_taxons_content_ids, child_taxon_branch))
+      end
+
+      matched_taxons
     end
   end
 end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -15,6 +15,10 @@ module TaxonomyHelper
     "child"
   end
 
+  def draft_taxon_1_content_id
+    "draft_taxon_1"
+  end
+
   def grandparent_taxon_content_id
     "grandparent"
   end
@@ -94,7 +98,7 @@ private
     {
       "title" => "About your organisation",
       "base_path" => "/about-your-organisation",
-      "content_id" => "draft_taxon_1",
+      "content_id" => draft_taxon_1_content_id,
       "expanded_links_hash" => {
         "expanded_links" => {
           "child_taxons" => []

--- a/test/unit/models/taxonomy_tag_form_test.rb
+++ b/test/unit/models/taxonomy_tag_form_test.rb
@@ -40,25 +40,6 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
     assert_equal(form.previous_version, 1)
   end
 
-  test '#most_specific_taxons ignores taxons if there is a more specific one' do
-    stub_taxonomy_with_all_taxons
-
-    selected_taxons = [
-      grandparent_taxon_content_id,
-      parent_taxon_content_id,
-      child_taxon_content_id
-    ]
-
-    form = TaxonomyTagForm.new(
-      selected_taxons: selected_taxons,
-      content_id: "abc",
-      previous_version: 1,
-      all_taxons: Taxonomy::GovukTaxonomy.new.all_taxons
-    )
-
-    assert_equal [child_taxon_content_id], form.most_specific_taxons
-  end
-
   test '#published_taxons returns all published taxons tagged to the content item' do
     content_id = "64aadc14-9bca-40d9-abb6-4f21f9792a05"
 

--- a/test/unit/services/edition_taxon_link_patcher_test.rb
+++ b/test/unit/services/edition_taxon_link_patcher_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class EditionTaxonLinkPatcherTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
+  test 'sends patch links request to publishing api' do
+    stub_taxonomy_with_all_taxons
+
+    EditionTaxonLinkPatcher.new.call(
+      content_id: "1234",
+      selected_taxons: [child_taxon_content_id],
+      invisible_taxons: [],
+      previous_version: "2",
+    )
+
+    assert_publishing_api_patch_links(
+      "1234",
+      links: {
+        taxons: [child_taxon_content_id]
+      },
+      previous_version: "2"
+    )
+  end
+
+  test 'ignores taxons if there is a more specific one' do
+    stub_taxonomy_with_all_taxons
+
+    EditionTaxonLinkPatcher.new.call(
+      content_id: "1234",
+      selected_taxons: [
+        grandparent_taxon_content_id,
+        parent_taxon_content_id,
+        child_taxon_content_id
+      ],
+      invisible_taxons: [],
+      previous_version: "2",
+    )
+
+    assert_publishing_api_patch_links(
+      "1234",
+      links: {
+        taxons: [child_taxon_content_id]
+      },
+      previous_version: "2"
+    )
+  end
+end

--- a/test/unit/taxonomy/govuk_taxonomy_test.rb
+++ b/test/unit/taxonomy/govuk_taxonomy_test.rb
@@ -29,4 +29,78 @@ class Taxonomy::GovukTaxonomyTest < ActiveSupport::TestCase
     result = @subject.all_taxons
     assert_equal result, [:root_taxon, :root_taxon, :root_taxon, :root_taxon]
   end
+
+  test "#matching_against_published_taxons returns taxon content ids found in branch" do
+    taxon_hash = {
+      "base_path" => "/root-path",
+      "content_id" => "root-taxon-in-tree",
+      "title" => "I am the root taxon.",
+      "expanded_links_hash" => {
+        "expanded_links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/child-path-one",
+              "content_id" => "child-taxon-in-tree",
+              "title" => "I am one child taxon.",
+              "links" => {
+                "child_taxons" => [
+                  {
+                    "base_path" => "/grand-child-path",
+                    "content_id" => "grand-child-taxon-in-tree",
+                    "title" => "I am the grand child taxon.",
+                    "links" => {},
+                  }
+                ]
+              }
+            },
+          ]
+        }
+      }
+    }
+
+    @subject
+      .stubs(:children)
+      .returns([Taxonomy::Tree.new(taxon_hash).root_taxon])
+
+    taxons = ['grand-child-taxon-in-tree', 'taxon-not-in-tree']
+
+    assert_equal ['grand-child-taxon-in-tree'], @subject.matching_against_published_taxons(taxons)
+  end
+
+  test "#matching_against_visible_draft_taxons returns taxon content ids found in branch" do
+    taxon_hash = {
+      "base_path" => "/draft-root-path",
+      "content_id" => "root-taxon-in-tree",
+      "title" => "I am the root draft taxon.",
+      "expanded_links_hash" => {
+        "expanded_links" => {
+          "child_taxons" => [
+            {
+              "base_path" => "/draft-child-path-one",
+              "content_id" => "draft-child-taxon-in-tree",
+              "title" => "I am one child draft taxon.",
+              "links" => {
+                "child_taxons" => [
+                  {
+                    "base_path" => "draft-grand-child-path",
+                    "content_id" => "draft-grand-child-taxon-in-tree",
+                    "title" => "I am the grand child draft taxon.",
+                    "links" => {},
+                  }
+                ]
+              }
+            },
+          ]
+        }
+      }
+    }
+
+    @subject
+      .stubs(:draft_child_taxons)
+      .returns([Taxonomy::Tree.new(taxon_hash).root_taxon])
+
+    taxons = ['draft-grand-child-taxon-in-tree', 'draft-taxon-not-in-tree']
+
+    assert_equal ['draft-grand-child-taxon-in-tree'], @subject.matching_against_visible_draft_taxons(taxons)
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/MNOyFuby/186-fix-whitehall-admin-ui-overwrites-draft-links-when-editing-taxon-tagging

Fixes the problem that invisible taxons that were tagged to content (eg from legacy taxonomies) would be overwritten when a publisher edits the taxon taggings for a piece of content.

The commits doing most of the work are https://github.com/alphagov/whitehall/pull/3564/commits/71af956f5784d178d24993776c084908b618544f and https://github.com/alphagov/whitehall/pull/3564/commits/817cb69f8dea4bc20faee79ad0379b095e6804ea. Essentially we compare the content item's tagged taxons to all taxons from the govuk taxonomy. By filtering out the matching published and visible draft taxons, the remainder makes up the invisible draft taxons (this doesn't seem ideal, but currently we have no other way of determining the 'state' (published/visible draft/invisible draft) of a content item's taxons). Finally we add the list of invisible taxon content ids to the edit tag form via a hidden field, and add those links to the final payload before the patch links call gets made to the PublishingAPI.