### PR TITLE
Add a migration to rename digital-academy policy group

### DIFF
--- a/db/data_migration/20171128105848_rename_gds_academy_slug.rb
+++ b/db/data_migration/20171128105848_rename_gds_academy_slug.rb
@@ -1,0 +1,13 @@
+old_slug = "digital-academy"
+new_slug = "gds-academy"
+
+group = PolicyGroup.find_by!(slug: old_slug)
+
+Whitehall::SearchIndex.delete(group)
+
+group.update_attributes!(slug: new_slug)
+
+Whitehall::PublishingApi.republish_async(group)
+Whitehall::SearchIndex.add(group)
+
+puts "#{old_slug} -> #{new_slug}"


### PR DESCRIPTION
It has been requested that this is renamed to gds-academy.

[Trello Card](https://trello.com/c/TVPSMD6O/397-changing-slug-for-gds-academy)