### PR TITLE
Add broken link fix on hover

### DIFF
--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -19,7 +19,7 @@
       <p>We’ve found links in this document that may be broken:</p>
       <ul>
         <% report.broken_links.each do |link| %>
-          <li><%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %></li>
+          <li><%= link_to link.uri.truncate(50), link.uri, title: link.suggested_fix, class: 'link-inherit' %></li>
         <% end %>
       </ul>
       <%= render 'admin/link_check_reports/form', reportable: report.link_reportable, button_text: 'Check again' %>


### PR DESCRIPTION
This adds the suggested fix for the broken link when hovering over a broken link in the Whitehall edition link checker. This is to help speed up the process of fixing links by providing the user with a faster way of finding the current issue