### PR TITLE
[DO NOT MERGE] Spike content review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'activemodel-serializers-xml'
 gem 'deprecated_columns', '~> 0.1.1'
 gem 'record_tag_helper', '~> 1.0'
 gem 'govuk_ab_testing', '~> 2.4x'
+gem 'rest-client'
 
 if ENV['GDS_API_ADAPTERS_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,7 @@ DEPENDENCIES
   record_tag_helper (~> 1.0)
   redis-namespace
   responders (~> 2.4)
+  rest-client
   rinku
   ruby-prof
   ruby-progressbar
@@ -603,4 +604,4 @@ DEPENDENCIES
   whenever (~> 0.9.7)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/assets/stylesheets/admin/views/_edition_show.scss
+++ b/app/assets/stylesheets/admin/views/_edition_show.scss
@@ -19,4 +19,9 @@
       margin-bottom: 8px;
     }
   }
+
+  .review-by-date-section {
+    margin: 40px 0 20px;
+    border-bottom: 1px solid #eee;
+  }
 }

--- a/app/controllers/admin/content_reviews_controller.rb
+++ b/app/controllers/admin/content_reviews_controller.rb
@@ -1,0 +1,18 @@
+class Admin::ContentReviewsController < Admin::BaseController
+  def update
+    @review_by_date = Date.parse(params[:review_by].values.join("-"))
+
+    response = RestClient.patch("http://127.0.0.1:3206/content/reviews", review_by: @review_by_date, content_id: params[:content_id])
+
+    data = JSON.parse(response.body)
+
+    @review_by_date = Date.parse(data['review_by'])
+
+    edition = Edition.find(params[:id])
+    @edition = LocalisedModel.new(edition, edition.primary_locale)
+
+    respond_to do |format|
+      format.js { render template: "admin/update" }
+    end
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,7 +3,33 @@ class Admin::DashboardController < Admin::BaseController
   def index
     if current_user.organisation
       @draft_documents = Edition.authored_by(current_user).where(state: 'draft').includes(:translations, :versions).in_reverse_chronological_order
+      @reviewables = fetch_reviewable
       @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5)
     end
+  end
+
+private
+
+  def fetch_reviewable
+    response = RestClient.get("http://127.0.0.1:3206/content/reviews")
+    build_links(JSON.parse(response.body))
+  end
+
+  def build_links(results)
+    return nil unless results
+
+    items = []
+    results.each do |result|
+      item = Document.find_by(content_id: result["content_id"])
+
+      reviewable_item = OpenStruct.new
+      reviewable_item.title = result["title"]
+      reviewable_item.review_by = result["review_by"]
+      reviewable_item.edition = item.editions.last
+
+      items << reviewable_item
+    end
+
+    items
   end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -28,12 +28,29 @@
 </div>
 
 <div class="row">
-  <div class="col-md-6 draft-documents">
+  <div class="col-md-4 draft-documents">
     <h2>My draft documents</h2>
     <%= render partial: 'document_table', locals: { documents: @draft_documents, title: 'draft documents' } %>
   </div>
+  <div class="col-md-4">
+    <h2>Documents to review</h2>
+    <ol class="document-list list-unstyled">
+      <% @reviewables.each do |reviewable| %>
+        <li class="document-row">
+          <h3 class="add-label-margin">
+            <%= link_to reviewable.title, admin_edition_path(reviewable.edition, review_by: reviewable.review_by) %>
+          </h3>
+          <ul class="attributes list-unstyled list-inline text-muted">
+            <li class="type">
+              Expiring: <%= reviewable.review_by.to_date.to_s(:rfc822) %>
+            </li>
+          </ul>
+        </li>
+      <% end %>
+    </ol>
+  </div>
   <% if current_user.organisation %>
-    <div class="col-md-6 force-published-documents">
+    <div class="col-md-4 force-published-documents">
       <h2>
         <%= organisation_acronym_or_name(current_user.organisation) %>’s
         force-published documents

--- a/app/views/admin/editions/_review_date.html.erb
+++ b/app/views/admin/editions/_review_date.html.erb
@@ -2,6 +2,6 @@
   <%= form_tag admin_content_review_path(content_id: @edition.content_id), method: :patch, remote: true do %>
       <%= label_tag :review_by, "Set review by date:" %>
       <%= select_date @review_by_date.present? ? @review_by_date : Date.parse(params[:review_by]), prefix: :review_by %>
-      <%= submit_tag "Update review date", id: "update-review" %>
+      <%= submit_tag "Update review date", id: "update-review", class: "btn btn-default btn-lg add-left-margin" %>
   <% end %>
 </div>

--- a/app/views/admin/editions/_review_date.html.erb
+++ b/app/views/admin/editions/_review_date.html.erb
@@ -1,0 +1,7 @@
+<div id="review-date">
+  <%= form_tag admin_content_review_path(content_id: @edition.content_id), method: :patch, remote: true do %>
+      <%= label_tag :review_by, "Set review by date:" %>
+      <%= select_date @review_by_date.present? ? @review_by_date : Date.parse(params[:review_by]), prefix: :review_by %>
+      <%= submit_tag "Update review date", id: "update-review" %>
+  <% end %>
+</div>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -26,6 +26,7 @@
 <%= render partial: "rejected_by", locals: { edition: @edition } %>
 <%= render partial: 'alerts', locals: {edition: @edition}  %>
 
+<%= render partial: 'review_date' %>
 <%= render 'edition_view_edit_buttons' %>
 
 <% if @edition.change_note_required? %>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -26,7 +26,9 @@
 <%= render partial: "rejected_by", locals: { edition: @edition } %>
 <%= render partial: 'alerts', locals: {edition: @edition}  %>
 
-<%= render partial: 'review_date' %>
+<section class="review-by-date-section">
+  <%= render partial: 'review_date' %>
+</section>
 <%= render 'edition_view_edit_buttons' %>
 
 <% if @edition.change_note_required? %>

--- a/app/views/admin/update.js.erb
+++ b/app/views/admin/update.js.erb
@@ -1,0 +1,1 @@
+$("#review-date").html("<%= j render(partial: 'admin/editions/review_date') %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,6 +336,7 @@ Whitehall::Application.routes.draw do
         resources :suggestions, only: [:index]
 
         resources :publications, except: [:index]
+        resources :content_reviews
 
         get "/policies/:policy_id/topics" => "policies#topics"
 


### PR DESCRIPTION
This is a proof of concept prototype and must not be merged into master!

Shows a list of content items needing review (review by date expiring
in the next 7 days). Then links through to allow you update that
review date. All review date data is stored in the Content
Performance Manager.

And link to the edit functions for each item. This is part of a spike to
prototype "life expectancy" of content.

This goes with this PR in Content Performance Manager: https://github.com/alphagov/content-performance-manager/pull/413