### PR TITLE
Add link fix below broken link

### DIFF
--- a/app/assets/stylesheets/admin/helpers/_broken_links_report.scss
+++ b/app/assets/stylesheets/admin/helpers/_broken_links_report.scss
@@ -5,3 +5,45 @@
     }
   }
 }
+
+.broken-links-report {
+  .issue-summary {
+    font-weight: normal;
+  }
+
+  .issue-list {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-top: 5px;
+    }
+  }
+
+  .issue-status-description {
+    margin-top: 10px;
+  }
+
+  .issue-list + .issue-status-description {
+    margin: 15px 0;
+  }
+
+  .display-issue-details {
+    display: block;
+    font-weight: bold;
+    padding-top: 5px;
+  }
+
+  .display-issue-details::-webkit-details-marker {
+    display: none;
+  }
+
+  .display-issue-details::before {
+    content: '\25B6';
+    padding-right: 3px;  
+  }
+
+  details[open] > .display-issue-details::before {
+    content: '\25BC';
+  }
+}

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -13,15 +13,27 @@
                   class: 'js-broken-links-refresh js-hidden',
                   remote: true %>
     </section>
-  <% elsif report.broken_links.present? %>
+  <% elsif report.broken_links.any? || report.caution_links.any? %>
     <section class="alert alert-warning">
-      <h3 class="remove-top-margin">Broken links</h3>
-      <p>We’ve found links in this document that may be broken:</p>
-      <ul>
-        <% report.broken_links.each do |link| %>
-          <li><%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %></li>
-        <% end %>
-      </ul>
+      <h3 class="remove-top-margin"><%= t "broken_links.title" %></h3>
+      <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
+        <% next unless %w(broken caution).include? status %>
+        <p class="issue-status-description"><%= t "broken_links.#{status}.subheading" %></p>
+        <ul class="issue-list">
+          <% links.each do |link| %>
+            <li>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %>
+              <details>
+                <summary class="display-issue-details">See more details about this link</summary>
+                <p class="issue-summary"><%= link.problem_summary %></p>
+                <% if link.suggested_fix %>
+                  <p class="issue-summary">Suggested fix: <%= link.suggested_fix %></p>
+                <% end %>
+              </details>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
       <%= render 'admin/link_check_reports/form', reportable: report.link_reportable, button_text: 'Check again' %>
     </section>
   <% else %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -471,6 +471,12 @@ ar:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -60,6 +60,12 @@ az:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -369,6 +369,12 @@ be:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -271,6 +271,12 @@ bg:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -265,6 +265,12 @@ bn:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -320,6 +320,12 @@ cs:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -472,6 +472,12 @@ cy:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history: Hanes
     published_at:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -268,6 +268,12 @@ de:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -267,6 +267,12 @@ dr:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -269,6 +269,12 @@ el:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -486,3 +486,9 @@ en:
     transparency: See all our transparency data
     written_statement: See all our written statements to Parliament
     authored_article: See all our authored articles
+  broken_links:
+    title: Broken links
+    broken: 
+      subheading: We’ve found links in this document that may be broken
+    caution:
+      subheading: We’ve found some issues with links that may indicate problems, you should apply caution in linking to them

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -268,6 +268,12 @@ es-419:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -268,6 +268,12 @@ es:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -269,6 +269,12 @@ et:
       help_html: See fail on <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a>
         formaadis
     see_more: 'Loe lähemalt: %{document_type}'
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history: Ajalugu
     published_at: Esmane publikatsioon

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -62,6 +62,12 @@ fa:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -268,6 +268,12 @@ fr:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history: Historique de page
     published_at:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -370,6 +370,12 @@ he:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -268,6 +268,12 @@ hi:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -63,6 +63,12 @@ hu:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -268,6 +268,12 @@ hy:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -62,6 +62,12 @@ id:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -268,6 +268,12 @@ it:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,12 @@ ja:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -60,6 +60,12 @@ ka:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -61,6 +61,12 @@ ko:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -318,6 +318,12 @@ lt:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -267,6 +267,12 @@ lv:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -60,6 +60,12 @@ ms:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -371,6 +371,12 @@ pl:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -267,6 +267,12 @@ ps:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -267,6 +267,12 @@ pt:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -318,6 +318,12 @@ ro:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -368,6 +368,12 @@ ru:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -267,6 +267,12 @@ si:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -316,6 +316,12 @@ sk:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -269,6 +269,12 @@ so:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -268,6 +268,12 @@ sq:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -370,6 +370,12 @@ sr:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -265,6 +265,12 @@ sw:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -269,6 +269,12 @@ ta:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -61,6 +61,12 @@ th:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -265,6 +265,12 @@ tk:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -62,6 +62,12 @@ tr:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -369,6 +369,12 @@ uk:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -268,6 +268,12 @@ ur:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -267,6 +267,12 @@ uz:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -62,6 +62,12 @@ vi:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -60,6 +60,12 @@ zh-hk:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -60,6 +60,12 @@ zh-tw:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -60,6 +60,12 @@ zh:
     opendocument:
       help_html:
     see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
   change_notes:
     page_history:
     published_at:


### PR DESCRIPTION
This separates links based on status: broken or caution. It adds the suggested fix as an expansion below the link in the Whitehall edition link checker. This is to help speed up the process of fixing links by providing the user with a faster way of finding the current issue. 

<img width="378" alt="screen shot 2017-12-04 at 16 00 35" src="https://user-images.githubusercontent.com/15086186/33562126-509278e4-d90c-11e7-9039-6a37559d7f9a.png">

