### PR TITLE
Remove deleted doc from yardopts

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---private --protected app/**/*.rb lib/**/*.rb - docs/misc/inside-government-i18n-notes.md docs/misc/guidelines-for-translators.md
+--private --protected app/**/*.rb lib/**/*.rb - docs/misc/guidelines-for-translators.md


### PR DESCRIPTION
This commit removes a reference to `inside-government-i18n-notes.md`, which was deleted in a previous commit.