### PR TITLE
Dont show hidden taxons on edition show page

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -73,7 +73,7 @@ class Admin::EditionsController < Admin::BaseController
     fetch_version_and_remark_trails
 
     if @edition.can_be_tagged_to_taxonomy?
-      @expanded_links = ExpandedLinksFetcher.new(@edition.content_id).fetch
+      @edition_taxon_links = EditionTaxonsFetcher.new(@edition.content_id).fetch
     end
   end
 

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -10,7 +10,7 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
 
   def show
     if @statistics_announcement.can_be_tagged_to_taxonomy?
-      @expanded_links = ExpandedLinksFetcher.new(@statistics_announcement.content_id).fetch
+      @edition_taxon_links = EditionTaxonsFetcher.new(@statistics_announcement.content_id).fetch
     end
   end
 

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -1,4 +1,4 @@
-class ExpandedLinksFetcher
+class EditionTaxonsFetcher
   attr_accessor :content_id
 
   def initialize(content_id)

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -9,7 +9,6 @@ class EditionTaxonsFetcher
     ExpandedLinks.new(
       Services.publishing_api.get_expanded_links(content_id)
     )
-
   rescue GdsApi::HTTPNotFound
     MissingExpandedLinks.new
   end
@@ -29,16 +28,42 @@ class EditionTaxonsFetcher
     end
 
     def selected_taxon_paths
-      response["expanded_links"].fetch("taxons", []).map { |taxon_hash| taxon_path(taxon_hash) }
+      visible_taxon_links.map { |taxon_hash| taxon_path(taxon_hash) }
     end
 
   private
 
     attr_reader :response
 
+    def visible_taxon_links
+      taxon_links.select do |taxon_link|
+        published_taxon_content_ids.include?(taxon_link["content_id"]) ||
+          visible_draft_taxon_content_ids.include?(taxon_link["content_id"])
+      end
+    end
+
+    def taxon_links
+      response["expanded_links"].fetch("taxons", [])
+    end
+
+    def published_taxon_content_ids
+      govuk_taxonomy.matching_against_published_taxons(taxon_content_ids)
+    end
+
+    def visible_draft_taxon_content_ids
+      govuk_taxonomy.matching_against_visible_draft_taxons(taxon_content_ids)
+    end
+
+    def taxon_content_ids
+      taxon_links.map { |t| t["content_id"] }
+    end
+
+    def govuk_taxonomy
+      Taxonomy::GovukTaxonomy.new
+    end
+
     def taxon_path(taxon_hash)
       parents = [{ title: taxon_hash["title"] }]
-
 
       direct_parents = taxon_hash["links"]["parent_taxons"]
       while direct_parents

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -48,7 +48,7 @@
 <% if @edition.can_be_tagged_to_taxonomy? %>
   <%= render partial: '/admin/shared/tagging/show_topics_box', locals: {
     path_to_edit_tags: edit_admin_edition_tags_path(@edition.id),
-    selected_taxon_paths: @expanded_links.selected_taxon_paths,
+    selected_taxon_paths: @edition_taxon_links.selected_taxon_paths,
     no_topics_message: 'No topics - please add a topic before publishing'
   } %>
 <% end %>

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -73,7 +73,7 @@
     <% if @statistics_announcement.can_be_tagged_to_taxonomy? %>
       <%= render partial: '/admin/shared/tagging/show_topics_box', locals: {
         path_to_edit_tags: edit_admin_statistics_announcement_tags_path(@statistics_announcement.id),
-        selected_taxon_paths: @expanded_links.selected_taxon_paths,
+        selected_taxon_paths: @edition_taxon_links.selected_taxon_paths,
         no_topics_message: 'No topics - please add a topic'
       } %>
     <% end %>

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Admin::PublicationsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
+
   setup do
     @organisation = create(:organisation)
     @user = create(:writer, organisation: @organisation)
@@ -208,11 +210,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     login_as(create(:user, organisation: sfa_organisation))
 
     publication_has_expanded_links(publication.content_id)
-
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_published_taxons)
-      .with(["aaaa"])
-      .returns(["aaaa"])
+    stub_govuk_taxonomy_matching_published_taxons(["aaaa"], ["aaaa"])
 
     get :show, params: { id: publication }
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -48,12 +48,11 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   test 'POST :create with an statistics announcement id assigns the publication to the announcement' do
     statistics_announcement = create(:statistics_announcement)
     post :create, params: {
-edition: controller_attributes_for(:publication,
-      publication_type_id: PublicationType::OfficialStatistics.id,
-      lead_organisation_ids: [@organisation.id],
-      statistics_announcement_id: statistics_announcement.id
-    )
-}
+      edition: controller_attributes_for(:publication,
+        publication_type_id: PublicationType::OfficialStatistics.id,
+        lead_organisation_ids: [@organisation.id],
+        statistics_announcement_id: statistics_announcement.id)
+    }
 
     publication = Publication.last
     assert publication.present?, assigns(:edition).errors.full_messages.inspect
@@ -63,11 +62,10 @@ edition: controller_attributes_for(:publication,
 
   test "create should create a new publication" do
     post :create, params: {
-edition: controller_attributes_for(:publication,
-      first_published_at: Time.zone.parse("2001-10-21 00:00:00"),
-      publication_type_id: PublicationType::ResearchAndAnalysis.id
-    )
-}
+      edition: controller_attributes_for(:publication,
+        first_published_at: Time.zone.parse("2001-10-21 00:00:00"),
+        publication_type_id: PublicationType::ResearchAndAnalysis.id)
+    }
 
     created_publication = Publication.last
     assert_equal Time.zone.parse("2001-10-21 00:00:00"), created_publication.first_published_at
@@ -210,6 +208,12 @@ edition: controller_attributes_for(:publication,
     login_as(create(:user, organisation: sfa_organisation))
 
     publication_has_expanded_links(publication.content_id)
+
+    Taxonomy::GovukTaxonomy
+      .any_instance.stubs(:matching_against_published_taxons)
+      .with(["aaaa"])
+      .returns(["aaaa"])
+
     get :show, params: { id: publication }
 
     refute_select '.taxonomy-topics .no-content'
@@ -233,10 +237,12 @@ edition: controller_attributes_for(:publication,
         "taxons" => [
           {
             "title" => "Primary Education",
+            "content_id" => "aaaa",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => "Education, Training and Skills",
+                  "content_id" => "bbbb",
                   "links" => {}
                 }
               ]

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
+
   setup do
     @organisation = create(:organisation)
     @user = login_as create(:gds_editor, organisation: @organisation)
@@ -181,11 +183,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     login_as(create(:user, organisation: sfa_organisation))
 
     announcement_has_expanded_links(announcement.content_id)
-
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_published_taxons)
-      .with(["aaaa"])
-      .returns(["aaaa"])
+    stub_govuk_taxonomy_matching_published_taxons(["aaaa"], ["aaaa"])
 
     get :show, params: { id: announcement }
 

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -181,6 +181,12 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     login_as(create(:user, organisation: sfa_organisation))
 
     announcement_has_expanded_links(announcement.content_id)
+
+    Taxonomy::GovukTaxonomy
+      .any_instance.stubs(:matching_against_published_taxons)
+      .with(["aaaa"])
+      .returns(["aaaa"])
+
     get :show, params: { id: announcement }
 
     refute_select '.taxonomy-topics .no-content'
@@ -204,10 +210,12 @@ private
         "taxons" => [
           {
             "title" => "Primary Education",
+            "content_id" => "aaaa",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => "Education, Training and Skills",
+                  "content_id" => "bbbb",
                   "links" => {}
                 }
               ]

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -42,6 +42,20 @@ module TaxonomyHelper
       .returns(JSON.dump(taxons))
   end
 
+  def stub_govuk_taxonomy_matching_published_taxons(taxon_content_ids, matched_taxon_content_ids)
+    Taxonomy::GovukTaxonomy
+      .any_instance.stubs(:matching_against_published_taxons)
+      .with(taxon_content_ids)
+      .returns(matched_taxon_content_ids)
+  end
+
+  def stub_govuk_taxonomy_matching_visible_draft_taxons(taxon_content_ids, matched_taxon_content_ids)
+    Taxonomy::GovukTaxonomy
+      .any_instance.stubs(:matching_against_visible_draft_taxons)
+      .with(taxon_content_ids)
+      .returns(matched_taxon_content_ids)
+  end
+
 private
 
   def redis_client

--- a/test/unit/models/taxonomy_tag_form_test.rb
+++ b/test/unit/models/taxonomy_tag_form_test.rb
@@ -50,11 +50,7 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
       },
       "version" => 1
     )
-
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_published_taxons)
-      .with(%w[bbbb cccc])
-      .returns(['bbbb'])
+    stub_govuk_taxonomy_matching_published_taxons(%w[bbbb cccc], ['bbbb'])
 
     form = TaxonomyTagForm.load(content_id)
     assert_equal ['bbbb'], form.published_taxons
@@ -70,11 +66,7 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
       },
       "version" => 1
     )
-
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_visible_draft_taxons)
-      .with(%w[bbbb cccc])
-      .returns(['cccc'])
+    stub_govuk_taxonomy_matching_visible_draft_taxons(%w[bbbb cccc], ['cccc'])
 
     form = TaxonomyTagForm.load(content_id)
     assert_equal ['cccc'], form.visible_draft_taxons

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class EditionTaxonsFetcherTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
   test "it returns '[]' if there are no expanded_links" do
     content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
 
@@ -271,19 +273,5 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     ]
 
     assert_equal expected_taxon_paths, links_fetcher.fetch.selected_taxon_paths
-  end
-
-  def stub_govuk_taxonomy_matching_published_taxons(taxon_content_ids, matched_taxon_content_ids)
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_published_taxons)
-      .with(taxon_content_ids)
-      .returns(matched_taxon_content_ids)
-  end
-
-  def stub_govuk_taxonomy_matching_visible_draft_taxons(taxon_content_ids, matched_taxon_content_ids)
-    Taxonomy::GovukTaxonomy
-      .any_instance.stubs(:matching_against_visible_draft_taxons)
-      .with(taxon_content_ids)
-      .returns(matched_taxon_content_ids)
   end
 end

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ExpandedLinksFetcherTest < ActiveSupport::TestCase
+class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   test "it returns '[]' if there are no expanded_links" do
     content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
 
@@ -14,7 +14,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
     stub_request(:get, %r{.*/v2/expanded-links/#{content_id}.*})
       .to_return(body: body, status: 404)
 
-    links_fetcher = ExpandedLinksFetcher.new(content_id)
+    links_fetcher = EditionTaxonsFetcher.new(content_id)
 
     assert_equal links_fetcher.fetch.selected_taxon_paths, []
   end
@@ -25,7 +25,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       expanded_links:  {}
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal links_fetcher.fetch.selected_taxon_paths, []
   end
 
@@ -44,7 +44,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       }
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: title }]]
   end
 
@@ -71,7 +71,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       }
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_title }, { title: title }]]
   end
 
@@ -104,7 +104,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       }
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: grandparent_title }, { title: parent_title }, { title: title }]]
   end
 
@@ -145,7 +145,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       }
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal(
       links_fetcher.fetch.selected_taxon_paths,
       [
@@ -183,7 +183,7 @@ class ExpandedLinksFetcherTest < ActiveSupport::TestCase
       }
     )
 
-    links_fetcher = ExpandedLinksFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
+    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_title_1 }, { title: title }]]
   end
 end


### PR DESCRIPTION
For https://trello.com/c/XCnd2ToE/185-investigate-and-fix-discrepancies-between-whitehall-admin-show-and-edit-taxon-pages

Only display visible taxons on the edition show page (ie published and visible draft taxons).

See individual commits for more information. For testing this out in the UI, I usually filter by the DfE organisation and document type of "detailed guide" (since the logic for when the taxonomy is shown is very specific).

The logic around taxons is still a bit scattered throughout the code base within this app, but any refactoring can be done after this PR gets merged.

## Screenshots

### Before

<img width="777" alt="screen shot 2017-11-30 at 10 54 35" src="https://user-images.githubusercontent.com/5112255/33427462-449d7acc-d5bd-11e7-80f3-d2ac496151f2.png">

### After

<img width="778" alt="screen shot 2017-11-30 at 10 54 41" src="https://user-images.githubusercontent.com/5112255/33427461-44842b3a-d5bd-11e7-8176-e51c76bd59c5.png">

