### PR TITLE
Change training environment to dev VM

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,8 +86,7 @@ Whitehall::Application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Send emails via SMTP if SMTP_PORT is set, otherwise send via SES
-  # This is mainly used for sending emails to MailHog in the training
-  # environment
+  # This is mainly used for sending emails to MailHog in the dev VM
   if ENV['SMTP_PORT']
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Since the training environment doesn't exist any more but this setting is also useful on the dev VM.