### PR TITLE
Stop notifying Rummager for Finder Format

### DIFF
--- a/app/services/publish_finder.rb
+++ b/app/services/publish_finder.rb
@@ -11,7 +11,6 @@ class PublishFinder
 
   def call
     send_to_publishing_api
-    send_to_rummager
   end
 
 private
@@ -22,25 +21,6 @@ private
       finder_content_item
     )
     Services.publishing_api.publish(content_id)
-  end
-
-  def send_to_rummager
-    index = Whitehall::SearchIndex.for(:government)
-    index.add(present_for_rummager)
-  end
-
-  def present_for_rummager
-    {
-      _id: finder_content_item.fetch("base_path"),
-      link: finder_content_item.fetch("base_path"),
-      format: "finder",
-      title: finder_content_item.fetch("title"),
-      description: finder_content_item.fetch("description", ""),
-      content_store_document_type: finder_content_item.fetch("document_type"),
-      content_id: content_id,
-      publishing_app: finder_content_item.fetch("publishing_app"),
-      rendering_app: finder_content_item.fetch("rendering_app"),
-    }
   end
 
   def content_id

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -2,7 +2,7 @@ class PublishStaticPages
   def publish
     index = Whitehall::SearchIndex.for(:government)
     pages.each do |page|
-      index.add(present_for_rummager(page))
+      index.add(present_for_rummager(page)) unless page[:document_type] == "finder"
 
       payload = present_for_publishing_api(page)
       Services.publishing_api.put_content(payload[:content_id], payload[:content])
@@ -81,7 +81,6 @@ class PublishStaticPages
         title: "All publications",
         document_type: "finder",
         description: "Find publications from across government including policy papers, consultations, statistics, research, transparency data and Freedom of Information responses.",
-        indexable_content: "Find publications from across government including policy papers, consultations, statistics, research, transparency data and Freedom of Information responses.",
         base_path: "/government/publications",
       },
       {
@@ -89,7 +88,6 @@ class PublishStaticPages
         title: "Statistics",
         document_type: "finder",
         description: "Find statistics publications from across government, including statistical releases, live data tables, and National Statistics.",
-        indexable_content: "Find statistics publications from across government, including statistical releases, live data tables, and National Statistics. statistics, live tables, live table, statistical release, stats",
         base_path: "/government/statistics",
       },
       {
@@ -97,7 +95,6 @@ class PublishStaticPages
         title: "Government announcements",
         document_type: "finder",
         description: "Find news articles, speeches and statements from government organisations",
-        indexable_content: "Find news articles, speeches and statements from government organisations news, press release, speech, press notice, statement, wms, oms",
         base_path: "/government/announcements",
       },
       {
@@ -105,7 +102,6 @@ class PublishStaticPages
         title: "Ministers",
         document_type: "finder",
         description: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business",
-        indexable_content: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business government, parliament, parliamentary, minister, ministers, mp, rt hon, right honourable, secretary of state, westminster, whitehall, house of commons, house of lords",
         base_path: "/government/ministers",
       },
       {
@@ -114,7 +110,6 @@ class PublishStaticPages
         base_path: "/world/embassies",
         document_type: "finder",
         description: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
-        indexable_content: "Contact details of British embassies, consulates, high commissions around the world for help with visas, passports and more.",
       },
       {
         content_id: "fde62e52-dfb6-42ae-b336-2c4faf068101",
@@ -122,7 +117,6 @@ class PublishStaticPages
         base_path: "/government/organisations",
         document_type: "finder",
         description: "Information from government departments, agencies and public bodies, including news, campaigns, policies and contact details.",
-        indexable_content: "Information from government departments, agencies and public bodies, including news, campaigns, policies and contact details.",
       },
     ]
   end

--- a/test/unit/services/publish_finder_test.rb
+++ b/test/unit/services/publish_finder_test.rb
@@ -6,7 +6,6 @@ class PublishFinderTest < ActiveSupport::TestCase
 
     publishing_api_has_lookups({})
     SecureRandom.stubs(:uuid).returns('a-content-id')
-    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
 
     PublishFinder.call(people_finder)
 
@@ -18,7 +17,6 @@ class PublishFinderTest < ActiveSupport::TestCase
     people_finder = JSON.parse(File.read("lib/finders/people.json"))
 
     publishing_api_has_lookups('/government/people' => 'existing-content-id')
-    Whitehall::FakeRummageableIndex.any_instance.expects(:add).at_least_once.with(kind_of(Hash))
 
     PublishFinder.call(people_finder)
 


### PR DESCRIPTION
We no longer need to publish Finders directly to Rummager as this is now done through the notification queue via the publishing API.

The static pages which publish finders include indexable content which the publishing API does not pass through to Rummager. Only 3 of those Finder static pages had different indexable content to the description (which is passed through to Rummager) so we have decided to use the description field for indexable content as that contains nearly all the words that people use to get to those pages:

news | /government/announcements | 819 | 41%
-- | -- | -- | --
announcements | /government/announcements | 284 | 76%
press release | /government/announcements | 56 | 27%
press releases | /government/announcements | 28 | 11%
press notices | /government/announcements | 11 | 33%
announce,mets | /government/announcements | 6 | 100%
news released | /government/announcements | 6 | 100%
white paper | /government/announcements | 6 | 1%
speech trafficking | /government/announcements | 6 | 100%
improving lives white paper | /government/announcements | 6 | 100%
minister | /government/ministers | 128 | 47%
fco ministers | /government/ministers | 33 | 59%
minister for education | /government/ministers | 11 | 50%
the minister | /government/ministers | 11 | 183%
what does a cabinet minister do | /government/ministers | 6 | 55%
business minister | /government/ministers | 6 | 35%
dclg ministers | /government/ministers | 6 | 100%
cabinet office ministers | /government/ministers | 6 | 55%
statistics | /government/statistics | 535 | 44%
statistic | /government/statistics | 45 | 54%
diabetes statistics | /government/statistics | 39 | 21%
national statistics | /government/statistics | 17 | 16%
malnutrition statistics | /government/statistics | 6 | 100%
prison release statistics | /government/statistics | 6 | 100%
statistical releases | /government/statistics | 6 | 100%

https://trello.com/c/4O39wiIg