### PR TITLE
Add a CSV generator service class for LinkCheckerReports

### DIFF
--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -1,0 +1,69 @@
+class LinkReporterCsvService
+  def initialize(reports_dir:, organisation:)
+    @organisation = organisation
+    @reports_dir = reports_dir
+  end
+
+  def generate
+    CSV.open(file_path, "w", encoding: "UTF-8") do |csv|
+      csv << headings
+      public_editions.each do |edition|
+        csv << row_for_edition(edition) if broken_links(edition).any?
+      end
+    end
+  end
+
+private
+
+  attr_reader :organisation, :reports_dir
+
+  def public_editions
+    Edition.publicly_visible.with_translations.in_organisation(organisation)
+  end
+
+  def file_path
+    reports_dir.join("#{@organisation.slug}_links_report.csv")
+  end
+
+  def headings
+    ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"]
+  end
+
+  def row_for_edition(edition)
+    [
+      public_url(edition),
+      admin_url(edition),
+      timestamp(edition),
+      edition.type,
+      broken_links(edition).size,
+      broken_links(edition).join("\r\n")
+    ]
+  end
+
+  def public_url(edition)
+    Whitehall.url_maker.public_document_url(edition, host: public_host, protocol: "https")
+  end
+
+  def admin_url(edition)
+    Whitehall.url_maker.admin_edition_url(edition, host: admin_host, protocol: "https")
+  end
+
+  def timestamp(edition)
+    edition.public_timestamp.to_s
+  end
+
+  def broken_links(edition)
+    return [] unless edition.link_check_reports.present?
+    edition.link_check_reports.last.broken_links.map(&:uri)
+  end
+
+  # These hosts are hardcoded because we run this on integration but want the
+  # generated URLs to be production ones.
+  def public_host
+    "www.gov.uk"
+  end
+
+  def admin_host
+    "whitehall-admin.publishing.service.gov.uk"
+  end
+end

--- a/test/factories/link_checker_api_report.rb
+++ b/test/factories/link_checker_api_report.rb
@@ -12,4 +12,18 @@ FactoryBot.define do
       ]
     end
   end
+
+  factory :link_checker_api_report_completed, class: LinkCheckerApiReport do
+    batch_id 1
+    status "completed"
+    link_reportable do
+      create(:draft_edition, body: "Includes a [link](http://www.example.com)")
+    end
+    links do
+      [
+        create(:link_checker_api_report_link, uri: "http://www.example.com", ordering: 0),
+        create(:link_checker_api_report_link, uri: "http://www.example.org", ordering: 0),
+      ]
+    end
+  end
 end

--- a/test/unit/services/link_reporter_csv_service_test.rb
+++ b/test/unit/services/link_reporter_csv_service_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+
+class LinkReporterCsvServiceTest < ActiveSupport::TestCase
+  setup do
+    Dir.mkdir(reports_dir) unless File.directory?(reports_dir)
+  end
+
+  teardown do
+    if File.directory?(reports_dir)
+      FileUtils.rm Dir.glob(reports_dir.join("*_links_report.csv"))
+    end
+  end
+
+  test "creates a new csv file with the correct headers" do
+    hmrc = create(:organisation, name: "HM Revenue & Customs")
+    LinkReporterCsvService.new(reports_dir: reports_dir, organisation: hmrc).generate
+
+    csv_test_file_path = reports_dir.join("hm-revenue-customs_links_report.csv")
+    assert File.exist?(csv_test_file_path)
+
+    expected_response = ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"]
+    actual_response = CSV.read(csv_test_file_path)
+    assert_equal expected_response, actual_response[0]
+  end
+
+  test "populates the CSV with details about the broken links per edition" do
+    hmrc = create(:organisation, name: "HM Revenue & Customs")
+    detailed_guide = create(:published_detailed_guide,
+                            lead_organisations: [hmrc],
+                            body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)")
+    publication = create(:published_publication,
+                         lead_organisations: [hmrc],
+                         body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)")
+
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
+    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+    another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+
+    create(:link_checker_api_report_completed, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link])
+    create(:link_checker_api_report_completed, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link])
+
+    LinkReporterCsvService.new(reports_dir: reports_dir, organisation: hmrc).generate
+    hmrc_csv = CSV.read(reports_dir.join("hm-revenue-customs_links_report.csv"))
+    assert_equal 3, hmrc_csv.size
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                  detailed_guide.public_timestamp.to_s,
+                  "DetailedGuide",
+                  "2",
+                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"], hmrc_csv[1]
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                  publication.public_timestamp.to_s,
+                  "Publication",
+                  "1",
+                  "https://www.gov.uk/another-bad-link"], hmrc_csv[2]
+  end
+
+  test "populates the csv only with details about broken links on editions associated with the specified organisation" do
+    hmrc = create(:organisation, name: "HM Revenue & Customs")
+    embassy_paris = create(:worldwide_organisation, name: "British Embassy Paris")
+    detailed_guide = create(:published_detailed_guide,
+                            lead_organisations: [hmrc],
+                            body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)")
+    publication = create(:published_publication,
+                         lead_organisations: [hmrc],
+                         body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)")
+    news_article = create(:world_location_news_article,
+                          :withdrawn,
+                          worldwide_organisations: [embassy_paris],
+                          body: "[Good link](https://www.gov.uk/good-link)\n[Missing page](https://www.gov.uk/missing-link)")
+
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
+    another_bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+    another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+
+    create(:link_checker_api_report, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link], status: "completed")
+    create(:link_checker_api_report, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link], status: "completed")
+    create(:link_checker_api_report, batch_id: 3, link_reportable: news_article, links: [good_link, missing_link], status: "completed")
+
+    LinkReporterCsvService.new(reports_dir: reports_dir, organisation: hmrc).generate
+    hmrc_csv = CSV.read(reports_dir.join("hm-revenue-customs_links_report.csv"))
+    refute File.file?(reports_dir.join("british-embassy-paris_links_report.csv"))
+    assert_equal 3, hmrc_csv.size
+  end
+
+  test "populates the csv only if there is a link check report for the edition" do
+    hmrc = create(:organisation, name: "HM Revenue & Customs")
+    detailed_guide = create(:published_detailed_guide,
+                            lead_organisations: [hmrc],
+                            body: "[Good](https://www.gov.uk/good-link)\n[broken link](https://www.gov.uk/bad-link)\n[Missing page](https://www.gov.uk/missing-link)")
+    publication = create(:published_publication,
+                         lead_organisations: [hmrc],
+                         body: "[A broken page](https://www.gov.uk/another-bad-link)\n[A good link](https://www.gov.uk/another-good-link)")
+
+    bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
+    missing_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/missing-link", status: "broken")
+    good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+
+    create(:link_checker_api_report_completed, batch_id: 1, link_reportable: detailed_guide, links: [bad_link, missing_link, good_link])
+    # create(:link_checker_api_report_completed, batch_id: 2, link_reportable: publication, links: [another_good_link, another_bad_link])
+
+    LinkReporterCsvService.new(reports_dir: reports_dir, organisation: hmrc).generate
+    hmrc_csv = CSV.read(reports_dir.join("hm-revenue-customs_links_report.csv"))
+    assert_equal 2, hmrc_csv.size
+    assert_equal ["https://www.gov.uk#{Whitehall.url_maker.detailed_guide_path(detailed_guide.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_detailed_guide_path(detailed_guide)}",
+                  detailed_guide.public_timestamp.to_s,
+                  "DetailedGuide",
+                  "2",
+                  "https://www.gov.uk/bad-link\r\nhttps://www.gov.uk/missing-link"], hmrc_csv[1]
+    refute_equal ["https://www.gov.uk#{Whitehall.url_maker.publication_path(publication.slug)}",
+                  "https://whitehall-admin.publishing.service.gov.uk#{Whitehall.url_maker.admin_publication_path(publication)}",
+                  publication.public_timestamp.to_s,
+                  "Publication",
+                  "0",
+                  ""], hmrc_csv[2]
+  end
+
+private
+
+  def reports_dir
+    Rails.root.join("tmp/broken_link_reports")
+  end
+end


### PR DESCRIPTION
This commit adds a new CSV generating service class that will generate a BrokenLinkReporter CSV. This service class uses the new `LinkCheckerApiReport` to populate the CSV.

This is part of a feature to move the current broken link checker to use the Link Checker API, linked to https://github.com/alphagov/whitehall/pull/3574.