### PR TITLE
Fix document filter presenter previous/next URL

### DIFF
--- a/app/presenters/document_filter_presenter.rb
+++ b/app/presenters/document_filter_presenter.rb
@@ -28,11 +28,13 @@ class DocumentFilterPresenter < Struct.new(:filter, :context, :document_decorato
       data[:next_page?] = true
       data[:next_page] = documents.current_page + 1
       data[:next_page_url] = url(page: documents.current_page + 1)
+      data[:next_page_web_url] = url(page: documents.current_page + 1, format: nil)
     end
     unless documents.first_page?
       data[:prev_page?] = true
       data[:prev_page] = documents.current_page - 1
       data[:prev_page_url] = url(page: documents.current_page - 1)
+      data[:prev_page_web_url] = url(page: documents.current_page - 1, format: nil)
     end
     data
   end

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -40,12 +40,12 @@
       <ul class="previous-next-navigation">
         {{#prev_page?}}
           <li class="previous">
-            <a href="{{prev_page_url}}">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
+            <a href="{{prev_page_web_url}}">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
           </li>
         {{/prev_page?}}
         {{#next_page?}}
           <li class="next">
-            <a href="{{next_page_url}}">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
+            <a href="{{next_page_web_url}}">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
           </li>
         {{/next_page?}}
       </ul>

--- a/test/javascripts/unit/document_filter_test.js
+++ b/test/javascripts/unit/document_filter_test.js
@@ -32,8 +32,10 @@ module("Document filter", {
       "next_page?": true,
       "next_page": 2,
       "next_page_url": '/next-page-url',
+      "next_page_web_url": '/next-page-url',
 
       "prev_page_url": '/prev-page-url',
+      "prev_page_web_url": '/prev-page-url',
       "more_pages?": true,
       "total_pages": 5,
 

--- a/test/unit/presenters/document_filter_presenter_test.rb
+++ b/test/unit/presenters/document_filter_presenter_test.rb
@@ -5,6 +5,7 @@ class DocumentFilterPresenterTest < PresenterTestCase
     @filter = Whitehall::DocumentFilter::FakeSearch.new
     @view_context.params[:action] = :index
     @view_context.params[:controller] = :publications
+    @view_context.params[:format] = :json
   end
 
   def stub_publication
@@ -44,8 +45,10 @@ class DocumentFilterPresenterTest < PresenterTestCase
     assert_equal 3, json['total_pages']
     assert_equal 3, json['next_page']
     assert_equal 1, json['prev_page']
-    assert_equal "/government/publications?page=3", json['next_page_url']
-    assert_equal "/government/publications?page=1", json['prev_page_url']
+    assert_equal "/government/publications.json?page=3", json['next_page_url']
+    assert_equal "/government/publications.json?page=1", json['prev_page_url']
+    assert_equal "/government/publications?page=3", json['next_page_web_url']
+    assert_equal "/government/publications?page=1", json['prev_page_web_url']
   end
 
   test 'next_page omitted if last page' do
@@ -53,6 +56,7 @@ class DocumentFilterPresenterTest < PresenterTestCase
     json = JSON.parse(DocumentFilterPresenter.new(@filter, @view_context).to_json)
     refute json.has_key?("next_page")
     refute json.has_key?("next_page_url")
+    refute json.has_key?("next_page_web_url")
   end
 
   test 'prev_page omitted if first page' do
@@ -60,6 +64,7 @@ class DocumentFilterPresenterTest < PresenterTestCase
     json = JSON.parse(DocumentFilterPresenter.new(@filter, @view_context).to_json)
     refute json.has_key?("prev_page")
     refute json.has_key?("prev_page_url")
+    refute json.has_key?("prev_page_web_url")
   end
 
   test 'json provides a list of documents with their positions' do


### PR DESCRIPTION
This commit adds a new previous/next URL to the document filter presenter that always points to the “web” (human-readable) version of the page rather than being context-driven. Currently, this is a JSON URL when called from the frontend JavaScript which means the previous/next buttons on the relevant finders point to JSON URLs.

Trello: https://trello.com/c/qmKw5mOK/420-fix-whitehall-finders-paginating-to-json-when-changing-filters