### PR TITLE
Refactor EditionTaxonsFetcher to return Taxon objects

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -73,7 +73,7 @@ class Admin::EditionsController < Admin::BaseController
     fetch_version_and_remark_trails
 
     if @edition.can_be_tagged_to_taxonomy?
-      @edition_taxon_links = EditionTaxonsFetcher.new(@edition.content_id).fetch
+      @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
     end
   end
 

--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -10,7 +10,7 @@ class Admin::StatisticsAnnouncementsController < Admin::BaseController
 
   def show
     if @statistics_announcement.can_be_tagged_to_taxonomy?
-      @edition_taxon_links = EditionTaxonsFetcher.new(@statistics_announcement.content_id).fetch
+      @edition_taxons = EditionTaxonsFetcher.new(@statistics_announcement.content_id).fetch
     end
   end
 

--- a/app/models/taxonomy_tag_form.rb
+++ b/app/models/taxonomy_tag_form.rb
@@ -25,11 +25,11 @@ class TaxonomyTagForm
   end
 
   def published_taxons
-    govuk_taxonomy.matching_against_published_taxons(selected_taxons)
+    @_published_ids ||= govuk_taxonomy.matching_against_published_taxons(selected_taxons)
   end
 
   def visible_draft_taxons
-    govuk_taxonomy.matching_against_visible_draft_taxons(selected_taxons)
+    @_visible_draft_ids ||= govuk_taxonomy.matching_against_visible_draft_taxons(selected_taxons)
   end
 
   def invisible_draft_taxons

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -6,63 +6,56 @@ class EditionTaxonsFetcher
   end
 
   def fetch
-    response =  Services.publishing_api.get_expanded_links(content_id)
-    ExpandedLinks.new(response).visible_taxons
+    taxons.select { |t| visible?(t) }
+  end
+
+private
+
+  def taxons
+    @_taxons ||= taxon_links.map { |taxon_link| build_taxon(taxon_link) }
+  end
+
+  def build_taxon(taxon_link)
+    taxon = Taxonomy::Taxon.new(taxon_link.symbolize_keys.slice(:title, :base_path, :content_id))
+
+    parent_taxons = taxon_link.fetch("links", {}).fetch("parent_taxons", [])
+    if parent_taxons.present?
+      # There should not be more than one parent for a taxon. If there is,
+      # pick the first one.
+      taxon.parent_node = build_taxon(parent_taxons.first)
+    end
+
+    taxon
+  end
+
+  def taxon_links
+    response["expanded_links"].fetch("taxons", [])
   rescue GdsApi::HTTPNotFound
     []
   end
 
-  class ExpandedLinks
-    def initialize(publishing_api_response)
-      @response = publishing_api_response
-    end
+  def response
+    Services.publishing_api.get_expanded_links(content_id)
+  end
 
-    def visible_taxons
-      taxons.select do |taxon|
-        published_taxon_content_ids.include?(taxon.content_id) ||
-          visible_draft_taxon_content_ids.include?(taxon.content_id)
-      end
-    end
+  def visible?(taxon)
+    published_taxon_content_ids.include?(taxon.content_id) ||
+      visible_draft_taxon_content_ids.include?(taxon.content_id)
+  end
 
-  private
+  def published_taxon_content_ids
+    @_published_ids ||= govuk_taxonomy.matching_against_published_taxons(taxon_content_ids)
+  end
 
-    attr_reader :response
+  def visible_draft_taxon_content_ids
+    @_visible_draft_ids ||= govuk_taxonomy.matching_against_visible_draft_taxons(taxon_content_ids)
+  end
 
-    def taxons
-      @_taxons ||= taxon_links.map { |taxon_link| build_taxon(taxon_link) }
-    end
+  def taxon_content_ids
+    taxon_links.map { |t| t["content_id"] }
+  end
 
-    def build_taxon(taxon_link)
-      taxon = Taxonomy::Taxon.new(taxon_link.symbolize_keys.slice(:title, :base_path, :content_id))
-
-      parent_taxons = taxon_link.fetch("links", {}).fetch("parent_taxons", [])
-      if parent_taxons.present?
-        # There should not be more than one parent for a taxon. If there is,
-        # pick the first one.
-        taxon.parent_node = build_taxon(parent_taxons.first)
-      end
-
-      taxon
-    end
-
-    def taxon_links
-      response["expanded_links"].fetch("taxons", [])
-    end
-
-    def published_taxon_content_ids
-      govuk_taxonomy.matching_against_published_taxons(taxon_content_ids)
-    end
-
-    def visible_draft_taxon_content_ids
-      govuk_taxonomy.matching_against_visible_draft_taxons(taxon_content_ids)
-    end
-
-    def taxon_content_ids
-      taxon_links.map { |t| t["content_id"] }
-    end
-
-    def govuk_taxonomy
-      Taxonomy::GovukTaxonomy.new
-    end
+  def govuk_taxonomy
+    Taxonomy::GovukTaxonomy.new
   end
 end

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -48,7 +48,7 @@
 <% if @edition.can_be_tagged_to_taxonomy? %>
   <%= render partial: '/admin/shared/tagging/show_topics_box', locals: {
     path_to_edit_tags: edit_admin_edition_tags_path(@edition.id),
-    selected_taxon_paths: @edition_taxon_links.selected_taxon_paths,
+    selected_taxon_paths: @edition_taxons.map(&:full_path),
     no_topics_message: 'No topics - please add a topic before publishing'
   } %>
 <% end %>

--- a/app/views/admin/statistics_announcements/show.html.erb
+++ b/app/views/admin/statistics_announcements/show.html.erb
@@ -73,7 +73,7 @@
     <% if @statistics_announcement.can_be_tagged_to_taxonomy? %>
       <%= render partial: '/admin/shared/tagging/show_topics_box', locals: {
         path_to_edit_tags: edit_admin_statistics_announcement_tags_path(@statistics_announcement.id),
-        selected_taxon_paths: @edition_taxon_links.selected_taxon_paths,
+        selected_taxon_paths: @edition_taxons.map(&:full_path),
         no_topics_message: 'No topics - please add a topic'
       } %>
     <% end %>

--- a/lib/taxonomy/govuk_taxonomy.rb
+++ b/lib/taxonomy/govuk_taxonomy.rb
@@ -22,11 +22,11 @@ module Taxonomy
     end
 
     def matching_against_published_taxons(taxons)
-      @_published_taxons ||= matching_against_taxonomy_branches(taxons, children)
+      matching_against_taxonomy_branches(taxons, children)
     end
 
     def matching_against_visible_draft_taxons(taxons)
-      @_draft_visible_taxons ||= matching_against_taxonomy_branches(taxons, draft_child_taxons)
+      matching_against_taxonomy_branches(taxons, draft_child_taxons)
     end
 
   private

--- a/lib/taxonomy/taxon.rb
+++ b/lib/taxonomy/taxon.rb
@@ -42,6 +42,10 @@ module Taxonomy
       ancestors + [self]
     end
 
+    def full_path
+      breadcrumb_trail.map { |t| { title: t.name } }
+    end
+
     def count
       tree.count
     end

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -236,11 +236,13 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
           {
             "title" => "Primary Education",
             "content_id" => "aaaa",
+            "base_path" => "i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => "Education, Training and Skills",
                   "content_id" => "bbbb",
+                  "base_path" => "i-am-a-parent-taxon",
                   "links" => {}
                 }
               ]

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -209,11 +209,13 @@ private
           {
             "title" => "Primary Education",
             "content_id" => "aaaa",
+            "base_path" => "i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => "Education, Training and Skills",
                   "content_id" => "bbbb",
+                  "base_path" => "i-am-a-parent-taxon",
                   "links" => {}
                 }
               ]

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -18,7 +18,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
 
     links_fetcher = EditionTaxonsFetcher.new(content_id)
 
-    assert_equal links_fetcher.fetch.selected_taxon_paths, []
+    assert_equal [], links_fetcher.fetch
   end
 
   test "it returns '[]' if there are no taxons" do
@@ -28,10 +28,10 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
 
     links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal links_fetcher.fetch.selected_taxon_paths, []
+    assert_equal [], links_fetcher.fetch
   end
 
-  test "it returns a single taxon for the path if the taxon has no parents" do
+  test "it returns a taxon without a parent" do
     title = "Education, training and skills"
 
     publishing_api_has_expanded_links(
@@ -49,26 +49,23 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
     stub_govuk_taxonomy_matching_published_taxons(['aaaa'], ['aaaa'])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: title }]]
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal 'aaaa', taxons.first.content_id
   end
 
-  test "it returns both taxons for the path if the taxon has a parent but no grandparents" do
-    parent_title = "Education, training and skills"
-    title = "Further Education"
-
+  test "it returns a taxon with a parent" do
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       expanded_links:  {
         "taxons" => [
           {
-            "title" => title,
+            "title" => "Further Education",
             "content_id" => "aaaa",
             "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_title,
+                  "title" => "Education, training and skills",
                   "content_id" => "bbbb",
                   "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
@@ -81,32 +78,29 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
     stub_govuk_taxonomy_matching_published_taxons(['aaaa'], ['aaaa'])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_title }, { title: title }]]
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal 'aaaa', taxons.first.content_id
+    assert_equal 'bbbb', taxons.first.parent_node.content_id
   end
 
-  test "it returns all taxons for the path if the taxon has a parent, grandparent, but no great-grandparents" do
-    grandparent_title = "Education, training and skills"
-    parent_title = "Further Education"
-    title = "Student Finance"
-
+  test "it returns a taxon with parent and grandparent" do
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       expanded_links:  {
         "taxons" => [
           {
-            "title" => title,
+            "title" => "Student Finance",
             "content_id" => "aaaa",
             "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_title,
+                  "title" => "Further Education",
                   "content_id" => "bbbb",
                   "base_path" => "/i-am-a-parent-taxon",
                   "links" => {
                     "parent_taxons" => [
-                      "title" => grandparent_title,
+                      "title" => "Education, training and skills",
                       "content_id" => "cccc",
                       "base_path" => "/i-am-a-grand-parent-taxon",
                       "links" => {}
@@ -121,29 +115,25 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
     stub_govuk_taxonomy_matching_published_taxons(['aaaa'], ['aaaa'])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: grandparent_title }, { title: parent_title }, { title: title }]]
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal 'aaaa', taxons.first.content_id
+    assert_equal 'bbbb', taxons.first.parent_node.content_id
+    assert_equal 'cccc', taxons.first.parent_node.parent_node.content_id
   end
 
   test "it returns paths for multiple taxons" do
-    parent_education_title = "Education, training and skills"
-    education_title = "Further Education"
-
-    parent_taxes_title = "Money"
-    taxes_title = "Paying taxes"
-
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       expanded_links:  {
         "taxons" => [
           {
-            "title" => education_title,
+            "title" => "Further Education",
             "content_id" => "aaaa",
             "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_education_title,
+                  "title" => "Education, training and skills",
                   "content_id" => "bbbb",
                   "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
@@ -152,13 +142,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
             }
           },
           {
-            "title" => taxes_title,
+            "title" => "Paying taxes",
             "content_id" => "cccc",
             "base_path" => "/i-am-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_taxes_title,
+                  "title" => "Money",
                   "content_id" => "dddd",
                   "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
@@ -171,39 +161,33 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
     stub_govuk_taxonomy_matching_published_taxons(%w[aaaa cccc], %w[aaaa cccc])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal(
-      links_fetcher.fetch.selected_taxon_paths,
-      [
-        [{ title: parent_education_title }, { title: education_title }],
-        [{ title: parent_taxes_title }, { title: taxes_title }],
-      ]
-    )
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal 2, taxons.count
+    assert_equal "aaaa", taxons.first.content_id
+    assert_equal "bbbb", taxons.first.parent_node.content_id
+    assert_equal "cccc", taxons.last.content_id
+    assert_equal "dddd", taxons.last.parent_node.content_id
   end
 
-  test "it uses the first taxon if there are multiple parents" do
-    parent_education_title = "Education, training and skills"
-    parent_work_title = "Work and pensions"
-    education_title = "Further Education"
-
+  test "it sets the first parent taxon if there are multiple parents" do
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       expanded_links:  {
         "taxons" => [
           {
-            "title" => education_title,
+            "title" => "Further Education",
             "content_id" => "aaaa",
             "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_education_title,
+                  "title" => "Education, training and skills",
                   "content_id" => "bbbb",
                   "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
                 },
                 {
-                  "title" => parent_work_title,
+                  "title" => "Work and pensions",
                   "content_id" => "cccc",
                   "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
@@ -216,32 +200,24 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     )
     stub_govuk_taxonomy_matching_published_taxons(['aaaa'], ['aaaa'])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    assert_equal links_fetcher.fetch.selected_taxon_paths, [[{ title: parent_education_title }, { title: education_title }]]
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal "aaaa", taxons.first.content_id
+    assert_equal "bbbb", taxons.first.parent_node.content_id
   end
 
   test "it only returns published or visible draft taxons" do
-    published_title = "I am the published taxon"
-    parent_published_title = "I am the parent of the published taxon"
-
-    visible_draft_title = "I am the visible draft taxon"
-    parent_visible_draft_title = "I am the parent of the visible draft taxon"
-
-    invisible_draft_title = "I am the invisible draft taxon"
-    parent_invisible_draft_title = "I am the parent of the invisible draft taxon"
-
     publishing_api_has_expanded_links(
       content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       expanded_links:  {
         "taxons" => [
           {
-            "title" => published_title,
+            "title" => "I am the published taxon",
             "content_id" => "aaaa",
             "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_published_title,
+                  "title" => "I am the parent of the published taxon",
                   "content_id" => "bbbb",
                   "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
@@ -250,13 +226,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
             }
           },
           {
-            "title" => visible_draft_title,
+            "title" => "I am the visible draft taxon",
             "content_id" => "cccc",
             "base_path" => "/i-am-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_visible_draft_title,
+                  "title" => "I am the parent of the visible draft taxon",
                   "content_id" => "dddd",
                   "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
@@ -265,13 +241,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
             }
           },
           {
-            "title" => invisible_draft_title,
+            "title" => "I am the invisible draft taxon",
             "content_id" => "eeee",
             "base_path" => "/i-am-yet-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
-                  "title" => parent_invisible_draft_title,
+                  "title" => "I am the parent of the invisible draft taxon",
                   "content_id" => "ffff",
                   "base_path" => "/i-am-yet-another-parent-taxon",
                   "links" => {}
@@ -285,12 +261,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
     stub_govuk_taxonomy_matching_published_taxons(%w[aaaa cccc eeee], ["aaaa"])
     stub_govuk_taxonomy_matching_visible_draft_taxons(%w[aaaa cccc eeee], ["cccc"])
 
-    links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
-    expected_taxon_paths = [
-      [{ title: parent_published_title }, { title: published_title }],
-      [{ title: parent_visible_draft_title }, { title: visible_draft_title }],
-    ]
-
-    assert_equal expected_taxon_paths, links_fetcher.fetch.selected_taxon_paths
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
+    assert_equal %w[aaaa cccc], taxons.map(&:content_id)
   end
 end

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -41,6 +41,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {},
           }
         ]
@@ -63,11 +64,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_title,
                   "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
                 }
               ]
@@ -94,15 +97,18 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_title,
                   "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
                   "links" => {
                     "parent_taxons" => [
                       "title" => grandparent_title,
                       "content_id" => "cccc",
+                      "base_path" => "/i-am-a-grand-parent-taxon",
                       "links" => {}
                     ]
                   }
@@ -133,11 +139,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => education_title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_education_title,
                   "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
                 }
               ]
@@ -146,11 +154,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => taxes_title,
             "content_id" => "cccc",
+            "base_path" => "/i-am-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_taxes_title,
                   "content_id" => "dddd",
+                  "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
                 }
               ]
@@ -183,16 +193,19 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => education_title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_education_title,
                   "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
                 },
                 {
                   "title" => parent_work_title,
                   "content_id" => "cccc",
+                  "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
                 },
               ]
@@ -224,11 +237,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => published_title,
             "content_id" => "aaaa",
+            "base_path" => "/i-am-a-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_published_title,
                   "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
                   "links" => {}
                 },
               ]
@@ -237,11 +252,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => visible_draft_title,
             "content_id" => "cccc",
+            "base_path" => "/i-am-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_visible_draft_title,
                   "content_id" => "dddd",
+                  "base_path" => "/i-am-another-parent-taxon",
                   "links" => {}
                 },
               ]
@@ -250,11 +267,13 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           {
             "title" => invisible_draft_title,
             "content_id" => "eeee",
+            "base_path" => "/i-am-yet-another-taxon",
             "links" => {
               "parent_taxons" => [
                 {
                   "title" => parent_invisible_draft_title,
                   "content_id" => "ffff",
+                  "base_path" => "/i-am-yet-another-parent-taxon",
                   "links" => {}
                 },
               ]


### PR DESCRIPTION
Part of https://trello.com/c/XCnd2ToE/185-investigate-and-fix-discrepancies-between-whitehall-admin-show-and-edit-taxon-pages

This refactors the `EditionTaxonsFetcher` class to return instances of the `Taxon` class instead of `ExpandedLinks` (which was not a very expressive abstraction with regards to Taxonomy). That allows us to remove some code duplication around calculating the path for a taxon and its ancestors and provide an obvious place for future taxonomy related code.

Note that there are still parts of Whitehall[1][2] that get taxons for an edition via a `get_links` call to the PublishingAPI (as opposed to `get_expanded_links` in `EditionTaxonsFetcher`, presumably for performance reasons?). It would be good make all taxon fetching happen via the `EditionTaxonsFetcher` class (in a future PR)...

[1] https://github.com/alphagov/whitehall/blob/662456131c5ecd7e55ba3772ba8506403fe215ec/app/models/taxonomy_tag_form.rb#L8

[2] https://github.com/alphagov/whitehall/blob/662456131c5ecd7e55ba3772ba8506403fe215ec/app/models/edition.rb#L432

