### PR TITLE
Re-enable atom feeds for world locations

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -15,12 +15,12 @@ class WorldLocationsController < PublicFacingController
   end
 
   def show
-    # Don't serve world locations unless they're international delegations
-    # All other world locations are served by collections
-    raise ActiveRecord::RecordNotFound unless @world_location.world_location_type == WorldLocationType::InternationalDelegation
     recently_updated_source = @world_location.published_editions.with_translations(I18n.locale).in_reverse_chronological_order
     respond_to do |format|
       format.html do
+        # Don't serve world locations unless they're international delegations
+        # All other world locations are served by collections
+        raise ActiveRecord::RecordNotFound unless @world_location.world_location_type == WorldLocationType::InternationalDelegation
         @recently_updated = recently_updated_source.limit(3)
         publications = Publication.published.in_world_location(@world_location)
         @non_statistics_publications = latest_presenters(publications.not_statistics, translated: true, count: 2)

--- a/test/functional/world_locations_controller_test.rb
+++ b/test/functional/world_locations_controller_test.rb
@@ -104,7 +104,20 @@ class WorldLocationsControllerTest < ActionController::TestCase
     assert_select "a.feed[href=?]", atom_feed_url_for(world_location)
   end
 
-  view_test "show generates an atom feed with entries for latest activity" do
+  view_test "show world location generates an atom feed with entries for latest activity" do
+    world_location = create(
+      :world_location,
+      world_location_type: WorldLocationType::WorldLocation
+    )
+    pub = create(:published_publication, world_locations: [world_location], first_published_at: 1.week.ago.to_date)
+    news = create(:published_news_article, world_locations: [world_location], first_published_at: 1.day.ago)
+    get :show, params: { id: world_location }, format: :atom
+    assert_select_atom_feed do
+      assert_select_atom_entries([news, pub])
+    end
+  end
+
+  view_test "show international delegation generates an atom feed with entries for latest activity" do
     world_location = create(
       :world_location,
       world_location_type: WorldLocationType::InternationalDelegation


### PR DESCRIPTION
This commit re-enables atom feeds for all world locations that were inadvertently disabled in https://github.com/alphagov/whitehall/pull/3544.

Trello: https://trello.com/c/pv5N8aRc/419-problems-with-adding-rss-feeds-from-govuk