### PR TITLE
Change column type of link_checker_api_report_links.uri to text

### DIFF
--- a/db/migrate/20171206121121_change_uri_column_on_link_checker_report_links.rb
+++ b/db/migrate/20171206121121_change_uri_column_on_link_checker_report_links.rb
@@ -1,0 +1,9 @@
+class ChangeUriColumnOnLinkCheckerReportLinks < ActiveRecord::Migration[5.0]
+  def up
+    change_column :link_checker_api_report_links, :uri, :text, null: false
+  end
+
+  def down
+    change_column :link_checker_api_report_links, :uri, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170821152429) do
+ActiveRecord::Schema.define(version: 20171206121121) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -658,7 +658,7 @@ ActiveRecord::Schema.define(version: 20170821152429) do
 
   create_table "link_checker_api_report_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "link_checker_api_report_id"
-    t.string   "uri",                                      null: false
+    t.text     "uri",                        limit: 65535, null: false
     t.string   "status",                                   null: false
     t.datetime "checked"
     t.text     "check_warnings",             limit: 65535


### PR DESCRIPTION
There are some instances of some _really_ long links within editions e.g.

```md
https://online.businesslink.gov.uk/hub/action/render?pageId=mynewbusiness&furlname=mynewbusiness&furlparam=mynewbusiness&ref=http%3A//www.businesslink.gov.uk/bdotg/action/detail%3FitemId%3D1097188312%26type%3DCAMPAIGN%26furlname%3Dnewservices%26furlparam%3Dnewservices%26ref%3D%26domain%3Dwww.businesslink.gov.uk&domain=www.businesslink.gov.uk
```

To accomodate these links we need to change the column type.