### PR TITLE
Add pill to broken and caution links on documents view

### DIFF
--- a/app/assets/stylesheets/admin/views/_editions-index.scss
+++ b/app/assets/stylesheets/admin/views/_editions-index.scss
@@ -25,6 +25,11 @@
     margin-left: 1em;
   }
 
+  .has-broken-links,
+  .has-link-warnings {
+    margin-left: 1em;
+  }
+
   .additional_information {
     padding: 0.4em 1em 0.2em 1em;
     margin: 0.3em 0 0 0;

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -66,6 +66,13 @@
             <% if edition.access_limited? %>
               <span class="access_limited label label-danger">limited access</span>
             <% end %>
+            <% if edition.link_check_reports.any? %>
+              <% if edition.link_check_reports.last.broken_links %>
+                <span class="has-broken-links label label-primary">has broken links</span>
+              <% elsif edition.link_check_reports.last.caution_links %>
+                <span class="has-link-warnings label label-info">has link warnings</span>
+              <% end %>
+            <% end %>
           </td>
           <td class="author"><%= linked_author(edition.last_author) %></td>
           <td class="updated"><span title="<%= edition.updated_at %>"><%= time_ago_in_words edition.updated_at %> ago</span></td>


### PR DESCRIPTION
Display most urgent status of links (broken or caution) on the document overview table. This will make it easier for users to prioritise which documents need most urgent review

<img width="1060" alt="screen shot 2017-12-07 at 12 03 34" src="https://user-images.githubusercontent.com/15086186/33714406-b64169fc-db46-11e7-94b4-502523c55d60.png">

<img width="1068" alt="screen shot 2017-12-07 at 12 03 20" src="https://user-images.githubusercontent.com/15086186/33714405-b629110e-db46-11e7-8c70-212f8ff7eff7.png">
