### PR TITLE
Add ability to filter editions by broken links

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -297,7 +297,7 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def params_filters
-    params.permit!.to_h.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date)
+    params.permit!.to_h.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links)
   end
 
   def params_filters_with_default_state

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -108,6 +108,7 @@ module Admin
       editions = editions.in_world_location(selected_world_locations) if selected_world_locations.any?
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
+      editions = editions.only_broken_links if only_broken_links
 
       @unpaginated_editions = editions
     end
@@ -219,6 +220,10 @@ module Admin
         sentence = selected_world_locations.map { |l| WorldLocation.friendly.find(l).name }.to_sentence
         " about #{sentence}"
       end
+    end
+
+    def only_broken_links
+      options[:only_broken_links].present?
     end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -195,6 +195,14 @@ class Edition < ApplicationRecord
     where("editions.updated_at <= ?", date)
   end
 
+  # used by Admin::EditionFilter
+  def self.only_broken_links
+    joins("INNER JOIN link_checker_api_reports ON link_checker_api_reports.link_reportable_id = editions.id")
+    .joins("INNER JOIN link_checker_api_report_links ON link_checker_api_report_links.link_checker_api_report_id = link_checker_api_reports.id")
+    .where("link_checker_api_reports.link_reportable_type = 'Edition' AND link_checker_api_report_links.status != 'ok'")
+    .distinct
+  end
+
   def self.latest_edition
     where("NOT EXISTS (
       SELECT 1

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,6 +1,6 @@
 <% initialise_script "GOVUK.FilterOptions", filter_form: '.js-editions-filter-form', search_results: '#search_results' %>
 <%
-  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date]
+  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links]
   raise "filter action required" unless defined?(filter_action)
 %>
 <form class="filter-options js-editions-filter-form" method="get" action="<%= filter_action %>">
@@ -72,6 +72,13 @@
       </div>
     </div>
   <% end %>
+  <% if filter_by.include?(:only_broken_links) %>
+    <div class="filter-grouping checkbox-filter">
+      <%= check_box_tag :only_broken_links, "1", false %>
+      <%= label_tag "only_broken_links", "Only broken links" %>
+    </div>
+  <% end %>
+
   <%= submit_tag "Search", class: 'btn btn-default add-bottom-margin' %>
   <p><a href="?state=active">Reset all fields</a></p>
 </form>

--- a/features/filtering-editions.feature
+++ b/features/filtering-editions.feature
@@ -1,0 +1,9 @@
+Feature: Filtering Editions
+
+  Background:
+    Given there is a topic with published documents that have links
+    When I view the documents index page
+
+  Scenario: User filters by broken links
+    When I filter by broken links
+    Then I see only documents with broken links

--- a/features/step_definitions/filtering_editions_steps.rb
+++ b/features/step_definitions/filtering_editions_steps.rb
@@ -1,0 +1,35 @@
+Given(/^there is a topic with published documents that have links$/) do
+  @topic = create(:topic, name: "A Topic")
+  @department = create(:ministerial_department, name: "A Department")
+
+  publication_one = create(:published_publication,
+                           title: "Publication #1",
+                           lead_organisations: [@department],
+                           body: "[A broken page](https://www.gov.uk/bad-link)\n[A good link](https://www.gov.uk/another-good-link)")
+  publication_two = create(:published_publication,
+                           title: "Publication #2",
+                           lead_organisations: [@department],
+                           body: "[Good](https://www.gov.uk/good-link)\n[A good link](https://www.gov.uk/another-good-link)")
+
+  good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/good-link", status: "ok")
+  another_good_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/another-good-link", status: "ok")
+  bad_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/bad-link", status: "broken")
+  create(:link_checker_api_report, batch_id: 1, link_reportable: publication_one, links: [bad_link, another_good_link])
+  create(:link_checker_api_report, batch_id: 2, link_reportable: publication_two, links: [good_link, another_good_link])
+end
+
+When(/^I view the documents index page$/) do
+  visit admin_editions_path(organisation: @department.id)
+  page.click_on "Reset all fields"
+end
+
+When(/^I filter by broken links$/) do
+  page.check "Only broken links"
+  page.click_on "Search"
+end
+
+Then(/^I see only documents with broken links$/) do
+  assert page.has_content?("Publication #1")
+
+  assert page.has_no_content?("Publication #2")
+end


### PR DESCRIPTION
This commit adds the ability to filter editions by broken links on the index page so users are able
to quickly see editions with broken links. This expands on the work done on https://github.com/alphagov/whitehall/pull/3582
along with the other LinkCheckerAPI integration work.

![screen shot 2017-12-08 at 11 20 18](https://user-images.githubusercontent.com/8478978/33764160-2f32de6c-dc0b-11e7-8cc5-2c46c4dab918.png)
