### PR TITLE
Display link report pill only if has completed

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -66,7 +66,7 @@
             <% if edition.access_limited? %>
               <span class="access_limited label label-danger">limited access</span>
             <% end %>
-            <% if edition.link_check_reports.any? %>
+            <% if edition.link_check_reports.any? && edition.link_check_reports.last.completed? %>
               <% if edition.link_check_reports.last.broken_links %>
                 <span class="has-broken-links label label-primary">has broken links</span>
               <% elsif edition.link_check_reports.last.caution_links %>


### PR DESCRIPTION
Hide pill messages for link reports if they are still in progress in order to not alarm users.