### PR TITLE
Store ImageUploader attachments in Asset Manager as well as NFS

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,4 +1,6 @@
 class ImageUploader < WhitehallUploader
+  storage :asset_manager_and_quarantined_file_storage
+
   include CarrierWave::MiniMagick
 
   configure do |config|

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -104,6 +104,52 @@ class AssetManagerIntegrationTest
     end
   end
 
+  class RemovingAPersonImage < ActiveSupport::TestCase
+    setup do
+      @filename = 'minister-of-funk.960x640.jpg'
+      @person = FactoryBot.create(
+        :person,
+        image: File.open(fixture_path.join(@filename))
+      )
+
+      VirusScanHelpers.simulate_virus_scan(@person.image, include_versions: true)
+      @person.reload
+
+      @asset_id = 'asset-id'
+      Services.asset_manager.stubs(:whitehall_asset).returns('id' => "http://asset-manager/assets/#{@asset_id}")
+    end
+
+    test 'removes the person image and all its versions from asset manager' do
+      # Creating a person creates one entry in asset manager for the
+      # uploaded asset and one entry for each of the versions defined
+      # in ImageUploader
+      expected_number_of_versions = @person.image.versions.size + 1
+      Services.asset_manager.expects(:delete_asset).with(@asset_id).times(expected_number_of_versions)
+
+      @person.remove_image!
+    end
+
+    test 'removes the person image from the file system' do
+      image_path = @person.image.path
+
+      assert File.exist?(image_path)
+
+      @person.remove_image!
+
+      refute File.exist?(image_path)
+    end
+
+    test 'removes each version of the person image from the file system' do
+      file_paths = @person.image.versions.map { |_, image| image.file.path }
+
+      file_paths.each { |path| assert File.exist?(path) }
+
+      @person.remove_image!
+
+      file_paths.each { |path| refute File.exist?(path) }
+    end
+  end
+
   class CreatingAConsultationResponseFormData < ActiveSupport::TestCase
     setup do
       @filename = 'greenpaper.pdf'

--- a/test/support/virus_scan_helpers.rb
+++ b/test/support/virus_scan_helpers.rb
@@ -1,5 +1,5 @@
 module VirusScanHelpers
-  def self.simulate_virus_scan(*uploaders)
+  def self.simulate_virus_scan(*uploaders, include_versions: false)
     if uploaders.empty?
       uploaders = AttachmentData.all.map(&:file) + ImageData.all.map(&:file)
     end
@@ -7,11 +7,24 @@ module VirusScanHelpers
     uploaders.each do |uploader|
       absolute_path = File.join(Whitehall.incoming_uploads_root, uploader.relative_path)
       target_dir = File.join(Whitehall.clean_uploads_root, File.dirname(uploader.relative_path))
-      if File.exists?(absolute_path)
-        FileUtils.mkdir_p(target_dir)
-        FileUtils.cp(absolute_path, target_dir)
-        FileUtils.rm(absolute_path)
+      move_file(absolute_path, target_dir)
+
+      if include_versions
+        uploader.versions.each_pair do |_, version_uploader|
+          absolute_path = File.join(Whitehall.incoming_uploads_root, version_uploader.store_path)
+          target_dir = File.join(Whitehall.clean_uploads_root, File.dirname(version_uploader.store_path))
+
+          move_file(absolute_path, target_dir)
+        end
       end
+    end
+  end
+
+  def self.move_file(absolute_path, target_dir)
+    if File.exist?(absolute_path)
+      FileUtils.mkdir_p(target_dir)
+      FileUtils.cp(absolute_path, target_dir)
+      FileUtils.rm(absolute_path)
     end
   end
 

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -11,6 +11,10 @@ class ImageUploaderTest < ActiveSupport::TestCase
     ImageUploader.enable_processing = false
   end
 
+  test 'uses the asset manager and quarantined file storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ImageUploader.storage
+  end
+
   test "should only allow JPG, GIF, PNG or SVG images" do
     uploader = ImageUploader.new
     assert_equal %w(jpg jpeg gif png svg), uploader.extension_whitelist


### PR DESCRIPTION
This PR switches the `ImageUploader` to use the `asset_manager_and_quarantined_file_storage` storage engine - ensuring that any new files that are uploaded using this uploader will be stored in Asset Manager. This is a precursor to migrating all of the existing files that use this uploader to Asset Manager and eventually removing them from NFS altogether. 

The change itself (in the first commit) is simple. Subsequent commits add some additional integration testing to make sure that Create, Update and Delete operations on a model that mounts this uploader (`Person`) work as expected. 

Note that the `ImageUploader` is configured to not remove files when they are replaced with new ones.

Fixes: https://github.com/alphagov/asset-manager/issues/325