### PR TITLE
Send empty array of people links to API if no roles attached

### DIFF
--- a/app/presenters/publishing_api/payload_builder/people.rb
+++ b/app/presenters/publishing_api/payload_builder/people.rb
@@ -19,8 +19,6 @@ module PublishingApi
     private
 
       def people
-        return {} unless role_appointments.present?
-
         {
           key => role_appointments
             .map(&:person)

--- a/app/presenters/publishing_api/payload_builder/roles.rb
+++ b/app/presenters/publishing_api/payload_builder/roles.rb
@@ -18,8 +18,6 @@ module PublishingApi
     private
 
       def roles
-        return {} unless role_appointments.present?
-
         {
           roles: role_appointments
             .map(&:role)

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -65,10 +65,13 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
 
   test "it presents edition links" do
     expected_links = {
-      organisations:  [],
+      field_of_operation: [@fatality_notice.operational_field.content_id],
+      ministers: [],
+      organisations: [],
+      people: [],
+      policy_areas: [],
       primary_publishing_organisation: [],
-      policy_areas:   [],
-      field_of_operation: [@fatality_notice.operational_field.content_id]
+      roles: [],
     }
     assert_equal expected_links, @presented_content[:links]
   end

--- a/test/unit/presenters/publishing_api/payload_builder/people_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/people_test.rb
@@ -3,18 +3,18 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class PayloadBuilderPeopleTest < ActiveSupport::TestCase
-      test "returns empty hash if no role_appointment or edition_role_appointments" do
+      test "returns empty array of people if no role_appointment or edition_role_appointments" do
         edition_with_no_roles_or_people = Object.new
 
-        expected_hash = {}
+        expected_hash = { people: [] }
 
         assert_equal expected_hash, People.for(edition_with_no_roles_or_people, :people)
       end
 
-      test "returns empty hash if role_appointment is nil" do
+      test "returns empty array of people if role_appointment is nil" do
         stubbed_edition = stub(role_appointment: nil)
 
-        expected_hash = {}
+        expected_hash = { people: [] }
 
         assert_equal expected_hash, People.for(stubbed_edition, :people)
       end
@@ -29,10 +29,10 @@ module PublishingApi
         assert_equal expected_hash, People.for(stubbed_edition, :people)
       end
 
-      test "returns an empty hash if role_appointments are nil" do
+      test "returns an empty array of people if role_appointments are nil" do
         stubbed_edition = stub(role_appointments: nil)
 
-        expected_hash = {}
+        expected_hash = { people: [] }
 
         assert_equal expected_hash, People.for(stubbed_edition, :people)
       end

--- a/test/unit/presenters/publishing_api/payload_builder/roles_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/roles_test.rb
@@ -3,18 +3,18 @@ require "test_helper"
 module PublishingApi
   module PayloadBuilder
     class PayloadBuilderRolesTest < ActiveSupport::TestCase
-      test "returns empty hash if no roles" do
+      test "returns empty array of roles if no roles" do
         edition_with_no_roles = Object.new
 
-        expected_hash = {}
+        expected_hash = { roles: [] }
 
         assert_equal expected_hash, Roles.for(edition_with_no_roles)
       end
 
-      test "returns empty hash if role_appointment is nil" do
+      test "returns empty array of roles if role_appointment is nil" do
         stubbed_edition = stub(role_appointment: nil)
 
-        expected_hash = {}
+        expected_hash = { roles: [] }
 
         assert_equal expected_hash, Roles.for(stubbed_edition)
       end
@@ -28,10 +28,10 @@ module PublishingApi
         assert_equal expected_hash, Roles.for(stubbed_edition)
       end
 
-      test "returns empty hash if role_appointments are nil" do
+      test "returns empty array of roles if role_appointments are nil" do
         stubbed_edition = stub(role_appointments: nil)
 
-        expected_hash = {}
+        expected_hash = { roles: [] }
 
         assert_equal expected_hash, Roles.for(stubbed_edition)
       end

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -115,12 +115,12 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         refute(presented.links.has_key?(:speaker))
       end
 
-      it "doesn't present a roles link" do
-        refute(presented.links.has_key?(:roles))
+      it "presents an empty roles link" do
+        assert_empty(presented.links[:roles])
       end
 
-      it "doesn't present a people link" do
-        refute(presented.links.has_key?(:people))
+      it "presents an empty people link" do
+        assert_empty(presented.links[:people])
       end
     end
   end


### PR DESCRIPTION
If a publisher removes people from an article, we stop sending the
“people” key in the links hash. Because this is processed on the
Publishing API side using PatchLinks, the people aren’t removed as it
ignores link types which aren’t included. If we want to remove all
people from a document, we need to send an empty array instead.

Fixes Zendesk ticket 2531517