### PR TITLE
Use Asset Manager and NFS to store files in ImageUploader

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,4 +1,6 @@
 class ImageUploader < WhitehallUploader
+  storage :asset_manager_and_quarantined_file_storage
+
   include CarrierWave::MiniMagick
 
   configure do |config|

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -10,11 +10,7 @@ class AssetManagerIntegrationTest
         logo: File.open(fixture_path.join('images', filename))
       )
 
-      Services.asset_manager.expects(:create_whitehall_asset).with(
-        all_of(
-          has_entry(:file, instance_of(File)),
-          has_entry(:legacy_url_path, regexp_matches(/#{filename}/)))
-      )
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{filename}/))
 
       organisation.save!
     end
@@ -71,11 +67,7 @@ class AssetManagerIntegrationTest
     end
 
     test 'sends the person image to Asset Manager' do
-      Services.asset_manager.expects(:create_whitehall_asset).with(
-        all_of(
-          has_entry(:file, instance_of(File)),
-          has_entry(:legacy_url_path, regexp_matches(/#{@filename}/)))
-      )
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
 
       @person.save!
     end
@@ -83,9 +75,7 @@ class AssetManagerIntegrationTest
     test 'sends each version of the person image to Asset Manager' do
       ImageUploader.versions.each_key do |version_prefix|
         Services.asset_manager.expects(:create_whitehall_asset).with(
-          all_of(
-            has_entry(:file, instance_of(File)),
-            has_entry(:legacy_url_path, regexp_matches(/#{version_prefix}_#{@filename}/)))
+          file_and_legacy_url_path_matching(/#{version_prefix}_#{@filename}/)
         )
       end
 
@@ -230,9 +220,7 @@ class AssetManagerIntegrationTest
 
     test 'sends the consultation response form data file to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(
-        all_of(
-          has_entry(:file, instance_of(File)),
-          has_entry(:legacy_url_path, regexp_matches(/#{@filename}/)))
+        file_and_legacy_url_path_matching(/#{@filename}/)
       )
 
       @consultation_response_form_data.save!

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -10,10 +10,11 @@ class AssetManagerIntegrationTest
         logo: File.open(fixture_path.join('images', filename))
       )
 
-      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
-        args[:file].is_a?(File) &&
-          args[:legacy_url_path] =~ /#{filename}/
-      end
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        all_of(
+          has_entry(:file, instance_of(File)),
+          has_entry(:legacy_url_path, regexp_matches(/#{filename}/)))
+      )
 
       organisation.save!
     end
@@ -70,20 +71,22 @@ class AssetManagerIntegrationTest
     end
 
     test 'sends the person image to Asset Manager' do
-      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
-        args[:file].is_a?(File) &&
-          args[:legacy_url_path] =~ /#{@filename}/
-      end
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        all_of(
+          has_entry(:file, instance_of(File)),
+          has_entry(:legacy_url_path, regexp_matches(/#{@filename}/)))
+      )
 
       @person.save!
     end
 
     test 'sends each version of the person image to Asset Manager' do
       ImageUploader.versions.each_key do |version_prefix|
-        Services.asset_manager.expects(:create_whitehall_asset).with do |args|
-          args[:file].is_a?(File) &&
-            args[:legacy_url_path] =~ /#{version_prefix}_#{@filename}/
-        end
+        Services.asset_manager.expects(:create_whitehall_asset).with(
+          all_of(
+            has_entry(:file, instance_of(File)),
+            has_entry(:legacy_url_path, regexp_matches(/#{version_prefix}_#{@filename}/)))
+        )
       end
 
       @person.save!
@@ -226,10 +229,11 @@ class AssetManagerIntegrationTest
     end
 
     test 'sends the consultation response form data file to Asset Manager' do
-      Services.asset_manager.expects(:create_whitehall_asset).with do |args|
-        args[:file].is_a?(File) &&
-          args[:legacy_url_path] =~ /#{@filename}/
-      end
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        all_of(
+          has_entry(:file, instance_of(File)),
+          has_entry(:legacy_url_path, regexp_matches(/#{@filename}/)))
+      )
 
       @consultation_response_form_data.save!
     end

--- a/test/support/asset_manager_test_helpers.rb
+++ b/test/support/asset_manager_test_helpers.rb
@@ -1,0 +1,8 @@
+module AssetManagerTestHelpers
+  def file_and_legacy_url_path_matching(regex)
+    all_of(
+      has_entry(:file, instance_of(File)),
+      has_entry(:legacy_url_path, regexp_matches(regex))
+    )
+  end
+end

--- a/test/support/virus_scan_helpers.rb
+++ b/test/support/virus_scan_helpers.rb
@@ -1,5 +1,5 @@
 module VirusScanHelpers
-  def self.simulate_virus_scan(*uploaders)
+  def self.simulate_virus_scan(*uploaders, include_versions: false)
     if uploaders.empty?
       uploaders = AttachmentData.all.map(&:file) + ImageData.all.map(&:file)
     end
@@ -7,11 +7,24 @@ module VirusScanHelpers
     uploaders.each do |uploader|
       absolute_path = File.join(Whitehall.incoming_uploads_root, uploader.relative_path)
       target_dir = File.join(Whitehall.clean_uploads_root, File.dirname(uploader.relative_path))
-      if File.exists?(absolute_path)
-        FileUtils.mkdir_p(target_dir)
-        FileUtils.cp(absolute_path, target_dir)
-        FileUtils.rm(absolute_path)
+      move_file(absolute_path, target_dir)
+
+      if include_versions
+        uploader.versions.each_pair do |_, version_uploader|
+          absolute_path = File.join(Whitehall.incoming_uploads_root, version_uploader.store_path)
+          target_dir = File.join(Whitehall.clean_uploads_root, File.dirname(version_uploader.store_path))
+
+          move_file(absolute_path, target_dir)
+        end
       end
+    end
+  end
+
+  def self.move_file(absolute_path, target_dir)
+    if File.exist?(absolute_path)
+      FileUtils.mkdir_p(target_dir)
+      FileUtils.cp(absolute_path, target_dir)
+      FileUtils.rm(absolute_path)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ GovukContentSchemaTestHelpers.configure do |config|
 end
 
 class ActiveSupport::TestCase
+  include AssetManagerTestHelpers
   include FactoryBot::Syntax::Methods
   include ModelHelpers
   include ModelStubbingHelpers

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -11,6 +11,10 @@ class ImageUploaderTest < ActiveSupport::TestCase
     ImageUploader.enable_processing = false
   end
 
+  test 'uses the asset manager and quarantined file storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ImageUploader.storage
+  end
+
   test "should only allow JPG, GIF, PNG or SVG images" do
     uploader = ImageUploader.new
     assert_equal %w(jpg jpeg gif png svg), uploader.extension_whitelist


### PR DESCRIPTION
I've reopened this PR after addressing the comments in #3589.

This PR switches the `ImageUploader` to use the `asset_manager_and_quarantined_file_storage` storage engine - ensuring that any new files that are uploaded using this uploader will be stored in Asset Manager. This is a precursor to migrating all of the existing files that use this uploader to Asset Manager and eventually removing them from NFS altogether. 

The change itself (in the first commit) is simple. Subsequent commits add some additional integration testing to make sure that Create, Update and Delete operations on a model that mounts this uploader (`Person`) work as expected. 

Note that the `ImageUploader` is configured to not remove files when they are replaced with new ones. This change to the `remove_previously_stored_files_after_update` config variable was added in 32932249 to ensure that already published links to assets that had been replaced would continue to work with the switch to the publishing API. This is an issue because URLs to assets are "burnt in" to the published content in the publishing API and the relationship to the included assets is not modelled - so when the asset URLs change the published content does not.

In terms of asset manager, when an asset is replaced by a file with a different name, two assets with different `legacy_url_path` will exist in asset manager and links to the old assets will continue to work. If an asset is replaced by a new file with the *same* name, the old asset will be soft-deleted in asset manager and the new asset will take its `legacy_url_path`. This change was introduced in https://github.com/alphagov/asset-manager/pull/336.

Fixes: https://github.com/alphagov/asset-manager/issues/325