### PR TITLE
MigrateAssetsToAssetManager#to_s returns a count

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,4 +1,6 @@
 class MigrateAssetsToAssetManager
+  include ActionView::Helpers::TextHelper
+
   def initialize(target_dir)
     @file_paths = AssetFilePaths.new(target_dir)
   end
@@ -10,7 +12,7 @@ class MigrateAssetsToAssetManager
   end
 
   def to_s
-    @file_paths.join("\n")
+    "Migrating #{pluralize(@file_paths.size, 'file')}"
   end
 
   class Worker < WorkerBase
@@ -40,7 +42,7 @@ class MigrateAssetsToAssetManager
   end
 
   class AssetFilePaths
-    delegate :each, :join, to: :file_paths
+    delegate :each, :size, to: :file_paths
 
     def initialize(target_dir)
       @target_dir = target_dir

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -61,8 +61,8 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     @subject.perform
   end
 
-  test 'to_s is a string of asset file paths to be migrated' do
-    assert_equal @organisation_logo_path, @subject.to_s
+  test 'to_s is a count of the number of files to be migrated' do
+    assert_equal 'Migrating 1 file', @subject.to_s
   end
 end
 
@@ -91,8 +91,8 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     assert @subject.respond_to?(:each)
   end
 
-  test 'delegates join to file_paths' do
-    assert @subject.respond_to?(:join)
+  test 'delegates size to file_paths' do
+    assert @subject.respond_to?(:size)
   end
 
   test '#files includes only organisation logos' do


### PR DESCRIPTION
Before this commit MigrateAssetsToAssetManager#to_s returned a newline
separated list of all of the files to be migrated. When we migrate
`system/uploads/image_data/file`, for example, there will be almost
500,000 files[1]. It is probably not a good idea to generate this much
output in the rake task that calls this method, and a simple count
will be sufficient to verify that the correct number of assets have
been migrated.

[1] https://github.com/alphagov/asset-manager/issues/341