### PR TITLE
Configure email alert api with bearer token

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -1,14 +1,7 @@
-require 'gds_api/helpers'
-
 class EmailSignup
   include ActiveModel::Conversion
   extend ActiveModel::Naming
   include ActiveModel::Validations
-  extend GdsApi::Helpers
-
-  def self.client
-    email_alert_api
-  end
 
   attr_reader :feed
   validates_presence_of :feed
@@ -26,7 +19,8 @@ class EmailSignup
   end
 
   def ensure_govdelivery_topic_exists
-    @ensure_govdelivery_topic_exists ||= self.class.client.find_or_create_subscriber_list(criteria)
+    @ensure_govdelivery_topic_exists ||=
+      Services.email_alert_api.find_or_create_subscriber_list(criteria)
   end
 
   def criteria

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -1,5 +1,5 @@
 Given(/^email alert api exists$/) do
-  EmailSignup.stubs(client: mock_email_alert_api)
+  Services.stubs(:email_alert_api).returns(mock_email_alert_api)
 end
 
 When(/^I sign up for emails$/) do

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,6 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/asset_manager'
+require "gds_api/email_alert_api"
 
 module Services
   def self.publishing_api
@@ -22,6 +23,13 @@ module Services
     @asset_manager ||= GdsApi::AssetManager.new(
       Plek.find("asset-manager"),
       bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || '12345678',
+    )
+  end
+
+  def self.email_alert_api
+    @email_alert_api ||= GdsApi::EmailAlertApi.new(
+      Plek.find("email-alert-api"),
+      bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "gazorpazorp")
     )
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,12 +1,12 @@
-require 'gds_api/publishing_api_v2'
-require 'gds_api/asset_manager'
+require "gds_api/publishing_api_v2"
+require "gds_api/asset_manager"
 require "gds_api/email_alert_api"
 
 module Services
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.find('publishing-api'),
-      bearer_token: (ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'),
+      Plek.find("publishing-api"),
+      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
       timeout: 20,
     )
   end
@@ -22,7 +22,7 @@ module Services
   def self.asset_manager
     @asset_manager ||= GdsApi::AssetManager.new(
       Plek.find("asset-manager"),
-      bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || '12345678',
+      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "12345678"),
     )
   end
 


### PR DESCRIPTION
Email-alert-api is getting authentication/authorisation. This PR adds configures the client with a bearer token. Also rights some crimes against consistency.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)