### PR TITLE
Redirect asset requests to asset host

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,5 +1,6 @@
 class AttachmentsController < PublicUploadsController
   include PublicDocumentRoutesHelper
+  skip_before_action :redirect_to_asset_host
 
   before_action :reject_non_previewable_attachments, only: :preview
 

--- a/app/controllers/public_uploads_controller.rb
+++ b/app/controllers/public_uploads_controller.rb
@@ -1,5 +1,6 @@
 class PublicUploadsController < ApplicationController
   include ActionView::Helpers::AssetTagHelper
+  before_action :redirect_to_asset_host
 
   def show
     if attachment_visible?
@@ -75,5 +76,12 @@ class PublicUploadsController < ApplicationController
 
   def real_path_for_x_accel_mapping(potentially_symlinked_path)
     File.realpath(potentially_symlinked_path)
+  end
+
+  def redirect_to_asset_host
+    asset_host = URI.parse(Plek.new.public_asset_host).host
+    unless request.host == asset_host
+      redirect_to host: asset_host
+    end
   end
 end

--- a/app/controllers/public_uploads_controller.rb
+++ b/app/controllers/public_uploads_controller.rb
@@ -52,7 +52,7 @@ class PublicUploadsController < ApplicationController
   end
 
   def upload_path
-    basename = [params[:path], params[:extension], params[:format]].compact.join('.')
+    basename = [params[:path], params[:format]].compact.join('.')
     File.join(Whitehall.clean_uploads_root, basename)
   end
 

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -310,7 +310,7 @@ module PublishingApi
 
         path = File.join(dirname, basename)
 
-        url_helpers.public_upload_url(path, extension: extension.delete('.'))
+        url_helpers.public_upload_url(path, format: extension.delete('.'))
       end
 
       def email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -422,5 +422,5 @@ Whitehall::Application.routes.draw do
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "attachments#preview", as: :preview_attachment
-  get '/government/uploads/*path.:extension' => "public_uploads#show", as: :public_upload
+  get '/government/uploads/*path.:format' => "public_uploads#show", as: :public_upload
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -422,5 +422,5 @@ Whitehall::Application.routes.draw do
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "attachments#preview", as: :preview_attachment
-  get '/government/uploads/*path.:format' => "public_uploads#show", as: :public_upload
+  get '/government/uploads/*path' => "public_uploads#show", as: :public_upload, format: true
 end

--- a/test/functional/public_uploads_controller_test.rb
+++ b/test/functional/public_uploads_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class PublicUploadsControllerTest < ActionController::TestCase
+  setup do
+    Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
+  end
+
+  test "redirects asset requests that aren't made via the asset host" do
+    request.host = 'not-asset-host.com'
+
+    get :show, params: { path: 'asset', format: 'txt' }
+
+    assert_redirected_to 'http://asset-host.com/government/uploads/asset.txt'
+  end
+
+  test 'does not redirect asset requests that are made via the asset host' do
+    asset_filesystem_path = File.join(Whitehall.clean_uploads_root, 'asset.txt')
+    FileUtils.touch(asset_filesystem_path)
+
+    request.host = 'asset-host.com'
+
+    get :show, params: { path: 'asset', format: 'txt' }
+
+    assert_response 200
+  end
+end

--- a/test/integration/upload_access_test.rb
+++ b/test/integration/upload_access_test.rb
@@ -30,7 +30,7 @@ class UploadAccessTest < ActionDispatch::IntegrationTest
   end
 
   def assert_redirected_to_placeholder_image
-    assert_redirected_to "http://www.example.com/government/assets/thumbnail-placeholder.png"
+    assert_redirected_to "/government/assets/thumbnail-placeholder.png"
   end
 
   def assert_sent_public_upload(upload, content_type)
@@ -44,6 +44,11 @@ class UploadAccessTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
     assert_equal content_type, response.content_type
     assert_cache_control "no-cache"
+  end
+
+  setup do
+    asset_host = URI.parse(Plek.new.public_asset_host).host
+    host! asset_host
   end
 
   test 'allows everyone access to general uploads' do

--- a/test/integration/upload_access_test.rb
+++ b/test/integration/upload_access_test.rb
@@ -25,10 +25,6 @@ class UploadAccessTest < ActionDispatch::IntegrationTest
     }
   end
 
-  def assert_redirected_to_placeholder_page
-    assert_redirected_to "http://www.example.com/government/placeholder"
-  end
-
   def assert_redirected_to_placeholder_image
     assert_redirected_to "/government/assets/thumbnail-placeholder.png"
   end


### PR DESCRIPTION
This branch ensures that assets (but not attachments) are all served from the asset host (e.g. assets.publishing.service.gov.uk). This addresses https://github.com/alphagov/asset-manager/issues/348 and will allow us to configure things like caching and routing in a single place.