### PR TITLE
Build the Dockerfile image for the branch and push to hub.docker.com

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,14 @@ node {
       }
     }
 
+    stage("Build Docker image") {
+      govuk.buildDockerImage(REPOSITORY, env.BRANCH_NAME)
+    }
+
+    stage("Push Docker image") {
+      govuk.pushDockerImage(REPOSITORY, env.BRANCH_NAME)
+    }
+
     stage("Precompile assets") {
       if (params.IS_SCHEMA_TEST) {
         echo "Skipping precompile step because this is a schema test"


### PR DESCRIPTION
As part of the publishing end to end testing we are migrating from building the image as part of the E2E test build and towards using the pre-built images.

Whitehall is the only app without an image build step.