### PR TITLE
Use the asset host in consultation response form URLs

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -310,7 +310,8 @@ module PublishingApi
 
         path = File.join(dirname, basename)
 
-        url_helpers.public_upload_url(path, format: extension.delete('.'))
+        asset_host = URI.parse(Plek.new.public_asset_host).host
+        url_helpers.public_upload_url(path, format: extension.delete('.'), host: asset_host)
       end
 
       def email

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -255,8 +255,9 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test 'ways to respond' do
+      Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
       expected_ways_to_respond = {
-        attachment_url: 'https://www.test.gov.uk/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
+        attachment_url: 'https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
         email: 'postmaster@example.com',
         link_url: 'http://www.example.com',
         postal_address: <<-ADDRESS.strip_heredoc.chop


### PR DESCRIPTION
We want Whitehall assets to be served by the asset host (instead of
either by the asset host or gov.uk) so that we can make caching and
routing changes in a single place.

PR #3627 adds a redirect to ensure that asset requests made to gov.uk
are redirect to the asset host. This change will ensure that we're using
the canonical asset host when writing consultation content to the
Content Store.

These URLs are rendered in the "Ways to respond" section on a
consultation page.