### PR TITLE
Avoid redirecting requests for HMRC assets

### DIFF
--- a/app/controllers/public_uploads_controller.rb
+++ b/app/controllers/public_uploads_controller.rb
@@ -79,9 +79,15 @@ class PublicUploadsController < ApplicationController
   end
 
   def redirect_to_asset_host
+    return if request_for_an_hmrc_asset?
+
     asset_host = URI.parse(Plek.new.public_asset_host).host
     unless request.host == asset_host
       redirect_to host: asset_host
     end
+  end
+
+  def request_for_an_hmrc_asset?
+    request.path.match?(%r(^/government/uploads/uploaded/hmrc/))
   end
 end

--- a/test/functional/public_uploads_controller_test.rb
+++ b/test/functional/public_uploads_controller_test.rb
@@ -23,4 +23,17 @@ class PublicUploadsControllerTest < ActionController::TestCase
 
     assert_response 200
   end
+
+  test "does not redirect hmrc asset requests that aren't made via the asset host" do
+    hmrc_asset_directory = File.join(Whitehall.clean_uploads_root, 'uploaded', 'hmrc')
+    asset_filesystem_path = File.join(hmrc_asset_directory, 'asset.txt')
+    FileUtils.makedirs(hmrc_asset_directory)
+    FileUtils.touch(asset_filesystem_path)
+
+    request.host = 'not-asset-host.com'
+
+    get :show, params: { path: 'uploaded/hmrc/asset', format: 'txt' }
+
+    assert_response 200
+  end
 end


### PR DESCRIPTION
We host a number of assets for [HMRC's Basic PAYE Tools software][1] on
gov.uk. Some of these files are requested from within the Basic PAYE
Tools app - to check for updates, for example. It's not clear how the
app will behave if the request responds with a 302 redirect instead of a
200 with the content of the file. We plan to ask HMRC to update the URL
that they're checking from within the app but we should avoid
redirecting them in the short term to avoid any problems.

I initially used `=~` to check the regexp in the
`PublicUploadsController` but have changed it to `match?` as instructed
by RuboCop.

I explored reducing the duplication of 'government/uploads' in the app
but it became clear that it was going to take quite some time to do it.
It's not obvious that it's worth the investment at the moment given that
some of this code will go away as we migrate more assets to Asset
Manager.

[1]: https://www.gov.uk/basic-paye-tools