### PR TITLE
Ensure asset directory exists before creating an asset in test

### DIFF
--- a/test/functional/public_uploads_controller_test.rb
+++ b/test/functional/public_uploads_controller_test.rb
@@ -15,6 +15,7 @@ class PublicUploadsControllerTest < ActionController::TestCase
 
   test 'does not redirect asset requests that are made via the asset host' do
     asset_filesystem_path = File.join(Whitehall.clean_uploads_root, 'asset.txt')
+    FileUtils.makedirs(Whitehall.clean_uploads_root)
     FileUtils.touch(asset_filesystem_path)
 
     request.host = 'asset-host.com'


### PR DESCRIPTION
This test was failing intermittently on Jenkins. It would fail if the
`Whitehall.clean_uploads_root` didn't exist. I replicated this locally
by deleting the `tmp/test` directory and running the test. I saw the
following error:

```
PublicUploadsControllerTest#test_does_not_redirect_asset_requests_that_are_made_via_the_asset_host:
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/chrisroos/Code/alphagov/whitehall/tmp/test/env_1/clean-uploads/asset.txt
```

I believe the test would have passed if it was run after a call to
`VirusScanHelpers#simulate_virus_scan` as that method will create the
upload directory.