### PR TITLE
Allow worldwide organisation preview

### DIFF
--- a/app/controllers/worldwide_organisations_controller.rb
+++ b/app/controllers/worldwide_organisations_controller.rb
@@ -1,5 +1,7 @@
 class WorldwideOrganisationsController < PublicFacingController
   include CacheControlHelper
+  include PermissionsChecker
+
   enable_request_formats show: :json
   before_action :load_worldwide_organisation
 
@@ -24,8 +26,21 @@ class WorldwideOrganisationsController < PublicFacingController
 
 private
 
+  def preview?
+    params[:preview]
+  end
+
+  def current_user_can_preview?
+    preview? && user_signed_in?
+  end
+
   def load_worldwide_organisation
     @worldwide_organisation = WorldwideOrganisation.with_translations(I18n.locale).find(params[:id])
+
+    if current_user_can_preview?
+      expires_now
+      @draft = true
+    end
   end
 
   def primary_role

--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -34,4 +34,7 @@ module HasCorporateInformationPages
     @about ||= corporate_information_pages.published.for_slug('about')
   end
 
+  def draft_about_us
+    @draft_about ||= corporate_information_pages.draft.for_slug('about')
+  end
 end

--- a/app/views/worldwide_organisations/show.html.erb
+++ b/app/views/worldwide_organisations/show.html.erb
@@ -9,7 +9,11 @@
       <div class="content">
         <p class="summary"><%= @worldwide_organisation.summary %></p>
         <div class="description">
+          <% if @draft %>
+          <%= govspeak_edition_to_html @worldwide_organisation.draft_about_us %>
+          <% else %>
           <%= govspeak_edition_to_html @worldwide_organisation.about_us %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -9,8 +9,13 @@ FactoryBot.define do
   end
 
   factory :published_corporate_information_page, parent: :corporate_information_page, traits: [:published]
+  factory :draft_corporate_information_page, parent: :corporate_information_page, traits: [:draft]
 
   factory :about_corporate_information_page, parent: :published_corporate_information_page do
+    corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
+  end
+
+  factory :draft_about_corporate_information_page, parent: :draft_corporate_information_page do
     corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
   end
 

--- a/test/functional/worldwide_organisations_controller_test.rb
+++ b/test/functional/worldwide_organisations_controller_test.rb
@@ -63,4 +63,32 @@ class WorldwideOrganisationsControllerTest < ActionController::TestCase
     worldwide_organisation.reload
     refute worldwide_organisation.has_home_page_offices_list?
   end
+
+  view_test "showing a preview of draft content when requested and a user is logged in" do
+    login_as :gds_editor
+
+    worldwide_organisation = create(:worldwide_organisation)
+    create(:about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: 'pre-edit body')
+    get :show, params: { id: worldwide_organisation }
+    assert_select ".description", text: "pre-edit body"
+
+    draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: 'post-edit body')
+
+    get :show, params: { id: worldwide_organisation }
+    assert_select ".description", text: "pre-edit body"
+
+    get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
+    assert_select ".description", text: "post-edit body"
+  end
+
+  view_test "not showing a preview of draft content when requested and a user is not logged in" do
+    worldwide_organisation = create(:worldwide_organisation)
+    create(:about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: 'pre-edit body')
+    get :show, params: { id: worldwide_organisation }
+    assert_select ".description", text: "pre-edit body"
+
+    draft_cip = create(:draft_about_corporate_information_page, organisation: nil, worldwide_organisation: worldwide_organisation, body: 'post-edit body')
+    get :show, params: { id: worldwide_organisation, preview: draft_cip.id }
+    assert_select ".description", text: "pre-edit body"
+  end
 end


### PR DESCRIPTION
This commit adds support for previewing worldwide organisation page changes before they are published.

Trello: https://trello.com/c/sxsdgcmR/464-preview-pages-not-working-correctly