### PR TITLE
HCA URL changes

### DIFF
--- a/db/data_migration/20171221134048_rename_sdr_survey_responses.rb
+++ b/db/data_migration/20171221134048_rename_sdr_survey_responses.rb
@@ -1,0 +1,12 @@
+old_slug = "statistical-data-return-2012-to-2013-survey-responses"
+new_slug = "statistical-data-return-survey-responses"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"

--- a/db/data_migration/20171221134303_rename_large_housing_providers.rb
+++ b/db/data_migration/20171221134303_rename_large_housing_providers.rb
@@ -1,0 +1,12 @@
+old_slug = "letter-from-julian-ashby-to-chairs-and-chief-executives-of-large-housing-providers"
+new_slug = "letter-from-julian-ashby-to-chairs-and-chief-executives-of-social-housing-providers"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"

--- a/db/data_migration/20171221134448_rename_disposal_proceeds_fund.rb
+++ b/db/data_migration/20171221134448_rename_disposal_proceeds_fund.rb
@@ -1,0 +1,12 @@
+old_slug = "temp-disposal-proceeds-fund"
+new_slug = "disposal-proceeds-fund"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"

--- a/db/data_migration/20171221134602_rename_hca_regulation_committee_minutes.rb
+++ b/db/data_migration/20171221134602_rename_hca_regulation_committee_minutes.rb
@@ -1,0 +1,12 @@
+old_slug = "regulation-committee-minutes"
+new_slug = "regulation-committee-minutes-2016"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"


### PR DESCRIPTION
This PR adds data migrations for four slug changes to HCA documents.

Trello: https://trello.com/c/uIAR365z/474-url-change