### PR TITLE
Add healthcheck to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ ADD . $APP_HOME
 ARG COMPILE_ASSETS=false
 RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
 
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
+
 CMD bash -c "bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
As part of the E2E tests project we boot up Whitehall as a dependency of manuals-publisher. We've identified that Whitehall can be slow to boot up and become responsive to API requests.  This healthcheck will prevent Docker from running the tests until the healthcheck route is up.