### PR TITLE
Remove the '[Archived]' title prefix from HTML attachments

### DIFF
--- a/db/data_migration/20171114161502_correct_spelling_for_dane_housing_publication.rb
+++ b/db/data_migration/20171114161502_correct_spelling_for_dane_housing_publication.rb
@@ -1,12 +1,15 @@
 old_slug = "regulatory-judgment-plus-dane-housing-group-limited"
 new_slug = "regulatory-judgement-plus-dane-housing-group-limited"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171114161648_correct_spelling_for_paradigm_housing_publication.rb
+++ b/db/data_migration/20171114161648_correct_spelling_for_paradigm_housing_publication.rb
@@ -1,12 +1,15 @@
 old_slug = "regulatory-notice-paradigm-housing-group-limited"
 new_slug = "regulatory-judgement-paradigm-housing-group-limited"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171128105848_rename_gds_academy_slug.rb
+++ b/db/data_migration/20171128105848_rename_gds_academy_slug.rb
@@ -1,13 +1,15 @@
 old_slug = "digital-academy"
 new_slug = "gds-academy"
 
-group = PolicyGroup.find_by!(slug: old_slug)
+group = PolicyGroup.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(group)
+if group
+  Whitehall::SearchIndex.delete(group)
 
-group.update_attributes!(slug: new_slug)
+  group.update_attributes!(slug: new_slug)
 
-Whitehall::PublishingApi.republish_async(group)
-Whitehall::SearchIndex.add(group)
+  Whitehall::PublishingApi.republish_async(group)
+  Whitehall::SearchIndex.add(group)
 
-puts "#{old_slug} -> #{new_slug}"
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171221134048_rename_sdr_survey_responses.rb
+++ b/db/data_migration/20171221134048_rename_sdr_survey_responses.rb
@@ -1,12 +1,15 @@
 old_slug = "statistical-data-return-2012-to-2013-survey-responses"
 new_slug = "statistical-data-return-survey-responses"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171221134303_rename_large_housing_providers.rb
+++ b/db/data_migration/20171221134303_rename_large_housing_providers.rb
@@ -1,12 +1,15 @@
 old_slug = "letter-from-julian-ashby-to-chairs-and-chief-executives-of-large-housing-providers"
 new_slug = "letter-from-julian-ashby-to-chairs-and-chief-executives-of-social-housing-providers"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171221134448_rename_disposal_proceeds_fund.rb
+++ b/db/data_migration/20171221134448_rename_disposal_proceeds_fund.rb
@@ -1,12 +1,15 @@
 old_slug = "temp-disposal-proceeds-fund"
 new_slug = "disposal-proceeds-fund"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20171221134602_rename_hca_regulation_committee_minutes.rb
+++ b/db/data_migration/20171221134602_rename_hca_regulation_committee_minutes.rb
@@ -1,12 +1,15 @@
 old_slug = "regulation-committee-minutes"
 new_slug = "regulation-committee-minutes-2016"
 
-document = Document.find_by!(slug: old_slug)
-edition = document.editions.published.last
+document = Document.find_by(slug: old_slug)
 
-Whitehall::SearchIndex.delete(edition)
+if document
+  edition = document.editions.published.last
 
-document.update_attributes!(slug: new_slug)
-PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  Whitehall::SearchIndex.delete(edition)
 
-puts "#{old_slug} -> #{new_slug}"
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+  puts "#{old_slug} -> #{new_slug}"
+end

--- a/db/data_migration/20180103105439_remove_archived_title_prefix_html_attachments.rb
+++ b/db/data_migration/20180103105439_remove_archived_title_prefix_html_attachments.rb
@@ -1,0 +1,31 @@
+HtmlAttachment.where("title like '[%'").each do |attachment|
+  id = attachment.id
+
+  old_title = attachment.title
+  new_title = old_title.sub(/^\[archived?\]\s*/i, "")
+
+  raise "Title should have changed for id=#{id}" if old_title == new_title
+
+  puts "id=#{id}: #{old_title} -> #{new_title}"
+  next if ENV["DRY_RUN"]
+
+  attachable = attachment.attachable
+  document = attachable.document
+
+  print "  Removing from search index..."
+  Whitehall::SearchIndex.delete(attachable)
+  puts "Done."
+
+  print "  Updating title..."
+  attachment.title = new_title
+  attachment.save!(validate: false)
+  puts "Done."
+
+  print "  Republishing... "
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  puts "Done."
+
+  print "  Re-adding to search index..."
+  Whitehall::SearchIndex.add(attachable.reload)
+  puts "Done."
+end


### PR DESCRIPTION
https://trello.com/c/qZgjF7EN/472-rename-withdrawn-and-archived-html-publications

**This is probably easier to review as two separate commits.**

Some users have manually added '[Archived]' to the title of HTML
attachments, but the system already handles this. The result is we're
rendering titles like '[Withdrawn] [Archived] Something'.

At time of writing, there are 37 HTML attachments exhibiting this
problem. This is more than those listed in the Trello ticket, but we
decided to fix all of them.

Rake task output on integration:
https://deploy.integration.publishing.service.gov.uk/job/Run_Whitehall_Data_Migrations/131/console

Example that has been fixed:
https://www-origin.integration.publishing.service.gov.uk/government/publications/business-visitor-academic-visitor-vat12/business-visitor-academic-visitor-vat12

(note: the title is now just `[Withdrawn]` rather than `[Withdrawn] [Archived]`)