### PR TITLE
Reduce organisation edition limit

### DIFF
--- a/app/workers/check_organisation_links_worker.rb
+++ b/app/workers/check_organisation_links_worker.rb
@@ -1,7 +1,7 @@
 # Calls the Link Checker API to verify all links in public editions, either per organisation or not
 class CheckOrganisationLinksWorker
   include Sidekiq::Worker
-  ORGANISATION_EDITION_LIMIT = 1000
+  ORGANISATION_EDITION_LIMIT = 500
 
   sidekiq_options queue: "link_checks"
 


### PR DESCRIPTION
This PR reduces the number of editions checked on staging by half, we didn't need to check 1000.

We have `1023` organisations, and around `2177027` documents. To check every document over a 7 day period we should process 435000 a day.

```ruby
435000/1023 = 500
```