### PR TITLE
Ensure hidden files are migrated to asset manager

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -19,8 +19,9 @@ class MigrateAssetsToAssetManager
     sidekiq_options queue: :asset_migration
 
     def perform(file_path)
-      file = AssetFile.open(file_path)
-      create_whitehall_asset(file) unless asset_exists?(file)
+      AssetFile.open(file_path) do |file|
+        create_whitehall_asset(file) unless asset_exists?(file)
+      end
     end
 
   private

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -56,7 +56,7 @@ class MigrateAssetsToAssetManager
   private
 
     def all_paths_under_target_directory
-      Dir.glob(File.join(full_target_dir, '**', '*'))
+      Dir.glob(File.join(full_target_dir, '**', '*'), File::FNM_DOTMATCH)
     end
 
     def full_target_dir

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -143,8 +143,9 @@ end
 class AssetFileTest < ActiveSupport::TestCase
   setup do
     @path = Rails.root.join('test/fixtures/logo.png')
-    file = MigrateAssetsToAssetManager::AssetFile.open(@path)
-    @parts = file.legacy_etag.split('-')
+    MigrateAssetsToAssetManager::AssetFile.open(@path) do |file|
+      @parts = file.legacy_etag.split('-')
+    end
   end
 
   test 'returns string made up of 2 parts separated by a hyphen' do

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -4,21 +4,17 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   setup do
     Services.asset_manager.stubs(:whitehall_asset).raises(GdsApi::HTTPNotFound.new(404))
 
-    organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
     FileUtils.mkdir_p(organisation_logo_dir)
+    FileUtils.cp(dummy_asset_path, organisation_logo_path)
 
-    @organisation_logo_path = File.join(organisation_logo_dir, 'logo.jpg')
-    dummy_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
-    FileUtils.cp(dummy_asset_path, @organisation_logo_path)
-
-    @organisation_logo_file = File.open(@organisation_logo_path)
+    @organisation_logo_file = File.open(organisation_logo_path)
 
     @subject = MigrateAssetsToAssetManager.new('system/uploads/organisation/logo')
   end
 
   test 'it calls create_whitehall_asset for each file in the list' do
     Services.asset_manager.expects(:create_whitehall_asset)
-      .with(has_entry(:file, responds_with(:read, File.read(@organisation_logo_path))))
+      .with(has_entry(:file, responds_with(:read, File.read(organisation_logo_path))))
 
     @subject.perform
   end
@@ -43,8 +39,8 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
 
   test 'it calls create_whitehall_asset with the legacy etag' do
     expected_etag = [
-      File.stat(@organisation_logo_path).mtime.to_i.to_s(16),
-      File.stat(@organisation_logo_path).size.to_i.to_s(16),
+      File.stat(organisation_logo_path).mtime.to_i.to_s(16),
+      File.stat(organisation_logo_path).size.to_i.to_s(16),
     ].join('-')
 
     Services.asset_manager.expects(:create_whitehall_asset).with(
@@ -64,19 +60,26 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   test 'to_s is a count of the number of files to be migrated' do
     assert_equal 'Migrating 1 file', @subject.to_s
   end
+
+private
+
+  def organisation_logo_dir
+    File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
+  end
+
+  def organisation_logo_path
+    File.join(organisation_logo_dir, 'logo.jpg')
+  end
+
+  def dummy_asset_path
+    Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
+  end
 end
 
 class AssetFilePathsTest < ActiveSupport::TestCase
   setup do
-    organisation_logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
-    other_asset_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'other')
-
     FileUtils.mkdir_p(organisation_logo_dir)
     FileUtils.mkdir_p(other_asset_dir)
-
-    organisation_logo_path = File.join(organisation_logo_dir, 'logo.jpg')
-    other_asset_path = File.join(other_asset_dir, 'other_asset.png')
-    dummy_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
 
     FileUtils.cp(dummy_asset_path, organisation_logo_path)
     FileUtils.cp(dummy_asset_path, other_asset_path)
@@ -108,6 +111,28 @@ class AssetFilePathsTest < ActiveSupport::TestCase
   test '#files includes all files when initialised with a top level target directory' do
     subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads')
     assert_equal 2, subject.file_paths.size
+  end
+
+private
+
+  def organisation_logo_dir
+    File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo', '1')
+  end
+
+  def other_asset_dir
+    File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'other')
+  end
+
+  def organisation_logo_path
+    File.join(organisation_logo_dir, 'logo.jpg')
+  end
+
+  def other_asset_path
+    File.join(other_asset_dir, 'other_asset.png')
+  end
+
+  def dummy_asset_path
+    Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
   end
 end
 

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -117,6 +117,13 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     assert_equal 2, subject.file_paths.size
   end
 
+  test '#files includes hidden files' do
+    hidden_path = File.join(organisation_logo_dir, '.hidden.jpg')
+    FileUtils.cp(dummy_asset_path, hidden_path)
+
+    assert_equal 2, @subject.file_paths.size
+  end
+
 private
 
   def organisation_logo_dir

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -12,6 +12,10 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     @subject = MigrateAssetsToAssetManager.new('system/uploads/organisation/logo')
   end
 
+  teardown do
+    FileUtils.rm_rf(organisation_logo_dir)
+  end
+
   test 'it calls create_whitehall_asset for each file in the list' do
     Services.asset_manager.expects(:create_whitehall_asset)
       .with(has_entry(:file, responds_with(:read, File.read(organisation_logo_path))))
@@ -88,6 +92,11 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     @other_asset = File.open(other_asset_path)
 
     @subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads/organisation/logo')
+  end
+
+  teardown do
+    FileUtils.rm_rf(organisation_logo_dir)
+    FileUtils.rm_rf(other_asset_dir)
   end
 
   test 'delegates each to file_paths' do

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -88,9 +88,6 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     FileUtils.cp(dummy_asset_path, organisation_logo_path)
     FileUtils.cp(dummy_asset_path, other_asset_path)
 
-    @organisation_logo = File.open(organisation_logo_path)
-    @other_asset = File.open(other_asset_path)
-
     @subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads/organisation/logo')
   end
 

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -103,7 +103,7 @@ class AssetFilePathsTest < ActiveSupport::TestCase
   end
 
   test '#files includes only organisation logos' do
-    assert_equal 1, @subject.file_paths.size
+    assert_same_elements [organisation_logo_path], @subject.file_paths
   end
 
   test '#files does not includes directories' do
@@ -114,14 +114,14 @@ class AssetFilePathsTest < ActiveSupport::TestCase
 
   test '#files includes all files when initialised with a top level target directory' do
     subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads')
-    assert_equal 2, subject.file_paths.size
+    assert_same_elements [organisation_logo_path, other_asset_path], subject.file_paths
   end
 
   test '#files includes hidden files' do
     hidden_path = File.join(organisation_logo_dir, '.hidden.jpg')
     FileUtils.cp(dummy_asset_path, hidden_path)
 
-    assert_equal 2, @subject.file_paths.size
+    assert_same_elements [organisation_logo_path, hidden_path], @subject.file_paths
   end
 
 private

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -7,8 +7,6 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     FileUtils.mkdir_p(organisation_logo_dir)
     FileUtils.cp(dummy_asset_path, organisation_logo_path)
 
-    @organisation_logo_file = File.open(organisation_logo_path)
-
     @subject = MigrateAssetsToAssetManager.new('system/uploads/organisation/logo')
   end
 
@@ -32,7 +30,7 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
   end
 
   test 'it calls create_whitehall_asset with the legacy last modified time' do
-    expected_last_modified = File.stat(@organisation_logo_file.path).mtime
+    expected_last_modified = File.stat(organisation_logo_path).mtime
 
     Services.asset_manager.expects(:create_whitehall_asset).with(
       has_entry(:legacy_last_modified, expected_last_modified)


### PR DESCRIPTION
C.f alphagov/asset-manager#368

We noticed that some assets in Whitehall have file names which include a leading dot[1] These files are treated as "hidden" by Ruby's `Dir.glob` by default and were therefore not being included in the `asset_manager:migrate_assets` rake task. 

In this PR I first refactor the tests for the migration code to allow me to more easily fix an issue with hidden NFS lock files that occurs when running the tests on the development VM on an OS X host. I then fix that issue. In the final commit I fix the issue described above. 

We have already run the rake task against a number of directories. In a subsequent PR I'll introduce another task that [ensures that any hidden files we've missed are also migrated](https://github.com/alphagov/asset-manager/issues/382).
  
[1] e.g. `/data/uploads/whitehall/clean/system/uploads/consultation_response_form_data/file/257/.doc_Response_form.docx`.