### PR TITLE
Update govuk-app-config to 1.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
-    govuk_app_config (1.2.0)
+    govuk_app_config (1.2.1)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)


### PR DESCRIPTION
This prevents us logging everything at debug level in production

hashtag not-dependabot