### PR TITLE
Use edition's organisation for link check report

### DIFF
--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -2,20 +2,21 @@ class LinkReporterCsvService
   def initialize(reports_dir:, organisation: nil)
     @organisation = organisation
     @reports_dir = reports_dir
+    @csv_reports = {}
   end
 
   def generate
-    CSV.open(file_path, "w", encoding: "UTF-8") do |csv|
-      csv << headings
-      public_editions.each do |edition|
-        csv << row_for_edition(edition) if broken_links(edition).any?
-      end
+    public_editions.each do |edition|
+      next unless broken_links(edition).any?
+      csv_for_organisation(edition_organisation(edition)) << row_for_edition(edition)
     end
+
+    close_reports
   end
 
 private
 
-  attr_reader :organisation, :reports_dir
+  attr_reader :organisation, :reports_dir, :csv_reports
 
   def public_editions
     if organisation.nil?
@@ -25,13 +26,17 @@ private
     end
   end
 
-  def file_path
-    slug = @organisation.try(:slug) || 'no-organisation'
-    Pathname.new(reports_dir).join("#{slug}_links_report.csv")
+  def csv_for_organisation(edition_organisation)
+    slug = edition_organisation.try(:slug) || 'no-organisation'
+    csv_reports[slug] ||= CsvReport.new(csv_report_path(slug))
   end
 
-  def headings
-    ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"]
+  def csv_report_path(file_prefix)
+    Pathname.new(reports_dir).join("#{file_prefix}_links_report.csv")
+  end
+
+  def close_reports
+    csv_reports.each_value(&:close)
   end
 
   def row_for_edition(edition)
@@ -62,6 +67,16 @@ private
     edition.link_check_reports.last.broken_links.map(&:uri)
   end
 
+  def edition_organisation(edition)
+    if edition.respond_to?(:worldwide_organisations)
+      edition.worldwide_organisations.first
+    elsif edition.respond_to?(:lead_organisations)
+      edition.lead_organisations.first || edition.organisations.first
+    else
+      edition.organisations.first
+    end
+  end
+
   # These hosts are hardcoded because we run this on integration but want the
   # generated URLs to be production ones.
   def public_host
@@ -70,5 +85,22 @@ private
 
   def admin_host
     "whitehall-admin.publishing.service.gov.uk"
+  end
+
+  class CsvReport
+    delegate :<<, :close, to: :csv
+
+    def initialize(file_path)
+      @csv = CSV.open(file_path, 'w', encoding: 'UTF-8')
+      @csv << headings
+    end
+
+  private
+
+    attr_accessor :csv
+
+    def headings
+      ["page", "admin link", "public timestamp", "format", "broken link count", "broken links"]
+    end
   end
 end


### PR DESCRIPTION
When generating a broken link check report, use the edition's organisation if no organisation is passed to the report. If no csv exists for that organisation, generate a 'no-organisation' CSV report