### PR TITLE
Reslug DH and DCLG

### DIFF
--- a/db/data_migration/20180109122401_reslug_dh.rb
+++ b/db/data_migration/20180109122401_reslug_dh.rb
@@ -1,0 +1,5 @@
+require "data_hygiene/organisation_reslugger"
+
+organisation = Organisation.find_by(slug: "department-of-health")
+
+DataHygiene::OrganisationReslugger.new(organisation, "department-of-health-and-social-care").run!

--- a/db/data_migration/20180109122408_reslug_dclg.rb
+++ b/db/data_migration/20180109122408_reslug_dclg.rb
@@ -1,0 +1,5 @@
+require "data_hygiene/organisation_reslugger"
+
+organisation = Organisation.find_by(slug: "department-for-communities-and-local-government")
+
+DataHygiene::OrganisationReslugger.new(organisation, "ministry-of-housing-communities-and-local-government").run!


### PR DESCRIPTION
This commit changes the organisation slugs for the Department of Health and the Department for Communities and Local Government to Department of Health and Social Care, and Ministry of Housing, Communities and Local Government respectively, following a reshuffle on 8 January 2018.