### PR TITLE
Regenerate locales to strip quotes

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -3,30 +3,30 @@ ar:
     headings:
       attachments:
         zero:
-        one: "وثيقة"
+        one: وثيقة
         two:
         few:
         many:
-        other: "وثائق"
-      applies_to_nations: "ينطبق على"
+        other: وثائق
+      applies_to_nations: ينطبق على
       from:
       location:
       part_of:
     type:
       announcement:
         zero:
-        one: "إعلان"
+        one: إعلان
         two:
         few:
         many:
-        other: "إعلانات"
+        other: إعلانات
       authored_article:
         zero:
-        one: "مقال مرخص"
+        one: مقال مرخص
         two:
         few:
         many:
-        other: "مقالات مرخصة"
+        other: مقالات مرخصة
       blog_post:
         zero:
         one:
@@ -36,46 +36,46 @@ ar:
         other:
       case_study:
         zero:
-        one: "دراسة حالة"
+        one: دراسة حالة
         two:
         few:
         many:
-        other: "دراسات حالة"
+        other: دراسات حالة
       closed_consultation:
         zero:
-        one: "مشاورة منتهية"
+        one: مشاورة منتهية
         two:
         few:
         many:
-        other: "مشاورات منتهية"
+        other: مشاورات منتهية
       consultation:
         zero:
-        one: "مشاورة"
+        one: مشاورة
         two:
         few:
         many:
-        other: "مشاورات"
+        other: مشاورات
       consultation_outcome:
         zero:
-        one: "نتيجة المشاورة"
+        one: نتيجة المشاورة
         two:
         few:
         many:
-        other: "نتائج المشاورات"
+        other: نتائج المشاورات
       corporate_report:
         zero:
-        one: "تقرير الوزارة"
+        one: تقرير الوزارة
         two:
         few:
         many:
-        other: "تقارير الوزارة"
+        other: تقارير الوزارة
       correspondence:
         zero:
-        one: "مراسلة"
+        one: مراسلة
         two:
         few:
         many:
-        other: "مراسلات"
+        other: مراسلات
       decision:
         zero:
         one:
@@ -85,74 +85,74 @@ ar:
         other:
       detailed_guidance:
         zero:
-        one: "توجيه مفصل"
+        one: توجيه مفصل
         two:
         few:
         many:
-        other: "توجيهات مفصل"
+        other: توجيهات مفصل
       document_collection:
         zero:
-        one: "سلسة"
+        one: سلسة
         two:
         few:
         many:
         other:
       draft_text:
         zero:
-        one: "مسودة النص"
+        one: مسودة النص
         two:
         few:
         many:
-        other: "مسودة النصوص"
+        other: مسودة النصوص
       foi_release:
         zero:
-        one: "نشرة وفق حرية الحصول على المعلومات"
+        one: نشرة وفق حرية الحصول على المعلومات
         two:
         few:
         many:
-        other: "نشرات وفق حرية الحصول على المعلومات"
+        other: نشرات وفق حرية الحصول على المعلومات
       form:
         zero:
-        one: "نموذج"
+        one: نموذج
         two:
         few:
         many:
-        other: "نماذج"
+        other: نماذج
       government_response:
         zero:
-        one: "رد من الحكومة"
+        one: رد من الحكومة
         two:
         few:
         many:
-        other: "ردود من الحكومة"
+        other: ردود من الحكومة
       guidance:
         zero:
-        one: "توجيه"
+        one: توجيه
         two:
         few:
         many:
-        other: "توجيهات"
+        other: توجيهات
       impact_assessment:
         zero:
-        one: "تقييم التأثير"
+        one: تقييم التأثير
         two:
         few:
         many:
-        other: "تقييمات التأثير"
+        other: تقييمات التأثير
       imported:
         zero:
-        one: "استلم - بانتظار الطباعة"
+        one: استلم - بانتظار الطباعة
         two:
         few:
         many:
-        other: "استلم - بانتظار الطباعة"
+        other: استلم - بانتظار الطباعة
       independent_report:
         zero:
-        one: "تقرير مستقل"
+        one: تقرير مستقل
         two:
         few:
         many:
-        other: "تقارير مستقلة"
+        other: تقارير مستقلة
       international_treaty:
         zero:
         one:
@@ -169,32 +169,32 @@ ar:
         other:
       map:
         zero:
-        one: "خريطة"
+        one: خريطة
         two:
         few:
         many:
-        other: "خرائط"
+        other: خرائط
       national_statistics:
         zero:
-        one: "إحصائية - إحصائية محلية"
+        one: إحصائية - إحصائية محلية
         two:
         few:
         many:
-        other: "إحصائيات - إحصائيات محلية"
+        other: إحصائيات - إحصائيات محلية
       news_article:
         zero:
-        one: "مقال إخباري"
+        one: مقال إخباري
         two:
         few:
         many:
-        other: "مقالات إخبارية"
+        other: مقالات إخبارية
       news_story:
         zero:
-        one: "قصة إخبارية"
+        one: قصة إخبارية
         two:
         few:
         many:
-        other: "قصص إخبارية"
+        other: قصص إخبارية
       nhs_content:
         zero:
         one:
@@ -211,53 +211,53 @@ ar:
         other:
       official_statistics:
         zero:
-        one: "إحصائية"
+        one: إحصائية
         two:
         few:
         many:
-        other: "إحصائيات"
+        other: إحصائيات
       open_consultation:
         zero:
-        one: "مشاورة جارية"
+        one: مشاورة جارية
         two:
         few:
         many:
-        other: "مشاورات جارية"
+        other: مشاورات جارية
       oral_statement:
         zero:
-        one: "تصريح شفهي للبرلمان"
+        one: تصريح شفهي للبرلمان
         two:
         few:
         many:
-        other: "تصريحات شفهية للبرلمان"
+        other: تصريحات شفهية للبرلمان
       policy_paper:
         zero:
-        one: "ورقة عن السياسة"
+        one: ورقة عن السياسة
         two:
         few:
         many:
-        other: "ورقة عن السياسات"
+        other: ورقة عن السياسات
       press_release:
         zero:
-        one: "بيان صحفي"
+        one: بيان صحفي
         two:
         few:
         many:
-        other: "بيانات صحفية"
+        other: بيانات صحفية
       promotional:
         zero:
-        one: "مادة ترويجية"
+        one: مادة ترويجية
         two:
         few:
         many:
-        other: "مواد ترويجية"
+        other: مواد ترويجية
       publication:
         zero:
-        one: "مطبوعة"
+        one: مطبوعة
         two:
         few:
         many:
-        other: "مطبوعات"
+        other: مطبوعات
       regulation:
         zero:
         one:
@@ -267,39 +267,39 @@ ar:
         other:
       research:
         zero:
-        one: "بحث وتحليل"
+        one: بحث وتحليل
         two:
         few:
         many:
-        other: "بحوث وتحليلات"
+        other: بحوث وتحليلات
       speaking_notes:
         zero:
-        one: "مذكرات كلامية"
+        one: مذكرات كلامية
         two:
         few:
         many:
-        other: "مذكرات كلامية"
+        other: مذكرات كلامية
       speech:
         zero:
-        one: "كلمة"
+        one: كلمة
         two:
         few:
         many:
-        other: "كلمات"
+        other: كلمات
       statement_to_parliament:
         zero:
-        one: "تصريح للبرلمان"
+        one: تصريح للبرلمان
         two:
         few:
         many:
-        other: "تصريحات للبرلمان"
+        other: تصريحات للبرلمان
       statistical_data_set:
         zero:
-        one: "مجموعة بيانات إحصائية"
+        one: مجموعة بيانات إحصائية
         two:
         few:
         many:
-        other: "مجموعات بيانات إحصائية"
+        other: مجموعات بيانات إحصائية
       statutory_guidance:
         zero:
         one:
@@ -309,18 +309,18 @@ ar:
         other:
       transcript:
         zero:
-        one: "نص منسوخ"
+        one: نص منسوخ
         two:
         few:
         many:
-        other: "نصوص منسوخة"
+        other: نصوص منسوخة
       transparency:
         zero:
-        one: "بيانات تتعلق بالشفافية"
+        one: بيانات تتعلق بالشفافية
         two:
         few:
         many:
-        other: "بيانات تتعلق بالشفافية"
+        other: بيانات تتعلق بالشفافية
       world_news_story:
         zero:
         one:
@@ -330,30 +330,30 @@ ar:
         other:
       written_statement:
         zero:
-        one: "تصريح خطي"
+        one: تصريح خطي
         two:
         few:
         many:
-        other: "تصريحات خطية"
+        other: تصريحات خطية
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "نشر"
-    read: "اقرأ %{title} المقال"
+    published: نشر
+    read: اقرأ %{title} المقال
     speech:
       author_title:
-        minister: "وزير"
-        speaker: "كاتب"
-      delivered_on: "تاريخ التسليم"
+        minister: وزير
+        speaker: كاتب
+      delivered_on: تاريخ التسليم
       delivery_title:
-        minister: "وزير"
-        speaker: "متحدث"
-      written_on: "كتبت في:"
-    updated: "تحديث"
-    view: "اطلع على ’%{title}‘"
+        minister: وزير
+        speaker: متحدث
+      written_on: 'كتبت في:'
+    updated: تحديث
+    view: اطلع على ’%{title}‘
   people:
     heading:
       zero:
@@ -386,28 +386,28 @@ ar:
     type:
       international_delegation:
         zero:
-        one: "وفد دولي"
+        one: وفد دولي
         two:
         few:
         many:
-        other: "وفود دولية"
+        other: وفود دولية
       world_location:
         zero:
-        one: "بعثة في الخارج"
+        one: بعثة في الخارج
         two:
         few:
         many:
-        other: "بعثات في الخارج"
+        other: بعثات في الخارج
     headings:
-      announcements: "إعلاناتنا"
-      country: "البلد"
-      documents: "وثائق"
-      mission: "مهمتنا"
-      organisations: "مؤسسات"
-      publications: "مطبوعاتنا"
-      quick_links: "وصلات سريعة"
-      related_policies: "سياسات ذات صلة"
-      statistics: "إحصائياتنا"
+      announcements: إعلاناتنا
+      country: البلد
+      documents: وثائق
+      mission: مهمتنا
+      organisations: مؤسسات
+      publications: مطبوعاتنا
+      quick_links: وصلات سريعة
+      related_policies: سياسات ذات صلة
+      statistics: إحصائياتنا
   activerecord:
     attributes:
       attachment:
@@ -452,20 +452,20 @@ ar:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "إعلانات"
+    heading: إعلانات
     view_all:
   attachment:
     accessibility:
       full_help_html: لاستلام وثيقة مكتوبة بشكل آخر، كلغة بريل أو وثيقة صوتية أو أي
         نوع آخر من الوثائق، يرجى إرسال رسالة إلكترونية إلى %{email} مع كتابة عنوانك
         ورقم هاتفك إلى جانب عنوان الوثيقة المطلوبة ("{title}")%{references}
-      heading: "هذا المف قد لا يكون مناسبا لمستخدمي التكنولوجيا المساعدة على القراءة"
-      request_a_different_format: "طلب الوثيقة بشكل آخر"
+      heading: هذا المف قد لا يكون مناسبا لمستخدمي التكنولوجيا المساعدة على القراءة
+      request_a_different_format: طلب الوثيقة بشكل آخر
     headings:
-      order_a_copy: "طلب نسخة"
-      order_a_copy_full: "طلب نسخة عن المطبوعة"
-      published: "تاريخ النشر"
-      reference: "إشارة"
+      order_a_copy: طلب نسخة
+      order_a_copy_full: طلب نسخة عن المطبوعة
+      published: تاريخ النشر
+      reference: إشارة
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -483,8 +483,8 @@ ar:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "نموذج اتصال"
-    email: "بريد إلكتروني"
+    contact_form: نموذج اتصال
+    email: بريد إلكتروني
   corporate_information_page:
     type:
       link_text:
@@ -499,44 +499,44 @@ ar:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "ميثاق الاحتفاظ بالمعلومات الشخصية"
+        personal_information_charter: ميثاق الاحتفاظ بالمعلومات الشخصية
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "نظام المطبوعات"
+        publication_scheme: نظام المطبوعات
         recruitment:
         research:
-        social_media_use: "استخدام مواقع التواصل الاجتماعي"
+        social_media_use: استخدام مواقع التواصل الاجتماعي
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "برنامج لغة ويلز"
+        welsh_language_scheme: برنامج لغة ويلز
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "باستطاعتك استخدام الفلتر لعرض &nbsp; فقط النتائج التي تتطابق مع
-      &nbsp; اهتماماتك"
+    description: باستطاعتك استخدام الفلتر لعرض &nbsp; فقط النتائج التي تتطابق مع &nbsp;
+      اهتماماتك
     no_results:
-      description: "حاول توسيع البحث وحاول البحث مجددا"
-      title: "ليس هناك وثائق تطابق البحث"
+      description: حاول توسيع البحث وحاول البحث مجددا
+      title: ليس هناك وثائق تطابق البحث
       tna_heading:
       tna_link:
     world_locations:
-      all: "كافة المواقع"
-      label: "مواقع في العالم"
+      all: كافة المواقع
+      label: مواقع في العالم
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "أحدث المستجدات"
+    latest_activity: أحدث المستجدات
   i18n:
     direction: rtl
   language_names:
-    ar: "العربية"
+    ar: العربية
   latest_feed:
-    no_updates: "لا يوجد تحديثات بعد"
-    title: "آخر التحديثات"
+    no_updates: لا يوجد تحديثات بعد
+    title: آخر التحديثات
   national_statistics:
     heading:
   number:
@@ -545,99 +545,99 @@ ar:
         format: "%n%u"
   organisation:
     about:
-      read_more: "اقرأ المزيد عن عملنا"
+      read_more: اقرأ المزيد عن عملنا
     corporate_information:
-      access_our_info: "اطلع على معلوماتنا"
-      foi_how_to: "كيفية تقديم طلب حرية الحصول على المعلومات"
-      foi_releases: "إصدارات حرية الحصول على المعلومات"
-      jobs_and_contacts: "الوظائف والعقود"
+      access_our_info: اطلع على معلوماتنا
+      foi_how_to: كيفية تقديم طلب حرية الحصول على المعلومات
+      foi_releases: إصدارات حرية الحصول على المعلومات
+      jobs_and_contacts: الوظائف والعقود
       organisation_chart:
-      transparency: "بيانات تتعلق بالشفافية"
+      transparency: بيانات تتعلق بالشفافية
     foi_exemption_html:
     headings:
-      chief_professional_officers: "كبار المسؤولين المحترفين لدينا"
-      contact: "اتصل بـ%{name}"
-      corporate_information: "معلومات عن الوزارة"
-      corporate_reports: "تقارير الوزارة"
+      chief_professional_officers: كبار المسؤولين المحترفين لدينا
+      contact: اتصل بـ%{name}
+      corporate_information: معلومات عن الوزارة
+      corporate_reports: تقارير الوزارة
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "إعلاناتنا"
+      our_announcements: إعلاناتنا
       our_consultations:
       our_judges:
-      our_management: "إدارتنا"
-      our_ministers: "وزراؤنا"
-      our_policies: "سياساتنا"
-      our_publications: "مطبوعاتنا"
-      our_senior_military_officials: "كبار المسؤولين العسكريين"
-      our_services: "خدماتنا"
-      our_statistics: "إحصائياتنا"
-      our_topics: "عملينا بشأن هذه المواضيع"
-      special_representatives: "الممثلون الخاصون"
-      traffic_commissioners: "مفوضو المرور"
-      what_we_do: "عملنا"
+      our_management: إدارتنا
+      our_ministers: وزراؤنا
+      our_policies: سياساتنا
+      our_publications: مطبوعاتنا
+      our_senior_military_officials: كبار المسؤولين العسكريين
+      our_services: خدماتنا
+      our_statistics: إحصائياتنا
+      our_topics: عملينا بشأن هذه المواضيع
+      special_representatives: الممثلون الخاصون
+      traffic_commissioners: مفوضو المرور
+      what_we_do: عملنا
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "سياسات"
+    heading: سياسات
     view_all:
   publications:
-    heading: "مطبوعات"
+    heading: مطبوعات
     headings:
-      detail: "تفاصيل"
-  read_more: "اقرأ المزيد"
+      detail: تفاصيل
+  read_more: اقرأ المزيد
   see_all:
-    announcement: "اطلع على كافة إعلانات"
-    authored_article: "اطلع على كافة مقالات مرخصة"
-    case_study: "اطلع على كافة دراسات حالة"
-    closed_consultation: "اطلع على كافة مشاورات منتهية"
-    consultation: "اطلع على كافة مشاورات"
-    consultation_outcome: "اطلع على كافة نتائج المشاورات"
-    corporate_report: "اطلع على كافة تقارير الوزارة"
-    correspondence: "اطلع على كافة مراسلات"
+    announcement: اطلع على كافة إعلانات
+    authored_article: اطلع على كافة مقالات مرخصة
+    case_study: اطلع على كافة دراسات حالة
+    closed_consultation: اطلع على كافة مشاورات منتهية
+    consultation: اطلع على كافة مشاورات
+    consultation_outcome: اطلع على كافة نتائج المشاورات
+    corporate_report: اطلع على كافة تقارير الوزارة
+    correspondence: اطلع على كافة مراسلات
     decision:
-    detailed_guidance: "اطلع على كافة توجيهات مفصل"
+    detailed_guidance: اطلع على كافة توجيهات مفصل
     document_collection:
-    draft_text: "اطلع على كافة مسودة النصوص"
-    fatality_notice: "اطلع على كافة إشعارات وفاة"
-    foi_release: "اطلع على كافة نشرات وفق حرية الحصول على المعلومات"
-    form: "اطلع على كافة نماذج"
-    government_response: "اطلع على كافة ردود من الحكومة"
-    guidance: "اطلع على كافة توجيهات"
-    impact_assessment: "اطلع على كافة تقييمات التأثير"
-    imported: "اطلع على كافة استلم - بانتظار الطباعة"
+    draft_text: اطلع على كافة مسودة النصوص
+    fatality_notice: اطلع على كافة إشعارات وفاة
+    foi_release: اطلع على كافة نشرات وفق حرية الحصول على المعلومات
+    form: اطلع على كافة نماذج
+    government_response: اطلع على كافة ردود من الحكومة
+    guidance: اطلع على كافة توجيهات
+    impact_assessment: اطلع على كافة تقييمات التأثير
+    imported: اطلع على كافة استلم - بانتظار الطباعة
     international_treaty:
-    map: "اطلع على كافة خرائط"
-    national_statistics: "اطلع على كافة إحصائيات - إحصائيات محلية"
-    news_article: "اطلع على كافة مقالات إخبارية"
-    news_story: "اطلع على كافة قصص إخبارية"
+    map: اطلع على كافة خرائط
+    national_statistics: اطلع على كافة إحصائيات - إحصائيات محلية
+    news_article: اطلع على كافة مقالات إخبارية
+    news_story: اطلع على كافة قصص إخبارية
     notice:
-    open_consultation: "اطلع على كافة مشاورات جارية"
-    oral_statement: "اطلع على كافة تصريحات شفهية للبرلمان"
-    policy: "اطلع على كافة سياسات"
-    policy_paper: "اطلع على كافة ورقة عن السياسات"
-    press_release: "اطلع على كافة بيانات صحفية"
-    promotional: "اطلع على كافة مواد ترويجية"
-    publication: "اطلع على كافة مطبوعات"
+    open_consultation: اطلع على كافة مشاورات جارية
+    oral_statement: اطلع على كافة تصريحات شفهية للبرلمان
+    policy: اطلع على كافة سياسات
+    policy_paper: اطلع على كافة ورقة عن السياسات
+    press_release: اطلع على كافة بيانات صحفية
+    promotional: اطلع على كافة مواد ترويجية
+    publication: اطلع على كافة مطبوعات
     regulation:
-    research: "اطلع على كافة بحوث وتحليلات"
-    speaking_notes: "اطلع على كافة مذكرات كلامية"
-    speech: "اطلع على كافة كلمات"
-    statement_to_parliament: "اطلع على كافة تصريحات للبرلمان"
-    statistical_data_set: "اطلع على كافة مجموعات بيانات إحصائية"
-    statistics: "اطلع على كافة إحصائيات"
+    research: اطلع على كافة بحوث وتحليلات
+    speaking_notes: اطلع على كافة مذكرات كلامية
+    speech: اطلع على كافة كلمات
+    statement_to_parliament: اطلع على كافة تصريحات للبرلمان
+    statistical_data_set: اطلع على كافة مجموعات بيانات إحصائية
+    statistics: اطلع على كافة إحصائيات
     statutory_guidance:
-    transcript: "اطلع على كافة نصوص منسوخة"
-    transparency: "اطلع على كافة بيانات تتعلق بالشفافية"
-    written_statement: "اطلع على كافة تصريحات خطية"
+    transcript: اطلع على كافة نصوص منسوخة
+    transparency: اطلع على كافة بيانات تتعلق بالشفافية
+    written_statement: اطلع على كافة تصريحات خطية
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "و"
+      last_word_connector: و
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
@@ -646,17 +646,17 @@ ar:
       about_our_services_html:
       personal_information_charter_html: "%{link} يشرح كيفية التعامل مع المعلومات
         الشخصية الخاصة بك"
-      publication_scheme_html: "إقرأ عن أنواع المعلومات التي ننشرها بشكل روتيني في
-        موقعنا %{link} الرابط."
-      social_media_use_html: "اقرأ عن سياستنا تجاه %{link}"
-      welsh_language_scheme_html: "معرفة التزامنا النشر في%{link} الرابط."
-    find_out_more: "اطلع على النبذة بالكامل وكافة تفاصيل الاتصال"
+      publication_scheme_html: إقرأ عن أنواع المعلومات التي ننشرها بشكل روتيني في
+        موقعنا %{link} الرابط.
+      social_media_use_html: اقرأ عن سياستنا تجاه %{link}
+      welsh_language_scheme_html: معرفة التزامنا النشر في%{link} الرابط.
+    find_out_more: اطلع على النبذة بالكامل وكافة تفاصيل الاتصال
     headings:
-      about_us: "معلومات عنا"
-      contact_us: "اتصل بنا"
-      corporate_information: "معلومات عن الشركة"
-      follow_us: "تابعنا"
-      our_people: "مسؤولينا"
-      our_services: "خدماتنا"
-    location: "موقع"
-    part_of: "جزء من"
+      about_us: معلومات عنا
+      contact_us: اتصل بنا
+      corporate_information: معلومات عن الشركة
+      follow_us: تابعنا
+      our_people: مسؤولينا
+      our_services: خدماتنا
+    location: موقع
+    part_of: جزء من

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -72,7 +72,7 @@ az:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Əlaqə vasitəsi"
+    contact_form: Əlaqə vasitəsi
     email: elektron poçt
   corporate_information_page:
     type:
@@ -88,10 +88,10 @@ az:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "şəxsi məlumatlar bölümü"
+        personal_information_charter: şəxsi məlumatlar bölümü
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "çap sxemi"
+        publication_scheme: çap sxemi
         recruitment:
         research:
         social_media_use:
@@ -124,7 +124,7 @@ az:
       author_title:
         minister:
         speaker:
-      delivered_on: "çatdırılıb"
+      delivered_on: çatdırılıb
       delivery_title:
         minister: Nazir
         speaker: Spiker
@@ -140,8 +140,8 @@ az:
         one:
         other:
       case_study:
-        one: "Öyrənilib"
-        other: "Öyrənilib"
+        one: Öyrənilib
+        other: Öyrənilib
       closed_consultation:
         one: Bağlı məslətləşmə
         other: Bağlı məslətləşmələr
@@ -161,8 +161,8 @@ az:
         one:
         other:
       detailed_guidance:
-        one: "ətraflı məlumat"
-        other: "ətraflı məlumat"
+        one: ətraflı məlumat
+        other: ətraflı məlumat
       document_collection:
         one: növlər
         other:
@@ -179,8 +179,8 @@ az:
         one:
         other:
       guidance:
-        one: "İnstruksiya"
-        other: "İnstruksiya"
+        one: İnstruksiya
+        other: İnstruksiya
       impact_assessment:
         one: Dəyərləndirmə
         other: Dəyərləndirmə
@@ -242,11 +242,11 @@ az:
         one: Tətqiqat və analiz
         other: Tətqiqat və analiz
       speaking_notes:
-        one: "Çıxış üçün  qeydləri"
-        other: "Çıxış üçün  qeydləri"
+        one: Çıxış üçün  qeydləri
+        other: Çıxış üçün  qeydləri
       speech:
-        one: "çıxış"
-        other: "Çıxışlar"
+        one: çıxış
+        other: Çıxışlar
       statement_to_parliament:
         one: Parlamentə bəyanat
         other: Parlamentə bəyanatlar
@@ -260,8 +260,8 @@ az:
         one: Transkripsiya
         other: Transkripsiyalar
       transparency:
-        one: "Şəffaf məlumat"
-        other: "Şəffaf məlumat"
+        one: Şəffaf məlumat
+        other: Şəffaf məlumat
       world_news_story:
         one:
         other:
@@ -291,7 +291,7 @@ az:
     az: Azərbaycanca
   latest_feed:
     no_updates: yeni məlumat yoxdur
-    title: "Ən sonuncu"
+    title: Ən sonuncu
   national_statistics:
     heading:
   number:
@@ -351,7 +351,7 @@ az:
     heading: Nəşrlər
     headings:
       detail:
-  read_more: "Ətraflı oxu"
+  read_more: Ətraflı oxu
   roles:
     heading:
       one:
@@ -419,7 +419,7 @@ az:
   world_location:
     headings:
       announcements: Bizim elanlar
-      country: "Ölkə"
+      country: Ölkə
       documents: Sənədlər
       mission: Bizim missiyamız
       organisations: Təşkilatlar
@@ -444,7 +444,7 @@ az:
     find_out_more: Bütün profilə və əlaqə nömrələrinə bax
     headings:
       about_us: Barəmizdə
-      contact_us: "Əlaqə vasitəsi"
+      contact_us: Əlaqə vasitəsi
       corporate_information: Məlumatlar
       follow_us: Bizi izlə
       our_people: Bizim adamlar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -2,115 +2,115 @@ be:
   document:
     headings:
       attachments:
-        one: "Дакумент"
+        one: Дакумент
         few:
         many:
-        other: "Дакументы"
-      applies_to_nations: "У адносінах да"
+        other: Дакументы
+      applies_to_nations: У адносінах да
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Аб'ява"
+        one: Аб'ява
         few:
         many:
-        other: "Аб'явы"
+        other: Аб'явы
       authored_article:
-        one: "Аўтарскі артыкул"
+        one: Аўтарскі артыкул
         few:
         many:
-        other: "Аўтарскія артыкулы"
+        other: Аўтарскія артыкулы
       blog_post:
         one:
         few:
         many:
         other:
       case_study:
-        one: "Тэматычнае даследаванне"
+        one: Тэматычнае даследаванне
         few:
         many:
-        other: "Тэматычныя даследаванні"
+        other: Тэматычныя даследаванні
       closed_consultation:
-        one: "Закрытая кансультацыя"
+        one: Закрытая кансультацыя
         few:
         many:
-        other: "Закрытыя кансультацыі"
+        other: Закрытыя кансультацыі
       consultation:
-        one: "Кансультацыя"
+        one: Кансультацыя
         few:
         many:
-        other: "Кансультацыі"
+        other: Кансультацыі
       consultation_outcome:
-        one: "Вынік кансультацыі"
+        one: Вынік кансультацыі
         few:
         many:
-        other: "Вынікі кансультацыі"
+        other: Вынікі кансультацыі
       corporate_report:
-        one: "Карпаратыўная справаздача"
+        one: Карпаратыўная справаздача
         few:
         many:
-        other: "Карпаратыўныя справаздачы"
+        other: Карпаратыўныя справаздачы
       correspondence:
-        one: "Перапіска"
+        one: Перапіска
         few:
         many:
-        other: "Перапіска"
+        other: Перапіска
       decision:
         one:
         few:
         many:
         other:
       detailed_guidance:
-        one: "Падрабязнае кіраўніцтва"
+        one: Падрабязнае кіраўніцтва
         few:
         many:
-        other: "Падрабязнае кіраўніцтва"
+        other: Падрабязнае кіраўніцтва
       document_collection:
-        one: "Серыя"
+        one: Серыя
         few:
         many:
         other:
       draft_text:
-        one: "Чарнавік"
+        one: Чарнавік
         few:
         many:
-        other: "Чарнавікі"
+        other: Чарнавікі
       foi_release:
-        one: "Рэліз у межах Закона аб свабодзе інфармацыі"
+        one: Рэліз у межах Закона аб свабодзе інфармацыі
         few:
         many:
-        other: "Рэлізы ў межах Закона аб свабодзе інфармацыі"
+        other: Рэлізы ў межах Закона аб свабодзе інфармацыі
       form:
-        one: "Форма"
+        one: Форма
         few:
         many:
-        other: "Формы"
+        other: Формы
       government_response:
-        one: "Адказ ўрада"
+        one: Адказ ўрада
         few:
         many:
-        other: "Адказы ўрада"
+        other: Адказы ўрада
       guidance:
-        one: "Кіраўніцтва"
+        one: Кіраўніцтва
         few:
         many:
-        other: "Кіраўніцтва"
+        other: Кіраўніцтва
       impact_assessment:
-        one: "Ацэнка ўплыву"
+        one: Ацэнка ўплыву
         few:
         many:
-        other: "Ацэнкі ўплыву"
+        other: Ацэнкі ўплыву
       imported:
-        one: "імпартавана - чаканне тыпу"
+        one: імпартавана - чаканне тыпу
         few:
         many:
-        other: "імпартавана - чаканне тыпу"
+        other: імпартавана - чаканне тыпу
       independent_report:
-        one: "Незалежная справаздача"
+        one: Незалежная справаздача
         few:
         many:
-        other: "Незалежныя справаздачы"
+        other: Незалежныя справаздачы
       international_treaty:
         one:
         few:
@@ -122,25 +122,25 @@ be:
         many:
         other:
       map:
-        one: "Карта"
+        one: Карта
         few:
         many:
-        other: "Карты"
+        other: Карты
       national_statistics:
-        one: "Статыстыка - нацыянальная статыстыка"
+        one: Статыстыка - нацыянальная статыстыка
         few:
         many:
-        other: "Статыстыка - нацыянальная статыстыка"
+        other: Статыстыка - нацыянальная статыстыка
       news_article:
-        one: "Артыкул"
+        one: Артыкул
         few:
         many:
-        other: "Артыкулы"
+        other: Артыкулы
       news_story:
-        one: "Навіны"
+        one: Навіны
         few:
         many:
-        other: "Навіны"
+        other: Навіны
       nhs_content:
         one:
         few:
@@ -152,114 +152,114 @@ be:
         many:
         other:
       official_statistics:
-        one: "Статыстыка"
+        one: Статыстыка
         few:
         many:
-        other: "Статыстыка"
+        other: Статыстыка
       open_consultation:
-        one: "Адкрытая кансультацыя"
+        one: Адкрытая кансультацыя
         few:
         many:
-        other: "Адкрытыя кансультацыі"
+        other: Адкрытыя кансультацыі
       oral_statement:
-        one: "Вусны даклад у парламенце"
+        one: Вусны даклад у парламенце
         few:
         many:
-        other: "Вусныя даклады ў парламенце"
+        other: Вусныя даклады ў парламенце
       policy_paper:
-        one: "Праграмны дакумент"
+        one: Праграмны дакумент
         few:
         many:
-        other: "Праграмныя дакументы"
+        other: Праграмныя дакументы
       press_release:
-        one: "Прэс-рэліз"
+        one: Прэс-рэліз
         few:
         many:
-        other: "Прэс-рэлізы"
+        other: Прэс-рэлізы
       promotional:
-        one: "Рэкламны матэрыял"
+        one: Рэкламны матэрыял
         few:
         many:
-        other: "Рэкламныя матэрыялы"
+        other: Рэкламныя матэрыялы
       publication:
-        one: "Публікацыя"
+        one: Публікацыя
         few:
         many:
-        other: "Публікацыі"
+        other: Публікацыі
       regulation:
         one:
         few:
         many:
         other:
       research:
-        one: "Даследаванні і аналіз"
+        one: Даследаванні і аналіз
         few:
         many:
-        other: "Даследаванні і аналіз"
+        other: Даследаванні і аналіз
       speaking_notes:
-        one: "Нататкі да выступу"
+        one: Нататкі да выступу
         few:
         many:
-        other: "Нататкі да выступу"
+        other: Нататкі да выступу
       speech:
-        one: "Выступ"
+        one: Выступ
         few:
         many:
-        other: "Выступы"
+        other: Выступы
       statement_to_parliament:
-        one: "Заява ў парламенце"
+        one: Заява ў парламенце
         few:
         many:
-        other: "Заявы ў парламенце"
+        other: Заявы ў парламенце
       statistical_data_set:
-        one: "Статыстычныя дадзеныя"
+        one: Статыстычныя дадзеныя
         few:
         many:
-        other: "Статыстычныя дадзеныя"
+        other: Статыстычныя дадзеныя
       statutory_guidance:
         one:
         few:
         many:
         other:
       transcript:
-        one: "Поўны тэкст"
+        one: Поўны тэкст
         few:
         many:
-        other: "Поўны тэкст"
+        other: Поўны тэкст
       transparency:
-        one: "Адкрытыя дадзеныя"
+        one: Адкрытыя дадзеныя
         few:
         many:
-        other: "Адкрытыя дадзеныя"
+        other: Адкрытыя дадзеныя
       world_news_story:
         one:
         few:
         many:
         other:
       written_statement:
-        one: "Пісьмовая заява ў парламенце"
+        one: Пісьмовая заява ў парламенце
         few:
         many:
-        other: "Пісьмовыя заявы ў парламенце"
+        other: Пісьмовыя заявы ў парламенце
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "Апублікаваны"
-    read: "Чытаць %{title} артыкул"
+    published: Апублікаваны
+    read: Чытаць %{title} артыкул
     speech:
       author_title:
-        minister: "Міністр"
-        speaker: "Аўтар"
-      delivered_on: "Зроблена:"
+        minister: Міністр
+        speaker: Аўтар
+      delivered_on: 'Зроблена:'
       delivery_title:
-        minister: "Міністр"
-        speaker: "Прамоўца"
-      written_on: "Напісана"
-    updated: "Адноўлена"
-    view: "Паглядзець '%{title}'"
+        minister: Міністр
+        speaker: Прамоўца
+      written_on: Напісана
+    updated: Адноўлена
+    view: Паглядзець '%{title}'
   people:
     heading:
       one:
@@ -287,25 +287,25 @@ be:
   world_location:
     type:
       international_delegation:
-        one: "Міжнародная дэлегацыя"
+        one: Міжнародная дэлегацыя
         few:
         many:
-        other: "Міжнародныя дэлегацыі"
+        other: Міжнародныя дэлегацыі
       world_location:
-        one: "Месцазнаходжанне ў свеце"
+        one: Месцазнаходжанне ў свеце
         few:
         many:
-        other: "Месцазнаходжання "
+        other: 'Месцазнаходжання '
     headings:
-      announcements: "Нашы аб'явы"
-      country: "Краіна"
-      documents: "Дакументы"
-      mission: "Наша місія"
-      organisations: "Арганізацыі"
-      publications: "Нашы публікацыі"
-      quick_links: "Хуткія спасылкі"
-      related_policies: "Падобныя напрамкі дзейнасці "
-      statistics: "Наша статыстыка"
+      announcements: Нашы аб'явы
+      country: Краіна
+      documents: Дакументы
+      mission: Наша місія
+      organisations: Арганізацыі
+      publications: Нашы публікацыі
+      quick_links: Хуткія спасылкі
+      related_policies: 'Падобныя напрамкі дзейнасці '
+      statistics: Наша статыстыка
   activerecord:
     attributes:
       attachment:
@@ -350,20 +350,20 @@ be:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Аб'явы"
+    heading: Аб'явы
     view_all:
   attachment:
     accessibility:
       full_help_html: Каб зарасіць гэты дакумент у іншым фармаце, такім як шрыфт Брайля,
         аўдыё і інш. калі ласка, адпраўце электроннае паведамленне на %{email} з вашай
         адрэсай, тэлефонным нумарам і назвай дакумента ("%{title}")%{references}.
-      heading: "Гэты файл можа быць непрыдатным для карыстальнікаў дапаможных тэхналогій."
-      request_a_different_format: "Запрасіць файл у іншым фармаце."
+      heading: Гэты файл можа быць непрыдатным для карыстальнікаў дапаможных тэхналогій.
+      request_a_different_format: Запрасіць файл у іншым фармаце.
     headings:
-      order_a_copy: "Замовіць копію"
-      order_a_copy_full: "Замовіць копію гэтай публікацыі"
-      published: "Апублікаваны"
-      reference: "Спасылка"
+      order_a_copy: Замовіць копію
+      order_a_copy_full: Замовіць копію гэтай публікацыі
+      published: Апублікаваны
+      reference: Спасылка
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -381,8 +381,8 @@ be:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Кантактная форма"
-    email: "Электронная пошта"
+    contact_form: Кантактная форма
+    email: Электронная пошта
   corporate_information_page:
     type:
       link_text:
@@ -397,45 +397,45 @@ be:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Статут аб асабістай інфармацыі"
+        personal_information_charter: Статут аб асабістай інфармацыі
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "Схема публікацый"
+        publication_scheme: Схема публікацый
         recruitment:
         research:
-        social_media_use: "Ужыванне сацыяльных медый"
+        social_media_use: Ужыванне сацыяльных медый
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Валійская мова"
+        welsh_language_scheme: Валійская мова
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "Вы можаце выкарыстоўваць фільтры, каб пабачыць толькі тыя вынікі,
-      якія вас цікавяць."
+    description: Вы можаце выкарыстоўваць фільтры, каб пабачыць толькі тыя вынікі,
+      якія вас цікавяць.
     no_results:
-      description: "Паспрабуйце зрабіць ваш запыт больш шырокім і паспрабуйце яшчэ
-        раз."
-      title: "Няма адпаведных дакументаў."
+      description: Паспрабуйце зрабіць ваш запыт больш шырокім і паспрабуйце яшчэ
+        раз.
+      title: Няма адпаведных дакументаў.
       tna_heading:
       tna_link:
     world_locations:
-      all: "Усе месцазнаходжанні"
-      label: "Мы ў свеце"
+      all: Усе месцазнаходжанні
+      label: Мы ў свеце
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Апошнія аднаўленні"
+    latest_activity: Апошнія аднаўленні
   i18n:
     direction: ltr
   language_names:
-    be: "Беларуская"
+    be: Беларуская
   latest_feed:
-    no_updates: "Ніякіх абнаўленняў пакуль няма."
-    title: "Апошняе"
+    no_updates: Ніякіх абнаўленняў пакуль няма.
+    title: Апошняе
   national_statistics:
     heading:
   number:
@@ -444,119 +444,118 @@ be:
         format: "%n%u"
   organisation:
     about:
-      read_more: "Прачытайце больш пра нашу працу"
+      read_more: Прачытайце больш пра нашу працу
     corporate_information:
-      access_our_info: "Доступ да нашай інфармацыі"
-      foi_how_to: "Як зрабіць замову ў межах Закона аб свабодзе інфармацыі"
-      foi_releases: "Рэлізы ў межах Закона аб свабодзе інфармацыі"
-      jobs_and_contacts: "Праца і кантакты"
+      access_our_info: Доступ да нашай інфармацыі
+      foi_how_to: Як зрабіць замову ў межах Закона аб свабодзе інфармацыі
+      foi_releases: Рэлізы ў межах Закона аб свабодзе інфармацыі
+      jobs_and_contacts: Праца і кантакты
       organisation_chart:
-      transparency: "Адкрытыя дадзеныя"
+      transparency: Адкрытыя дадзеныя
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Нашы галоўныя прафесійныя афіцэры"
-      contact: "Звязацца з %{name}"
-      corporate_information: "Карпаратыўная інфармацыя"
-      corporate_reports: "Карпаратыўныя справаздачы"
+      chief_professional_officers: Нашы галоўныя прафесійныя афіцэры
+      contact: Звязацца з %{name}
+      corporate_information: Карпаратыўная інфармацыя
+      corporate_reports: Карпаратыўныя справаздачы
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Нашы абвесткі"
+      our_announcements: Нашы абвесткі
       our_consultations:
       our_judges:
-      our_management: "Наша кіраўніцтва"
-      our_ministers: "Нашы міністры"
-      our_policies: "Наша палітыка"
-      our_publications: "Нашы публікацыі"
-      our_senior_military_officials: "Нашы вышэйшыя ваенныя службоўцы"
-      our_services: "Нашы паслугі"
-      our_statistics: "Наша статыстыка"
-      our_topics: "Мы працуем па гэтым тэмам"
-      special_representatives: "Спецыяльныя прадстаўнікі"
-      traffic_commissioners: "Транспартны суд"
-      what_we_do: "Што мы робім"
+      our_management: Наша кіраўніцтва
+      our_ministers: Нашы міністры
+      our_policies: Наша палітыка
+      our_publications: Нашы публікацыі
+      our_senior_military_officials: Нашы вышэйшыя ваенныя службоўцы
+      our_services: Нашы паслугі
+      our_statistics: Наша статыстыка
+      our_topics: Мы працуем па гэтым тэмам
+      special_representatives: Спецыяльныя прадстаўнікі
+      traffic_commissioners: Транспартны суд
+      what_we_do: Што мы робім
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Напрамкі дзейнасці"
+    heading: Напрамкі дзейнасці
     view_all:
   publications:
-    heading: "Публікацыі"
+    heading: Публікацыі
     headings:
-      detail: "Падрабязней"
-  read_more: "Чытаць Падрабязней"
+      detail: Падрабязней
+  read_more: Чытаць Падрабязней
   see_all:
-    announcement: "Паглядзець усе Аб'явы"
-    authored_article: "Паглядзець усе Аўтарскія артыкулы"
-    case_study: "Паглядзець усе Тэматычныя даследаванні"
-    closed_consultation: "Паглядзець усе Закрытыя кансультацыі"
-    consultation: "Паглядзець усе Кансультацыі"
-    consultation_outcome: "Паглядзець усе Вынікі кансультацыі"
-    corporate_report: "Паглядзець усе Карпаратыўныя справаздачы"
-    correspondence: "Паглядзець усе Перапіска"
-    decision: "Паглядзець усе Падрабязнае кіраўніцтва"
+    announcement: Паглядзець усе Аб'явы
+    authored_article: Паглядзець усе Аўтарскія артыкулы
+    case_study: Паглядзець усе Тэматычныя даследаванні
+    closed_consultation: Паглядзець усе Закрытыя кансультацыі
+    consultation: Паглядзець усе Кансультацыі
+    consultation_outcome: Паглядзець усе Вынікі кансультацыі
+    corporate_report: Паглядзець усе Карпаратыўныя справаздачы
+    correspondence: Паглядзець усе Перапіска
+    decision: Паглядзець усе Падрабязнае кіраўніцтва
     detailed_guidance:
-    document_collection: "Паглядзець усе Чарнавікі"
+    document_collection: Паглядзець усе Чарнавікі
     draft_text:
-    fatality_notice: "Паглядзець усе Паведамленні"
-    foi_release: "Паглядзець усе Рэлізы ў межах Закона аб свабодзе інфармацыі"
-    form: "Паглядзець усе Формы"
-    government_response: "Паглядзець усе Адказы ўрада"
-    guidance: "Паглядзець усе Кіраўніцтва"
-    impact_assessment: "Паглядзець усе Ацэнкі ўплыву"
-    imported: "Паглядзець усе імпартавана - чаканне тыпу"
-    international_treaty: "Паглядзець усе Карты"
+    fatality_notice: Паглядзець усе Паведамленні
+    foi_release: Паглядзець усе Рэлізы ў межах Закона аб свабодзе інфармацыі
+    form: Паглядзець усе Формы
+    government_response: Паглядзець усе Адказы ўрада
+    guidance: Паглядзець усе Кіраўніцтва
+    impact_assessment: Паглядзець усе Ацэнкі ўплыву
+    imported: Паглядзець усе імпартавана - чаканне тыпу
+    international_treaty: Паглядзець усе Карты
     map:
-    national_statistics: "Паглядзець усе Статыстыка - нацыянальная статыстыка"
-    news_article: "Паглядзець усе Артыкулы"
-    news_story: "Паглядзець усе Навіны"
-    notice: "Паглядзець усе Адкрытыя кансультацыі"
+    national_statistics: Паглядзець усе Статыстыка - нацыянальная статыстыка
+    news_article: Паглядзець усе Артыкулы
+    news_story: Паглядзець усе Навіны
+    notice: Паглядзець усе Адкрытыя кансультацыі
     open_consultation:
-    oral_statement: "Паглядзець усе Вусныя даклады ў парламенце"
-    policy: "Паглядзець усе Напрамкі дзейнасці"
-    policy_paper: "Паглядзець усе Праграмныя дакументы"
-    press_release: "Паглядзець усе Прэс-рэлізы"
-    promotional: "Паглядзець усе Рэкламныя матэрыялы"
-    publication: "Паглядзець усе Публікацыі"
-    regulation: "Паглядзець усе Даследаванні і аналіз"
+    oral_statement: Паглядзець усе Вусныя даклады ў парламенце
+    policy: Паглядзець усе Напрамкі дзейнасці
+    policy_paper: Паглядзець усе Праграмныя дакументы
+    press_release: Паглядзець усе Прэс-рэлізы
+    promotional: Паглядзець усе Рэкламныя матэрыялы
+    publication: Паглядзець усе Публікацыі
+    regulation: Паглядзець усе Даследаванні і аналіз
     research:
-    speaking_notes: "Паглядзець усе Нататкі да выступу"
-    speech: "Паглядзець усе Выступы"
-    statement_to_parliament: "Паглядзець усе Заявы ў парламенце"
-    statistical_data_set: "Паглядзець усе Статыстычныя дадзеныя"
-    statistics: "Паглядзець усе Статыстыка"
-    statutory_guidance: "Паглядзець усе Поўны тэкст"
+    speaking_notes: Паглядзець усе Нататкі да выступу
+    speech: Паглядзець усе Выступы
+    statement_to_parliament: Паглядзець усе Заявы ў парламенце
+    statistical_data_set: Паглядзець усе Статыстычныя дадзеныя
+    statistics: Паглядзець усе Статыстыка
+    statutory_guidance: Паглядзець усе Поўны тэкст
     transcript:
-    transparency: "Паглядзець усе Адкрытыя дадзеныя"
-    written_statement: "Паглядзець усе Пісьмовыя заявы ў парламенце"
+    transparency: Паглядзець усе Адкрытыя дадзеныя
+    written_statement: Паглядзець усе Пісьмовыя заявы ў парламенце
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "і"
+      last_word_connector: і
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Наша %{link}  тлумачыць, як мы ставімся
-        да Вашай асабістай інфармацыі."
-      publication_scheme_html: "Чытайце пра тыпы інфармацыі, якую мы рэгулярна публікуем,
-        у нашым %{link}."
-      social_media_use_html: "Прачытайце пра нашу палітыку датычна %{link}."
-      welsh_language_scheme_html: "Даведайцеся аб нашых абавязках да публікацыі ў
-        %{link}."
-    find_out_more: "Паглядзець усю інфармацыю і кантактныя дадзеныя"
+      personal_information_charter_html: Наша %{link}  тлумачыць, як мы ставімся да
+        Вашай асабістай інфармацыі.
+      publication_scheme_html: Чытайце пра тыпы інфармацыі, якую мы рэгулярна публікуем,
+        у нашым %{link}.
+      social_media_use_html: Прачытайце пра нашу палітыку датычна %{link}.
+      welsh_language_scheme_html: Даведайцеся аб нашых абавязках да публікацыі ў %{link}.
+    find_out_more: Паглядзець усю інфармацыю і кантактныя дадзеныя
     headings:
-      about_us: "Пра нас"
-      contact_us: "Звяжыцеся з намі"
-      corporate_information: "Карпаратыўная іфармацыя"
-      follow_us: "Сачыце за намі"
-      our_people: "Нашы людзі"
-      our_services: "Нашы паслугі"
-    location: "Месцазнаходжанне"
-    part_of: "Частка"
+      about_us: Пра нас
+      contact_us: Звяжыцеся з намі
+      corporate_information: Карпаратыўная іфармацыя
+      follow_us: Сачыце за намі
+      our_people: Нашы людзі
+      our_services: Нашы паслугі
+    location: Месцазнаходжанне
+    part_of: Частка

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -2,73 +2,73 @@ bg:
   document:
     headings:
       attachments:
-        one: "Документ"
-        other: "Документи"
-      applies_to_nations: "Отнася се към"
+        one: Документ
+        other: Документи
+      applies_to_nations: Отнася се към
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Съобщение"
-        other: "Съобщения"
+        one: Съобщение
+        other: Съобщения
       authored_article:
-        one: "Авторска статия"
-        other: "Авторски статии"
+        one: Авторска статия
+        other: Авторски статии
       blog_post:
         one:
         other:
       case_study:
-        one: "Казус"
-        other: "Казуси"
+        one: Казус
+        other: Казуси
       closed_consultation:
-        one: "Затворена консултация"
-        other: "Затворени консултации"
+        one: Затворена консултация
+        other: Затворени консултации
       consultation:
-        one: "Консултация"
-        other: "Консултации"
+        one: Консултация
+        other: Консултации
       consultation_outcome:
-        one: "Резултат от консултацията"
-        other: "Резултат от консултациите"
+        one: Резултат от консултацията
+        other: Резултат от консултациите
       corporate_report:
-        one: "Корпоративен доклад"
-        other: "Корпоративни доклади"
+        one: Корпоративен доклад
+        other: Корпоративни доклади
       correspondence:
-        one: "Кореспонденция"
-        other: "Кореспонденции"
+        one: Кореспонденция
+        other: Кореспонденции
       decision:
         one:
         other:
       detailed_guidance:
-        one: "Подробна насока"
-        other: "Подробни насоки"
+        one: Подробна насока
+        other: Подробни насоки
       document_collection:
-        one: "Серии"
+        one: Серии
         other:
       draft_text:
-        one: "Чернова"
-        other: "Чернови"
+        one: Чернова
+        other: Чернови
       foi_release:
-        one: "Съобщение във връзка със свободен достъп до информация"
-        other: "Съобщения във връзка със свободен достъп до информация"
+        one: Съобщение във връзка със свободен достъп до информация
+        other: Съобщения във връзка със свободен достъп до информация
       form:
-        one: "Формуляр"
-        other: "Формуляри"
+        one: Формуляр
+        other: Формуляри
       government_response:
-        one: "Отговор на правителството"
-        other: "Отговори на правителството"
+        one: Отговор на правителството
+        other: Отговори на правителството
       guidance:
-        one: "Насоки"
-        other: "Насоки"
+        one: Насоки
+        other: Насоки
       impact_assessment:
-        one: "Оценка на влиянието"
-        other: "Оценки на влиянието"
+        one: Оценка на влиянието
+        other: Оценки на влиянието
       imported:
-        one: "импортирано-очаква тип "
-        other: "импортирано-очаква тип"
+        one: 'импортирано-очаква тип '
+        other: импортирано-очаква тип
       independent_report:
-        one: "Независим доклад"
-        other: "Независими доклади"
+        one: Независим доклад
+        other: Независими доклади
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ bg:
         one:
         other:
       map:
-        one: "Карта"
-        other: "Карти"
+        one: Карта
+        other: Карти
       national_statistics:
-        one: "Статистика- национална статистика"
-        other: "Статистики- национални статистики"
+        one: Статистика- национална статистика
+        other: Статистики- национални статистики
       news_article:
-        one: "Новинарска статия"
-        other: "Новинарски статии"
+        one: Новинарска статия
+        other: Новинарски статии
       news_story:
-        one: "Новина"
-        other: "Новини"
+        one: Новина
+        other: Новини
       nhs_content:
         one:
         other:
@@ -94,79 +94,80 @@ bg:
         one:
         other:
       official_statistics:
-        one: "Статистики"
-        other: "Статистики"
+        one: Статистики
+        other: Статистики
       open_consultation:
-        one: "Отворена консултация"
-        other: "Отворени консултации"
+        one: Отворена консултация
+        other: Отворени консултации
       oral_statement:
-        one: "Устно изказване в Парламента"
-        other: "Устни изказвания в Парламента"
+        one: Устно изказване в Парламента
+        other: Устни изказвания в Парламента
       policy_paper:
-        one: "Документ, залагащ политика"
-        other: "Документи, залагащи политика"
+        one: Документ, залагащ политика
+        other: Документи, залагащи политика
       press_release:
-        one: "Съобщение до медиите"
-        other: "Съобщения до медиите"
+        one: Съобщение до медиите
+        other: Съобщения до медиите
       promotional:
-        one: "Промоционален материал"
-        other: "Промоционален материал"
+        one: Промоционален материал
+        other: Промоционален материал
       publication:
-        one: "Публикация"
-        other: "Публикации"
+        one: Публикация
+        other: Публикации
       regulation:
         one:
         other:
       research:
-        one: "Проучване и анализ"
-        other: "Проучване и анализи"
+        one: Проучване и анализ
+        other: Проучване и анализи
       speaking_notes:
-        one: "Устна нота"
-        other: "Устни ноти"
+        one: Устна нота
+        other: Устни ноти
       speech:
-        one: "Реч"
-        other: "Речи"
+        one: Реч
+        other: Речи
       statement_to_parliament:
-        one: "Изявление в парламента"
-        other: "Изявления в парламента"
+        one: Изявление в парламента
+        other: Изявления в парламента
       statistical_data_set:
-        one: "Набор от статистически данни"
-        other: "Набори от статистически данни"
+        one: Набор от статистически данни
+        other: Набори от статистически данни
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "Препис"
-        other: "Преписи"
+        one: Препис
+        other: Преписи
       transparency:
-        one: "Информация за прозрачността"
-        other: "Информация за прозрачността"
+        one: Информация за прозрачността
+        other: Информация за прозрачността
       world_news_story:
         one:
         other:
       written_statement:
-        one: "Писмено изявление до парламента"
-        other: "Писмени изявления до парламента"
+        one: Писмено изявление до парламента
+        other: Писмени изявления до парламента
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "Публикувано"
-    read: "Прочетете статията %{title} "
+    published: Публикувано
+    read: 'Прочетете статията %{title} '
     speech:
       author_title:
-        minister: "Министър"
-        speaker: "Министри"
-      delivered_on: "Представено на"
+        minister: Министър
+        speaker: Министри
+      delivered_on: Представено на
       delivery_title:
-        minister: "Министър"
-        speaker: "Говорител"
-      written_on: |
-        Написана на:
-    updated: "обновено"
-    view: "Вижте '%{title}'"
+        minister: Министър
+        speaker: Говорител
+      written_on: 'Написана на:
+
+'
+    updated: обновено
+    view: Вижте '%{title}'
   people:
     heading:
       one:
@@ -190,21 +191,21 @@ bg:
   world_location:
     type:
       international_delegation:
-        one: "Международна делегация"
-        other: "Международни делегации"
+        one: Международна делегация
+        other: Международни делегации
       world_location:
-        one: "Световно място"
-        other: "Световни места"
+        one: Световно място
+        other: Световни места
     headings:
-      announcements: "Нашите съобщения"
-      country: "Държава"
-      documents: "Документи"
-      mission: "Нашата мисия"
-      organisations: "Организации"
-      publications: "Нашите публикации"
-      quick_links: "Бързи връзки"
-      related_policies: "Свързани политики"
-      statistics: "Нашите статистики"
+      announcements: Нашите съобщения
+      country: Държава
+      documents: Документи
+      mission: Нашата мисия
+      organisations: Организации
+      publications: Нашите публикации
+      quick_links: Бързи връзки
+      related_policies: Свързани политики
+      statistics: Нашите статистики
   activerecord:
     attributes:
       attachment:
@@ -249,7 +250,7 @@ bg:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Съобщения"
+    heading: Съобщения
     view_all:
   attachment:
     accessibility:
@@ -258,14 +259,15 @@ bg:
         пратете електронна поща на %{email}
         като упоменете Вашия адрес, телефон, както и заглавието на публикацията
         ("%{title}")%{references}.
-      heading: "Този файл може да не е подходящ за хора, ползващи помощни технологии"
-      request_a_different_format: |
-        Направете заявка за друг формат
+      heading: Този файл може да не е подходящ за хора, ползващи помощни технологии
+      request_a_different_format: 'Направете заявка за друг формат
+
+'
     headings:
-      order_a_copy: "Поръчайте копие"
-      order_a_copy_full: "Поръчайте копия"
-      published: "Публикувано"
-      reference: "Справка"
+      order_a_copy: Поръчайте копие
+      order_a_copy_full: Поръчайте копия
+      published: Публикувано
+      reference: Справка
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -283,8 +285,8 @@ bg:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Контактна форма"
-    email: "И-мейл"
+    contact_form: Контактна форма
+    email: И-мейл
   corporate_information_page:
     type:
       link_text:
@@ -299,44 +301,44 @@ bg:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Харта за персонална информация"
+        personal_information_charter: Харта за персонална информация
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "Схема за публикации"
+        publication_scheme: Схема за публикации
         recruitment:
         research:
-        social_media_use: "Ползване на социални медии"
+        social_media_use: Ползване на социални медии
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Уелска езикова схема"
+        welsh_language_scheme: Уелска езикова схема
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "Можете да използвате филтрите, за да видите резултатите, които пасват
-      на вашето търсене"
+    description: Можете да използвате филтрите, за да видите резултатите, които пасват
+      на вашето търсене
     no_results:
-      description: "Разширете търсенето си и опитайте отново"
-      title: "Няма намерени документи"
+      description: Разширете търсенето си и опитайте отново
+      title: Няма намерени документи
       tna_heading:
       tna_link:
     world_locations:
-      all: "Всички места"
-      label: "Световни места"
+      all: Всички места
+      label: Световни места
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Последна дейност"
+    latest_activity: Последна дейност
   i18n:
     direction: ltr
   language_names:
-    bg: "български"
+    bg: български
   latest_feed:
-    no_updates: "Няма нови обновления"
-    title: "Последни"
+    no_updates: Няма нови обновления
+    title: Последни
   national_statistics:
     heading:
   number:
@@ -345,119 +347,119 @@ bg:
         format: "%n%u"
   organisation:
     about:
-      read_more: "Прочетете повече за нашата дейност"
+      read_more: Прочетете повече за нашата дейност
     corporate_information:
-      access_our_info: "Получете достъп до информацията ни"
-      foi_how_to: "Как да направите запитване по закона за достъпа до информация"
-      foi_releases: "Съобщения по закона за достъп до информация"
-      jobs_and_contacts: "Работни места и договори"
+      access_our_info: Получете достъп до информацията ни
+      foi_how_to: Как да направите запитване по закона за достъпа до информация
+      foi_releases: Съобщения по закона за достъп до информация
+      jobs_and_contacts: Работни места и договори
       organisation_chart:
-      transparency: "Данни за прозрачността"
+      transparency: Данни за прозрачността
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Нашите служители"
-      contact: "Свържете се с %{name}"
-      corporate_information: "Корпоративна информация"
-      corporate_reports: "Корпоративни доклади"
+      chief_professional_officers: Нашите служители
+      contact: Свържете се с %{name}
+      corporate_information: Корпоративна информация
+      corporate_reports: Корпоративни доклади
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Съобщенията ни"
+      our_announcements: Съобщенията ни
       our_consultations:
       our_judges:
-      our_management: "Нашето ръководство"
-      our_ministers: "Нашите министи"
-      our_policies: "Нашите политики"
-      our_publications: "Нашите публикации"
-      our_senior_military_officials: "Нашите висши военни служители"
-      our_services: "Услуги, които извършваме"
-      our_statistics: "Нашата статистика"
-      our_topics: "Работим по тези теми"
-      special_representatives: "Специални представители"
-      traffic_commissioners: "Комисари по трафика"
-      what_we_do: "Нашата дейност"
+      our_management: Нашето ръководство
+      our_ministers: Нашите министи
+      our_policies: Нашите политики
+      our_publications: Нашите публикации
+      our_senior_military_officials: Нашите висши военни служители
+      our_services: Услуги, които извършваме
+      our_statistics: Нашата статистика
+      our_topics: Работим по тези теми
+      special_representatives: Специални представители
+      traffic_commissioners: Комисари по трафика
+      what_we_do: Нашата дейност
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Политики"
+    heading: Политики
     view_all:
   publications:
-    heading: "Публикации"
+    heading: Публикации
     headings:
-      detail: "Подробности"
-  read_more: "Прочетете повече"
+      detail: Подробности
+  read_more: Прочетете повече
   see_all:
-    announcement: "Вижте всички наши Съобщения"
-    authored_article: "Вижте всички наши Авторски статии"
-    case_study: "Вижте всички наши Казуси"
-    closed_consultation: "Вижте всички наши Затворени консултации"
-    consultation: "Вижте всички наши Консултации"
-    consultation_outcome: "Вижте всички наши Резултат от консултациите"
-    corporate_report: "Вижте всички наши Корпоративни доклади"
-    correspondence: "Вижте всички наши Кореспонденции"
+    announcement: Вижте всички наши Съобщения
+    authored_article: Вижте всички наши Авторски статии
+    case_study: Вижте всички наши Казуси
+    closed_consultation: Вижте всички наши Затворени консултации
+    consultation: Вижте всички наши Консултации
+    consultation_outcome: Вижте всички наши Резултат от консултациите
+    corporate_report: Вижте всички наши Корпоративни доклади
+    correspondence: Вижте всички наши Кореспонденции
     decision:
-    detailed_guidance: "Вижте всички наши Подробни насоки"
+    detailed_guidance: Вижте всички наши Подробни насоки
     document_collection:
-    draft_text: "Вижте всички наши Чернови"
-    fatality_notice: "Вижте всички наши Уведомления за кончина"
-    foi_release: "Вижте всички наши Съобщения във връзка със свободен достъп до информация"
-    form: "Вижте всички наши Формуляри"
-    government_response: "Вижте всички наши Отговори на правителството"
-    guidance: "Вижте всички наши Насоки"
-    impact_assessment: "Вижте всички наши Оценки на влиянието"
-    imported: "Вижте всички наши импортирано-очаква тип"
+    draft_text: Вижте всички наши Чернови
+    fatality_notice: Вижте всички наши Уведомления за кончина
+    foi_release: Вижте всички наши Съобщения във връзка със свободен достъп до информация
+    form: Вижте всички наши Формуляри
+    government_response: Вижте всички наши Отговори на правителството
+    guidance: Вижте всички наши Насоки
+    impact_assessment: Вижте всички наши Оценки на влиянието
+    imported: Вижте всички наши импортирано-очаква тип
     international_treaty:
-    map: "Вижте всички наши Карти"
-    national_statistics: "Вижте всички наши Статистики- национални статистики"
-    news_article: "Вижте всички наши Новинарски статии"
-    news_story: "Вижте всички наши Новини"
+    map: Вижте всички наши Карти
+    national_statistics: Вижте всички наши Статистики- национални статистики
+    news_article: Вижте всички наши Новинарски статии
+    news_story: Вижте всички наши Новини
     notice:
-    open_consultation: "Вижте всички наши Отворени консултации"
-    oral_statement: "Вижте всички наши Устни изказвания в Парламента"
-    policy: "Вижте всички наши Политики"
-    policy_paper: "Вижте всички наши Документи, залагащи политика"
-    press_release: "Вижте всички наши Съобщения до медиите"
-    promotional: "Вижте всички наши Промоционален материал"
-    publication: "Вижте всички наши Публикации"
+    open_consultation: Вижте всички наши Отворени консултации
+    oral_statement: Вижте всички наши Устни изказвания в Парламента
+    policy: Вижте всички наши Политики
+    policy_paper: Вижте всички наши Документи, залагащи политика
+    press_release: Вижте всички наши Съобщения до медиите
+    promotional: Вижте всички наши Промоционален материал
+    publication: Вижте всички наши Публикации
     regulation:
-    research: "Вижте всички наши Проучване и анализи"
-    speaking_notes: "Вижте всички наши Устни ноти"
-    speech: "Вижте всички наши Речи"
-    statement_to_parliament: "Вижте всички наши Изявления в парламента"
-    statistical_data_set: "Вижте всички наши Набори от статистически данни"
-    statistics: "Вижте всички наши Статистики"
+    research: Вижте всички наши Проучване и анализи
+    speaking_notes: Вижте всички наши Устни ноти
+    speech: Вижте всички наши Речи
+    statement_to_parliament: Вижте всички наши Изявления в парламента
+    statistical_data_set: Вижте всички наши Набори от статистически данни
+    statistics: Вижте всички наши Статистики
     statutory_guidance:
-    transcript: "Вижте всички наши Преписи"
-    transparency: "Вижте всички наши Информация за прозрачността"
-    written_statement: "Вижте всички наши Писмени изявления до парламента"
+    transcript: Вижте всички наши Преписи
+    transparency: Вижте всички наши Информация за прозрачността
+    written_statement: Вижте всички наши Писмени изявления до парламента
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "и"
+      last_word_connector: и
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Нашият %{link} дава информация за начина
-        на ползване на личните Ви данни"
-      publication_scheme_html: "Прочетете какви видове информация публикуваме в нашия
-        %{link}."
-      social_media_use_html: "Вижте политиката ни по %{link}."
-      welsh_language_scheme_html: "Разберете повече за нашето задължение да публикуваме
-        в %{link}."
-    find_out_more: "Вижте пълния профил и всички контакти"
+      personal_information_charter_html: Нашият %{link} дава информация за начина
+        на ползване на личните Ви данни
+      publication_scheme_html: Прочетете какви видове информация публикуваме в нашия
+        %{link}.
+      social_media_use_html: Вижте политиката ни по %{link}.
+      welsh_language_scheme_html: Разберете повече за нашето задължение да публикуваме
+        в %{link}.
+    find_out_more: Вижте пълния профил и всички контакти
     headings:
-      about_us: "За нас"
-      contact_us: "Свържете се с нас"
-      corporate_information: "Корпоративна информация"
-      follow_us: "Следвайте ни"
-      our_people: "Нашите служители"
-      our_services: "Нашите услуги"
-    location: "Местоположение"
-    part_of: "Част от"
+      about_us: За нас
+      contact_us: Свържете се с нас
+      corporate_information: Корпоративна информация
+      follow_us: Следвайте ни
+      our_people: Нашите служители
+      our_services: Нашите услуги
+    location: Местоположение
+    part_of: Част от

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -326,7 +326,7 @@ bn:
   i18n:
     direction: ltr
   language_names:
-    bn: "বাংলা"
+    bn: বাংলা
   latest_feed:
     no_updates:
     title:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -201,7 +201,7 @@ cs:
       published:
       updated:
     published: Publikováno
-    read: "Čtěte %{title}"
+    read: Čtěte %{title}
     speech:
       author_title:
         minister: Minister
@@ -209,7 +209,7 @@ cs:
       delivered_on: Doručeno
       delivery_title:
         minister: Ministr
-        speaker: "Řečník"
+        speaker: Řečník
       written_on: Napsáno
     updated: Aktualizováno
     view: Náhled '%{title}'
@@ -309,7 +309,7 @@ cs:
         ("%{title}")%{references}.
       heading: Tento dokument nemusí být přístupný pro občany používající asistenční
         technologie
-      request_a_different_format: "Žádat o jiný formát dokumentu"
+      request_a_different_format: Žádat o jiný formát dokumentu
     headings:
       order_a_copy: Objednat kopii
       order_a_copy_full: Objednat kopii této publikace
@@ -381,7 +381,7 @@ cs:
   i18n:
     direction: ltr
   language_names:
-    cs: "Česky"
+    cs: Česky
   latest_feed:
     no_updates: Aktualizace nejsou k dispozici
     title: Nejnovější

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -202,7 +202,7 @@ de:
       organisations: Organisationen
       publications: Unsere Veröffentlichungen
       quick_links: Quicklinks
-      related_policies: "Ähnliche Sachgebiete"
+      related_policies: Ähnliche Sachgebiete
       statistics: Unsere Statistiken
   activerecord:
     attributes:
@@ -450,7 +450,7 @@ de:
         in %{link}
     find_out_more: Vollständiges Profil und alle Kontaktdaten
     headings:
-      about_us: "Über uns"
+      about_us: Über uns
       contact_us: Schreiben Sie uns
       corporate_information: Administrative Informationen
       follow_us: Folgen Sie uns

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -2,73 +2,73 @@ dr:
   document:
     headings:
       attachments:
-        one: "سند"
-        other: "اسناد"
-      applies_to_nations: "اطلاق میشود به"
+        one: سند
+        other: اسناد
+      applies_to_nations: اطلاق میشود به
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "اعلان"
-        other: "اعلانات"
+        one: اعلان
+        other: اعلانات
       authored_article:
-        one: "مقاله نوشته شده"
-        other: "مقاله های نوشته شده"
+        one: مقاله نوشته شده
+        other: مقاله های نوشته شده
       blog_post:
         one:
         other:
       case_study:
-        one: "بررسی  موردی"
-        other: "بررسی های موردی"
+        one: بررسی  موردی
+        other: بررسی های موردی
       closed_consultation:
-        one: "مشوره محرم"
-        other: "مشوره های محرم"
+        one: مشوره محرم
+        other: مشوره های محرم
       consultation:
-        one: "مشوره"
-        other: "مشوره ها"
+        one: مشوره
+        other: مشوره ها
       consultation_outcome:
-        one: "نتیجه مشوره"
-        other: "نتایج مشوره"
+        one: نتیجه مشوره
+        other: نتایج مشوره
       corporate_report:
-        one: "گزارش توحیدی"
-        other: "گزارشات توحیدی"
+        one: گزارش توحیدی
+        other: گزارشات توحیدی
       correspondence:
-        one: "مطابقت"
-        other: "مطابقت ها"
+        one: مطابقت
+        other: مطابقت ها
       decision:
         one:
         other:
       detailed_guidance:
         one: " رهنمود مفصل"
-        other: "رهنمود های مفصل"
+        other: رهنمود های مفصل
       document_collection:
-        one: "سلسله"
+        one: سلسله
         other:
       draft_text:
-        one: "متن مسوده"
-        other: "متون مسوده"
+        one: متن مسوده
+        other: متون مسوده
       foi_release:
-        one: "نشرآزادی بیان"
-        other: "نشریه های آزادی بیان"
+        one: نشرآزادی بیان
+        other: نشریه های آزادی بیان
       form:
-        one: "فورمه"
-        other: "فورمه ها"
+        one: فورمه
+        other: فورمه ها
       government_response:
-        one: "جوابدهی دولت"
-        other: "جوابدهی های دولت"
+        one: جوابدهی دولت
+        other: جوابدهی های دولت
       guidance:
-        one: "رهنمود"
-        other: "رهنمود"
+        one: رهنمود
+        other: رهنمود
       impact_assessment:
-        one: "بررسی تاثیرات"
-        other: "بررسی های تاثیرات"
+        one: بررسی تاثیرات
+        other: بررسی های تاثیرات
       imported:
-        one: "وارد شده- نوع انتظار"
-        other: "وارد شده - نوع انتظار"
+        one: وارد شده- نوع انتظار
+        other: وارد شده - نوع انتظار
       independent_report:
-        one: "گزارش آزاد"
-        other: "گزارش های آزاد"
+        one: گزارش آزاد
+        other: گزارش های آزاد
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ dr:
         one:
         other:
       map:
-        one: "نقشه"
-        other: "نقشه ها"
+        one: نقشه
+        other: نقشه ها
       national_statistics:
-        one: "احصایه ها - احصایه های ملی"
-        other: "احصایه ها - احصایه های ملی"
+        one: احصایه ها - احصایه های ملی
+        other: احصایه ها - احصایه های ملی
       news_article:
-        one: "مقاله جدید"
-        other: "مقاله خبری"
+        one: مقاله جدید
+        other: مقاله خبری
       news_story:
-        one: "گزارش خبری"
-        other: "گزارش های خبری"
+        one: گزارش خبری
+        other: گزارش های خبری
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ dr:
         one:
         other:
       official_statistics:
-        one: "احصائیه ها"
-        other: "احصائیه ها"
+        one: احصائیه ها
+        other: احصائیه ها
       open_consultation:
-        one: "مشاورت باز"
-        other: "مشاورت های باز"
+        one: مشاورت باز
+        other: مشاورت های باز
       oral_statement:
-        one: "بیانیه شفایی به پارلمان"
-        other: "بیانیه های شفایی به پارلمان"
+        one: بیانیه شفایی به پارلمان
+        other: بیانیه های شفایی به پارلمان
       policy_paper:
-        one: "سند پالیسی"
-        other: "سندهای پالیسی"
+        one: سند پالیسی
+        other: سندهای پالیسی
       press_release:
-        one: "اعلامیه مطبوعاتی"
-        other: "اعلامیه های مصبوعاتی"
+        one: اعلامیه مطبوعاتی
+        other: اعلامیه های مصبوعاتی
       promotional:
-        one: "مواد تعلیمی"
-        other: "مواد تعلیمی"
+        one: مواد تعلیمی
+        other: مواد تعلیمی
       publication:
-        one: "نشر"
-        other: "نشریات"
+        one: نشر
+        other: نشریات
       regulation:
         one:
         other:
       research:
-        one: "تحقیق و تجزیه"
-        other: "تحقیق و تجزیه"
+        one: تحقیق و تجزیه
+        other: تحقیق و تجزیه
       speaking_notes:
-        one: "یادداشت سخنرانی"
-        other: "یادداشت سخنرانی"
+        one: یادداشت سخنرانی
+        other: یادداشت سخنرانی
       speech:
-        one: "سخنرانی"
-        other: "سخنرانی ها"
+        one: سخنرانی
+        other: سخنرانی ها
       statement_to_parliament:
-        one: "بیانیه به پارلمان"
-        other: "بیانیه ها به پارلمان"
+        one: بیانیه به پارلمان
+        other: بیانیه ها به پارلمان
       statistical_data_set:
-        one: "ارقام احصائیوی"
-        other: "ارقام احصائیوی"
+        one: ارقام احصائیوی
+        other: ارقام احصائیوی
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "نسخه"
-        other: "نسخه ها"
+        one: نسخه
+        other: نسخه ها
       transparency:
-        one: "ارقام شفافیت"
-        other: "ارقام شفافیت"
+        one: ارقام شفافیت
+        other: ارقام شفافیت
       world_news_story:
         one:
         other:
       written_statement:
-        one: "بیانیه تحریری به پارلمان"
-        other: "بیانیه های تحریری به پارلمان"
+        one: بیانیه تحریری به پارلمان
+        other: بیانیه های تحریری به پارلمان
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "نشر شده"
-    read: "مقاله %{title} را بخوانید"
+    published: نشر شده
+    read: مقاله %{title} را بخوانید
     speech:
       author_title:
-        minister: "وزیر"
-        speaker: "نویسنده"
-      delivered_on: "تحویل شده به"
+        minister: وزیر
+        speaker: نویسنده
+      delivered_on: تحویل شده به
       delivery_title:
-        minister: "وزیر"
-        speaker: "سخنگوی"
-      written_on: "نوشته شد به"
-    updated: "به روز شده"
-    view: "ببینید'%{title}'"
+        minister: وزیر
+        speaker: سخنگوی
+      written_on: نوشته شد به
+    updated: به روز شده
+    view: ببینید'%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ dr:
   world_location:
     type:
       international_delegation:
-        one: "هیئت بین المللی"
-        other: "هیئات بین المللی"
+        one: هیئت بین المللی
+        other: هیئات بین المللی
       world_location:
-        one: "موقعیت جهانی"
-        other: "موقعیت های جهانی"
+        one: موقعیت جهانی
+        other: موقعیت های جهانی
     headings:
-      announcements: "اعلانات ما"
-      country: "کشور"
-      documents: "اسناد"
-      mission: "ماموریت ما"
-      organisations: "سازمان ها"
-      publications: "نشریات ما"
-      quick_links: "لینک های عاجل"
-      related_policies: "پالیسی های مرتبط"
-      statistics: "احصائیه های ما"
+      announcements: اعلانات ما
+      country: کشور
+      documents: اسناد
+      mission: ماموریت ما
+      organisations: سازمان ها
+      publications: نشریات ما
+      quick_links: لینک های عاجل
+      related_policies: پالیسی های مرتبط
+      statistics: احصائیه های ما
   activerecord:
     attributes:
       attachment:
@@ -248,20 +248,20 @@ dr:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "اعلانات"
+    heading: اعلانات
     view_all:
   attachment:
     accessibility:
       full_help_html: جهت درخواست سند در فارمت بدیل مانند بریل، صوتی و یا هم در فارمت
         متفاوت لطفاً آدرس، شماره تماس با نام نشریه ("%{title}")%{references} را ایمیل
         %{email} کنید
-      heading: "این فایل برای استعمال کننده گان تکنالوجی کمکی مناسب نخواهد بود"
-      request_a_different_format: "فارمت متفاوت را درخواست نمائید"
+      heading: این فایل برای استعمال کننده گان تکنالوجی کمکی مناسب نخواهد بود
+      request_a_different_format: فارمت متفاوت را درخواست نمائید
     headings:
-      order_a_copy: "نقل را درخواست نمائید"
-      order_a_copy_full: "نقل نشریه را درخواست نمائید"
-      published: "نشر شده"
-      reference: "ماخذ"
+      order_a_copy: نقل را درخواست نمائید
+      order_a_copy_full: نقل نشریه را درخواست نمائید
+      published: نشر شده
+      reference: ماخذ
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -279,8 +279,8 @@ dr:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "فارم تماس"
-    email: "ایمیل"
+    contact_form: فارم تماس
+    email: ایمیل
   corporate_information_page:
     type:
       link_text:
@@ -295,44 +295,44 @@ dr:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "موافقه معلومات شخصی"
+        personal_information_charter: موافقه معلومات شخصی
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "طرح انتشار"
+        publication_scheme: طرح انتشار
         recruitment:
         research:
-        social_media_use: "استفاده از رسانه اجتماعی"
+        social_media_use: استفاده از رسانه اجتماعی
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "طرح زبان ویلش"
+        welsh_language_scheme: طرح زبان ویلش
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "شما میتوانید از فیلتر ها جهت نشان دادن و nbsp استفاده نمایید. تنها
-      نتایجی که با منفعت های شما و nbsp تطابق دارند"
+    description: شما میتوانید از فیلتر ها جهت نشان دادن و nbsp استفاده نمایید. تنها
+      نتایجی که با منفعت های شما و nbsp تطابق دارند
     no_results:
-      description: "کوشش کنید بیشتر جستجو کنید و دوباره امتحان نمایید"
-      title: "اسنادی که در مطابقت باشند وجود ندارد"
+      description: کوشش کنید بیشتر جستجو کنید و دوباره امتحان نمایید
+      title: اسنادی که در مطابقت باشند وجود ندارد
       tna_heading:
       tna_link:
     world_locations:
-      all: "تمام موقعیت ها"
-      label: "موقعیت های جهانی"
+      all: تمام موقعیت ها
+      label: موقعیت های جهانی
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "فعالیت اخیر"
+    latest_activity: فعالیت اخیر
   i18n:
     direction: rtl
   language_names:
-    dr: "دری"
+    dr: دری
   latest_feed:
-    no_updates: "معلومات به روز شده هنوز وجود ندارد"
-    title: "اخیر"
+    no_updates: معلومات به روز شده هنوز وجود ندارد
+    title: اخیر
   national_statistics:
     heading:
   number:
@@ -341,99 +341,99 @@ dr:
         format: "%n%u"
   organisation:
     about:
-      read_more: "جهت معلومات بیشتر در مورد فعالیت های ما بخوانید"
+      read_more: جهت معلومات بیشتر در مورد فعالیت های ما بخوانید
     corporate_information:
-      access_our_info: "دسترسی به معلومات"
-      foi_how_to: "شیوه درخواست کردن آزادی بیان"
-      foi_releases: "نشریه های آزادی بیان"
-      jobs_and_contacts: "وظایف و قرارداد ها"
+      access_our_info: دسترسی به معلومات
+      foi_how_to: شیوه درخواست کردن آزادی بیان
+      foi_releases: نشریه های آزادی بیان
+      jobs_and_contacts: وظایف و قرارداد ها
       organisation_chart:
-      transparency: "معلومات شفافیت"
+      transparency: معلومات شفافیت
     foi_exemption_html:
     headings:
-      chief_professional_officers: "مدیران مسلکی ارشد ما"
-      contact: "تماس %{name}"
-      corporate_information: "معلومات یکی شده"
-      corporate_reports: "گزارش های یکی شده"
+      chief_professional_officers: مدیران مسلکی ارشد ما
+      contact: تماس %{name}
+      corporate_information: معلومات یکی شده
+      corporate_reports: گزارش های یکی شده
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "اعلانات ما"
+      our_announcements: اعلانات ما
       our_consultations:
       our_judges:
-      our_management: "اداره ما"
-      our_ministers: "وزرای ما"
-      our_policies: "پالیسی های ما"
-      our_publications: "نشریات ما"
-      our_senior_military_officials: "اراکین ارشد نظامی"
-      our_services: "خدمات ما"
-      our_statistics: "احصائیه های ما"
-      our_topics: "ما روی این موضوعات کار میکنیم"
-      special_representatives: "نماینده های خاص"
-      traffic_commissioners: "کمشنران ترافیک"
-      what_we_do: "ما روی چه کار میکنیم"
+      our_management: اداره ما
+      our_ministers: وزرای ما
+      our_policies: پالیسی های ما
+      our_publications: نشریات ما
+      our_senior_military_officials: اراکین ارشد نظامی
+      our_services: خدمات ما
+      our_statistics: احصائیه های ما
+      our_topics: ما روی این موضوعات کار میکنیم
+      special_representatives: نماینده های خاص
+      traffic_commissioners: کمشنران ترافیک
+      what_we_do: ما روی چه کار میکنیم
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "پالیسی ها"
+    heading: پالیسی ها
     view_all:
   publications:
-    heading: "نشریات"
+    heading: نشریات
     headings:
-      detail: "تفصیل"
-  read_more: "بیشتر بخوانید"
+      detail: تفصیل
+  read_more: بیشتر بخوانید
   see_all:
-    announcement: "همه را ببینید اعلانات"
-    authored_article: "همه را ببینید مقاله های نوشته شده"
-    case_study: "همه را ببینید بررسی های موردی"
-    closed_consultation: "همه را ببینید مشوره های محرم"
-    consultation: "همه را ببینید مشوره ها"
-    consultation_outcome: "همه را ببینید نتایج مشوره"
-    corporate_report: "همه را ببینید گزارشات توحیدی"
-    correspondence: "همه را ببینید مطابقت ها"
+    announcement: همه را ببینید اعلانات
+    authored_article: همه را ببینید مقاله های نوشته شده
+    case_study: همه را ببینید بررسی های موردی
+    closed_consultation: همه را ببینید مشوره های محرم
+    consultation: همه را ببینید مشوره ها
+    consultation_outcome: همه را ببینید نتایج مشوره
+    corporate_report: همه را ببینید گزارشات توحیدی
+    correspondence: همه را ببینید مطابقت ها
     decision:
-    detailed_guidance: "همه را ببینید رهنمود های مفصل"
+    detailed_guidance: همه را ببینید رهنمود های مفصل
     document_collection:
-    draft_text: "همه را ببینید متون مسوده"
-    fatality_notice: "همه را ببینید اخبار مرگ و میر"
-    foi_release: "همه را ببینید نشریه های آزادی بیان"
-    form: "همه را ببینید فورمه ها"
-    government_response: "همه را ببینید جوابدهی های دولت"
-    guidance: "همه را ببینید رهنمود"
-    impact_assessment: "همه را ببینید بررسی های تاثیرات"
-    imported: "همه را ببینید وارد شده - نوع انتظار"
+    draft_text: همه را ببینید متون مسوده
+    fatality_notice: همه را ببینید اخبار مرگ و میر
+    foi_release: همه را ببینید نشریه های آزادی بیان
+    form: همه را ببینید فورمه ها
+    government_response: همه را ببینید جوابدهی های دولت
+    guidance: همه را ببینید رهنمود
+    impact_assessment: همه را ببینید بررسی های تاثیرات
+    imported: همه را ببینید وارد شده - نوع انتظار
     international_treaty:
-    map: "همه را ببینید نقشه ها"
-    national_statistics: "همه را ببینید احصایه ها - احصایه های ملی"
-    news_article: "همه را ببینید مقاله خبری"
-    news_story: "همه را ببینید گزارش های خبری"
+    map: همه را ببینید نقشه ها
+    national_statistics: همه را ببینید احصایه ها - احصایه های ملی
+    news_article: همه را ببینید مقاله خبری
+    news_story: همه را ببینید گزارش های خبری
     notice:
-    open_consultation: "همه را ببینید مشاورت های باز"
-    oral_statement: "همه را ببینید بیانیه های شفایی به پارلمان"
-    policy: "همه را ببینید پالیسی ها"
-    policy_paper: "همه را ببینید سندهای پالیسی"
-    press_release: "همه را ببینید اعلامیه های مصبوعاتی"
-    promotional: "همه را ببینید مواد تعلیمی"
-    publication: "همه را ببینید نشریات"
+    open_consultation: همه را ببینید مشاورت های باز
+    oral_statement: همه را ببینید بیانیه های شفایی به پارلمان
+    policy: همه را ببینید پالیسی ها
+    policy_paper: همه را ببینید سندهای پالیسی
+    press_release: همه را ببینید اعلامیه های مصبوعاتی
+    promotional: همه را ببینید مواد تعلیمی
+    publication: همه را ببینید نشریات
     regulation:
-    research: "همه را ببینید تحقیق و تجزیه"
-    speaking_notes: "همه را ببینید یادداشت سخنرانی"
-    speech: "همه را ببینید سخنرانی ها"
-    statement_to_parliament: "همه را ببینید بیانیه ها به پارلمان"
-    statistical_data_set: "همه را ببینید ارقام احصائیوی"
-    statistics: "همه را ببینید احصائیه ها"
+    research: همه را ببینید تحقیق و تجزیه
+    speaking_notes: همه را ببینید یادداشت سخنرانی
+    speech: همه را ببینید سخنرانی ها
+    statement_to_parliament: همه را ببینید بیانیه ها به پارلمان
+    statistical_data_set: همه را ببینید ارقام احصائیوی
+    statistics: همه را ببینید احصائیه ها
     statutory_guidance:
-    transcript: "همه را ببینید نسخه ها"
-    transparency: "همه را ببینید ارقام شفافیت"
-    written_statement: "همه را ببینید بیانیه های تحریری به پارلمان"
+    transcript: همه را ببینید نسخه ها
+    transparency: همه را ببینید ارقام شفافیت
+    written_statement: همه را ببینید بیانیه های تحریری به پارلمان
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "و"
+      last_word_connector: و
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
@@ -442,18 +442,17 @@ dr:
       about_our_services_html:
       personal_information_charter_html: "  %{link} ما شیوه برخود با معلومات شخصی
         را تشریح مینماید"
-      publication_scheme_html: "در مورد انواع معلوماتی بخوانید که ما به طور منظم نشر
-        می کنیم."
-      social_media_use_html: "پالیسی ما را در %{link} بخوانید"
-      welsh_language_scheme_html: "در مورد تعهد ما به نشر در %{link} معلومات حاصل
-        نمایید"
-    find_out_more: "نمایه مکمل و تفصیلات در مورد تماس ها را ببینید"
+      publication_scheme_html: در مورد انواع معلوماتی بخوانید که ما به طور منظم نشر
+        می کنیم.
+      social_media_use_html: پالیسی ما را در %{link} بخوانید
+      welsh_language_scheme_html: در مورد تعهد ما به نشر در %{link} معلومات حاصل نمایید
+    find_out_more: نمایه مکمل و تفصیلات در مورد تماس ها را ببینید
     headings:
-      about_us: "در مورد ما"
-      contact_us: "با ما تماس بگیرید"
-      corporate_information: "معلومات توحید شده"
-      follow_us: "ما را تعقیب نمایید"
-      our_people: "مردم ما"
-      our_services: "خدمات ما"
-    location: "موقعیت"
-    part_of: "بخشی از"
+      about_us: در مورد ما
+      contact_us: با ما تماس بگیرید
+      corporate_information: معلومات توحید شده
+      follow_us: ما را تعقیب نمایید
+      our_people: مردم ما
+      our_services: خدمات ما
+    location: موقعیت
+    part_of: بخشی از

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -2,73 +2,73 @@ el:
   document:
     headings:
       attachments:
-        one: "Έγγραφο"
-        other: "Έγγραφα"
-      applies_to_nations: "Ισχύει"
+        one: Έγγραφο
+        other: Έγγραφα
+      applies_to_nations: Ισχύει
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Ανακοίνωση"
-        other: "Ανακοινώσεις"
+        one: Ανακοίνωση
+        other: Ανακοινώσεις
       authored_article:
-        one: "Κείμενο συντάκτη"
-        other: "Κείμενα συντακτών"
+        one: Κείμενο συντάκτη
+        other: Κείμενα συντακτών
       blog_post:
         one:
         other:
       case_study:
-        one: "Παράδειγμα"
-        other: "Παραδείγματα"
+        one: Παράδειγμα
+        other: Παραδείγματα
       closed_consultation:
-        one: "Κλειστή διαβούλευση"
-        other: "Κλειστές διαβουλεύσεις"
+        one: Κλειστή διαβούλευση
+        other: Κλειστές διαβουλεύσεις
       consultation:
-        one: "Διαβούλευση"
-        other: "Διαβουλεύσεις"
+        one: Διαβούλευση
+        other: Διαβουλεύσεις
       consultation_outcome:
-        one: "Αποτέλεσμα διαβούλευσης"
-        other: "Αποτελέσματα διαβούλευσης"
+        one: Αποτέλεσμα διαβούλευσης
+        other: Αποτελέσματα διαβούλευσης
       corporate_report:
-        one: "Έκθεση Οργανισμού"
-        other: "Εκθέσεις Οργανισμού"
+        one: Έκθεση Οργανισμού
+        other: Εκθέσεις Οργανισμού
       correspondence:
-        one: "Αλληλογραφία"
-        other: "Αλληλογραφία"
+        one: Αλληλογραφία
+        other: Αλληλογραφία
       decision:
         one:
         other:
       detailed_guidance:
-        one: "Οδηγίες"
-        other: "Οδηγίες"
+        one: Οδηγίες
+        other: Οδηγίες
       document_collection:
-        one: "Σειρά"
+        one: Σειρά
         other:
       draft_text:
-        one: "Προσχέδιο"
-        other: "Προσχέδια"
+        one: Προσχέδιο
+        other: Προσχέδια
       foi_release:
-        one: "Δημοσιοποίηση"
-        other: "Δημοσιοποίηση"
+        one: Δημοσιοποίηση
+        other: Δημοσιοποίηση
       form:
-        one: "Έντυπο"
-        other: "Έντυπα"
+        one: Έντυπο
+        other: Έντυπα
       government_response:
-        one: "Η θέση της Κυβέρνησης"
-        other: "Οι θέσεις της Κυβέρνησης"
+        one: Η θέση της Κυβέρνησης
+        other: Οι θέσεις της Κυβέρνησης
       guidance:
-        one: "Οδηγίες"
-        other: "Οδηγίες"
+        one: Οδηγίες
+        other: Οδηγίες
       impact_assessment:
-        one: "Αξιολόγηση αποτελέσματος"
-        other: "Αξιολογήσεις αποτελέσματος"
+        one: Αξιολόγηση αποτελέσματος
+        other: Αξιολογήσεις αποτελέσματος
       imported:
         one: " εισηγμένο  - σε αναμονή"
-        other: "εισηγμένα - σε αναμονή"
+        other: εισηγμένα - σε αναμονή
       independent_report:
-        one: "Έκθεση ανεξάρτητης αρχής"
-        other: "Εκθέσεις ανεξάρτητων αρχών"
+        one: Έκθεση ανεξάρτητης αρχής
+        other: Εκθέσεις ανεξάρτητων αρχών
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ el:
         one:
         other:
       map:
-        one: "Χάρτης"
-        other: "Χάρτες"
+        one: Χάρτης
+        other: Χάρτες
       national_statistics:
-        one: "Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία"
-        other: "Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία"
+        one: Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία
+        other: Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία
       news_article:
-        one: "Είδηση"
-        other: "Ειδήσεις"
+        one: Είδηση
+        other: Ειδήσεις
       news_story:
-        one: "Νέα"
-        other: "Νέα"
+        one: Νέα
+        other: Νέα
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ el:
         one:
         other:
       official_statistics:
-        one: "Στατιστικά στοιχεία"
-        other: "Στατιστικά στοιχεία"
+        one: Στατιστικά στοιχεία
+        other: Στατιστικά στοιχεία
       open_consultation:
-        one: "Ανοιχτή διαβούλευση"
-        other: "Ανοιχτές διαβουλεύσεις"
+        one: Ανοιχτή διαβούλευση
+        other: Ανοιχτές διαβουλεύσεις
       oral_statement:
-        one: "Δήλωση στη Βουλή"
-        other: "Δηλώσεις στη Βουλή "
+        one: Δήλωση στη Βουλή
+        other: 'Δηλώσεις στη Βουλή '
       policy_paper:
-        one: "Κείμενο πολιτικής"
-        other: "Κείμενα πολιτικής"
+        one: Κείμενο πολιτικής
+        other: Κείμενα πολιτικής
       press_release:
-        one: "Δελτίο Τύπου"
-        other: "Δελτία Τύπου"
+        one: Δελτίο Τύπου
+        other: Δελτία Τύπου
       promotional:
-        one: "Προωθητικό υλικό"
-        other: "Προωθητικό υλικό"
+        one: Προωθητικό υλικό
+        other: Προωθητικό υλικό
       publication:
-        one: "Έκδοση"
-        other: "Εκδόσεις"
+        one: Έκδοση
+        other: Εκδόσεις
       regulation:
         one:
         other:
       research:
-        one: "Έρευνα και ανάλυση"
-        other: "Έρευνα και ανάλυση"
+        one: Έρευνα και ανάλυση
+        other: Έρευνα και ανάλυση
       speaking_notes:
-        one: "Βασικά σημεία ομιλίας"
-        other: "Βασικά σημεία ομιλίας"
+        one: Βασικά σημεία ομιλίας
+        other: Βασικά σημεία ομιλίας
       speech:
-        one: "Ομιλία"
-        other: "Ομιλίες"
+        one: Ομιλία
+        other: Ομιλίες
       statement_to_parliament:
-        one: "Δήλωση στη Βουλή"
-        other: "Δηλώσεις στη Βουλή "
+        one: Δήλωση στη Βουλή
+        other: 'Δηλώσεις στη Βουλή '
       statistical_data_set:
-        one: "Στατιστικά στοιχεία"
-        other: "Στατιστικά στοιχεία"
+        one: Στατιστικά στοιχεία
+        other: Στατιστικά στοιχεία
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "Απομαγνητοφώνηση"
-        other: "Απομαγνητοφωνήσεις"
+        one: Απομαγνητοφώνηση
+        other: Απομαγνητοφωνήσεις
       transparency:
-        one: "Στοιχεία διαφάνειας"
-        other: "Στοιχεία διαφάνειας"
+        one: Στοιχεία διαφάνειας
+        other: Στοιχεία διαφάνειας
       world_news_story:
         one:
         other:
       written_statement:
-        one: "Γραπτή  δήλωση στη Βουλή"
-        other: "Γραπτές δηλώσεις στη Βουλή"
+        one: Γραπτή  δήλωση στη Βουλή
+        other: Γραπτές δηλώσεις στη Βουλή
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "Δημοσιευμένο"
-    read: "Διαβάστε το άρθρο  %{title}"
+    published: Δημοσιευμένο
+    read: Διαβάστε το άρθρο  %{title}
     speech:
       author_title:
-        minister: "Υπουργός"
-        speaker: "Συγγραφέας"
-      delivered_on: "Παραδόθηκε στις:"
+        minister: Υπουργός
+        speaker: Συγγραφέας
+      delivered_on: 'Παραδόθηκε στις:'
       delivery_title:
-        minister: "Υπουργός"
-        speaker: "Ομιλητής"
-      written_on: "Γραφτηκε τη: "
-    updated: "ανανεωμένο "
-    view: "Δείτε '%{title}'"
+        minister: Υπουργός
+        speaker: Ομιλητής
+      written_on: 'Γραφτηκε τη: '
+    updated: 'ανανεωμένο '
+    view: Δείτε '%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ el:
   world_location:
     type:
       international_delegation:
-        one: "Διεθνής αντιπροσωπεία"
-        other: "Διεθνείς αντιπροσωπείες"
+        one: Διεθνής αντιπροσωπεία
+        other: Διεθνείς αντιπροσωπείες
       world_location:
-        one: "Χώρα"
-        other: "Χώρες"
+        one: Χώρα
+        other: Χώρες
     headings:
-      announcements: "Οι ανακοινώσεις μας"
-      country: "Χώρα"
-      documents: "Έγγραφα"
-      mission: "Η αποστολή μας"
-      organisations: "Οργανισμοί"
-      publications: "Οι εκδόσεις μας"
-      quick_links: "Σύντομοι σύνδεσμοι"
-      related_policies: "Σχετικές πολιτικές"
-      statistics: "Τα στατιστικά στοιχεία μας"
+      announcements: Οι ανακοινώσεις μας
+      country: Χώρα
+      documents: Έγγραφα
+      mission: Η αποστολή μας
+      organisations: Οργανισμοί
+      publications: Οι εκδόσεις μας
+      quick_links: Σύντομοι σύνδεσμοι
+      related_policies: Σχετικές πολιτικές
+      statistics: Τα στατιστικά στοιχεία μας
   activerecord:
     attributes:
       attachment:
@@ -248,7 +248,7 @@ el:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Ανακοινώσεις"
+    heading: Ανακοινώσεις
     view_all:
   attachment:
     accessibility:
@@ -256,14 +256,14 @@ el:
         μπρέιλ, ηχητική μορφή ή άλλο τύπο αρχείου παρακαλούμε συμπληρώστε το email
         σας %{email} τη διευθυνσή σας, το τηλέφωνό σας και τον τίτλο του εγγράφου
         ("%{title}")%{references}.
-      heading: "Το αρχείο μπορεί να μην είναι συμβατό με προγράμματα υποστηρικτικής
-        τεχνολογίας."
-      request_a_different_format: "Εναλλακτικός τύπος αρχείου"
+      heading: Το αρχείο μπορεί να μην είναι συμβατό με προγράμματα υποστηρικτικής
+        τεχνολογίας.
+      request_a_different_format: Εναλλακτικός τύπος αρχείου
     headings:
-      order_a_copy: "Ζητήστε αντίτυπο"
-      order_a_copy_full: "Ζητήστε αντιτυπο της έκδοσης"
-      published: "Δημοσιεύτηκε"
-      reference: "Σχετικά"
+      order_a_copy: Ζητήστε αντίτυπο
+      order_a_copy_full: Ζητήστε αντιτυπο της έκδοσης
+      published: Δημοσιεύτηκε
+      reference: Σχετικά
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -281,7 +281,7 @@ el:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Φόρμα επικοινωνίας"
+    contact_form: Φόρμα επικοινωνίας
     email: Email
   corporate_information_page:
     type:
@@ -297,43 +297,43 @@ el:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Προστασία προσωπικών δεδομένων"
+        personal_information_charter: Προστασία προσωπικών δεδομένων
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "Σχέδιο έκδοσης"
+        publication_scheme: Σχέδιο έκδοσης
         recruitment:
         research:
-        social_media_use: "Χρήση κοινωνικών δικτύων"
+        social_media_use: Χρήση κοινωνικών δικτύων
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Πρόγραμμα Ουαλλικής γλώσσας"
+        welsh_language_scheme: Πρόγραμμα Ουαλλικής γλώσσας
   date:
     formats:
       default:
       long_ordinal:
   document_filters:
-    description: "Χρησιμοποιήστε τα φίλτρα για εξειδίκευση αποτελεσμάτων"
+    description: Χρησιμοποιήστε τα φίλτρα για εξειδίκευση αποτελεσμάτων
     no_results:
-      description: "Διευρύνετε την αναζήτησή σας και δοκιμάστε ξανά"
-      title: "Δεν υπάρχουν αποτελέσματα"
+      description: Διευρύνετε την αναζήτησή σας και δοκιμάστε ξανά
+      title: Δεν υπάρχουν αποτελέσματα
       tna_heading:
       tna_link:
     world_locations:
-      all: "Όλες οι τοποθεσίες"
-      label: "Παγκόσμιες τοποθεσίες"
+      all: Όλες οι τοποθεσίες
+      label: Παγκόσμιες τοποθεσίες
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Πρόσφατες ενημερώσεις"
+    latest_activity: Πρόσφατες ενημερώσεις
   i18n:
     direction: ltr
   language_names:
-    el: "Ελληνικά "
+    el: 'Ελληνικά '
   latest_feed:
-    no_updates: "Δεν υπάρχουν ανανεώσεις ακόμα"
-    title: "Πρόσφατα"
+    no_updates: Δεν υπάρχουν ανανεώσεις ακόμα
+    title: Πρόσφατα
   national_statistics:
     heading:
   number:
@@ -342,120 +342,120 @@ el:
         format:
   organisation:
     about:
-      read_more: "Περισσότερα για τις δράσεις μας"
+      read_more: Περισσότερα για τις δράσεις μας
     corporate_information:
-      access_our_info: "Πρόσβαση στις πληροφορίες μας"
-      foi_how_to: "Διαδικάσία αιτήματος για πρόσβαση στις πληροφορίες μας βάσει της
-        νομοθεσίας για ελεύθερη πρόσβαση σεμ διοικητικά έγγραφα"
-      foi_releases: "Ελεύθερη πρόσβαση σε διοικητικά έγγραφα"
-      jobs_and_contacts: "Θέσεις εργασίας και συμβάσεις"
+      access_our_info: Πρόσβαση στις πληροφορίες μας
+      foi_how_to: Διαδικάσία αιτήματος για πρόσβαση στις πληροφορίες μας βάσει της
+        νομοθεσίας για ελεύθερη πρόσβαση σεμ διοικητικά έγγραφα
+      foi_releases: Ελεύθερη πρόσβαση σε διοικητικά έγγραφα
+      jobs_and_contacts: Θέσεις εργασίας και συμβάσεις
       organisation_chart:
-      transparency: "Στοιχεία διαφάνειας"
+      transparency: Στοιχεία διαφάνειας
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Τα ανώτερα στελέχη της υπηρεσίας μας"
-      contact: "Επικοινωνήστε%{name}"
-      corporate_information: "Πληροφορίες για τον Οργανισμό"
-      corporate_reports: "Εκθέσεις Οργανισμού"
+      chief_professional_officers: Τα ανώτερα στελέχη της υπηρεσίας μας
+      contact: Επικοινωνήστε%{name}
+      corporate_information: Πληροφορίες για τον Οργανισμό
+      corporate_reports: Εκθέσεις Οργανισμού
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Οι ανακοινώσεις μας"
+      our_announcements: Οι ανακοινώσεις μας
       our_consultations:
       our_judges:
-      our_management: "Η ηγεσία μας"
-      our_ministers: "Οι υπουργοί μας"
-      our_policies: "Οι πολιτικές μας"
-      our_publications: "Οι εκδόσεις μας"
-      our_senior_military_officials: "Η στρατιωτική ηγεσία"
-      our_services: "Οι υπηρεσίες μας"
-      our_statistics: "Τα στατιστικά μας"
-      our_topics: "Εργαζόμαστε στους παρακάτω τομείς"
-      special_representatives: "Ειδικοί αντιπρόσωποι"
-      traffic_commissioners: "Ομάδα ρύθμισης μεταφορών "
-      what_we_do: "Οι δράσεις μας"
+      our_management: Η ηγεσία μας
+      our_ministers: Οι υπουργοί μας
+      our_policies: Οι πολιτικές μας
+      our_publications: Οι εκδόσεις μας
+      our_senior_military_officials: Η στρατιωτική ηγεσία
+      our_services: Οι υπηρεσίες μας
+      our_statistics: Τα στατιστικά μας
+      our_topics: Εργαζόμαστε στους παρακάτω τομείς
+      special_representatives: Ειδικοί αντιπρόσωποι
+      traffic_commissioners: 'Ομάδα ρύθμισης μεταφορών '
+      what_we_do: Οι δράσεις μας
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Πολιτικές"
+    heading: Πολιτικές
     view_all:
   publications:
-    heading: "Εκδόσεις"
+    heading: Εκδόσεις
     headings:
-      detail: "Λεπτομέρεια"
-  read_more: "Διαβάστε περισσότερα"
+      detail: Λεπτομέρεια
+  read_more: Διαβάστε περισσότερα
   see_all:
-    announcement: "Δείτε τα Ανακοινώσεις"
-    authored_article: "Δείτε τα Κείμενα συντακτών"
-    case_study: "Δείτε τα Παραδείγματα"
-    closed_consultation: "Δείτε τα Κλειστές διαβουλεύσεις"
-    consultation: "Δείτε τα Διαβουλεύσεις"
-    consultation_outcome: "Δείτε τα Αποτελέσματα διαβούλευσης"
-    corporate_report: "Δείτε τα Εκθέσεις Οργανισμού"
-    correspondence: "Δείτε τα Αλληλογραφία"
+    announcement: Δείτε τα Ανακοινώσεις
+    authored_article: Δείτε τα Κείμενα συντακτών
+    case_study: Δείτε τα Παραδείγματα
+    closed_consultation: Δείτε τα Κλειστές διαβουλεύσεις
+    consultation: Δείτε τα Διαβουλεύσεις
+    consultation_outcome: Δείτε τα Αποτελέσματα διαβούλευσης
+    corporate_report: Δείτε τα Εκθέσεις Οργανισμού
+    correspondence: Δείτε τα Αλληλογραφία
     decision:
-    detailed_guidance: "Δείτε τα Οδηγίες"
+    detailed_guidance: Δείτε τα Οδηγίες
     document_collection:
-    draft_text: "Δείτε τα Προσχέδια"
-    fatality_notice: "Δείτε τα Ανακοινώσεις θανάτων"
-    foi_release: "Δείτε τα Δημοσιοποίηση"
-    form: "Δείτε τα Έντυπα"
-    government_response: "Δείτε τα Οι θέσεις της Κυβέρνησης"
-    guidance: "Δείτε τα Οδηγίες"
-    impact_assessment: "Δείτε τα Αξιολογήσεις αποτελέσματος"
-    imported: "Δείτε τα εισηγμένα - σε αναμονή"
+    draft_text: Δείτε τα Προσχέδια
+    fatality_notice: Δείτε τα Ανακοινώσεις θανάτων
+    foi_release: Δείτε τα Δημοσιοποίηση
+    form: Δείτε τα Έντυπα
+    government_response: Δείτε τα Οι θέσεις της Κυβέρνησης
+    guidance: Δείτε τα Οδηγίες
+    impact_assessment: Δείτε τα Αξιολογήσεις αποτελέσματος
+    imported: Δείτε τα εισηγμένα - σε αναμονή
     international_treaty:
-    map: "Δείτε τα Χάρτες"
-    national_statistics: "Δείτε τα Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία"
-    news_article: "Δείτε τα Ειδήσεις"
-    news_story: "Δείτε τα Νέα"
+    map: Δείτε τα Χάρτες
+    national_statistics: Δείτε τα Στατιστικά στοιχεία- εθνικά στατιστικά στοιχεία
+    news_article: Δείτε τα Ειδήσεις
+    news_story: Δείτε τα Νέα
     notice:
-    open_consultation: "Δείτε τα Ανοιχτές διαβουλεύσεις"
-    oral_statement: "Δείτε τα Δηλώσεις στη Βουλή "
-    policy: "Δείτε τα Πολιτικές"
-    policy_paper: "Δείτε τα Κείμενα πολιτικής"
-    press_release: "Δείτε τα Δελτία Τύπου"
-    promotional: "Δείτε τα Προωθητικό υλικό"
-    publication: "Δείτε τα Εκδόσεις"
+    open_consultation: Δείτε τα Ανοιχτές διαβουλεύσεις
+    oral_statement: 'Δείτε τα Δηλώσεις στη Βουλή '
+    policy: Δείτε τα Πολιτικές
+    policy_paper: Δείτε τα Κείμενα πολιτικής
+    press_release: Δείτε τα Δελτία Τύπου
+    promotional: Δείτε τα Προωθητικό υλικό
+    publication: Δείτε τα Εκδόσεις
     regulation:
-    research: "Δείτε τα Έρευνα και ανάλυση"
-    speaking_notes: "Δείτε τα Βασικά σημεία ομιλίας"
-    speech: "Δείτε τα Ομιλίες"
-    statement_to_parliament: "Δείτε τα Δηλώσεις στη Βουλή "
-    statistical_data_set: "Δείτε τα Στατιστικά στοιχεία"
-    statistics: "Δείτε τα Στατιστικά στοιχεία"
+    research: Δείτε τα Έρευνα και ανάλυση
+    speaking_notes: Δείτε τα Βασικά σημεία ομιλίας
+    speech: Δείτε τα Ομιλίες
+    statement_to_parliament: 'Δείτε τα Δηλώσεις στη Βουλή '
+    statistical_data_set: Δείτε τα Στατιστικά στοιχεία
+    statistics: Δείτε τα Στατιστικά στοιχεία
     statutory_guidance:
-    transcript: "Δείτε τα Απομαγνητοφωνήσεις"
-    transparency: "Δείτε τα Στοιχεία διαφάνειας"
-    written_statement: "Δείτε τα Γραπτές δηλώσεις στη Βουλή"
+    transcript: Δείτε τα Απομαγνητοφωνήσεις
+    transparency: Δείτε τα Στοιχεία διαφάνειας
+    written_statement: Δείτε τα Γραπτές δηλώσεις στη Βουλή
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "και"
+      last_word_connector: και
   time:
     formats:
       long_ordinal:
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Το %{link} εξηγεί πώς χειριζόμαστε τα προσωπικά
-        σας δεδομένα"
-      publication_scheme_html: "Μάθετε περισσότερα για τις πληροφορίας που δημοσιεύουμε
-        συνήθως στο %{link}"
-      social_media_use_html: "Μάθετε περισσότερα για την πολιτική μας στο %{link}."
-      welsh_language_scheme_html: "Μάθετε περισσότερα για την δέσμευση μας στη δημοσίευση
-        στο %{link}."
-    find_out_more: "Πλήρες προφίλ και στοιχεία επικοινωνίας"
+      personal_information_charter_html: Το %{link} εξηγεί πώς χειριζόμαστε τα προσωπικά
+        σας δεδομένα
+      publication_scheme_html: Μάθετε περισσότερα για τις πληροφορίας που δημοσιεύουμε
+        συνήθως στο %{link}
+      social_media_use_html: Μάθετε περισσότερα για την πολιτική μας στο %{link}.
+      welsh_language_scheme_html: Μάθετε περισσότερα για την δέσμευση μας στη δημοσίευση
+        στο %{link}.
+    find_out_more: Πλήρες προφίλ και στοιχεία επικοινωνίας
     headings:
-      about_us: "Σχετικά με εμάς"
-      contact_us: "Επικοινωνήστε μαζί μας"
-      corporate_information: "Πληροφορίες για τον οργανισμό"
-      follow_us: "Ακολουθείστε μας"
-      our_people: "Τα στελέχη μας"
-      our_services: "Οι υπηρεσίες μας"
-    location: "Χώρα"
-    part_of: "Μέρος του"
+      about_us: Σχετικά με εμάς
+      contact_us: Επικοινωνήστε μαζί μας
+      corporate_information: Πληροφορίες για τον οργανισμό
+      follow_us: Ακολουθείστε μας
+      our_people: Τα στελέχη μας
+      our_services: Οι υπηρεσίες μας
+    location: Χώρα
+    part_of: Μέρος του

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -176,8 +176,8 @@ et:
     read_more: Temast lähemalt
   roles:
     heading:
-      one: "Ülesanne"
-      other: "Ülesanded"
+      one: Ülesanne
+      other: Ülesanded
     headings:
       current_holder: Praegu sellel ametikohal
       previous_holders: Eelmised ametikoha täitjad
@@ -354,8 +354,11 @@ et:
       jobs_and_contacts: Töötajad ja kontaktid
       organisation_chart: Meie organisatsioon
       transparency: Läbipaistvusteave
-    foi_exemption_html: |
-      See organisatsioon ei kuulu Teabevabaduse seaduse (FOI) alla. Et vaadata, missugused organisatsioonid kuuluvad, vaadake: <a href="%{foi_url}">the legislation</a>.
+    foi_exemption_html: 'See organisatsioon ei kuulu Teabevabaduse seaduse (FOI) alla.
+      Et vaadata, missugused organisatsioonid kuuluvad, vaadake: <a href="%{foi_url}">the
+      legislation</a>.
+
+'
     headings:
       chief_professional_officers: Meie juhtivad ametnikud
       contact: 'Võtke ühendust: %{name}'
@@ -391,7 +394,7 @@ et:
   publications:
     heading: Publikatsioonid
     headings:
-      detail: "Üksikasjad"
+      detail: Üksikasjad
   read_more: 'Lugege lähemalt '
   see_all:
     announcement: Vaadake kõiki meie teadaandeid

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -43,20 +43,20 @@ fa:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "اطلاعیه ها"
+    heading: اطلاعیه ها
     view_all:
   attachment:
     accessibility:
       full_help_html: برای درخواست این مقاله در ساختاری متفاوت مانند بریل، شنیداری
         و یا گونه فایلی متفاوت لطفا به آدرس %{email} با درج آدرس، شماره تلفن به همراه
         شماره کلاسه مقاله ایمیل بدهید  ("%{title}")%{references}.
-      heading: "این فایل ممکن است برای کاربران فن آوری کمکی مناسب نباشد"
-      request_a_different_format: "ساختار متفاوتی درخواست کنید"
+      heading: این فایل ممکن است برای کاربران فن آوری کمکی مناسب نباشد
+      request_a_different_format: ساختار متفاوتی درخواست کنید
     headings:
-      order_a_copy: "کپی سفارش دهید"
-      order_a_copy_full: "کپی سفارش دهید"
-      published: "منتشر شده"
-      reference: "مرجع"
+      order_a_copy: کپی سفارش دهید
+      order_a_copy_full: کپی سفارش دهید
+      published: منتشر شده
+      reference: مرجع
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -74,8 +74,8 @@ fa:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "فرم ارتباط"
-    email: "ایمیل"
+    contact_form: فرم ارتباط
+    email: ایمیل
   corporate_information_page:
     type:
       link_text:
@@ -90,17 +90,17 @@ fa:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "منشور اطلاعات شخصی"
+        personal_information_charter: منشور اطلاعات شخصی
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "برنامه انتشار"
+        publication_scheme: برنامه انتشار
         recruitment:
         research:
-        social_media_use: "استفاده از رسانه اجتماعی"
+        social_media_use: استفاده از رسانه اجتماعی
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "برنامه زبان ولز"
+        welsh_language_scheme: برنامه زبان ولز
   date:
     formats:
       default: "%d %B %Y"
@@ -113,85 +113,85 @@ fa:
       published:
       updated:
     headings:
-      applies_to_nations: "در ارتباط با"
+      applies_to_nations: در ارتباط با
       attachments:
-        one: "مدرک"
-        other: "مدارک"
+        one: مدرک
+        other: مدارک
       from:
       location:
       part_of:
-    published: "منتشر شده"
-    read: "مقاله  %{title} را بخوانید"
+    published: منتشر شده
+    read: مقاله  %{title} را بخوانید
     speech:
       author_title:
-        minister: "معاون وزیر"
-        speaker: "نویسنده"
-      delivered_on: "ارائه شده در تاریخ:"
+        minister: معاون وزیر
+        speaker: نویسنده
+      delivered_on: 'ارائه شده در تاریخ:'
       delivery_title:
-        minister: "معاون وزیر"
-        speaker: "سخنگو"
-      written_on: "نوشته شده در:"
+        minister: معاون وزیر
+        speaker: سخنگو
+      written_on: 'نوشته شده در:'
     type:
       announcement:
-        one: "اعلامیه"
-        other: "اعلامیه ها"
+        one: اعلامیه
+        other: اعلامیه ها
       authored_article:
-        one: "مقاله"
-        other: "مقالات"
+        one: مقاله
+        other: مقالات
       blog_post:
         one:
         other:
       case_study:
-        one: "مطالعه ی موردی"
-        other: "مطالعه های موردی"
+        one: مطالعه ی موردی
+        other: مطالعه های موردی
       closed_consultation:
-        one: "رایزنی بسته"
-        other: "رایزنی های بسته"
+        one: رایزنی بسته
+        other: رایزنی های بسته
       consultation:
-        one: "رایزنی"
-        other: "رایزنی ها"
+        one: رایزنی
+        other: رایزنی ها
       consultation_outcome:
-        one: "نتیجه رایزنی"
-        other: "نتایج رایزنی"
+        one: نتیجه رایزنی
+        other: نتایج رایزنی
       corporate_report:
-        one: "گزارش سازمانی"
-        other: "گزارش های سازمانی"
+        one: گزارش سازمانی
+        other: گزارش های سازمانی
       correspondence:
-        one: "مکاتبه"
-        other: "مکاتبات"
+        one: مکاتبه
+        other: مکاتبات
       decision:
         one:
         other:
       detailed_guidance:
-        one: "راهنمای تفصیلی"
-        other: "راهنمای تفصیلی"
+        one: راهنمای تفصیلی
+        other: راهنمای تفصیلی
       document_collection:
-        one: "ردیف"
+        one: ردیف
         other:
       draft_text:
-        one: "متن پیش نویس"
-        other: "متون پیش نویس"
+        one: متن پیش نویس
+        other: متون پیش نویس
       foi_release:
-        one: "انتشار آزاد اطلاعات"
-        other: "انتشار آزاد اطلاعات"
+        one: انتشار آزاد اطلاعات
+        other: انتشار آزاد اطلاعات
       form:
-        one: "فرم"
-        other: "فرم ها"
+        one: فرم
+        other: فرم ها
       government_response:
-        one: "جوابیه دولت"
-        other: "جوابیه های دولت"
+        one: جوابیه دولت
+        other: جوابیه های دولت
       guidance:
-        one: "راهنمایی"
-        other: "راهنمایی"
+        one: راهنمایی
+        other: راهنمایی
       impact_assessment:
-        one: "ارزیابی تاثیرات"
-        other: "ارزیابی های تاثیرات"
+        one: ارزیابی تاثیرات
+        other: ارزیابی های تاثیرات
       imported:
-        one: "منتقل شده - در انتظار دسته بندی"
-        other: "منتقل شده - در انتظار دسته بندی"
+        one: منتقل شده - در انتظار دسته بندی
+        other: منتقل شده - در انتظار دسته بندی
       independent_report:
-        one: "گزارش مستقل"
-        other: "گزارش های مستقل"
+        one: گزارش مستقل
+        other: گزارش های مستقل
       international_treaty:
         one:
         other:
@@ -199,17 +199,17 @@ fa:
         one:
         other:
       map:
-        one: "نقشه"
-        other: "نقشه ها"
+        one: نقشه
+        other: نقشه ها
       national_statistics:
-        one: "آمار - آمار ملی"
-        other: "آمار - آمار ملی"
+        one: آمار - آمار ملی
+        other: آمار - آمار ملی
       news_article:
-        one: "مقاله ی خبری"
-        other: "مقالات خبری"
+        one: مقاله ی خبری
+        other: مقالات خبری
       news_story:
-        one: "خبر"
-        other: "اخبار"
+        one: خبر
+        other: اخبار
       nhs_content:
         one:
         other:
@@ -217,84 +217,84 @@ fa:
         one:
         other:
       official_statistics:
-        one: "آمار"
-        other: "آمار"
+        one: آمار
+        other: آمار
       open_consultation:
-        one: "رایزنی باز"
-        other: "رایزنی های باز"
+        one: رایزنی باز
+        other: رایزنی های باز
       oral_statement:
-        one: "گزارش شفاهی به پارلمان"
-        other: "گزارش های شفاهی به پارلمان"
+        one: گزارش شفاهی به پارلمان
+        other: گزارش های شفاهی به پارلمان
       policy_paper:
-        one: "مقاله ی سیاسی"
-        other: "مقاله های سیاسی"
+        one: مقاله ی سیاسی
+        other: مقاله های سیاسی
       press_release:
-        one: "بیانیه"
-        other: "بیانیه ها"
+        one: بیانیه
+        other: بیانیه ها
       promotional:
-        one: "مطالب تبلیغاتی"
-        other: "مطالب تبلیغاتی"
+        one: مطالب تبلیغاتی
+        other: مطالب تبلیغاتی
       publication:
-        one: "نشریه"
-        other: "نشریات"
+        one: نشریه
+        other: نشریات
       regulation:
         one:
         other:
       research:
-        one: "پژوهش و تحلیل"
-        other: "پژوهش و تحلیل"
+        one: پژوهش و تحلیل
+        other: پژوهش و تحلیل
       speaking_notes:
-        one: "موضوعات سخنرانی"
-        other: "موضوعات سخنرانی"
+        one: موضوعات سخنرانی
+        other: موضوعات سخنرانی
       speech:
-        one: "سخنرانی"
-        other: "سخنرانی ها"
+        one: سخنرانی
+        other: سخنرانی ها
       statement_to_parliament:
-        one: "گزارش به پارلمان"
-        other: "گزارش ها به پارلمان"
+        one: گزارش به پارلمان
+        other: گزارش ها به پارلمان
       statistical_data_set:
-        one: "بسته ی داده های آماری"
-        other: "بسته های داده های آماری"
+        one: بسته ی داده های آماری
+        other: بسته های داده های آماری
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "رونوشت"
-        other: "رونوشت ها"
+        one: رونوشت
+        other: رونوشت ها
       transparency:
-        one: "داده های شفاف سازی"
-        other: "داده های شفاف سازی"
+        one: داده های شفاف سازی
+        other: داده های شفاف سازی
       world_news_story:
         one:
         other:
       written_statement:
-        one: "گزارش کتبی به پارلمان"
-        other: "گزارش های کتبی به پارلمان"
-    updated: "به روز رسانی شده"
-    view: "مشاهده '%{title}'"
+        one: گزارش کتبی به پارلمان
+        other: گزارش های کتبی به پارلمان
+    updated: به روز رسانی شده
+    view: مشاهده '%{title}'
   document_filters:
-    description: "با استفاده از این فیلتر ها می توانید نتایج جستجو را به سلیقه ی خود
-      محدود کنید"
+    description: با استفاده از این فیلتر ها می توانید نتایج جستجو را به سلیقه ی خود
+      محدود کنید
     no_results:
-      description: "جستجوی خود را گسترده تر و مجددا تلاش کنید"
-      title: "اسناد منطبق وجود ندارد"
+      description: جستجوی خود را گسترده تر و مجددا تلاش کنید
+      title: اسناد منطبق وجود ندارد
       tna_heading:
       tna_link:
     world_locations:
-      all: "تمام نقاط"
-      label: "موقعیت های جهانی"
+      all: تمام نقاط
+      label: موقعیت های جهانی
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "آخرین تحولات"
+    latest_activity: آخرین تحولات
   i18n:
     direction: rtl
   language_names:
-    fa: "فارسی"
+    fa: فارسی
   latest_feed:
-    no_updates: "اطلاعات جدیدی در دست نیست"
-    title: "آخرین"
+    no_updates: اطلاعات جدیدی در دست نیست
+    title: آخرین
   national_statistics:
     heading:
   number:
@@ -303,37 +303,37 @@ fa:
         format:
   organisation:
     about:
-      read_more: "درباره ی فعالیت های ما بیشتر بخوانید"
+      read_more: درباره ی فعالیت های ما بیشتر بخوانید
     corporate_information:
-      access_our_info: "دسترسی به اطلاعات ما"
-      foi_how_to: "چگونه درخواست برای انتشار آزاد اطلاعات ارائه دهید"
-      foi_releases: "انتشار آزاد اطلاعات"
-      jobs_and_contacts: "مشاغل و قراردادها"
+      access_our_info: دسترسی به اطلاعات ما
+      foi_how_to: چگونه درخواست برای انتشار آزاد اطلاعات ارائه دهید
+      foi_releases: انتشار آزاد اطلاعات
+      jobs_and_contacts: مشاغل و قراردادها
       organisation_chart:
-      transparency: "داده های شفاف سازی"
+      transparency: داده های شفاف سازی
     foi_exemption_html:
     headings:
-      chief_professional_officers: "افسران ارشد حرفه ای ما"
-      contact: "تماس با %{name}"
-      corporate_information: "اطلاعات سازمانی"
-      corporate_reports: "گزارش های سازمانی"
+      chief_professional_officers: افسران ارشد حرفه ای ما
+      contact: تماس با %{name}
+      corporate_information: اطلاعات سازمانی
+      corporate_reports: گزارش های سازمانی
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "اطلاعیه های ما"
+      our_announcements: اطلاعیه های ما
       our_consultations:
       our_judges:
-      our_management: "مدیریت ما"
-      our_ministers: "معاونین وزیر ما"
-      our_policies: "سیاست های ما"
-      our_publications: "انتشارات ما"
-      our_senior_military_officials: "مقامات ارشد نظامی ما"
-      our_services: "خدمات ما"
-      our_statistics: "آمار ما"
-      our_topics: "ما در خصوص این موضوعات فعالیت می کنیم"
-      special_representatives: "نمایندگان ویژه"
-      traffic_commissioners: "ماموران ترافیک"
-      what_we_do: "فعالیت ما"
+      our_management: مدیریت ما
+      our_ministers: معاونین وزیر ما
+      our_policies: سیاست های ما
+      our_publications: انتشارات ما
+      our_senior_military_officials: مقامات ارشد نظامی ما
+      our_services: خدمات ما
+      our_statistics: آمار ما
+      our_topics: ما در خصوص این موضوعات فعالیت می کنیم
+      special_representatives: نمایندگان ویژه
+      traffic_commissioners: ماموران ترافیک
+      what_we_do: فعالیت ما
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -348,13 +348,13 @@ fa:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "سیاست ها"
+    heading: سیاست ها
     view_all:
   publications:
-    heading: "انتشارات"
+    heading: انتشارات
     headings:
-      detail: "جزئیات"
-  read_more: "اطلاعات بیشتر"
+      detail: جزئیات
+  read_more: اطلاعات بیشتر
   roles:
     heading:
       one:
@@ -368,91 +368,91 @@ fa:
     previous_holders:
     read_more:
   see_all:
-    announcement: "تمامی اعلامیه ها ما را مشاهده کنید"
-    authored_article: "تمامی مقالات ما را مشاهده کنید"
-    case_study: "تمامی مطالعه های موردی ما را مشاهده کنید"
-    closed_consultation: "تمامی رایزنی های بسته ما را مشاهده کنید"
-    consultation: "تمامی رایزنی ها ما را مشاهده کنید"
-    consultation_outcome: "تمامی نتایج رایزنی ما را مشاهده کنید"
-    corporate_report: "تمامی گزارش های سازمانی ما را مشاهده کنید"
-    correspondence: "تمامی مکاتبات ما را مشاهده کنید"
+    announcement: تمامی اعلامیه ها ما را مشاهده کنید
+    authored_article: تمامی مقالات ما را مشاهده کنید
+    case_study: تمامی مطالعه های موردی ما را مشاهده کنید
+    closed_consultation: تمامی رایزنی های بسته ما را مشاهده کنید
+    consultation: تمامی رایزنی ها ما را مشاهده کنید
+    consultation_outcome: تمامی نتایج رایزنی ما را مشاهده کنید
+    corporate_report: تمامی گزارش های سازمانی ما را مشاهده کنید
+    correspondence: تمامی مکاتبات ما را مشاهده کنید
     decision:
-    detailed_guidance: "تمامی راهنمای تفصیلی ما را مشاهده کنید"
+    detailed_guidance: تمامی راهنمای تفصیلی ما را مشاهده کنید
     document_collection:
-    draft_text: "تمامی متون پیش نویس ما را مشاهده کنید"
-    fatality_notice: "تمامی اطلاعیه تلفات ما را مشاهده کنید"
-    foi_release: "تمامی انتشار آزاد اطلاعات ما را مشاهده کنید"
-    form: "تمامی فرم ها ما را مشاهده کنید"
-    government_response: "تمامی جوابیه های دولت ما را مشاهده کنید"
-    guidance: "تمامی راهنمایی ما را مشاهده کنید"
-    impact_assessment: "تمامی ارزیابی های تاثیرات ما را مشاهده کنید"
-    imported: "تمامی منتقل شده - در انتظار دسته بندی ما را مشاهده کنید"
+    draft_text: تمامی متون پیش نویس ما را مشاهده کنید
+    fatality_notice: تمامی اطلاعیه تلفات ما را مشاهده کنید
+    foi_release: تمامی انتشار آزاد اطلاعات ما را مشاهده کنید
+    form: تمامی فرم ها ما را مشاهده کنید
+    government_response: تمامی جوابیه های دولت ما را مشاهده کنید
+    guidance: تمامی راهنمایی ما را مشاهده کنید
+    impact_assessment: تمامی ارزیابی های تاثیرات ما را مشاهده کنید
+    imported: تمامی منتقل شده - در انتظار دسته بندی ما را مشاهده کنید
     international_treaty:
-    map: "تمامی نقشه ها ما را مشاهده کنید"
-    national_statistics: "تمامی آمار - آمار ملی ما را مشاهده کنید"
-    news_article: "تمامی مقالات خبری ما را مشاهده کنید"
-    news_story: "تمامی اخبار ما را مشاهده کنید"
+    map: تمامی نقشه ها ما را مشاهده کنید
+    national_statistics: تمامی آمار - آمار ملی ما را مشاهده کنید
+    news_article: تمامی مقالات خبری ما را مشاهده کنید
+    news_story: تمامی اخبار ما را مشاهده کنید
     notice:
-    open_consultation: "تمامی رایزنی های باز ما را مشاهده کنید"
-    oral_statement: "تمامی گزارش های شفاهی به پارلمان ما را مشاهده کنید"
-    policy: "تمامی سیاست ها ما را مشاهده کنید"
-    policy_paper: "تمامی مقاله های سیاسی ما را مشاهده کنید"
-    press_release: "تمامی بیانیه ها ما را مشاهده کنید"
-    promotional: "تمامی مطالب تبلیغاتی ما را مشاهده کنید"
-    publication: "تمامی نشریات ما را مشاهده کنید"
+    open_consultation: تمامی رایزنی های باز ما را مشاهده کنید
+    oral_statement: تمامی گزارش های شفاهی به پارلمان ما را مشاهده کنید
+    policy: تمامی سیاست ها ما را مشاهده کنید
+    policy_paper: تمامی مقاله های سیاسی ما را مشاهده کنید
+    press_release: تمامی بیانیه ها ما را مشاهده کنید
+    promotional: تمامی مطالب تبلیغاتی ما را مشاهده کنید
+    publication: تمامی نشریات ما را مشاهده کنید
     regulation:
-    research: "تمامی پژوهش و تحلیل ما را مشاهده کنید"
-    speaking_notes: "تمامی موضوعات سخنرانی ما را مشاهده کنید"
-    speech: "تمامی سخنرانی ها ما را مشاهده کنید"
-    statement_to_parliament: "تمامی گزارش ها به پارلمان ما را مشاهده کنید"
-    statistical_data_set: "تمامی بسته های داده های آماری ما را مشاهده کنید"
-    statistics: "تمامی آمار ما را مشاهده کنید"
+    research: تمامی پژوهش و تحلیل ما را مشاهده کنید
+    speaking_notes: تمامی موضوعات سخنرانی ما را مشاهده کنید
+    speech: تمامی سخنرانی ها ما را مشاهده کنید
+    statement_to_parliament: تمامی گزارش ها به پارلمان ما را مشاهده کنید
+    statistical_data_set: تمامی بسته های داده های آماری ما را مشاهده کنید
+    statistics: تمامی آمار ما را مشاهده کنید
     statutory_guidance:
-    transcript: "تمامی رونوشت ها ما را مشاهده کنید"
-    transparency: "تمامی داده های شفاف سازی ما را مشاهده کنید"
-    written_statement: "تمامی گزارش های کتبی به پارلمان ما را مشاهده کنید"
+    transcript: تمامی رونوشت ها ما را مشاهده کنید
+    transparency: تمامی داده های شفاف سازی ما را مشاهده کنید
+    written_statement: تمامی گزارش های کتبی به پارلمان ما را مشاهده کنید
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "و"
+      last_word_connector: و
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "اطلاعیه های ما"
-      country: "کشور"
-      documents: "مدارک"
-      mission: "هدف ما"
-      organisations: "سازمان ها"
-      publications: "انتشارات ما"
-      quick_links: "دسترسی سریع"
-      related_policies: "سیاست های مربوط"
-      statistics: "آمار ما"
+      announcements: اطلاعیه های ما
+      country: کشور
+      documents: مدارک
+      mission: هدف ما
+      organisations: سازمان ها
+      publications: انتشارات ما
+      quick_links: دسترسی سریع
+      related_policies: سیاست های مربوط
+      statistics: آمار ما
     type:
       international_delegation:
-        one: "هیأت بین المللی"
-        other: "هیأت های بین المللی"
+        one: هیأت بین المللی
+        other: هیأت های بین المللی
       world_location:
-        one: "موقعیت جهانی"
-        other: "موقعیت های جهانی"
+        one: موقعیت جهانی
+        other: موقعیت های جهانی
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
       personal_information_charter_html: "%{link} چگونگی نگهداری از اطلاعات شخصی شما
         را توضیح می دهد"
-      publication_scheme_html: "درباره نوع اطلاعاتی که ما به طور روال در %{link} منتشر
-        می کنیم بخوانید "
-      social_media_use_html: "سیاست ما را درباره  %{link} بخوانید"
-      welsh_language_scheme_html: "درباره تعهد ما به انتشار مطالب به %{link} بخوانید"
-    find_out_more: "مشاهده مشخصات کامل و تمام جزئیات تماس"
+      publication_scheme_html: 'درباره نوع اطلاعاتی که ما به طور روال در %{link} منتشر
+        می کنیم بخوانید '
+      social_media_use_html: سیاست ما را درباره  %{link} بخوانید
+      welsh_language_scheme_html: درباره تعهد ما به انتشار مطالب به %{link} بخوانید
+    find_out_more: مشاهده مشخصات کامل و تمام جزئیات تماس
     headings:
-      about_us: "درباره ما"
-      contact_us: "تماس با ما"
-      corporate_information: "اطلاعات سازمانی"
-      follow_us: "به صفحه های ما بپیوندید"
-      our_people: "کارمندان ما"
-      our_services: "خدمات ما"
-    location: "مکان"
-    part_of: "بخشی از"
+      about_us: درباره ما
+      contact_us: تماس با ما
+      corporate_information: اطلاعات سازمانی
+      follow_us: به صفحه های ما بپیوندید
+      our_people: کارمندان ما
+      our_services: خدمات ما
+    location: مکان
+    part_of: بخشی از

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -2,269 +2,173 @@ he:
   document:
     headings:
       attachments:
-        one: "מסמך"
-        two:
-        many:
-        other: "מסמכים"
-      applies_to_nations: "מתייחס ל"
+        one:
+        other:
+      applies_to_nations: מתייחס ל
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "הודעה"
-        two:
-        many:
-        other: "הודעות"
+        one:
+        other:
       authored_article:
-        one: "מאמר מאושר"
-        two:
-        many:
-        other: "מאמרים מאושרים"
+        one:
+        other:
       blog_post:
         one:
-        two:
-        many:
         other:
       case_study:
-        one: "מקרה בוחן"
-        two:
-        many:
-        other: "מקרי בוחן"
+        one:
+        other:
       closed_consultation:
-        one: "דיון סגור"
-        two:
-        many:
-        other: "דיונים סגורים"
+        one:
+        other:
       consultation:
-        one: "דיון"
-        two:
-        many:
-        other: "דיונים"
+        one:
+        other:
       consultation_outcome:
-        one: "תוצאות דיון"
-        two:
-        many:
-        other: "תוצאות דיונים"
+        one:
+        other:
       corporate_report:
-        one: דו"ח משותף
-        two:
-        many:
-        other: דו"חות משותפים
+        one:
+        other:
       correspondence:
-        one: "תכתובת"
-        two:
-        many:
-        other: "תכתובות"
+        one:
+        other:
       decision:
         one:
-        two:
-        many:
         other:
       detailed_guidance:
-        one: "מדריך מפורט"
-        two:
-        many:
-        other: "מדריך מפורט"
+        one:
+        other:
       document_collection:
-        one: "סדרות"
-        two:
-        many:
+        one:
         other:
       draft_text:
-        one: "טיוטה"
-        two:
-        many:
-        other: "טיוטות"
+        one:
+        other:
       foi_release:
-        one: "פרסום חופש מידע"
-        two:
-        many:
-        other: "פרסומי חופש מידע"
+        one:
+        other:
       form:
-        one: "טופס"
-        two:
-        many:
-        other: "טפסים"
+        one:
+        other:
       government_response:
-        one: "תגובה ממשלתית"
-        two:
-        many:
-        other: "תגובות ממשלתיות"
+        one:
+        other:
       guidance:
-        one: "הדרכה"
-        two:
-        many:
-        other: "הדרכה"
+        one:
+        other:
       impact_assessment:
-        one: "הערכת השפעה"
-        two:
-        many:
-        other: "הערכת השפעות"
+        one:
+        other:
       imported:
-        one: "יבוא- המתנה לסוג"
-        two:
-        many:
-        other: "יבוא- המתנה לסוג"
+        one:
+        other:
       independent_report:
-        one: דו"ח עצמאי
-        two:
-        many:
-        other: דו"ות עצמאיים
+        one:
+        other:
       international_treaty:
         one:
-        two:
-        many:
         other:
       manual:
         one:
-        two:
-        many:
         other:
       map:
-        one: "מפה"
-        two:
-        many:
-        other: "מפות"
+        one:
+        other:
       national_statistics:
-        one: "סטטיסטיקות- סטטיסטיקה לאומית"
-        two:
-        many:
-        other: "סטטיסטיקות- סטטסטיקה לאומית"
+        one:
+        other:
       news_article:
-        one: "מאמר חדשות"
-        two:
-        many:
-        other: "מאמרי חדשות"
+        one:
+        other:
       news_story:
-        one: "חדשות"
-        two:
-        many:
-        other: "חדשות"
+        one:
+        other:
       nhs_content:
         one:
-        two:
-        many:
         other:
       notice:
         one:
-        two:
-        many:
         other:
       official_statistics:
-        one: "נתונים"
-        two:
-        many:
-        other: "נתונים"
+        one:
+        other:
       open_consultation:
-        one: "דיון פתוח"
-        two:
-        many:
-        other: "דיון פתוח"
+        one:
+        other:
       oral_statement:
-        one: "הצהרה בעל פה לפרלמנט"
-        two:
-        many:
-        other: "הצהרות בעל פה לפרלמנט"
+        one:
+        other:
       policy_paper:
-        one: "נייר מדיניות"
-        two:
-        many:
-        other: "ניירות מדיניות"
+        one:
+        other:
       press_release:
-        one: "הודעה לעיתונות"
-        two:
-        many:
-        other: "הודעות לעיתונות"
+        one:
+        other:
       promotional:
-        one: "חומר פרסומי"
-        two:
-        many:
-        other: "חומר פרסומי"
+        one:
+        other:
       publication:
-        one: "פרסום"
-        two:
-        many:
-        other: "פרסומים"
+        one:
+        other:
       regulation:
         one:
-        two:
-        many:
         other:
       research:
-        one: "מחקר וניתוח"
-        two:
-        many:
-        other: "מחקר וניתוח"
+        one:
+        other:
       speaking_notes:
-        one: "נאומים"
-        two:
-        many:
-        other: "נאומים"
+        one:
+        other:
       speech:
-        one: "נאום"
-        two:
-        many:
-        other: "נאומים"
+        one:
+        other:
       statement_to_parliament:
-        one: "הצהרה לפרלמנט"
-        two:
-        many:
-        other: "הצהרות לפרלמנט"
+        one:
+        other:
       statistical_data_set:
-        one: "מידע סטטיסטי"
-        two:
-        many:
-        other: "מידע סטטיסטי"
+        one:
+        other:
       statutory_guidance:
         one:
-        two:
-        many:
         other:
       transcript:
-        one: "תמלול"
-        two:
-        many:
-        other: "תמלולים"
+        one:
+        other:
       transparency:
-        one: "שקיפות מידע"
-        two:
-        many:
-        other: "שקיפות מידע"
+        one:
+        other:
       world_news_story:
         one:
-        two:
-        many:
         other:
       written_statement:
-        one: "הצהרה בכתב לפרלמנט"
-        two:
-        many:
-        other: "הצהרות בכתב לפרלמנט"
+        one:
+        other:
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "פורסם"
-    read: "קראו את מאמר %{title}"
+    published: פורסם
+    read: קראו את מאמר %{title}
     speech:
       author_title:
-        minister: "שר"
-        speaker: "מחבר"
-      delivered_on: "נשלח ב:"
+        minister: שר
+        speaker: מחבר
+      delivered_on: 'נשלח ב:'
       delivery_title:
-        minister: "שר"
-        speaker: "דובר"
-      written_on: "נכתב על:"
-    updated: "מעודכן"
-    view: "ראה '%{title}'"
+        minister: שר
+        speaker: דובר
+      written_on: 'נכתב על:'
+    updated: מעודכן
+    view: ראה '%{title}'
   people:
     heading:
       one:
-      two:
-      many:
       other:
     biography:
     previous_roles:
@@ -273,8 +177,6 @@ he:
   roles:
     heading:
       one:
-      two:
-      many:
       other:
     headings:
       current_holder:
@@ -287,25 +189,21 @@ he:
   world_location:
     type:
       international_delegation:
-        one: "משלחת בין לאומית"
-        two:
-        many:
-        other: "משלחות בין לאומיות"
+        one:
+        other:
       world_location:
-        one: "מיקום עולמי"
-        two:
-        many:
-        other: "מיקומים עולמיים"
+        one:
+        other:
     headings:
-      announcements: "ההודעות שלנו"
-      country: "מדינה"
-      documents: "מסמכים"
-      mission: "החזון שלנו"
-      organisations: "ארגונים"
-      publications: "הפרסומים שלנו"
-      quick_links: "קישורים מהירים"
-      related_policies: "מדיניות רלוונטית"
-      statistics: "הנתונים שלנו"
+      announcements: ההודעות שלנו
+      country: מדינה
+      documents: מסמכים
+      mission: החזון שלנו
+      organisations: ארגונים
+      publications: הפרסומים שלנו
+      quick_links: קישורים מהירים
+      related_policies: מדיניות רלוונטית
+      statistics: הנתונים שלנו
   activerecord:
     attributes:
       attachment:
@@ -350,7 +248,7 @@ he:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "הודעות"
+    heading: הודעות
     view_all:
   attachment:
     accessibility:
@@ -358,13 +256,13 @@ he:
         כדי להזמין את המסמך בפורמט אלטרנטיבי כגון ברייל, אודיו או
         סוגי קובץ שונים אנא שלח/י אימייל %{title} עם כתובת וטלפון יחד עם שם המסמך
         המבוקש ("%{title}")%{references}.
-      heading: "הקובץ אינו תומך במשתמשי טכנולוגית סיוע"
-      request_a_different_format: "אנא בקש/י פורמט אחר"
+      heading: הקובץ אינו תומך במשתמשי טכנולוגית סיוע
+      request_a_different_format: אנא בקש/י פורמט אחר
     headings:
-      order_a_copy: "הזמן עותק"
-      order_a_copy_full: "הזמן עותק של הפרסום"
-      published: "פורסם"
-      reference: "הפניה"
+      order_a_copy: הזמן עותק
+      order_a_copy_full: הזמן עותק של הפרסום
+      published: פורסם
+      reference: הפניה
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -382,8 +280,8 @@ he:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "טופס יצירת קשר"
-    email: "דואר אלקטרוני"
+    contact_form: טופס יצירת קשר
+    email: דואר אלקטרוני
   corporate_information_page:
     type:
       link_text:
@@ -398,43 +296,43 @@ he:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "טבלת מידע אישי"
+        personal_information_charter: טבלת מידע אישי
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "תכנית פרסומים"
+        publication_scheme: תכנית פרסומים
         recruitment:
         research:
-        social_media_use: "מדיה חברתית"
+        social_media_use: מדיה חברתית
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "תכנית שפה וולשית"
+        welsh_language_scheme: תכנית שפה וולשית
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "ניתן לעשות שימוש בפילטרים כדי לראות תוצאות ממוקדות"
+    description: ניתן לעשות שימוש בפילטרים כדי לראות תוצאות ממוקדות
     no_results:
-      description: "נסי/ה להרחיב את החיפוש וחפש/י שוב"
-      title: "אין מסמכים תואמים"
+      description: נסי/ה להרחיב את החיפוש וחפש/י שוב
+      title: אין מסמכים תואמים
       tna_heading:
       tna_link:
     world_locations:
-      all: "כל המיקומים"
-      label: "מיקומים גלובאליים"
+      all: כל המיקומים
+      label: מיקומים גלובאליים
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "פעילות אחרונה"
+    latest_activity: פעילות אחרונה
   i18n:
     direction: rtl
   language_names:
-    he: "עברית"
+    he: עברית
   latest_feed:
-    no_updates: "אין עדכונים נוספים"
-    title: "אחרון"
+    no_updates: אין עדכונים נוספים
+    title: אחרון
   national_statistics:
     heading:
   number:
@@ -443,117 +341,117 @@ he:
         format: "%n%u"
   organisation:
     about:
-      read_more: "קרא/י עוד על פועלינו"
+      read_more: קרא/י עוד על פועלינו
     corporate_information:
-      access_our_info: "גישה למידע"
-      foi_how_to: "כיצד להגיש בקשה לחופש המידע"
-      foi_releases: "שוחרר תחת חופש המידע"
-      jobs_and_contacts: "עבודות וחוזים"
+      access_our_info: גישה למידע
+      foi_how_to: כיצד להגיש בקשה לחופש המידע
+      foi_releases: שוחרר תחת חופש המידע
+      jobs_and_contacts: עבודות וחוזים
       organisation_chart:
-      transparency: "מידע נגיש"
+      transparency: מידע נגיש
     foi_exemption_html:
     headings:
-      chief_professional_officers: "אנשי המקצוע הבכירים שלנו"
-      contact: "חוזה %{name}"
-      corporate_information: "מידע מסחרי"
+      chief_professional_officers: אנשי המקצוע הבכירים שלנו
+      contact: חוזה %{name}
+      corporate_information: מידע מסחרי
       corporate_reports: דו"חות מסחריים
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "ההודעות שלנו"
+      our_announcements: ההודעות שלנו
       our_consultations:
       our_judges:
-      our_management: "ההנהלה שלנו"
-      our_ministers: "השרים שלנו"
-      our_policies: "המדיניות שלנו"
-      our_publications: "הפרסומים שלנו"
-      our_senior_military_officials: "הנספחים הצבאיים שלנו"
-      our_services: "השירותים שלנו"
-      our_statistics: "הנתונים שלנו"
-      our_topics: "אנו עוסקים בנושאים הללו"
-      special_representatives: "נציגים מיוחדים"
-      traffic_commissioners: "ממונים על תעבורה"
-      what_we_do: "מה אנחנו עושים"
+      our_management: ההנהלה שלנו
+      our_ministers: השרים שלנו
+      our_policies: המדיניות שלנו
+      our_publications: הפרסומים שלנו
+      our_senior_military_officials: הנספחים הצבאיים שלנו
+      our_services: השירותים שלנו
+      our_statistics: הנתונים שלנו
+      our_topics: אנו עוסקים בנושאים הללו
+      special_representatives: נציגים מיוחדים
+      traffic_commissioners: ממונים על תעבורה
+      what_we_do: מה אנחנו עושים
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "מדיניות"
+    heading: מדיניות
     view_all:
   publications:
-    heading: "פרסומים"
+    heading: פרסומים
     headings:
-      detail: "פרטים"
-  read_more: "קרא עוד"
+      detail: פרטים
+  read_more: קרא עוד
   see_all:
-    announcement: "ראה כל הודעות"
-    authored_article: "ראה כל מאמרים מאושרים"
-    case_study: "ראה כל מקרי בוחן"
-    closed_consultation: "ראה כל דיונים סגורים"
-    consultation: "ראה כל דיונים"
-    consultation_outcome: "ראה כל תוצאות דיונים"
+    announcement: ראה כל הודעות
+    authored_article: ראה כל מאמרים מאושרים
+    case_study: ראה כל מקרי בוחן
+    closed_consultation: ראה כל דיונים סגורים
+    consultation: ראה כל דיונים
+    consultation_outcome: ראה כל תוצאות דיונים
     corporate_report: ראה כל דו"חות משותפים
-    correspondence: "ראה כל תכתובות"
+    correspondence: ראה כל תכתובות
     decision:
-    detailed_guidance: "ראה כל מדריך מפורט"
+    detailed_guidance: ראה כל מדריך מפורט
     document_collection:
-    draft_text: "ראה כל טיוטות"
-    fatality_notice: "ראה כל הודעות פטירה"
-    foi_release: "ראה כל פרסומי חופש מידע"
-    form: "ראה כל טפסים"
-    government_response: "ראה כל תגובות ממשלתיות"
-    guidance: "ראה כל הדרכה"
-    impact_assessment: "ראה כל הערכת השפעות"
-    imported: "ראה כל יבוא- המתנה לסוג"
+    draft_text: ראה כל טיוטות
+    fatality_notice: ראה כל הודעות פטירה
+    foi_release: ראה כל פרסומי חופש מידע
+    form: ראה כל טפסים
+    government_response: ראה כל תגובות ממשלתיות
+    guidance: ראה כל הדרכה
+    impact_assessment: ראה כל הערכת השפעות
+    imported: ראה כל יבוא- המתנה לסוג
     international_treaty:
-    map: "ראה כל מפות"
-    national_statistics: "ראה כל סטטיסטיקות- סטטסטיקה לאומית"
-    news_article: "ראה כל מאמרי חדשות"
-    news_story: "ראה כל חדשות"
+    map: ראה כל מפות
+    national_statistics: ראה כל סטטיסטיקות- סטטסטיקה לאומית
+    news_article: ראה כל מאמרי חדשות
+    news_story: ראה כל חדשות
     notice:
-    open_consultation: "ראה כל דיון פתוח"
-    oral_statement: "ראה כל הצהרות בעל פה לפרלמנט"
-    policy: "ראה כל מדיניות"
-    policy_paper: "ראה כל ניירות מדיניות"
-    press_release: "ראה כל הודעות לעיתונות"
-    promotional: "ראה כל חומר פרסומי"
-    publication: "ראה כל פרסומים"
+    open_consultation: ראה כל דיון פתוח
+    oral_statement: ראה כל הצהרות בעל פה לפרלמנט
+    policy: ראה כל מדיניות
+    policy_paper: ראה כל ניירות מדיניות
+    press_release: ראה כל הודעות לעיתונות
+    promotional: ראה כל חומר פרסומי
+    publication: ראה כל פרסומים
     regulation:
-    research: "ראה כל מחקר וניתוח"
-    speaking_notes: "ראה כל נאומים"
-    speech: "ראה כל נאומים"
-    statement_to_parliament: "ראה כל הצהרות לפרלמנט"
-    statistical_data_set: "ראה כל מידע סטטיסטי"
-    statistics: "ראה כל נתונים"
+    research: ראה כל מחקר וניתוח
+    speaking_notes: ראה כל נאומים
+    speech: ראה כל נאומים
+    statement_to_parliament: ראה כל הצהרות לפרלמנט
+    statistical_data_set: ראה כל מידע סטטיסטי
+    statistics: ראה כל נתונים
     statutory_guidance:
-    transcript: "ראה כל תמלולים"
-    transparency: "ראה כל שקיפות מידע"
-    written_statement: "ראה כל הצהרות בכתב לפרלמנט"
+    transcript: ראה כל תמלולים
+    transparency: ראה כל שקיפות מידע
+    written_statement: ראה כל הצהרות בכתב לפרלמנט
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "בנוסף"
+      last_word_connector: בנוסף
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "ה%{link} מסביר אודות המדיניות שלנו כלפי
-        מידע פרטי"
-      publication_scheme_html: "קרא/י אודות סוגי מידע שאנחנו מפרסמים %{link}"
-      social_media_use_html: "קרא/י אודות המדיניות שלנו %{link}"
-      welsh_language_scheme_html: "מידע נוסף על המחויבות שלנו לפרסום %{link}"
-    find_out_more: "ראה/י פרופיל מלא ופרטי התקשרות"
+      personal_information_charter_html: ה%{link} מסביר אודות המדיניות שלנו כלפי מידע
+        פרטי
+      publication_scheme_html: קרא/י אודות סוגי מידע שאנחנו מפרסמים %{link}
+      social_media_use_html: קרא/י אודות המדיניות שלנו %{link}
+      welsh_language_scheme_html: מידע נוסף על המחויבות שלנו לפרסום %{link}
+    find_out_more: ראה/י פרופיל מלא ופרטי התקשרות
     headings:
-      about_us: "אודותינו"
-      contact_us: "צור קשר"
-      corporate_information: "מידע תאגידי"
-      follow_us: "עקבו אחרינו"
-      our_people: "הצוות שלנו"
-      our_services: "השירותים שלנו"
-    location: "מיקום"
-    part_of: "חלק מ"
+      about_us: אודותינו
+      contact_us: צור קשר
+      corporate_information: מידע תאגידי
+      follow_us: עקבו אחרינו
+      our_people: הצוות שלנו
+      our_services: השירותים שלנו
+    location: מיקום
+    part_of: חלק מ

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -2,73 +2,73 @@ hi:
   document:
     headings:
       attachments:
-        one: "दस्तावेज़"
-        other: "दस्तावेजों"
-      applies_to_nations: "पर लागू"
+        one: दस्तावेज़
+        other: दस्तावेजों
+      applies_to_nations: पर लागू
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "घोषणा"
-        other: "घोषणाएं"
+        one: घोषणा
+        other: घोषणाएं
       authored_article:
-        one: "मूल आलेख"
-        other: "मूल आलेख"
+        one: मूल आलेख
+        other: मूल आलेख
       blog_post:
         one:
         other:
       case_study:
-        one: "विषय अध्ययन"
-        other: "विषय अध्ययन"
+        one: विषय अध्ययन
+        other: विषय अध्ययन
       closed_consultation:
-        one: "बंद कमरे में परामर्श"
-        other: "बंद कमरे में परामर्श"
+        one: बंद कमरे में परामर्श
+        other: बंद कमरे में परामर्श
       consultation:
-        one: "परामर्श"
-        other: "परामर्श"
+        one: परामर्श
+        other: परामर्श
       consultation_outcome:
-        one: "परामर्श का नतीजा"
-        other: "परामर्श के नतीजे"
+        one: परामर्श का नतीजा
+        other: परामर्श के नतीजे
       corporate_report:
-        one: "कॉरपोरेट विवरण"
-        other: "कॉरपोरेट विवरण"
+        one: कॉरपोरेट विवरण
+        other: कॉरपोरेट विवरण
       correspondence:
-        one: "पत्र व्यवहार"
-        other: "पत्र व्यवहार"
+        one: पत्र व्यवहार
+        other: पत्र व्यवहार
       decision:
         one:
         other:
       detailed_guidance:
-        one: "विस्तृत मार्गदर्शन"
-        other: "विस्तृत मार्गदर्शन"
+        one: विस्तृत मार्गदर्शन
+        other: विस्तृत मार्गदर्शन
       document_collection:
-        one: "श्रृंखला"
+        one: श्रृंखला
         other:
       draft_text:
-        one: "मसौदा पाठ"
-        other: "मसौदे के पाठ"
+        one: मसौदा पाठ
+        other: मसौदे के पाठ
       foi_release:
-        one: "एफओआई की विज्ञप्ति"
-        other: "एफओआई की विज्ञप्तियां"
+        one: एफओआई की विज्ञप्ति
+        other: एफओआई की विज्ञप्तियां
       form:
-        one: "प्रपत्र"
-        other: "प्रपत्र"
+        one: प्रपत्र
+        other: प्रपत्र
       government_response:
-        one: "सरकारी जवाब"
-        other: "सरकारी जवाब"
+        one: सरकारी जवाब
+        other: सरकारी जवाब
       guidance:
-        one: "मार्गदर्शन"
-        other: "मार्गदर्शन"
+        one: मार्गदर्शन
+        other: मार्गदर्शन
       impact_assessment:
-        one: "प्रभाव का आंकलन"
-        other: "प्रभाव का आंकलन"
+        one: प्रभाव का आंकलन
+        other: प्रभाव का आंकलन
       imported:
-        one: "आयातित - प्रतीक्षा का प्रकार"
-        other: "आयातित - प्रतीक्षा का प्रकार"
+        one: आयातित - प्रतीक्षा का प्रकार
+        other: आयातित - प्रतीक्षा का प्रकार
       independent_report:
-        one: "स्वतंत्र रिपोर्ट"
-        other: "स्वतंत्र रिपोर्टें"
+        one: स्वतंत्र रिपोर्ट
+        other: स्वतंत्र रिपोर्टें
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ hi:
         one:
         other:
       map:
-        one: "मानचित्र"
-        other: "मानचित्रों"
+        one: मानचित्र
+        other: मानचित्रों
       national_statistics:
-        one: "सांख्यिकी - राष्ट्रीय सांख्यिकी"
-        other: "सांख्यिकी - राष्ट्रीय सांख्यिकी"
+        one: सांख्यिकी - राष्ट्रीय सांख्यिकी
+        other: सांख्यिकी - राष्ट्रीय सांख्यिकी
       news_article:
-        one: "समाचार लेख"
-        other: "समाचार लेख"
+        one: समाचार लेख
+        other: समाचार लेख
       news_story:
-        one: "समाचार कथा"
-        other: "समाचार कथाएं"
+        one: समाचार कथा
+        other: समाचार कथाएं
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ hi:
         one:
         other:
       official_statistics:
-        one: "आंकड़े"
-        other: "आंकड़े"
+        one: आंकड़े
+        other: आंकड़े
       open_consultation:
-        one: "खुला परामर्श"
-        other: "खुले परामर्श"
+        one: खुला परामर्श
+        other: खुले परामर्श
       oral_statement:
-        one: "संसद में मौखिक बयान"
-        other: "संसद में मौखिक बयान"
+        one: संसद में मौखिक बयान
+        other: संसद में मौखिक बयान
       policy_paper:
-        one: "नीति पत्र"
-        other: "नीति पत्र"
+        one: नीति पत्र
+        other: नीति पत्र
       press_release:
-        one: "प्रेस विज्ञप्ति"
-        other: "प्रेस विज्ञप्तियां"
+        one: प्रेस विज्ञप्ति
+        other: प्रेस विज्ञप्तियां
       promotional:
-        one: "प्रचार सामग्री"
-        other: "प्रचार सामग्री"
+        one: प्रचार सामग्री
+        other: प्रचार सामग्री
       publication:
-        one: "प्रकाशन"
-        other: "प्रकाशन"
+        one: प्रकाशन
+        other: प्रकाशन
       regulation:
         one:
         other:
       research:
-        one: "अनुसंधान एवं विश्लेषण"
-        other: "अनुसंधान एवं विश्लेषण"
+        one: अनुसंधान एवं विश्लेषण
+        other: अनुसंधान एवं विश्लेषण
       speaking_notes:
         one: " उदबोधन अंश"
         other: " उदबोधन अंश"
       speech:
-        one: "भाषण"
-        other: "भाषण"
+        one: भाषण
+        other: भाषण
       statement_to_parliament:
-        one: "संसद में बयान"
-        other: "संसद में बयान"
+        one: संसद में बयान
+        other: संसद में बयान
       statistical_data_set:
-        one: "सांख्यिकीय आंकड़े का समूह"
-        other: "सांख्यिकीय आंकड़े का समूह"
+        one: सांख्यिकीय आंकड़े का समूह
+        other: सांख्यिकीय आंकड़े का समूह
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "प्रतिलिपि"
-        other: "प्रतिलिपियां"
+        one: प्रतिलिपि
+        other: प्रतिलिपियां
       transparency:
-        one: "पारदर्शिता आंकड़े"
-        other: "पारदर्शिता आंकड़े"
+        one: पारदर्शिता आंकड़े
+        other: पारदर्शिता आंकड़े
       world_news_story:
         one:
         other:
       written_statement:
-        one: "संसद में लिखित बयान"
-        other: "संसद में लिखित बयान"
+        one: संसद में लिखित बयान
+        other: संसद में लिखित बयान
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "प्रकाशित"
-    read: "पढ़ें %{title} लेख"
+    published: प्रकाशित
+    read: पढ़ें %{title} लेख
     speech:
       author_title:
-        minister: "मंत्री"
-        speaker: "लेखक "
-      delivered_on: "को वितरित:"
+        minister: मंत्री
+        speaker: लेखक 
+      delivered_on: 'को वितरित:'
       delivery_title:
-        minister: "मंत्री"
-        speaker: "वक्ता"
-      written_on: "लिखा गया"
-    updated: "अद्यतन"
-    view: "देखें '%{title}'"
+        minister: मंत्री
+        speaker: वक्ता
+      written_on: लिखा गया
+    updated: अद्यतन
+    view: देखें '%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ hi:
   world_location:
     type:
       international_delegation:
-        one: "अंतर्राष्ट्रीय प्रतिनिधिमंडल"
-        other: "अंतर्राष्ट्रीय प्रतिनिधिमंडल"
+        one: अंतर्राष्ट्रीय प्रतिनिधिमंडल
+        other: अंतर्राष्ट्रीय प्रतिनिधिमंडल
       world_location:
-        one: "वैश्विक स्थान"
-        other: "वैश्विक स्थान"
+        one: वैश्विक स्थान
+        other: वैश्विक स्थान
     headings:
-      announcements: "हमारी घोषणाएं"
-      country: "देश"
-      documents: "दस्तावेज़"
-      mission: "हमारा लक्ष्य"
-      organisations: "संगठन"
-      publications: "हमारे प्रकाशन"
-      quick_links: "क्विक लिंक्स"
-      related_policies: "सम्बंधित नीतियां"
-      statistics: "हमारे आंकड़े"
+      announcements: हमारी घोषणाएं
+      country: देश
+      documents: दस्तावेज़
+      mission: हमारा लक्ष्य
+      organisations: संगठन
+      publications: हमारे प्रकाशन
+      quick_links: क्विक लिंक्स
+      related_policies: सम्बंधित नीतियां
+      statistics: हमारे आंकड़े
   activerecord:
     attributes:
       attachment:
@@ -248,21 +248,21 @@ hi:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "घोषणाएं"
+    heading: घोषणाएं
     view_all:
   attachment:
     accessibility:
       full_help_html: |-
         इस  दस्तावेज को एक  वैकल्पिक प्रारूप जैसे कि ब्रेल, ऑडियो में निवेदन करें, %{email}
         अपना पता, टेलीफोन नंबर और प्रकाशन के  शीर्षक के साथ ("%{title}")%{references}.
-      heading: "संभव है  कि यह फाइल सहायक प्रोद्योगिकी का इस्तेमाल करने वालों के लिए
-        उपयोगी ना हो"
-      request_a_different_format: "एक  अलग प्रारूप का निवेदन"
+      heading: संभव है  कि यह फाइल सहायक प्रोद्योगिकी का इस्तेमाल करने वालों के लिए
+        उपयोगी ना हो
+      request_a_different_format: एक  अलग प्रारूप का निवेदन
     headings:
-      order_a_copy: "प्रतिलिपि मंगाएँ"
-      order_a_copy_full: "प्रकाशन की प्रतिलिपि मंगाएँ"
-      published: "प्रकाशित"
-      reference: "संदर्भ"
+      order_a_copy: प्रतिलिपि मंगाएँ
+      order_a_copy_full: प्रकाशन की प्रतिलिपि मंगाएँ
+      published: प्रकाशित
+      reference: संदर्भ
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -280,8 +280,8 @@ hi:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "संपर्क प्रपत्र"
-    email: "ईमेल"
+    contact_form: संपर्क प्रपत्र
+    email: ईमेल
   corporate_information_page:
     type:
       link_text:
@@ -296,44 +296,44 @@ hi:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "व्यक्तिगत जानकारी चार्टर"
+        personal_information_charter: व्यक्तिगत जानकारी चार्टर
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "प्रकाशन योजना"
+        publication_scheme: प्रकाशन योजना
         recruitment:
         research:
-        social_media_use: "सोशल मीडिया का प्रयोग"
+        social_media_use: सोशल मीडिया का प्रयोग
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "वेल्श भाषा योजना"
+        welsh_language_scheme: वेल्श भाषा योजना
   date:
     formats:
       default: "%e %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "आप फिल्टरों का उपयोग सिर्फ उन नतीजों को दर्शाने के लिए कर सकते हैं,
-      जिनमें आप की दिलचस्पी हो।"
+    description: आप फिल्टरों का उपयोग सिर्फ उन नतीजों को दर्शाने के लिए कर सकते हैं,
+      जिनमें आप की दिलचस्पी हो।
     no_results:
-      description: "अपनी खोज़ को व्यापक बनाए और पुन: कोशिश करें"
-      title: "मेल खाने वाले दस्तावेज़ नहीं हैं"
+      description: 'अपनी खोज़ को व्यापक बनाए और पुन: कोशिश करें'
+      title: मेल खाने वाले दस्तावेज़ नहीं हैं
       tna_heading:
       tna_link:
     world_locations:
-      all: "सभी स्थान"
-      label: "वैश्विक स्थान"
+      all: सभी स्थान
+      label: वैश्विक स्थान
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "नवीनतम गतिविधि"
+    latest_activity: नवीनतम गतिविधि
   i18n:
     direction: ltr
   language_names:
-    hi: "हिंदी"
+    hi: हिंदी
   latest_feed:
-    no_updates: "अभी तक कोई नए समाचार नहीं हैं"
-    title: "नवीनतम"
+    no_updates: अभी तक कोई नए समाचार नहीं हैं
+    title: नवीनतम
   national_statistics:
     heading:
   number:
@@ -342,119 +342,119 @@ hi:
         format: "%n%u"
   organisation:
     about:
-      read_more: "पढ़ें हम और क्या करते हैं"
+      read_more: पढ़ें हम और क्या करते हैं
     corporate_information:
-      access_our_info: "हमारी  सूचना तक पहुंचें"
-      foi_how_to: "एफओआई निवेदन कैसे करें"
-      foi_releases: "एफओआई की विज्ञप्तियां"
-      jobs_and_contacts: "नौकरी एवं अनुबंध"
+      access_our_info: हमारी  सूचना तक पहुंचें
+      foi_how_to: एफओआई निवेदन कैसे करें
+      foi_releases: एफओआई की विज्ञप्तियां
+      jobs_and_contacts: नौकरी एवं अनुबंध
       organisation_chart:
-      transparency: "पारदर्शिता आंकड़े"
+      transparency: पारदर्शिता आंकड़े
     foi_exemption_html:
     headings:
-      chief_professional_officers: "हमारे मुख्य पेशेवर अधिकारी"
-      contact: "संपर्क %{name}"
-      corporate_information: "निकाय सूचना"
-      corporate_reports: "कम्पनी रपट"
+      chief_professional_officers: हमारे मुख्य पेशेवर अधिकारी
+      contact: संपर्क %{name}
+      corporate_information: निकाय सूचना
+      corporate_reports: कम्पनी रपट
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "हमारी घोषणाएं"
+      our_announcements: हमारी घोषणाएं
       our_consultations:
       our_judges:
-      our_management: "हमारा प्रबंधन"
-      our_ministers: "हमारे मंत्री"
-      our_policies: "हमारी नीतियां"
-      our_publications: "हमारे प्रकाशन"
-      our_senior_military_officials: "हमारे वरिष्ठ सैन्य अधिकारी"
-      our_services: "हमारी सेवाएं"
-      our_statistics: "हमारे आंकड़े"
-      our_topics: "हम इन विषयों पर काम करतें हैं"
-      special_representatives: "विशेष प्रतिनिधि"
-      traffic_commissioners: "यातायात आयुक्त"
-      what_we_do: "हम क्या करते हैं"
+      our_management: हमारा प्रबंधन
+      our_ministers: हमारे मंत्री
+      our_policies: हमारी नीतियां
+      our_publications: हमारे प्रकाशन
+      our_senior_military_officials: हमारे वरिष्ठ सैन्य अधिकारी
+      our_services: हमारी सेवाएं
+      our_statistics: हमारे आंकड़े
+      our_topics: हम इन विषयों पर काम करतें हैं
+      special_representatives: विशेष प्रतिनिधि
+      traffic_commissioners: यातायात आयुक्त
+      what_we_do: हम क्या करते हैं
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "नीतियां"
+    heading: नीतियां
     view_all:
   publications:
-    heading: "प्रकाशन"
+    heading: प्रकाशन
     headings:
-      detail: "विस्तृत"
-  read_more: "विस्तार में पढ़ें"
+      detail: विस्तृत
+  read_more: विस्तार में पढ़ें
   see_all:
-    announcement: "देखें हमारे सभी घोषणाएं"
-    authored_article: "देखें हमारे सभी मूल आलेख"
-    case_study: "देखें हमारे सभी विषय अध्ययन"
-    closed_consultation: "देखें हमारे सभी बंद कमरे में परामर्श"
-    consultation: "देखें हमारे सभी परामर्श"
-    consultation_outcome: "देखें हमारे सभी परामर्श के नतीजे"
-    corporate_report: "देखें हमारे सभी कॉरपोरेट विवरण"
-    correspondence: "देखें हमारे सभी पत्र व्यवहार"
+    announcement: देखें हमारे सभी घोषणाएं
+    authored_article: देखें हमारे सभी मूल आलेख
+    case_study: देखें हमारे सभी विषय अध्ययन
+    closed_consultation: देखें हमारे सभी बंद कमरे में परामर्श
+    consultation: देखें हमारे सभी परामर्श
+    consultation_outcome: देखें हमारे सभी परामर्श के नतीजे
+    corporate_report: देखें हमारे सभी कॉरपोरेट विवरण
+    correspondence: देखें हमारे सभी पत्र व्यवहार
     decision:
-    detailed_guidance: "देखें हमारे सभी विस्तृत मार्गदर्शन"
+    detailed_guidance: देखें हमारे सभी विस्तृत मार्गदर्शन
     document_collection:
-    draft_text: "देखें हमारे सभी मसौदे के पाठ"
-    fatality_notice: "देखें हमारे सभी विपत्ति की सूचना"
-    foi_release: "देखें हमारे सभी एफओआई की विज्ञप्तियां"
-    form: "देखें हमारे सभी प्रपत्र"
-    government_response: "देखें हमारे सभी सरकारी जवाब"
-    guidance: "देखें हमारे सभी मार्गदर्शन"
-    impact_assessment: "देखें हमारे सभी प्रभाव का आंकलन"
-    imported: "देखें हमारे सभी आयातित - प्रतीक्षा का प्रकार"
+    draft_text: देखें हमारे सभी मसौदे के पाठ
+    fatality_notice: देखें हमारे सभी विपत्ति की सूचना
+    foi_release: देखें हमारे सभी एफओआई की विज्ञप्तियां
+    form: देखें हमारे सभी प्रपत्र
+    government_response: देखें हमारे सभी सरकारी जवाब
+    guidance: देखें हमारे सभी मार्गदर्शन
+    impact_assessment: देखें हमारे सभी प्रभाव का आंकलन
+    imported: देखें हमारे सभी आयातित - प्रतीक्षा का प्रकार
     international_treaty:
-    map: "देखें हमारे सभी मानचित्रों"
-    national_statistics: "देखें हमारे सभी सांख्यिकी - राष्ट्रीय सांख्यिकी"
-    news_article: "देखें हमारे सभी समाचार लेख"
-    news_story: "देखें हमारे सभी समाचार कथाएं"
+    map: देखें हमारे सभी मानचित्रों
+    national_statistics: देखें हमारे सभी सांख्यिकी - राष्ट्रीय सांख्यिकी
+    news_article: देखें हमारे सभी समाचार लेख
+    news_story: देखें हमारे सभी समाचार कथाएं
     notice:
-    open_consultation: "देखें हमारे सभी खुले परामर्श"
-    oral_statement: "देखें हमारे सभी संसद में मौखिक बयान"
-    policy: "देखें हमारे सभी नीतियां"
-    policy_paper: "देखें हमारे सभी नीति पत्र"
-    press_release: "देखें हमारे सभी प्रेस विज्ञप्तियां"
-    promotional: "देखें हमारे सभी प्रचार सामग्री"
-    publication: "देखें हमारे सभी प्रकाशन"
+    open_consultation: देखें हमारे सभी खुले परामर्श
+    oral_statement: देखें हमारे सभी संसद में मौखिक बयान
+    policy: देखें हमारे सभी नीतियां
+    policy_paper: देखें हमारे सभी नीति पत्र
+    press_release: देखें हमारे सभी प्रेस विज्ञप्तियां
+    promotional: देखें हमारे सभी प्रचार सामग्री
+    publication: देखें हमारे सभी प्रकाशन
     regulation:
-    research: "देखें हमारे सभी अनुसंधान एवं विश्लेषण"
-    speaking_notes: "देखें हमारे सभी  उदबोधन अंश"
-    speech: "देखें हमारे सभी भाषण"
-    statement_to_parliament: "देखें हमारे सभी संसद में बयान"
-    statistical_data_set: "देखें हमारे सभी सांख्यिकीय आंकड़े का समूह"
-    statistics: "देखें हमारे सभी आंकड़े"
+    research: देखें हमारे सभी अनुसंधान एवं विश्लेषण
+    speaking_notes: देखें हमारे सभी  उदबोधन अंश
+    speech: देखें हमारे सभी भाषण
+    statement_to_parliament: देखें हमारे सभी संसद में बयान
+    statistical_data_set: देखें हमारे सभी सांख्यिकीय आंकड़े का समूह
+    statistics: देखें हमारे सभी आंकड़े
     statutory_guidance:
-    transcript: "देखें हमारे सभी प्रतिलिपियां"
-    transparency: "देखें हमारे सभी पारदर्शिता आंकड़े"
-    written_statement: "देखें हमारे सभी संसद में लिखित बयान"
+    transcript: देखें हमारे सभी प्रतिलिपियां
+    transparency: देखें हमारे सभी पारदर्शिता आंकड़े
+    written_statement: देखें हमारे सभी संसद में लिखित बयान
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "और"
+      last_word_connector: और
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "हमारे %{link} बताते हैं कि हम कैसे आपकी
-        व्यक्तिगत सूचना का उपयोग करते हैं।"
-      publication_scheme_html: "सूचना के उन प्रकारों के बारे में पढ़ें, जिन्हें हम
-        अपने %{link} में नियमित रूप से प्रकाशित करते हैं।"
-      social_media_use_html: "इस बारे में हमारी नीतियां पढ़ें %{link}"
-      welsh_language_scheme_html: "हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें
-        %(link)।"
-    find_out_more: "पूरी रूप रेखा और समस्त संपर्क विवरण देखें"
+      personal_information_charter_html: हमारे %{link} बताते हैं कि हम कैसे आपकी व्यक्तिगत
+        सूचना का उपयोग करते हैं।
+      publication_scheme_html: सूचना के उन प्रकारों के बारे में पढ़ें, जिन्हें हम
+        अपने %{link} में नियमित रूप से प्रकाशित करते हैं।
+      social_media_use_html: इस बारे में हमारी नीतियां पढ़ें %{link}
+      welsh_language_scheme_html: हमारी प्रकाशन के प्रति वचनबद्धता के बारे में जानें
+        %(link)।
+    find_out_more: पूरी रूप रेखा और समस्त संपर्क विवरण देखें
     headings:
-      about_us: "हमारे बारे में"
-      contact_us: "हमसे संपर्क करें"
-      corporate_information: "निकाय सूचना"
-      follow_us: "हमारा अनुसरण करें"
-      our_people: "हमारे लोग"
-      our_services: "हमारी सेवाएं"
-    location: "स्थान"
-    part_of: "का अंग"
+      about_us: हमारे बारे में
+      contact_us: हमसे संपर्क करें
+      corporate_information: निकाय सूचना
+      follow_us: हमारा अनुसरण करें
+      our_people: हमारे लोग
+      our_services: हमारी सेवाएं
+    location: स्थान
+    part_of: का अंग

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -176,14 +176,14 @@ hu:
         one: Információhoz való joggal kapcsolatos közlemény
         other: Információhoz való joggal kapcsolatos közlemények
       form:
-        one: "Űrlap"
-        other: "Űrlapok"
+        one: Űrlap
+        other: Űrlapok
       government_response:
         one: Kormányválasz
         other: Kormányválaszok
       guidance:
-        one: "Útmutató"
-        other: "Útmutató"
+        one: Útmutató
+        other: Útmutató
       impact_assessment:
         one: Hatásvizsgálat
         other: Hatásvizsgálatok
@@ -260,17 +260,17 @@ hu:
         one:
         other:
       transcript:
-        one: "Átirat"
-        other: "Átiratok"
+        one: Átirat
+        other: Átiratok
       transparency:
-        one: "Átláthatósági adatok"
-        other: "Átláthatósági adatok"
+        one: Átláthatósági adatok
+        other: Átláthatósági adatok
       world_news_story:
         one:
         other:
       written_statement:
-        one: "Írásbeli parlamenti nyilatkozat"
-        other: "Írásbeli parlamenti nyilatkozatok"
+        one: Írásbeli parlamenti nyilatkozat
+        other: Írásbeli parlamenti nyilatkozatok
     updated: 'Utolsó frissítés:'
     view: Tekintse meg a következő dokumentumot '%{title}'
   document_filters:
@@ -309,9 +309,9 @@ hu:
       access_our_info: Hozzáférés információinkhoz
       foi_how_to: Az információigénylés menete
       foi_releases: Információhoz való joggal kapcsolatos közlemények
-      jobs_and_contacts: "Állások"
+      jobs_and_contacts: Állások
       organisation_chart:
-      transparency: "Átláthatósági adatok"
+      transparency: Átláthatósági adatok
     foi_exemption_html:
     headings:
       chief_professional_officers: Szakmai vezetőink
@@ -416,7 +416,7 @@ hu:
     follow_us:
   support:
     array:
-      last_word_connector: "és"
+      last_word_connector: és
   time:
     formats:
       long_ordinal: "%Y %B %e %H:%M"

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -2,73 +2,73 @@ hy:
   document:
     headings:
       attachments:
-        one: "Փաստաթուղթ"
-        other: "Փաստաթղթեր"
-      applies_to_nations: "Վերաբերվում է"
+        one: Փաստաթուղթ
+        other: Փաստաթղթեր
+      applies_to_nations: Վերաբերվում է
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Հայտարարություն"
-        other: "Հայտարարություններ"
+        one: Հայտարարություն
+        other: Հայտարարություններ
       authored_article:
-        one: "Հեղինակային հոդված"
-        other: "Հեղինակային հոդվածներ"
+        one: Հեղինակային հոդված
+        other: Հեղինակային հոդվածներ
       blog_post:
         one:
         other:
       case_study:
-        one: "Թեմատիկ ուսումնասիրություն"
-        other: "Թեմատիկ ուսումնասիրություններ"
+        one: Թեմատիկ ուսումնասիրություն
+        other: Թեմատիկ ուսումնասիրություններ
       closed_consultation:
-        one: "Փակ խորհրդատվություն"
-        other: "Փակ խորհրդատվություններ"
+        one: Փակ խորհրդատվություն
+        other: Փակ խորհրդատվություններ
       consultation:
-        one: "Խորհրդատվություն"
-        other: "Խորհրդատվություններ"
+        one: Խորհրդատվություն
+        other: Խորհրդատվություններ
       consultation_outcome:
-        one: "Խորհրդատվության արդյունք"
-        other: "Խորհրդատվության արդյունքներ"
+        one: Խորհրդատվության արդյունք
+        other: Խորհրդատվության արդյունքներ
       corporate_report:
-        one: "Կորպորատիվ հաշվետվություն"
-        other: "Կորպորատիվ հաշվետվություններ"
+        one: Կորպորատիվ հաշվետվություն
+        other: Կորպորատիվ հաշվետվություններ
       correspondence:
-        one: "Նամակագրություն"
-        other: "Նամակագրություններ"
+        one: Նամակագրություն
+        other: Նամակագրություններ
       decision:
         one:
         other:
       detailed_guidance:
-        one: "Մանրամասն ուղեցույց"
-        other: "Մանրամասն ուղեցույցեր"
+        one: Մանրամասն ուղեցույց
+        other: Մանրամասն ուղեցույցեր
       document_collection:
-        one: "Մի շարք"
+        one: Մի շարք
         other:
       draft_text:
-        one: "Սևագիր տեքստ"
-        other: "Սևագիր տեքստեր"
+        one: Սևագիր տեքստ
+        other: Սևագիր տեքստեր
       foi_release:
-        one: "Ազատ տեղեկատվության հաղորդագրություն"
-        other: "Ազատ տեղեկատվության հաղորդագրություններ"
+        one: Ազատ տեղեկատվության հաղորդագրություն
+        other: Ազատ տեղեկատվության հաղորդագրություններ
       form:
-        one: "Ձևաթուղթ"
-        other: "Ձևաթղթեր"
+        one: Ձևաթուղթ
+        other: Ձևաթղթեր
       government_response:
-        one: "Կառավարության արձագանք"
-        other: "Կառավարության արձագանքներ"
+        one: Կառավարության արձագանք
+        other: Կառավարության արձագանքներ
       guidance:
-        one: "Ուղեցույց"
-        other: "Ուղեցույցեր"
+        one: Ուղեցույց
+        other: Ուղեցույցեր
       impact_assessment:
-        one: "Ազդեցության գնահատում"
-        other: "Ազդեցության գնահատումներ"
+        one: Ազդեցության գնահատում
+        other: Ազդեցության գնահատումներ
       imported:
-        one: "Ներկրված - սպասման տեսակ"
-        other: "Ներկրված - սպասման տեսակներ"
+        one: Ներկրված - սպասման տեսակ
+        other: Ներկրված - սպասման տեսակներ
       independent_report:
-        one: "Անկախ հաշվետվություն"
-        other: "Անկախ հաշվետվություններ"
+        one: Անկախ հաշվետվություն
+        other: Անկախ հաշվետվություններ
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ hy:
         one:
         other:
       map:
-        one: "Քարտեզ"
-        other: "Քարտեզներ"
+        one: Քարտեզ
+        other: Քարտեզներ
       national_statistics:
-        one: "Վիճակագրություն-ազգային վիճակագրություն"
-        other: "Վիճակագրություն-ազգային վիճակագրություններ"
+        one: Վիճակագրություն-ազգային վիճակագրություն
+        other: Վիճակագրություն-ազգային վիճակագրություններ
       news_article:
-        one: "Տեղեկատվական հոդված"
-        other: "Տեղեկատվական հոդվածներ"
+        one: Տեղեկատվական հոդված
+        other: Տեղեկատվական հոդվածներ
       news_story:
-        one: "Լուր"
-        other: "Լուրեր"
+        one: Լուր
+        other: Լուրեր
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ hy:
         one:
         other:
       official_statistics:
-        one: "Վիճակագրություն"
-        other: "Վիճակագրություն"
+        one: Վիճակագրություն
+        other: Վիճակագրություն
       open_consultation:
-        one: "Բաց խորհրդատվություն"
-        other: "Բաց խորհրդատվություններ"
+        one: Բաց խորհրդատվություն
+        other: Բաց խորհրդատվություններ
       oral_statement:
-        one: "Բանավոր դիմում խորհրդարան"
-        other: "Բանավոր դիմումներ խորհրդարան"
+        one: Բանավոր դիմում խորհրդարան
+        other: Բանավոր դիմումներ խորհրդարան
       policy_paper:
-        one: "Ծրագրային փաստաթուղթ"
-        other: "Ծրագրային փաստաթղթեր"
+        one: Ծրագրային փաստաթուղթ
+        other: Ծրագրային փաստաթղթեր
       press_release:
-        one: "Մամլո հաղորդագրություն"
-        other: "Մամլո հաղորդագրություններ"
+        one: Մամլո հաղորդագրություն
+        other: Մամլո հաղորդագրություններ
       promotional:
-        one: "Քարոզչական նյութ"
-        other: "Քարոզչական նյութներ"
+        one: Քարոզչական նյութ
+        other: Քարոզչական նյութներ
       publication:
-        one: "Հրապարակում"
-        other: "Հրապարակումներ"
+        one: Հրապարակում
+        other: Հրապարակումներ
       regulation:
         one:
         other:
       research:
-        one: "Հետազոտություն և վերլուծություն"
-        other: "Հետազոտություններ և վերլուծություններ"
+        one: Հետազոտություն և վերլուծություն
+        other: Հետազոտություններ և վերլուծություններ
       speaking_notes:
-        one: "Խոսքի գրառում"
-        other: "Խոսքի գրառումներ"
+        one: Խոսքի գրառում
+        other: Խոսքի գրառումներ
       speech:
-        one: "Ելույթ"
-        other: "Ելույթներ"
+        one: Ելույթ
+        other: Ելույթներ
       statement_to_parliament:
-        one: "Դիմում խորհրդարան"
-        other: "Դիմումներ խորհրդարան"
+        one: Դիմում խորհրդարան
+        other: Դիմումներ խորհրդարան
       statistical_data_set:
-        one: "Վիճակագրական տվյալ"
-        other: "Վիճակագրական տվյալներ"
+        one: Վիճակագրական տվյալ
+        other: Վիճակագրական տվյալներ
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "Վերծանում"
-        other: "Վերծանումներ"
+        one: Վերծանում
+        other: Վերծանումներ
       transparency:
-        one: "Բաց տեղեկատվություն"
-        other: "Բաց տեղեկատվություններ"
+        one: Բաց տեղեկատվություն
+        other: Բաց տեղեկատվություններ
       world_news_story:
         one:
         other:
       written_statement:
-        one: "Գրավոր դիմում խորհրդարան"
-        other: "Գրավոր դիմումներ խորհրդարան"
+        one: Գրավոր դիմում խորհրդարան
+        other: Գրավոր դիմումներ խորհրդարան
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "հրապարակված"
-    read: "Կարդացեք  %{title} հոդվածը"
+    published: հրապարակված
+    read: Կարդացեք  %{title} հոդվածը
     speech:
       author_title:
-        minister: "Նախարար"
-        speaker: "Գրող"
-      delivered_on: "Առաքվել է"
+        minister: Նախարար
+        speaker: Գրող
+      delivered_on: Առաքվել է
       delivery_title:
-        minister: "Նախարար"
-        speaker: "Խոսնակ"
-      written_on: "Գրված է՝"
-    updated: "Թարմացված"
-    view: "Տես '%{title}'-ը"
+        minister: Նախարար
+        speaker: Խոսնակ
+      written_on: Գրված է՝
+    updated: Թարմացված
+    view: Տես '%{title}'-ը
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ hy:
   world_location:
     type:
       international_delegation:
-        one: "Միջազգային պատվիրակություն"
-        other: "Միջազգային պատվիրակություններ"
+        one: Միջազգային պատվիրակություն
+        other: Միջազգային պատվիրակություններ
       world_location:
-        one: "Համաշխարհային տեղաբաշխում"
-        other: "Համաշխարհային տեղաբաշխումներ"
+        one: Համաշխարհային տեղաբաշխում
+        other: Համաշխարհային տեղաբաշխումներ
     headings:
-      announcements: "Մեր հայտարարությունները"
-      country: "Երկիր"
-      documents: "Փաստաթղթեր"
-      mission: "Մեր գործունեությունը"
-      organisations: "Կազմակերպություններ"
-      publications: "Մեր հրատարակությունները"
-      quick_links: "Հղումներ"
-      related_policies: "Համանման նյութեր"
-      statistics: "Մեր վիճակագրությունը"
+      announcements: Մեր հայտարարությունները
+      country: Երկիր
+      documents: Փաստաթղթեր
+      mission: Մեր գործունեությունը
+      organisations: Կազմակերպություններ
+      publications: Մեր հրատարակությունները
+      quick_links: Հղումներ
+      related_policies: Համանման նյութեր
+      statistics: Մեր վիճակագրությունը
   activerecord:
     attributes:
       attachment:
@@ -248,21 +248,21 @@ hy:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Հայտարարություններ"
+    heading: Հայտարարություններ
     view_all:
   attachment:
     accessibility:
       full_help_html: "Այս փաստաթղթի այլ տարբերակ ստանալու համար՝ բռալյան, ձայնային
         կամ այլ, խնդրում ենք դիմել \n%{email} նշելով ձեր հասցեն, հեռախոսահամարն ու
         նյութը, որ հայցում եք (\"%{title}\")%{references}."
-      heading: "այս նյութը հավանաբար հարմար չի լինի հատուկ կարիքների տեխնոլոգիաներ
-        ունեցող օգտատերների համար"
-      request_a_different_format: "Պահանջել այլ տարբերակ"
+      heading: այս նյութը հավանաբար հարմար չի լինի հատուկ կարիքների տեխնոլոգիաներ
+        ունեցող օգտատերների համար
+      request_a_different_format: Պահանջել այլ տարբերակ
     headings:
-      order_a_copy: "Պատվիրել կրկնօրինակը"
-      order_a_copy_full: "Պատվիրել հրապարակման կրկնօրինակը"
-      published: "Հրապարակված"
-      reference: "Հղում"
+      order_a_copy: Պատվիրել կրկնօրինակը
+      order_a_copy_full: Պատվիրել հրապարակման կրկնօրինակը
+      published: Հրապարակված
+      reference: Հղում
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -280,8 +280,8 @@ hy:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Կապի միջոց"
-    email: "Էլելտրոնային հասցե"
+    contact_form: Կապի միջոց
+    email: Էլելտրոնային հասցե
   corporate_information_page:
     type:
       link_text:
@@ -296,44 +296,44 @@ hy:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Անձնական տվյալների կանոնադրություն"
+        personal_information_charter: Անձնական տվյալների կանոնադրություն
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "Հրապարակման համակարգ"
+        publication_scheme: Հրապարակման համակարգ
         recruitment:
         research:
-        social_media_use: "Սոցիալական լրատվամիջոցի օգտագործում"
+        social_media_use: Սոցիալական լրատվամիջոցի օգտագործում
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Ուելսերենի կանոնադրություն"
+        welsh_language_scheme: Ուելսերենի կանոնադրություն
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "Դուք կարող եք օգտագործել ֆիլտրերը պահպանելու համար միայն ձեզ հետաքրքրող
-      արդյունքները"
+    description: Դուք կարող եք օգտագործել ֆիլտրերը պահպանելու համար միայն ձեզ հետաքրքրող
+      արդյունքները
     no_results:
-      description: "Փորձեք առավել տարածական դարձնել ձեր փնտրածը և նորից փորձեք"
-      title: "Համապատասխան ինֆորմացի չի գտնվել"
+      description: Փորձեք առավել տարածական դարձնել ձեր փնտրածը և նորից փորձեք
+      title: Համապատասխան ինֆորմացի չի գտնվել
       tna_heading:
       tna_link:
     world_locations:
-      all: "Բոլոր վայրերը"
-      label: "Տեղակայված բառեր"
+      all: Բոլոր վայրերը
+      label: Տեղակայված բառեր
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Վերջին գործողություն"
+    latest_activity: Վերջին գործողություն
   i18n:
     direction: ltr
   language_names:
-    hy: "Հայերեն"
+    hy: Հայերեն
   latest_feed:
-    no_updates: "Դեռևս թարմացումներ չկան"
-    title: "Վերջին գործողություն"
+    no_updates: Դեռևս թարմացումներ չկան
+    title: Վերջին գործողություն
   national_statistics:
     heading:
   number:
@@ -342,120 +342,120 @@ hy:
         format: "%n%u"
   organisation:
     about:
-      read_more: "Կարդալ ավելին մեր գործունեության մասին"
+      read_more: Կարդալ ավելին մեր գործունեության մասին
     corporate_information:
-      access_our_info: "Տեղեկատվություն մեր մասին"
-      foi_how_to: "Ինչպես կատարել տեղեկատվության հարցում"
-      foi_releases: "Տեղեկատվության հարցում"
-      jobs_and_contacts: "Աշխատանք և պայմանագրեր"
+      access_our_info: Տեղեկատվություն մեր մասին
+      foi_how_to: Ինչպես կատարել տեղեկատվության հարցում
+      foi_releases: Տեղեկատվության հարցում
+      jobs_and_contacts: Աշխատանք և պայմանագրեր
       organisation_chart:
-      transparency: "Թափանցիկ տեղեկատվությ"
+      transparency: Թափանցիկ տեղեկատվությ
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Մեր գլխավոր մասնագետները"
-      contact: "Տվյալ %{name}"
-      corporate_information: "Կորպորատիվ տեղեկատվություն"
-      corporate_reports: "Կորպորատիվ հաշվետվություններ"
+      chief_professional_officers: Մեր գլխավոր մասնագետները
+      contact: Տվյալ %{name}
+      corporate_information: Կորպորատիվ տեղեկատվություն
+      corporate_reports: Կորպորատիվ հաշվետվություններ
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Մեր հայտարարությունները"
+      our_announcements: Մեր հայտարարությունները
       our_consultations:
       our_judges:
-      our_management: "Մեր ղեկավարումը"
-      our_ministers: "Մեր նաքարարներ"
-      our_policies: "Մեր քաղաքականությույնը"
-      our_publications: "Մեր հրատարակումները"
-      our_senior_military_officials: "Մեր ավագ զինվորական գծով ղեկավարները"
-      our_services: "Մեր ծառայությունները"
-      our_statistics: "Մեր ցուցանիշները"
-      our_topics: "Մենք աշքատում ենք տյալ թեմայի շուրջ"
-      special_representatives: "Հատուկ ներկայացուցիչներ"
-      traffic_commissioners: "Երթևեկության հանձնաժողով"
-      what_we_do: "Ինչ ենք մենք անում"
+      our_management: Մեր ղեկավարումը
+      our_ministers: Մեր նաքարարներ
+      our_policies: Մեր քաղաքականությույնը
+      our_publications: Մեր հրատարակումները
+      our_senior_military_officials: Մեր ավագ զինվորական գծով ղեկավարները
+      our_services: Մեր ծառայությունները
+      our_statistics: Մեր ցուցանիշները
+      our_topics: Մենք աշքատում ենք տյալ թեմայի շուրջ
+      special_representatives: Հատուկ ներկայացուցիչներ
+      traffic_commissioners: Երթևեկության հանձնաժողով
+      what_we_do: Ինչ ենք մենք անում
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Քաղաքականություն"
+    heading: Քաղաքականություն
     view_all:
   publications:
-    heading: "Հրապարակումներ"
+    heading: Հրապարակումներ
     headings:
-      detail: "Տվյալ"
-  read_more: "Կարդալ ավելին"
+      detail: Տվյալ
+  read_more: Կարդալ ավելին
   see_all:
-    announcement: "Տես՝ մեր բոլոր Հայտարարություններ -ը"
-    authored_article: "Տես՝ մեր բոլոր Հեղինակային հոդվածներ -ը"
-    case_study: "Տես՝ մեր բոլոր Թեմատիկ ուսումնասիրություններ -ը"
-    closed_consultation: "Տես՝ մեր բոլոր Փակ խորհրդատվություններ -ը"
-    consultation: "Տես՝ մեր բոլոր Խորհրդատվություններ -ը"
-    consultation_outcome: "Տես՝ մեր բոլոր Խորհրդատվության արդյունքներ -ը"
-    corporate_report: "Տես՝ մեր բոլոր Կորպորատիվ հաշվետվություններ -ը"
-    correspondence: "Տես՝ մեր բոլոր Նամակագրություններ -ը"
+    announcement: Տես՝ մեր բոլոր Հայտարարություններ -ը
+    authored_article: Տես՝ մեր բոլոր Հեղինակային հոդվածներ -ը
+    case_study: Տես՝ մեր բոլոր Թեմատիկ ուսումնասիրություններ -ը
+    closed_consultation: Տես՝ մեր բոլոր Փակ խորհրդատվություններ -ը
+    consultation: Տես՝ մեր բոլոր Խորհրդատվություններ -ը
+    consultation_outcome: Տես՝ մեր բոլոր Խորհրդատվության արդյունքներ -ը
+    corporate_report: Տես՝ մեր բոլոր Կորպորատիվ հաշվետվություններ -ը
+    correspondence: Տես՝ մեր բոլոր Նամակագրություններ -ը
     decision:
-    detailed_guidance: "Տես՝ մեր բոլոր Մանրամասն ուղեցույցեր -ը"
+    detailed_guidance: Տես՝ մեր բոլոր Մանրամասն ուղեցույցեր -ը
     document_collection:
-    draft_text: "Տես՝ մեր բոլոր Սևագիր տեքստեր -ը"
-    fatality_notice: "Տես՝ մեր բոլոր Մահվան ծանուցումներ -ը"
-    foi_release: "Տես՝ մեր բոլոր Ազատ տեղեկատվության հաղորդագրություններ -ը"
-    form: "Տես՝ մեր բոլոր Ձևաթղթեր -ը"
-    government_response: "Տես՝ մեր բոլոր Կառավարության արձագանքներ -ը"
-    guidance: "Տես՝ մեր բոլոր Ուղեցույցեր -ը"
-    impact_assessment: "Տես՝ մեր բոլոր Ազդեցության գնահատումներ -ը"
-    imported: "Տես՝ մեր բոլոր Ներկրված - սպասման տեսակներ -ը"
+    draft_text: Տես՝ մեր բոլոր Սևագիր տեքստեր -ը
+    fatality_notice: Տես՝ մեր բոլոր Մահվան ծանուցումներ -ը
+    foi_release: Տես՝ մեր բոլոր Ազատ տեղեկատվության հաղորդագրություններ -ը
+    form: Տես՝ մեր բոլոր Ձևաթղթեր -ը
+    government_response: Տես՝ մեր բոլոր Կառավարության արձագանքներ -ը
+    guidance: Տես՝ մեր բոլոր Ուղեցույցեր -ը
+    impact_assessment: Տես՝ մեր բոլոր Ազդեցության գնահատումներ -ը
+    imported: Տես՝ մեր բոլոր Ներկրված - սպասման տեսակներ -ը
     international_treaty:
-    map: "Տես՝ մեր բոլոր Քարտեզներ -ը"
-    national_statistics: "Տես՝ մեր բոլոր Վիճակագրություն-ազգային վիճակագրություններ
-      -ը"
-    news_article: "Տես՝ մեր բոլոր Տեղեկատվական հոդվածներ -ը"
-    news_story: "Տես՝ մեր բոլոր Լուրեր -ը"
+    map: Տես՝ մեր բոլոր Քարտեզներ -ը
+    national_statistics: Տես՝ մեր բոլոր Վիճակագրություն-ազգային վիճակագրություններ
+      -ը
+    news_article: Տես՝ մեր բոլոր Տեղեկատվական հոդվածներ -ը
+    news_story: Տես՝ մեր բոլոր Լուրեր -ը
     notice:
-    open_consultation: "Տես՝ մեր բոլոր Բաց խորհրդատվություններ -ը"
-    oral_statement: "Տես՝ մեր բոլոր Բանավոր դիմումներ խորհրդարան -ը"
-    policy: "Տես՝ մեր բոլոր Քաղաքականություններ -ը"
-    policy_paper: "Տես՝ մեր բոլոր Ծրագրային փաստաթղթեր -ը"
-    press_release: "Տես՝ մեր բոլոր Մամլո հաղորդագրություններ -ը"
-    promotional: "Տես՝ մեր բոլոր Քարոզչական նյութներ -ը"
-    publication: "Տես՝ մեր բոլոր Հրապարակումներ -ը"
+    open_consultation: Տես՝ մեր բոլոր Բաց խորհրդատվություններ -ը
+    oral_statement: Տես՝ մեր բոլոր Բանավոր դիմումներ խորհրդարան -ը
+    policy: Տես՝ մեր բոլոր Քաղաքականություններ -ը
+    policy_paper: Տես՝ մեր բոլոր Ծրագրային փաստաթղթեր -ը
+    press_release: Տես՝ մեր բոլոր Մամլո հաղորդագրություններ -ը
+    promotional: Տես՝ մեր բոլոր Քարոզչական նյութներ -ը
+    publication: Տես՝ մեր բոլոր Հրապարակումներ -ը
     regulation:
-    research: "Տես՝ մեր բոլոր Հետազոտություններ և վերլուծություններ -ը"
-    speaking_notes: "Տես՝ մեր բոլոր Խոսքի գրառումներ -ը"
-    speech: "Տես՝ մեր բոլոր Ելույթներ -ը"
-    statement_to_parliament: "Տես՝ մեր բոլոր Դիմումներ խորհրդարան -ը"
-    statistical_data_set: "Տես՝ մեր բոլոր Վիճակագրական տվյալներ -ը"
-    statistics: "Տես՝ մեր բոլոր Վիճակագրություն -ը"
+    research: Տես՝ մեր բոլոր Հետազոտություններ և վերլուծություններ -ը
+    speaking_notes: Տես՝ մեր բոլոր Խոսքի գրառումներ -ը
+    speech: Տես՝ մեր բոլոր Ելույթներ -ը
+    statement_to_parliament: Տես՝ մեր բոլոր Դիմումներ խորհրդարան -ը
+    statistical_data_set: Տես՝ մեր բոլոր Վիճակագրական տվյալներ -ը
+    statistics: Տես՝ մեր բոլոր Վիճակագրություն -ը
     statutory_guidance:
-    transcript: "Տես՝ մեր բոլոր Վերծանումներ -ը"
-    transparency: "Տես՝ մեր բոլոր Բաց տեղեկատվություններ -ը"
-    written_statement: "Տես՝ մեր բոլոր Գրավոր դիմումներ խորհրդարան -ը"
+    transcript: Տես՝ մեր բոլոր Վերծանումներ -ը
+    transparency: Տես՝ մեր բոլոր Բաց տեղեկատվություններ -ը
+    written_statement: Տես՝ մեր բոլոր Գրավոր դիմումներ խորհրդարան -ը
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "և"
+      last_word_connector: և
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Մեր %{link} ը կպարզաբանի մեր մոտեցումները
-        անձնական տեղեկատվությանը "
-      publication_scheme_html: "Կարդացեք այն ամնենի մասին ինչ մենք հրապարակում ենք
-        մեր %{link} ում"
-      social_media_use_html: "Կարդացեք մեր քաղաքականության մասին"
-      welsh_language_scheme_html: "Գտեք այստեղ %{link} ում հրապարակելու մեր պարտավորության
-        մասին"
-    find_out_more: "Տես՝ մեր ամբողջական պրոֆիլն ու կոնտակտային տվյալները"
+      personal_information_charter_html: 'Մեր %{link} ը կպարզաբանի մեր մոտեցումները
+        անձնական տեղեկատվությանը '
+      publication_scheme_html: Կարդացեք այն ամնենի մասին ինչ մենք հրապարակում ենք
+        մեր %{link} ում
+      social_media_use_html: Կարդացեք մեր քաղաքականության մասին
+      welsh_language_scheme_html: Գտեք այստեղ %{link} ում հրապարակելու մեր պարտավորության
+        մասին
+    find_out_more: Տես՝ մեր ամբողջական պրոֆիլն ու կոնտակտային տվյալները
     headings:
-      about_us: "Մեր մասին"
-      contact_us: "Կապ մեզ հետ"
-      corporate_information: "Կորպորատիվ տեղեկատվություն"
-      follow_us: "Հետևեք մեզ"
-      our_people: "Մեր անձնակազմը"
-      our_services: "Մեր ծառայությունները"
-    location: "Տարածք"
-    part_of: "Մաս"
+      about_us: Մեր մասին
+      contact_us: Կապ մեզ հետ
+      corporate_information: Կորպորատիվ տեղեկատվություն
+      follow_us: Հետևեք մեզ
+      our_people: Մեր անձնակազմը
+      our_services: Մեր ծառայությունները
+    location: Տարածք
+    part_of: Մաս

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,18 +43,18 @@ ja:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "ニュース"
+    heading: ニュース
     view_all:
   attachment:
     accessibility:
       full_help_html: この文書の点字版、音声版、その他のフォーマットをリクエストするには、%{email}に、ご住所、お電話番号、文書のタイトル
         ("%{title}")%{references}.をお送り下さい。
-      heading: "このファイルは支援技術のユーザーには利用できない場合があります"
-      request_a_different_format: "異なるフォーマットを要求"
+      heading: このファイルは支援技術のユーザーには利用できない場合があります
+      request_a_different_format: 異なるフォーマットを要求
     headings:
-      order_a_copy: "コピーを注文"
-      order_a_copy_full: "コピーを注文"
-      published: "掲載日"
+      order_a_copy: コピーを注文
+      order_a_copy_full: コピーを注文
+      published: 掲載日
       reference: Ref
       unnumbered_command_paper:
       unnumbered_hoc_paper:
@@ -73,7 +73,7 @@ ja:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "連絡フォーム"
+    contact_form: 連絡フォーム
     email: Email
   corporate_information_page:
     type:
@@ -89,17 +89,17 @@ ja:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "個人情報保護法"
+        personal_information_charter: 個人情報保護法
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "情報公開法"
+        publication_scheme: 情報公開法
         recruitment:
         research:
-        social_media_use: "ソーシャルメディア"
+        social_media_use: ソーシャルメディア
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "ウェールズ語スキーム"
+        welsh_language_scheme: ウェールズ語スキーム
   date:
     formats:
       default: "%Y %B %d"
@@ -112,28 +112,28 @@ ja:
       published:
       updated:
     headings:
-      applies_to_nations: "対象国"
+      applies_to_nations: 対象国
       attachments:
-        one: "お知らせ"
-        other: "お知らせ"
+        one: お知らせ
+        other: お知らせ
       from:
       location:
       part_of:
-    published: "掲載日"
+    published: 掲載日
     read: "%{title} の記事を読む"
     speech:
       author_title:
-        minister: "大臣"
-        speaker: "ライター"
-      delivered_on: "場所"
+        minister: 大臣
+        speaker: ライター
+      delivered_on: 場所
       delivery_title:
-        minister: "大臣"
-        speaker: "スピーカー"
+        minister: 大臣
+        speaker: スピーカー
       written_on:
     type:
       announcement:
-        one: "ニュース"
-        other: "ニュース"
+        one: ニュース
+        other: ニュース
       authored_article:
         one: Authored article
         other: Authored articles
@@ -141,56 +141,56 @@ ja:
         one:
         other:
       case_study:
-        one: "ケーススタディ"
-        other: "ケーススタディ"
+        one: ケーススタディ
+        other: ケーススタディ
       closed_consultation:
-        one: "非公開協議"
-        other: "非公開協議"
+        one: 非公開協議
+        other: 非公開協議
       consultation:
-        one: "協議"
-        other: "協議"
+        one: 協議
+        other: 協議
       consultation_outcome:
-        one: "協議結果"
-        other: "協議結果"
+        one: 協議結果
+        other: 協議結果
       corporate_report:
-        one: "事業報告"
-        other: "事業報告"
+        one: 事業報告
+        other: 事業報告
       correspondence:
-        one: "通信文書"
-        other: "通信文書"
+        one: 通信文書
+        other: 通信文書
       decision:
         one:
         other:
       detailed_guidance:
-        one: "詳細説明"
-        other: "詳細説明"
+        one: 詳細説明
+        other: 詳細説明
       document_collection:
-        one: "シリーズ"
+        one: シリーズ
         other:
       draft_text:
-        one: "草稿"
-        other: "草稿"
+        one: 草稿
+        other: 草稿
       foi_release:
-        one: "情報公開に関するニュース"
-        other: "情報公開に関するニュース"
+        one: 情報公開に関するニュース
+        other: 情報公開に関するニュース
       form:
-        one: "フォーム"
-        other: "フォーム"
+        one: フォーム
+        other: フォーム
       government_response:
-        one: "レスポンス"
-        other: "レスポンス"
+        one: レスポンス
+        other: レスポンス
       guidance:
-        one: "ガイダンス"
-        other: "ガイダンス"
+        one: ガイダンス
+        other: ガイダンス
       impact_assessment:
-        one: "影響評価"
-        other: "影響評価"
+        one: 影響評価
+        other: 影響評価
       imported:
-        one: "確認中"
-        other: "確認中"
+        one: 確認中
+        other: 確認中
       independent_report:
-        one: "第三者機関によるレポート"
-        other: "第三者機関によるレポート"
+        one: 第三者機関によるレポート
+        other: 第三者機関によるレポート
       international_treaty:
         one:
         other:
@@ -198,17 +198,17 @@ ja:
         one:
         other:
       map:
-        one: "地図"
-        other: "地図"
+        one: 地図
+        other: 地図
       national_statistics:
-        one: "国家統計"
-        other: "国家統計"
+        one: 国家統計
+        other: 国家統計
       news_article:
-        one: "ニュース"
-        other: "ニュース"
+        one: ニュース
+        other: ニュース
       news_story:
-        one: "ニュース"
-        other: "ニュース"
+        one: ニュース
+        other: ニュース
       nhs_content:
         one:
         other:
@@ -216,82 +216,82 @@ ja:
         one:
         other:
       official_statistics:
-        one: "統計"
-        other: "統計"
+        one: 統計
+        other: 統計
       open_consultation:
-        one: "公開協議"
-        other: "公開協議"
+        one: 公開協議
+        other: 公開協議
       oral_statement:
-        one: "議会に対する口頭陳述"
-        other: "議会に対する口頭陳述"
+        one: 議会に対する口頭陳述
+        other: 議会に対する口頭陳述
       policy_paper:
-        one: "政策文書"
-        other: "政策文書"
+        one: 政策文書
+        other: 政策文書
       press_release:
-        one: "新聞発表"
-        other: "新聞発表"
+        one: 新聞発表
+        other: 新聞発表
       promotional:
-        one: "宣伝資料"
-        other: "宣伝資料"
+        one: 宣伝資料
+        other: 宣伝資料
       publication:
-        one: "出版物"
-        other: "出版物"
+        one: 出版物
+        other: 出版物
       regulation:
         one:
         other:
       research:
-        one: "調査と分析"
-        other: "調査と分析"
+        one: 調査と分析
+        other: 調査と分析
       speaking_notes:
-        one: "キーポイント"
-        other: "キーポイント"
+        one: キーポイント
+        other: キーポイント
       speech:
-        one: "スピーチ"
-        other: "スピーチ"
+        one: スピーチ
+        other: スピーチ
       statement_to_parliament:
-        one: "閣僚声明"
-        other: "閣僚声明"
+        one: 閣僚声明
+        other: 閣僚声明
       statistical_data_set:
-        one: "統計データセット"
-        other: "統計データセット"
+        one: 統計データセット
+        other: 統計データセット
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "スピーチ全文"
-        other: "スピーチ全文"
+        one: スピーチ全文
+        other: スピーチ全文
       transparency:
-        one: "透明性データ"
-        other: "透明性データ"
+        one: 透明性データ
+        other: 透明性データ
       world_news_story:
         one:
         other:
       written_statement:
-        one: "閣僚声明文"
-        other: "閣僚声明文"
-    updated: "更新"
+        one: 閣僚声明文
+        other: 閣僚声明文
+    updated: 更新
     view: "%{title}' を見る"
   document_filters:
-    description: "検索精度を上げるために、各種フィルターをご利用下さい"
+    description: 検索精度を上げるために、各種フィルターをご利用下さい
     no_results:
-      description: "検索内容を変更して再度検索下さい"
-      title: "該当するページはありません"
+      description: 検索内容を変更して再度検索下さい
+      title: 該当するページはありません
       tna_heading:
       tna_link:
     world_locations:
-      all: "全ての地域"
-      label: "地域"
+      all: 全ての地域
+      label: 地域
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "最新情報"
+    latest_activity: 最新情報
   i18n:
     direction: ltr
   language_names:
-    ja: "日本語"
+    ja: 日本語
   latest_feed:
-    no_updates: "更新情報はありません"
+    no_updates: 更新情報はありません
     title: Latest
   national_statistics:
     heading:
@@ -301,37 +301,37 @@ ja:
         format: "%n%u"
   organisation:
     about:
-      read_more: "続き"
+      read_more: 続き
     corporate_information:
-      access_our_info: "情報開示"
-      foi_how_to: "情報開示請求"
-      foi_releases: "情報公開関連"
-      jobs_and_contacts: "求人と調達"
+      access_our_info: 情報開示
+      foi_how_to: 情報開示請求
+      foi_releases: 情報公開関連
+      jobs_and_contacts: 求人と調達
       organisation_chart:
-      transparency: "データ開示"
+      transparency: データ開示
     foi_exemption_html:
     headings:
-      chief_professional_officers: "チーフ・プロフェッショナル・オフィサー"
-      contact: "連絡先"
-      corporate_information: "各種情報"
-      corporate_reports: "各種レポート"
+      chief_professional_officers: チーフ・プロフェッショナル・オフィサー
+      contact: 連絡先
+      corporate_information: 各種情報
+      corporate_reports: 各種レポート
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "ニュース"
+      our_announcements: ニュース
       our_consultations:
       our_judges:
-      our_management: "幹部職員"
-      our_ministers: "大臣"
-      our_policies: "政策"
-      our_publications: "出版物"
-      our_senior_military_officials: "武官"
-      our_services: "業務案内"
-      our_statistics: "統計"
-      our_topics: "トピックス"
-      special_representatives: "特別代表"
-      traffic_commissioners: "交通担当コミッショナー"
-      what_we_do: "業務案内"
+      our_management: 幹部職員
+      our_ministers: 大臣
+      our_policies: 政策
+      our_publications: 出版物
+      our_senior_military_officials: 武官
+      our_services: 業務案内
+      our_statistics: 統計
+      our_topics: トピックス
+      special_representatives: 特別代表
+      traffic_commissioners: 交通担当コミッショナー
+      what_we_do: 業務案内
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -346,13 +346,13 @@ ja:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "政策"
+    heading: 政策
     view_all:
   publications:
-    heading: "出版物"
+    heading: 出版物
     headings:
-      detail: "詳細"
-  read_more: "続き"
+      detail: 詳細
+  read_more: 続き
   roles:
     heading:
       one:
@@ -366,49 +366,49 @@ ja:
     previous_holders:
     read_more:
   see_all:
-    announcement: "ニュース を全て見る"
+    announcement: ニュース を全て見る
     authored_article: authored articles を全て見る
-    case_study: "ケーススタディ を全て見る"
-    closed_consultation: "非公開協議 を全て見る"
-    consultation: "協議 を全て見る"
-    consultation_outcome: "協議結果 を全て見る"
-    corporate_report: "事業報告 を全て見る"
-    correspondence: "通信文書 を全て見る"
+    case_study: ケーススタディ を全て見る
+    closed_consultation: 非公開協議 を全て見る
+    consultation: 協議 を全て見る
+    consultation_outcome: 協議結果 を全て見る
+    corporate_report: 事業報告 を全て見る
+    correspondence: 通信文書 を全て見る
     decision:
-    detailed_guidance: "詳細説明 を全て見る"
+    detailed_guidance: 詳細説明 を全て見る
     document_collection:
-    draft_text: "草稿 を全て見る"
-    fatality_notice: "死亡告示 を全て見る"
-    foi_release: "情報公開に関するニュース を全て見る"
-    form: "フォーム を全て見る"
-    government_response: "レスポンス を全て見る"
-    guidance: "ガイダンス を全て見る"
-    impact_assessment: "影響評価 を全て見る"
-    imported: "確認中 を全て見る"
+    draft_text: 草稿 を全て見る
+    fatality_notice: 死亡告示 を全て見る
+    foi_release: 情報公開に関するニュース を全て見る
+    form: フォーム を全て見る
+    government_response: レスポンス を全て見る
+    guidance: ガイダンス を全て見る
+    impact_assessment: 影響評価 を全て見る
+    imported: 確認中 を全て見る
     international_treaty:
-    map: "地図 を全て見る"
-    national_statistics: "国家統計 を全て見る"
-    news_article: "ニュース を全て見る"
-    news_story: "ニュース を全て見る"
+    map: 地図 を全て見る
+    national_statistics: 国家統計 を全て見る
+    news_article: ニュース を全て見る
+    news_story: ニュース を全て見る
     notice:
-    open_consultation: "公開協議 を全て見る"
-    oral_statement: "議会に対する口頭陳述 を全て見る"
-    policy: "政策 を全て見る"
-    policy_paper: "政策文書 を全て見る"
-    press_release: "新聞発表 を全て見る"
-    promotional: "宣伝資料 を全て見る"
-    publication: "出版物 を全て見る"
+    open_consultation: 公開協議 を全て見る
+    oral_statement: 議会に対する口頭陳述 を全て見る
+    policy: 政策 を全て見る
+    policy_paper: 政策文書 を全て見る
+    press_release: 新聞発表 を全て見る
+    promotional: 宣伝資料 を全て見る
+    publication: 出版物 を全て見る
     regulation:
-    research: "調査と分析 を全て見る"
-    speaking_notes: "キーポイント を全て見る"
-    speech: "スピーチ を全て見る"
-    statement_to_parliament: "閣僚声明 を全て見る"
-    statistical_data_set: "統計データセット を全て見る"
-    statistics: "統計 を全て見る"
+    research: 調査と分析 を全て見る
+    speaking_notes: キーポイント を全て見る
+    speech: スピーチ を全て見る
+    statement_to_parliament: 閣僚声明 を全て見る
+    statistical_data_set: 統計データセット を全て見る
+    statistics: 統計 を全て見る
     statutory_guidance:
-    transcript: "スピーチ全文 を全て見る"
-    transparency: "透明性データ を全て見る"
-    written_statement: "閣僚声明文 を全て見る"
+    transcript: スピーチ全文 を全て見る
+    transparency: 透明性データ を全て見る
+    written_statement: 閣僚声明文 を全て見る
   social_media:
     follow_us:
   support:
@@ -419,36 +419,36 @@ ja:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "発表"
-      country: "国名"
-      documents: "お知らせ"
-      mission: "役割"
-      organisations: "組織"
-      publications: "出版物"
+      announcements: 発表
+      country: 国名
+      documents: お知らせ
+      mission: 役割
+      organisations: 組織
+      publications: 出版物
       quick_links: Quick links
-      related_policies: "関連政策"
-      statistics: "統計"
+      related_policies: 関連政策
+      statistics: 統計
     type:
       international_delegation:
-        one: "海外代表団"
-        other: "海外代表団"
+        one: 海外代表団
+        other: 海外代表団
       world_location:
-        one: "地域"
-        other: "地域"
+        one: 地域
+        other: 地域
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "個人情報の取り扱いについては %{link} をご覧下さい"
-      publication_scheme_html: "情報公開の種類については %{link} をご覧下さい"
+      personal_information_charter_html: 個人情報の取り扱いについては %{link} をご覧下さい
+      publication_scheme_html: 情報公開の種類については %{link} をご覧下さい
       social_media_use_html: "%{link}に関する政策を読む"
-      welsh_language_scheme_html: "情報公開の詳細については %{link} をご覧下さい"
-    find_out_more: "業務案内と連絡先を見る"
+      welsh_language_scheme_html: 情報公開の詳細については %{link} をご覧下さい
+    find_out_more: 業務案内と連絡先を見る
     headings:
-      about_us: "大使館について"
-      contact_us: "連絡先"
-      corporate_information: "組織情報"
+      about_us: 大使館について
+      contact_us: 連絡先
+      corporate_information: 組織情報
       follow_us: Follow us
-      our_people: "主な職員"
-      our_services: "業務内容"
-    location: "アクセス"
-    part_of: "所属"
+      our_people: 主な職員
+      our_services: 業務内容
+    location: アクセス
+    part_of: 所属

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -288,7 +288,7 @@ ka:
   i18n:
     direction: ltr
   language_names:
-    ka: "ქართული"
+    ka: ქართული
   latest_feed:
     no_updates:
     title:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -43,19 +43,19 @@ ko:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "공지사항"
+    heading: 공지사항
     view_all:
   attachment:
     accessibility:
       full_help_html: 점자, 오디오 혹은 다른 타입의 ("%{title}")%{references} 파일을 다운로드받으시려면, 주소,
         전화번호, 요청하시는 자료의 제목을 명시하여, %{email} 로 이메일을 주십시오.
-      heading: "본 파일은 지원 기술이 필요한 분들께 적합하지 않을 수 있습니다. "
-      request_a_different_format: "다른 포맷으로 요청"
+      heading: '본 파일은 지원 기술이 필요한 분들께 적합하지 않을 수 있습니다. '
+      request_a_different_format: 다른 포맷으로 요청
     headings:
-      order_a_copy: "카피 주문하기"
-      order_a_copy_full: "본 문서의 카피 주문하기"
-      published: "퍼블리시"
-      reference: "레퍼런스"
+      order_a_copy: 카피 주문하기
+      order_a_copy_full: 본 문서의 카피 주문하기
+      published: 퍼블리시
+      reference: 레퍼런스
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -73,8 +73,8 @@ ko:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "콘택트 폼"
-    email: "이메일"
+    contact_form: 콘택트 폼
+    email: 이메일
   corporate_information_page:
     type:
       link_text:
@@ -89,17 +89,17 @@ ko:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "개인정보 규정"
+        personal_information_charter: 개인정보 규정
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "발행 계획"
+        publication_scheme: 발행 계획
         recruitment:
         research:
-        social_media_use: "소셜미디어 사용"
+        social_media_use: 소셜미디어 사용
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "웨일스어 계획"
+        welsh_language_scheme: 웨일스어 계획
   date:
     formats:
       default: "%d %B %Y"
@@ -112,85 +112,85 @@ ko:
       published:
       updated:
     headings:
-      applies_to_nations: "적용"
+      applies_to_nations: 적용
       attachments:
-        one: "문서"
-        other: "문서"
+        one: 문서
+        other: 문서
       from:
       location:
       part_of:
-    published: "발행"
+    published: 발행
     read: "%{title} 기사를 확인하세요"
     speech:
       author_title:
-        minister: "장관"
-        speaker: "저자"
-      delivered_on: "행사일시"
+        minister: 장관
+        speaker: 저자
+      delivered_on: 행사일시
       delivery_title:
-        minister: "장관"
-        speaker: "스피커"
-      written_on: "작성일시:"
+        minister: 장관
+        speaker: 스피커
+      written_on: '작성일시:'
     type:
       announcement:
-        one: "공지"
-        other: "공지"
+        one: 공지
+        other: 공지
       authored_article:
-        one: "기사"
-        other: "기사"
+        one: 기사
+        other: 기사
       blog_post:
         one:
         other:
       case_study:
-        one: "케이스 스터디"
-        other: "케이스 스터디"
+        one: 케이스 스터디
+        other: 케이스 스터디
       closed_consultation:
-        one: "비공개 협의"
-        other: "비공개 협의"
+        one: 비공개 협의
+        other: 비공개 협의
       consultation:
-        one: "협의"
-        other: "협의"
+        one: 협의
+        other: 협의
       consultation_outcome:
-        one: "협의 결과"
-        other: "협의 결과"
+        one: 협의 결과
+        other: 협의 결과
       corporate_report:
-        one: "기업 레포트"
-        other: "기업 레포트"
+        one: 기업 레포트
+        other: 기업 레포트
       correspondence:
-        one: "서신"
-        other: "서신"
+        one: 서신
+        other: 서신
       decision:
         one:
         other:
       detailed_guidance:
-        one: "상세 안내"
-        other: "상세 안내"
+        one: 상세 안내
+        other: 상세 안내
       document_collection:
-        one: "시리즈"
+        one: 시리즈
         other:
       draft_text:
-        one: "드래프트 택스트"
-        other: "드래프트 택스트"
+        one: 드래프트 택스트
+        other: 드래프트 택스트
       foi_release:
         one: FOI 보도자료
         other: FOI 보도자료
       form:
-        one: "문서"
-        other: "문서"
+        one: 문서
+        other: 문서
       government_response:
-        one: "정부 대책"
-        other: "정부 대책"
+        one: 정부 대책
+        other: 정부 대책
       guidance:
-        one: "안내"
-        other: "안내"
+        one: 안내
+        other: 안내
       impact_assessment:
-        one: "임팩트 평가"
-        other: "임팩트 평가"
+        one: 임팩트 평가
+        other: 임팩트 평가
       imported:
-        one: "수입 - 대기"
-        other: "수입 - 대기"
+        one: 수입 - 대기
+        other: 수입 - 대기
       independent_report:
-        one: "독립 레포트"
-        other: "독립 레포트"
+        one: 독립 레포트
+        other: 독립 레포트
       international_treaty:
         one:
         other:
@@ -198,17 +198,17 @@ ko:
         one:
         other:
       map:
-        one: "지도"
-        other: "지도"
+        one: 지도
+        other: 지도
       national_statistics:
-        one: "통계 - 국가 통계"
-        other: "통계 - 국가 통계"
+        one: 통계 - 국가 통계
+        other: 통계 - 국가 통계
       news_article:
-        one: "뉴스"
-        other: "뉴스"
+        one: 뉴스
+        other: 뉴스
       news_story:
-        one: "뉴스 스토리"
-        other: "뉴스 스토리"
+        one: 뉴스 스토리
+        other: 뉴스 스토리
       nhs_content:
         one:
         other:
@@ -216,83 +216,83 @@ ko:
         one:
         other:
       official_statistics:
-        one: "통계"
-        other: "통계"
+        one: 통계
+        other: 통계
       open_consultation:
-        one: "오픈 컨설테이션"
-        other: "오픈 컨설테이션"
+        one: 오픈 컨설테이션
+        other: 오픈 컨설테이션
       oral_statement:
-        one: "의회로 구두 성명"
-        other: "의회로 구두 성명"
+        one: 의회로 구두 성명
+        other: 의회로 구두 성명
       policy_paper:
-        one: "정책 논문"
-        other: "정책 논문"
+        one: 정책 논문
+        other: 정책 논문
       press_release:
-        one: "보도자료"
-        other: "보도자료"
+        one: 보도자료
+        other: 보도자료
       promotional:
-        one: "홍보물"
-        other: "홍보물"
+        one: 홍보물
+        other: 홍보물
       publication:
-        one: "간행물"
-        other: "간행물"
+        one: 간행물
+        other: 간행물
       regulation:
         one:
         other:
       research:
-        one: "리써치 및 분석"
-        other: "리써치 및 분석"
+        one: 리써치 및 분석
+        other: 리써치 및 분석
       speaking_notes:
-        one: "요점사항"
-        other: "요점사항"
+        one: 요점사항
+        other: 요점사항
       speech:
-        one: "연설문"
-        other: "연설문"
+        one: 연설문
+        other: 연설문
       statement_to_parliament:
-        one: "의회로 성명"
-        other: "의회로 성명"
+        one: 의회로 성명
+        other: 의회로 성명
       statistical_data_set:
-        one: "통계 데이터 세트"
-        other: "통계 데이터 세트"
+        one: 통계 데이터 세트
+        other: 통계 데이터 세트
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "트랜스크립트"
-        other: "트랜스크립트"
+        one: 트랜스크립트
+        other: 트랜스크립트
       transparency:
-        one: "투명성 데이타"
-        other: "투명성 데이타"
+        one: 투명성 데이타
+        other: 투명성 데이타
       world_news_story:
         one:
         other:
       written_statement:
-        one: "의회로 서면 성명"
-        other: "의회로 서면 성명"
-    updated: "업데이트"
+        one: 의회로 서면 성명
+        other: 의회로 서면 성명
+    updated: 업데이트
     view: "'%{title}' 을 확인하세요."
   document_filters:
-    description: "원하시는 내용으로 써치를 제한하는 필터를 사용하실 수 있습니다"
+    description: 원하시는 내용으로 써치를 제한하는 필터를 사용하실 수 있습니다
     no_results:
-      description: "다시 써치해주시기 바랍니다."
-      title: "매치되는 문서가 없습니다."
+      description: 다시 써치해주시기 바랍니다.
+      title: 매치되는 문서가 없습니다.
       tna_heading:
       tna_link:
     world_locations:
-      all: "모든 로케이션"
-      label: "월드 로케이션"
+      all: 모든 로케이션
+      label: 월드 로케이션
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "최근 활동"
+    latest_activity: 최근 활동
   i18n:
     direction: ltr
   language_names:
-    ko: "한국어"
+    ko: 한국어
   latest_feed:
-    no_updates: "관련 내용이 아직 없습니다."
-    title: "최신"
+    no_updates: 관련 내용이 아직 없습니다.
+    title: 최신
   national_statistics:
     heading:
   number:
@@ -301,37 +301,37 @@ ko:
         format: "%n%u"
   organisation:
     about:
-      read_more: "우리 업무에 대한 자세한 내용을 확인하세요."
+      read_more: 우리 업무에 대한 자세한 내용을 확인하세요.
     corporate_information:
-      access_our_info: "정보 접근"
+      access_our_info: 정보 접근
       foi_how_to: FOI 요청하기
       foi_releases: FOI 자료
-      jobs_and_contacts: "채용 및 연락처"
+      jobs_and_contacts: 채용 및 연락처
       organisation_chart:
-      transparency: "투명성 데이터"
+      transparency: 투명성 데이터
     foi_exemption_html:
     headings:
-      chief_professional_officers: "최고책임자"
+      chief_professional_officers: 최고책임자
       contact: "%{name} 에게 연락하세요"
-      corporate_information: "대사관 정보"
-      corporate_reports: "대사관 보고서"
+      corporate_information: 대사관 정보
+      corporate_reports: 대사관 보고서
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "뉴스"
+      our_announcements: 뉴스
       our_consultations:
       our_judges:
-      our_management: "조직"
-      our_ministers: "장관급"
-      our_policies: "정책"
-      our_publications: "자료"
-      our_senior_military_officials: "고위 군관계자"
-      our_services: "서비스"
-      our_statistics: "통계자료"
-      our_topics: "업무 토픽"
-      special_representatives: "특별 대사"
-      traffic_commissioners: "트래픽 커미셔너"
-      what_we_do: "업무 내용"
+      our_management: 조직
+      our_ministers: 장관급
+      our_policies: 정책
+      our_publications: 자료
+      our_senior_military_officials: 고위 군관계자
+      our_services: 서비스
+      our_statistics: 통계자료
+      our_topics: 업무 토픽
+      special_representatives: 특별 대사
+      traffic_commissioners: 트래픽 커미셔너
+      what_we_do: 업무 내용
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -346,13 +346,13 @@ ko:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "정책사안"
+    heading: 정책사안
     view_all:
   publications:
-    heading: "출판물"
+    heading: 출판물
     headings:
-      detail: "디테일"
-  read_more: "더 자세한 정보 알아보기"
+      detail: 디테일
+  read_more: 더 자세한 정보 알아보기
   roles:
     heading:
       one:
@@ -366,89 +366,89 @@ ko:
     previous_holders:
     read_more:
   see_all:
-    announcement: "공지 모두 둘러보기"
-    authored_article: "기사 모두 둘러보기"
-    case_study: "케이스 스터디 모두 둘러보기"
-    closed_consultation: "비공개 협의 모두 둘러보기"
-    consultation: "협의 모두 둘러보기"
-    consultation_outcome: "협의 결과 모두 둘러보기"
-    corporate_report: "기업 레포트 모두 둘러보기"
-    correspondence: "서신 모두 둘러보기"
+    announcement: 공지 모두 둘러보기
+    authored_article: 기사 모두 둘러보기
+    case_study: 케이스 스터디 모두 둘러보기
+    closed_consultation: 비공개 협의 모두 둘러보기
+    consultation: 협의 모두 둘러보기
+    consultation_outcome: 협의 결과 모두 둘러보기
+    corporate_report: 기업 레포트 모두 둘러보기
+    correspondence: 서신 모두 둘러보기
     decision:
-    detailed_guidance: "상세 안내 모두 둘러보기"
+    detailed_guidance: 상세 안내 모두 둘러보기
     document_collection:
-    draft_text: "드래프트 택스트 모두 둘러보기"
-    fatality_notice: "사상자 공지 모두 둘러보기"
+    draft_text: 드래프트 택스트 모두 둘러보기
+    fatality_notice: 사상자 공지 모두 둘러보기
     foi_release: foi 보도자료 모두 둘러보기
-    form: "문서 모두 둘러보기"
-    government_response: "정부 대책 모두 둘러보기"
-    guidance: "안내 모두 둘러보기"
-    impact_assessment: "임팩트 평가 모두 둘러보기"
-    imported: "수입 - 대기 모두 둘러보기"
+    form: 문서 모두 둘러보기
+    government_response: 정부 대책 모두 둘러보기
+    guidance: 안내 모두 둘러보기
+    impact_assessment: 임팩트 평가 모두 둘러보기
+    imported: 수입 - 대기 모두 둘러보기
     international_treaty:
-    map: "지도 모두 둘러보기"
-    national_statistics: "통계 - 국가 통계 모두 둘러보기"
-    news_article: "뉴스 모두 둘러보기"
-    news_story: "뉴스 스토리 모두 둘러보기"
+    map: 지도 모두 둘러보기
+    national_statistics: 통계 - 국가 통계 모두 둘러보기
+    news_article: 뉴스 모두 둘러보기
+    news_story: 뉴스 스토리 모두 둘러보기
     notice:
-    open_consultation: "오픈 컨설테이션 모두 둘러보기"
-    oral_statement: "의회로 구두 성명 모두 둘러보기"
-    policy: "정책 모두 둘러보기"
-    policy_paper: "정책 논문 모두 둘러보기"
-    press_release: "보도자료 모두 둘러보기"
-    promotional: "홍보물 모두 둘러보기"
-    publication: "간행물 모두 둘러보기"
+    open_consultation: 오픈 컨설테이션 모두 둘러보기
+    oral_statement: 의회로 구두 성명 모두 둘러보기
+    policy: 정책 모두 둘러보기
+    policy_paper: 정책 논문 모두 둘러보기
+    press_release: 보도자료 모두 둘러보기
+    promotional: 홍보물 모두 둘러보기
+    publication: 간행물 모두 둘러보기
     regulation:
-    research: "리써치 및 분석 모두 둘러보기"
-    speaking_notes: "요점사항 모두 둘러보기"
-    speech: "연설문 모두 둘러보기"
-    statement_to_parliament: "의회로 성명 모두 둘러보기"
-    statistical_data_set: "통계 데이터 세트 모두 둘러보기"
-    statistics: "통계 모두 둘러보기"
+    research: 리써치 및 분석 모두 둘러보기
+    speaking_notes: 요점사항 모두 둘러보기
+    speech: 연설문 모두 둘러보기
+    statement_to_parliament: 의회로 성명 모두 둘러보기
+    statistical_data_set: 통계 데이터 세트 모두 둘러보기
+    statistics: 통계 모두 둘러보기
     statutory_guidance:
-    transcript: "트랜스크립트 모두 둘러보기"
-    transparency: "투명성 데이타 모두 둘러보기"
-    written_statement: "의회로 서면 성명 모두 둘러보기"
+    transcript: 트랜스크립트 모두 둘러보기
+    transparency: 투명성 데이타 모두 둘러보기
+    written_statement: 의회로 서면 성명 모두 둘러보기
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "그리고"
+      last_word_connector: 그리고
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "공지사항"
-      country: "국가"
-      documents: "자료"
-      mission: "대사관 안내"
-      organisations: "조직 안내"
-      publications: "출판물"
-      quick_links: "퀵 링크"
-      related_policies: "관련 정책"
-      statistics: "통계"
+      announcements: 공지사항
+      country: 국가
+      documents: 자료
+      mission: 대사관 안내
+      organisations: 조직 안내
+      publications: 출판물
+      quick_links: 퀵 링크
+      related_policies: 관련 정책
+      statistics: 통계
     type:
       international_delegation:
-        one: "국제 사절단"
-        other: "국제 사절단"
+        one: 국제 사절단
+        other: 국제 사절단
       world_location:
-        one: "월드 로케이션"
-        other: "월드 로케이션"
+        one: 월드 로케이션
+        other: 월드 로케이션
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
       personal_information_charter_html: "%{link} 에서 개인정보 처리에 대한 안내"
-      publication_scheme_html: "정기적으로 공개되는 %{link} 정보에 대한 안내"
+      publication_scheme_html: 정기적으로 공개되는 %{link} 정보에 대한 안내
       social_media_use_html: "%{link} 에서 정책 정보 확인"
       welsh_language_scheme_html: "%{link} 에서 정보 공개에 대한 내용"
-    find_out_more: "프로필과 연락처 보기"
+    find_out_more: 프로필과 연락처 보기
     headings:
-      about_us: "대사관 안내"
-      contact_us: "연락처"
-      corporate_information: "대사관 정보"
-      follow_us: "소셜네트워크"
-      our_people: "직원"
-      our_services: "서비스"
-    location: "로케이션"
-    part_of: "파트"
+      about_us: 대사관 안내
+      contact_us: 연락처
+      corporate_information: 대사관 정보
+      follow_us: 소셜네트워크
+      our_people: 직원
+      our_services: 서비스
+    location: 로케이션
+    part_of: 파트

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -99,9 +99,9 @@ lt:
         few:
         other:
       map:
-        one: "Žemėlapis"
+        one: Žemėlapis
         few:
-        other: "Žemėlapiai"
+        other: Žemėlapiai
       national_statistics:
         one: 'Statistika - nacionalinė statistika '
         few:
@@ -131,9 +131,9 @@ lt:
         few:
         other: 'Atviros konsultacijos '
       oral_statement:
-        one: "Žodinis kreipimasis į parlamentą"
+        one: Žodinis kreipimasis į parlamentą
         few:
-        other: "Žodiniai kreipimaisi į parlamentą"
+        other: Žodiniai kreipimaisi į parlamentą
       policy_paper:
         one: Strategijos dokumentas
         few:
@@ -212,7 +212,7 @@ lt:
         speaker: Pranešėjas
       written_on: Parašyta
     updated: atnaujinta
-    view: "Žiūrėkite '%{title}'"
+    view: Žiūrėkite '%{title}'
   people:
     heading:
       one:
@@ -247,7 +247,7 @@ lt:
         other: Geografinės vietos
     headings:
       announcements: Mūsų skelbimai
-      country: "Šalis"
+      country: Šalis
       documents: Dokumentai
       mission: Mūsų misija
       organisations: Organizacijos
@@ -306,7 +306,7 @@ lt:
       full_help_html: Jei norėtumėte gauti šį dokumentą kitokiu formatu (brailio,
         audio ar pan.), siųskite el. paštą %{email}, parašydami savo adresą, telefoną
         bei leidinio pavadinimą ("%{title}")%{references}.
-      heading: "Šis failas gali būti netinkamas, naudojantiems pagalbines technologijas."
+      heading: Šis failas gali būti netinkamas, naudojantiems pagalbines technologijas.
       request_a_different_format: Paprašykite kito formato
     headings:
       order_a_copy: Užsisakykite leidinį
@@ -491,8 +491,8 @@ lt:
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Čia %{link} rasite paaiškinimą, kaip tvarkoma
-        Jūsų asmeninė informacija"
+      personal_information_charter_html: Čia %{link} rasite paaiškinimą, kaip tvarkoma
+        Jūsų asmeninė informacija
       publication_scheme_html: Sužinokite, kokią informaciją mes pastoviai pateikiame
         puslapyje %{link}.
       social_media_use_html: Perskaitykite mūsų strategiją %{link}.

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -201,7 +201,7 @@ lv:
       mission: Misija
       organisations: Organizācijas
       publications: Publikācijas
-      quick_links: "Ātrās saites"
+      quick_links: Ātrās saites
       related_policies: Saistītās politikas jomas
       statistics: Statistikas dati
   activerecord:
@@ -368,7 +368,7 @@ lv:
       our_services: Mūsu pakalpojumi
       our_statistics: Statistika
       our_topics: Mēs strādājam ar šiem jautājumiem
-      special_representatives: "Īpašie pārstāvji"
+      special_representatives: Īpašie pārstāvji
       traffic_commissioners: Satiksmes komisāri
       what_we_do: Par mums
       who_we_are:
@@ -439,8 +439,8 @@ lv:
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Šeit %{link} izskaidrots, kā tiks apstrādāta
-        Jūsu sniegtā personīgā informācija"
+      personal_information_charter_html: Šeit %{link} izskaidrots, kā tiks apstrādāta
+        Jūsu sniegtā personīgā informācija
       publication_scheme_html: Iepazīsties ar informāciju, kāda parasti tiek publicēta
         mūsu %{link}
       social_media_use_html: Iepazīsties ar mūsu nostāju par %{link}.

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -2,73 +2,73 @@ ps:
   document:
     headings:
       attachments:
-        one: "سند"
-        other: "سندونه"
-      applies_to_nations: "پورې اړه لری"
+        one: سند
+        other: سندونه
+      applies_to_nations: پورې اړه لری
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "خبرتیا"
-        other: "خبرتیاوې"
+        one: خبرتیا
+        other: خبرتیاوې
       authored_article:
-        one: "تالیف شوی مضمون"
-        other: "تالیف شوي مضامین"
+        one: تالیف شوی مضمون
+        other: تالیف شوي مضامین
       blog_post:
         one:
         other:
       case_study:
-        one: "موردی څیړنه"
-        other: "مودری څیړنی"
+        one: موردی څیړنه
+        other: مودری څیړنی
       closed_consultation:
-        one: "محرمه مشوره"
-        other: "محرمه مشوری"
+        one: محرمه مشوره
+        other: محرمه مشوری
       consultation:
-        one: "مشوره"
-        other: "مشوری"
+        one: مشوره
+        other: مشوری
       consultation_outcome:
-        one: "د مشوری پایله"
-        other: "د مشورو پایله"
+        one: د مشوری پایله
+        other: د مشورو پایله
       corporate_report:
-        one: "متحد راپور"
-        other: "متحد راپورونه"
+        one: متحد راپور
+        other: متحد راپورونه
       correspondence:
-        one: "ارتباط ساتنه"
-        other: "ارتباطات ساتنه"
+        one: ارتباط ساتنه
+        other: ارتباطات ساتنه
       decision:
         one:
         other:
       detailed_guidance:
-        one: "مفصله لارښوونه"
-        other: "مفصلی لارښوونی"
+        one: مفصله لارښوونه
+        other: مفصلی لارښوونی
       document_collection:
-        one: "سلسله"
+        one: سلسله
         other:
       draft_text:
-        one: "مسوده"
-        other: "مسودی"
+        one: مسوده
+        other: مسودی
       foi_release:
-        one: "د بیان د آزادی خپرونه"
-        other: "د بیان د آزادی خپرونی"
+        one: د بیان د آزادی خپرونه
+        other: د بیان د آزادی خپرونی
       form:
-        one: "فارم"
-        other: "فارمونه"
+        one: فارم
+        other: فارمونه
       government_response:
-        one: "د دولت ځواب"
-        other: "د دولت ځوابونه"
+        one: د دولت ځواب
+        other: د دولت ځوابونه
       guidance:
-        one: "رهنمایی"
-        other: "رهنمایی"
+        one: رهنمایی
+        other: رهنمایی
       impact_assessment:
-        one: "د تاثیراتو څیړنه"
-        other: "د تاثیراتو څیړنی"
+        one: د تاثیراتو څیړنه
+        other: د تاثیراتو څیړنی
       imported:
-        one: "وارد شوی - د انتظار نمونه"
-        other: "وارد شوی - د انتظار نمونه"
+        one: وارد شوی - د انتظار نمونه
+        other: وارد شوی - د انتظار نمونه
       independent_report:
-        one: "آزاد راپور"
-        other: "آزاد راپورونه"
+        one: آزاد راپور
+        other: آزاد راپورونه
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ ps:
         one:
         other:
       map:
-        one: "نقشه"
-        other: "نقشی"
+        one: نقشه
+        other: نقشی
       national_statistics:
-        one: "شمیرنه - ملی شمیرنې"
-        other: "شمیرنه - ملی شمیرنې"
+        one: شمیرنه - ملی شمیرنې
+        other: شمیرنه - ملی شمیرنې
       news_article:
-        one: "خبری مقاله"
-        other: "خبری مقالی"
+        one: خبری مقاله
+        other: خبری مقالی
       news_story:
-        one: "خبری راپور"
-        other: "خبری راپورونه"
+        one: خبری راپور
+        other: خبری راپورونه
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ ps:
         one:
         other:
       official_statistics:
-        one: "شمیرنه"
-        other: "شمیرنه"
+        one: شمیرنه
+        other: شمیرنه
       open_consultation:
-        one: "آزاده مشوره"
-        other: "آزادې مشورې"
+        one: آزاده مشوره
+        other: آزادې مشورې
       oral_statement:
-        one: "پارلمان ته شفاهی اعلامیه"
-        other: "پارلمان ته شفاهی اعلامیی"
+        one: پارلمان ته شفاهی اعلامیه
+        other: پارلمان ته شفاهی اعلامیی
       policy_paper:
-        one: "د پالیسۍ سند"
-        other: "د پالیسې سندونه"
+        one: د پالیسۍ سند
+        other: د پالیسې سندونه
       press_release:
-        one: "مطبوعاتی خبرپاڼه"
-        other: "مطبوعاتی خبرپاڼې"
+        one: مطبوعاتی خبرپاڼه
+        other: مطبوعاتی خبرپاڼې
       promotional:
-        one: "روزونکې مواد"
-        other: "روزونکی مواد"
+        one: روزونکې مواد
+        other: روزونکی مواد
       publication:
-        one: "خپرونه"
-        other: "خپرونې"
+        one: خپرونه
+        other: خپرونې
       regulation:
         one:
         other:
       research:
-        one: "څیړنه او تجزیه"
-        other: "ځیړنه او تجزیه"
+        one: څیړنه او تجزیه
+        other: ځیړنه او تجزیه
       speaking_notes:
-        one: "د وینا یادښت"
-        other: "د وینا یادښتونه"
+        one: د وینا یادښت
+        other: د وینا یادښتونه
       speech:
-        one: "وینا"
-        other: "ویناوې"
+        one: وینا
+        other: ویناوې
       statement_to_parliament:
-        one: "پارلمان ته اعلامیه"
-        other: "پارلمان ته اعلامیې"
+        one: پارلمان ته اعلامیه
+        other: پارلمان ته اعلامیې
       statistical_data_set:
-        one: "د شمیرنې اطلاعات"
-        other: "د شمیرنې اطلاعات"
+        one: د شمیرنې اطلاعات
+        other: د شمیرنې اطلاعات
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "لیکنه"
-        other: "لیکنې"
+        one: لیکنه
+        other: لیکنې
       transparency:
-        one: "د روڼوالې اطلاعات"
-        other: "د روڼوالي اطلاعات"
+        one: د روڼوالې اطلاعات
+        other: د روڼوالي اطلاعات
       world_news_story:
         one:
         other:
       written_statement:
-        one: "پارلمان ته لیکلې اعلامیه"
-        other: "پارلمان ته لیکلې اعلامیې"
+        one: پارلمان ته لیکلې اعلامیه
+        other: پارلمان ته لیکلې اعلامیې
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "خپور شوی"
-    read: "دا مضمون ووایاست %{title}"
+    published: خپور شوی
+    read: دا مضمون ووایاست %{title}
     speech:
       author_title:
-        minister: "وزیر"
-        speaker: "لیکونکی"
-      delivered_on: "پر دې نیټه ورکړل شو"
+        minister: وزیر
+        speaker: لیکونکی
+      delivered_on: پر دې نیټه ورکړل شو
       delivery_title:
-        minister: "وزیر"
-        speaker: "ویونکی"
-      written_on: "لیکلی دی په"
-    updated: "تازه شوي"
-    view: "لید '%{title}'"
+        minister: وزیر
+        speaker: ویونکی
+      written_on: لیکلی دی په
+    updated: تازه شوي
+    view: لید '%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ ps:
   world_location:
     type:
       international_delegation:
-        one: "نړیوال هیئت"
-        other: "نړیوال هیئتونه"
+        one: نړیوال هیئت
+        other: نړیوال هیئتونه
       world_location:
-        one: "په نړۍ کې موقعیت"
-        other: "په نړۍ کې موقعیتونه"
+        one: په نړۍ کې موقعیت
+        other: په نړۍ کې موقعیتونه
     headings:
-      announcements: "زموږ اعلانات"
-      country: "هیواد"
-      documents: "سندونه"
-      mission: "زموږ ماموریت"
-      organisations: "دفترونه"
-      publications: "زموږ نشریات"
-      quick_links: "چټکی اړیکی"
-      related_policies: "ارتباط لرونکی پالیسی ګانی"
-      statistics: "زموږه احصایی"
+      announcements: زموږ اعلانات
+      country: هیواد
+      documents: سندونه
+      mission: زموږ ماموریت
+      organisations: دفترونه
+      publications: زموږ نشریات
+      quick_links: چټکی اړیکی
+      related_policies: ارتباط لرونکی پالیسی ګانی
+      statistics: زموږه احصایی
   activerecord:
     attributes:
       attachment:
@@ -248,20 +248,20 @@ ps:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "اعلانونه"
+    heading: اعلانونه
     view_all:
   attachment:
     accessibility:
       full_help_html: که غواړی چی دا سند په مختلف فارمت یعنی بریل، صوتی شکل کی ترلاسه
         کړی %{email} لطفاْ خپل ادرس، تیلیفون نمبر او د سند نوم ایمیل کړی ("%{title}")%{references}
-      heading: "دا فایل کیدای شی جی د کومکی تیکنالوژی د استعمالوونکو لپاره مناسب نه
-        وی"
-      request_a_different_format: "د یو مختلف فارمت غوښتنه وکړی"
+      heading: دا فایل کیدای شی جی د کومکی تیکنالوژی د استعمالوونکو لپاره مناسب نه
+        وی
+      request_a_different_format: د یو مختلف فارمت غوښتنه وکړی
     headings:
-      order_a_copy: "د کاپی غوښتنه وکړی"
-      order_a_copy_full: "د سند د کاپی غوښتنه وکړی"
-      published: "خپور شوی"
-      reference: "مواخذ"
+      order_a_copy: د کاپی غوښتنه وکړی
+      order_a_copy_full: د سند د کاپی غوښتنه وکړی
+      published: خپور شوی
+      reference: مواخذ
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -279,8 +279,8 @@ ps:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "د اړیکوپاڼه"
-    email: "برښنالیک"
+    contact_form: د اړیکوپاڼه
+    email: برښنالیک
   corporate_information_page:
     type:
       link_text:
@@ -295,44 +295,44 @@ ps:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "د شخصی معلوماتی په اړه سند"
+        personal_information_charter: د شخصی معلوماتی په اړه سند
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "د خپرولو پلان"
+        publication_scheme: د خپرولو پلان
         recruitment:
         research:
-        social_media_use: "د ټولنیزو رسنیو استعمال"
+        social_media_use: د ټولنیزو رسنیو استعمال
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "د ویلز د ژبی پلان"
+        welsh_language_scheme: د ویلز د ژبی پلان
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "تاسې کولای شي  د فیلترونه څخه یوازې د هغو پایلو د ښودلو په خاطر
-      کار واخلۍ چې ستاسې لپاره په زړه پوری وی"
+    description: تاسې کولای شي  د فیلترونه څخه یوازې د هغو پایلو د ښودلو په خاطر کار
+      واخلۍ چې ستاسې لپاره په زړه پوری وی
     no_results:
-      description: "کوښښ وکړۍ لا زیات ولتوۍ او بیا کوښښ وکړۍ"
-      title: "سمون لرونکی اسناد شتون نه لری"
+      description: کوښښ وکړۍ لا زیات ولتوۍ او بیا کوښښ وکړۍ
+      title: سمون لرونکی اسناد شتون نه لری
       tna_heading:
       tna_link:
     world_locations:
-      all: "ټول موقعیتونه"
-      label: "نړیوال موقعیتونه"
+      all: ټول موقعیتونه
+      label: نړیوال موقعیتونه
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "اخیرنی فعالیت"
+    latest_activity: اخیرنی فعالیت
   i18n:
     direction: rtl
   language_names:
-    ps: "پښتو"
+    ps: پښتو
   latest_feed:
-    no_updates: "تر اوسه تازه معلومات په لاس کی نشته"
-    title: "آخرنی"
+    no_updates: تر اوسه تازه معلومات په لاس کی نشته
+    title: آخرنی
   national_statistics:
     heading:
   number:
@@ -341,99 +341,99 @@ ps:
         format: "%n%u"
   organisation:
     about:
-      read_more: "زمونږ د فعالیتونو په اړه نور معلومات ووایاست"
+      read_more: زمونږ د فعالیتونو په اړه نور معلومات ووایاست
     corporate_information:
-      access_our_info: "زمونږمعلوماتو ته لاس رسی پیدا کړی"
-      foi_how_to: "څنګه کولای شی چی د بیان د آزادی درخواست جوړ کړی"
-      foi_releases: "د بیان د آزادی خپرونی"
-      jobs_and_contacts: "دندی او تړونونه"
+      access_our_info: زمونږمعلوماتو ته لاس رسی پیدا کړی
+      foi_how_to: څنګه کولای شی چی د بیان د آزادی درخواست جوړ کړی
+      foi_releases: د بیان د آزادی خپرونی
+      jobs_and_contacts: دندی او تړونونه
       organisation_chart:
-      transparency: "د شفافیت معلومات"
+      transparency: د شفافیت معلومات
     foi_exemption_html:
     headings:
-      chief_professional_officers: "زمونږه لوړپوړي مسلکی مدیران"
-      contact: "تماس  %{name}"
-      corporate_information: "متحد معلومات"
-      corporate_reports: "متحد راپورونه"
+      chief_professional_officers: زمونږه لوړپوړي مسلکی مدیران
+      contact: تماس  %{name}
+      corporate_information: متحد معلومات
+      corporate_reports: متحد راپورونه
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "زمونږه اعلانات"
+      our_announcements: زمونږه اعلانات
       our_consultations:
       our_judges:
-      our_management: "زمونږه اداره"
-      our_ministers: "زموږه وزیران"
-      our_policies: "زموږه پالیسی ګانی"
-      our_publications: "زموږه نشریات"
-      our_senior_military_officials: "زموږه لوړپوړي نظامی اراکین"
-      our_services: "زموږه خدمتونه"
-      our_statistics: "زموږه احصائی"
-      our_topics: "موږ په دغه موضوعاتو کار کوو"
-      special_representatives: "خصوصی نمایندګان"
-      traffic_commissioners: "د ترافیکو کمشنران"
-      what_we_do: "موږڅه کوو"
+      our_management: زمونږه اداره
+      our_ministers: زموږه وزیران
+      our_policies: زموږه پالیسی ګانی
+      our_publications: زموږه نشریات
+      our_senior_military_officials: زموږه لوړپوړي نظامی اراکین
+      our_services: زموږه خدمتونه
+      our_statistics: زموږه احصائی
+      our_topics: موږ په دغه موضوعاتو کار کوو
+      special_representatives: خصوصی نمایندګان
+      traffic_commissioners: د ترافیکو کمشنران
+      what_we_do: موږڅه کوو
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "پالیسی ګانی"
+    heading: پالیسی ګانی
     view_all:
   publications:
-    heading: "نشریات"
+    heading: نشریات
     headings:
-      detail: "تفصیل"
-  read_more: "نور ووایاست"
+      detail: تفصیل
+  read_more: نور ووایاست
   see_all:
-    announcement: "ټول وګوری خبرتیاوې"
-    authored_article: "ټول وګوری تالیف شوي مضامین"
-    case_study: "ټول وګوری مودری څیړنی"
-    closed_consultation: "ټول وګوری محرمه مشوری"
-    consultation: "ټول وګوری مشوری"
-    consultation_outcome: "ټول وګوری د مشورو پایله"
-    corporate_report: "ټول وګوری متحد راپورونه"
-    correspondence: "ټول وګوری ارتباطات ساتنه"
+    announcement: ټول وګوری خبرتیاوې
+    authored_article: ټول وګوری تالیف شوي مضامین
+    case_study: ټول وګوری مودری څیړنی
+    closed_consultation: ټول وګوری محرمه مشوری
+    consultation: ټول وګوری مشوری
+    consultation_outcome: ټول وګوری د مشورو پایله
+    corporate_report: ټول وګوری متحد راپورونه
+    correspondence: ټول وګوری ارتباطات ساتنه
     decision:
-    detailed_guidance: "ټول وګوری مفصلی لارښوونی"
+    detailed_guidance: ټول وګوری مفصلی لارښوونی
     document_collection:
-    draft_text: "ټول وګوری مسودی"
-    fatality_notice: "ټول وګوری دمړینی خبرتیاوی"
-    foi_release: "ټول وګوری د بیان د آزادی خپرونی"
-    form: "ټول وګوری فارمونه"
-    government_response: "ټول وګوری د دولت ځوابونه"
-    guidance: "ټول وګوری رهنمایی"
-    impact_assessment: "ټول وګوری د تاثیراتو څیړنی"
-    imported: "ټول وګوری وارد شوی - د انتظار نمونه"
+    draft_text: ټول وګوری مسودی
+    fatality_notice: ټول وګوری دمړینی خبرتیاوی
+    foi_release: ټول وګوری د بیان د آزادی خپرونی
+    form: ټول وګوری فارمونه
+    government_response: ټول وګوری د دولت ځوابونه
+    guidance: ټول وګوری رهنمایی
+    impact_assessment: ټول وګوری د تاثیراتو څیړنی
+    imported: ټول وګوری وارد شوی - د انتظار نمونه
     international_treaty:
-    map: "ټول وګوری نقشی"
-    national_statistics: "ټول وګوری شمیرنه - ملی شمیرنې"
-    news_article: "ټول وګوری خبری مقالی"
-    news_story: "ټول وګوری خبری راپورونه"
+    map: ټول وګوری نقشی
+    national_statistics: ټول وګوری شمیرنه - ملی شمیرنې
+    news_article: ټول وګوری خبری مقالی
+    news_story: ټول وګوری خبری راپورونه
     notice:
-    open_consultation: "ټول وګوری آزادې مشورې"
-    oral_statement: "ټول وګوری پارلمان ته شفاهی اعلامیی"
-    policy: "ټول وګوری پالیسی ګانی"
-    policy_paper: "ټول وګوری د پالیسې سندونه"
-    press_release: "ټول وګوری مطبوعاتی خبرپاڼې"
-    promotional: "ټول وګوری روزونکی مواد"
-    publication: "ټول وګوری خپرونې"
+    open_consultation: ټول وګوری آزادې مشورې
+    oral_statement: ټول وګوری پارلمان ته شفاهی اعلامیی
+    policy: ټول وګوری پالیسی ګانی
+    policy_paper: ټول وګوری د پالیسې سندونه
+    press_release: ټول وګوری مطبوعاتی خبرپاڼې
+    promotional: ټول وګوری روزونکی مواد
+    publication: ټول وګوری خپرونې
     regulation:
-    research: "ټول وګوری ځیړنه او تجزیه"
-    speaking_notes: "ټول وګوری د وینا یادښتونه"
-    speech: "ټول وګوری ویناوې"
-    statement_to_parliament: "ټول وګوری پارلمان ته اعلامیې"
-    statistical_data_set: "ټول وګوری د شمیرنې اطلاعات"
-    statistics: "ټول وګوری شمیرنه"
+    research: ټول وګوری ځیړنه او تجزیه
+    speaking_notes: ټول وګوری د وینا یادښتونه
+    speech: ټول وګوری ویناوې
+    statement_to_parliament: ټول وګوری پارلمان ته اعلامیې
+    statistical_data_set: ټول وګوری د شمیرنې اطلاعات
+    statistics: ټول وګوری شمیرنه
     statutory_guidance:
-    transcript: "ټول وګوری لیکنې"
-    transparency: "ټول وګوری د روڼوالي اطلاعات"
-    written_statement: "ټول وګوری پارلمان ته لیکلې اعلامیې"
+    transcript: ټول وګوری لیکنې
+    transparency: ټول وګوری د روڼوالي اطلاعات
+    written_statement: ټول وګوری پارلمان ته لیکلې اعلامیې
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "او"
+      last_word_connector: او
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
@@ -442,18 +442,18 @@ ps:
       about_our_services_html:
       personal_information_charter_html: " زموږ تشریح کوی چې موږ د شخصی معلوماتو سره
         څرنګه چلند کوو"
-      publication_scheme_html: "زموږ د هغو معلوماتو په اړه ولولۍ چې هره ورڅ یې موږ
-        خپروو %{link}."
-      social_media_use_html: "زموږه پالسی ولولی %{link}."
-      welsh_language_scheme_html: "د نشریاتو په اړه  زموږ د ژمنو  معلومات ترلاسه کړۍ
-        %{link}."
-    find_out_more: "بشپړ معلومات او د اړیکو په اړه ټول تفصیلات وګورۍ"
+      publication_scheme_html: زموږ د هغو معلوماتو په اړه ولولۍ چې هره ورڅ یې موږ
+        خپروو %{link}.
+      social_media_use_html: زموږه پالسی ولولی %{link}.
+      welsh_language_scheme_html: د نشریاتو په اړه  زموږ د ژمنو  معلومات ترلاسه کړۍ
+        %{link}.
+    find_out_more: بشپړ معلومات او د اړیکو په اړه ټول تفصیلات وګورۍ
     headings:
-      about_us: "زموږ په هکله"
-      contact_us: "تماس ونیسی"
-      corporate_information: "متحد معلومات"
-      follow_us: "مونږ تعقیب کړی"
-      our_people: "زموږ خلک"
-      our_services: "زموږ خدمتونه"
-    location: "موقعیت"
-    part_of: "یوه برخه د"
+      about_us: زموږ په هکله
+      contact_us: تماس ونیسی
+      corporate_information: متحد معلومات
+      follow_us: مونږ تعقیب کړی
+      our_people: زموږ خلک
+      our_services: زموږ خدمتونه
+    location: موقعیت
+    part_of: یوه برخه د

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -325,14 +325,14 @@ pt:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Últimas atividades"
+    latest_activity: Últimas atividades
   i18n:
     direction: ltr
   language_names:
     pt: Português
   latest_feed:
     no_updates: Ainda não há atualizações
-    title: "Últimas"
+    title: Últimas
   national_statistics:
     heading:
   number:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -11,9 +11,9 @@ ro:
       part_of:
     type:
       announcement:
-        one: "Știre"
+        one: Știre
         few:
-        other: "Știri"
+        other: Știri
       authored_article:
         one: 'Articol '
         few:
@@ -107,13 +107,13 @@ ro:
         few:
         other: Statistici - statistici naționale
       news_article:
-        one: "Știre"
+        one: Știre
         few:
-        other: "Știri"
+        other: Știri
       news_story:
-        one: "Știre"
+        one: Știre
         few:
-        other: "Știri"
+        other: Știri
       nhs_content:
         one:
         few:
@@ -139,9 +139,9 @@ ro:
         few:
         other:
       press_release:
-        one: "Știre"
+        one: Știre
         few:
-        other: "Știri"
+        other: Știri
       promotional:
         one: Material promoțional
         few:
@@ -246,8 +246,8 @@ ro:
         few:
         other: Localizare
     headings:
-      announcements: "Știri"
-      country: "Țară"
+      announcements: Știri
+      country: Țară
       documents: Documente
       mission: Obiectiv
       organisations: Organizații
@@ -299,12 +299,16 @@ ro:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Știri"
+    heading: Știri
     view_all:
   attachment:
     accessibility:
-      full_help_html: |
-        Pentru a solicita acest document într-un format alternativ (braille, audio, etc.) vă rugăm să transmiteți o solicitare pe email către %{email}, specificând adresa de corespondență, numărul dumneavoastră  de telefon, precum și titlul publicației ("%{title}")%{references}.
+      full_help_html: 'Pentru a solicita acest document într-un format alternativ
+        (braille, audio, etc.) vă rugăm să transmiteți o solicitare pe email către
+        %{email}, specificând adresa de corespondență, numărul dumneavoastră  de telefon,
+        precum și titlul publicației ("%{title}")%{references}.
+
+'
       heading: Este posibil ca acest fișier să nu fie adecvat utilizatorilor de  tehnologii
         de asistare
       request_a_different_format: 'Solicită un format diferit '
@@ -409,7 +413,7 @@ ro:
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Știri "
+      our_announcements: 'Știri '
       our_consultations:
       our_judges:
       our_management: 'Echipa ambasadei '
@@ -484,7 +488,7 @@ ro:
     follow_us:
   support:
     array:
-      last_word_connector: "și"
+      last_word_connector: și
   time:
     formats:
       long_ordinal:
@@ -506,5 +510,5 @@ ro:
       follow_us: Ne găsești și pe
       our_people: Echipa noastră
       our_services: 'Servicii '
-    location: "Țară"
+    location: Țară
     part_of: Parte din

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,115 +2,115 @@ ru:
   document:
     headings:
       attachments:
-        one: "Документ"
+        one: Документ
         few:
         many:
-        other: "Документы"
-      applies_to_nations: "Применимо к"
+        other: Документы
+      applies_to_nations: Применимо к
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Объявление"
+        one: Объявление
         few:
         many:
-        other: "Объявления"
+        other: Объявления
       authored_article:
-        one: "Авторская статья"
+        one: Авторская статья
         few:
         many:
-        other: "Авторские статьи"
+        other: Авторские статьи
       blog_post:
         one:
         few:
         many:
         other:
       case_study:
-        one: "Ситуационный анализ"
+        one: Ситуационный анализ
         few:
         many:
-        other: "Ситуационные анализы"
+        other: Ситуационные анализы
       closed_consultation:
-        one: "Закрытая консультация"
+        one: Закрытая консультация
         few:
         many:
-        other: "Закрытые консультации"
+        other: Закрытые консультации
       consultation:
-        one: "Консультация"
+        one: Консультация
         few:
         many:
-        other: "Консультации"
+        other: Консультации
       consultation_outcome:
-        one: "Результат консультации"
+        one: Результат консультации
         few:
         many:
-        other: "Результаты консультаций"
+        other: Результаты консультаций
       corporate_report:
-        one: "Корпоративный отчет"
+        one: Корпоративный отчет
         few:
         many:
-        other: "Корпоративные отчеты"
+        other: Корпоративные отчеты
       correspondence:
-        one: "Корреспонденция"
+        one: Корреспонденция
         few:
         many:
-        other: "Корреспонденция"
+        other: Корреспонденция
       decision:
         one:
         few:
         many:
         other:
       detailed_guidance:
-        one: "Подробное руководство"
+        one: Подробное руководство
         few:
         many:
-        other: "Подробное руководство"
+        other: Подробное руководство
       document_collection:
-        one: "Серии"
+        one: Серии
         few:
         many:
         other:
       draft_text:
-        one: "Проект текста"
+        one: Проект текста
         few:
         many:
-        other: "Проект текстов"
+        other: Проект текстов
       foi_release:
-        one: "Свобода распространения информации "
+        one: 'Свобода распространения информации '
         few:
         many:
-        other: "Свобода распространения информации "
+        other: 'Свобода распространения информации '
       form:
-        one: "Форма"
+        one: Форма
         few:
         many:
-        other: "Формы"
+        other: Формы
       government_response:
-        one: "Ответ правительства"
+        one: Ответ правительства
         few:
         many:
-        other: "Ответы правительства"
+        other: Ответы правительства
       guidance:
-        one: "Руководство"
+        one: Руководство
         few:
         many:
-        other: "Руководство"
+        other: Руководство
       impact_assessment:
-        one: "Оценка воздействия"
+        one: Оценка воздействия
         few:
         many:
-        other: "Оценки воздействия"
+        other: Оценки воздействия
       imported:
-        one: "импортировано - тип ожидания"
+        one: импортировано - тип ожидания
         few:
         many:
-        other: "импортировано - тип ожидания"
+        other: импортировано - тип ожидания
       independent_report:
-        one: "Независимый отчет"
+        one: Независимый отчет
         few:
         many:
-        other: "Независимые отчеты"
+        other: Независимые отчеты
       international_treaty:
         one:
         few:
@@ -122,25 +122,25 @@ ru:
         many:
         other:
       map:
-        one: "Карта"
+        one: Карта
         few:
         many:
-        other: "Карты"
+        other: Карты
       national_statistics:
-        one: "Статистика - национальная статистика"
+        one: Статистика - национальная статистика
         few:
         many:
-        other: "Статистика - национальная статистика"
+        other: Статистика - национальная статистика
       news_article:
-        one: "Новостная статья"
+        one: Новостная статья
         few:
         many:
-        other: "Новостные статьи"
+        other: Новостные статьи
       news_story:
-        one: "Новостная заметка"
+        one: Новостная заметка
         few:
         many:
-        other: "Новостные заметки"
+        other: Новостные заметки
       nhs_content:
         one:
         few:
@@ -152,114 +152,114 @@ ru:
         many:
         other:
       official_statistics:
-        one: "Статистика"
+        one: Статистика
         few:
         many:
-        other: "Статистика"
+        other: Статистика
       open_consultation:
-        one: "Открытая консультация"
+        one: Открытая консультация
         few:
         many:
-        other: "Открытые консультации"
+        other: Открытые консультации
       oral_statement:
-        one: "Устное заявление парламенту"
+        one: Устное заявление парламенту
         few:
         many:
-        other: "Устные заявления парламенту"
+        other: Устные заявления парламенту
       policy_paper:
-        one: "Директивный документ"
+        one: Директивный документ
         few:
         many:
-        other: "Директивные документы"
+        other: Директивные документы
       press_release:
-        one: "Пресс-релиз"
+        one: Пресс-релиз
         few:
         many:
-        other: "Пресс-релизы"
+        other: Пресс-релизы
       promotional:
-        one: "Рекламный материал"
+        one: Рекламный материал
         few:
         many:
-        other: "Рекламные материалы"
+        other: Рекламные материалы
       publication:
-        one: "Публикация"
+        one: Публикация
         few:
         many:
-        other: "Публикации"
+        other: Публикации
       regulation:
         one:
         few:
         many:
         other:
       research:
-        one: "Исследования и аналитика"
+        one: Исследования и аналитика
         few:
         many:
-        other: "Исследования и аналитика"
+        other: Исследования и аналитика
       speaking_notes:
-        one: "Тезисы выступления"
+        one: Тезисы выступления
         few:
         many:
-        other: "Тезисы выступления"
+        other: Тезисы выступления
       speech:
-        one: "Текст выступления"
+        one: Текст выступления
         few:
         many:
-        other: "Тексты выступлений"
+        other: Тексты выступлений
       statement_to_parliament:
-        one: "Заявление парламенту"
+        one: Заявление парламенту
         few:
         many:
-        other: "Заявления парламенту"
+        other: Заявления парламенту
       statistical_data_set:
-        one: "Статистика"
+        one: Статистика
         few:
         many:
-        other: "Статистические данные"
+        other: Статистические данные
       statutory_guidance:
         one:
         few:
         many:
         other:
       transcript:
-        one: "Текст"
+        one: Текст
         few:
         many:
-        other: "Тексты"
+        other: Тексты
       transparency:
-        one: "Прозрачность данных"
+        one: Прозрачность данных
         few:
         many:
-        other: "Прозрачность данных"
+        other: Прозрачность данных
       world_news_story:
         one:
         few:
         many:
         other:
       written_statement:
-        one: "Письменное заявление парламенту"
+        one: Письменное заявление парламенту
         few:
         many:
-        other: "Письменные заявления парламенту"
+        other: Письменные заявления парламенту
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "Опубликовано"
-    read: "Прочитать статью %{title}"
+    published: Опубликовано
+    read: Прочитать статью %{title}
     speech:
       author_title:
-        minister: "Министр"
-        speaker: "Автор"
-      delivered_on: "Представлено в"
+        minister: Министр
+        speaker: Автор
+      delivered_on: Представлено в
       delivery_title:
-        minister: "Министр"
-        speaker: "Докладчик"
-      written_on: "Написано: "
-    updated: "обновлено"
-    view: "Просмотреть '%{title}'"
+        minister: Министр
+        speaker: Докладчик
+      written_on: 'Написано: '
+    updated: обновлено
+    view: Просмотреть '%{title}'
   people:
     heading:
       one:
@@ -287,25 +287,25 @@ ru:
   world_location:
     type:
       international_delegation:
-        one: "Международное представительство"
+        one: Международное представительство
         few:
         many:
-        other: "Международные представительства"
+        other: Международные представительства
       world_location:
-        one: "Место нахождения"
+        one: Место нахождения
         few:
         many:
-        other: "Места нахождения"
+        other: Места нахождения
     headings:
-      announcements: "Наши объявления"
-      country: "Страна"
-      documents: "Документы"
-      mission: "Наша цель"
-      organisations: "Организации"
-      publications: "Наши публикации"
-      quick_links: "Быстрые ссылки"
-      related_policies: "Публикации на схожие темы"
-      statistics: "Наша статистика"
+      announcements: Наши объявления
+      country: Страна
+      documents: Документы
+      mission: Наша цель
+      organisations: Организации
+      publications: Наши публикации
+      quick_links: Быстрые ссылки
+      related_policies: Публикации на схожие темы
+      statistics: Наша статистика
   activerecord:
     attributes:
       attachment:
@@ -350,19 +350,19 @@ ru:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Объявления"
+    heading: Объявления
     view_all:
   attachment:
     accessibility:
-      full_help_html: "Получить данный документ в ином формате (шрифт Брайля, аудиоформат)"
-      heading: "Данный документ может быть не доступен лицам, использующим вспомогательные
-        технологии"
-      request_a_different_format: "Получить в другом формате"
+      full_help_html: Получить данный документ в ином формате (шрифт Брайля, аудиоформат)
+      heading: Данный документ может быть не доступен лицам, использующим вспомогательные
+        технологии
+      request_a_different_format: Получить в другом формате
     headings:
-      order_a_copy: "Заказать копию"
-      order_a_copy_full: "Заказать копию публикации"
-      published: "Опубликовано"
-      reference: "Ссылка"
+      order_a_copy: Заказать копию
+      order_a_copy_full: Заказать копию публикации
+      published: Опубликовано
+      reference: Ссылка
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -380,8 +380,8 @@ ru:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Контактная форма"
-    email: "Электронный адрес"
+    contact_form: Контактная форма
+    email: Электронный адрес
   corporate_information_page:
     type:
       link_text:
@@ -396,44 +396,44 @@ ru:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Раздел личной информации"
+        personal_information_charter: Раздел личной информации
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "Схема публикации"
+        publication_scheme: Схема публикации
         recruitment:
         research:
-        social_media_use: "Использование социальных сетей"
+        social_media_use: Использование социальных сетей
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Выбор Уэльского языка"
+        welsh_language_scheme: Выбор Уэльского языка
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "Чтобы увидеть результаты, соответствующие Вашим требовниям, используйте
-      фильтры"
+    description: Чтобы увидеть результаты, соответствующие Вашим требовниям, используйте
+      фильтры
     no_results:
-      description: "Расширьте параметры поиска и попытайтесь еще раз"
-      title: "Соответствующих документов не найдено"
+      description: Расширьте параметры поиска и попытайтесь еще раз
+      title: Соответствующих документов не найдено
       tna_heading:
       tna_link:
     world_locations:
-      all: "Все места нахождения"
-      label: "Места нахождения"
+      all: Все места нахождения
+      label: Места нахождения
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Реестр активности"
+    latest_activity: Реестр активности
   i18n:
     direction: ltr
   language_names:
-    ru: "Русский"
+    ru: Русский
   latest_feed:
-    no_updates: "Обновлений нет"
-    title: "Последние новости"
+    no_updates: Обновлений нет
+    title: Последние новости
   national_statistics:
     heading:
   number:
@@ -442,119 +442,119 @@ ru:
         format: "%n%u"
   organisation:
     about:
-      read_more: "Читать далее о нашей деятельности"
+      read_more: Читать далее о нашей деятельности
     corporate_information:
-      access_our_info: "Доступ к нашей информации"
-      foi_how_to: "запрос  Свобода распространения информации"
-      foi_releases: "Свобода распространения информации "
-      jobs_and_contacts: "Рабочие места и контракты"
+      access_our_info: Доступ к нашей информации
+      foi_how_to: запрос  Свобода распространения информации
+      foi_releases: 'Свобода распространения информации '
+      jobs_and_contacts: Рабочие места и контракты
       organisation_chart:
-      transparency: "Данные о прозрачности"
+      transparency: Данные о прозрачности
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Наши главные профессиональные служащие"
-      contact: "Обратиться к %{name}"
-      corporate_information: "Корпоративная информация"
-      corporate_reports: "Корпоративные отчеты"
+      chief_professional_officers: Наши главные профессиональные служащие
+      contact: Обратиться к %{name}
+      corporate_information: Корпоративная информация
+      corporate_reports: Корпоративные отчеты
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Наши объявления"
+      our_announcements: Наши объявления
       our_consultations:
       our_judges:
-      our_management: "Наше руководство"
-      our_ministers: "Наши министры"
-      our_policies: "Наша политика"
-      our_publications: "Наши публикации"
-      our_senior_military_officials: "Наши старшие военные чиновники"
-      our_services: "Наши службы"
-      our_statistics: "Наша статистика"
-      our_topics: "Мы работаем над данными вопросами"
-      special_representatives: "Специальные преставители"
-      traffic_commissioners: "Сотрудники, Ответственные за транспортные перевозки"
-      what_we_do: "Чем мы занимаемся"
+      our_management: Наше руководство
+      our_ministers: Наши министры
+      our_policies: Наша политика
+      our_publications: Наши публикации
+      our_senior_military_officials: Наши старшие военные чиновники
+      our_services: Наши службы
+      our_statistics: Наша статистика
+      our_topics: Мы работаем над данными вопросами
+      special_representatives: Специальные преставители
+      traffic_commissioners: Сотрудники, Ответственные за транспортные перевозки
+      what_we_do: Чем мы занимаемся
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Политика"
+    heading: Политика
     view_all:
   publications:
-    heading: "Публикации"
+    heading: Публикации
     headings:
-      detail: "Детали"
-  read_more: "Подробнее"
+      detail: Детали
+  read_more: Подробнее
   see_all:
-    announcement: "Посмотреть все наши Объявления"
-    authored_article: "Посмотреть все наши Авторские статьи"
-    case_study: "Посмотреть все наши Ситуационные анализы"
-    closed_consultation: "Посмотреть все наши Закрытые консультации"
-    consultation: "Посмотреть все наши Консультации"
-    consultation_outcome: "Посмотреть все наши Результаты консультаций"
-    corporate_report: "Посмотреть все наши Корпоративные отчеты"
-    correspondence: "Посмотреть все наши Корреспонденция"
+    announcement: Посмотреть все наши Объявления
+    authored_article: Посмотреть все наши Авторские статьи
+    case_study: Посмотреть все наши Ситуационные анализы
+    closed_consultation: Посмотреть все наши Закрытые консультации
+    consultation: Посмотреть все наши Консультации
+    consultation_outcome: Посмотреть все наши Результаты консультаций
+    corporate_report: Посмотреть все наши Корпоративные отчеты
+    correspondence: Посмотреть все наши Корреспонденция
     decision:
-    detailed_guidance: "Посмотреть все наши Подробное руководство"
+    detailed_guidance: Посмотреть все наши Подробное руководство
     document_collection:
-    draft_text: "Посмотреть все наши Проект текстов"
-    fatality_notice: "Посмотреть все наши Уведомления о несчастных случаях"
-    foi_release: "Посмотреть все наши Свобода распространения информации "
-    form: "Посмотреть все наши Формы"
-    government_response: "Посмотреть все наши Ответы правительства"
-    guidance: "Посмотреть все наши Руководство"
-    impact_assessment: "Посмотреть все наши Оценки воздействия"
-    imported: "Посмотреть все наши импортировано - тип ожидания"
+    draft_text: Посмотреть все наши Проект текстов
+    fatality_notice: Посмотреть все наши Уведомления о несчастных случаях
+    foi_release: 'Посмотреть все наши Свобода распространения информации '
+    form: Посмотреть все наши Формы
+    government_response: Посмотреть все наши Ответы правительства
+    guidance: Посмотреть все наши Руководство
+    impact_assessment: Посмотреть все наши Оценки воздействия
+    imported: Посмотреть все наши импортировано - тип ожидания
     international_treaty:
-    map: "Посмотреть все наши Карты"
-    national_statistics: "Посмотреть все наши Статистика - национальная статистика"
-    news_article: "Посмотреть все наши Новостные статьи"
-    news_story: "Посмотреть все наши Новостные заметки"
+    map: Посмотреть все наши Карты
+    national_statistics: Посмотреть все наши Статистика - национальная статистика
+    news_article: Посмотреть все наши Новостные статьи
+    news_story: Посмотреть все наши Новостные заметки
     notice:
-    open_consultation: "Посмотреть все наши Открытые консультации"
-    oral_statement: "Посмотреть все наши Устные заявления парламенту"
-    policy: "Посмотреть все наши Политика"
-    policy_paper: "Посмотреть все наши Директивные документы"
-    press_release: "Посмотреть все наши Пресс-релизы"
-    promotional: "Посмотреть все наши Рекламные материалы"
-    publication: "Посмотреть все наши Публикации"
+    open_consultation: Посмотреть все наши Открытые консультации
+    oral_statement: Посмотреть все наши Устные заявления парламенту
+    policy: Посмотреть все наши Политика
+    policy_paper: Посмотреть все наши Директивные документы
+    press_release: Посмотреть все наши Пресс-релизы
+    promotional: Посмотреть все наши Рекламные материалы
+    publication: Посмотреть все наши Публикации
     regulation:
-    research: "Посмотреть все наши Исследования и аналитика"
-    speaking_notes: "Посмотреть все наши Тезисы выступления"
-    speech: "Посмотреть все наши Тексты выступлений"
-    statement_to_parliament: "Посмотреть все наши Заявления парламенту"
-    statistical_data_set: "Посмотреть все наши Статистические данные"
-    statistics: "Посмотреть все наши Статистика"
+    research: Посмотреть все наши Исследования и аналитика
+    speaking_notes: Посмотреть все наши Тезисы выступления
+    speech: Посмотреть все наши Тексты выступлений
+    statement_to_parliament: Посмотреть все наши Заявления парламенту
+    statistical_data_set: Посмотреть все наши Статистические данные
+    statistics: Посмотреть все наши Статистика
     statutory_guidance:
-    transcript: "Посмотреть все наши Тексты"
-    transparency: "Посмотреть все наши Прозрачность данных"
-    written_statement: "Посмотреть все наши Письменные заявления парламенту"
+    transcript: Посмотреть все наши Тексты
+    transparency: Посмотреть все наши Прозрачность данных
+    written_statement: Посмотреть все наши Письменные заявления парламенту
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "и"
+      last_word_connector: и
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "По %{link} объяснение о том, как мы обращаемся
-        с вашей личной информацией"
-      publication_scheme_html: "Прочитать информацию, которая обычно публикуется,
-        \ по указанной %{link}."
-      social_media_use_html: "Ознакомиться с нашей политикой по %{link}."
-      welsh_language_scheme_html: "Выяснить о наших обязательствах по публикации можно
-        по %{link}."
-    find_out_more: "Общая информация и контакты"
+      personal_information_charter_html: По %{link} объяснение о том, как мы обращаемся
+        с вашей личной информацией
+      publication_scheme_html: Прочитать информацию, которая обычно публикуется,  по
+        указанной %{link}.
+      social_media_use_html: Ознакомиться с нашей политикой по %{link}.
+      welsh_language_scheme_html: Выяснить о наших обязательствах по публикации можно
+        по %{link}.
+    find_out_more: Общая информация и контакты
     headings:
-      about_us: "О нас"
-      contact_us: "Связь с нами"
-      corporate_information: "Корпоративная информация"
-      follow_us: "Следите за нами"
-      our_people: "Наши сотрудники"
-      our_services: "Наши услуги"
-    location: "Расположение"
-    part_of: "Является частью"
+      about_us: О нас
+      contact_us: Связь с нами
+      corporate_information: Корпоративная информация
+      follow_us: Следите за нами
+      our_people: Наши сотрудники
+      our_services: Наши услуги
+    location: Расположение
+    part_of: Является частью

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -2,73 +2,73 @@ si:
   document:
     headings:
       attachments:
-        one: "ලේඛණය"
-        other: "ලේඛණ"
-      applies_to_nations: "අදාළ වන්නේ"
+        one: ලේඛණය
+        other: ලේඛණ
+      applies_to_nations: අදාළ වන්නේ
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "නිවේදනය"
-        other: "නිවේදන"
+        one: නිවේදනය
+        other: නිවේදන
       authored_article:
-        one: "රචිත ලිපිය  "
-        other: "රචිත ලිපි"
+        one: රචිත ලිපිය  
+        other: රචිත ලිපි
       blog_post:
         one:
         other:
       case_study:
-        one: "සිද්ධි අධ්යනයනය"
-        other: "සිද්ධීන්  අධ්යයයනය"
+        one: සිද්ධි අධ්යනයනය
+        other: සිද්ධීන්  අධ්යයයනය
       closed_consultation:
-        one: "සංවෘත මත විමසුම"
-        other: "සංවෘත"
+        one: සංවෘත මත විමසුම
+        other: සංවෘත
       consultation:
         one: " මත විමසුම"
-        other: "මත විමසුම්"
+        other: මත විමසුම්
       consultation_outcome:
-        one: "මත විමසුමේ ප්‍රතිපල"
-        other: "මත විමසුමේ ප්‍රතිපලයන්"
+        one: මත විමසුමේ ප්‍රතිපල
+        other: මත විමසුමේ ප්‍රතිපලයන්
       corporate_report:
-        one: "සංවිධාන වාර්තාව"
-        other: "සංවිධාන වාර්තා"
+        one: සංවිධාන වාර්තාව
+        other: සංවිධාන වාර්තා
       correspondence:
-        one: "ලිපි ගනුදෙනුව  "
-        other: "ලිපි ගනුදෙනු"
+        one: ලිපි ගනුදෙනුව  
+        other: ලිපි ගනුදෙනු
       decision:
         one:
         other:
       detailed_guidance:
-        one: "විස්තරාත්මක උපදෙස්"
-        other: "විස්තරාත්මක උපදෙස්"
+        one: විස්තරාත්මක උපදෙස්
+        other: විස්තරාත්මක උපදෙස්
       document_collection:
-        one: "කාණ්ඩය"
+        one: කාණ්ඩය
         other:
       draft_text:
-        one: "අශෝදිත වැකිය"
-        other: "අශෝදිත වැකි"
+        one: අශෝදිත වැකිය
+        other: අශෝදිත වැකි
       foi_release:
-        one: "එෆ්. ඉ. ඕ. දැන්වීම"
-        other: "එෆ්. ඉ. ඕ. දැන්වීම්"
+        one: එෆ්. ඉ. ඕ. දැන්වීම
+        other: එෆ්. ඉ. ඕ. දැන්වීම්
       form:
-        one: "පෝරමය"
-        other: "පෝරම"
+        one: පෝරමය
+        other: පෝරම
       government_response:
-        one: "ආණ්ඩුවේ ප්‍රතිචාරය"
-        other: "ආණ්ඩුවේ ප්‍රතිචාර"
+        one: ආණ්ඩුවේ ප්‍රතිචාරය
+        other: ආණ්ඩුවේ ප්‍රතිචාර
       guidance:
-        one: "උපදෙස්"
-        other: "උපදෙස්"
+        one: උපදෙස්
+        other: උපදෙස්
       impact_assessment:
-        one: "ප්‍රතිපල ඇගයීම"
-        other: "ප්‍රතිපල ඇගයීම්"
+        one: ප්‍රතිපල ඇගයීම
+        other: ප්‍රතිපල ඇගයීම්
       imported:
-        one: "ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න"
-        other: "ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න"
+        one: ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න
+        other: ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න
       independent_report:
-        one: "ස්වාධීන වාර්තාව"
-        other: "ස්වාධීන වාර්තා"
+        one: ස්වාධීන වාර්තාව
+        other: ස්වාධීන වාර්තා
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ si:
         one:
         other:
       map:
-        one: "සිතියම"
-        other: "සිතියම්"
+        one: සිතියම
+        other: සිතියම්
       national_statistics:
-        one: "සංඛ්යාන - ජාතික සංඛ්යාන"
-        other: "සංඛ්යාන - ජාතික සංඛ්යාන"
+        one: සංඛ්යාන - ජාතික සංඛ්යාන
+        other: සංඛ්යාන - ජාතික සංඛ්යාන
       news_article:
-        one: "පුවත් ලිපිය"
-        other: "පුවත් ලිපි"
+        one: පුවත් ලිපිය
+        other: පුවත් ලිපි
       news_story:
-        one: "පුවත් වාර්තාව"
-        other: "පුවත් වාර්තා"
+        one: පුවත් වාර්තාව
+        other: පුවත් වාර්තා
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ si:
         one:
         other:
       official_statistics:
-        one: "සංඛ්යාන"
-        other: "සංඛ්යාන"
+        one: සංඛ්යාන
+        other: සංඛ්යාන
       open_consultation:
-        one: "විවෘත මත විමසුම"
-        other: "විවෘත මත විමසුම්"
+        one: විවෘත මත විමසුම
+        other: විවෘත මත විමසුම්
       oral_statement:
         one: " පාර්ලිමේන්තුවේ වාචික ප්රුකාශය"
-        other: "පාර්ලිමේන්තුවේ වාචික ප්රේකාශ"
+        other: පාර්ලිමේන්තුවේ වාචික ප්රේකාශ
       policy_paper:
-        one: "ප්‍රතිපත්ති  ලිපිය"
-        other: "ප්‍රතිපත්ති  ලිපි"
+        one: ප්‍රතිපත්ති  ලිපිය
+        other: ප්‍රතිපත්ති  ලිපි
       press_release:
-        one: "මාධ්යි නිවේදනය"
-        other: "මාධ්යි නිවේදන"
+        one: මාධ්යි නිවේදනය
+        other: මාධ්යි නිවේදන
       promotional:
-        one: "ප්ර්චාරණ ද්රිච්ය"
-        other: "ප්ර්චාරණ ද්රිච්ය"
+        one: ප්ර්චාරණ ද්රිච්ය
+        other: ප්ර්චාරණ ද්රිච්ය
       publication:
-        one: "ප්ර්කාශනය"
-        other: "ප්ර්කාශන"
+        one: ප්ර්කාශනය
+        other: ප්ර්කාශන
       regulation:
         one:
         other:
       research:
-        one: "පර්යේෂණ සහ විශ්ලේෂණ"
-        other: "පර්යේෂණ සහ විශ්ලේෂණ"
+        one: පර්යේෂණ සහ විශ්ලේෂණ
+        other: පර්යේෂණ සහ විශ්ලේෂණ
       speaking_notes:
-        one: "දේශනයට අදාළ සටහන්"
-        other: "දේශනයට අදාළ සටහන්"
+        one: දේශනයට අදාළ සටහන්
+        other: දේශනයට අදාළ සටහන්
       speech:
-        one: "කථාව"
-        other: "කථා"
+        one: කථාව
+        other: කථා
       statement_to_parliament:
-        one: "පාර්ලිමේන්තුවට කල ප්‍රකාශය"
-        other: "පාර්ලිමේන්තුවට කල ප්‍රකාශ"
+        one: පාර්ලිමේන්තුවට කල ප්‍රකාශය
+        other: පාර්ලිමේන්තුවට කල ප්‍රකාශ
       statistical_data_set:
-        one: "සංඛ්යාන දත්ත සමූහය  "
-        other: "සංඛ්යාන දත්ත සමූහ"
+        one: සංඛ්යාන දත්ත සමූහය  
+        other: සංඛ්යාන දත්ත සමූහ
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "අනුපත"
+        one: අනුපත
         other: " අනුපත්"
       transparency:
-        one: "විනිවිධභාවයේ දත්ත"
-        other: "විනිවිධභාවයේ දත්ත"
+        one: විනිවිධභාවයේ දත්ත
+        other: විනිවිධභාවයේ දත්ත
       world_news_story:
         one:
         other:
       written_statement:
-        one: "පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශය"
-        other: "පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ"
+        one: පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශය
+        other: පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "පල කරන ලදී"
-    read: "ලිපිය  %{title} කියවන්න"
+    published: පල කරන ලදී
+    read: ලිපිය  %{title} කියවන්න
     speech:
       author_title:
-        minister: "අමාත්‍යවරයා"
-        speaker: "රචකයා"
-      delivered_on: "බෙදාහරින ලද දිනය"
+        minister: අමාත්‍යවරයා
+        speaker: රචකයා
+      delivered_on: බෙදාහරින ලද දිනය
       delivery_title:
-        minister: "අමාත්‍යවරයා"
-        speaker: "කතානායකවරයා"
-      written_on: "ලියන ලද දිනය:"
-    updated: "යාවත්කාලීන කල"
-    view: "බලන්න  '%{title}'"
+        minister: අමාත්‍යවරයා
+        speaker: කතානායකවරයා
+      written_on: 'ලියන ලද දිනය:'
+    updated: යාවත්කාලීන කල
+    view: බලන්න  '%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ si:
   world_location:
     type:
       international_delegation:
-        one: "ජාත්‍යන්තර කණ්ඩායම"
-        other: "ජාත්‍යන්තර කණ්ඩායම්"
+        one: ජාත්‍යන්තර කණ්ඩායම
+        other: ජාත්‍යන්තර කණ්ඩායම්
       world_location:
-        one: "ලෝක ස්ථානය"
-        other: "ලෝක ස්ථාන"
+        one: ලෝක ස්ථානය
+        other: ලෝක ස්ථාන
     headings:
-      announcements: "අපේ නිවේදන"
-      country: "රට"
-      documents: "ලේඛන"
-      mission: "අපේ මෙහෙවර ප්‍රකාශය"
-      organisations: "සංවිධාන"
-      publications: "අපේ ප්‍රකාශන"
-      quick_links: "ක්ෂණික සන්ධිය"
-      related_policies: "අදාල ප්‍රතිපත්තීන්"
-      statistics: "අපේ සංඛ්‍යා දත්ත"
+      announcements: අපේ නිවේදන
+      country: රට
+      documents: ලේඛන
+      mission: අපේ මෙහෙවර ප්‍රකාශය
+      organisations: සංවිධාන
+      publications: අපේ ප්‍රකාශන
+      quick_links: ක්ෂණික සන්ධිය
+      related_policies: අදාල ප්‍රතිපත්තීන්
+      statistics: අපේ සංඛ්‍යා දත්ත
   activerecord:
     attributes:
       attachment:
@@ -248,20 +248,20 @@ si:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "නිවේදන"
+    heading: නිවේදන
     view_all:
   attachment:
     accessibility:
       full_help_html: මෙම ලේඛනය බ්‍රේල්, ශබ්ද හෝ වෙනත් ආකාරයකින් ලබාගැනීමට  කරුණාකර
         විද්‍යුත් තැපැල් මගින් විමසන්න %{email} ඔබගේ ලිපිනය, දුරකථන අංකය සහ අවශ්‍ය
         ලේඛනයේ නම සමග  ("%{title}")%{references}.
-      heading: "විශේෂ තාක්ෂණික සහය භාවිතා කරන්නන්ට මෙම ලේඛනය සුදුසු නොවිය හැක"
-      request_a_different_format: "වෙනත් වර්ගයකින් ඉල්ලීමට"
+      heading: විශේෂ තාක්ෂණික සහය භාවිතා කරන්නන්ට මෙම ලේඛනය සුදුසු නොවිය හැක
+      request_a_different_format: වෙනත් වර්ගයකින් ඉල්ලීමට
     headings:
-      order_a_copy: "පිටපතක් ඇනවුම් කිරීමට"
-      order_a_copy_full: "ප්‍රකාශනයේ පිටපතක් ඇනවුම් කිරීමට"
-      published: "පල කරනලද"
-      reference: "අංකය"
+      order_a_copy: පිටපතක් ඇනවුම් කිරීමට
+      order_a_copy_full: ප්‍රකාශනයේ පිටපතක් ඇනවුම් කිරීමට
+      published: පල කරනලද
+      reference: අංකය
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -279,8 +279,8 @@ si:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "තොරතුරු පෝරමය"
-    email: "විද්‍යුත් තැපැල්"
+    contact_form: තොරතුරු පෝරමය
+    email: විද්‍යුත් තැපැල්
   corporate_information_page:
     type:
       link_text:
@@ -295,43 +295,43 @@ si:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "පුද්ගලික තොරතුරු ප්‍රඥප්තිය"
+        personal_information_charter: පුද්ගලික තොරතුරු ප්‍රඥප්තිය
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "මහජය පටිපාටිය"
+        publication_scheme: මහජය පටිපාටිය
         recruitment:
         research:
-        social_media_use: "සමාජ මාධ්‍ය භාවිතය"
+        social_media_use: සමාජ මාධ්‍ය භාවිතය
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "වේල්සයේ භාෂා පටිපාටිය"
+        welsh_language_scheme: වේල්සයේ භාෂා පටිපාටිය
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "ඔබේ රුචිකත්වයන්ට පමණක් ගැලපෙන ප්‍රතිපල ලබාගැනීමට පෙරනය භාවිතා කරන්න"
+    description: ඔබේ රුචිකත්වයන්ට පමණක් ගැලපෙන ප්‍රතිපල ලබාගැනීමට පෙරනය භාවිතා කරන්න
     no_results:
-      description: "ඔබගේ සෙවුම පුළුල් කර නැවත සොයන්න"
-      title: "ගැලපෙන ලේඛන කිසිවක් නැත"
+      description: ඔබගේ සෙවුම පුළුල් කර නැවත සොයන්න
+      title: ගැලපෙන ලේඛන කිසිවක් නැත
       tna_heading:
       tna_link:
     world_locations:
-      all: "සියලු ස්ථාන"
-      label: "ලෝක ස්ථාන"
+      all: සියලු ස්ථාන
+      label: ලෝක ස්ථාන
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "අලුත්ම ක්‍රියාකාරකම්"
+    latest_activity: අලුත්ම ක්‍රියාකාරකම්
   i18n:
     direction: ltr
   language_names:
-    si: "සිංහල"
+    si: සිංහල
   latest_feed:
-    no_updates: "අලුත් තොරතුරු නැත"
-    title: "අලුත්"
+    no_updates: අලුත් තොරතුරු නැත
+    title: අලුත්
   national_statistics:
     heading:
   number:
@@ -340,117 +340,117 @@ si:
         format: "%n%u"
   organisation:
     about:
-      read_more: "අපට කළහැකි දේ ගැන තව දුරටත් කියවන්න"
+      read_more: අපට කළහැකි දේ ගැන තව දුරටත් කියවන්න
     corporate_information:
-      access_our_info: "අපේ තොරතුරු වලට පිවිසෙන්න"
-      foi_how_to: "එෆ්.ඔ.ඉ. ඉල්ලීමක් කරන්නේ කෙසේද"
-      foi_releases: "එෆ්.ඔ.ඉ. තොරතුරු"
-      jobs_and_contacts: "රැකියා සහ කොන්තරාත්තු"
+      access_our_info: අපේ තොරතුරු වලට පිවිසෙන්න
+      foi_how_to: එෆ්.ඔ.ඉ. ඉල්ලීමක් කරන්නේ කෙසේද
+      foi_releases: එෆ්.ඔ.ඉ. තොරතුරු
+      jobs_and_contacts: රැකියා සහ කොන්තරාත්තු
       organisation_chart:
-      transparency: "විනිවිධභාවයේ දත්ත"
+      transparency: විනිවිධභාවයේ දත්ත
     foi_exemption_html:
     headings:
-      chief_professional_officers: "අපේ ප්‍රධාන වෘත්තීය නිලධාරීන්"
-      contact: "විස්තර %{name}"
-      corporate_information: "සංවිධානයේ තොරතුරු"
-      corporate_reports: "සංවිධානයේ වාර්තා"
+      chief_professional_officers: අපේ ප්‍රධාන වෘත්තීය නිලධාරීන්
+      contact: විස්තර %{name}
+      corporate_information: සංවිධානයේ තොරතුරු
+      corporate_reports: සංවිධානයේ වාර්තා
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "අපේ නිවේදන"
+      our_announcements: අපේ නිවේදන
       our_consultations:
       our_judges:
-      our_management: "අපේ කළමනාකරණය"
-      our_ministers: "අපේ ඇමතිවරුන්"
-      our_policies: "අපේ ප්‍රතිපත්ති"
-      our_publications: "අපේ ප්‍රකාශන"
-      our_senior_military_officials: "අපේ ජේෂ්ඨ හමුදා නිලධාරීන්"
-      our_services: "අපේ සේවාවන්"
-      our_statistics: "අපේ සංඛ්‍යා දත්ත"
-      our_topics: "අපි මෙම මාතෘකා ගැන වැඩ කරනවා"
-      special_representatives: "විශේෂ නියෝජිතයන්"
-      traffic_commissioners: "රථ වාහන කොමසාරිස්වරු"
-      what_we_do: "අපි කරන්නේ මොනවද"
+      our_management: අපේ කළමනාකරණය
+      our_ministers: අපේ ඇමතිවරුන්
+      our_policies: අපේ ප්‍රතිපත්ති
+      our_publications: අපේ ප්‍රකාශන
+      our_senior_military_officials: අපේ ජේෂ්ඨ හමුදා නිලධාරීන්
+      our_services: අපේ සේවාවන්
+      our_statistics: අපේ සංඛ්‍යා දත්ත
+      our_topics: අපි මෙම මාතෘකා ගැන වැඩ කරනවා
+      special_representatives: විශේෂ නියෝජිතයන්
+      traffic_commissioners: රථ වාහන කොමසාරිස්වරු
+      what_we_do: අපි කරන්නේ මොනවද
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "ප්‍රතිපත්ති"
+    heading: ප්‍රතිපත්ති
     view_all:
   publications:
-    heading: "ප්‍රකාශන"
+    heading: ප්‍රකාශන
     headings:
-      detail: "විස්තර"
-  read_more: "තව කියවන්න"
+      detail: විස්තර
+  read_more: තව කියවන්න
   see_all:
-    announcement: "අපගේ සියලු නිවේදන බලන්න"
-    authored_article: "අපගේ සියලු රචිත ලිපි බලන්න"
-    case_study: "අපගේ සියලු සිද්ධීන්  අධ්යයයනය බලන්න"
-    closed_consultation: "අපගේ සියලු සංවෘත බලන්න"
-    consultation: "අපගේ සියලු මත විමසුම් බලන්න"
-    consultation_outcome: "අපගේ සියලු මත විමසුමේ ප්‍රතිපලයන් බලන්න"
-    corporate_report: "අපගේ සියලු සංවිධාන වාර්තා බලන්න"
-    correspondence: "අපගේ සියලු ලිපි ගනුදෙනු බලන්න"
+    announcement: අපගේ සියලු නිවේදන බලන්න
+    authored_article: අපගේ සියලු රචිත ලිපි බලන්න
+    case_study: අපගේ සියලු සිද්ධීන්  අධ්යයයනය බලන්න
+    closed_consultation: අපගේ සියලු සංවෘත බලන්න
+    consultation: අපගේ සියලු මත විමසුම් බලන්න
+    consultation_outcome: අපගේ සියලු මත විමසුමේ ප්‍රතිපලයන් බලන්න
+    corporate_report: අපගේ සියලු සංවිධාන වාර්තා බලන්න
+    correspondence: අපගේ සියලු ලිපි ගනුදෙනු බලන්න
     decision:
-    detailed_guidance: "අපගේ සියලු විස්තරාත්මක උපදෙස් බලන්න"
+    detailed_guidance: අපගේ සියලු විස්තරාත්මක උපදෙස් බලන්න
     document_collection:
-    draft_text: "අපගේ සියලු අශෝදිත වැකි බලන්න"
-    fatality_notice: "අපගේ සියලු තීරණාත්මක  දැන්වීම් බලන්න"
-    foi_release: "අපගේ සියලු එෆ්. ඉ. ඕ. දැන්වීම් බලන්න"
-    form: "අපගේ සියලු පෝරම බලන්න"
-    government_response: "අපගේ සියලු ආණ්ඩුවේ ප්‍රතිචාර බලන්න"
-    guidance: "අපගේ සියලු උපදෙස් බලන්න"
-    impact_assessment: "අපගේ සියලු ප්‍රතිපල ඇගයීම් බලන්න"
-    imported: "අපගේ සියලු ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න බලන්න"
+    draft_text: අපගේ සියලු අශෝදිත වැකි බලන්න
+    fatality_notice: අපගේ සියලු තීරණාත්මක  දැන්වීම් බලන්න
+    foi_release: අපගේ සියලු එෆ්. ඉ. ඕ. දැන්වීම් බලන්න
+    form: අපගේ සියලු පෝරම බලන්න
+    government_response: අපගේ සියලු ආණ්ඩුවේ ප්‍රතිචාර බලන්න
+    guidance: අපගේ සියලු උපදෙස් බලන්න
+    impact_assessment: අපගේ සියලු ප්‍රතිපල ඇගයීම් බලන්න
+    imported: අපගේ සියලු ගෙන්වන ලද - ටයිප් කිරීමට මදක් ඉන්න බලන්න
     international_treaty:
-    map: "අපගේ සියලු සිතියම් බලන්න"
-    national_statistics: "අපගේ සියලු සංඛ්යාන - ජාතික සංඛ්යාන බලන්න"
-    news_article: "අපගේ සියලු පුවත් ලිපි බලන්න"
-    news_story: "අපගේ සියලු පුවත් වාර්තා බලන්න"
+    map: අපගේ සියලු සිතියම් බලන්න
+    national_statistics: අපගේ සියලු සංඛ්යාන - ජාතික සංඛ්යාන බලන්න
+    news_article: අපගේ සියලු පුවත් ලිපි බලන්න
+    news_story: අපගේ සියලු පුවත් වාර්තා බලන්න
     notice:
-    open_consultation: "අපගේ සියලු විවෘත මත විමසුම් බලන්න"
-    oral_statement: "අපගේ සියලු පාර්ලිමේන්තුවේ වාචික ප්රේකාශ බලන්න"
-    policy: "අපගේ සියලු ප්‍රතිපත්තීන් බලන්න"
-    policy_paper: "අපගේ සියලු ප්‍රතිපත්ති  ලිපි බලන්න"
-    press_release: "අපගේ සියලු මාධ්යි නිවේදන බලන්න"
-    promotional: "අපගේ සියලු ප්ර්චාරණ ද්රිච්ය බලන්න"
-    publication: "අපගේ සියලු ප්ර්කාශන බලන්න"
+    open_consultation: අපගේ සියලු විවෘත මත විමසුම් බලන්න
+    oral_statement: අපගේ සියලු පාර්ලිමේන්තුවේ වාචික ප්රේකාශ බලන්න
+    policy: අපගේ සියලු ප්‍රතිපත්තීන් බලන්න
+    policy_paper: අපගේ සියලු ප්‍රතිපත්ති  ලිපි බලන්න
+    press_release: අපගේ සියලු මාධ්යි නිවේදන බලන්න
+    promotional: අපගේ සියලු ප්ර්චාරණ ද්රිච්ය බලන්න
+    publication: අපගේ සියලු ප්ර්කාශන බලන්න
     regulation:
-    research: "අපගේ සියලු පර්යේෂණ සහ විශ්ලේෂණ බලන්න"
-    speaking_notes: "අපගේ සියලු දේශනයට අදාළ සටහන් බලන්න"
-    speech: "අපගේ සියලු කථා බලන්න"
-    statement_to_parliament: "අපගේ සියලු පාර්ලිමේන්තුවට කල ප්‍රකාශ බලන්න"
-    statistical_data_set: "අපගේ සියලු සංඛ්යාන දත්ත සමූහ බලන්න"
-    statistics: "අපගේ සියලු සංඛ්යාන බලන්න"
+    research: අපගේ සියලු පර්යේෂණ සහ විශ්ලේෂණ බලන්න
+    speaking_notes: අපගේ සියලු දේශනයට අදාළ සටහන් බලන්න
+    speech: අපගේ සියලු කථා බලන්න
+    statement_to_parliament: අපගේ සියලු පාර්ලිමේන්තුවට කල ප්‍රකාශ බලන්න
+    statistical_data_set: අපගේ සියලු සංඛ්යාන දත්ත සමූහ බලන්න
+    statistics: අපගේ සියලු සංඛ්යාන බලන්න
     statutory_guidance:
-    transcript: "අපගේ සියලු  අනුපත් බලන්න"
-    transparency: "අපගේ සියලු විනිවිධභාවයේ දත්ත බලන්න"
-    written_statement: "අපගේ සියලු පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ බලන්න"
+    transcript: අපගේ සියලු  අනුපත් බලන්න
+    transparency: අපගේ සියලු විනිවිධභාවයේ දත්ත බලන්න
+    written_statement: අපගේ සියලු පාර්ලිමේන්තුවට කල ලිඛිත ප්‍රකාශ බලන්න
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "සහ"
+      last_word_connector: සහ
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "ඔබගේ පුද්ගලික තොරතුරු භාවිතා කිරීම ගැන අපේ
-        %{link} පැහැදිලි කිරීම"
-      publication_scheme_html: "අප නිතර අපේ %{link} පල කරන තොරතුරු වර්ගයන් ගැන කියවන්න"
+      personal_information_charter_html: ඔබගේ පුද්ගලික තොරතුරු භාවිතා කිරීම ගැන අපේ
+        %{link} පැහැදිලි කිරීම
+      publication_scheme_html: අප නිතර අපේ %{link} පල කරන තොරතුරු වර්ගයන් ගැන කියවන්න
       social_media_use_html: " %{link}හිදී අපේ ප්‍රතිපත්ති කියවන්න"
       welsh_language_scheme_html: " %{link} හි පල කිරීමට අපේ ඇති කැපවීම ගැන කියවන්න"
-    find_out_more: "අපේ සම්පුර්ණ විස්තර සහ සම්බන්ධ වීමට අවශ්‍ය තොරතරු බලන්න"
+    find_out_more: අපේ සම්පුර්ණ විස්තර සහ සම්බන්ධ වීමට අවශ්‍ය තොරතරු බලන්න
     headings:
-      about_us: "අප ගැන"
-      contact_us: "අප හා සම්බන්ධවීමට"
-      corporate_information: "සංවිධානයේ තොරතුරු"
-      follow_us: "අප හා එක්වන්න"
-      our_people: "අපේ පිරිස"
-      our_services: "අපේ සේවාවන්"
-    location: "ස්ථානය"
+      about_us: අප ගැන
+      contact_us: අප හා සම්බන්ධවීමට
+      corporate_information: සංවිධානයේ තොරතුරු
+      follow_us: අප හා එක්වන්න
+      our_people: අපේ පිරිස
+      our_services: අපේ සේවාවන්
+    location: ස්ථානය
     part_of: " කොටසක්"

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -546,8 +546,8 @@ sr:
       about_our_services_html:
       personal_information_charter_html: "%{link} daje informacije o tome kako obrađujemo
         vaše lične podatke. "
-      publication_scheme_html: "Čitajte o tipovima informacija koje redovno objavljujemo
-        u  %{link}."
+      publication_scheme_html: Čitajte o tipovima informacija koje redovno objavljujemo
+        u  %{link}.
       social_media_use_html: Pročitajte o našoj politici prema  %{link}.
       welsh_language_scheme_html: Saznajte naš stav o objavljivanju u %{link}.
     find_out_more: 'Pogledajte pun profil i sve kontakt detalje '

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -3,72 +3,72 @@ ta:
     headings:
       attachments:
         one: " ஆவணம்"
-        other: "ஆவணங்கள்"
-      applies_to_nations: "பிரயோகமாகிறது"
+        other: ஆவணங்கள்
+      applies_to_nations: பிரயோகமாகிறது
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "அறிவிப்பு"
-        other: "அறிவிப்புகள்"
+        one: அறிவிப்பு
+        other: அறிவிப்புகள்
       authored_article:
         one: " எழுதப்பட்ட   கட்டுரை"
-        other: "எழுதப்பட்ட கட்டுரைகள்"
+        other: எழுதப்பட்ட கட்டுரைகள்
       blog_post:
         one:
         other:
       case_study:
-        one: "சம்பவ ஆய்வுக் கற்கை"
-        other: "சம்பவ ஆய்வுக் கற்கைகள்"
+        one: சம்பவ ஆய்வுக் கற்கை
+        other: சம்பவ ஆய்வுக் கற்கைகள்
       closed_consultation:
-        one: "வரையறுக்கப்பட்ட நிலையிலான கலந்தாலோசனை"
-        other: "வரையறுக்கப்பட்ட நிலையிலான  கலந்தாலோசனைகள்"
+        one: வரையறுக்கப்பட்ட நிலையிலான கலந்தாலோசனை
+        other: வரையறுக்கப்பட்ட நிலையிலான  கலந்தாலோசனைகள்
       consultation:
-        one: "கலந்தாலோசனை"
-        other: "கலந்தாலோசனைகள்"
+        one: கலந்தாலோசனை
+        other: கலந்தாலோசனைகள்
       consultation_outcome:
-        one: "கலந்தாலோசனையின் முடிவு"
-        other: "கலந்தாலோசனைப்முடிவுகள்"
+        one: கலந்தாலோசனையின் முடிவு
+        other: கலந்தாலோசனைப்முடிவுகள்
       corporate_report:
-        one: "கூட்டாண்மை அறிக்கை"
-        other: "கூட்டாண்மை அறிக்கைகள்"
+        one: கூட்டாண்மை அறிக்கை
+        other: கூட்டாண்மை அறிக்கைகள்
       correspondence:
-        one: "தொடர்பு"
-        other: "தொடர்புகள்"
+        one: தொடர்பு
+        other: தொடர்புகள்
       decision:
         one:
         other:
       detailed_guidance:
-        one: "விளக்கமான வழிகாட்டல்"
-        other: "விளக்கமான வழிகாட்டல்"
+        one: விளக்கமான வழிகாட்டல்
+        other: விளக்கமான வழிகாட்டல்
       document_collection:
-        one: "தொடர்"
+        one: தொடர்
         other:
       draft_text:
-        one: "வரைபு உரை"
-        other: "வரைபு உரைகள்"
+        one: வரைபு உரை
+        other: வரைபு உரைகள்
       foi_release:
-        one: "தகவலின் சுதந்திரமான  வெளியிடுதல்"
-        other: "தகவல்களின் சுதந்திரமான  வெளியிடுதல்கள்"
+        one: தகவலின் சுதந்திரமான  வெளியிடுதல்
+        other: தகவல்களின் சுதந்திரமான  வெளியிடுதல்கள்
       form:
-        one: "படிவம்"
-        other: "படிவங்கள்"
+        one: படிவம்
+        other: படிவங்கள்
       government_response:
-        one: "அரசாங்க பதிலிறுப்பு"
-        other: "அரசாங்க பதிலிறுப்புகள்"
+        one: அரசாங்க பதிலிறுப்பு
+        other: அரசாங்க பதிலிறுப்புகள்
       guidance:
-        one: "வழிகாட்டல்"
-        other: "வழிகாட்டல்"
+        one: வழிகாட்டல்
+        other: வழிகாட்டல்
       impact_assessment:
-        one: "தாக்க மதிப்பீடு"
-        other: "தாக்க மதிப்பீடுகள்"
+        one: தாக்க மதிப்பீடு
+        other: தாக்க மதிப்பீடுகள்
       imported:
-        one: "இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை"
-        other: "இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை"
+        one: இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை
+        other: இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை
       independent_report:
-        one: "சுயாதீன அறிக்கை"
-        other: "சுயாதீன அறிக்கைகள்"
+        one: சுயாதீன அறிக்கை
+        other: சுயாதீன அறிக்கைகள்
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ ta:
         one:
         other:
       map:
-        one: "வரைபடம்"
-        other: "வரைபடங்கள்"
+        one: வரைபடம்
+        other: வரைபடங்கள்
       national_statistics:
-        one: "புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்"
-        other: "புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்"
+        one: புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்
+        other: புள்ளிவிபரம் - தேசிய புள்ளிவிபரம்
       news_article:
-        one: "செய்திக் கட்டுரை"
-        other: "செய்திக் கட்டுரைகள்"
+        one: செய்திக் கட்டுரை
+        other: செய்திக் கட்டுரைகள்
       news_story:
-        one: "செய்திக் கதை"
-        other: "செய்திக் கதைகள்"
+        one: செய்திக் கதை
+        other: செய்திக் கதைகள்
       nhs_content:
         one:
         other:
@@ -94,78 +94,78 @@ ta:
         one:
         other:
       official_statistics:
-        one: "புள்ளிவிபரம்"
-        other: "புள்ளிவிபரம்"
+        one: புள்ளிவிபரம்
+        other: புள்ளிவிபரம்
       open_consultation:
-        one: "திறந்த கலந்தாலோசனை"
-        other: "திறந்த கலந்தாலோசனைகள்"
+        one: திறந்த கலந்தாலோசனை
+        other: திறந்த கலந்தாலோசனைகள்
       oral_statement:
-        one: "பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கை"
-        other: "பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கைகள்"
+        one: பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கை
+        other: பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கைகள்
       policy_paper:
-        one: "கொள்கைப் பத்திரம்"
-        other: "கொள்கைப் பத்திரங்கள்"
+        one: கொள்கைப் பத்திரம்
+        other: கொள்கைப் பத்திரங்கள்
       press_release:
-        one: "செய்தி வெளியீடு"
-        other: "செய்தி வெளியீடுகள்"
+        one: செய்தி வெளியீடு
+        other: செய்தி வெளியீடுகள்
       promotional:
-        one: "விளம்பர ஊக்குவிப்பு பொருள்"
-        other: "விளம்பர ஊக்குவிப்பு பொருள்"
+        one: விளம்பர ஊக்குவிப்பு பொருள்
+        other: விளம்பர ஊக்குவிப்பு பொருள்
       publication:
-        one: "பிரசுரம்"
-        other: "பிரசுரங்கள்"
+        one: பிரசுரம்
+        other: பிரசுரங்கள்
       regulation:
         one:
         other:
       research:
-        one: "ஆராய்ச்சி மற்றும் பகுப்பாய்தல்"
-        other: "ஆராய்ச்சி மற்றும் பகுப்பாய்தல்"
+        one: ஆராய்ச்சி மற்றும் பகுப்பாய்தல்
+        other: ஆராய்ச்சி மற்றும் பகுப்பாய்தல்
       speaking_notes:
-        one: "உரைக் குறிப்புகள்"
-        other: "உரைக் குறிப்புகள்"
+        one: உரைக் குறிப்புகள்
+        other: உரைக் குறிப்புகள்
       speech:
-        one: "உரை"
-        other: "உரைகள்"
+        one: உரை
+        other: உரைகள்
       statement_to_parliament:
-        one: "பாராளுமன்றத்துக்கான அறிக்கை"
-        other: "பாராளுமன்றத்துக்கான அறிக்கைகள்"
+        one: பாராளுமன்றத்துக்கான அறிக்கை
+        other: பாராளுமன்றத்துக்கான அறிக்கைகள்
       statistical_data_set:
-        one: "புள்ளிவிபர தரவுத் தொகுதி"
-        other: "புள்ளிவிபர தரவுத் தொகுதிகள்"
+        one: புள்ளிவிபர தரவுத் தொகுதி
+        other: புள்ளிவிபர தரவுத் தொகுதிகள்
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "உரை வடிவம்"
-        other: "உரை வடிவங்கள்"
+        one: உரை வடிவம்
+        other: உரை வடிவங்கள்
       transparency:
-        one: "வெளிப்படையான தரவு"
-        other: "வெளிப்படையான தரவு"
+        one: வெளிப்படையான தரவு
+        other: வெளிப்படையான தரவு
       world_news_story:
         one:
         other:
       written_statement:
-        one: "பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கை"
-        other: "பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்"
+        one: பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கை
+        other: பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "பிரசுரிக்கப்பட்டது"
-    read: "கட்டுரையின் %{title} வாசிக்கவும்"
+    published: பிரசுரிக்கப்பட்டது
+    read: கட்டுரையின் %{title} வாசிக்கவும்
     speech:
       author_title:
-        minister: "அமைச்சர்"
-        speaker: "எழுத்தாளர்"
-      delivered_on: "அன்று விநியோகிக்கப்பட்டது:"
+        minister: அமைச்சர்
+        speaker: எழுத்தாளர்
+      delivered_on: 'அன்று விநியோகிக்கப்பட்டது:'
       delivery_title:
-        minister: "அமைச்சர்"
-        speaker: "சபாநாயகர்"
-      written_on: "அன்று எழுதப்பட்டது:"
-    updated: "இற்றைப்படுத்தப்பட்டது"
-    view: "பார்வையிடுக '%{title}'"
+        minister: அமைச்சர்
+        speaker: சபாநாயகர்
+      written_on: 'அன்று எழுதப்பட்டது:'
+    updated: இற்றைப்படுத்தப்பட்டது
+    view: பார்வையிடுக '%{title}'
   people:
     heading:
       one:
@@ -189,21 +189,21 @@ ta:
   world_location:
     type:
       international_delegation:
-        one: "சர்வதேச தூதுக்குழு"
-        other: "சர்வதேச தூதுக்குழுக்கள்"
+        one: சர்வதேச தூதுக்குழு
+        other: சர்வதேச தூதுக்குழுக்கள்
       world_location:
-        one: "உலக அமைவிடம்"
-        other: "உலக அமைவிடங்கள்"
+        one: உலக அமைவிடம்
+        other: உலக அமைவிடங்கள்
     headings:
-      announcements: "எங்களது அறிவிப்புகள்"
-      country: "நாடு"
-      documents: "ஆவணங்கள்"
-      mission: "எங்களது இலட்சியம்"
-      organisations: "ஸ்தாபனங்கள்"
-      publications: "எங்களது வெளியீடுகள்"
-      quick_links: "விரைவான இணைப்புகள்"
-      related_policies: "சம்பந்தப்பட்ட கொள்கைகள்"
-      statistics: "எங்களது புள்ளிவிபரம்"
+      announcements: எங்களது அறிவிப்புகள்
+      country: நாடு
+      documents: ஆவணங்கள்
+      mission: எங்களது இலட்சியம்
+      organisations: ஸ்தாபனங்கள்
+      publications: எங்களது வெளியீடுகள்
+      quick_links: விரைவான இணைப்புகள்
+      related_policies: சம்பந்தப்பட்ட கொள்கைகள்
+      statistics: எங்களது புள்ளிவிபரம்
   activerecord:
     attributes:
       attachment:
@@ -248,7 +248,7 @@ ta:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "அறிவிப்பு"
+    heading: அறிவிப்பு
     view_all:
   attachment:
     accessibility:
@@ -256,14 +256,14 @@ ta:
         மாற்று வடிவில் இந்த ஆவணத்தை  வேண்டிக் கொள்வதற்கு  வெளியீட்டின் தலைப்புடன்
         ("%{title}")%{references} உங்களது முகவரி, தொலைபேசி இலக்கம் என்பவற்றையும்  குறிப்பிட்டு
         தயவுசெய்து மின்னஞ்சல் %{email} செய்யவும்.
-      heading: "விசேட  தேவை  கொண்டவர்களுக்கான உறுதுணை  தொழில்நுட்பத்தை உபயோகிப்பவர்களுக்கு
-        இந்தக்  கோவை பொருத்தமானதாக இல்லாதிருக்கலாம்."
-      request_a_different_format: "ஓர் வேறுபட்ட வடிவத்தை  வேண்டிக்கொள்ளுதல்"
+      heading: விசேட  தேவை  கொண்டவர்களுக்கான உறுதுணை  தொழில்நுட்பத்தை உபயோகிப்பவர்களுக்கு
+        இந்தக்  கோவை பொருத்தமானதாக இல்லாதிருக்கலாம்.
+      request_a_different_format: ஓர் வேறுபட்ட வடிவத்தை  வேண்டிக்கொள்ளுதல்
     headings:
-      order_a_copy: "பிரதியொன்றுக்கு கட்டளையிடுதல்"
-      order_a_copy_full: "வெளியீடு ஒன்றின் பிரதிக்கு கட்டளையிடுதல்"
-      published: "பிரசுரிக்கப்பட்டது"
-      reference: "குறிப்புரை"
+      order_a_copy: பிரதியொன்றுக்கு கட்டளையிடுதல்
+      order_a_copy_full: வெளியீடு ஒன்றின் பிரதிக்கு கட்டளையிடுதல்
+      published: பிரசுரிக்கப்பட்டது
+      reference: குறிப்புரை
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -281,8 +281,8 @@ ta:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "தொடர்புகொள்ளல் படிவம்"
-    email: "மின்னஞ்சல்"
+    contact_form: தொடர்புகொள்ளல் படிவம்
+    email: மின்னஞ்சல்
   corporate_information_page:
     type:
       link_text:
@@ -297,44 +297,44 @@ ta:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "தனிப்பட்ட தகவல் பட்டயம்"
+        personal_information_charter: தனிப்பட்ட தகவல் பட்டயம்
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "பிரசுரித்தல் திட்டம்"
+        publication_scheme: பிரசுரித்தல் திட்டம்
         recruitment:
         research:
-        social_media_use: "சமூக ஊடகப் பயன்பாடு"
+        social_media_use: சமூக ஊடகப் பயன்பாடு
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "வெல்ஷ் மொழித் திட்டம்"
+        welsh_language_scheme: வெல்ஷ் மொழித் திட்டம்
   date:
     formats:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "உங்களது &nbsp உடன் பொருந்தும் &nbsp பெறுபேறுகளைக் காண்பிப்பதற்கு
-      வடிகட்டிகளை நீங்கள் உபயோகிப்பதற்கு முடியும்."
+    description: உங்களது &nbsp உடன் பொருந்தும் &nbsp பெறுபேறுகளைக் காண்பிப்பதற்கு
+      வடிகட்டிகளை நீங்கள் உபயோகிப்பதற்கு முடியும்.
     no_results:
-      description: "உங்களது தேடல் எல்லையை நிர்ணயிப்பதற்கு முயற்சித்து மீண்டும் முயலவும்"
-      title: "பொருந்தும் வகையிலான ஆவணங்கள் அங்கில்லை"
+      description: உங்களது தேடல் எல்லையை நிர்ணயிப்பதற்கு முயற்சித்து மீண்டும் முயலவும்
+      title: பொருந்தும் வகையிலான ஆவணங்கள் அங்கில்லை
       tna_heading:
       tna_link:
     world_locations:
-      all: "அனைத்து அமைவிடங்களும்"
-      label: "உலக அமைவிடங்கள்"
+      all: அனைத்து அமைவிடங்களும்
+      label: உலக அமைவிடங்கள்
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "சமீபத்தைய நடவடிக்கை"
+    latest_activity: சமீபத்தைய நடவடிக்கை
   i18n:
     direction: ltr
   language_names:
-    ta: "தமிழ்"
+    ta: தமிழ்
   latest_feed:
-    no_updates: "இதுவரை இற்றைப்படுத்தல்கள் இல்லை"
-    title: "சமீபத்தையது"
+    no_updates: இதுவரை இற்றைப்படுத்தல்கள் இல்லை
+    title: சமீபத்தையது
   national_statistics:
     heading:
   number:
@@ -343,121 +343,121 @@ ta:
         format: "%n%u"
   organisation:
     about:
-      read_more: "நாங்கள் என்ன  செய்கிறோம் என்பது பற்றி கூடுதலாக வாசிக்கவும்"
+      read_more: நாங்கள் என்ன  செய்கிறோம் என்பது பற்றி கூடுதலாக வாசிக்கவும்
     corporate_information:
-      access_our_info: "எங்களது தகவல்களை மதிப்பிடவும்"
-      foi_how_to: "தகவல் சுதந்திரத்துக்கான வேண்டுகோளை எப்படி மேற்கொள்வது"
-      foi_releases: "தகவல் சுதந்திர  வெளியிடுதல்கள்"
-      jobs_and_contacts: "வேலைகள் மற்றும் ஒப்பந்தங்கள்"
+      access_our_info: எங்களது தகவல்களை மதிப்பிடவும்
+      foi_how_to: தகவல் சுதந்திரத்துக்கான வேண்டுகோளை எப்படி மேற்கொள்வது
+      foi_releases: தகவல் சுதந்திர  வெளியிடுதல்கள்
+      jobs_and_contacts: வேலைகள் மற்றும் ஒப்பந்தங்கள்
       organisation_chart:
-      transparency: "வெளிப்படையான தரவு"
+      transparency: வெளிப்படையான தரவு
     foi_exemption_html:
     headings:
-      chief_professional_officers: "எங்களது பிரதம தொழில்சார் தகைமை அதிகாரிகள்"
-      contact: "தொடர்பு %{name}"
-      corporate_information: "கூட்டாண்மைத் தகவல்"
-      corporate_reports: "கூட்டாண்மை அறிக்கைகள்"
+      chief_professional_officers: எங்களது பிரதம தொழில்சார் தகைமை அதிகாரிகள்
+      contact: தொடர்பு %{name}
+      corporate_information: கூட்டாண்மைத் தகவல்
+      corporate_reports: கூட்டாண்மை அறிக்கைகள்
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "எங்களது அறிவிப்புகள்"
+      our_announcements: எங்களது அறிவிப்புகள்
       our_consultations:
       our_judges:
-      our_management: "எங்களது முகாமைத்துவம்"
-      our_ministers: "எங்களது அமைச்சர்கள்"
-      our_policies: "எங்களது கொள்கைகள்"
-      our_publications: "எங்களது  வெளியீடுகள்"
-      our_senior_military_officials: "எங்களது சிரேஷ்ட இராணுவ அதிகாரிகள்"
-      our_services: "எங்களது  சேவைகள்"
-      our_statistics: "எங்களது புள்ளிவிபரம்"
-      our_topics: "இந்த விடயங்கள் மீது நாங்கள் செயலாற்றுகிறோம்"
-      special_representatives: "விசேட பிரதிநிதிகள்"
-      traffic_commissioners: "போக்குவரத்து ஆணையாளர்கள்"
-      what_we_do: "நாங்கள் செய்வது என்ன"
+      our_management: எங்களது முகாமைத்துவம்
+      our_ministers: எங்களது அமைச்சர்கள்
+      our_policies: எங்களது கொள்கைகள்
+      our_publications: எங்களது  வெளியீடுகள்
+      our_senior_military_officials: எங்களது சிரேஷ்ட இராணுவ அதிகாரிகள்
+      our_services: எங்களது  சேவைகள்
+      our_statistics: எங்களது புள்ளிவிபரம்
+      our_topics: இந்த விடயங்கள் மீது நாங்கள் செயலாற்றுகிறோம்
+      special_representatives: விசேட பிரதிநிதிகள்
+      traffic_commissioners: போக்குவரத்து ஆணையாளர்கள்
+      what_we_do: நாங்கள் செய்வது என்ன
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "கொள்கைகள்"
+    heading: கொள்கைகள்
     view_all:
   publications:
-    heading: "வெளியீடுகள்"
+    heading: வெளியீடுகள்
     headings:
-      detail: "விபரம்"
-  read_more: "மேலும் வாசிக்கவும்"
+      detail: விபரம்
+  read_more: மேலும் வாசிக்கவும்
   see_all:
-    announcement: "எங்களது அனைத்து அறிவிப்புகள் பார்க்கவும்"
-    authored_article: "எங்களது அனைத்து எழுதப்பட்ட கட்டுரைகள் பார்க்கவும்"
-    case_study: "எங்களது அனைத்து சம்பவ ஆய்வுக் கற்கைகள் பார்க்கவும்"
-    closed_consultation: "எங்களது அனைத்து வரையறுக்கப்பட்ட நிலையிலான  கலந்தாலோசனைகள்
-      பார்க்கவும்"
-    consultation: "எங்களது அனைத்து கலந்தாலோசனைகள் பார்க்கவும்"
-    consultation_outcome: "எங்களது அனைத்து கலந்தாலோசனைப்முடிவுகள் பார்க்கவும்"
-    corporate_report: "எங்களது அனைத்து கூட்டாண்மை அறிக்கைகள் பார்க்கவும்"
-    correspondence: "எங்களது அனைத்து தொடர்புகள் பார்க்கவும்"
+    announcement: எங்களது அனைத்து அறிவிப்புகள் பார்க்கவும்
+    authored_article: எங்களது அனைத்து எழுதப்பட்ட கட்டுரைகள் பார்க்கவும்
+    case_study: எங்களது அனைத்து சம்பவ ஆய்வுக் கற்கைகள் பார்க்கவும்
+    closed_consultation: எங்களது அனைத்து வரையறுக்கப்பட்ட நிலையிலான  கலந்தாலோசனைகள்
+      பார்க்கவும்
+    consultation: எங்களது அனைத்து கலந்தாலோசனைகள் பார்க்கவும்
+    consultation_outcome: எங்களது அனைத்து கலந்தாலோசனைப்முடிவுகள் பார்க்கவும்
+    corporate_report: எங்களது அனைத்து கூட்டாண்மை அறிக்கைகள் பார்க்கவும்
+    correspondence: எங்களது அனைத்து தொடர்புகள் பார்க்கவும்
     decision:
-    detailed_guidance: "எங்களது அனைத்து விளக்கமான வழிகாட்டல் பார்க்கவும்"
+    detailed_guidance: எங்களது அனைத்து விளக்கமான வழிகாட்டல் பார்க்கவும்
     document_collection:
-    draft_text: "எங்களது அனைத்து வரைபு உரைகள் பார்க்கவும்"
-    fatality_notice: "எங்களது அனைத்து இடர் அறிவித்தல்கள் பார்க்கவும்"
-    foi_release: "எங்களது அனைத்து தகவல்களின் சுதந்திரமான  வெளியிடுதல்கள் பார்க்கவும்"
-    form: "எங்களது அனைத்து படிவங்கள் பார்க்கவும்"
-    government_response: "எங்களது அனைத்து அரசாங்க பதிலிறுப்புகள் பார்க்கவும்"
-    guidance: "எங்களது அனைத்து வழிகாட்டல் பார்க்கவும்"
-    impact_assessment: "எங்களது அனைத்து தாக்க மதிப்பீடுகள் பார்க்கவும்"
-    imported: "எங்களது அனைத்து இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை பார்க்கவும்"
+    draft_text: எங்களது அனைத்து வரைபு உரைகள் பார்க்கவும்
+    fatality_notice: எங்களது அனைத்து இடர் அறிவித்தல்கள் பார்க்கவும்
+    foi_release: எங்களது அனைத்து தகவல்களின் சுதந்திரமான  வெளியிடுதல்கள் பார்க்கவும்
+    form: எங்களது அனைத்து படிவங்கள் பார்க்கவும்
+    government_response: எங்களது அனைத்து அரசாங்க பதிலிறுப்புகள் பார்க்கவும்
+    guidance: எங்களது அனைத்து வழிகாட்டல் பார்க்கவும்
+    impact_assessment: எங்களது அனைத்து தாக்க மதிப்பீடுகள் பார்க்கவும்
+    imported: எங்களது அனைத்து இறக்குமதி செய்யப்பட்ட - எதிர்பார்க்கும் வகை பார்க்கவும்
     international_treaty:
-    map: "எங்களது அனைத்து வரைபடங்கள் பார்க்கவும்"
-    national_statistics: "எங்களது அனைத்து புள்ளிவிபரம் - தேசிய புள்ளிவிபரம் பார்க்கவும்"
-    news_article: "எங்களது அனைத்து செய்திக் கட்டுரைகள் பார்க்கவும்"
-    news_story: "எங்களது அனைத்து செய்திக் கதைகள் பார்க்கவும்"
+    map: எங்களது அனைத்து வரைபடங்கள் பார்க்கவும்
+    national_statistics: எங்களது அனைத்து புள்ளிவிபரம் - தேசிய புள்ளிவிபரம் பார்க்கவும்
+    news_article: எங்களது அனைத்து செய்திக் கட்டுரைகள் பார்க்கவும்
+    news_story: எங்களது அனைத்து செய்திக் கதைகள் பார்க்கவும்
     notice:
-    open_consultation: "எங்களது அனைத்து திறந்த கலந்தாலோசனைகள் பார்க்கவும்"
-    oral_statement: "எங்களது அனைத்து பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கைகள் பார்க்கவும்"
-    policy: "எங்களது அனைத்து கொள்கைகள் பார்க்கவும்"
-    policy_paper: "எங்களது அனைத்து கொள்கைப் பத்திரங்கள் பார்க்கவும்"
-    press_release: "எங்களது அனைத்து செய்தி வெளியீடுகள் பார்க்கவும்"
-    promotional: "எங்களது அனைத்து விளம்பர ஊக்குவிப்பு பொருள் பார்க்கவும்"
-    publication: "எங்களது அனைத்து பிரசுரங்கள் பார்க்கவும்"
+    open_consultation: எங்களது அனைத்து திறந்த கலந்தாலோசனைகள் பார்க்கவும்
+    oral_statement: எங்களது அனைத்து பாராளுமன்றத்துக்கு வாய் மூலமான அறிக்கைகள் பார்க்கவும்
+    policy: எங்களது அனைத்து கொள்கைகள் பார்க்கவும்
+    policy_paper: எங்களது அனைத்து கொள்கைப் பத்திரங்கள் பார்க்கவும்
+    press_release: எங்களது அனைத்து செய்தி வெளியீடுகள் பார்க்கவும்
+    promotional: எங்களது அனைத்து விளம்பர ஊக்குவிப்பு பொருள் பார்க்கவும்
+    publication: எங்களது அனைத்து பிரசுரங்கள் பார்க்கவும்
     regulation:
-    research: "எங்களது அனைத்து ஆராய்ச்சி மற்றும் பகுப்பாய்தல் பார்க்கவும்"
-    speaking_notes: "எங்களது அனைத்து உரைக் குறிப்புகள் பார்க்கவும்"
-    speech: "எங்களது அனைத்து உரைகள் பார்க்கவும்"
-    statement_to_parliament: "எங்களது அனைத்து பாராளுமன்றத்துக்கான அறிக்கைகள் பார்க்கவும்"
-    statistical_data_set: "எங்களது அனைத்து புள்ளிவிபர தரவுத் தொகுதிகள் பார்க்கவும்"
-    statistics: "எங்களது அனைத்து புள்ளிவிபரம் பார்க்கவும்"
+    research: எங்களது அனைத்து ஆராய்ச்சி மற்றும் பகுப்பாய்தல் பார்க்கவும்
+    speaking_notes: எங்களது அனைத்து உரைக் குறிப்புகள் பார்க்கவும்
+    speech: எங்களது அனைத்து உரைகள் பார்க்கவும்
+    statement_to_parliament: எங்களது அனைத்து பாராளுமன்றத்துக்கான அறிக்கைகள் பார்க்கவும்
+    statistical_data_set: எங்களது அனைத்து புள்ளிவிபர தரவுத் தொகுதிகள் பார்க்கவும்
+    statistics: எங்களது அனைத்து புள்ளிவிபரம் பார்க்கவும்
     statutory_guidance:
-    transcript: "எங்களது அனைத்து உரை வடிவங்கள் பார்க்கவும்"
-    transparency: "எங்களது அனைத்து வெளிப்படையான தரவு பார்க்கவும்"
-    written_statement: "எங்களது அனைத்து பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்
-      பார்க்கவும்"
+    transcript: எங்களது அனைத்து உரை வடிவங்கள் பார்க்கவும்
+    transparency: எங்களது அனைத்து வெளிப்படையான தரவு பார்க்கவும்
+    written_statement: எங்களது அனைத்து பாராளுமன்றத்துக்கான எழுத்து மூலமான அறிக்கைகள்
+      பார்க்கவும்
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "மற்றும்"
+      last_word_connector: மற்றும்
   time:
     formats:
       long_ordinal: "%e %B %Y%H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "உங்களது தனிப்பட்ட தகவல்களை எப்படி நாங்கள்
-        கையாள்கிறோம் என்பதை எங்களது %{link} விளக்கும்"
-      publication_scheme_html: "எங்களது %{link} நாங்கள் வழமையாக வெளியிடும் தகவல்களின்
-        \ வகைகள் பற்றி வாசிக்கவும்"
-      social_media_use_html: "எங்களது  கொள்கையை %{link} இல் வாசிக்கவும்"
+      personal_information_charter_html: உங்களது தனிப்பட்ட தகவல்களை எப்படி நாங்கள்
+        கையாள்கிறோம் என்பதை எங்களது %{link} விளக்கும்
+      publication_scheme_html: எங்களது %{link} நாங்கள் வழமையாக வெளியிடும் தகவல்களின்  வகைகள்
+        பற்றி வாசிக்கவும்
+      social_media_use_html: எங்களது  கொள்கையை %{link} இல் வாசிக்கவும்
       welsh_language_scheme_html: "%{link} இல் பிரசுரிப்பதற்கான எங்களது பற்றுறுதி
         பற்றி கண்டறியவும்"
-    find_out_more: "முழுமையான விபரம் மற்றும்  அனைத்து தொடர்பு விபரங்களையும் காண்க"
+    find_out_more: முழுமையான விபரம் மற்றும்  அனைத்து தொடர்பு விபரங்களையும் காண்க
     headings:
-      about_us: "எங்களைப் பற்றி"
-      contact_us: "எங்களைத் தொடர்பு கொள்க"
-      corporate_information: "கூட்டாண்மைத் தகவல்"
-      follow_us: "எங்களைப் பின்பற்றுங்கள்"
-      our_people: "எங்களது மக்கள்"
-      our_services: "எங்களது சேவைகள்"
-    location: "அமைவிடம்"
-    part_of: "பகுதி"
+      about_us: எங்களைப் பற்றி
+      contact_us: எங்களைத் தொடர்பு கொள்க
+      corporate_information: கூட்டாண்மைத் தகவல்
+      follow_us: எங்களைப் பின்பற்றுங்கள்
+      our_people: எங்களது மக்கள்
+      our_services: எங்களது சேவைகள்
+    location: அமைவிடம்
+    part_of: பகுதி

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -43,19 +43,19 @@ th:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "ข่าวสาร"
+    heading: ข่าวสาร
     view_all:
   attachment:
     accessibility:
       full_help_html: ต้องการเอกสารในรูปแบบอื่นเช่นอักษรเบรลล์, ไฟล์เสียง หรือไฟล์ชนิดอื่น
         กรุณาอีเมล์%{email}พร้อมที่อยู่, เบอร์โทรศัพท์ และหัวข้อเอกสารที่ต้องการ("%{title}")%{references}.
-      heading: "ไฟล์นี้อาจไม่เหมาะสำหรับผู้ใช้เทคโนโลยี่อำนวยความสะดวก"
-      request_a_different_format: "ขอรูปแบบอื่น"
+      heading: ไฟล์นี้อาจไม่เหมาะสำหรับผู้ใช้เทคโนโลยี่อำนวยความสะดวก
+      request_a_different_format: ขอรูปแบบอื่น
     headings:
-      order_a_copy: "สั่งสำเนาหนึ่งชุด"
-      order_a_copy_full: "สั่งสำเนาเอกสารหนึ่งชุด"
-      published: "ตีพิมพ์"
-      reference: "อ้างอิง"
+      order_a_copy: สั่งสำเนาหนึ่งชุด
+      order_a_copy_full: สั่งสำเนาเอกสารหนึ่งชุด
+      published: ตีพิมพ์
+      reference: อ้างอิง
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -73,8 +73,8 @@ th:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "แบบฟอร์มการติดต่อ"
-    email: "อีเมล์"
+    contact_form: แบบฟอร์มการติดต่อ
+    email: อีเมล์
   corporate_information_page:
     type:
       link_text:
@@ -89,17 +89,17 @@ th:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "กฎบัตรข้อมูลส่วนบุคคล"
+        personal_information_charter: กฎบัตรข้อมูลส่วนบุคคล
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "โครงการสิ่งพิม์"
+        publication_scheme: โครงการสิ่งพิม์
         recruitment:
         research:
-        social_media_use: "การใช้สื่อสังคมออนล์"
+        social_media_use: การใช้สื่อสังคมออนล์
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "โครงการภาษาเวลช์"
+        welsh_language_scheme: โครงการภาษาเวลช์
   date:
     formats:
       default: "%d %B %Y"
@@ -112,85 +112,85 @@ th:
       published:
       updated:
     headings:
-      applies_to_nations: "นำไปใช้กับ"
+      applies_to_nations: นำไปใช้กับ
       attachments:
-        one: "เอกสาร"
-        other: "เอกสารต่างๆ"
+        one: เอกสาร
+        other: เอกสารต่างๆ
       from:
       location:
       part_of:
-    published: "ตีพิมพ์"
-    read: "อ่าน%{title}บทความ"
+    published: ตีพิมพ์
+    read: อ่าน%{title}บทความ
     speech:
       author_title:
-        minister: "รัฐมนตรี"
-        speaker: "ผู้เขียน"
-      delivered_on: "กล่าวเมื่อ"
+        minister: รัฐมนตรี
+        speaker: ผู้เขียน
+      delivered_on: กล่าวเมื่อ
       delivery_title:
-        minister: "รัฐมนตรี"
-        speaker: "ผู้กล่าว"
-      written_on: "เขียนเมือ"
+        minister: รัฐมนตรี
+        speaker: ผู้กล่าว
+      written_on: เขียนเมือ
     type:
       announcement:
-        one: "ข่าวสาร"
-        other: "ข่าวสาร"
+        one: ข่าวสาร
+        other: ข่าวสาร
       authored_article:
-        one: "บทความที่เขียน"
-        other: "บทความที่เขียน"
+        one: บทความที่เขียน
+        other: บทความที่เขียน
       blog_post:
         one:
         other:
       case_study:
-        one: "กรณีศึกษา"
-        other: "กรณีศึกษา"
+        one: กรณีศึกษา
+        other: กรณีศึกษา
       closed_consultation:
-        one: "การศึกษาแบบปิด"
-        other: "การศึกษาแบบปิด"
+        one: การศึกษาแบบปิด
+        other: การศึกษาแบบปิด
       consultation:
-        one: "การปรึกษา"
-        other: "การปรึกษา"
+        one: การปรึกษา
+        other: การปรึกษา
       consultation_outcome:
-        one: "ผลการปรึกษา"
-        other: "ผลการปรึกษา"
+        one: ผลการปรึกษา
+        other: ผลการปรึกษา
       corporate_report:
-        one: "รายงานบริษัท"
-        other: "รายงานบริษัท"
+        one: รายงานบริษัท
+        other: รายงานบริษัท
       correspondence:
-        one: "จดหมาย"
-        other: "จดหมาย"
+        one: จดหมาย
+        other: จดหมาย
       decision:
         one:
         other:
       detailed_guidance:
-        one: "คู่มือโดยละเอียด"
-        other: "คู่มือโดยละเอียด"
+        one: คู่มือโดยละเอียด
+        other: คู่มือโดยละเอียด
       document_collection:
-        one: "ตอน"
+        one: ตอน
         other:
       draft_text:
-        one: "ร่างข้อความ"
-        other: "ร่างข้อความ"
+        one: ร่างข้อความ
+        other: ร่างข้อความ
       foi_release:
-        one: "ข้อมูลที่เปิดเผยได้"
-        other: "ข้อมูลที่เปิดเผยได้"
+        one: ข้อมูลที่เปิดเผยได้
+        other: ข้อมูลที่เปิดเผยได้
       form:
-        one: "แบบฟอร์ม"
-        other: "แบบฟอร์ม"
+        one: แบบฟอร์ม
+        other: แบบฟอร์ม
       government_response:
-        one: "การตอบสนองของรัฐบาล"
-        other: "การตอบสนองของรัฐบาล"
+        one: การตอบสนองของรัฐบาล
+        other: การตอบสนองของรัฐบาล
       guidance:
-        one: "คู่มือ"
-        other: "คู่มือ"
+        one: คู่มือ
+        other: คู่มือ
       impact_assessment:
-        one: "การประเมินผลกระทบ"
-        other: "การประเมินผลกระทบ"
+        one: การประเมินผลกระทบ
+        other: การประเมินผลกระทบ
       imported:
-        one: "ประเภทรอนำเข้า"
-        other: "ประเภทรอนำเข้า"
+        one: ประเภทรอนำเข้า
+        other: ประเภทรอนำเข้า
       independent_report:
-        one: "รายงานอิสระ"
-        other: "รายงานอิสระ"
+        one: รายงานอิสระ
+        other: รายงานอิสระ
       international_treaty:
         one:
         other:
@@ -198,17 +198,17 @@ th:
         one:
         other:
       map:
-        one: "แผนที่"
-        other: "แผนที่"
+        one: แผนที่
+        other: แผนที่
       national_statistics:
-        one: "สถิติ-สถิติแห่งชาน"
-        other: "สถิติ-สถิติแห่งชาติ"
+        one: สถิติ-สถิติแห่งชาน
+        other: สถิติ-สถิติแห่งชาติ
       news_article:
-        one: "บทความข่าว"
-        other: "บทความข่าว"
+        one: บทความข่าว
+        other: บทความข่าว
       news_story:
-        one: "ข่าว"
-        other: "ข่าว"
+        one: ข่าว
+        other: ข่าว
       nhs_content:
         one:
         other:
@@ -216,83 +216,83 @@ th:
         one:
         other:
       official_statistics:
-        one: "สถิติ"
-        other: "สถิติ"
+        one: สถิติ
+        other: สถิติ
       open_consultation:
-        one: "การให้คำปรึกษาเปิด"
-        other: "การให้คำปรึกษาเปิด"
+        one: การให้คำปรึกษาเปิด
+        other: การให้คำปรึกษาเปิด
       oral_statement:
-        one: "แถลงการณ์ด้วยวาจาต่อรัฐสภา"
-        other: "แถลงการณ์ด้วยวาจาต่อรัฐสภา"
+        one: แถลงการณ์ด้วยวาจาต่อรัฐสภา
+        other: แถลงการณ์ด้วยวาจาต่อรัฐสภา
       policy_paper:
-        one: "เอกสารนโยบาย"
-        other: "เอกสารนโยบาย"
+        one: เอกสารนโยบาย
+        other: เอกสารนโยบาย
       press_release:
-        one: "ข่าวประชาสัมพันธ์"
-        other: "ข่าวประชาสัมพันธ์"
+        one: ข่าวประชาสัมพันธ์
+        other: ข่าวประชาสัมพันธ์
       promotional:
-        one: "เอกสารเพี่อการประชาสัมพันธ์"
-        other: "เอกสารเพือการประชาสัมพันธ์"
+        one: เอกสารเพี่อการประชาสัมพันธ์
+        other: เอกสารเพือการประชาสัมพันธ์
       publication:
-        one: "สิ่งพิมพ์"
-        other: "สิ่งพิมพ์"
+        one: สิ่งพิมพ์
+        other: สิ่งพิมพ์
       regulation:
         one:
         other:
       research:
-        one: "บทวิจัยและบทวิเคราะห์"
-        other: "บทวิจัยและบทวิเคราะห์"
+        one: บทวิจัยและบทวิเคราะห์
+        other: บทวิจัยและบทวิเคราะห์
       speaking_notes:
-        one: "ประเด็นการพูด"
-        other: "ประเด็นการพูด"
+        one: ประเด็นการพูด
+        other: ประเด็นการพูด
       speech:
-        one: "สุนทรพจน์"
-        other: "สุนทรพจน์"
+        one: สุนทรพจน์
+        other: สุนทรพจน์
       statement_to_parliament:
-        one: "แถลงการณ์ต่อรัฐสภา"
-        other: "แถลงการณ์ต่อรัฐสภา"
+        one: แถลงการณ์ต่อรัฐสภา
+        other: แถลงการณ์ต่อรัฐสภา
       statistical_data_set:
-        one: "ชุดข้อมูลสถิติ"
-        other: "ชุดข้อมูลสถิติ"
+        one: ชุดข้อมูลสถิติ
+        other: ชุดข้อมูลสถิติ
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "สำเนา"
-        other: "สำเนา"
+        one: สำเนา
+        other: สำเนา
       transparency:
-        one: "ข้อมูลโปร่งใส"
-        other: "ข้อมูลโปร่งใส"
+        one: ข้อมูลโปร่งใส
+        other: ข้อมูลโปร่งใส
       world_news_story:
         one:
         other:
       written_statement:
-        one: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
-        other: "แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
-    updated: "ปรับปรุง"
-    view: "ดู '%{title}'"
+        one: 'แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
+        other: 'แถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
+    updated: ปรับปรุง
+    view: ดู '%{title}'
   document_filters:
-    description: "คุณสามารถใช้เครื่องมือค้นหาเพื่อแสดงผลเฉพาะหัวข้อที่ตรงกับความสนใจของคุณ"
+    description: คุณสามารถใช้เครื่องมือค้นหาเพื่อแสดงผลเฉพาะหัวข้อที่ตรงกับความสนใจของคุณ
     no_results:
-      description: "ลองค้นหาอีกครั้งด้วยคำค้นหาที่กว้างขึ้น"
-      title: "ไม่มีเอกสารที่ตรงตามต้องการ"
+      description: ลองค้นหาอีกครั้งด้วยคำค้นหาที่กว้างขึ้น
+      title: ไม่มีเอกสารที่ตรงตามต้องการ
       tna_heading:
       tna_link:
     world_locations:
-      all: "ที่ตั้งทั้งหมด"
-      label: "ที่ตั้งทั่วโลก"
+      all: ที่ตั้งทั้งหมด
+      label: ที่ตั้งทั่วโลก
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "กิจกรรมล่าสุด"
+    latest_activity: กิจกรรมล่าสุด
   i18n:
     direction: ltr
   language_names:
-    th: "ไทย"
+    th: ไทย
   latest_feed:
-    no_updates: "ยังไม่มีการปรับปรุงข้อมูล"
-    title: "ล่าสุด"
+    no_updates: ยังไม่มีการปรับปรุงข้อมูล
+    title: ล่าสุด
   national_statistics:
     heading:
   number:
@@ -301,37 +301,37 @@ th:
         format: "%n%u"
   organisation:
     about:
-      read_more: "อ่านเพิ่มเติมเกี่ยวกับสิ่งที่เราทำ"
+      read_more: อ่านเพิ่มเติมเกี่ยวกับสิ่งที่เราทำ
     corporate_information:
-      access_our_info: "เข้าถึงข้อมูลของเรา"
-      foi_how_to: "การร้องขอเกี่ยวกับการเปิดเผยข้อมูล"
-      foi_releases: "ข้อมูลที่เปิดเผยได้"
-      jobs_and_contacts: "งานและการทำสัญญา"
+      access_our_info: เข้าถึงข้อมูลของเรา
+      foi_how_to: การร้องขอเกี่ยวกับการเปิดเผยข้อมูล
+      foi_releases: ข้อมูลที่เปิดเผยได้
+      jobs_and_contacts: งานและการทำสัญญา
       organisation_chart:
-      transparency: "ข้อมูลที่มีความโปร่งใส"
+      transparency: ข้อมูลที่มีความโปร่งใส
     foi_exemption_html:
     headings:
-      chief_professional_officers: "หัวหน้าผู้ชำนาญการ"
-      contact: "สัญญา %{name}"
-      corporate_information: "ข้อมูลบริษัท"
-      corporate_reports: "รายงานบริษัท"
+      chief_professional_officers: หัวหน้าผู้ชำนาญการ
+      contact: สัญญา %{name}
+      corporate_information: ข้อมูลบริษัท
+      corporate_reports: รายงานบริษัท
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "ข่าวสารของเรา"
+      our_announcements: ข่าวสารของเรา
       our_consultations:
       our_judges:
-      our_management: "การบริหารจัดการของเรา"
-      our_ministers: "รัฐมนตรีของเรา"
-      our_policies: "นโยบายของเรา"
-      our_publications: "สิ่งพิมพ์ของเรา"
-      our_senior_military_officials: "เจ้าหน้าที่ทหารอาวุโสของเรา"
-      our_services: "บริการของเรา"
-      our_statistics: "สถิติของเรา"
-      our_topics: "เราทำงานในห้วข้อเหล่านี้"
-      special_representatives: "ผู้แทนพิเศษ"
-      traffic_commissioners: "ผู้บัญชาการจราจร"
-      what_we_do: "สิ่งที่เราทำ"
+      our_management: การบริหารจัดการของเรา
+      our_ministers: รัฐมนตรีของเรา
+      our_policies: นโยบายของเรา
+      our_publications: สิ่งพิมพ์ของเรา
+      our_senior_military_officials: เจ้าหน้าที่ทหารอาวุโสของเรา
+      our_services: บริการของเรา
+      our_statistics: สถิติของเรา
+      our_topics: เราทำงานในห้วข้อเหล่านี้
+      special_representatives: ผู้แทนพิเศษ
+      traffic_commissioners: ผู้บัญชาการจราจร
+      what_we_do: สิ่งที่เราทำ
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -346,13 +346,13 @@ th:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "นโยบาย"
+    heading: นโยบาย
     view_all:
   publications:
-    heading: "สิ่งพิมพ์"
+    heading: สิ่งพิมพ์
     headings:
-      detail: "รายละเอียด"
-  read_more: "อ่านเพิ่มเติม"
+      detail: รายละเอียด
+  read_more: อ่านเพิ่มเติม
   roles:
     heading:
       one:
@@ -366,90 +366,90 @@ th:
     previous_holders:
     read_more:
   see_all:
-    announcement: "ดูทั้งหมดข่าวสาร"
-    authored_article: "ดูทั้งหมดบทความที่เขียน"
-    case_study: "ดูทั้งหมดกรณีศึกษา"
-    closed_consultation: "ดูทั้งหมดการศึกษาแบบปิด"
-    consultation: "ดูทั้งหมดการปรึกษา"
-    consultation_outcome: "ดูทั้งหมดผลการปรึกษา"
-    corporate_report: "ดูทั้งหมดรายงานบริษัท"
-    correspondence: "ดูทั้งหมดจดหมาย"
+    announcement: ดูทั้งหมดข่าวสาร
+    authored_article: ดูทั้งหมดบทความที่เขียน
+    case_study: ดูทั้งหมดกรณีศึกษา
+    closed_consultation: ดูทั้งหมดการศึกษาแบบปิด
+    consultation: ดูทั้งหมดการปรึกษา
+    consultation_outcome: ดูทั้งหมดผลการปรึกษา
+    corporate_report: ดูทั้งหมดรายงานบริษัท
+    correspondence: ดูทั้งหมดจดหมาย
     decision:
-    detailed_guidance: "ดูทั้งหมดคู่มือโดยละเอียด"
+    detailed_guidance: ดูทั้งหมดคู่มือโดยละเอียด
     document_collection:
-    draft_text: "ดูทั้งหมดร่างข้อความ"
-    fatality_notice: "ดูทั้งหมดการแจ้งมรณะกรรม"
-    foi_release: "ดูทั้งหมดข้อมูลที่เปิดเผยได้"
-    form: "ดูทั้งหมดแบบฟอร์ม"
-    government_response: "ดูทั้งหมดการตอบสนองของรัฐบาล"
-    guidance: "ดูทั้งหมดคู่มือ"
-    impact_assessment: "ดูทั้งหมดการประเมินผลกระทบ"
-    imported: "ดูทั้งหมดประเภทรอนำเข้า"
+    draft_text: ดูทั้งหมดร่างข้อความ
+    fatality_notice: ดูทั้งหมดการแจ้งมรณะกรรม
+    foi_release: ดูทั้งหมดข้อมูลที่เปิดเผยได้
+    form: ดูทั้งหมดแบบฟอร์ม
+    government_response: ดูทั้งหมดการตอบสนองของรัฐบาล
+    guidance: ดูทั้งหมดคู่มือ
+    impact_assessment: ดูทั้งหมดการประเมินผลกระทบ
+    imported: ดูทั้งหมดประเภทรอนำเข้า
     international_treaty:
-    map: "ดูทั้งหมดแผนที่"
-    national_statistics: "ดูทั้งหมดสถิติ-สถิติแห่งชาติ"
-    news_article: "ดูทั้งหมดบทความข่าว"
-    news_story: "ดูทั้งหมดข่าว"
+    map: ดูทั้งหมดแผนที่
+    national_statistics: ดูทั้งหมดสถิติ-สถิติแห่งชาติ
+    news_article: ดูทั้งหมดบทความข่าว
+    news_story: ดูทั้งหมดข่าว
     notice:
-    open_consultation: "ดูทั้งหมดการให้คำปรึกษาเปิด"
-    oral_statement: "ดูทั้งหมดแถลงการณ์ด้วยวาจาต่อรัฐสภา"
-    policy: "ดูทั้งหมดนโยบาย"
-    policy_paper: "ดูทั้งหมดเอกสารนโยบาย"
-    press_release: "ดูทั้งหมดข่าวประชาสัมพันธ์"
-    promotional: "ดูทั้งหมดเอกสารเพือการประชาสัมพันธ์"
-    publication: "ดูทั้งหมดสิ่งพิมพ์"
+    open_consultation: ดูทั้งหมดการให้คำปรึกษาเปิด
+    oral_statement: ดูทั้งหมดแถลงการณ์ด้วยวาจาต่อรัฐสภา
+    policy: ดูทั้งหมดนโยบาย
+    policy_paper: ดูทั้งหมดเอกสารนโยบาย
+    press_release: ดูทั้งหมดข่าวประชาสัมพันธ์
+    promotional: ดูทั้งหมดเอกสารเพือการประชาสัมพันธ์
+    publication: ดูทั้งหมดสิ่งพิมพ์
     regulation:
-    research: "ดูทั้งหมดบทวิจัยและบทวิเคราะห์"
-    speaking_notes: "ดูทั้งหมดประเด็นการพูด"
-    speech: "ดูทั้งหมดสุนทรพจน์"
-    statement_to_parliament: "ดูทั้งหมดแถลงการณ์ต่อรัฐสภา"
-    statistical_data_set: "ดูทั้งหมดชุดข้อมูลสถิติ"
-    statistics: "ดูทั้งหมดสถิติ"
+    research: ดูทั้งหมดบทวิจัยและบทวิเคราะห์
+    speaking_notes: ดูทั้งหมดประเด็นการพูด
+    speech: ดูทั้งหมดสุนทรพจน์
+    statement_to_parliament: ดูทั้งหมดแถลงการณ์ต่อรัฐสภา
+    statistical_data_set: ดูทั้งหมดชุดข้อมูลสถิติ
+    statistics: ดูทั้งหมดสถิติ
     statutory_guidance:
-    transcript: "ดูทั้งหมดสำเนา"
-    transparency: "ดูทั้งหมดข้อมูลโปร่งใส"
-    written_statement: "ดูทั้งหมดแถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา "
+    transcript: ดูทั้งหมดสำเนา
+    transparency: ดูทั้งหมดข้อมูลโปร่งใส
+    written_statement: 'ดูทั้งหมดแถลงการเป็นลายลักษณ์อักษรต่อรัฐสภา '
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "และ"
+      last_word_connector: และ
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "ข่าวสารของเรา"
-      country: "ประเทศ"
-      documents: "เอกสาร"
-      mission: "ภาระกิจของเรา"
-      organisations: "องค์กร"
-      publications: "สิ่งพิมพ์ของเรา"
-      quick_links: "ลิงค์ด่วน"
-      related_policies: "นโยบายที่เกี่ยวข้อง"
-      statistics: "สถิติของเรา"
+      announcements: ข่าวสารของเรา
+      country: ประเทศ
+      documents: เอกสาร
+      mission: ภาระกิจของเรา
+      organisations: องค์กร
+      publications: สิ่งพิมพ์ของเรา
+      quick_links: ลิงค์ด่วน
+      related_policies: นโยบายที่เกี่ยวข้อง
+      statistics: สถิติของเรา
     type:
       international_delegation:
-        one: "ผู้แทนนานาประเทศ"
-        other: "คณะผู้แทนนานาประเทศ"
+        one: ผู้แทนนานาประเทศ
+        other: คณะผู้แทนนานาประเทศ
       world_location:
-        one: "ที่ตั้ง"
-        other: "ทีตั้ง"
+        one: ที่ตั้ง
+        other: ทีตั้ง
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "ลิงค์นี้อธิบายถึงวิธีการที่เราปฏิบัติต่อข้อมูลส่วนบุคคลของคุณ"
-      publication_scheme_html: "อ่านประเภทข้อมูลซึ่งเราเผยแพร่เป็นประจำได้ที่ %{link}"
-      social_media_use_html: "อ่านนโยบายของเราได้ที่ %{link}"
-      welsh_language_scheme_html: "ค้นหาข้อมูลเกี่ยวกับพันธสัญญาในการตีพิมพ์ของเราได้ที่
-        %{link}."
-    find_out_more: "ดูรายละเอียดและข้อมูลการติดต่อทั้งหมด"
+      personal_information_charter_html: ลิงค์นี้อธิบายถึงวิธีการที่เราปฏิบัติต่อข้อมูลส่วนบุคคลของคุณ
+      publication_scheme_html: อ่านประเภทข้อมูลซึ่งเราเผยแพร่เป็นประจำได้ที่ %{link}
+      social_media_use_html: อ่านนโยบายของเราได้ที่ %{link}
+      welsh_language_scheme_html: ค้นหาข้อมูลเกี่ยวกับพันธสัญญาในการตีพิมพ์ของเราได้ที่
+        %{link}.
+    find_out_more: ดูรายละเอียดและข้อมูลการติดต่อทั้งหมด
     headings:
-      about_us: "เกี่ยวกับเรา"
-      contact_us: "ติดต่อเรา"
-      corporate_information: "ข้อมูลองค์กร"
-      follow_us: "ติดตามเรา"
-      our_people: "เจ้าหน้าที่ของเรา"
-      our_services: "บริการของเรา"
-    location: "ที่ตั้ง"
-    part_of: "ส่วนของ"
+      about_us: เกี่ยวกับเรา
+      contact_us: ติดต่อเรา
+      corporate_information: ข้อมูลองค์กร
+      follow_us: ติดตามเรา
+      our_people: เจ้าหน้าที่ของเรา
+      our_services: บริการของเรา
+    location: ที่ตั้ง
+    part_of: ส่วนของ

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -74,7 +74,7 @@ tr:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "İletişim Formu"
+    contact_form: İletişim Formu
     email: E-posta
   corporate_information_page:
     type:
@@ -142,8 +142,8 @@ tr:
         one:
         other:
       case_study:
-        one: "Örnek Olay"
-        other: "Örnek Olaylar"
+        one: Örnek Olay
+        other: Örnek Olaylar
       closed_consultation:
         one: Sona eren çalışmalar
         other: Sona eren çalışmalar
@@ -202,8 +202,8 @@ tr:
         one: Harita
         other: Haritalar
       national_statistics:
-        one: "İstatistikler - ulusal istatistikler"
-        other: "İstatistikler - ulusal istatistikler"
+        one: İstatistikler - ulusal istatistikler
+        other: İstatistikler - ulusal istatistikler
       news_article:
         one: Makale
         other: Makaleler
@@ -217,8 +217,8 @@ tr:
         one:
         other:
       official_statistics:
-        one: "İstatistikler"
-        other: "İstatistikler"
+        one: İstatistikler
+        other: İstatistikler
       open_consultation:
         one: Devam eden çalışma
         other: Devam eden çalışmalar
@@ -253,8 +253,8 @@ tr:
         one: Parlamento'ya yapılan açıklama
         other: Parlamento'ya yapılan açıklamalar
       statistical_data_set:
-        one: "İstatiksel veri setleri"
-        other: "İstatiksel veri setleri"
+        one: İstatiksel veri setleri
+        other: İstatiksel veri setleri
       statutory_guidance:
         one:
         other:
@@ -281,7 +281,7 @@ tr:
       tna_link:
     world_locations:
       all: Tüm yerler
-      label: "Ülkeler"
+      label: Ülkeler
   feeds:
     email:
     feed:
@@ -307,13 +307,13 @@ tr:
       access_our_info: Bilgilere erişim
       foi_how_to: Bilgi Edinme Hakkı nasıl kullanılır
       foi_releases: Bilgi Edinme Hakkı Raporu
-      jobs_and_contacts: "İş ve sözleşmeler"
+      jobs_and_contacts: İş ve sözleşmeler
       organisation_chart:
       transparency: Veri saydamlığı
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Üst düzey uzman "
-      contact: "İletişim %{name}"
+      chief_professional_officers: 'Üst düzey uzman '
+      contact: İletişim %{name}
       corporate_information: Kurumsal bilgi
       corporate_reports: Kurumsal raporlar
       documents:
@@ -328,9 +328,9 @@ tr:
       our_publications: Yayınlarımız
       our_senior_military_officials: Kıdemli askeri görevli
       our_services: Hizmetlerimiz
-      our_statistics: "İstatistikler"
+      our_statistics: İstatistikler
       our_topics: Bu konular üzerine çalışıyoruz
-      special_representatives: "Özel temsilciler"
+      special_representatives: Özel temsilciler
       traffic_commissioners: Trafik Şube Müdürü
       what_we_do: 'Hakkımızda '
       who_we_are:
@@ -421,21 +421,21 @@ tr:
   world_location:
     headings:
       announcements: Duyurularımız
-      country: "Ülke"
+      country: Ülke
       documents: Belgeler
       mission: Misyonumuz
       organisations: Organizasyon
       publications: Yayınlarımız
       quick_links: Kısa Yollar
-      related_policies: "İlgili politikalar"
-      statistics: "İstatistiklerimiz"
+      related_policies: İlgili politikalar
+      statistics: İstatistiklerimiz
     type:
       international_delegation:
         one: Uluslararası heyet
         other: Uluslararası heyetler
       world_location:
-        one: "Ülke "
-        other: "Ülkeler"
+        one: 'Ülke '
+        other: Ülkeler
   worldwide_organisation:
     corporate_information:
       about_our_services_html:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -2,115 +2,115 @@ uk:
   document:
     headings:
       attachments:
-        one: "Документ"
+        one: Документ
         few:
         many:
-        other: "Документи"
-      applies_to_nations: "Застосовується до"
+        other: Документи
+      applies_to_nations: Застосовується до
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "Оголошення"
+        one: Оголошення
         few:
         many:
-        other: "Оголошення"
+        other: Оголошення
       authored_article:
-        one: "Стаття"
+        one: Стаття
         few:
         many:
-        other: "Статті"
+        other: Статті
       blog_post:
         one:
         few:
         many:
         other:
       case_study:
-        one: "Тематичне дослідження"
+        one: Тематичне дослідження
         few:
         many:
-        other: "Тематичні дослідження"
+        other: Тематичні дослідження
       closed_consultation:
-        one: "Закрите обговорення"
+        one: Закрите обговорення
         few:
         many:
-        other: "Закриті обговорення"
+        other: Закриті обговорення
       consultation:
-        one: "Обговорення"
+        one: Обговорення
         few:
         many:
-        other: "Обговорення"
+        other: Обговорення
       consultation_outcome:
-        one: "Результат обговорення"
+        one: Результат обговорення
         few:
         many:
-        other: "Результати обговорення"
+        other: Результати обговорення
       corporate_report:
-        one: "Корпоративний звіт"
+        one: Корпоративний звіт
         few:
         many:
-        other: "Корпоративні звіти"
+        other: Корпоративні звіти
       correspondence:
-        one: "Кореспонденція"
+        one: Кореспонденція
         few:
         many:
-        other: "Кореспонденція"
+        other: Кореспонденція
       decision:
         one:
         few:
         many:
         other:
       detailed_guidance:
-        one: "Детальні інструкції"
+        one: Детальні інструкції
         few:
         many:
-        other: "Детальні інструкції"
+        other: Детальні інструкції
       document_collection:
-        one: "Серія"
+        one: Серія
         few:
         many:
         other:
       draft_text:
-        one: "Проект документу"
+        one: Проект документу
         few:
         many:
-        other: "Проекти документів"
+        other: Проекти документів
       foi_release:
-        one: "Відповідь на інформаційний запит"
+        one: Відповідь на інформаційний запит
         few:
         many:
-        other: "Відповіді на інформаційні запити "
+        other: 'Відповіді на інформаційні запити '
       form:
-        one: "Форма"
+        one: Форма
         few:
         many:
-        other: "Форми"
+        other: Форми
       government_response:
-        one: "Реакція уряду"
+        one: Реакція уряду
         few:
         many:
-        other: "Реакція уряду"
+        other: Реакція уряду
       guidance:
-        one: "Інструкції"
+        one: Інструкції
         few:
         many:
-        other: "Інструкції"
+        other: Інструкції
       impact_assessment:
-        one: "Оцінка впливу"
+        one: Оцінка впливу
         few:
         many:
-        other: "Оцінки впливу"
+        other: Оцінки впливу
       imported:
-        one: "імпортовано - в очікуванні"
+        one: імпортовано - в очікуванні
         few:
         many:
-        other: "імпортовано - в очікуванні"
+        other: імпортовано - в очікуванні
       independent_report:
-        one: "Незалежний звіт"
+        one: Незалежний звіт
         few:
         many:
-        other: "Незалежні звіти"
+        other: Незалежні звіти
       international_treaty:
         one:
         few:
@@ -122,25 +122,25 @@ uk:
         many:
         other:
       map:
-        one: "Мапа"
+        one: Мапа
         few:
         many:
-        other: "Мапи"
+        other: Мапи
       national_statistics:
-        one: "Статистика - національна статистика"
+        one: Статистика - національна статистика
         few:
         many:
-        other: "Статистика - національна статистика"
+        other: Статистика - національна статистика
       news_article:
-        one: "Стаття"
+        one: Стаття
         few:
         many:
-        other: "Статті"
+        other: Статті
       news_story:
-        one: "Новина"
+        one: Новина
         few:
         many:
-        other: "Новини"
+        other: Новини
       nhs_content:
         one:
         few:
@@ -152,114 +152,114 @@ uk:
         many:
         other:
       official_statistics:
-        one: "Статистика"
+        one: Статистика
         few:
         many:
-        other: "Статистика"
+        other: Статистика
       open_consultation:
-        one: "Відкрите обговорення"
+        one: Відкрите обговорення
         few:
         many:
-        other: "Відкриті обговорення"
+        other: Відкриті обговорення
       oral_statement:
-        one: "Усна заява у парламенті"
+        one: Усна заява у парламенті
         few:
         many:
-        other: "Усні заяви у парламенті"
+        other: Усні заяви у парламенті
       policy_paper:
-        one: "Програмний документ"
+        one: Програмний документ
         few:
         many:
-        other: "Програмні документи"
+        other: Програмні документи
       press_release:
-        one: "Прес-реліз"
+        one: Прес-реліз
         few:
         many:
-        other: "Прес-релізи"
+        other: Прес-релізи
       promotional:
-        one: "Інформаційний матеріал"
+        one: Інформаційний матеріал
         few:
         many:
-        other: "Інформаційний матеріал"
+        other: Інформаційний матеріал
       publication:
-        one: "Публікація"
+        one: Публікація
         few:
         many:
-        other: "Публікації"
+        other: Публікації
       regulation:
         one:
         few:
         many:
         other:
       research:
-        one: "Дослідження та аналіз"
+        one: Дослідження та аналіз
         few:
         many:
-        other: "Дослідження та аналіз"
+        other: Дослідження та аналіз
       speaking_notes:
-        one: "Тези для промови"
+        one: Тези для промови
         few:
         many:
-        other: "Тези для промови"
+        other: Тези для промови
       speech:
-        one: "Промова"
+        one: Промова
         few:
         many:
-        other: "Промови"
+        other: Промови
       statement_to_parliament:
-        one: "Заява у парламенті"
+        one: Заява у парламенті
         few:
         many:
-        other: "Заяви у парламенті"
+        other: Заяви у парламенті
       statistical_data_set:
-        one: "Набір статистичних даних"
+        one: Набір статистичних даних
         few:
         many:
-        other: "Набори статистичних даних"
+        other: Набори статистичних даних
       statutory_guidance:
         one:
         few:
         many:
         other:
       transcript:
-        one: "Транскрипт"
+        one: Транскрипт
         few:
         many:
-        other: "Транскрипти"
+        other: Транскрипти
       transparency:
-        one: "Прозорість інформації"
+        one: Прозорість інформації
         few:
         many:
-        other: "Прозорість інформації"
+        other: Прозорість інформації
       world_news_story:
         one:
         few:
         many:
         other:
       written_statement:
-        one: "Письмова заява у парламенті"
+        one: Письмова заява у парламенті
         few:
         many:
-        other: "Письмові заяви у парламенті"
+        other: Письмові заяви у парламенті
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "опубліковано"
-    read: "Читати %{title} статтю"
+    published: опубліковано
+    read: Читати %{title} статтю
     speech:
       author_title:
-        minister: "Міністр"
-        speaker: "Автор"
-      delivered_on: "Виголошено"
+        minister: Міністр
+        speaker: Автор
+      delivered_on: Виголошено
       delivery_title:
-        minister: "Міністр"
-        speaker: "Промовець"
-      written_on: "Написано"
-    updated: "оновлено"
-    view: "Переглянути"
+        minister: Міністр
+        speaker: Промовець
+      written_on: Написано
+    updated: оновлено
+    view: Переглянути
   people:
     heading:
       one:
@@ -287,25 +287,25 @@ uk:
   world_location:
     type:
       international_delegation:
-        one: "Міжнародна делегація"
+        one: Міжнародна делегація
         few:
         many:
-        other: "Міжнародні делегації"
+        other: Міжнародні делегації
       world_location:
-        one: "Країна"
+        one: Країна
         few:
         many:
-        other: "Країни"
+        other: Країни
     headings:
-      announcements: "Наші оголошення"
-      country: "Країна"
-      documents: "Документи"
-      mission: "Наша місія"
-      organisations: "Організації"
-      publications: "Наші публікації"
-      quick_links: "Короткі посилання"
-      related_policies: "Подібні документи"
-      statistics: "Наша статистика"
+      announcements: Наші оголошення
+      country: Країна
+      documents: Документи
+      mission: Наша місія
+      organisations: Організації
+      publications: Наші публікації
+      quick_links: Короткі посилання
+      related_policies: Подібні документи
+      statistics: Наша статистика
   activerecord:
     attributes:
       attachment:
@@ -350,19 +350,19 @@ uk:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "Оголошення"
+    heading: Оголошення
     view_all:
   attachment:
     accessibility:
       full_help_html: Щоб запросити цей документ в іншому форматі, наприклад, шрифтом
         Брайля, аудіо тощо, будь ласка, напишіть на електронну пошту %{email}, зазначивши
         Вашу адресу, номер телефону та назву публікації ("%{title}")%{references}.
-      heading: "Цей файл може не бути прийнятним для користувачів допоміжних технологій."
-      request_a_different_format: "Запросити інший формат"
+      heading: Цей файл може не бути прийнятним для користувачів допоміжних технологій.
+      request_a_different_format: Запросити інший формат
     headings:
-      order_a_copy: "Замовити примірник"
-      order_a_copy_full: "Замовити примірник публікації"
-      published: "Опубліковано"
+      order_a_copy: Замовити примірник
+      order_a_copy_full: Замовити примірник публікації
+      published: Опубліковано
       reference: Ref
       unnumbered_command_paper:
       unnumbered_hoc_paper:
@@ -381,8 +381,8 @@ uk:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "Форма зворотнього зв'язку"
-    email: "Електронна пошта"
+    contact_form: Форма зворотнього зв'язку
+    email: Електронна пошта
   corporate_information_page:
     type:
       link_text:
@@ -397,44 +397,44 @@ uk:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "Персональна інформація"
+        personal_information_charter: Персональна інформація
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "План публікацій"
+        publication_scheme: План публікацій
         recruitment:
         research:
-        social_media_use: "Використання соціальних медіа"
+        social_media_use: Використання соціальних медіа
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "Програма збереження валійської мови"
+        welsh_language_scheme: Програма збереження валійської мови
   date:
     formats:
       default:
       long_ordinal:
   document_filters:
-    description: "Ви можете скористатись фільтрами для отримання тільки тих результатів,
-      що відповідають Вашому запиту"
+    description: Ви можете скористатись фільтрами для отримання тільки тих результатів,
+      що відповідають Вашому запиту
     no_results:
-      description: "Спробуйте розширити параметри пошуку та повторіть пошук."
-      title: "Документів не знайдено."
+      description: Спробуйте розширити параметри пошуку та повторіть пошук.
+      title: Документів не знайдено.
       tna_heading:
       tna_link:
     world_locations:
-      all: "Будь-яке місце"
-      label: "Країна"
+      all: Будь-яке місце
+      label: Країна
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "Останні новини"
+    latest_activity: Останні новини
   i18n:
     direction: ltr
   language_names:
-    uk: "Українська"
+    uk: Українська
   latest_feed:
-    no_updates: "Оновлень поки що немає."
-    title: "Останні новини"
+    no_updates: Оновлень поки що немає.
+    title: Останні новини
   national_statistics:
     heading:
   number:
@@ -443,119 +443,119 @@ uk:
         format:
   organisation:
     about:
-      read_more: "Читати далі про нашу діяльність"
+      read_more: Читати далі про нашу діяльність
     corporate_information:
-      access_our_info: "Доступ до нашої інформації"
-      foi_how_to: "Як зробити інформаційний запит"
-      foi_releases: "Відповіді на інформаційні запити "
-      jobs_and_contacts: "Вакансії та контракти"
+      access_our_info: Доступ до нашої інформації
+      foi_how_to: Як зробити інформаційний запит
+      foi_releases: 'Відповіді на інформаційні запити '
+      jobs_and_contacts: Вакансії та контракти
       organisation_chart:
-      transparency: "Прозорість інформації"
+      transparency: Прозорість інформації
     foi_exemption_html:
     headings:
-      chief_professional_officers: "Наші головні спеціалісти"
-      contact: "Контактна особа  %{name}"
-      corporate_information: "Корпоративна інформація"
-      corporate_reports: "Корпоративні звіти"
+      chief_professional_officers: Наші головні спеціалісти
+      contact: Контактна особа  %{name}
+      corporate_information: Корпоративна інформація
+      corporate_reports: Корпоративні звіти
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "Наші оголошення"
+      our_announcements: Наші оголошення
       our_consultations:
       our_judges:
-      our_management: "Наше керівництво"
-      our_ministers: "Наші міністри"
-      our_policies: "Наша політика"
-      our_publications: "Наші публікації"
-      our_senior_military_officials: "Наші старші військові керівники"
-      our_services: "Наші послуги"
-      our_statistics: "Наша статистика"
-      our_topics: "Ми працюємо над цими темами"
-      special_representatives: "Спеціальні представники"
-      traffic_commissioners: "Уповноважені з питань транспорту"
-      what_we_do: "Що ми робимо"
+      our_management: Наше керівництво
+      our_ministers: Наші міністри
+      our_policies: Наша політика
+      our_publications: Наші публікації
+      our_senior_military_officials: Наші старші військові керівники
+      our_services: Наші послуги
+      our_statistics: Наша статистика
+      our_topics: Ми працюємо над цими темами
+      special_representatives: Спеціальні представники
+      traffic_commissioners: Уповноважені з питань транспорту
+      what_we_do: Що ми робимо
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "Політика"
+    heading: Політика
     view_all:
   publications:
-    heading: "Публікації"
+    heading: Публікації
     headings:
-      detail: "Деталі"
-  read_more: "Читати далі"
+      detail: Деталі
+  read_more: Читати далі
   see_all:
-    announcement: "Дивіться всі наші Оголошення"
-    authored_article: "Дивіться всі наші Статті"
-    case_study: "Дивіться всі наші Тематичні дослідження"
-    closed_consultation: "Дивіться всі наші Закриті обговорення"
-    consultation: "Дивіться всі наші Обговорення"
-    consultation_outcome: "Дивіться всі наші Результати обговорення"
-    corporate_report: "Дивіться всі наші Корпоративні звіти"
-    correspondence: "Дивіться всі наші Кореспонденція"
+    announcement: Дивіться всі наші Оголошення
+    authored_article: Дивіться всі наші Статті
+    case_study: Дивіться всі наші Тематичні дослідження
+    closed_consultation: Дивіться всі наші Закриті обговорення
+    consultation: Дивіться всі наші Обговорення
+    consultation_outcome: Дивіться всі наші Результати обговорення
+    corporate_report: Дивіться всі наші Корпоративні звіти
+    correspondence: Дивіться всі наші Кореспонденція
     decision:
-    detailed_guidance: "Дивіться всі наші Детальні інструкції"
+    detailed_guidance: Дивіться всі наші Детальні інструкції
     document_collection:
-    draft_text: "Дивіться всі наші Проекти документів"
-    fatality_notice: "Дивіться всі наші Повідомлення про смерть"
-    foi_release: "Дивіться всі наші Відповіді на інформаційні запити "
-    form: "Дивіться всі наші Форми"
-    government_response: "Дивіться всі наші Реакція уряду"
-    guidance: "Дивіться всі наші Інструкції"
-    impact_assessment: "Дивіться всі наші Оцінки впливу"
-    imported: "Дивіться всі наші імпортовано - в очікуванні"
+    draft_text: Дивіться всі наші Проекти документів
+    fatality_notice: Дивіться всі наші Повідомлення про смерть
+    foi_release: 'Дивіться всі наші Відповіді на інформаційні запити '
+    form: Дивіться всі наші Форми
+    government_response: Дивіться всі наші Реакція уряду
+    guidance: Дивіться всі наші Інструкції
+    impact_assessment: Дивіться всі наші Оцінки впливу
+    imported: Дивіться всі наші імпортовано - в очікуванні
     international_treaty:
-    map: "Дивіться всі наші Мапи"
-    national_statistics: "Дивіться всі наші Статистика - національна статистика"
-    news_article: "Дивіться всі наші Статті"
-    news_story: "Дивіться всі наші Новини"
+    map: Дивіться всі наші Мапи
+    national_statistics: Дивіться всі наші Статистика - національна статистика
+    news_article: Дивіться всі наші Статті
+    news_story: Дивіться всі наші Новини
     notice:
-    open_consultation: "Дивіться всі наші Відкриті обговорення"
-    oral_statement: "Дивіться всі наші Усні заяви у парламенті"
-    policy: "Дивіться всі наші Політики"
-    policy_paper: "Дивіться всі наші Програмні документи"
-    press_release: "Дивіться всі наші Прес-релізи"
-    promotional: "Дивіться всі наші Інформаційний матеріал"
-    publication: "Дивіться всі наші Публікації"
+    open_consultation: Дивіться всі наші Відкриті обговорення
+    oral_statement: Дивіться всі наші Усні заяви у парламенті
+    policy: Дивіться всі наші Політики
+    policy_paper: Дивіться всі наші Програмні документи
+    press_release: Дивіться всі наші Прес-релізи
+    promotional: Дивіться всі наші Інформаційний матеріал
+    publication: Дивіться всі наші Публікації
     regulation:
-    research: "Дивіться всі наші Дослідження та аналіз"
-    speaking_notes: "Дивіться всі наші Тези для промови"
-    speech: "Дивіться всі наші Промови"
-    statement_to_parliament: "Дивіться всі наші Заяви у парламенті"
-    statistical_data_set: "Дивіться всі наші Набори статистичних даних"
-    statistics: "Дивіться всі наші Статистика"
+    research: Дивіться всі наші Дослідження та аналіз
+    speaking_notes: Дивіться всі наші Тези для промови
+    speech: Дивіться всі наші Промови
+    statement_to_parliament: Дивіться всі наші Заяви у парламенті
+    statistical_data_set: Дивіться всі наші Набори статистичних даних
+    statistics: Дивіться всі наші Статистика
     statutory_guidance:
-    transcript: "Дивіться всі наші Транскрипти"
-    transparency: "Дивіться всі наші Прозорість інформації"
-    written_statement: "Дивіться всі наші Письмові заяви у парламенті"
+    transcript: Дивіться всі наші Транскрипти
+    transparency: Дивіться всі наші Прозорість інформації
+    written_statement: Дивіться всі наші Письмові заяви у парламенті
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "та"
+      last_word_connector: та
   time:
     formats:
       long_ordinal:
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "Це %{link} пояснює наші принципи роботи
-        з персональними даними. "
-      publication_scheme_html: "Прочитайти, яку інформацію ми регулярно публікуємо
-        у %{link}."
-      social_media_use_html: "Прочитайне про наші принципи роботи щодо %{link}."
-      welsh_language_scheme_html: "Дізнайтеся про наші зобов'язання щодо публікації
-        інформації у %{link}. "
-    find_out_more: "Дивіться повний профіль та всі контакти"
+      personal_information_charter_html: 'Це %{link} пояснює наші принципи роботи
+        з персональними даними. '
+      publication_scheme_html: Прочитайти, яку інформацію ми регулярно публікуємо
+        у %{link}.
+      social_media_use_html: Прочитайне про наші принципи роботи щодо %{link}.
+      welsh_language_scheme_html: 'Дізнайтеся про наші зобов''язання щодо публікації
+        інформації у %{link}. '
+    find_out_more: Дивіться повний профіль та всі контакти
     headings:
-      about_us: "Про нас"
-      contact_us: "Зв'яжіться з нами"
-      corporate_information: "Корпоративна інформація"
-      follow_us: "Слідкуйте за нами"
-      our_people: "Наші співробітники"
-      our_services: "Наші послуги"
-    location: "Розташування"
-    part_of: "Організація"
+      about_us: Про нас
+      contact_us: Зв'яжіться з нами
+      corporate_information: Корпоративна інформація
+      follow_us: Слідкуйте за нами
+      our_people: Наші співробітники
+      our_services: Наші послуги
+    location: Розташування
+    part_of: Організація

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -2,73 +2,73 @@ ur:
   document:
     headings:
       attachments:
-        one: "دستاویز"
-        other: "دستاویزات"
-      applies_to_nations: "اطلاق ہوتا ہے"
+        one: دستاویز
+        other: دستاویزات
+      applies_to_nations: اطلاق ہوتا ہے
       from:
       location:
       part_of:
     type:
       announcement:
-        one: "اعلان"
-        other: "اعلانات"
+        one: اعلان
+        other: اعلانات
       authored_article:
-        one: "تحریر کردہ مضمون"
-        other: "تحریر کردہ مضامین"
+        one: تحریر کردہ مضمون
+        other: تحریر کردہ مضامین
       blog_post:
         one:
         other:
       case_study:
-        one: "کیس اسٹڈی"
-        other: "کیس اسٹڈیز"
+        one: کیس اسٹڈی
+        other: کیس اسٹڈیز
       closed_consultation:
-        one: "مشاورت ختم"
+        one: مشاورت ختم
         other: " مشاورت ختم"
       consultation:
-        one: "مشاورت"
-        other: "مشاورت"
+        one: مشاورت
+        other: مشاورت
       consultation_outcome:
-        one: "مشاورت کا نتیجہ"
-        other: "مشاورت کے نتائج"
+        one: مشاورت کا نتیجہ
+        other: مشاورت کے نتائج
       corporate_report:
-        one: "کارپوریٹ رپورٹ"
-        other: "کارپوریٹ رپورٹس"
+        one: کارپوریٹ رپورٹ
+        other: کارپوریٹ رپورٹس
       correspondence:
-        one: "مراسلت"
-        other: "مراسلات"
+        one: مراسلت
+        other: مراسلات
       decision:
         one:
         other:
       detailed_guidance:
-        one: "مفصل رہنمائی"
-        other: "مفصل رہنمائی"
+        one: مفصل رہنمائی
+        other: مفصل رہنمائی
       document_collection:
-        one: "سلسلہ"
+        one: سلسلہ
         other:
       draft_text:
-        one: "ڈرافٹ متن"
-        other: "ڈرافٹ متن"
+        one: ڈرافٹ متن
+        other: ڈرافٹ متن
       foi_release:
-        one: "آزادئی معلومات کی اشاعت"
-        other: "آزادئی معلومات کی اشاعت"
+        one: آزادئی معلومات کی اشاعت
+        other: آزادئی معلومات کی اشاعت
       form:
-        one: "فارم"
-        other: "فارمز"
+        one: فارم
+        other: فارمز
       government_response:
-        one: "حکومتی جوابی اقدام"
-        other: "حکومتی جوابی اقدامات"
+        one: حکومتی جوابی اقدام
+        other: حکومتی جوابی اقدامات
       guidance:
-        one: "رہنمائی"
-        other: "رہنمائی"
+        one: رہنمائی
+        other: رہنمائی
       impact_assessment:
-        one: "اثرات کا تجزیہ"
-        other: "اثرات کے تجزیے"
+        one: اثرات کا تجزیہ
+        other: اثرات کے تجزیے
       imported:
-        one: "امپورٹڈ- نوع کا انتظار"
-        other: "امپورٹڈ- نوع کا انتظار"
+        one: امپورٹڈ- نوع کا انتظار
+        other: امپورٹڈ- نوع کا انتظار
       independent_report:
-        one: "غیر جانبدار رپورٹ"
-        other: "غیر جانبداررپورٹس"
+        one: غیر جانبدار رپورٹ
+        other: غیر جانبداررپورٹس
       international_treaty:
         one:
         other:
@@ -76,17 +76,17 @@ ur:
         one:
         other:
       map:
-        one: "نقشہ"
-        other: "نقشے"
+        one: نقشہ
+        other: نقشے
       national_statistics:
-        one: "شماریات- قومی اعدادوشمار"
-        other: "شماریات- قومی اعدادوشمار"
+        one: شماریات- قومی اعدادوشمار
+        other: شماریات- قومی اعدادوشمار
       news_article:
-        one: "نیوزآرٹیکل"
-        other: "نیوزآرٹیکلز"
+        one: نیوزآرٹیکل
+        other: نیوزآرٹیکلز
       news_story:
-        one: "نیوز اسٹوری"
-        other: "نیوزاسٹوریز"
+        one: نیوز اسٹوری
+        other: نیوزاسٹوریز
       nhs_content:
         one:
         other:
@@ -94,77 +94,77 @@ ur:
         one:
         other:
       official_statistics:
-        one: "اعدادوشمار"
-        other: "اعدادو شمار"
+        one: اعدادوشمار
+        other: اعدادو شمار
       open_consultation:
-        one: "جاری مشاورت"
-        other: "جاری مشاورت"
+        one: جاری مشاورت
+        other: جاری مشاورت
       oral_statement:
-        one: "پارلیمنٹ میں زبانی بیان"
-        other: "پارلیمنٹ میں زبانی بیانات"
+        one: پارلیمنٹ میں زبانی بیان
+        other: پارلیمنٹ میں زبانی بیانات
       policy_paper:
-        one: "پالیسی پیپر"
-        other: "پالیسی پیپرز"
+        one: پالیسی پیپر
+        other: پالیسی پیپرز
       press_release:
-        one: "پریس ریلیز"
-        other: "پریس ریلیزز"
+        one: پریس ریلیز
+        other: پریس ریلیزز
       promotional:
-        one: "تشہیری مواد"
-        other: "تشہیری مواد"
+        one: تشہیری مواد
+        other: تشہیری مواد
       publication:
-        one: "مطبوعہ"
-        other: "مطبوعات"
+        one: مطبوعہ
+        other: مطبوعات
       regulation:
         one:
         other:
       research:
-        one: "تحقیق وتجزیہ"
-        other: "تحقیق وتجزیہ"
+        one: تحقیق وتجزیہ
+        other: تحقیق وتجزیہ
       speaking_notes:
-        one: "تقریری نوٹ"
-        other: "تقریری نوٹ"
+        one: تقریری نوٹ
+        other: تقریری نوٹ
       speech:
-        one: "تقریر"
-        other: "تقاریر"
+        one: تقریر
+        other: تقاریر
       statement_to_parliament:
-        one: "پارلیمنٹ میں بیان"
-        other: "پارلیمنٹ میں بیانات"
+        one: پارلیمنٹ میں بیان
+        other: پارلیمنٹ میں بیانات
       statistical_data_set:
-        one: "شماریاتی ڈیٹا سیٹ"
+        one: شماریاتی ڈیٹا سیٹ
         other: " شماریاتی ڈیٹا سیٹس"
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "ٹرانسکرپٹ"
-        other: "ٹرانسکرپٹس"
+        one: ٹرانسکرپٹ
+        other: ٹرانسکرپٹس
       transparency:
-        one: "ٹرانسپیرنسی ڈیٹا"
-        other: "ٹرانسپیرنسی ڈیٹا"
+        one: ٹرانسپیرنسی ڈیٹا
+        other: ٹرانسپیرنسی ڈیٹا
       world_news_story:
         one:
         other:
       written_statement:
-        one: "پارلیمنٹ میں تحریری بیان"
-        other: "پارلیمنٹ میں تحریری بیانات"
+        one: پارلیمنٹ میں تحریری بیان
+        other: پارلیمنٹ میں تحریری بیانات
     contents:
     footer_meta:
       full_page_history:
       page_history:
       published:
       updated:
-    published: "شائع شدہ"
-    read: "پڑھئیے {title}% مضمون"
+    published: شائع شدہ
+    read: پڑھئیے {title}% مضمون
     speech:
       author_title:
-        minister: "وزیر"
-        speaker: "مصنف"
-      delivered_on: "تقریرکی تاریخ:"
+        minister: وزیر
+        speaker: مصنف
+      delivered_on: 'تقریرکی تاریخ:'
       delivery_title:
-        minister: "وزیر"
-        speaker: "مقرر"
-      written_on: "تحریر کی  تاریخ:"
-    updated: "تجدید شدہ"
+        minister: وزیر
+        speaker: مقرر
+      written_on: 'تحریر کی  تاریخ:'
+    updated: تجدید شدہ
     view: "'%{title}' دیکھئیے"
   people:
     heading:
@@ -189,21 +189,21 @@ ur:
   world_location:
     type:
       international_delegation:
-        one: "عالمی وفد"
-        other: "عالمی وفود"
+        one: عالمی وفد
+        other: عالمی وفود
       world_location:
         one: " عالمی محل وقوع"
-        other: "عالمی محل ہائے وقوع"
+        other: عالمی محل ہائے وقوع
     headings:
-      announcements: "ہمارے اعلانات"
-      country: "ملک"
-      documents: "دستاویزات"
-      mission: "ہمارا مشن"
-      organisations: "ادارے"
-      publications: "ہماری مطبوعات"
-      quick_links: "فوری لنکس"
-      related_policies: "متعلقہ پالیسیاں"
-      statistics: "ہمارے اعدادو شمار"
+      announcements: ہمارے اعلانات
+      country: ملک
+      documents: دستاویزات
+      mission: ہمارا مشن
+      organisations: ادارے
+      publications: ہماری مطبوعات
+      quick_links: فوری لنکس
+      related_policies: متعلقہ پالیسیاں
+      statistics: ہمارے اعدادو شمار
   activerecord:
     attributes:
       attachment:
@@ -248,21 +248,21 @@ ur:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "اعلانات"
+    heading: اعلانات
     view_all:
   attachment:
     accessibility:
       full_help_html: اس عبارت کو کسی دوسرے فارمیٹ مثلا بریل،آڈیو یا مختلف فائل ٹائپ
         میں حاصل کرنے کے لئے برائے مہربانی ایمیل %{email} کیجئیے، جس میں اپنا پتا،ٹیلیفون
         نمبراور  %{title}"(%{references}") لکھئیے
-      heading: "ممکن ہےیہ فائل  معاون ٹیکنالوجی استعمال کرنے والوں کے لئے موزوں نہ
-        ہو"
-      request_a_different_format: "مختلف فارمیٹ طلب کیجئیے"
+      heading: ممکن ہےیہ فائل  معاون ٹیکنالوجی استعمال کرنے والوں کے لئے موزوں نہ
+        ہو
+      request_a_different_format: مختلف فارمیٹ طلب کیجئیے
     headings:
-      order_a_copy: "کاپی منگائیے"
-      order_a_copy_full: "اشاعت کی کاپی طلب کیجئیے"
-      published: "شائع شدہ"
-      reference: "حوالہ"
+      order_a_copy: کاپی منگائیے
+      order_a_copy_full: اشاعت کی کاپی طلب کیجئیے
+      published: شائع شدہ
+      reference: حوالہ
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -280,8 +280,8 @@ ur:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "کانٹیکٹ فارم"
-    email: "ای میل"
+    contact_form: کانٹیکٹ فارم
+    email: ای میل
   corporate_information_page:
     type:
       link_text:
@@ -296,13 +296,13 @@ ur:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "ذاتی معلومات کاچارٹر"
+        personal_information_charter: ذاتی معلومات کاچارٹر
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "اشاعتی اسکیم"
+        publication_scheme: اشاعتی اسکیم
         recruitment:
         research:
-        social_media_use: "سوشل میڈیاکااستعمال"
+        social_media_use: سوشل میڈیاکااستعمال
         staff_update:
         statistics:
         terms_of_reference:
@@ -312,28 +312,28 @@ ur:
       default: "%d %B %Y"
       long_ordinal: "%e %B %Y"
   document_filters:
-    description: "آپ صرف اپنی دلچسپی &nbsp;کے نتائج دیکھنے&nbsp;کے لئے فلٹرزاستعمال
-      کر سکتے ہیں"
+    description: آپ صرف اپنی دلچسپی &nbsp;کے نتائج دیکھنے&nbsp;کے لئے فلٹرزاستعمال
+      کر سکتے ہیں
     no_results:
-      description: "اپنی تلاش کو وسیع تر کرکے دوبارا کوشش کیجئیے "
-      title: "مطلوبہ یا ملتا جلتا مضمون نہیں ملا"
+      description: 'اپنی تلاش کو وسیع تر کرکے دوبارا کوشش کیجئیے '
+      title: مطلوبہ یا ملتا جلتا مضمون نہیں ملا
       tna_heading:
       tna_link:
     world_locations:
-      all: "تمام مقامات"
-      label: "عالمی مقامات"
+      all: تمام مقامات
+      label: عالمی مقامات
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "تازہ ترین سرگرمیاں"
+    latest_activity: تازہ ترین سرگرمیاں
   i18n:
     direction: rtl
   language_names:
-    ur: "اردو"
+    ur: اردو
   latest_feed:
-    no_updates: "فی الحال کوئی تجدید نہیں"
-    title: "آخری فیڈ"
+    no_updates: فی الحال کوئی تجدید نہیں
+    title: آخری فیڈ
   national_statistics:
     heading:
   number:
@@ -342,119 +342,119 @@ ur:
         format: "%n%u"
   organisation:
     about:
-      read_more: "ہمارے کام کے بارے میں مزید پڑھئیے"
+      read_more: ہمارے کام کے بارے میں مزید پڑھئیے
     corporate_information:
-      access_our_info: "ہماری معلومات تک رسائی حاصل کیجئیے"
-      foi_how_to: "آزادئی معلومات کی درخواست کیسے کی جائے"
-      foi_releases: "آزادئی معلومات کی اشاعتیں"
-      jobs_and_contacts: "ملازمتیں اورکنٹریکٹس"
+      access_our_info: ہماری معلومات تک رسائی حاصل کیجئیے
+      foi_how_to: آزادئی معلومات کی درخواست کیسے کی جائے
+      foi_releases: آزادئی معلومات کی اشاعتیں
+      jobs_and_contacts: ملازمتیں اورکنٹریکٹس
       organisation_chart:
-      transparency: "ٹرانسپیرنسی ڈیٹا"
+      transparency: ٹرانسپیرنسی ڈیٹا
     foi_exemption_html:
     headings:
-      chief_professional_officers: "ہمارے چیف پروفیشنل افسران"
-      contact: "رابطہ %{name}"
-      corporate_information: "کارپوریٹ معلومات"
-      corporate_reports: "کارپوریٹ رپورٹس"
+      chief_professional_officers: ہمارے چیف پروفیشنل افسران
+      contact: رابطہ %{name}
+      corporate_information: کارپوریٹ معلومات
+      corporate_reports: کارپوریٹ رپورٹس
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "ہمارے اعلانات"
+      our_announcements: ہمارے اعلانات
       our_consultations:
       our_judges:
-      our_management: "ہماری انتظامیہ"
-      our_ministers: "ہمارے وزرا"
-      our_policies: "ہماری پالیسیاں"
-      our_publications: "ہماری اشاعتیں"
-      our_senior_military_officials: "ہمارے سینئیر فوجی اہلکار"
-      our_services: "ہماری خدمات"
-      our_statistics: "ہمارے اعدادو شمار"
-      our_topics: "ہم ان موضوعات پر کام کرتے ہیں"
-      special_representatives: "خصوصی نمائندے"
-      traffic_commissioners: "ٹریفک کمشنرز"
-      what_we_do: "ہمارے فرائض"
+      our_management: ہماری انتظامیہ
+      our_ministers: ہمارے وزرا
+      our_policies: ہماری پالیسیاں
+      our_publications: ہماری اشاعتیں
+      our_senior_military_officials: ہمارے سینئیر فوجی اہلکار
+      our_services: ہماری خدمات
+      our_statistics: ہمارے اعدادو شمار
+      our_topics: ہم ان موضوعات پر کام کرتے ہیں
+      special_representatives: خصوصی نمائندے
+      traffic_commissioners: ٹریفک کمشنرز
+      what_we_do: ہمارے فرائض
       who_we_are:
     making_foi_requests:
       step1_html:
       step2_html:
       step3_html:
   policies:
-    heading: "پالیسیاں"
+    heading: پالیسیاں
     view_all:
   publications:
-    heading: "اشاعتیں"
+    heading: اشاعتیں
     headings:
-      detail: "تفصیل"
-  read_more: "آگے پڑھئیے"
+      detail: تفصیل
+  read_more: آگے پڑھئیے
   see_all:
-    announcement: "تما م دیکھئیے اعلانات"
-    authored_article: "تما م دیکھئیے تحریر کردہ مضامین"
-    case_study: "تما م دیکھئیے کیس اسٹڈیز"
-    closed_consultation: "تما م دیکھئیے  مشاورت ختم"
-    consultation: "تما م دیکھئیے مشاورت"
-    consultation_outcome: "تما م دیکھئیے مشاورت کے نتائج"
-    corporate_report: "تما م دیکھئیے کارپوریٹ رپورٹس"
-    correspondence: "تما م دیکھئیے مراسلات"
+    announcement: تما م دیکھئیے اعلانات
+    authored_article: تما م دیکھئیے تحریر کردہ مضامین
+    case_study: تما م دیکھئیے کیس اسٹڈیز
+    closed_consultation: تما م دیکھئیے  مشاورت ختم
+    consultation: تما م دیکھئیے مشاورت
+    consultation_outcome: تما م دیکھئیے مشاورت کے نتائج
+    corporate_report: تما م دیکھئیے کارپوریٹ رپورٹس
+    correspondence: تما م دیکھئیے مراسلات
     decision:
-    detailed_guidance: "تما م دیکھئیے مفصل رہنمائی"
+    detailed_guidance: تما م دیکھئیے مفصل رہنمائی
     document_collection:
-    draft_text: "تما م دیکھئیے ڈرافٹ متن"
-    fatality_notice: "تما م دیکھئیے وفات کی اطلاعات"
-    foi_release: "تما م دیکھئیے آزادئی معلومات کی اشاعت"
-    form: "تما م دیکھئیے فارمز"
-    government_response: "تما م دیکھئیے حکومتی جوابی اقدامات"
-    guidance: "تما م دیکھئیے رہنمائی"
-    impact_assessment: "تما م دیکھئیے اثرات کے تجزیے"
-    imported: "تما م دیکھئیے امپورٹڈ- نوع کا انتظار"
+    draft_text: تما م دیکھئیے ڈرافٹ متن
+    fatality_notice: تما م دیکھئیے وفات کی اطلاعات
+    foi_release: تما م دیکھئیے آزادئی معلومات کی اشاعت
+    form: تما م دیکھئیے فارمز
+    government_response: تما م دیکھئیے حکومتی جوابی اقدامات
+    guidance: تما م دیکھئیے رہنمائی
+    impact_assessment: تما م دیکھئیے اثرات کے تجزیے
+    imported: تما م دیکھئیے امپورٹڈ- نوع کا انتظار
     international_treaty:
-    map: "تما م دیکھئیے نقشے"
-    national_statistics: "تما م دیکھئیے شماریات- قومی اعدادوشمار"
-    news_article: "تما م دیکھئیے نیوزآرٹیکلز"
-    news_story: "تما م دیکھئیے نیوزاسٹوریز"
+    map: تما م دیکھئیے نقشے
+    national_statistics: تما م دیکھئیے شماریات- قومی اعدادوشمار
+    news_article: تما م دیکھئیے نیوزآرٹیکلز
+    news_story: تما م دیکھئیے نیوزاسٹوریز
     notice:
-    open_consultation: "تما م دیکھئیے جاری مشاورت"
-    oral_statement: "تما م دیکھئیے پارلیمنٹ میں زبانی بیانات"
-    policy: "تما م دیکھئیے پالیسیاں"
-    policy_paper: "تما م دیکھئیے پالیسی پیپرز"
-    press_release: "تما م دیکھئیے پریس ریلیزز"
-    promotional: "تما م دیکھئیے تشہیری مواد"
-    publication: "تما م دیکھئیے مطبوعات"
+    open_consultation: تما م دیکھئیے جاری مشاورت
+    oral_statement: تما م دیکھئیے پارلیمنٹ میں زبانی بیانات
+    policy: تما م دیکھئیے پالیسیاں
+    policy_paper: تما م دیکھئیے پالیسی پیپرز
+    press_release: تما م دیکھئیے پریس ریلیزز
+    promotional: تما م دیکھئیے تشہیری مواد
+    publication: تما م دیکھئیے مطبوعات
     regulation:
-    research: "تما م دیکھئیے تحقیق وتجزیہ"
-    speaking_notes: "تما م دیکھئیے تقریری نوٹ"
-    speech: "تما م دیکھئیے تقاریر"
-    statement_to_parliament: "تما م دیکھئیے پارلیمنٹ میں بیانات"
-    statistical_data_set: "تما م دیکھئیے  شماریاتی ڈیٹا سیٹس"
-    statistics: "تما م دیکھئیے اعدادو شمار"
+    research: تما م دیکھئیے تحقیق وتجزیہ
+    speaking_notes: تما م دیکھئیے تقریری نوٹ
+    speech: تما م دیکھئیے تقاریر
+    statement_to_parliament: تما م دیکھئیے پارلیمنٹ میں بیانات
+    statistical_data_set: تما م دیکھئیے  شماریاتی ڈیٹا سیٹس
+    statistics: تما م دیکھئیے اعدادو شمار
     statutory_guidance:
-    transcript: "تما م دیکھئیے ٹرانسکرپٹس"
-    transparency: "تما م دیکھئیے ٹرانسپیرنسی ڈیٹا"
-    written_statement: "تما م دیکھئیے پارلیمنٹ میں تحریری بیانات"
+    transcript: تما م دیکھئیے ٹرانسکرپٹس
+    transparency: تما م دیکھئیے ٹرانسپیرنسی ڈیٹا
+    written_statement: تما م دیکھئیے پارلیمنٹ میں تحریری بیانات
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "اور"
+      last_word_connector: اور
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "ہمارے %{link} واضح کرتے ہیں کہ ہم آپکی ذاتی
-        معلومات کو کیسے استعمال کرتے ہیں"
-      publication_scheme_html: "ہماری معمول کے مطابق  شائع کردہ معلومات کی نوعیت  %{link}
-        پرملاحظہ کیجئیے "
-      social_media_use_html: "ہماری پالیسی  %{link} پر ملاحظہ کیجئیے"
-      welsh_language_scheme_html: "اشاعت کے باب میں ہمارے کمٹ منٹ %{link} میں ملاحظہ
-        کیجئیے"
-    find_out_more: "مکمل پروفائل اوررابطے کی تمام تفصیلات دیکھئیے"
+      personal_information_charter_html: ہمارے %{link} واضح کرتے ہیں کہ ہم آپکی ذاتی
+        معلومات کو کیسے استعمال کرتے ہیں
+      publication_scheme_html: 'ہماری معمول کے مطابق  شائع کردہ معلومات کی نوعیت  %{link}
+        پرملاحظہ کیجئیے '
+      social_media_use_html: ہماری پالیسی  %{link} پر ملاحظہ کیجئیے
+      welsh_language_scheme_html: اشاعت کے باب میں ہمارے کمٹ منٹ %{link} میں ملاحظہ
+        کیجئیے
+    find_out_more: مکمل پروفائل اوررابطے کی تمام تفصیلات دیکھئیے
     headings:
-      about_us: "ہمارے بارے میں"
-      contact_us: "ہم سے رابطہ"
-      corporate_information: "کارپوریٹ معلومات"
-      follow_us: "ہمیں فالوکیجئیے"
-      our_people: "ہمارا عملہ"
-      our_services: "ہماری خدمات"
-    location: "مقام"
-    part_of: "حصہ"
+      about_us: ہمارے بارے میں
+      contact_us: ہم سے رابطہ
+      corporate_information: کارپوریٹ معلومات
+      follow_us: ہمیں فالوکیجئیے
+      our_people: ہمارا عملہ
+      our_services: ہماری خدمات
+    location: مقام
+    part_of: حصہ

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -53,10 +53,10 @@ vi:
       heading: 'File này không phù hợp với công nghệ hỗ trợ của người dùng '
       request_a_different_format: Yêu cầu một định dạng khác
     headings:
-      order_a_copy: "Đặt một bản sao"
-      order_a_copy_full: "Đặt một bản sao của ấn phẩm truyền thông"
-      published: "Đã đăng"
-      reference: "đối với"
+      order_a_copy: Đặt một bản sao
+      order_a_copy_full: Đặt một bản sao của ấn phẩm truyền thông
+      published: Đã đăng
+      reference: đối với
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -113,20 +113,20 @@ vi:
       published:
       updated:
     headings:
-      applies_to_nations: "Áp dụngng cho"
+      applies_to_nations: Áp dụngng cho
       attachments:
         one: Tài liệu
         other: Tài liệu
       from:
       location:
       part_of:
-    published: "Đã xuất bản"
-    read: "Đọc bài có  %{title}"
+    published: Đã xuất bản
+    read: Đọc bài có  %{title}
     speech:
       author_title:
         minister: Thứ trưởng
         speaker: Tác giả
-      delivered_on: "Đưa ra:"
+      delivered_on: 'Đưa ra:'
       delivery_title:
         minister: Thứ trưởng
         speaker: Người phát biểu
@@ -184,8 +184,8 @@ vi:
         one: hướng dẫn
         other: hướng dẫn
       impact_assessment:
-        one: "Đánh giá tác động"
-        other: "Đánh giá tác động"
+        one: Đánh giá tác động
+        other: Đánh giá tác động
       imported:
         one: Loại tài liệu đính kèm
         other: Loại tài liệu đính kèm
@@ -331,9 +331,9 @@ vi:
       our_services: Các dịch vụ của chúng tôi
       our_statistics: Thống kê
       our_topics: Những lĩnh vực chúng tôi hoạt động
-      special_representatives: "Đại diện đặc biệt"
+      special_representatives: Đại diện đặc biệt
       traffic_commissioners: Các ủy viên giao thông
-      what_we_do: "Điều chúng tôi làm"
+      what_we_do: Điều chúng tôi làm
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -354,7 +354,7 @@ vi:
     heading: Tài liệu truyền thông
     headings:
       detail: Chi tiết
-  read_more: "Đọc thêm"
+  read_more: Đọc thêm
   roles:
     heading:
       one:
@@ -423,7 +423,7 @@ vi:
   world_location:
     headings:
       announcements: Các thông báo của chúng tôi
-      country: "Đất nước"
+      country: Đất nước
       documents: Tài liệu
       mission: Nhiệm vụ của chúng tôi
       organisations: Các tổ chức
@@ -436,7 +436,7 @@ vi:
         one: Phái đoàn quốc tế
         other: Các phái đoàn quốc tế
       world_location:
-        one: "Địa điểm trên thế giới"
+        one: Địa điểm trên thế giới
         other: Các địa điểm trên thế giới
   worldwide_organisation:
     corporate_information:
@@ -445,7 +445,7 @@ vi:
         tôi xử lý thông tin cá nhân của bạn"
       publication_scheme_html: Xem các loại thông tin mà chúng tôi cập nhật thường
         xuyên tại %{link}
-      social_media_use_html: "Đọc chính sách của chúng tôi tại %{link}"
+      social_media_use_html: Đọc chính sách của chúng tôi tại %{link}
       welsh_language_scheme_html: Tìm hiểu các cam kết của chúng tôi trong việc công
         bố thông tin tại %{link}
     find_out_more: Xem hồ sơ đầy đủ và tất cả các chi tiết liên hệ
@@ -456,5 +456,5 @@ vi:
       follow_us: Kết nối với chúng tôi
       our_people: Nhân viên Bộ Ngoại giao Anh
       our_services: Dịch vụ của chúng tôi
-    location: "Địa điểm"
+    location: Địa điểm
     part_of: Phần của

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -43,18 +43,18 @@ zh-hk:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "公告"
+    heading: 公告
     view_all:
   attachment:
     accessibility:
-      full_help_html: "尋求另一種檔案格式：點字或音檔"
-      heading: "此檔案不適合使用科技輔助的使用者"
-      request_a_different_format: "尋求別種格式"
+      full_help_html: 尋求另一種檔案格式：點字或音檔
+      heading: 此檔案不適合使用科技輔助的使用者
+      request_a_different_format: 尋求別種格式
     headings:
-      order_a_copy: "訂閱副本"
-      order_a_copy_full: "訂閱報告副本"
-      published: "已發布"
-      reference: "參考"
+      order_a_copy: 訂閱副本
+      order_a_copy_full: 訂閱報告副本
+      published: 已發布
+      reference: 參考
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -72,8 +72,8 @@ zh-hk:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "聯絡資料表"
-    email: "電子郵件"
+    contact_form: 聯絡資料表
+    email: 電子郵件
   corporate_information_page:
     type:
       link_text:
@@ -88,17 +88,17 @@ zh-hk:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "個人資訊表"
+        personal_information_charter: 個人資訊表
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "出版計畫"
+        publication_scheme: 出版計畫
         recruitment:
         research:
-        social_media_use: "社交媒體應用"
+        social_media_use: 社交媒體應用
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "威爾士語言計畫"
+        welsh_language_scheme: 威爾士語言計畫
   date:
     formats:
       default: "%d %B %Y"
@@ -111,85 +111,85 @@ zh-hk:
       published:
       updated:
     headings:
-      applies_to_nations: "適用於"
+      applies_to_nations: 適用於
       attachments:
-        one: "文件"
-        other: "其他文件"
+        one: 文件
+        other: 其他文件
       from:
       location:
       part_of:
-    published: "已發布"
-    read: "閱讀%{title}文章"
+    published: 已發布
+    read: 閱讀%{title}文章
     speech:
       author_title:
-        minister: "大臣"
-        speaker: "作者"
-      delivered_on: "發表於："
+        minister: 大臣
+        speaker: 作者
+      delivered_on: 發表於：
       delivery_title:
-        minister: "大臣"
-        speaker: "講者"
-      written_on: "撰寫於："
+        minister: 大臣
+        speaker: 講者
+      written_on: 撰寫於：
     type:
       announcement:
-        one: "公告"
-        other: "其他公告"
+        one: 公告
+        other: 其他公告
       authored_article:
-        one: "撰寫文章"
-        other: "其他撰寫文章"
+        one: 撰寫文章
+        other: 其他撰寫文章
       blog_post:
         one:
         other:
       case_study:
-        one: "案例研究"
-        other: "其他案例研究"
+        one: 案例研究
+        other: 其他案例研究
       closed_consultation:
-        one: "專屬諮詢"
-        other: "其他專屬諮詢"
+        one: 專屬諮詢
+        other: 其他專屬諮詢
       consultation:
-        one: "諮詢"
-        other: "其他諮詢"
+        one: 諮詢
+        other: 其他諮詢
       consultation_outcome:
-        one: "諮詢結果"
-        other: "其他諮詢結果"
+        one: 諮詢結果
+        other: 其他諮詢結果
       corporate_report:
-        one: "政府報告"
-        other: "其他政府報告"
+        one: 政府報告
+        other: 其他政府報告
       correspondence:
-        one: "通信"
-        other: "其他通信"
+        one: 通信
+        other: 其他通信
       decision:
         one:
         other:
       detailed_guidance:
-        one: "詳細指引"
-        other: "其他詳細指引"
+        one: 詳細指引
+        other: 其他詳細指引
       document_collection:
-        one: "系列"
+        one: 系列
         other:
       draft_text:
-        one: "內容"
-        other: "其他內容"
+        one: 內容
+        other: 其他內容
       foi_release:
-        one: "資訊自由(FOI)資訊發布"
-        other: "其他資訊自由(FOI)資訊發布"
+        one: 資訊自由(FOI)資訊發布
+        other: 其他資訊自由(FOI)資訊發布
       form:
-        one: "表格"
-        other: "其他表格"
+        one: 表格
+        other: 其他表格
       government_response:
-        one: "政府回應"
-        other: "政府其他回應"
+        one: 政府回應
+        other: 政府其他回應
       guidance:
-        one: "指引"
-        other: "其他指引"
+        one: 指引
+        other: 其他指引
       impact_assessment:
-        one: "影響評估"
-        other: "其他影響評估"
+        one: 影響評估
+        other: 其他影響評估
       imported:
-        one: "輸入-等待類型中"
-        other: "輸入-等待類型中"
+        one: 輸入-等待類型中
+        other: 輸入-等待類型中
       independent_report:
-        one: "獨立報告"
-        other: "其他獨立報告"
+        one: 獨立報告
+        other: 其他獨立報告
       international_treaty:
         one:
         other:
@@ -197,17 +197,17 @@ zh-hk:
         one:
         other:
       map:
-        one: "地圖"
-        other: "其他地圖"
+        one: 地圖
+        other: 其他地圖
       national_statistics:
-        one: "國家統計數據"
-        other: "其他國家統計數據"
+        one: 國家統計數據
+        other: 其他國家統計數據
       news_article:
-        one: "新聞"
-        other: "其他新聞"
+        one: 新聞
+        other: 其他新聞
       news_story:
-        one: "新聞"
-        other: "其他新聞"
+        one: 新聞
+        other: 其他新聞
       nhs_content:
         one:
         other:
@@ -215,83 +215,83 @@ zh-hk:
         one:
         other:
       official_statistics:
-        one: "統計資料"
-        other: "其他統計資料"
+        one: 統計資料
+        other: 其他統計資料
       open_consultation:
-        one: "公開諮詢"
-        other: "其他公開諮詢"
+        one: 公開諮詢
+        other: 其他公開諮詢
       oral_statement:
-        one: "提交國會的口頭聲明"
-        other: "提交國會的其他口頭聲明"
+        one: 提交國會的口頭聲明
+        other: 提交國會的其他口頭聲明
       policy_paper:
-        one: "政策文件"
-        other: "其他政策文件"
+        one: 政策文件
+        other: 其他政策文件
       press_release:
-        one: "新聞稿"
-        other: "其他新聞稿"
+        one: 新聞稿
+        other: 其他新聞稿
       promotional:
-        one: "宣傳資料"
-        other: "其他宣傳資料"
+        one: 宣傳資料
+        other: 其他宣傳資料
       publication:
-        one: "出版物"
-        other: "其他出版物"
+        one: 出版物
+        other: 其他出版物
       regulation:
         one:
         other:
       research:
-        one: "研究與分析"
-        other: "其他研究與分析"
+        one: 研究與分析
+        other: 其他研究與分析
       speaking_notes:
-        one: "演講稿"
-        other: "其他演講稿"
+        one: 演講稿
+        other: 其他演講稿
       speech:
-        one: "演講"
-        other: "其他演講"
+        one: 演講
+        other: 其他演講
       statement_to_parliament:
-        one: "提交國會的聲明"
-        other: "提交國會的其他聲明"
+        one: 提交國會的聲明
+        other: 提交國會的其他聲明
       statistical_data_set:
-        one: "統計數據資料"
-        other: "其他統計數據資料"
+        one: 統計數據資料
+        other: 其他統計數據資料
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "談話副本"
-        other: "其他談話副本"
+        one: 談話副本
+        other: 其他談話副本
       transparency:
-        one: "透明化數據"
-        other: "其他透明化數據"
+        one: 透明化數據
+        other: 其他透明化數據
       world_news_story:
         one:
         other:
       written_statement:
-        one: "提交國會的書面聲明"
-        other: "提交國會的其他書面聲明"
-    updated: "已更新"
-    view: "查看'%{title}'"
+        one: 提交國會的書面聲明
+        other: 提交國會的其他書面聲明
+    updated: 已更新
+    view: 查看'%{title}'
   document_filters:
-    description: "你可以使用過濾功能顯示&nbsp;只符合你需要的&nbsp;結果。"
+    description: 你可以使用過濾功能顯示&nbsp;只符合你需要的&nbsp;結果。
     no_results:
-      description: "嘗試擴大你的搜尋範圍並且再次搜索。"
-      title: "沒有符合的文件。"
+      description: 嘗試擴大你的搜尋範圍並且再次搜索。
+      title: 沒有符合的文件。
       tna_heading:
       tna_link:
     world_locations:
-      all: "所有駐點"
-      label: "全球駐點"
+      all: 所有駐點
+      label: 全球駐點
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "最新的活動"
+    latest_activity: 最新的活動
   i18n:
     direction: ltr
   language_names:
-    zh-hk: "中文"
+    zh-hk: 中文
   latest_feed:
-    no_updates: "目前暫無更新。"
-    title: "最新消息"
+    no_updates: 目前暫無更新。
+    title: 最新消息
   national_statistics:
     heading:
   number:
@@ -300,37 +300,37 @@ zh-hk:
         format: "%n%u"
   organisation:
     about:
-      read_more: "查閱更多關於我們的工作"
+      read_more: 查閱更多關於我們的工作
     corporate_information:
-      access_our_info: "閱讀我們的資訊"
-      foi_how_to: "如何進行資訊自由(FOI)申請"
-      foi_releases: "資訊自由(FOI)資訊發布"
-      jobs_and_contacts: "職位及聯絡方法"
+      access_our_info: 閱讀我們的資訊
+      foi_how_to: 如何進行資訊自由(FOI)申請
+      foi_releases: 資訊自由(FOI)資訊發布
+      jobs_and_contacts: 職位及聯絡方法
       organisation_chart:
-      transparency: "透明化數據"
+      transparency: 透明化數據
     foi_exemption_html:
     headings:
-      chief_professional_officers: "我們的首席專業官員"
-      contact: "聯繫%{name}"
-      corporate_information: "政府資訊"
-      corporate_reports: "政府報告"
+      chief_professional_officers: 我們的首席專業官員
+      contact: 聯繫%{name}
+      corporate_information: 政府資訊
+      corporate_reports: 政府報告
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "我們的公告"
+      our_announcements: 我們的公告
       our_consultations:
       our_judges:
-      our_management: "我們的管理層"
-      our_ministers: "我們的大臣"
-      our_policies: "我們的政策"
-      our_publications: "我們的出版物"
-      our_senior_military_officials: "我們的高級軍事官員"
-      our_services: "我們的服務"
-      our_statistics: "我們的統計資料"
-      our_topics: "我們工作的領域"
-      special_representatives: "特別代表"
-      traffic_commissioners: "交通事務專員"
-      what_we_do: "我們的工作"
+      our_management: 我們的管理層
+      our_ministers: 我們的大臣
+      our_policies: 我們的政策
+      our_publications: 我們的出版物
+      our_senior_military_officials: 我們的高級軍事官員
+      our_services: 我們的服務
+      our_statistics: 我們的統計資料
+      our_topics: 我們工作的領域
+      special_representatives: 特別代表
+      traffic_commissioners: 交通事務專員
+      what_we_do: 我們的工作
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -345,13 +345,13 @@ zh-hk:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "政策"
+    heading: 政策
     view_all:
   publications:
-    heading: "出版物"
+    heading: 出版物
     headings:
-      detail: "詳情"
-  read_more: "閱讀更多"
+      detail: 詳情
+  read_more: 閱讀更多
   roles:
     heading:
       one:
@@ -365,89 +365,89 @@ zh-hk:
     previous_holders:
     read_more:
   see_all:
-    announcement: "查閱我們所有的其他公告"
-    authored_article: "查閱我們所有的其他撰寫文章"
-    case_study: "查閱我們所有的其他案例研究"
-    closed_consultation: "查閱我們所有的其他專屬諮詢"
-    consultation: "查閱我們所有的其他諮詢"
-    consultation_outcome: "查閱我們所有的其他諮詢結果"
-    corporate_report: "查閱我們所有的其他政府報告"
-    correspondence: "查閱我們所有的其他通信"
+    announcement: 查閱我們所有的其他公告
+    authored_article: 查閱我們所有的其他撰寫文章
+    case_study: 查閱我們所有的其他案例研究
+    closed_consultation: 查閱我們所有的其他專屬諮詢
+    consultation: 查閱我們所有的其他諮詢
+    consultation_outcome: 查閱我們所有的其他諮詢結果
+    corporate_report: 查閱我們所有的其他政府報告
+    correspondence: 查閱我們所有的其他通信
     decision:
-    detailed_guidance: "查閱我們所有的其他詳細指引"
+    detailed_guidance: 查閱我們所有的其他詳細指引
     document_collection:
-    draft_text: "查閱我們所有的其他內容"
-    fatality_notice: "查閱我們所有的其他安全事故通知"
-    foi_release: "查閱我們所有的其他資訊自由(foi)資訊發布"
-    form: "查閱我們所有的其他表格"
-    government_response: "查閱我們所有的政府其他回應"
-    guidance: "查閱我們所有的其他指引"
-    impact_assessment: "查閱我們所有的其他影響評估"
-    imported: "查閱我們所有的輸入-等待類型中"
+    draft_text: 查閱我們所有的其他內容
+    fatality_notice: 查閱我們所有的其他安全事故通知
+    foi_release: 查閱我們所有的其他資訊自由(foi)資訊發布
+    form: 查閱我們所有的其他表格
+    government_response: 查閱我們所有的政府其他回應
+    guidance: 查閱我們所有的其他指引
+    impact_assessment: 查閱我們所有的其他影響評估
+    imported: 查閱我們所有的輸入-等待類型中
     international_treaty:
-    map: "查閱我們所有的其他地圖"
-    national_statistics: "查閱我們所有的其他國家統計數據"
-    news_article: "查閱我們所有的其他新聞"
-    news_story: "查閱我們所有的其他新聞"
+    map: 查閱我們所有的其他地圖
+    national_statistics: 查閱我們所有的其他國家統計數據
+    news_article: 查閱我們所有的其他新聞
+    news_story: 查閱我們所有的其他新聞
     notice:
-    open_consultation: "查閱我們所有的其他公開諮詢"
-    oral_statement: "查閱我們所有的提交國會的其他口頭聲明"
-    policy: "查閱我們所有的其他政策"
-    policy_paper: "查閱我們所有的其他政策文件"
-    press_release: "查閱我們所有的其他新聞稿"
-    promotional: "查閱我們所有的其他宣傳資料"
-    publication: "查閱我們所有的其他出版物"
+    open_consultation: 查閱我們所有的其他公開諮詢
+    oral_statement: 查閱我們所有的提交國會的其他口頭聲明
+    policy: 查閱我們所有的其他政策
+    policy_paper: 查閱我們所有的其他政策文件
+    press_release: 查閱我們所有的其他新聞稿
+    promotional: 查閱我們所有的其他宣傳資料
+    publication: 查閱我們所有的其他出版物
     regulation:
-    research: "查閱我們所有的其他研究與分析"
-    speaking_notes: "查閱我們所有的其他演講稿"
-    speech: "查閱我們所有的其他演講"
-    statement_to_parliament: "查閱我們所有的提交國會的其他聲明"
-    statistical_data_set: "查閱我們所有的其他統計數據資料"
-    statistics: "查閱我們所有的其他統計資料"
+    research: 查閱我們所有的其他研究與分析
+    speaking_notes: 查閱我們所有的其他演講稿
+    speech: 查閱我們所有的其他演講
+    statement_to_parliament: 查閱我們所有的提交國會的其他聲明
+    statistical_data_set: 查閱我們所有的其他統計數據資料
+    statistics: 查閱我們所有的其他統計資料
     statutory_guidance:
-    transcript: "查閱我們所有的其他談話副本"
-    transparency: "查閱我們所有的其他透明化數據"
-    written_statement: "查閱我們所有的提交國會的其他書面聲明"
+    transcript: 查閱我們所有的其他談話副本
+    transparency: 查閱我們所有的其他透明化數據
+    written_statement: 查閱我們所有的提交國會的其他書面聲明
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "和"
+      last_word_connector: 和
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "我們的公告"
-      country: "國家"
-      documents: "文件"
-      mission: "我們的使命"
-      organisations: "組織"
-      publications: "我們的出版物"
-      quick_links: "快速連結"
-      related_policies: "相關政策"
-      statistics: "我們的統計資料"
+      announcements: 我們的公告
+      country: 國家
+      documents: 文件
+      mission: 我們的使命
+      organisations: 組織
+      publications: 我們的出版物
+      quick_links: 快速連結
+      related_policies: 相關政策
+      statistics: 我們的統計資料
     type:
       international_delegation:
-        one: "國際代表"
-        other: "其他國際代表"
+        one: 國際代表
+        other: 其他國際代表
       world_location:
-        one: "全球駐點"
-        other: "其他全球駐點"
+        one: 全球駐點
+        other: 其他全球駐點
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "我們的%{link}解釋我們如何處理你的個人資料。"
-      publication_scheme_html: "查閱我們在%{link}定期發布的資訊。"
-      social_media_use_html: "查閱我們在%{link}的政策。"
-      welsh_language_scheme_html: "查閱我們在%{link}的發布承諾。"
-    find_out_more: "查閱全部資訊和聯絡資料"
+      personal_information_charter_html: 我們的%{link}解釋我們如何處理你的個人資料。
+      publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
+      social_media_use_html: 查閱我們在%{link}的政策。
+      welsh_language_scheme_html: 查閱我們在%{link}的發布承諾。
+    find_out_more: 查閱全部資訊和聯絡資料
     headings:
-      about_us: "關於我們"
-      contact_us: "聯絡我們"
-      corporate_information: "詳細的資訊"
-      follow_us: "關注我們"
-      our_people: "主要館員"
-      our_services: "我們的服務"
-    location: "位置"
-    part_of: "隸屬於"
+      about_us: 關於我們
+      contact_us: 聯絡我們
+      corporate_information: 詳細的資訊
+      follow_us: 關注我們
+      our_people: 主要館員
+      our_services: 我們的服務
+    location: 位置
+    part_of: 隸屬於

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -43,18 +43,18 @@ zh-tw:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "公告"
+    heading: 公告
     view_all:
   attachment:
     accessibility:
-      full_help_html: "尋求另一種檔案格式：點字或音檔"
-      heading: "此檔案不適合使用科技輔助的使用者"
-      request_a_different_format: "尋求別種格式"
+      full_help_html: 尋求另一種檔案格式：點字或音檔
+      heading: 此檔案不適合使用科技輔助的使用者
+      request_a_different_format: 尋求別種格式
     headings:
-      order_a_copy: "訂購備份"
-      order_a_copy_full: "訂購發行刊物"
-      published: "發行"
-      reference: "參考"
+      order_a_copy: 訂購備份
+      order_a_copy_full: 訂購發行刊物
+      published: 發行
+      reference: 參考
       unnumbered_command_paper:
       unnumbered_hoc_paper:
     opendocument:
@@ -72,8 +72,8 @@ zh-tw:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "聯絡資料表"
-    email: "電子郵件"
+    contact_form: 聯絡資料表
+    email: 電子郵件
   corporate_information_page:
     type:
       link_text:
@@ -88,17 +88,17 @@ zh-tw:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "個人資訊表"
+        personal_information_charter: 個人資訊表
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "出版計畫"
+        publication_scheme: 出版計畫
         recruitment:
         research:
-        social_media_use: "社群應用"
+        social_media_use: 社群應用
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "威爾士語言計畫"
+        welsh_language_scheme: 威爾士語言計畫
   date:
     formats:
       default: "%d %B %Y"
@@ -111,85 +111,85 @@ zh-tw:
       published:
       updated:
     headings:
-      applies_to_nations: "應用"
+      applies_to_nations: 應用
       attachments:
-        one: "文件"
-        other: "其他文件"
+        one: 文件
+        other: 其他文件
       from:
       location:
       part_of:
-    published: "發行"
-    read: "閱讀%{title}文章"
+    published: 發行
+    read: 閱讀%{title}文章
     speech:
       author_title:
-        minister: "部長"
-        speaker: "作者"
-      delivered_on: "交付："
+        minister: 部長
+        speaker: 作者
+      delivered_on: 交付：
       delivery_title:
-        minister: "部長"
-        speaker: "發言人"
-      written_on: "撰寫於:"
+        minister: 部長
+        speaker: 發言人
+      written_on: '撰寫於:'
     type:
       announcement:
-        one: "公告"
-        other: "其他公告"
+        one: 公告
+        other: 其他公告
       authored_article:
-        one: "撰寫文章"
-        other: "撰寫其他文章"
+        one: 撰寫文章
+        other: 撰寫其他文章
       blog_post:
         one:
         other:
       case_study:
-        one: "案例研究"
-        other: "其他案例研究"
+        one: 案例研究
+        other: 其他案例研究
       closed_consultation:
-        one: "專屬諮詢"
-        other: "其他專屬諮詢"
+        one: 專屬諮詢
+        other: 其他專屬諮詢
       consultation:
-        one: "諮詢"
-        other: "其他諮詢"
+        one: 諮詢
+        other: 其他諮詢
       consultation_outcome:
-        one: "諮詢結果"
-        other: "其他諮詢結果"
+        one: 諮詢結果
+        other: 其他諮詢結果
       corporate_report:
-        one: "公司報告"
-        other: "其他公司報告"
+        one: 公司報告
+        other: 其他公司報告
       correspondence:
-        one: "對應"
-        other: "對應"
+        one: 對應
+        other: 對應
       decision:
         one:
         other:
       detailed_guidance:
-        one: "詳細指引"
-        other: "詳細指引"
+        one: 詳細指引
+        other: 詳細指引
       document_collection:
-        one: "系列"
+        one: 系列
         other:
       draft_text:
-        one: "內容"
-        other: "其他內容"
+        one: 內容
+        other: 其他內容
       foi_release:
-        one: "政府公開訊息"
-        other: "其他政府公開訊息"
+        one: 政府公開訊息
+        other: 其他政府公開訊息
       form:
-        one: "表格"
-        other: "其他表格"
+        one: 表格
+        other: 其他表格
       government_response:
-        one: "政府回應"
-        other: "政府其他回應"
+        one: 政府回應
+        other: 政府其他回應
       guidance:
-        one: "指引"
-        other: "指引"
+        one: 指引
+        other: 指引
       impact_assessment:
-        one: "影響評估"
-        other: "其他影響評估"
+        one: 影響評估
+        other: 其他影響評估
       imported:
-        one: "輸入 - 等待中"
-        other: "輸入 - 等待中"
+        one: 輸入 - 等待中
+        other: 輸入 - 等待中
       independent_report:
-        one: "獨立報告"
-        other: "其他獨立報告"
+        one: 獨立報告
+        other: 其他獨立報告
       international_treaty:
         one:
         other:
@@ -197,17 +197,17 @@ zh-tw:
         one:
         other:
       map:
-        one: "地圖"
-        other: "其他地圖"
+        one: 地圖
+        other: 其他地圖
       national_statistics:
-        one: "國家統計數據"
-        other: "國家統計數據"
+        one: 國家統計數據
+        other: 國家統計數據
       news_article:
-        one: "新聞"
-        other: "其他新聞"
+        one: 新聞
+        other: 其他新聞
       news_story:
-        one: "新聞"
-        other: "其他新聞"
+        one: 新聞
+        other: 其他新聞
       nhs_content:
         one:
         other:
@@ -215,83 +215,83 @@ zh-tw:
         one:
         other:
       official_statistics:
-        one: "統計"
-        other: "統計"
+        one: 統計
+        other: 統計
       open_consultation:
-        one: "公開諮詢"
-        other: "其他公開諮詢"
+        one: 公開諮詢
+        other: 其他公開諮詢
       oral_statement:
-        one: "議會口頭聲明"
-        other: "其他議會口頭聲明"
+        one: 議會口頭聲明
+        other: 其他議會口頭聲明
       policy_paper:
-        one: "政策報告"
-        other: "其他政策報告"
+        one: 政策報告
+        other: 其他政策報告
       press_release:
-        one: "新聞稿"
-        other: "其他新聞稿"
+        one: 新聞稿
+        other: 其他新聞稿
       promotional:
-        one: "宣傳資料"
-        other: "宣傳資料"
+        one: 宣傳資料
+        other: 宣傳資料
       publication:
-        one: "發行物"
-        other: "其他發行物"
+        one: 發行物
+        other: 其他發行物
       regulation:
         one:
         other:
       research:
-        one: "研究與分析"
-        other: "研究與分析"
+        one: 研究與分析
+        other: 研究與分析
       speaking_notes:
-        one: "演講稿"
-        other: "演講稿"
+        one: 演講稿
+        other: 演講稿
       speech:
-        one: "演講"
-        other: "其他演講"
+        one: 演講
+        other: 其他演講
       statement_to_parliament:
-        one: "議會聲明"
-        other: "議會聲明"
+        one: 議會聲明
+        other: 議會聲明
       statistical_data_set:
-        one: "統計數據資料"
-        other: "其他統計數據料"
+        one: 統計數據資料
+        other: 其他統計數據料
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "談話副本"
-        other: "其他談話副本"
+        one: 談話副本
+        other: 其他談話副本
       transparency:
-        one: "透明化數據"
-        other: "透明化數據"
+        one: 透明化數據
+        other: 透明化數據
       world_news_story:
         one:
         other:
       written_statement:
-        one: "提交國會的書面聲明"
-        other: "提交國會的其他書面聲明"
-    updated: "更新"
-    view: "查看'%{title}'"
+        one: 提交國會的書面聲明
+        other: 提交國會的其他書面聲明
+    updated: 更新
+    view: 查看'%{title}'
   document_filters:
-    description: "你可以使用過濾功能顯示&nbsp;只符合你需要的&nbsp;結果。"
+    description: 你可以使用過濾功能顯示&nbsp;只符合你需要的&nbsp;結果。
     no_results:
-      description: "嘗試擴大你的搜尋範圍並且再次搜索。"
-      title: "沒有符合的文件。"
+      description: 嘗試擴大你的搜尋範圍並且再次搜索。
+      title: 沒有符合的文件。
       tna_heading:
       tna_link:
     world_locations:
-      all: "所有地區位置"
-      label: "世界地區位置"
+      all: 所有地區位置
+      label: 世界地區位置
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "最新的活動"
+    latest_activity: 最新的活動
   i18n:
     direction: ltr
   language_names:
-    zh-tw: "中文"
+    zh-tw: 中文
   latest_feed:
-    no_updates: "目前暫無更新。"
-    title: "最新消息"
+    no_updates: 目前暫無更新。
+    title: 最新消息
   national_statistics:
     heading:
   number:
@@ -300,37 +300,37 @@ zh-tw:
         format: "%n%u"
   organisation:
     about:
-      read_more: "查閱更多關於我們的工作"
+      read_more: 查閱更多關於我們的工作
     corporate_information:
-      access_our_info: "閱讀我們的資訊"
-      foi_how_to: "如何進行資訊自由（FOI）申請"
-      foi_releases: "資訊自由（FOI）資訊發布"
-      jobs_and_contacts: "職位及聯絡方法"
+      access_our_info: 閱讀我們的資訊
+      foi_how_to: 如何進行資訊自由（FOI）申請
+      foi_releases: 資訊自由（FOI）資訊發布
+      jobs_and_contacts: 職位及聯絡方法
       organisation_chart:
-      transparency: "透明化數據"
+      transparency: 透明化數據
     foi_exemption_html:
     headings:
-      chief_professional_officers: "我們的首席專業官員"
-      contact: "聯繫%{name}"
-      corporate_information: "政府資訊"
-      corporate_reports: "政府報告"
+      chief_professional_officers: 我們的首席專業官員
+      contact: 聯繫%{name}
+      corporate_information: 政府資訊
+      corporate_reports: 政府報告
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "我們的公告"
+      our_announcements: 我們的公告
       our_consultations:
       our_judges:
-      our_management: "我們的管理層"
-      our_ministers: "我們的首相/大臣"
-      our_policies: "我們的政策"
-      our_publications: "我們的出版物"
-      our_senior_military_officials: "我們的高級軍事官員"
-      our_services: "我們的服務"
-      our_statistics: "我們的統計資料"
-      our_topics: "我們工作的領域"
-      special_representatives: "特別代表"
-      traffic_commissioners: "交通事務專員"
-      what_we_do: "我們的工作"
+      our_management: 我們的管理層
+      our_ministers: 我們的首相/大臣
+      our_policies: 我們的政策
+      our_publications: 我們的出版物
+      our_senior_military_officials: 我們的高級軍事官員
+      our_services: 我們的服務
+      our_statistics: 我們的統計資料
+      our_topics: 我們工作的領域
+      special_representatives: 特別代表
+      traffic_commissioners: 交通事務專員
+      what_we_do: 我們的工作
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -345,13 +345,13 @@ zh-tw:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "政策"
+    heading: 政策
     view_all:
   publications:
-    heading: "出版物"
+    heading: 出版物
     headings:
-      detail: "詳情"
-  read_more: "閱讀更多"
+      detail: 詳情
+  read_more: 閱讀更多
   roles:
     heading:
       one:
@@ -365,89 +365,89 @@ zh-tw:
     previous_holders:
     read_more:
   see_all:
-    announcement: "查閱我們所有的其他公告"
-    authored_article: "查閱我們所有的撰寫其他文章"
-    case_study: "查閱我們所有的其他案例研究"
-    closed_consultation: "查閱我們所有的其他專屬諮詢"
-    consultation: "查閱我們所有的其他諮詢"
-    consultation_outcome: "查閱我們所有的其他諮詢結果"
-    corporate_report: "查閱我們所有的其他公司報告"
-    correspondence: "查閱我們所有的對應"
+    announcement: 查閱我們所有的其他公告
+    authored_article: 查閱我們所有的撰寫其他文章
+    case_study: 查閱我們所有的其他案例研究
+    closed_consultation: 查閱我們所有的其他專屬諮詢
+    consultation: 查閱我們所有的其他諮詢
+    consultation_outcome: 查閱我們所有的其他諮詢結果
+    corporate_report: 查閱我們所有的其他公司報告
+    correspondence: 查閱我們所有的對應
     decision:
-    detailed_guidance: "查閱我們所有的詳細指引"
+    detailed_guidance: 查閱我們所有的詳細指引
     document_collection:
-    draft_text: "查閱我們所有的其他內容"
-    fatality_notice: "查閱我們所有的安全事故通知"
-    foi_release: "查閱我們所有的其他政府公開訊息"
-    form: "查閱我們所有的其他表格"
-    government_response: "查閱我們所有的政府其他回應"
-    guidance: "查閱我們所有的指引"
-    impact_assessment: "查閱我們所有的其他影響評估"
-    imported: "查閱我們所有的輸入 - 等待中"
+    draft_text: 查閱我們所有的其他內容
+    fatality_notice: 查閱我們所有的安全事故通知
+    foi_release: 查閱我們所有的其他政府公開訊息
+    form: 查閱我們所有的其他表格
+    government_response: 查閱我們所有的政府其他回應
+    guidance: 查閱我們所有的指引
+    impact_assessment: 查閱我們所有的其他影響評估
+    imported: 查閱我們所有的輸入 - 等待中
     international_treaty:
-    map: "查閱我們所有的其他地圖"
-    national_statistics: "查閱我們所有的國家統計數據"
-    news_article: "查閱我們所有的其他新聞"
-    news_story: "查閱我們所有的其他新聞"
+    map: 查閱我們所有的其他地圖
+    national_statistics: 查閱我們所有的國家統計數據
+    news_article: 查閱我們所有的其他新聞
+    news_story: 查閱我們所有的其他新聞
     notice:
-    open_consultation: "查閱我們所有的其他公開諮詢"
-    oral_statement: "查閱我們所有的其他議會口頭聲明"
-    policy: "查閱我們所有的其他政策"
-    policy_paper: "查閱我們所有的其他政策報告"
-    press_release: "查閱我們所有的其他新聞稿"
-    promotional: "查閱我們所有的宣傳資料"
-    publication: "查閱我們所有的其他發行物"
+    open_consultation: 查閱我們所有的其他公開諮詢
+    oral_statement: 查閱我們所有的其他議會口頭聲明
+    policy: 查閱我們所有的其他政策
+    policy_paper: 查閱我們所有的其他政策報告
+    press_release: 查閱我們所有的其他新聞稿
+    promotional: 查閱我們所有的宣傳資料
+    publication: 查閱我們所有的其他發行物
     regulation:
-    research: "查閱我們所有的研究與分析"
-    speaking_notes: "查閱我們所有的演講稿"
-    speech: "查閱我們所有的其他演講"
-    statement_to_parliament: "查閱我們所有的議會聲明"
-    statistical_data_set: "查閱我們所有的其他統計數據料"
-    statistics: "查閱我們所有的統計"
+    research: 查閱我們所有的研究與分析
+    speaking_notes: 查閱我們所有的演講稿
+    speech: 查閱我們所有的其他演講
+    statement_to_parliament: 查閱我們所有的議會聲明
+    statistical_data_set: 查閱我們所有的其他統計數據料
+    statistics: 查閱我們所有的統計
     statutory_guidance:
-    transcript: "查閱我們所有的其他談話副本"
-    transparency: "查閱我們所有的透明化數據"
-    written_statement: "查閱我們所有的提交國會的其他書面聲明"
+    transcript: 查閱我們所有的其他談話副本
+    transparency: 查閱我們所有的透明化數據
+    written_statement: 查閱我們所有的提交國會的其他書面聲明
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "和"
+      last_word_connector: 和
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "我們的公告"
-      country: "國家"
-      documents: "文件"
-      mission: "我們的使命"
-      organisations: "組織"
-      publications: "我們的出版物"
-      quick_links: "快速連結"
-      related_policies: "相關政策"
-      statistics: "我們的統計資料"
+      announcements: 我們的公告
+      country: 國家
+      documents: 文件
+      mission: 我們的使命
+      organisations: 組織
+      publications: 我們的出版物
+      quick_links: 快速連結
+      related_policies: 相關政策
+      statistics: 我們的統計資料
     type:
       international_delegation:
-        one: "國際代表"
-        other: "其他國際代表"
+        one: 國際代表
+        other: 其他國際代表
       world_location:
-        one: "世界地區位置"
-        other: "其他世界地區位置"
+        one: 世界地區位置
+        other: 其他世界地區位置
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "我們的%{link}解釋我們如何處理你的個人資料。"
-      publication_scheme_html: "查閱我們在%{link}定期發布的資訊。"
-      social_media_use_html: "查閱我們在%{link}的政策。"
-      welsh_language_scheme_html: "查閱我們在%{link}的發佈承諾。"
-    find_out_more: "查閱全部資訊和聯絡資料"
+      personal_information_charter_html: 我們的%{link}解釋我們如何處理你的個人資料。
+      publication_scheme_html: 查閱我們在%{link}定期發布的資訊。
+      social_media_use_html: 查閱我們在%{link}的政策。
+      welsh_language_scheme_html: 查閱我們在%{link}的發佈承諾。
+    find_out_more: 查閱全部資訊和聯絡資料
     headings:
-      about_us: "關於我們"
-      contact_us: "聯絡我們"
-      corporate_information: "詳細的資訊"
-      follow_us: "關注我們"
-      our_people: "主要館員"
-      our_services: "我們的服務"
-    location: "位置"
-    part_of: "隸屬於"
+      about_us: 關於我們
+      contact_us: 聯絡我們
+      corporate_information: 詳細的資訊
+      follow_us: 關注我們
+      our_people: 主要館員
+      our_services: 我們的服務
+    location: 位置
+    part_of: 隸屬於

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -43,17 +43,17 @@ zh:
       unique_reference:
       unnumbered_hoc_paper:
   announcements:
-    heading: "公告"
+    heading: 公告
     view_all:
   attachment:
     accessibility:
       full_help_html: 申请本文件的其它格式，如盲文、音频或者不同的文件类型，请发送邮件%{email}并写明您的地址、电话号码以及此报告的标题("%{title}")%{references}。
-      heading: "此文件可能对使用辅助技术的用户不适合。"
-      request_a_different_format: "申请另一种格式。"
+      heading: 此文件可能对使用辅助技术的用户不适合。
+      request_a_different_format: 申请另一种格式。
     headings:
-      order_a_copy: "订阅副本"
-      order_a_copy_full: "订阅报告副本"
-      published: "已发布"
+      order_a_copy: 订阅副本
+      order_a_copy_full: 订阅报告副本
+      published: 已发布
       reference: Ref
       unnumbered_command_paper:
       unnumbered_hoc_paper:
@@ -72,8 +72,8 @@ zh:
     see_all_updates:
     updated_at:
   contact:
-    contact_form: "联系表格"
-    email: "邮件"
+    contact_form: 联系表格
+    email: 邮件
   corporate_information_page:
     type:
       link_text:
@@ -88,17 +88,17 @@ zh:
         membership:
         our_energy_use:
         our_governance:
-        personal_information_charter: "个人信息资料"
+        personal_information_charter: 个人信息资料
         petitions_and_campaigns:
         procurement:
-        publication_scheme: "报告发布计划"
+        publication_scheme: 报告发布计划
         recruitment:
         research:
-        social_media_use: "社交媒体使用"
+        social_media_use: 社交媒体使用
         staff_update:
         statistics:
         terms_of_reference:
-        welsh_language_scheme: "威尔士语言计划"
+        welsh_language_scheme: 威尔士语言计划
   date:
     formats:
       default: "%d %B %Y"
@@ -111,85 +111,85 @@ zh:
       published:
       updated:
     headings:
-      applies_to_nations: "适用于"
+      applies_to_nations: 适用于
       attachments:
-        one: "文件"
-        other: "文件"
+        one: 文件
+        other: 文件
       from:
       location:
       part_of:
-    published: "已发布"
-    read: "阅读%{title}文章"
+    published: 已发布
+    read: 阅读%{title}文章
     speech:
       author_title:
-        minister: "首相/大臣/秘书"
-        speaker: "作者"
-      delivered_on: "发表于："
+        minister: 首相/大臣/秘书
+        speaker: 作者
+      delivered_on: 发表于：
       delivery_title:
-        minister: "首相/大臣/秘书"
-        speaker: "演讲者"
-      written_on: "撰写于："
+        minister: 首相/大臣/秘书
+        speaker: 演讲者
+      written_on: 撰写于：
     type:
       announcement:
-        one: "公告"
-        other: "公告"
+        one: 公告
+        other: 公告
       authored_article:
-        one: "撰写的文章"
-        other: "撰写的文章"
+        one: 撰写的文章
+        other: 撰写的文章
       blog_post:
         one:
         other:
       case_study:
-        one: "实例研究"
-        other: "实例研究"
+        one: 实例研究
+        other: 实例研究
       closed_consultation:
-        one: "已办结的咨询"
-        other: "已办结的咨询"
+        one: 已办结的咨询
+        other: 已办结的咨询
       consultation:
-        one: "咨询"
-        other: "咨询"
+        one: 咨询
+        other: 咨询
       consultation_outcome:
-        one: "咨询结果"
-        other: "咨询结果"
+        one: 咨询结果
+        other: 咨询结果
       corporate_report:
-        one: "政府报告"
-        other: "政府报告"
+        one: 政府报告
+        other: 政府报告
       correspondence:
-        one: "交流"
-        other: "交流"
+        one: 交流
+        other: 交流
       decision:
         one:
         other:
       detailed_guidance:
-        one: "详细指导"
-        other: "详细指导"
+        one: 详细指导
+        other: 详细指导
       document_collection:
-        one: "系列"
+        one: 系列
         other:
       draft_text:
-        one: "草拟稿件"
-        other: "草拟稿件"
+        one: 草拟稿件
+        other: 草拟稿件
       foi_release:
-        one: "资讯自由(FOI)信息发布"
-        other: "资讯自由(FOI)信息发布"
+        one: 资讯自由(FOI)信息发布
+        other: 资讯自由(FOI)信息发布
       form:
-        one: "表格"
-        other: "表格"
+        one: 表格
+        other: 表格
       government_response:
-        one: "政府反应"
-        other: "政府反应"
+        one: 政府反应
+        other: 政府反应
       guidance:
-        one: "指导"
-        other: "指导"
+        one: 指导
+        other: 指导
       impact_assessment:
-        one: "影响评估"
-        other: "影响评估"
+        one: 影响评估
+        other: 影响评估
       imported:
-        one: "导入 - 正在等待的类型"
-        other: "导入 - 正在等待的类型"
+        one: 导入 - 正在等待的类型
+        other: 导入 - 正在等待的类型
       independent_report:
-        one: "独立报告"
-        other: "独立报告"
+        one: 独立报告
+        other: 独立报告
       international_treaty:
         one:
         other:
@@ -197,17 +197,17 @@ zh:
         one:
         other:
       map:
-        one: "地图"
-        other: "地图"
+        one: 地图
+        other: 地图
       national_statistics:
-        one: "统计数据 - 国家数据"
-        other: "统计数据 - 国家数据"
+        one: 统计数据 - 国家数据
+        other: 统计数据 - 国家数据
       news_article:
-        one: "新闻文章"
-        other: "新闻文章"
+        one: 新闻文章
+        other: 新闻文章
       news_story:
-        one: "新闻报道"
-        other: "新闻报道"
+        one: 新闻报道
+        other: 新闻报道
       nhs_content:
         one:
         other:
@@ -215,83 +215,83 @@ zh:
         one:
         other:
       official_statistics:
-        one: "统计数据"
-        other: "统计数据"
+        one: 统计数据
+        other: 统计数据
       open_consultation:
-        one: "公开咨询"
-        other: "公开咨询"
+        one: 公开咨询
+        other: 公开咨询
       oral_statement:
-        one: "对议会的口头声明"
-        other: "对议会的口头声明"
+        one: 对议会的口头声明
+        other: 对议会的口头声明
       policy_paper:
-        one: "政策文件"
-        other: "政策文件"
+        one: 政策文件
+        other: 政策文件
       press_release:
-        one: "新闻稿"
-        other: "新闻稿"
+        one: 新闻稿
+        other: 新闻稿
       promotional:
-        one: "宣传材料"
-        other: "宣传材料"
+        one: 宣传材料
+        other: 宣传材料
       publication:
-        one: "发布的报告"
-        other: "发布的报告"
+        one: 发布的报告
+        other: 发布的报告
       regulation:
         one:
         other:
       research:
-        one: "研究及分析"
-        other: "研究及分析"
+        one: 研究及分析
+        other: 研究及分析
       speaking_notes:
-        one: "演讲稿"
-        other: "演讲稿"
+        one: 演讲稿
+        other: 演讲稿
       speech:
-        one: "演讲"
-        other: "演讲"
+        one: 演讲
+        other: 演讲
       statement_to_parliament:
-        one: "对议会的声明"
-        other: "对议会的声明"
+        one: 对议会的声明
+        other: 对议会的声明
       statistical_data_set:
-        one: "统计数据集"
-        other: "统计数据集"
+        one: 统计数据集
+        other: 统计数据集
       statutory_guidance:
         one:
         other:
       transcript:
-        one: "副本"
-        other: "副本"
+        one: 副本
+        other: 副本
       transparency:
-        one: "透明化数据"
-        other: "透明化数据"
+        one: 透明化数据
+        other: 透明化数据
       world_news_story:
         one:
         other:
       written_statement:
-        one: "对议会的书面声明"
-        other: "对议会的书面声明"
-    updated: "已更新"
-    view: "阅读'%{title}'"
+        one: 对议会的书面声明
+        other: 对议会的书面声明
+    updated: 已更新
+    view: 阅读'%{title}'
   document_filters:
-    description: "您可以使用过滤功能显示只符合您需要的结果。"
+    description: 您可以使用过滤功能显示只符合您需要的结果。
     no_results:
-      description: "尝试扩大您的搜索范围并再次搜索。"
-      title: "没有符合的文件。"
+      description: 尝试扩大您的搜索范围并再次搜索。
+      title: 没有符合的文件。
       tna_heading:
       tna_link:
     world_locations:
-      all: "所有地区位置"
-      label: "世界地区位置"
+      all: 所有地区位置
+      label: 世界地区位置
   feeds:
     email:
     feed:
     get_updates_to_this_list:
-    latest_activity: "最新活动"
+    latest_activity: 最新活动
   i18n:
     direction: ltr
   language_names:
-    zh: "中文"
+    zh: 中文
   latest_feed:
-    no_updates: "目前暂无更新。"
-    title: "最新消息"
+    no_updates: 目前暂无更新。
+    title: 最新消息
   national_statistics:
     heading:
   number:
@@ -300,37 +300,37 @@ zh:
         format: "%n%u"
   organisation:
     about:
-      read_more: "阅读更多关于我们的工作"
+      read_more: 阅读更多关于我们的工作
     corporate_information:
-      access_our_info: "阅读我们的信息"
-      foi_how_to: "如何进行资讯自由（FOI）申请"
-      foi_releases: "资讯自由(FOI)信息发布"
-      jobs_and_contacts: "职位及联系方式"
+      access_our_info: 阅读我们的信息
+      foi_how_to: 如何进行资讯自由（FOI）申请
+      foi_releases: 资讯自由(FOI)信息发布
+      jobs_and_contacts: 职位及联系方式
       organisation_chart:
-      transparency: "透明化数据"
+      transparency: 透明化数据
     foi_exemption_html:
     headings:
-      chief_professional_officers: "我们的首席专业官员"
-      contact: "联系%{name}"
-      corporate_information: "政府信息"
-      corporate_reports: "政府报告"
+      chief_professional_officers: 我们的首席专业官员
+      contact: 联系%{name}
+      corporate_information: 政府信息
+      corporate_reports: 政府报告
       documents:
       freedom_of_information_act:
       making_foi_requests:
-      our_announcements: "我们的公告"
+      our_announcements: 我们的公告
       our_consultations:
       our_judges:
-      our_management: "我们的管理层"
-      our_ministers: "我们的首相/大臣/秘书"
-      our_policies: "我们的政策"
-      our_publications: "我们的报告"
-      our_senior_military_officials: "我们的高级军事官员"
-      our_services: "我们的服务"
-      our_statistics: "我们的数据"
-      our_topics: "我们围绕这些主题进行工作"
-      special_representatives: "特别代表"
-      traffic_commissioners: "交通事务专员"
-      what_we_do: "我们的工作"
+      our_management: 我们的管理层
+      our_ministers: 我们的首相/大臣/秘书
+      our_policies: 我们的政策
+      our_publications: 我们的报告
+      our_senior_military_officials: 我们的高级军事官员
+      our_services: 我们的服务
+      our_statistics: 我们的数据
+      our_topics: 我们围绕这些主题进行工作
+      special_representatives: 特别代表
+      traffic_commissioners: 交通事务专员
+      what_we_do: 我们的工作
       who_we_are:
     making_foi_requests:
       step1_html:
@@ -345,13 +345,13 @@ zh:
     previous_roles_in_government:
     read_more:
   policies:
-    heading: "政策"
+    heading: 政策
     view_all:
   publications:
-    heading: "发布的报告"
+    heading: 发布的报告
     headings:
-      detail: "详情"
-  read_more: "阅读更多"
+      detail: 详情
+  read_more: 阅读更多
   roles:
     heading:
       one:
@@ -365,89 +365,89 @@ zh:
     previous_holders:
     read_more:
   see_all:
-    announcement: "查阅我们所有的公告"
-    authored_article: "查阅我们所有的撰写的文章"
-    case_study: "查阅我们所有的实例研究"
-    closed_consultation: "查阅我们所有的已办结的咨询"
-    consultation: "查阅我们所有的咨询"
-    consultation_outcome: "查阅我们所有的咨询结果"
-    corporate_report: "查阅我们所有的政府报告"
-    correspondence: "查阅我们所有的交流"
+    announcement: 查阅我们所有的公告
+    authored_article: 查阅我们所有的撰写的文章
+    case_study: 查阅我们所有的实例研究
+    closed_consultation: 查阅我们所有的已办结的咨询
+    consultation: 查阅我们所有的咨询
+    consultation_outcome: 查阅我们所有的咨询结果
+    corporate_report: 查阅我们所有的政府报告
+    correspondence: 查阅我们所有的交流
     decision:
-    detailed_guidance: "查阅我们所有的详细指导"
+    detailed_guidance: 查阅我们所有的详细指导
     document_collection:
-    draft_text: "查阅我们所有的草拟稿件"
-    fatality_notice: "查阅我们所有的死亡通告"
-    foi_release: "查阅我们所有的资讯自由(foi)信息发布"
-    form: "查阅我们所有的表格"
-    government_response: "查阅我们所有的政府反应"
-    guidance: "查阅我们所有的指导"
-    impact_assessment: "查阅我们所有的影响评估"
-    imported: "查阅我们所有的导入 - 正在等待的类型"
+    draft_text: 查阅我们所有的草拟稿件
+    fatality_notice: 查阅我们所有的死亡通告
+    foi_release: 查阅我们所有的资讯自由(foi)信息发布
+    form: 查阅我们所有的表格
+    government_response: 查阅我们所有的政府反应
+    guidance: 查阅我们所有的指导
+    impact_assessment: 查阅我们所有的影响评估
+    imported: 查阅我们所有的导入 - 正在等待的类型
     international_treaty:
-    map: "查阅我们所有的地图"
-    national_statistics: "查阅我们所有的统计数据 - 国家数据"
-    news_article: "查阅我们所有的新闻文章"
-    news_story: "查阅我们所有的新闻报道"
+    map: 查阅我们所有的地图
+    national_statistics: 查阅我们所有的统计数据 - 国家数据
+    news_article: 查阅我们所有的新闻文章
+    news_story: 查阅我们所有的新闻报道
     notice:
-    open_consultation: "查阅我们所有的公开咨询"
-    oral_statement: "查阅我们所有的对议会的口头声明"
-    policy: "查阅我们所有的政策"
-    policy_paper: "查阅我们所有的政策文件"
-    press_release: "查阅我们所有的新闻稿"
-    promotional: "查阅我们所有的宣传材料"
-    publication: "查阅我们所有的发布的报告"
+    open_consultation: 查阅我们所有的公开咨询
+    oral_statement: 查阅我们所有的对议会的口头声明
+    policy: 查阅我们所有的政策
+    policy_paper: 查阅我们所有的政策文件
+    press_release: 查阅我们所有的新闻稿
+    promotional: 查阅我们所有的宣传材料
+    publication: 查阅我们所有的发布的报告
     regulation:
-    research: "查阅我们所有的研究及分析"
-    speaking_notes: "查阅我们所有的演讲稿"
-    speech: "查阅我们所有的演讲"
-    statement_to_parliament: "查阅我们所有的对议会的声明"
-    statistical_data_set: "查阅我们所有的统计数据集"
-    statistics: "查阅我们所有的统计数据"
+    research: 查阅我们所有的研究及分析
+    speaking_notes: 查阅我们所有的演讲稿
+    speech: 查阅我们所有的演讲
+    statement_to_parliament: 查阅我们所有的对议会的声明
+    statistical_data_set: 查阅我们所有的统计数据集
+    statistics: 查阅我们所有的统计数据
     statutory_guidance:
-    transcript: "查阅我们所有的副本"
-    transparency: "查阅我们所有的透明化数据"
-    written_statement: "查阅我们所有的对议会的书面声明"
+    transcript: 查阅我们所有的副本
+    transparency: 查阅我们所有的透明化数据
+    written_statement: 查阅我们所有的对议会的书面声明
   social_media:
     follow_us:
   support:
     array:
-      last_word_connector: "和"
+      last_word_connector: 和
   time:
     formats:
       long_ordinal: "%e %B %Y %H:%M"
   world_location:
     headings:
-      announcements: "我们的公告"
-      country: "国家"
-      documents: "文件"
-      mission: "我们的任务"
-      organisations: "机构"
-      publications: "我们的报告"
-      quick_links: "快速链接"
-      related_policies: "相关政策"
-      statistics: "我们的数据"
+      announcements: 我们的公告
+      country: 国家
+      documents: 文件
+      mission: 我们的任务
+      organisations: 机构
+      publications: 我们的报告
+      quick_links: 快速链接
+      related_policies: 相关政策
+      statistics: 我们的数据
     type:
       international_delegation:
-        one: "国际代表"
-        other: "国际代表"
+        one: 国际代表
+        other: 国际代表
       world_location:
-        one: "世界地区位置"
-        other: "世界地区位置"
+        one: 世界地区位置
+        other: 世界地区位置
   worldwide_organisation:
     corporate_information:
       about_our_services_html:
-      personal_information_charter_html: "我们的%{link}解释了我们如何对待您的个人信息。"
-      publication_scheme_html: "阅读我们在%{link}定期发布的信息。"
-      social_media_use_html: "阅读我们在%{link}的政策"
-      welsh_language_scheme_html: "查阅我们在%{link}发布的信息。"
-    find_out_more: "查阅全部内容和联系方式"
+      personal_information_charter_html: 我们的%{link}解释了我们如何对待您的个人信息。
+      publication_scheme_html: 阅读我们在%{link}定期发布的信息。
+      social_media_use_html: 阅读我们在%{link}的政策
+      welsh_language_scheme_html: 查阅我们在%{link}发布的信息。
+    find_out_more: 查阅全部内容和联系方式
     headings:
-      about_us: "关于我们"
-      contact_us: "联系我们"
-      corporate_information: "政府信息"
-      follow_us: "关注我们"
-      our_people: "我们的人员"
-      our_services: "我们的服务"
-    location: "位置"
-    part_of: "隶属于"
+      about_us: 关于我们
+      contact_us: 联系我们
+      corporate_information: 政府信息
+      follow_us: 关注我们
+      our_people: 我们的人员
+      our_services: 我们的服务
+    location: 位置
+    part_of: 隶属于


### PR DESCRIPTION
Changes to underlying versions of rails-i18n mean that when regenerating
translations using `rake translation:regenerate` we now have quotes
removed. Adding as its own commit as a precursor to adding a new
translation key.

There is some irony in the fact that this is the opposite of a PR from
three years ago https://github.com/alphagov/whitehall/pull/2083.
  