### PR TITLE
Log minitest runtime

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ require 'whitehall/not_quite_as_fake_search'
 require 'whitehall/search_index'
 require 'sidekiq/testing/inline'
 require 'govuk-content-schema-test-helpers/test_unit'
+require 'parallel_tests/test/runtime_logger'
 
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
`parallel_test` provides runtime logging functionality for tests. We seem to have this enabled for cucumber but not for minitest.

This commit enables it. The logs are written to `tmp/parallel_runtime_test.log`

Unfortunately the log gets summarised and due to Whitehall's inheritance within the tests it's still difficult to interpret but this helps a bit towards benchmarking changes to try and improve test speed.