### PR TITLE
Replace 'root_taxons' with 'level_one_taxons'

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -20,13 +20,13 @@
         data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.children } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @govuk_taxonomy.children } %>
 
         <h2>Draft topics</h2>
 
         <p>These topic pages are in development, and are not shown on GOV.UK</p>
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @govuk_taxonomy.draft_child_taxons } %>
       </div>
 
       <%= form.hidden_field "invisible_draft_taxons", value: @tag_form.invisible_draft_taxons.join(",") %>

--- a/app/views/admin/shared/tagging/_taxonomy.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy.html.erb
@@ -1,14 +1,14 @@
-<% root_taxons.each do |root_taxon| %>
-  <% root_taxon = TopicTreePresenter.new(root_taxon, collapsed: root_taxons.size > 1) %>
+<% level_one_taxons.each do |taxon| %>
+  <% taxon = TopicTreePresenter.new(taxon, collapsed: level_one_taxons.size > 1) %>
 
-  <% if root_taxon.children.empty? %>
-    <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: [root_taxon] } %>
+  <% if taxon.children.empty? %>
+    <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: [taxon] } %>
   <% else %>
     <div class="topic-tree">
-      <a class="<%= root_taxon.toggle_classes %>" data-toggle="collapse" href="#<%= root_taxon.content_id %>"><span class='icon'></span><%= root_taxon.name %></a>
+      <a class="<%= taxon.toggle_classes %>" data-toggle="collapse" href="#<%= taxon.content_id %>"><span class='icon'></span><%= taxon.name %></a>
 
-      <div class="<%= root_taxon.tree_classes %>" id="<%= root_taxon.content_id %>">
-        <%= render partial: "/admin/shared/tagging/sub_taxons", locals: {selected_taxons: selected_taxons, taxons: root_taxon.children } %>
+      <div class="<%= taxon.tree_classes %>" id="<%= taxon.content_id %>">
+        <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: taxon.children } %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -20,13 +20,13 @@
         data-content-format="statistics_announcement"
         data-content-public-path="<%= @statistics_announcement.public_path %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.children } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @govuk_taxonomy.children } %>
 
         <h2>Draft topics</h2>
 
         <p>These topic pages are in development, and are not shown on GOV.UK</p>
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, root_taxons: @govuk_taxonomy.draft_child_taxons } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @govuk_taxonomy.draft_child_taxons } %>
       </div>
 
       <p>

--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -10,7 +10,7 @@ module Taxonomy
 
     def published_taxon_data
       @_published_data ||= begin
-        taxons = get_root_taxons(with_drafts: false)
+        taxons = get_level_one_taxons(with_drafts: false)
         expand_taxon_array(taxons)
       end
     end
@@ -34,7 +34,7 @@ module Taxonomy
     end
 
     def all_taxon_data_including_draft
-      @_all_data ||= get_root_taxons(with_drafts: true)
+      @_all_data ||= get_level_one_taxons(with_drafts: true)
     end
 
     def draft_taxons_data
@@ -47,10 +47,10 @@ module Taxonomy
       end
     end
 
-    def get_root_taxons(with_drafts:)
+    def get_level_one_taxons(with_drafts:)
       get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
         .fetch('expanded_links', {})
-        .fetch('root_taxons', [])
+        .fetch('level_one_taxons', [])
     end
 
     def get_expanded_links_hash(content_id, with_drafts:)

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -47,30 +47,30 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
     }
   end
 
-  def setup_published_taxons(root_taxons)
+  def setup_published_taxons(level_one_taxons)
     homepage_expanded_links = {
       "content_id" => Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID,
       "expanded_links" => {
-        "root_taxons" => root_taxons
+        "level_one_taxons" => level_one_taxons
       }
     }
     publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: false)
 
-    root_taxons.each do |taxon|
+    level_one_taxons.each do |taxon|
       publishing_api_has_expanded_links(taxon, with_drafts: true)
     end
   end
 
-  def setup_draft_taxons(root_taxons)
+  def setup_draft_taxons(level_one_taxons)
     homepage_expanded_links = {
       "content_id" => Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID,
       "expanded_links" => {
-        "root_taxons" => root_taxons
+        "level_one_taxons" => level_one_taxons
       }
     }
     publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: true)
 
-    root_taxons.each do |taxon|
+    level_one_taxons.each do |taxon|
       publishing_api_has_expanded_links(taxon, with_drafts: true)
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/g41T515W/314-clean-up-use-of-the-roottaxons-link-on-the-homepage-content-item

The 'root_taxons' link type is soon to be replaced by the 'level_one_taxons' link type. 