### PR TITLE
Create or update link reports

### DIFF
--- a/app/models/link_checker_api_report/create_from_batch_report.rb
+++ b/app/models/link_checker_api_report/create_from_batch_report.rb
@@ -1,35 +1,41 @@
 class LinkCheckerApiReport::CreateFromBatchReport
-  def initialize(payload, link_reportable)
+  def initialize(payload, reportable)
     @payload = payload
-    @link_reportable = link_reportable
+    @reportable = reportable
   end
 
   def create
-    report = create_report
-    create_links(report)
-    report
+    ActiveRecord::Base.transaction do
+      report = create_report
+      create_links(report)
+      report
+    end
   end
 
 private
 
-  attr_reader :payload, :link_reportable
+  attr_reader :payload, :reportable
 
   def create_report
     LinkCheckerApiReport.create!(
       batch_id: payload.fetch("id"),
       completed_at: payload.fetch("completed_at"),
-      link_reportable: link_reportable,
+      link_reportable: reportable,
       status: payload.fetch("status"),
     )
   end
 
   def create_links(report)
     payload.fetch("links", []).each_with_index do |link_payload, index|
-      attributes = LinkCheckerApiReport::Link
-        .attributes_from_link_report(link_payload)
-        .merge(ordering: index)
-
-      report.links.create!(attributes)
+      report.links.create!(
+        link_attributes_from_report(link_payload, index)
+      )
     end
+  end
+
+  def link_attributes_from_report(payload, index)
+    LinkCheckerApiReport::Link
+      .attributes_from_link_report(payload)
+      .merge(ordering: index)
   end
 end

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -1,6 +1,6 @@
 class LinkCheckerApiService
   def self.has_links?(reportable)
-    extract_links(reportable).count > 0
+    !extract_links(reportable).empty?
   end
 
   def self.extract_links(reportable)
@@ -9,18 +9,20 @@ class LinkCheckerApiService
 
   def self.check_links(reportable, webhook_uri)
     uris = extract_links(reportable)
-    raise "Reportable has no links to check" unless uris.count > 0
+    raise "Reportable has no links to check" if uris.empty?
 
     batch_report = Whitehall.link_checker_api_client.create_batch(
       uris,
       webhook_uri: webhook_uri,
       webhook_secret_token: webhook_secret_token
     )
+
     LinkCheckerApiReport.create_from_batch_report(batch_report, reportable)
   end
 
   def self.webhook_secret_token
     Rails.application.secrets.link_checker_api_secret_token
   end
+
   private_class_method :webhook_secret_token
 end

--- a/test/unit/models/link_checker_api_report_test.rb
+++ b/test/unit/models/link_checker_api_report_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+class LinkCheckerApiReportTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  test "replaces a batch report if it already exists" do
+    link = "http://www.example.com"
+    publication = create(:publication, body: "[link](#{link})")
+
+    batch_id = 5
+
+    report_payload = link_checker_api_batch_report_hash(
+      id: batch_id,
+      links: [{ uri: link }],
+      status: "completed",
+    ).with_indifferent_access
+
+    LinkCheckerApiReport.create!(
+      batch_id: batch_id,
+      link_reportable: publication,
+      status: "in_progress",
+    )
+
+    LinkCheckerApiReport.create_from_batch_report(report_payload, publication)
+
+    report = LinkCheckerApiReport.find_by(batch_id: batch_id)
+    assert_equal "completed", report.status
+  end
+end


### PR DESCRIPTION
We're coming across a problem whereby the data sync is causing a mismatch in the batch IDs stored in Whitehall and the batch IDs stored in the Link Checker API. This is because the databases don't get copied across at the same time.

We thought the best solution to this would be to simply replace any existing link report that exists with the same batch ID.