### PR TITLE
Upgrade gds-api-adapters to 50.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,8 @@ GEM
     ffi (1.9.18)
     friendly_id (5.2.3)
       activerecord (>= 4.0.0)
-    gds-api-adapters (50.7.0)
+    gds-api-adapters (50.9.1)
+      addressable
       link_header
       lrucache (~> 0.1.1)
       null_logger


### PR DESCRIPTION
So that I can get the change in
https://github.com/alphagov/gds-api-adapters/pull/794 which should allow
me to fix https://github.com/alphagov/asset-manager/issues/384.