### PR TITLE
Avoid saving consultation response form data to NFS

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -291,8 +291,6 @@ module PublishingApi
 
     private
 
-      GOVERNMENT_UPLOADS_PATH = '/government/uploads/'.freeze
-
       attr_accessor :consultation, :url_helpers
       def_delegator :consultation, :consultation_participation, :participation
       def_delegator :participation, :consultation_response_form, :participation_response_form
@@ -300,18 +298,7 @@ module PublishingApi
       def attachment_url
         return unless participation.has_response_form?
 
-        absolute_path = Pathname(participation_response_form.file.url)
-        parent_path = Pathname(GOVERNMENT_UPLOADS_PATH)
-        child_path = absolute_path.relative_path_from(parent_path)
-
-        extension = child_path.extname
-        basename = child_path.basename(extension)
-        dirname = child_path.dirname
-
-        path = File.join(dirname, basename)
-
-        asset_host = URI.parse(Plek.new.public_asset_host).host
-        url_helpers.public_upload_url(path, format: extension.delete('.'), host: asset_host)
+        participation_response_form.file.url
       end
 
       def email

--- a/app/uploaders/consultation_response_form_uploader.rb
+++ b/app/uploaders/consultation_response_form_uploader.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class ConsultationResponseFormUploader < WhitehallUploader
-  storage :asset_manager_and_quarantined_file_storage
+  storage :asset_manager
 
   def extension_whitelist
     %w(pdf csv rtf doc docx xls xlsx odt ods)

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -219,6 +219,8 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   end
 
   view_test 'updating should respect the attachment_action for response forms to remove it' do
+    AssetManagerDeleteAssetWorker.stubs(:perform_async)
+
     response_form = create(:consultation_response_form)
     participation = create(:consultation_participation, consultation_response_form: response_form)
     consultation = create(:consultation, consultation_participation: participation)

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -225,12 +225,6 @@ class AssetManagerIntegrationTest
 
       @consultation_response_form_data.save!
     end
-
-    test 'saves the consultation response form data file to the file system' do
-      @consultation_response_form_data.save!
-
-      assert File.exist?(@consultation_response_form_data.file.path)
-    end
   end
 
   class RemovingAConsultationResponseFormData < ActiveSupport::TestCase
@@ -241,7 +235,6 @@ class AssetManagerIntegrationTest
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename))
       )
-      VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
       @consultation_response_form_data.reload
       @file_path = @consultation_response_form_data.file.path
 
@@ -249,14 +242,6 @@ class AssetManagerIntegrationTest
         .with(regexp_matches(/#{filename}/))
         .returns('id' => "http://asset-manager/assets/#{@consultation_response_form_asset_id}")
       Services.asset_manager.stubs(:delete_asset)
-    end
-
-    test 'removing a consultation response form data file removes it from the file system' do
-      assert File.exist?(@file_path)
-
-      @consultation_response_form_data.remove_file!
-
-      refute File.exist?(@file_path)
     end
 
     test 'removing a consultation response form data file removes it from asset manager' do
@@ -275,7 +260,6 @@ class AssetManagerIntegrationTest
         :consultation_response_form_data,
         file: File.open(fixture_path.join(filename))
       )
-      VirusScanHelpers.simulate_virus_scan(@consultation_response_form_data.file)
       @consultation_response_form_data.reload
       @file_path = @consultation_response_form_data.file.path
 
@@ -283,15 +267,6 @@ class AssetManagerIntegrationTest
         .with(regexp_matches(/#{filename}/))
         .returns('id' => "http://asset-manager/assets/#{@consultation_response_form_asset_id}")
       Services.asset_manager.stubs(:delete_asset)
-    end
-
-    test 'replacing a consultation response form data file removes the old file from the file system' do
-      assert File.exist?(@file_path)
-
-      @consultation_response_form_data.file = File.open(fixture_path.join('whitepaper.pdf'))
-      @consultation_response_form_data.save!
-
-      refute File.exist?(@file_path)
     end
 
     test 'replacing a consultation response form data file removes the old file from asset manager' do

--- a/test/unit/consultation_participation_test.rb
+++ b/test/unit/consultation_participation_test.rb
@@ -56,6 +56,8 @@ class ConsultationParticipationTest < ActiveSupport::TestCase
   end
 
   test "should allow deletion of response form via nested attributes" do
+    AssetManagerDeleteAssetWorker.stubs(:perform_async)
+
     form = create(:consultation_response_form)
     participation = create(:consultation_participation, consultation_response_form: form)
 
@@ -66,6 +68,8 @@ class ConsultationParticipationTest < ActiveSupport::TestCase
   end
 
   test "destroys attached form when no editions are associated" do
+    AssetManagerDeleteAssetWorker.stubs(:perform_async)
+
     participation = create(:consultation_participation)
     form = create(:consultation_response_form, consultation_participation: participation)
 

--- a/test/unit/consultation_response_form_uploader_test.rb
+++ b/test/unit/consultation_response_form_uploader_test.rb
@@ -13,6 +13,6 @@ class ConsultationResponseFormUploaderTest < ActiveSupport::TestCase
   end
 
   test 'uses the asset manager storage engine' do
-    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ConsultationResponseFormUploader.storage
+    assert_equal Whitehall::AssetManagerStorage, ConsultationResponseFormUploader.storage
   end
 end

--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -255,7 +255,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test 'ways to respond' do
-      Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
+      Plek.any_instance.stubs(:public_asset_host).returns('https://asset-host.com')
       expected_ways_to_respond = {
         attachment_url: 'https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
         email: 'postmaster@example.com',


### PR DESCRIPTION
We've recently switched to serving ConsultationResponseFormData assets from Asset Manager (see https://github.com/alphagov/asset-manager/issues/297 for more info) so we can stop saving them to NFS.

This is similar to the change for Organisation logos in PR #3532.