### PR TITLE
Update french translations for corp info pages

### DIFF
--- a/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
+++ b/app/views/corporate_information_pages/show_worldwide_organisation.html.erb
@@ -8,7 +8,7 @@
     <% if headers.any? %>
       <nav>
         <div class="content">
-          <h1>Contents</h1>
+          <h1><%= t('worldwide_organisation.headings.contents', default: 'Contents') %></h1>
           <ol>
             <% headers.each do |header| %>
               <li><%= link_to header.text, "##{header.id}" %></li>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -654,6 +654,7 @@ ar:
     headings:
       about_us: معلومات عنا
       contact_us: اتصل بنا
+      contents:
       corporate_information: معلومات عن الشركة
       follow_us: تابعنا
       our_people: مسؤولينا

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -445,6 +445,7 @@ az:
     headings:
       about_us: Barəmizdə
       contact_us: Əlaqə vasitəsi
+      contents:
       corporate_information: Məlumatlar
       follow_us: Bizi izlə
       our_people: Bizim adamlar

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -553,6 +553,7 @@ be:
     headings:
       about_us: Пра нас
       contact_us: Звяжыцеся з намі
+      contents:
       corporate_information: Карпаратыўная іфармацыя
       follow_us: Сачыце за намі
       our_people: Нашы людзі

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -457,6 +457,7 @@ bg:
     headings:
       about_us: За нас
       contact_us: Свържете се с нас
+      contents:
       corporate_information: Корпоративна информация
       follow_us: Следвайте ни
       our_people: Нашите служители

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -445,6 +445,7 @@ bn:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -502,6 +502,7 @@ cs:
     headings:
       about_us: O nás
       contact_us: Kontaktujte nás
+      contents:
       corporate_information: Korporátní informace
       follow_us: Buďte s námi
       our_people: Naši lidé

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -658,6 +658,7 @@ cy:
     headings:
       about_us: Gwybodaeth amdanom ni
       contact_us: Cysylltu â ni
+      contents:
       corporate_information: Gwybodaeth gorfforaethol
       follow_us: Dilynwch ni
       our_people: Ein pobl

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -452,6 +452,7 @@ de:
     headings:
       about_us: Über uns
       contact_us: Schreiben Sie uns
+      contents:
       corporate_information: Administrative Informationen
       follow_us: Folgen Sie uns
       our_people: Unsere Mitarbeiter

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -450,6 +450,7 @@ dr:
     headings:
       about_us: در مورد ما
       contact_us: با ما تماس بگیرید
+      contents:
       corporate_information: معلومات توحید شده
       follow_us: ما را تعقیب نمایید
       our_people: مردم ما

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -453,6 +453,7 @@ el:
     headings:
       about_us: Σχετικά με εμάς
       contact_us: Επικοινωνήστε μαζί μας
+      contents:
       corporate_information: Πληροφορίες για τον οργανισμό
       follow_us: Ακολουθείστε μας
       our_people: Τα στελέχη μας

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,7 @@ en:
       our_services: Our services
       our_people: Our people
       contact_us: Contact us
+      contents: Contents
       corporate_information: Corporate information
     corporate_information:
       publication_scheme_html: Read about the types of information we routinely publish in our %{link}.

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -452,6 +452,7 @@ es-419:
     headings:
       about_us: Sobre nosotros
       contact_us: Comuníquese con nosotros
+      contents:
       corporate_information: Información institucional
       follow_us: Síganos en
       our_people: Nuestra gente

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -451,6 +451,7 @@ es:
     headings:
       about_us: Nosotros
       contact_us: Contáctenos
+      contents:
       corporate_information: Información corporativa
       follow_us: Síguenos
       our_people: Nuestro equipo

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -462,6 +462,7 @@ et:
     headings:
       about_us: Meist
       contact_us: Võtke ühendust
+      contents:
       corporate_information: Korporatiivne teave
       follow_us: Jälgige meid
       our_people: Meie inimesed

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -450,6 +450,7 @@ fa:
     headings:
       about_us: درباره ما
       contact_us: تماس با ما
+      contents:
       corporate_information: اطلاعات سازمانی
       follow_us: به صفحه های ما بپیوندید
       our_people: کارمندان ما

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -452,6 +452,7 @@ fr:
     headings:
       about_us: L'ambassade
       contact_us: Contactez-nous
+      contents:
       corporate_information: Informations générales
       follow_us: Suivez-nous
       our_people: Nos responsables

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,7 +300,7 @@ fr:
         petitions_and_campaigns:
         procurement:
         publication_scheme: Régime de publication
-        recruitment: Travail pour %{organisation_name}
+        recruitment: Travailler pour %{organisation_name}
         research:
         social_media_use: 'Utilisation réseaux sociaux '
         staff_update:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -290,7 +290,7 @@ fr:
         about:
         about_our_services:
         access_and_opening:
-        complaints_procedure:
+        complaints_procedure: Procédure de recours
         equality_and_diversity:
         media_enquiries:
         membership:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -452,7 +452,7 @@ fr:
     headings:
       about_us: L'ambassade
       contact_us: Contactez-nous
-      contents:
+      contents: Contenu
       corporate_information: Informations générales
       follow_us: Suivez-nous
       our_people: Nos responsables

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -449,6 +449,7 @@ he:
     headings:
       about_us: אודותינו
       contact_us: צור קשר
+      contents:
       corporate_information: מידע תאגידי
       follow_us: עקבו אחרינו
       our_people: הצוות שלנו

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -452,6 +452,7 @@ hi:
     headings:
       about_us: हमारे बारे में
       contact_us: हमसे संपर्क करें
+      contents:
       corporate_information: निकाय सूचना
       follow_us: हमारा अनुसरण करें
       our_people: हमारे लोग

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -452,6 +452,7 @@ hu:
     headings:
       about_us: Rólunk
       contact_us: Kapcsolat
+      contents:
       corporate_information: Szervezeti adatok
       follow_us: Kövessen bennünket
       our_people: Munkatársaink

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -453,6 +453,7 @@ hy:
     headings:
       about_us: Մեր մասին
       contact_us: Կապ մեզ հետ
+      contents:
       corporate_information: Կորպորատիվ տեղեկատվություն
       follow_us: Հետևեք մեզ
       our_people: Մեր անձնակազմը

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -451,6 +451,7 @@ id:
     headings:
       about_us: Tentang kami
       contact_us: Hubungi kami
+      contents:
       corporate_information: Informasi korporat
       follow_us: Ikuti kami
       our_people: Staf kami

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -452,6 +452,7 @@ it:
     headings:
       about_us: Chi siamo
       contact_us: Contatti
+      contents:
       corporate_information: Informazioni aziendali
       follow_us: Seguici
       our_people: Il nostro personale

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -446,6 +446,7 @@ ja:
     headings:
       about_us: 大使館について
       contact_us: 連絡先
+      contents:
       corporate_information: 組織情報
       follow_us: Follow us
       our_people: 主な職員

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -445,6 +445,7 @@ ka:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -446,6 +446,7 @@ ko:
     headings:
       about_us: 대사관 안내
       contact_us: 연락처
+      contents:
       corporate_information: 대사관 정보
       follow_us: 소셜네트워크
       our_people: 직원

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -501,6 +501,7 @@ lt:
     headings:
       about_us: Apie mus
       contact_us: Parašykite mums
+      contents:
       corporate_information: Korporatyvinė informacija
       follow_us: Sekite mus
       our_people: Mūsų darbuotojai

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -450,6 +450,7 @@ lv:
     headings:
       about_us: Par mums
       contact_us: Sazinies ar mums
+      contents:
       corporate_information: Korporatīvā informācija
       follow_us: Seko mums
       our_people: Darbinieki

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -445,6 +445,7 @@ ms:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -555,6 +555,7 @@ pl:
     headings:
       about_us: O nas
       contact_us: Skontaktuj się z nami
+      contents:
       corporate_information: Informacje korporacyjne
       follow_us: Obserwuj nasz profil
       our_people: Nasi ludzie

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -451,6 +451,7 @@ ps:
     headings:
       about_us: زموږ په هکله
       contact_us: تماس ونیسی
+      contents:
       corporate_information: متحد معلومات
       follow_us: مونږ تعقیب کړی
       our_people: زموږ خلک

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -451,6 +451,7 @@ pt:
     headings:
       about_us: Sobre
       contact_us: Contato
+      contents:
       corporate_information: Informação corporativa
       follow_us: Siga-nos
       our_people: Nosso pessoal

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -506,6 +506,7 @@ ro:
     headings:
       about_us: Despre noi
       contact_us: Contactează-ne
+      contents:
       corporate_information: Informaţii despre ambasadă
       follow_us: Ne găsești și pe
       our_people: Echipa noastră

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -552,6 +552,7 @@ ru:
     headings:
       about_us: О нас
       contact_us: Связь с нами
+      contents:
       corporate_information: Корпоративная информация
       follow_us: Следите за нами
       our_people: Наши сотрудники

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -448,6 +448,7 @@ si:
     headings:
       about_us: අප ගැන
       contact_us: අප හා සම්බන්ධවීමට
+      contents:
       corporate_information: සංවිධානයේ තොරතුරු
       follow_us: අප හා එක්වන්න
       our_people: අපේ පිරිස

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -496,6 +496,7 @@ sk:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -454,6 +454,7 @@ so:
     headings:
       about_us: Nagu saabsan
       contact_us: Nala soo xiriir
+      contents:
       corporate_information: Macluumaad hay'adeed
       follow_us: Nala jaanqaad
       our_people: Dadkeenna

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -451,6 +451,7 @@ sq:
     headings:
       about_us: Rreth nesh
       contact_us: Kontakto
+      contents:
       corporate_information: Informacion korporate
       follow_us: Na ndiq
       our_people: Njerezit tane

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -554,6 +554,7 @@ sr:
     headings:
       about_us: O nama
       contact_us: Kontakt
+      contents:
       corporate_information: Informacije o organizaciji
       follow_us: Pratite nas
       our_people: Naše osoblje

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -445,6 +445,7 @@ sw:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -455,6 +455,7 @@ ta:
     headings:
       about_us: எங்களைப் பற்றி
       contact_us: எங்களைத் தொடர்பு கொள்க
+      contents:
       corporate_information: கூட்டாண்மைத் தகவல்
       follow_us: எங்களைப் பின்பற்றுங்கள்
       our_people: எங்களது மக்கள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -447,6 +447,7 @@ th:
     headings:
       about_us: เกี่ยวกับเรา
       contact_us: ติดต่อเรา
+      contents:
       corporate_information: ข้อมูลองค์กร
       follow_us: ติดตามเรา
       our_people: เจ้าหน้าที่ของเรา

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -445,6 +445,7 @@ tk:
     headings:
       about_us:
       contact_us:
+      contents:
       corporate_information:
       follow_us:
       our_people:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -451,6 +451,7 @@ tr:
     headings:
       about_us: Hakkımızda
       contact_us: Bize ulaşın
+      contents:
       corporate_information: Kurumsal Bilgi
       follow_us: Bizi takip edin
       our_people: Biz Kimiz

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -553,6 +553,7 @@ uk:
     headings:
       about_us: Про нас
       contact_us: Зв'яжіться з нами
+      contents:
       corporate_information: Корпоративна інформація
       follow_us: Слідкуйте за нами
       our_people: Наші співробітники

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -452,6 +452,7 @@ ur:
     headings:
       about_us: ہمارے بارے میں
       contact_us: ہم سے رابطہ
+      contents:
       corporate_information: کارپوریٹ معلومات
       follow_us: ہمیں فالوکیجئیے
       our_people: ہمارا عملہ

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -451,6 +451,7 @@ uz:
     headings:
       about_us: Biz haqimizda
       contact_us: Biz bilan bog'laning
+      contents:
       corporate_information: Korporativ ma'lumot
       follow_us: Bizni qayd eting
       our_people: Bizning odamlar

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -452,6 +452,7 @@ vi:
     headings:
       about_us: Về chúng tôi
       contact_us: Liên hệ với chúng tôi
+      contents:
       corporate_information: Thông tin tổng hợp
       follow_us: Kết nối với chúng tôi
       our_people: Nhân viên Bộ Ngoại giao Anh

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -445,6 +445,7 @@ zh-hk:
     headings:
       about_us: 關於我們
       contact_us: 聯絡我們
+      contents:
       corporate_information: 詳細的資訊
       follow_us: 關注我們
       our_people: 主要館員

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -445,6 +445,7 @@ zh-tw:
     headings:
       about_us: 關於我們
       contact_us: 聯絡我們
+      contents:
       corporate_information: 詳細的資訊
       follow_us: 關注我們
       our_people: 主要館員

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -445,6 +445,7 @@ zh:
     headings:
       about_us: 关于我们
       contact_us: 联系我们
+      contents:
       corporate_information: 政府信息
       follow_us: 关注我们
       our_people: 我们的人员


### PR DESCRIPTION
This both corrects and adds some French translations as per a zendesk request from the FCO.

* Correct the translation of "Travail" to "Travailler" on https://www.gov.uk/world/organisations/british-embassy-paris/about/recruitment.fr

* Add a translation for "Complaints procedure" -> "Procédure de recours" for https://www.gov.uk/world/organisations/british-embassy-paris/about/complaints-procedure.fr

* Add a new field to the locales to allow for translation of the word "Contents" on worldwide organisation pages. 

* Regenerate locales to propagate the new field.

* Add the French translation for "Contents" -> "Contenu" on the above pages (https://www.gov.uk/world/organisations/british-embassy-paris/about/complaints-procedure.fr and
https://www.gov.uk/world/organisations/british-embassy-paris/about/recruitment.fr)

[Trello for email team](https://trello.com/c/mnDRoSir/462-change-of-translated-titles) and also [Trello for platform support](https://trello.com/c/2yM3d2Ld/89-change-of-translated-titles)


## Screenshots 

### Before (https://www.gov.uk/world/organisations/british-embassy-paris/about/recruitment.fr )
<img width="987" alt="screen shot 2018-01-16 at 11 51 00" src="https://user-images.githubusercontent.com/647311/34988161-a68af184-fab5-11e7-8904-85df5a01f636.png">

### After
<img width="981" alt="screen shot 2018-01-16 at 11 51 19" src="https://user-images.githubusercontent.com/647311/34988166-ae64aee0-fab5-11e7-9eff-3bdb8479f8f7.png">

---

### Before (https://www.gov.uk/world/organisations/british-embassy-paris/about/complaints-procedure.fr)
<img width="996" alt="screen shot 2018-01-16 at 10 10 11" src="https://user-images.githubusercontent.com/647311/34988091-5a06fb32-fab5-11e7-9a34-8d6e8819c7c6.png">

### After
<img width="981" alt="screen shot 2018-01-16 at 11 50 22" src="https://user-images.githubusercontent.com/647311/34988173-b4d00a90-fab5-11e7-9dbc-21011ee53602.png">







