### PR TITLE
Remove LinksReport model

### DIFF
--- a/db/migrate/20180116144233_drop_links_reports.rb
+++ b/db/migrate/20180116144233_drop_links_reports.rb
@@ -1,0 +1,5 @@
+class DropLinksReports < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :links_reports
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171206121121) do
+ActiveRecord::Schema.define(version: 20180116144233) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -680,18 +680,6 @@ ActiveRecord::Schema.define(version: 20171206121121) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.index ["batch_id"], name: "index_link_checker_api_reports_on_batch_id", unique: true, using: :btree
-  end
-
-  create_table "links_reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "links",                limit: 16777215
-    t.text     "broken_links",         limit: 65535
-    t.string   "status"
-    t.string   "link_reportable_type"
-    t.integer  "link_reportable_id"
-    t.datetime "completed_at"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.index ["link_reportable_id", "link_reportable_type"], name: "link_reportable_index", using: :btree
   end
 
   create_table "nation_inapplicabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
Remove LinksReport model that is not used in the code base; this is to keep code concise.