### PR TITLE
Update LinksReport naming to LinkCheckReport

### DIFF
--- a/test/functional/admin/link_check_reports_controller_test.rb
+++ b/test/functional/admin/link_check_reports_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
     assert @publication.link_check_reports.last
   end
 
-  test "POST :create saves a LinksReport and redirects back to the edition" do
+  test "POST :create saves a LinkCheckReport and redirects back to the edition" do
     post :create, edition_id: @publication.id
 
     assert_redirected_to admin_publication_url(@publication)
@@ -41,7 +41,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
     assert @publication.link_check_reports.last
   end
 
-  test "AJAX GET :show renders assigns the LinksReport and renders the template" do
+  test "AJAX GET :show renders assigns the LinkCheckReport and renders the template" do
     link_check_report = create(:link_checker_api_report, link_reportable: @publication)
     xhr :get, :show, id: link_check_report, edition_id: @publication
 


### PR DESCRIPTION
Update LinksReport to be LinkCheckReport. This is done because the LinksReport model was not used, so has been removed (https://github.com/alphagov/whitehall/pull/3689) in order to keep code consice. This name has been changed to keep the code up to date.