### PR TITLE
Reslug nhs-counter-fraud-agency

### DIFF
--- a/db/data_migration/20180116170135_reslug_nhs_counter_fraud_agency.rb
+++ b/db/data_migration/20180116170135_reslug_nhs_counter_fraud_agency.rb
@@ -1,0 +1,8 @@
+old_slug = "nhs-counter-fraud-agency"
+new_slug = "nhs-counter-fraud-authority"
+
+organisation = Organisation.find_by(slug: old_slug)
+
+if organisation
+  DataHygiene::OrganisationReslugger.new(organisation, new_slug).run!
+end


### PR DESCRIPTION
Should be `-authority`. This commit adds a data migration to fix it.

[Zendesk](https://govuk.zendesk.com/agent/tickets/2530628)