### PR TITLE
Pass relative paths to MigrateAssetsToAssetManager::Worker

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -2,17 +2,17 @@ class MigrateAssetsToAssetManager
   include ActionView::Helpers::TextHelper
 
   def initialize(target_dir)
-    @file_paths = AssetFilePaths.new(target_dir)
+    @relative_file_paths = AssetFilePaths.new(target_dir)
   end
 
   def perform
-    @file_paths.each do |file_path|
-      Worker.perform_async(file_path)
+    @relative_file_paths.each do |relative_file_path|
+      Worker.perform_async(relative_file_path)
     end
   end
 
   def to_s
-    "Migrating #{pluralize(@file_paths.size, 'file')}"
+    "Migrating #{pluralize(@relative_file_paths.size, 'file')}"
   end
 
   class Worker < WorkerBase
@@ -44,13 +44,13 @@ class MigrateAssetsToAssetManager
   end
 
   class AssetFilePaths
-    delegate :each, :size, to: :file_paths
+    delegate :each, :size, to: :relative_file_paths
 
     def initialize(target_dir)
       @target_dir = target_dir
     end
 
-    def file_paths
+    def relative_file_paths
       absolute_file_paths.map { |p| path_relative_to_clean_uploads_root(p) }
     end
 

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -103,25 +103,26 @@ class AssetFilePathsTest < ActiveSupport::TestCase
   end
 
   test '#files includes only organisation logos' do
-    assert_same_elements [organisation_logo_path], @subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg'], @subject.file_paths
   end
 
   test '#files does not includes directories' do
     @subject.file_paths.each do |file_path|
-      refute File.directory?(file_path)
+      absolute_file_path = File.join(Whitehall.clean_uploads_root, file_path)
+      refute File.directory?(absolute_file_path)
     end
   end
 
   test '#files includes all files when initialised with a top level target directory' do
     subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads')
-    assert_same_elements [organisation_logo_path, other_asset_path], subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg', 'system/uploads/other/other_asset.png'], subject.file_paths
   end
 
   test '#files includes hidden files' do
     hidden_path = File.join(organisation_logo_dir, '.hidden.jpg')
     FileUtils.cp(dummy_asset_path, hidden_path)
 
-    assert_same_elements [organisation_logo_path, hidden_path], @subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/.hidden.jpg', 'system/uploads/organisation/logo/1/logo.jpg'], @subject.file_paths
   end
 
 private

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -94,35 +94,35 @@ class AssetFilePathsTest < ActiveSupport::TestCase
     FileUtils.rm_rf(other_asset_dir)
   end
 
-  test 'delegates each to file_paths' do
+  test 'delegates each to relative_file_paths' do
     assert @subject.respond_to?(:each)
   end
 
-  test 'delegates size to file_paths' do
+  test 'delegates size to relative_file_paths' do
     assert @subject.respond_to?(:size)
   end
 
   test '#files includes only organisation logos' do
-    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg'], @subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg'], @subject.relative_file_paths
   end
 
   test '#files does not includes directories' do
-    @subject.file_paths.each do |file_path|
-      absolute_file_path = File.join(Whitehall.clean_uploads_root, file_path)
+    @subject.relative_file_paths.each do |relative_file_path|
+      absolute_file_path = File.join(Whitehall.clean_uploads_root, relative_file_path)
       refute File.directory?(absolute_file_path)
     end
   end
 
   test '#files includes all files when initialised with a top level target directory' do
     subject = MigrateAssetsToAssetManager::AssetFilePaths.new('system/uploads')
-    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg', 'system/uploads/other/other_asset.png'], subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/logo.jpg', 'system/uploads/other/other_asset.png'], subject.relative_file_paths
   end
 
   test '#files includes hidden files' do
     hidden_path = File.join(organisation_logo_dir, '.hidden.jpg')
     FileUtils.cp(dummy_asset_path, hidden_path)
 
-    assert_same_elements ['system/uploads/organisation/logo/1/.hidden.jpg', 'system/uploads/organisation/logo/1/logo.jpg'], @subject.file_paths
+    assert_same_elements ['system/uploads/organisation/logo/1/.hidden.jpg', 'system/uploads/organisation/logo/1/logo.jpg'], @subject.relative_file_paths
   end
 
 private


### PR DESCRIPTION
See: https://github.com/alphagov/asset-manager/issues/414

Before this commit we were creating `MigrateAssetsToAssetManager::Worker` jobs with the full path to each asset to be migrated. Due to the way capistrono works and `Whitehall.clean_uploads_root` is defined these paths took the form

    /data/vhost/whitehall-admin/releases/20180116155427/clean-uploads/system/uploads/person/1/image.jpg

If a deployment happened while these jobs were on the queue, they would start to fail as the release directory would change.

With this commit we pass the relative path to the asset (e.g. `system/uploads/person/1/image.jpg`) to the worker and join it to the current `Whitehall.clean_uploads_root` when the job is run.

I've changed the test to refute that `AssetFilePaths#file_paths` does not return directories to use the absolute path. The way it was written before it could have given a false positive.
