### PR TITLE
Allow users to search for their own name

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -56,7 +56,7 @@ module Admin::EditionsHelper
 
   def admin_author_filter_options(current_user)
     other_users = User.enabled.to_a - [current_user]
-    [["All authors", ""], ["Me", current_user.id]] + other_users.map { |u| [u.name, u.id] }
+    [["All authors", ""], ["Me (#{current_user.name})", current_user.id]] + other_users.map { |u| [u.name, u.id] }
   end
 
   def admin_state_filter_options


### PR DESCRIPTION
If a user searches for their own name, no results would show because
they are represented as “Me” in the list.

Update this to be “Me (name)” so that searching both your name or “Me” works.

## Before
![screen shot 2018-01-18 at 08 37 54](https://user-images.githubusercontent.com/319055/35088315-5236bf92-fc2b-11e7-966c-8609b12e56c5.png)
![screen shot 2018-01-18 at 08 37 46](https://user-images.githubusercontent.com/319055/35088320-543d189a-fc2b-11e7-8e07-65af00121ff3.png)

## After
![screen shot 2018-01-18 at 08 36 27](https://user-images.githubusercontent.com/319055/35088322-55412de4-fc2b-11e7-9325-b457b142426c.png)

cc @benhazell