### PR TITLE
Use low threshold when checking links again

### DIFF
--- a/app/controllers/admin/link_check_reports_controller.rb
+++ b/app/controllers/admin/link_check_reports_controller.rb
@@ -4,7 +4,8 @@ class Admin::LinkCheckReportsController < Admin::BaseController
   def create
     @report = LinkCheckerApiService.check_links(
       @reportable,
-      admin_link_checker_api_callback_url
+      admin_link_checker_api_callback_url,
+      checked_within: 1.second,
     )
 
     respond_to do |format|

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -7,12 +7,13 @@ class LinkCheckerApiService
     Govspeak::Document.new(reportable.body).extracted_links(website_root: website_root)
   end
 
-  def self.check_links(reportable, webhook_uri)
+  def self.check_links(reportable, webhook_uri, checked_within: nil)
     uris = extract_links(reportable)
     raise "Reportable has no links to check" if uris.empty?
 
     batch_report = Whitehall.link_checker_api_client.create_batch(
       uris,
+      checked_within: checked_within,
       webhook_uri: webhook_uri,
       webhook_secret_token: webhook_secret_token
     )


### PR DESCRIPTION
The link checker services caches it's results by default.

If we invoke the "check again" button from the admin UI we don't want to just get back the same cached results again.