### PR TITLE
Additional rake tasks to remove assets

### DIFF
--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,5 +1,5 @@
 class AssetRemover
-  def remove_organisation_logos
+  def remove_organisation_logo
     target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
     remove_asset_dir(target_dir)
   end

--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,6 +1,52 @@
 class AssetRemover
   def remove_organisation_logos
     target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_consultation_response_form_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'consultation_response_form_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_classification_featuring_image_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'classification_featuring_image_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_default_news_organisation_image_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'default_news_organisation_image_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_feature_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'feature', 'image')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_image_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'image_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_person_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'person', 'image')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_promotional_feature_item_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'promotional_feature_item', 'image')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_take_part_page_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'take_part_page', 'image')
+    remove_asset_dir(target_dir)
+  end
+
+private
+
+  def remove_asset_dir(target_dir)
     files = Dir.glob(File.join(target_dir, '**', '*'))
     FileUtils.remove_dir(target_dir)
     files

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -19,7 +19,7 @@ namespace :asset_manager do
     desc "Calls AssetRemover##{method}."
     task method => :environment do
       files = AssetRemover.new.send(method)
-      puts files
+      puts "#{files.size} files removed"
     end
   end
 

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,10 +7,20 @@ namespace :asset_manager do
     migrator.perform
   end
 
-  desc "Removes all organisation logos."
-  task remove_organisation_logo: :environment do
-    files = AssetRemover.new.remove_organisation_logo
-    puts files
+  %i(remove_organisation_logo
+     remove_consultation_response_form_data_file
+     remove_classification_featuring_image_data_file
+     remove_default_news_organisation_image_data_file
+     remove_feature_image
+     remove_image_data_file
+     remove_person_image
+     remove_promotional_feature_item_image
+     remove_take_part_page_image).each do |method|
+    desc "Calls AssetRemover##{method}."
+    task method => :environment do
+      files = AssetRemover.new.send(method)
+      puts files
+    end
   end
 
   private

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -8,8 +8,8 @@ namespace :asset_manager do
   end
 
   desc "Removes all organisation logos."
-  task remove_organisation_logos: :environment do
-    files = AssetRemover.new.remove_organisation_logos
+  task remove_organisation_logo: :environment do
+    files = AssetRemover.new.remove_organisation_logo
     puts files
   end
 

--- a/test/unit/asset_remover_test.rb
+++ b/test/unit/asset_remover_test.rb
@@ -16,24 +16,24 @@ class AssetRemoverTest < ActiveSupport::TestCase
     FileUtils.remove_dir(@logo_dir, true)
   end
 
-  test '#remove_organisation_logos removes all logos' do
+  test '#remove_organisation_logo removes all logos' do
     assert File.exist?(@logo_path)
 
-    @subject.remove_organisation_logos
+    @subject.remove_organisation_logo
 
     refute File.exist?(@logo_path)
   end
 
-  test '#remove_organisation_logos removes the containing directory' do
+  test '#remove_organisation_logo removes the containing directory' do
     assert Dir.exist?(@logo_dir)
 
-    @subject.remove_organisation_logos
+    @subject.remove_organisation_logo
 
     refute Dir.exist?(@logo_dir)
   end
 
-  test '#remove_organisation_logos returns an array of the files removed' do
-    files = @subject.remove_organisation_logos
+  test '#remove_organisation_logo returns an array of the files removed' do
+    files = @subject.remove_organisation_logo
 
     assert_equal [@logo_path], files
   end


### PR DESCRIPTION
We are migrating ConsultationResponseFormUploader (alphagov/asset-manager#297) and ImageUploader (alphagov/asset-manager#405) assets to Asset Manager. This means they can be removed from NFS. This PR adds rake tasks to remove these assets.
