### PR TITLE
Fix flash notice analytics tracking

### DIFF
--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -1,8 +1,9 @@
 module Admin
   module AnalyticsHelper
-    def track_analytics_data(type, message)
+    def track_analytics_data(category, type, message)
       {
         'module' => 'auto-track-event',
+        'track-category' => category,
         'track-action' => "alert-#{type}",
         'track-label' => strip_tags(message),
       }

--- a/app/views/shared/_notices.html.erb
+++ b/app/views/shared/_notices.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:alert] %>
-  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data(:danger, flash[:alert]) %>
+  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data('flash-message', :danger, flash[:alert]) %>
 <% end %>
 <% if flash[:notice] %>
-  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data(:success, flash[:notice]) %>
+  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data('flash-message', :success, flash[:notice]) %>
 <% end %>


### PR DESCRIPTION
As of govuk_admin_template v6 analytics events require a category. As this is not set, the event is not being registered in GA. This broke in https://github.com/alphagov/whitehall/pull/3219

https://github.com/alphagov/govuk_admin_template/blob/master/CHANGELOG.md#600
https://github.com/alphagov/govuk_admin_template/blob/master/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js