### PR TITLE
Track all form error messages

### DIFF
--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -1,11 +1,11 @@
 module Admin
   module AnalyticsHelper
-    def track_analytics_data(category, type, message)
+    def track_analytics_data(category, action, label)
       {
         'module' => 'auto-track-event',
         'track-category' => category,
-        'track-action' => "alert-#{type}",
-        'track-label' => strip_tags(message),
+        'track-action' => action,
+        'track-label' => ActionController::Base.helpers.strip_tags(label),
       }
     end
   end

--- a/app/views/shared/_notices.html.erb
+++ b/app/views/shared/_notices.html.erb
@@ -1,6 +1,6 @@
 <% if flash[:alert] %>
-  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data('flash-message', :danger, flash[:alert]) %>
+  <%= content_tag :div, flash[:alert].html_safe, class: "flash alert", data: track_analytics_data('flash-message', 'alert-danger', flash[:alert]) %>
 <% end %>
 <% if flash[:notice] %>
-  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data('flash-message', :success, flash[:notice]) %>
+  <%= content_tag :div, flash[:notice], class: "flash notice", data: track_analytics_data('flash-message', 'alert-success', flash[:notice]) %>
 <% end %>

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -233,7 +233,7 @@ end
 
 Then(/^my attempt to save it should fail with error "([^"]*)"/) do |error_message|
   click_button "Save"
-  assert page.has_css?(".errors li", text: error_message)
+  assert page.has_css?(".errors li[data-track-category='form-error'][data-track-action$='-error'][data-track-label=\"#{error_message}\"]", text: error_message)
 end
 
 When(/^I am on the edit page for (.*?) "(.*?)"$/) do |document_type, title|

--- a/lib/whitehall/form_builder.rb
+++ b/lib/whitehall/form_builder.rb
@@ -1,5 +1,7 @@
 module Whitehall
   class FormBuilder < ActionView::Helpers::FormBuilder
+    include Admin::AnalyticsHelper
+
     def label(method, text = nil, options = {})
       if calculate_required(method, options)
         unless !options[:required].nil? && options[:required] == false
@@ -35,8 +37,9 @@ module Whitehall
 
     def error_list
       @template.content_tag(:ul, "class" => "errors disc") do
+        analytics_action = "#{object.class.name.demodulize.underscore.dasherize}-error"
         object.errors.full_messages.each do |msg|
-          @template.concat @template.content_tag(:li, msg)
+          @template.concat @template.content_tag(:li, msg, data: track_analytics_data('form-error', analytics_action, msg))
         end
       end
     end

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -70,7 +70,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   view_test 'POST #create prompts for missing data if new group invalid' do
     post_create(heading: '')
     assert_response :success
-    assert_select '.errors li', text: /Heading/
+    assert_select '.errors li[data-track-action="document-collection-group-error"]', text: /Heading/
   end
 
   view_test 'GET #edit renders successfully' do

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -66,7 +66,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     post :create, params: { statistics_announcement: { title: '', summary: 'Summary text' } }
 
     assert_response :success
-    assert_select "ul.errors li", text: "Title can't be blank"
+    assert_select "ul.errors li[data-track-action='statistics-announcement-error'][data-track-label=\"Title can't be blank\"]", text: "Title can't be blank"
     refute StatisticsAnnouncement.any?
   end
 
@@ -99,7 +99,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     put :update, params: { id: announcement.id, statistics_announcement: { title: '' } }
 
     assert_response :success
-    assert_select "ul.errors li", text: "Title can't be blank"
+    assert_select "ul.errors li[data-track-action='statistics-announcement-error'][data-track-label=\"Title can't be blank\"]", text: "Title can't be blank"
   end
 
   test "POST :publish_cancellation cancels the announcement" do


### PR DESCRIPTION
Example event:

category: `form-error`
action: `publication-error`
label: `Title can't be blank`

Example markup that generates event:

```html
<li data-module="auto-track-event" data-track-category="form-error" data-track-action="statistical-data-set-error" data-track-label="Title can't be blank">Title can't be blank</li>
```

Example errors that will be tracked:

![screen shot 2018-01-23 at 11 26 18](https://user-images.githubusercontent.com/319055/35273610-0d5ca2ce-0031-11e8-9f7a-005a3bf294b5.png)

Notes:
* `object.class.name.demodulize.underscore.humanize` is used to present the error summary, so the dash variant will also work for keeping note of the format the error was on
* Update `strip_tags` to `ActionController::Base.helpers.strip_tags` so it can be used anywhere

Example view of real time events being tracked:

![screen shot 2018-01-23 at 11 46 15](https://user-images.githubusercontent.com/319055/35274198-1e7dfbf0-0033-11e8-893a-5617f4423980.png)
