### PR TITLE
Allow the disabling secure cookies in Rails production environment

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_whitehall_session',
-                                                           secure: !(Rails.env.test? || Rails.env.development?)
+                                                      secure: !(Rails.env.test? || Rails.env.development? || ENV['DISABLE_SECURE_COOKIES'])
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
The publishing end to end tests run Whitehall in Rails production mode so we can mimic how the app will behave in production as closely as possible.

We haven't set up HTTPS however which means that the secure cookie marker is preventing the browser from storing the cookie, and therefore sessions aren't working properly.

This ENV config allows us to run the app in Rails production mode from end to end tests.