### PR TITLE
Fix Whitehall link checker for admin URLs

### DIFF
--- a/lib/govspeak/admin_link_replacer.rb
+++ b/lib/govspeak/admin_link_replacer.rb
@@ -17,52 +17,27 @@ module Govspeak
       end
     end
 
-    def replacement_html_for_admin_link(anchor, &block)
-      case anchor['href']
-      when ADMIN_ORGANISATION_CIP_PATH
-        convert_link_for_corporate_information_page(anchor, $1, $2, &block)
-      when ADMIN_WORLDWIDE_ORGANISATION_CIP_PATH
-        convert_link_for_worldwide_corporate_information_page(anchor, $1, $2, &block)
-      when ADMIN_EDITION_PATH
-        edition = Edition.unscoped.find_by(id: $1)
-        convert_link_for_edition(anchor, edition, &block)
+    def replacement_html_for_admin_link(anchor)
+      edition = Whitehall::AdminLinkLookup.find_edition(anchor['href'])
+
+      if edition.present? && edition.linkable?
+        public_url = Whitehall.url_maker.public_document_url(edition)
+        new_html = convert_link(anchor, public_url)
       else
-        replace_bad_link(anchor, &block)
+        new_html = anchor.inner_text
       end
-    end
-
-  private
-
-    def convert_link_for_corporate_information_page(anchor, organisation_slug, slug, &block)
-      organisation = Organisation.find_by(slug: organisation_slug)
-      corporate_info_page = organisation.corporate_information_pages.find(slug)
-
-      convert_link_for_edition(anchor, corporate_info_page, &block)
-    end
-
-    def convert_link_for_worldwide_corporate_information_page(anchor, world_org_slug, slug, &block)
-      organisation = WorldwideOrganisation.find_by(slug: world_org_slug)
-      corporate_info_page = organisation.corporate_information_pages.find(slug)
-
-      convert_link_for_edition(anchor, corporate_info_page, &block)
-    end
-
-    def convert_link_for_edition(anchor, edition)
-      new_html = if edition.present? && edition.linkable?
-                   anchor
-                     .dup
-                     .tap { |new_anchor| new_anchor['href'] = Whitehall.url_maker.public_document_url(edition) }
-                     .to_html
-                     .html_safe
-                 else
-                   anchor.inner_text
-                 end
 
       block_given? ? yield(new_html, edition) : new_html
     end
 
-    def replace_bad_link(anchor)
-      block_given? ? yield(anchor.inner_text, nil) : anchor.inner_text
+  private
+
+    def convert_link(anchor, new_url)
+      anchor
+        .dup
+        .tap { |new_anchor| new_anchor['href'] = new_url }
+        .to_html
+        .html_safe
     end
   end
 end

--- a/lib/govspeak/admin_link_replacer.rb
+++ b/lib/govspeak/admin_link_replacer.rb
@@ -47,11 +47,11 @@ module Govspeak
       convert_link_for_edition(anchor, corporate_info_page, &block)
     end
 
-    def convert_link_for_edition(anchor, edition, options = {})
+    def convert_link_for_edition(anchor, edition)
       new_html = if edition.present? && edition.linkable?
                    anchor
                      .dup
-                     .tap { |new_anchor| new_anchor['href'] = Whitehall.url_maker.public_document_url(edition, options) }
+                     .tap { |new_anchor| new_anchor['href'] = Whitehall.url_maker.public_document_url(edition) }
                      .to_html
                      .html_safe
                  else

--- a/lib/whitehall/admin_link_lookup.rb
+++ b/lib/whitehall/admin_link_lookup.rb
@@ -1,0 +1,24 @@
+module Whitehall
+  class AdminLinkLookup
+    include Govspeak::EmbeddedContentPatterns
+
+    def self.find_edition(admin_url)
+      case admin_url
+      when ADMIN_ORGANISATION_CIP_PATH
+        organisation = Organisation.find_by(slug: $1)
+        corporate_info_page(organisation: organisation, corporate_info_slug: $2)
+      when ADMIN_WORLDWIDE_ORGANISATION_CIP_PATH
+        organisation = WorldwideOrganisation.find_by(slug: $1)
+        corporate_info_page(organisation: organisation, corporate_info_slug: $2)
+      when ADMIN_EDITION_PATH
+        Edition.unscoped.find_by(id: $1)
+      end
+    end
+
+    def self.corporate_info_page(organisation:, corporate_info_slug:)
+      organisation.corporate_information_pages.find(corporate_info_slug)
+    end
+
+    private_class_method :corporate_info_page
+  end
+end

--- a/test/unit/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/govspeak/admin_link_replacer_test.rb
@@ -20,7 +20,7 @@ module Govspeak
 
       AdminLinkReplacer.new(fragment).replace!
 
-      refute_select_within_html fragment.to_html, "a[href='#{public_url}']", text: "unpublished thing"
+      refute_select_within_html fragment.to_html, "a"
       assert_select_within_html fragment.to_html, "p", text: 'this is an unpublished thing'
     end
 

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class LinkCheckerApiServiceTest < ActiveSupport::TestCase
+  WEBHOOK_URI = "https://example.com/webhook_uri".freeze
+  LINK_CHECKER_RESPONSE = { id: 123, completed_at: nil, status: "completed" }.to_json.freeze
+
+  test "checks external URL" do
+    edition = Edition.new(body: "A doc with a link to [an external URL](https://example.com/some-page)")
+
+    link_check_request = stub_request(:post, "https://link-checker-api.test.gov.uk/batch").
+      with(body: /https:\/\/example\.com\/webhook_uri/).
+      to_return(status: 200, body: LINK_CHECKER_RESPONSE)
+
+    LinkCheckerApiService.check_links(edition, WEBHOOK_URI)
+
+    assert_requested(link_check_request)
+  end
+
+  test "checks internal URL" do
+    edition = Edition.new(body: "A doc with a link to [an internal URL](/bank-holidays)")
+
+    link_check_request = stub_request(:post, "https://link-checker-api.test.gov.uk/batch").
+      with(body: /\/bank-holidays/).
+      to_return(status: 200, body: LINK_CHECKER_RESPONSE)
+
+    LinkCheckerApiService.check_links(edition, WEBHOOK_URI)
+
+    assert_requested(link_check_request)
+  end
+
+  test "raises error if there are no URLs in the document" do
+    edition = Edition.new(body: "Some text")
+
+    assert_raises "Reportable has no links to check" do
+      LinkCheckerApiService.check_links(edition, WEBHOOK_URI)
+    end
+  end
+end

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -28,6 +28,21 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
     assert_requested(link_check_request)
   end
 
+  test "converts a Whitehall admin URL to its public URL" do
+    speech = create(:published_speech)
+    expected_url = Whitehall.url_maker.public_document_url(speech)
+
+    edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
+
+    link_check_request = stub_request(:post, "https://link-checker-api.test.gov.uk/batch").
+      with(body: /#{expected_url}/).
+      to_return(status: 200, body: LINK_CHECKER_RESPONSE)
+
+    LinkCheckerApiService.check_links(edition, WEBHOOK_URI)
+
+    assert_requested(link_check_request)
+  end
+
   test "raises error if there are no URLs in the document" do
     edition = Edition.new(body: "Some text")
 

--- a/test/unit/whitehall/admin_link_lookup_test.rb
+++ b/test/unit/whitehall/admin_link_lookup_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+module Whitehall
+  class AdminLinkLookupTest < ActiveSupport::TestCase
+    test "finds published edition" do
+      speech = create(:published_speech)
+
+      edition = AdminLinkLookup.find_edition("/government/admin/speeches/#{speech.id}")
+
+      assert_equal(speech, edition)
+    end
+
+    test "finds corporate information page" do
+      cip = create(:published_corporate_information_page)
+      admin_path = Whitehall.url_maker.polymorphic_path([:admin, cip.organisation, cip])
+
+      edition = AdminLinkLookup.find_edition(admin_path)
+
+      assert_equal(cip, edition)
+    end
+
+    test "finds worldwide corporate information page" do
+      world_org = create(:worldwide_organisation)
+      cip = create(:published_corporate_information_page, organisation: nil, worldwide_organisation: world_org)
+      admin_path = Whitehall.url_maker.polymorphic_path([:admin, world_org, cip])
+
+      edition = AdminLinkLookup.find_edition(admin_path)
+
+      assert_equal(cip, edition)
+    end
+
+    test "finds edition from full URL" do
+      speech = create(:published_speech)
+
+      edition = AdminLinkLookup.find_edition("https://whitehall-admin.publishing.service.gov.uk/government/admin/speeches/#{speech.id}")
+
+      assert_equal(speech, edition)
+    end
+
+    test "finds draft edition" do
+      speech = create(:draft_speech)
+
+      edition = AdminLinkLookup.find_edition("/government/admin/speeches/#{speech.id}")
+
+      assert_equal(speech, edition)
+    end
+
+    test "returns nil if edition does not exist" do
+      assert_nil(AdminLinkLookup.find_edition("/government/admin/speeches/1"))
+    end
+
+    test "does not find editions for pages which are not editions" do
+      topic = create(:topic)
+
+      assert_nil(AdminLinkLookup.find_edition("/government/admin/topics/#{topic.id}"))
+    end
+
+    test "does find editions for non-admin URLs" do
+      assert_nil(AdminLinkLookup.find_edition("/not/a/whitehall/admin/path"))
+    end
+  end
+end


### PR DESCRIPTION
Publishers can link to whitehall URLs in the body of documents, and these are converted to publicly-available GOV.UK URLs when the document is published.

This change adds the same conversion to the link checking feature so that it checks the GOV.UK URL rather than failing because it does not have permission to reach the admin URL.

This is probably easiest to review commit-by-commit - the first four commits are refactorings and new tests.

https://trello.com/c/bmMwHljS/33-2-fix-whitehall-link-checker-for-admin-links