### PR TITLE
Deprecate require_signing_permission!

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -5,7 +5,6 @@ class Admin::BaseController < ApplicationController
   layout 'admin'
   prepend_before_action :skip_slimmer
   prepend_before_action :authenticate_user!
-  before_action :require_signin_permission!
 
   def limit_edition_access!
     enforce_permission!(:see, @edition)

--- a/app/controllers/admin/fact_check_requests_controller.rb
+++ b/app/controllers/admin/fact_check_requests_controller.rb
@@ -5,7 +5,6 @@ class Admin::FactCheckRequestsController < Admin::BaseController
   before_action :limit_edition_access!, only: [:create]
   before_action :check_edition_availability, only: %i[show edit]
   skip_before_action :authenticate_user!, except: [:create]
-  skip_before_action :require_signin_permission!, except: [:create]
 
   def show; end
 

--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -1,6 +1,5 @@
 class Admin::TopicsController < Admin::ClassificationsController
   skip_before_action :authenticate_user!, only: [:show]
-  skip_before_action :require_signin_permission!, only: [:show]
 
   def show
     respond_to do |format|


### PR DESCRIPTION
GDS-SSO was at 13.2. Release 13.3 deprecated `require_signin_permission!`.
Instead, we should now be using `authenticate_user!` according to the
GDS-SSO Readme.