### PR TITLE
Add seed for HRMC organisation and add more permissions to user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,21 @@ else
   )
 end
 
+if Organisation.where(name: "HMRC").present?
+  puts "Skipping because HMRC organisation already exists"
+else
+  Organisation.create!(
+    name: "HMRC",
+    slug: "hm-revenue-customs",
+    acronym: "HRMC",
+    organisation_type_key: :other,
+    logo_formatted_name: "Test",
+    content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+  )
+end
+
 if Organisation.where(name: "Test Organisation").present?
-  puts "Skipping because organisation already exists"
+  puts "Skipping because Test Organisation already exists"
 else
   Organisation.create!(
     name: "Test Organisation",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,9 @@ else
   gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   User.create!(
     name: "Test user",
-    permissions: ["signin", "GDS Admin"],
+    permissions: ["signin", "GDS Admin", "GDS Editor"],
     organisation_content_id: gds_organisation_id,
+    organisation_slug: "test-organisation"
   )
 end
 


### PR DESCRIPTION
As part of the E2E testing we have found that the contacts admin is
specifically geared towards HMRC contacts and publishes a specific
finder that is useful in testing. As part of this we require a HMRC
organisation to exist to leverage the finder properly.

https://github.com/alphagov/contacts-admin/blob/3f421eaf16693ef616d15df3a7b83c9cc625d093/app/services/publish_finders.rb#L24