### PR TITLE
Add managing editor permission to the seed user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,7 @@ else
   gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
   User.create!(
     name: "Test user",
-    permissions: ["signin", "GDS Admin", "GDS Editor"],
+    permissions: ["signin", "GDS Admin", "GDS Editor", "Managing Editor"],
     organisation_content_id: gds_organisation_id,
     organisation_slug: "test-organisation"
   )


### PR DESCRIPTION
Unpublishing a document requires a user to have the "Managing Editor" permission.  We are adding a scenario for unpublishing a document to the end to end tests, so require our user to have this permission.