### PR TITLE
Use asset manager storage for image uploader

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,5 +1,5 @@
 class ImageUploader < WhitehallUploader
-  storage :asset_manager_and_quarantined_file_storage
+  storage :asset_manager
 
   include CarrierWave::MiniMagick
 

--- a/app/validators/image_validator.rb
+++ b/app/validators/image_validator.rb
@@ -14,6 +14,7 @@ class ImageValidator < ActiveModel::Validator
 
   def validate(record)
     return unless file_for(record).present?
+    return unless File.exist?(file_for(record).path)
     return if file_for(record).file.content_type.match?(/svg/)
 
     begin

--- a/features/people.feature
+++ b/features/people.feature
@@ -54,12 +54,6 @@ Scenario: Editing an existing translation
   Then when viewing the person "Amanda Appleford" with the locale "Français" I should see:
     | biography         | Elle est née. Elle a vécu. Elle est morte.                  |
 
-Scenario: Images are virus-checked before publication
-  When I add a new person called "Dave Cameroon"
-  Then the image will be quarantined for virus checking
-  When the image has been virus-checked
-  Then the virus checked image will be available for viewing
-
 Scenario: Viewing a person that previously had a role
   Given "Dale Cooper" is a minister with a history
   When I visit the person page for "Dale Cooper"

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -8,14 +8,6 @@ When(/^the (?:attachment|image)s? (?:has|have) been virus\-checked$/) do
   FileUtils.mkdir(Whitehall.incoming_uploads_root)
 end
 
-Then(/^the image will be quarantined for virus checking$/) do
-  assert_final_path(person_image_path, "thumbnail-placeholder.png")
-end
-
-Then(/^the virus checked image will be available for viewing$/) do
-  assert_final_path(person_image_path, person_image_path)
-end
-
 When(/^I start editing the attachments from the .*? page$/) do
   click_on 'Modify attachments'
 end

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -36,6 +36,8 @@ When(/^I add a new promotional feature with a single item$/) do
 end
 
 When(/^I delete the promotional feature$/) do
+  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
   visit admin_organisation_path(@executive_office)
   click_link 'Promotional features'
 
@@ -56,6 +58,8 @@ When(/^I edit the promotional item, set the summary to "([^"]*)"$/) do |new_summ
 end
 
 When(/^I delete the promotional item$/) do
+  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
   visit admin_organisation_path(@executive_office)
   click_link 'Promotional features'
   click_link @promotional_feature.title

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -44,6 +44,8 @@ Then(/^I see the take part pages in my specified order including the new page on
 end
 
 When(/^I remove one of the take part pages because it's not something we want to promote$/) do
+  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
   visit admin_get_involved_path
   click_on 'Take part pages'
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -39,5 +39,9 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     def path
       @legacy_url_path
     end
+
+    def content_type
+      MIME::Types.type_for(filename).first.to_s
+    end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -33,7 +33,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def filename
-      @legacy_url_path
+      ::File.basename(@legacy_url_path)
     end
 
     def path

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -87,6 +87,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
   end
 
   test 'DELETE :destroy deletes the promotional item' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
     delete :destroy, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
 

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -87,6 +87,7 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   end
 
   test 'DELETE :destroy removes the suppliued instance' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     page = create(:take_part_page)
 
     delete :destroy, params: { id: page }

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -81,20 +81,6 @@ class AssetManagerIntegrationTest
 
       @person.save!
     end
-
-    test 'saves the person image to the file system' do
-      @person.save!
-
-      assert File.exist?(@person.image.path)
-    end
-
-    test 'saves each version of the person image to the file system' do
-      @person.save!
-
-      @person.image.versions.each_pair do |_, image|
-        assert File.exist?(image.file.path)
-      end
-    end
   end
 
   class RemovingAPersonImage < ActiveSupport::TestCase
@@ -121,26 +107,6 @@ class AssetManagerIntegrationTest
 
       @person.remove_image!
     end
-
-    test 'removes the person image from the file system' do
-      image_path = @person.image.path
-
-      assert File.exist?(image_path)
-
-      @person.remove_image!
-
-      refute File.exist?(image_path)
-    end
-
-    test 'removes each version of the person image from the file system' do
-      file_paths = @person.image.versions.map { |_, image| image.file.path }
-
-      file_paths.each { |path| assert File.exist?(path) }
-
-      @person.remove_image!
-
-      file_paths.each { |path| refute File.exist?(path) }
-    end
   end
 
   class ReplacingAPersonImage < ActiveSupport::TestCase
@@ -161,44 +127,6 @@ class AssetManagerIntegrationTest
 
       @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
       @person.save!
-    end
-
-    test 'saves the person image to the file system' do
-      @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
-
-      assert File.exist?(@person.image.path)
-    end
-
-    test 'saves each version of the person image to the file system' do
-      @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
-
-      @person.image.versions.each_pair do |_, image|
-        assert File.exist?(image.file.path)
-      end
-    end
-
-    test 'does not remove the original image from the file system' do
-      image_path = @person.image.path
-
-      assert File.exist?(image_path)
-
-      @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
-
-      assert File.exist?(image_path)
-    end
-
-    test 'does not remove each version of the original person image from the file system' do
-      file_paths = @person.image.versions.map { |_, image| image.file.path }
-
-      file_paths.each { |path| assert File.exist?(path) }
-
-      @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
-
-      file_paths.each { |path| assert File.exist?(path) }
     end
 
     test 'does not remove the original images from asset manager' do

--- a/test/integration/take_part_page_test.rb
+++ b/test/integration/take_part_page_test.rb
@@ -27,6 +27,7 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test "TakePartPage publishes gone route to the Publishing API on destroy" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     @take_part_page.save!
 
     gone_request = stub_publishing_api_unpublish(

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -586,7 +586,8 @@ module AdminEditionControllerTestHelpers
 
       test 'updating an edition with an existing image allows image attributes to be changed' do
         edition = create(edition_type)
-        image = create(:image, edition: edition, alt_text: "old-alt-text", caption: 'old-caption')
+        image = create(:image, edition: edition, alt_text: "old-alt-text", caption: 'old-caption',
+                       image_data_attributes: attributes_for(:image_data, file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')))
         VirusScanHelpers.simulate_virus_scan
 
         put :update, params: {

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -725,9 +725,14 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test 'updating should allow removal of images' do
+        Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+        image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+
         edition = create(edition_type)
-        image_1 = create(:image, edition: edition, alt_text: "the first image")
-        image_2 = create(:image, edition: edition, alt_text: "the second image")
+        image_1 = create(:image, edition: edition, alt_text: "the first image",
+          image_data_attributes: attributes_for(:image_data, file: image))
+        image_2 = create(:image, edition: edition, alt_text: "the second image",
+          image_data_attributes: attributes_for(:image_data, file: image))
 
         attributes = {
           images_attributes: {

--- a/test/unit/edition/images_test.rb
+++ b/test/unit/edition/images_test.rb
@@ -126,6 +126,7 @@ class Edition::ImagesTest < ActiveSupport::TestCase
   end
 
   test "#destroy should also remove the image" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     image = create(:image)
     edition = EditionWithImages.create!(valid_edition_attributes.merge(images: [image]))
     edition.destroy

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -12,7 +12,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test 'uses the asset manager and quarantined file storage engine' do
-    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, ImageUploader.storage
+    assert_equal Whitehall::AssetManagerStorage, ImageUploader.storage
   end
 
   test "should only allow JPG, GIF, PNG or SVG images" do
@@ -20,21 +20,23 @@ class ImageUploaderTest < ActiveSupport::TestCase
     assert_equal %w(jpg jpeg gif png svg), uploader.extension_whitelist
   end
 
+  test "should send correctly resized versions of a bitmap image to asset manager" do
+    model = stub("AR Model", id: 1)
+    @uploader = ImageUploader.new(model, "mounted-as")
+
+    Services.asset_manager.stubs(:create_whitehall_asset)
+    Services.asset_manager.expects(:create_whitehall_asset).with do |value|
+      image_path = value[:file].path
+      assert_image_has_correct_size image_path
+    end
+
+    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+  end
+
   test "should store uploads in a directory that persists across deploys" do
     model = stub("AR Model", id: 1)
     uploader = ImageUploader.new(model, "mounted-as")
     assert_match %r[^system], uploader.store_dir
-  end
-
-  test "should create resized versions of a bitmap image" do
-    model = stub("AR Model", id: 1)
-    @uploader = ImageUploader.new(model, "mounted-as")
-
-    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
-
-    [[712, 480], [630, 420], [465, 310], [300, 195], [216, 140]].each do |(width, height)|
-      assert_image_size [width, height], @uploader.send(:"s#{width}")
-    end
   end
 
   test "should store all the versions of a bitmap image in asset manager" do
@@ -53,17 +55,6 @@ class ImageUploaderTest < ActiveSupport::TestCase
     @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
   end
 
-  test "stores the original svg only" do
-    model = stub("AR Model", id: 1)
-    @uploader = ImageUploader.new(model, "mounted-as")
-
-    @uploader.store!(fixture_file_upload('images/test-svg.svg', 'image/svg+xml'))
-
-    [[712, 480], [630, 420], [465, 310], [300, 195], [216, 140]].each do |(width, _height)|
-      assert_nil @uploader.send(:url, :"s#{width}")
-    end
-  end
-
   test "should store the original version only of a svg image in asset manager" do
     model = stub("AR Model", id: 1)
     @uploader = ImageUploader.new(model, "mounted-as")
@@ -76,10 +67,22 @@ class ImageUploaderTest < ActiveSupport::TestCase
 
 private
 
-  def assert_image_size(dimensions, uploader_version)
-    width, height = dimensions
-    image = MiniMagick::Image.open(uploader_version.path)
-    assert_equal width, image[:width], "#{dimensions.join('x')} image version should be #{width}px wide, but was #{image[:width]}"
-    assert_equal height, image[:height], "#{dimensions.join('x')} image version should be #{height}px high, but was #{image[:height]}"
+  def assert_image_has_correct_size(asset_path)
+    filename = File.basename(asset_path)
+
+    expected_sizes = {
+      "minister-of-funk.960x640.jpg" => [960, 640],
+      "s960_minister-of-funk.960x640.jpg" => [960, 640],
+      "s712_minister-of-funk.960x640.jpg" => [712, 480],
+      "s630_minister-of-funk.960x640.jpg" => [630, 420],
+      "s465_minister-of-funk.960x640.jpg" => [465, 310],
+      "s300_minister-of-funk.960x640.jpg" => [300, 195],
+      "s216_minister-of-funk.960x640.jpg" => [216, 140]
+    }
+
+    width, height = expected_sizes[filename]
+    image = MiniMagick::Image.open(asset_path)
+    assert_equal width, image[:width], "#{expected_sizes[filename].join('x')} image version should be #{width}px wide, but was #{image[:width]}"
+    assert_equal height, image[:height], "#{expected_sizes[filename].join('x')} image version should be #{height}px high, but was #{image[:height]}"
   end
 end

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -37,6 +37,22 @@ class ImageUploaderTest < ActiveSupport::TestCase
     end
   end
 
+  test "should store all the versions of a bitmap image in asset manager" do
+    model = stub("AR Model", id: 1)
+    @uploader = ImageUploader.new(model, "mounted-as")
+
+    Services.asset_manager.stubs(:create_whitehall_asset)
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s960_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s712_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s630_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s465_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s300_minister-of-funk.960x640.jpg/))
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s216_minister-of-funk.960x640.jpg/))
+
+    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+  end
+
   test "stores the original svg only" do
     model = stub("AR Model", id: 1)
     @uploader = ImageUploader.new(model, "mounted-as")
@@ -46,6 +62,16 @@ class ImageUploaderTest < ActiveSupport::TestCase
     [[712, 480], [630, 420], [465, 310], [300, 195], [216, 140]].each do |(width, _height)|
       assert_nil @uploader.send(:url, :"s#{width}")
     end
+  end
+
+  test "should store the original version only of a svg image in asset manager" do
+    model = stub("AR Model", id: 1)
+    @uploader = ImageUploader.new(model, "mounted-as")
+
+    Services.asset_manager.stubs(:create_whitehall_asset)
+    Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))
+
+    @uploader.store!(fixture_file_upload('images/test-svg.svg', 'image/svg+xml'))
   end
 
 private

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -310,7 +310,7 @@ class PublishingApi::WorldLocationNewsArticleImageDetailsTest < ActiveSupport::T
 
   test "includes details of the world location news article image if present" do
     expected_hash = {
-      url: (Whitehall.public_asset_host + @image.url(:s300)),
+      url: @image.url(:s300),
       alt_text: @image.alt_text,
       caption: @image.caption
     }

--- a/test/unit/take_part_page_test.rb
+++ b/test/unit/take_part_page_test.rb
@@ -160,6 +160,7 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test 'removes page from search index on destroying' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     page = create(:take_part_page)
 
     Whitehall::SearchIndex.expects(:delete).with(page)

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -87,4 +87,8 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
   test 'returns the legacy filename as the path' do
     assert_equal @asset_url_path, @file.path
   end
+
+  test '#content_type returns the first element of the content type array' do
+    assert_equal 'image/png', @file.content_type
+  end
 end


### PR DESCRIPTION
https://github.com/alphagov/asset-manager/issues/424

This PR switches the `ImageUploader` to use the `AssetManagerStorage` engine instead of the `AssetManagerAndQuarantinedFileStorage` engine. In practice this means that uploaded images will no longer be saved to NFS and will instead just be sent to Asset Manager. 

This, combined with the [completed work to migrate images to asset manager](https://github.com/alphagov/asset-manager/milestone/6) means that we will then be able to [delete the files from NFS](https://github.com/alphagov/asset-manager/issues/405). 

The actual change in eecaf7421 "Use asset manager storage for ImageUploader" is a single line, however it causes many existing tests to fail. I have tried to move the fixes to some of the failing tests before eecaf7421 in the history, but some tests only make sense to fix after the change has been made. I'm happy to either squash these 5 commits into eecaf7421 or leave them separate with the downside that eecaf7421 will be failing. For now they are separate to help with reviewing. 
