### PR TITLE
Fix tagging content to world taxons

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -48,9 +48,29 @@ module Taxonomy
     end
 
     def get_level_one_taxons(with_drafts:)
-      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
-        .fetch('expanded_links', {})
-        .fetch('level_one_taxons', [])
+      ids_from_publishing_api =
+        get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
+          .fetch('expanded_links', {})
+          .fetch('level_one_taxons', [])
+
+      # The World taxons were removed from the Topic taxonomy, because
+      # at least when the descision to remove them was made, they do
+      # not meet the criteria for being suitable taxons.
+      #
+      # Unfortunately the tagging interface in Whitehall depends on
+      # this link, so in the short term, add the World taxon in to
+      # Whitehall as a level one taxon. This should be fixed somehow
+      # in the future, but for now at least it's hard to tell what
+      # will happen with the World taxons and the coresponding
+      # navigation pages.
+      (
+        ids_from_publishing_api +
+        [
+          {
+            'content_id' => '91b8ef20-74e7-4552-880c-50e6d73c2ff9'
+          }
+        ]
+      ).uniq
     end
 
     def get_expanded_links_hash(content_id, with_drafts:)


### PR DESCRIPTION
The World taxons were removed from the Topic taxonomy [1], but this
has broken the tagging interface in Whitehall for users from the
Foreign and Commonwealth Office, so lets just add it back from the
perspective of Whitehall in the short term to fix this functionality.

1: https://trello.com/c/AwIIPzrU/51-remove-the-world-branch-from-the-topic-taxonomy