### PR TITLE
Add basic image upload guidance

### DIFF
--- a/app/views/admin/editions/_image_fields.html.erb
+++ b/app/views/admin/editions/_image_fields.html.erb
@@ -1,10 +1,11 @@
 <%= content_tag :fieldset, id: "image_fields", class: "images multiple_file_uploads#{' right-to-left' if edition.rtl?}" do %>
-  <legend>Images</legend>
+  <legend class="add-bottom-margin">Images</legend>
   <% i = 0 %>
   <%= form.fields_for :images do |images_fields| %>
     <% if images_fields.object.new_record? %>
       <div class="file_upload well">
         <h3 class="remove-top-margin">New image</h3>
+        <p>Images must be 960px wide and 640px tall.</p>
         <%= images_fields.fields_for :image_data do |image_data_fields| %>
           <%= image_data_fields.upload :file, required: false, class: 'js-upload-image-input' %>
         <% end %>


### PR DESCRIPTION
It helps to know the image dimensions before uploading.

## Before

![screen shot 2018-01-25 at 17 37 05](https://user-images.githubusercontent.com/319055/35403074-72b336c6-01f6-11e8-939b-2b9cb5240b5d.png)

## After

![screen shot 2018-01-25 at 17 38 27](https://user-images.githubusercontent.com/319055/35403103-91ffb7a2-01f6-11e8-923d-f45b2d051ec7.png)

@benhazell