### PR TITLE
Initial check that scheduled edition has appeared

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'ruby-prof'
+  gem 'sinatra'
   gem 'teaspoon-qunit'
   gem 'test-queue', '~> 0.2.13'
   # teaspoon has coffee assets that mean we need coffee script in order

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustache (1.0.5)
+    mustermann (1.0.1)
     mysql2 (0.4.10)
     netrc (0.11.0)
     newrelic_rpm (4.7.1.340)
@@ -466,6 +467,11 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
     slimmer (11.1.1)
       activesupport
       json
@@ -611,6 +617,7 @@ DEPENDENCIES
   sidekiq-scheduler (~> 2.2)
   simplecov
   simplecov-rcov
+  sinatra
   slimmer (~> 11.0)
   sprockets (~> 3.7)
   sprockets-rails
@@ -628,4 +635,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -10,7 +10,10 @@ class HealthcheckController < ActionController::Base
 
   def overdue
     # Check the number of overdue editions
-    render json: { 'overdue' => Edition.due_for_publication.count }
+    render json: {
+      'overdue' => Edition.due_for_publication.count,
+      'missing_from_site' => [],
+    }
   end
 
 private

--- a/app/models/missed_scheduled_publishing.rb
+++ b/app/models/missed_scheduled_publishing.rb
@@ -1,0 +1,2 @@
+class MissedScheduledPublishing < ApplicationRecord
+end

--- a/db/migrate/20180126114044_create_missed_scheduled_publishings.rb
+++ b/db/migrate/20180126114044_create_missed_scheduled_publishings.rb
@@ -1,0 +1,13 @@
+class CreateMissedScheduledPublishings < ActiveRecord::Migration[5.0]
+  def change
+    create_table :missed_scheduled_publishings do |t|
+      t.string :url
+      t.string :announcement_url
+      t.datetime :scheduled_publication
+      t.string :status
+      t.boolean :found_at_first_attempt
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116144233) do
+ActiveRecord::Schema.define(version: 20180126114044) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -680,6 +680,16 @@ ActiveRecord::Schema.define(version: 20180116144233) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.index ["batch_id"], name: "index_link_checker_api_reports_on_batch_id", unique: true, using: :btree
+  end
+
+  create_table "missed_scheduled_publishings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "url"
+    t.string   "announcement_url"
+    t.datetime "scheduled_publication"
+    t.string   "status"
+    t.boolean  "found_at_first_attempt"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "nation_inapplicabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/scheduled_publishing_checker.rb
+++ b/lib/scheduled_publishing_checker.rb
@@ -1,0 +1,76 @@
+class ScheduledPublishingChecker
+  MISSING_EDITION = 'missing_edition'.freeze
+  MISSING_REDIRECT = 'missing_redirect'.freeze
+  SUCCESSFULLY_PUBLISHED = 'successfully_published'.freeze
+
+  # scheduled tasks can only run at 0, 15, 30 and 45 minutes past the hour.
+  # This job should be run scheduled to run 30seconds later so that documents
+  # have a chance to be published first. In addition this job should run every
+  # minutes to check if the document has now appeared - this is inline with the
+  # healthcheck frequency
+  def check
+    start_date = MissedScheduledPublishing.maximum(:scheduled_publication) || 1.week.ago
+
+    since_last_run = Edition.includes(:document).where("scheduled_publication > ? and scheduled_publication < ?", start_date, Time.zone.now)
+
+    since_last_run.each do |edition|
+      url = Whitehall.url_maker.public_document_url(edition)
+      announcement_url = edition.respond_to?(:statistics_announcement) && edition.statistics_announcement.public_path
+
+      status = check_url(url, announcement_url)
+
+      MissedScheduledPublishing.create(
+        url: url,
+        announcement_url: announcement_url,
+        scheduled_publication: edition.scheduled_publication,
+        status: status,
+        found_at_first_attempt: status == SUCCESSFULLY_PUBLISHED,
+      )
+    end
+
+    MissedScheduledPublishing.where.not(status: SUCCESSFULLY_PUBLISHED).each do |missing|
+      missing.update(status: SUCCESSFULLY_PUBLISHED) if check_url(missing.url, missing.announcement_url) == SUCCESSFULLY_PUBLISHED
+    end
+
+    nil
+  end
+
+  def check_url(url, announcement_url)
+    # for the edition
+
+    # check the page is present on the site
+    if appears_on_site?(url)
+      Rails.logger.info "Found scheduled publication for: #{url}"
+
+      # if an announcement was made check that it has been correctly redirected.
+      if !announcement_url || redirected?(announcement_url, url)
+        SUCCESSFULLY_PUBLISHED
+      else
+        Rails.logger.info "Missing redirect to scheduled publication for: #{url}"
+        MISSING_REDIRECT
+      end
+    else
+      Rails.logger.info "Missing scheduled publication for: #{url}"
+      MISSING_EDITION
+    end
+  end
+
+  def connection
+    @connection ||= Faraday.new(headers: { accept_encoding: 'none' }) do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.basic_auth(user, password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
+    end
+  end
+
+  def appears_on_site?(url)
+    # TODO: Add functionality to determine correct version/redirect
+    (200..399).cover?(connection.get(URI.parse(url)).status)
+  end
+
+  def redirected?(old_url, new_url)
+    response = connection.get(URI.parse(old_url))
+
+    (300..399).cover?(response.status) && # redirect
+      [new_url, URI.parse(new_url).path].include?(response[:location])
+  end
+end

--- a/test/unit/scheduled_publishing_checker_test.rb
+++ b/test/unit/scheduled_publishing_checker_test.rb
@@ -1,0 +1,105 @@
+require 'test_helper'
+require 'sinatra/base'
+
+class ScheduledPublishingCheckerTest < ActiveSupport::TestCase
+  def test_success_when_published_edition_without_announcement
+    FactoryBot.create(:edition, :scheduled, scheduled_publication: 1.day.ago)
+
+    test_url = 'http://test.com/published_edition/12'
+    Whitehall.url_maker.stubs(:public_document_url).returns(test_url)
+
+    setup_server(urls: [test_url], redirects: [])
+
+    ScheduledPublishingChecker.new.check
+
+    assert_equal 1, MissedScheduledPublishing.count
+    assert_equal ScheduledPublishingChecker::SUCCESSFULLY_PUBLISHED, MissedScheduledPublishing.last.status
+  end
+
+  def test_success_when_published_edition_with_redirected_announcement
+    publication = FactoryBot.create(:publication, :statistics, :scheduled, scheduled_publication: 1.day.ago)
+    FactoryBot.create(:statistics_announcement, publication: publication, release_date: 1.day.ago)
+
+    test_url = 'http://test.com/published_edition/12'
+    redirect_url = 'http://test.com/announcement/12'
+    Whitehall.url_maker.stubs(:public_document_url).returns(test_url)
+    Whitehall.url_maker.stubs(:statistics_announcement_path).returns(redirect_url)
+
+    setup_server(urls: [test_url], redirects: { redirect_url => test_url })
+
+    ScheduledPublishingChecker.new.check
+
+    assert_equal 1, MissedScheduledPublishing.count
+    assert_equal ScheduledPublishingChecker::SUCCESSFULLY_PUBLISHED, MissedScheduledPublishing.last.status
+  end
+
+  def test_error_when_published_edition_with_redirected_announcement_to_incorrect_path
+    publication = FactoryBot.create(:publication, :statistics, :scheduled, scheduled_publication: 1.day.ago)
+    FactoryBot.create(:statistics_announcement, publication: publication, release_date: 1.day.ago)
+
+    test_url = 'http://test.com/published_edition/12'
+    redirect_url = 'http://test.com/announcement/12'
+    Whitehall.url_maker.stubs(:public_document_url).returns(test_url)
+    Whitehall.url_maker.stubs(:statistics_announcement_path).returns(redirect_url)
+
+    setup_server(urls: [test_url], redirects: { redirect_url => 'http://some.other/path' })
+
+    ScheduledPublishingChecker.new.check
+
+    assert_equal 1, MissedScheduledPublishing.count
+    assert_equal ScheduledPublishingChecker::MISSING_REDIRECT, MissedScheduledPublishing.last.status
+  end
+
+  def test_error_when_published_edition_with_non_redirected_announcement
+    publication = FactoryBot.create(:publication, :statistics, :scheduled, scheduled_publication: 1.day.ago)
+    FactoryBot.create(:statistics_announcement, publication: publication, release_date: 1.day.ago)
+
+    test_url = 'http://test.com/published_edition/12'
+    redirect_url = 'http://test.com/announcement/12'
+    Whitehall.url_maker.stubs(:public_document_url).returns(test_url)
+    Whitehall.url_maker.stubs(:statistics_announcement_path).returns(redirect_url)
+
+    setup_server(urls: [test_url, redirect_url], redirects: [])
+
+    ScheduledPublishingChecker.new.check
+
+    assert_equal 1, MissedScheduledPublishing.count
+    assert_equal ScheduledPublishingChecker::MISSING_REDIRECT, MissedScheduledPublishing.last.status
+  end
+
+  def test_error_when_missing_published_edition
+    FactoryBot.create(:edition, :scheduled, scheduled_publication: 1.day.ago)
+
+    test_url = 'http://test.com/published_edition/12'
+    Whitehall.url_maker.stubs(:public_document_url).returns(test_url)
+
+    setup_server(urls: [], redirects: [])
+
+    ScheduledPublishingChecker.new.check
+
+    assert_equal 1, MissedScheduledPublishing.count
+    assert_equal ScheduledPublishingChecker::MISSING_EDITION, MissedScheduledPublishing.last.status
+  end
+
+  def setup_server(urls:, redirects:)
+    fake_server = Class.new(Sinatra::Base) do
+      get '*' do
+        if urls.any? { |url| url.include?(params[:splat].first) }
+          body 'published document'
+          status 200
+        else
+          _, redirection_url = redirects.detect { |url, _| url.include?(params[:splat].first) }
+          if redirection_url
+            body 'redirected document'
+            redirect redirection_url
+          else
+            body 'missing document'
+            halt 404
+          end
+        end
+      end
+    end
+
+    stub_request(:any, /test.com/).to_rack(fake_server)
+  end
+end


### PR DESCRIPTION
This only checks that the edition is present on the site and that any
assocaited announcement has been correctly redirected to the edition.

https://trello.com/c/2G7KW0qS/34-spike-additional-monitoring-for-scheduled-publications-1-day