### PR TITLE
Fix URI::InvalidURIError in AssetManagerStorage

### DIFF
--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -29,7 +29,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     end
 
     def url
-      URI.join(Plek.new.public_asset_host, @legacy_url_path).to_s
+      URI.join(Plek.new.public_asset_host, Addressable::URI.encode(@legacy_url_path)).to_s
     end
 
     def filename

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -91,4 +91,13 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
   test '#content_type returns the first element of the content type array' do
     assert_equal 'image/png', @file.content_type
   end
+
+  test 'when the legacy_url_path contains non-ascii characters it percent-encodes' do
+    asset_path = 'path/to/ässet.png'
+    file = Whitehall::AssetManagerStorage::File.new(asset_path)
+
+    Plek.stubs(:new).returns(stub('plek', public_asset_host: 'http://assets-host'))
+
+    assert_equal 'http://assets-host/government/uploads/path/to/%C3%A4sset.png', file.url
+  end
 end


### PR DESCRIPTION
https://github.com/alphagov/whitehall/issues/3728

When the `legacy_url_path` contains non-ascii characters, generating a URI with `URI.join` raises an `URI::InvalidURIError`. We fix this by percent-encoding `legacy_url_path` before joining.

We fixed a similar issue[1] in `gds_api_adapters` in this way.

[1] https://github.com/alphagov/gds-api-adapters/pull/794/