### PR TITLE
Fix intermittent failure in PublishingApi::ConsultationPresenterTest

### DIFF
--- a/test/unit/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/consultation_presenter_test.rb
@@ -256,8 +256,9 @@ module PublishingApi::ConsultationPresenterTest
 
     test 'ways to respond' do
       Plek.any_instance.stubs(:public_asset_host).returns('https://asset-host.com')
+      expected_id = ConsultationResponseFormData.where(carrierwave_file: 'two-pages.pdf').last.id
       expected_ways_to_respond = {
-        attachment_url: 'https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf',
+        attachment_url: "https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/#{expected_id}/two-pages.pdf",
         email: 'postmaster@example.com',
         link_url: 'http://www.example.com',
         postal_address: <<-ADDRESS.strip_heredoc.chop


### PR DESCRIPTION
I saw this test fail in a recent build[1] - it succeeded when the build was retried.

The expected `attachment_url` contains a number which depends on the id of a database field. I think there must be some leaking between tests that meant that this number could be `3` instead of `1`. It's not actually important what id is given to the record, so I've replaced the number with a `\d` regex match.

[1]
https://ci.integration.publishing.service.gov.uk/job/whitehall/job/fix-uri-invalid-uri-error-in-asset-manager-storage/1/consoleText

Relevant part:

```
==> Failures

  1) Failure:
PublishingApi::ConsultationPresenterTest::OpenConsultationWithParticipationTest#test_ways_to_respond [/var/lib/jenkins/workspace/or-in-asset-manager-storage-47P4MMGGNAONPVWHBM3VSFRMNWC3ZBC5GCWDLBSRFCQBPK6G2YMA/test/unit/presenters/publishing_api/consultation_presenter_test.rb:272]:
--- expected
+++ actual
@@ -1,5 +1,5 @@
-{:attachment_url=>"https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/1/two-pages.pdf", :email=>"postmaster@example.com", :link_url=>"http://www.example.com", :postal_address=>"2 Home Farm Ln
+{:email=>"postmaster@example.com", :link_url=>"http://www.example.com", :postal_address=>"2 Home Farm Ln
 Kirklington
 Newark
 NG22 8PE
-UK"}
+UK", :attachment_url=>"https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/3/two-pages.pdf"}
```