### PR TITLE
Add aditional paths to asset delete tasks

### DIFF
--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,4 +1,9 @@
 class AssetRemover
+  def remove_government_uploads_system_uploads
+    target_dir = File.join(Whitehall.clean_uploads_root, 'government', 'uploads', 'system', 'uploads')
+    remove_asset_dir(target_dir)
+  end
+
   def remove_uploaded_number10
     target_dir = File.join(Whitehall.clean_uploads_root, 'uploaded', 'number10')
     remove_asset_dir(target_dir)

--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -57,8 +57,7 @@ class AssetRemover
 private
 
   def remove_asset_dir(target_dir)
-    files = Dir.glob(File.join(target_dir, '**', '*'))
     FileUtils.remove_dir(target_dir)
-    files
+    Dir.glob(File.join(target_dir, '**', '*'))
   end
 end

--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,4 +1,9 @@
 class AssetRemover
+  def remove_uploaded_number10
+    target_dir = File.join(Whitehall.clean_uploads_root, 'uploaded', 'number10')
+    remove_asset_dir(target_dir)
+  end
+
   def remove_organisation_logo
     target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
     remove_asset_dir(target_dir)

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -21,7 +21,7 @@ namespace :asset_manager do
     desc "Calls AssetRemover##{method}."
     task method => :environment do
       files = AssetRemover.new.send(method)
-      puts "#{files.size} files removed"
+      puts "#{files.size} files remaining"
     end
   end
 

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,7 +7,8 @@ namespace :asset_manager do
     migrator.perform
   end
 
-  %i(remove_uploaded_number10
+  %i(remove_government_uploads_system_uploads
+     remove_uploaded_number10
      remove_organisation_logo
      remove_consultation_response_form_data_file
      remove_classification_featuring_image_data_file

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,7 +7,8 @@ namespace :asset_manager do
     migrator.perform
   end
 
-  %i(remove_organisation_logo
+  %i(remove_uploaded_number10
+     remove_organisation_logo
      remove_consultation_response_form_data_file
      remove_classification_featuring_image_data_file
      remove_default_news_organisation_image_data_file

--- a/test/unit/asset_remover_test.rb
+++ b/test/unit/asset_remover_test.rb
@@ -32,9 +32,9 @@ class AssetRemoverTest < ActiveSupport::TestCase
     refute Dir.exist?(@logo_dir)
   end
 
-  test '#remove_organisation_logo returns an array of the files removed' do
+  test '#remove_organisation_logo returns an array of the files remaining after removal' do
     files = @subject.remove_organisation_logo
 
-    assert_equal [@logo_path], files
+    assert_equal [], files
   end
 end


### PR DESCRIPTION
This PR adds rake tasks to remove the assets under `uploaded/number10` and `government/uploads/system/uploads`. The commit notes have links to the relevant issues. 