### PR TITLE
Avoid prepending asset host to inline image URLs

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -255,13 +255,7 @@ private
   def build_govspeak_document(govspeak, images = [])
     hosts = [Whitehall.admin_host, Whitehall.public_host]
     Govspeak::Document.new(govspeak, document_domains: hosts).tap do |document|
-      document.images = images.map { |i| AssetHostDecorator.new(i) }
-    end
-  end
-
-  class AssetHostDecorator < SimpleDelegator
-    def url(*args)
-      Whitehall.public_asset_host + super
+      document.images = images
     end
   end
 end

--- a/test/functional/admin/preview_controller_test.rb
+++ b/test/functional/admin/preview_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::PreviewControllerTest < ActionController::TestCase
     image = create(:image, edition: edition)
 
     post :preview, params: { body: edition.body, image_ids: edition.images.map(&:id) }
-    assert_select ".document .body figure.image.embedded img[src=?]", Whitehall.public_asset_host + image.url
+    assert_select ".document .body figure.image.embedded img[src=?]", image.url
   end
 
   view_test "renders attached files if attachment_ids provided" do

--- a/test/unit/helpers/admin/admin_govspeak_helper_test.rb
+++ b/test/unit/helpers/admin/admin_govspeak_helper_test.rb
@@ -93,15 +93,14 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
   end
 
   test "should allow attached images to be embedded in admin html" do
-    images = [OpenStruct.new(alt_text: "My Alt", url: "/image.jpg")]
+    images = [OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")]
     html = govspeak_to_admin_html("!!1", images)
-    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", Whitehall.public_asset_host + "/image.jpg"
+    assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", "https://some.cdn.com/image.jpg"
   end
 
-  test "prefixes embedded image urls with asset host if present" do
-    Whitehall.stubs(:public_asset_host).returns("https://some.cdn.com")
+  test "should allow attached images to be embedded in edition body" do
     edition = build(:published_news_article, body: "!!1")
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "/image.jpg")])
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")])
     html = govspeak_edition_to_admin_html(edition)
     assert_select_within_html html, ".govspeak figure.image.embedded img[src=?]", "https://some.cdn.com/image.jpg"
   end

--- a/test/unit/helpers/govspeak_helper_test.rb
+++ b/test/unit/helpers/govspeak_helper_test.rb
@@ -250,10 +250,9 @@ class GovspeakHelperTest < ActionView::TestCase
     assert_select_within_html html, ".attachment.embedded"
   end
 
-  test "prefixes embedded image urls with asset host if present" do
-    Whitehall.stubs(:public_asset_host).returns("https://some.cdn.com")
+  test "embeds image urls" do
     edition = build(:published_news_article, body: "!!1")
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "/image.jpg")])
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg")])
     html = govspeak_edition_to_html(edition)
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end

--- a/test/unit/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/whitehall/govspeak_renderer_test.rb
@@ -55,7 +55,7 @@ private
 
         <figure class="image embedded">
           <div class="img">
-            <img alt="#{image.alt_text}" src="#{Whitehall.public_asset_host}#{image.url}">
+            <img alt="#{image.alt_text}" src="#{image.url}">
           </div>
         </figure>
       </div>

--- a/test/unit/workers/govspeak_content_worker_test.rb
+++ b/test/unit/workers/govspeak_content_worker_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 class GovspeakContentWorkerTest < ActiveSupport::TestCase
   setup do
     Whitehall.stubs(:skip_safe_html_validation).returns(false)
@@ -118,7 +120,7 @@ private
 
         <figure class="image embedded">
           <div class="img">
-            <img alt="#{image.alt_text}" src="#{Whitehall.public_asset_host}#{image.url}">
+            <img alt="#{image.alt_text}" src="#{image.url}">
           </div>
         </figure>
       </div>


### PR DESCRIPTION
This fixes the broken URLs we were generating when embedding inline images into markdown.

We've recently updated the `ImageUploader` to use the `AssetManagerStorage` engine. The `AssetManagerStorage::File#url` method already includes the asset host so we don't need to prepend it again.

The problem was highlighted by [this end-to-end test][1]

[1]: https://github.com/alphagov/publishing-e2e-tests/blob/master/spec/whitehall/uploading_attachment_spec.rb