### PR TITLE
Use AssetManagerAndQuarantinedFileStorage for attachments

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class AttachmentUploader < WhitehallUploader
+  storage :asset_manager_and_quarantined_file_storage
+
   PDF_CONTENT_TYPE = 'application/pdf'.freeze
   INDEXABLE_TYPES = %w(csv doc docx ods odp odt pdf ppt pptx rdf rtf txt xls xlsx xml).freeze
 

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -12,6 +12,10 @@ class AttachmentUploader < WhitehallUploader
 
   before :cache, :validate_zipfile_contents!
 
+  def assets_protected?
+    true
+  end
+
   process :set_content_type
   def set_content_type
     filename = full_filename(file.file)

--- a/app/uploaders/whitehall_uploader.rb
+++ b/app/uploaders/whitehall_uploader.rb
@@ -11,4 +11,8 @@ class WhitehallUploader < CarrierWave::Uploader::Base
   def clean_path
     File.join(Whitehall.clean_uploads_root, relative_path)
   end
+
+  def assets_protected?
+    false
+  end
 end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,7 +1,9 @@
 class AssetManagerCreateWhitehallAssetWorker < WorkerBase
   def perform(file_path, legacy_url_path)
     file = File.open(file_path)
-    Services.asset_manager.create_whitehall_asset(file: file, legacy_url_path: legacy_url_path)
+    asset_options = { file: file, legacy_url_path: legacy_url_path }
+    asset_options[:draft] = true if legacy_url_path.match?(/attachment_data/)
+    Services.asset_manager.create_whitehall_asset(asset_options)
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
   end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,8 +1,8 @@
 class AssetManagerCreateWhitehallAssetWorker < WorkerBase
-  def perform(file_path, legacy_url_path)
+  def perform(file_path, legacy_url_path, draft = false)
     file = File.open(file_path)
     asset_options = { file: file, legacy_url_path: legacy_url_path }
-    asset_options[:draft] = true if legacy_url_path.match?(/attachment_data/)
+    asset_options[:draft] = true if draft
     Services.asset_manager.create_whitehall_asset(asset_options)
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -10,7 +10,8 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.mkdir_p(::File.dirname(temporary_location))
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = ::File.join('/government/uploads', uploader.store_path)
-    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path)
+    draft = uploader.assets_protected?
+    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft)
     File.new(uploader.store_path)
   end
 

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -278,6 +278,8 @@ class AttachmentsControllerTest < ActionController::TestCase
   end
 
   test 'deleted attachments policy groups return 404' do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
     attachment = create(:file_attachment, attachable: create(:policy_group))
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -24,30 +24,25 @@ class AssetManagerIntegrationTest
   end
 
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
-    test 'sends the logo to Asset Manager' do
-      filename = '960x640_jpeg.jpg'
-      organisation = FactoryBot.build(
+    setup do
+      @filename = '960x640_jpeg.jpg'
+      @organisation = FactoryBot.build(
         :organisation,
         organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(fixture_path.join('images', filename))
+        logo: File.open(fixture_path.join('images', @filename))
       )
+    end
 
-      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{filename}/))
+    test 'sends the logo to Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
 
-      organisation.save!
+      @organisation.save!
     end
 
     test 'does not mark the logo as draft in Asset Manager' do
-      filename = '960x640_jpeg.jpg'
-      organisation = FactoryBot.build(
-        :organisation,
-        organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-        logo: File.open(fixture_path.join('images', filename))
-      )
-
       Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
-      organisation.save!
+      @organisation.save!
     end
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -1,6 +1,28 @@
 require 'test_helper'
 
 class AssetManagerIntegrationTest
+  class CreatingAFileAttachment < ActiveSupport::TestCase
+    setup do
+      @filename = '960x640_jpeg.jpg'
+      @attachment = FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('images', @filename))
+      )
+    end
+
+    test 'sends the attachment to Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
+
+      @attachment.save!
+    end
+
+    test 'marks the attachment as draft in Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
+
+      @attachment.save!
+    end
+  end
+
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase
     test 'sends the logo to Asset Manager' do
       filename = '960x640_jpeg.jpg'
@@ -11,6 +33,19 @@ class AssetManagerIntegrationTest
       )
 
       Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{filename}/))
+
+      organisation.save!
+    end
+
+    test 'does not mark the logo as draft in Asset Manager' do
+      filename = '960x640_jpeg.jpg'
+      organisation = FactoryBot.build(
+        :organisation,
+        organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+        logo: File.open(fixture_path.join('images', filename))
+      )
+
+      Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
       organisation.save!
     end
@@ -68,6 +103,12 @@ class AssetManagerIntegrationTest
 
     test 'sends the person image to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
+
+      @person.save!
+    end
+
+    test 'does not mark the image as draft in Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
       @person.save!
     end
@@ -150,6 +191,12 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:create_whitehall_asset).with(
         file_and_legacy_url_path_matching(/#{@filename}/)
       )
+
+      @consultation_response_form_data.save!
+    end
+
+    test 'does not mark the consultation response form data as draft in Asset Manager' do
+      Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
       @consultation_response_form_data.save!
     end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -45,6 +45,8 @@ class AttachmentDataTest < ActiveSupport::TestCase
   end
 
   test "should save content type and file size on update" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
     greenpaper_pdf = fixture_file_upload('greenpaper.pdf', 'application/pdf')
     whitepaper_pdf = fixture_file_upload('whitepaper.pdf', 'application/pdf')
     attachment = create(:attachment_data, file: greenpaper_pdf)
@@ -91,6 +93,8 @@ class AttachmentDataTest < ActiveSupport::TestCase
   end
 
   test "should set page count for PDF on update" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
     two_pages_pdf = fixture_file_upload('two-pages.pdf')
     three_pages_pdf = fixture_file_upload('three-pages.pdf')
     attachment = create(:attachment_data, file: two_pages_pdf)

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class AttachmentUploaderTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
+  test 'uses the asset manager and quarantined file storage engine' do
+    assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, AttachmentUploader.storage
+  end
+
   test 'should allow whitelisted file extensions' do
     graphics = %w(dxf eps gif jpg png ps)
     documents = %w(chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt)

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -7,6 +7,10 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
     assert_equal Whitehall::AssetManagerAndQuarantinedFileStorage, AttachmentUploader.storage
   end
 
+  test 'indicates that assets are protected' do
+    assert AttachmentUploader.new.assets_protected?
+  end
+
   test 'should allow whitelisted file extensions' do
     graphics = %w(dxf eps gif jpg png ps)
     documents = %w(chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt)

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -163,6 +163,8 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
   end
 
   test "#visible returns false for deleted attachment on a publication" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
     publication = create(:published_publication, :with_file_attachment)
     attachment = publication.attachments.last
     attachment.destroy
@@ -185,6 +187,8 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
   end
 
   test "#visible returns false for deleted attachment on a PolicyGroup" do
+    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
+
     policy_group = create(:policy_group, :with_file_attachment)
     attachment = policy_group.attachments.last
     attachment.destroy

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -4,6 +4,11 @@ require 'whitehall/asset_manager_storage'
 class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   class AssetManagerUploader < CarrierWave::Uploader::Base
     storage :asset_manager
+
+    attr_writer :assets_protected
+    def assets_protected?
+      @assets_protected
+    end
   end
 
   setup do
@@ -31,7 +36,23 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
     expected_filename = File.basename(@file.path)
     expected_path = File.join('/government/uploads/store-dir', expected_filename)
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything)
+
+    @uploader.store!(@file)
+  end
+
+  test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
+    @uploader.assets_protected = false
+
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, false)
+
+    @uploader.store!(@file)
+  end
+
+  test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
+    @uploader.assets_protected = true
+
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, true)
 
     @uploader.store!(@file)
   end

--- a/test/unit/whitehall_uploader_test.rb
+++ b/test/unit/whitehall_uploader_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class WhitehallUploaderTest < ActiveSupport::TestCase
+  test 'indicates that assets are not protected' do
+    refute WhitehallUploader.new.assets_protected?
+  end
+end

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -21,6 +21,19 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @legacy_url_path)
   end
 
+  test 'does not mark the asset as draft by default' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
+
+    @worker.perform(@file.path, @legacy_url_path)
+  end
+
+  test 'marks the asset as draft if it is an attachment' do
+    legacy_url_path = '/path/to/attachment_data'
+    Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
+
+    @worker.perform(@file.path, legacy_url_path)
+  end
+
   test 'removes the file after it has been successfully uploaded' do
     @worker.perform(@file.path, @legacy_url_path)
     refute File.exist?(@file.path)

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -27,11 +27,10 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @legacy_url_path)
   end
 
-  test 'marks the asset as draft if it is an attachment' do
-    legacy_url_path = '/path/to/attachment_data'
+  test 'marks the asset as draft if instructed' do
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
 
-    @worker.perform(@file.path, legacy_url_path)
+    @worker.perform(@file.path, @legacy_url_path, true)
   end
 
   test 'removes the file after it has been successfully uploaded' do


### PR DESCRIPTION
This PR configures the `AttachmentUploader` to store attachments on the file system and in Asset Manager. This addresses https://github.com/alphagov/asset-manager/issues/440.

I've tested this change as working in the development vm. I created a consultation and uploaded a single attachment and a single image. The attachment was created in the draft state while the images were created in a non-draft state:

We're not going to be ready to serve these attachment assets from Asset Manager for a while so marking them as draft seems like the safest option in the meantime.
