### PR TITLE
Ensure presenters use correct image urls

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -66,7 +66,7 @@ module PublishingApi
 
     def image_details
       {
-        url: Whitehall.public_asset_host + presented_case_study.lead_image_path,
+        url: presented_case_study.lead_image_path,
         alt_text: presented_case_study.lead_image_alt_text,
         caption: presented_case_study.lead_image_caption,
       }

--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -45,7 +45,7 @@ module PublishingApi
       {
         body: body,
         image: {
-          url: Whitehall.public_asset_host + item.image_url(:s300),
+          url: item.image_url(:s300),
           alt_text: item.image_alt_text,
         }
       }

--- a/test/unit/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/case_study_presenter_test.rb
@@ -73,7 +73,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     case_study = create(:published_case_study, images: [image])
 
     expected_hash = {
-      url: (Whitehall.public_asset_host + image.url(:s300)),
+      url: image.url(:s300),
       alt_text: image.alt_text,
       caption: image.caption
     }
@@ -88,7 +88,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     case_study = create(:published_case_study, images: [image])
 
     expected_hash = {
-      url: (Whitehall.public_asset_host + image.url(:s300)),
+      url: image.url(:s300),
       alt_text: image.alt_text,
       caption: nil
     }
@@ -105,7 +105,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     case_study = create(:published_case_study, lead_organisations: [organisation])
 
     expected_hash = {
-      url: (Whitehall.public_asset_host + organisation_image.file.url(:s300)),
+      url: organisation_image.file.url(:s300),
       alt_text: 'placeholder',
       caption: nil
     }

--- a/test/unit/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/take_part_presenter_test.rb
@@ -8,7 +8,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
   test "take part presentation includes the correct values" do
     take_part_page = create(:take_part_page, content_id: SecureRandom.uuid)
 
-    image_url = Whitehall.public_asset_host + take_part_page.image_url(:s300)
+    image_url = take_part_page.image_url(:s300)
 
     expected_hash = {
       base_path: take_part_page.search_link,


### PR DESCRIPTION
This PR fixes two instances where presenters were incorrectly prepending the asset host to image urls. We haven't needed to do that since we switched the storage engine in a024c0f. We fixed another one of these in a746706ac when the end-to-end tests picked up the problem. In the case of this PR the tests were giving false posiitives. This PR adds tests to catch the problem. 

There are two other places where we prepend the asset host in `test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb:334` where we use the path instead of the URL and in `test/unit/presenters/publishing_api/news_article_presenter_test.rb:241` where we are working with a static image. In both these cases the prepending is correct. 