### PR TITLE
Perform a database clean before starting tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,9 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.project_root = Rails.root
 end
 
+# Start any test run with a clean database
+DatabaseCleaner.clean_with(:truncation, pre_count: true, reset_ids: false)
+
 class ActiveSupport::TestCase
   include AssetManagerTestHelpers
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
The database cleaner was previously configured to truncate the database
after each test which assumed the database started off clean. However
the db:reset task we run in CI runs db:seed and since the seeds were
expanded in
https://github.com/alphagov/whitehall/commit/ab4ff750079d370264dd1aef8be5e425b02a7344
this now can produce an intermittent fail on the first test run.

To resolve this we run DatabaseCleaner before the suite and then after
each test.