### PR TITLE
Enable uploading of attachments to Asset Manager

### DIFF
--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,6 +1,16 @@
 class MigrateAssetsToAssetManager
   include ActionView::Helpers::TextHelper
 
+  def self.migrate_attachments
+    clean_uploads_root = Pathname.new(Whitehall.clean_uploads_root)
+    attachments_parent_dir = clean_uploads_root.join('system', 'uploads', 'attachment_data', 'file')
+    Pathname.glob(attachments_parent_dir.join('*')).each do |attachment_dir|
+      relative_attachment_dir = attachment_dir.relative_path_from(clean_uploads_root)
+      migrator = MigrateAssetsToAssetManager.new(relative_attachment_dir.to_s, true)
+      migrator.perform
+    end
+  end
+
   def initialize(target_dir, draft = false)
     @relative_file_paths = AssetFilePaths.new(target_dir)
     @draft = draft

--- a/lib/migrate_assets_to_asset_manager.rb
+++ b/lib/migrate_assets_to_asset_manager.rb
@@ -1,13 +1,14 @@
 class MigrateAssetsToAssetManager
   include ActionView::Helpers::TextHelper
 
-  def initialize(target_dir)
+  def initialize(target_dir, draft = false)
     @relative_file_paths = AssetFilePaths.new(target_dir)
+    @draft = draft
   end
 
   def perform
     @relative_file_paths.each do |relative_file_path|
-      Worker.perform_async(relative_file_path)
+      Worker.perform_async(relative_file_path, @draft)
     end
   end
 
@@ -18,21 +19,22 @@ class MigrateAssetsToAssetManager
   class Worker < WorkerBase
     sidekiq_options queue: :asset_migration
 
-    def perform(relative_file_path)
+    def perform(relative_file_path, draft = false)
       absolute_file_path = File.join(Whitehall.clean_uploads_root, relative_file_path)
       AssetFile.open(absolute_file_path) do |file|
-        create_whitehall_asset(file) unless asset_exists?(file)
+        create_whitehall_asset(file, draft) unless asset_exists?(file)
       end
     end
 
   private
 
-    def create_whitehall_asset(file)
+    def create_whitehall_asset(file, draft)
       Services.asset_manager.create_whitehall_asset(
         file: file,
         legacy_url_path: file.legacy_url_path,
         legacy_last_modified: file.legacy_last_modified,
-        legacy_etag: file.legacy_etag
+        legacy_etag: file.legacy_etag,
+        draft: draft
       )
     end
 

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,6 +7,10 @@ namespace :asset_manager do
     migrator.perform
   end
 
+  task migrate_attachments: :environment do
+    MigrateAssetsToAssetManager.migrate_attachments
+  end
+
   %i(remove_attachment_file
      remove_consultation_response_form_file
      remove_edition_organisation_image_data_file

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -52,6 +52,24 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     @subject.perform
   end
 
+  test 'it calls create_whitehall_asset with the draft flag set to false by default' do
+    Services.asset_manager.expects(:create_whitehall_asset).with(
+      has_entry(:draft, false)
+    )
+
+    @subject.perform
+  end
+
+  test 'it calls create_whitehall_asset with the draft flag set to true if explicitly set' do
+    subject = MigrateAssetsToAssetManager.new('system/uploads/organisation/logo', true)
+
+    Services.asset_manager.expects(:create_whitehall_asset).with(
+      has_entry(:draft, true)
+    )
+
+    subject.perform
+  end
+
   test 'it does not call create_whitehall_asset if the asset already exists in asset manager' do
     Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
     Services.asset_manager.expects(:create_whitehall_asset).never

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -96,6 +96,32 @@ private
   end
 end
 
+class MigrateAttachmentsToAssetManagerTest < ActiveSupport::TestCase
+  setup do
+    @attachments_parent_dir = Pathname.new(File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'attachment_data', 'file'))
+
+    FileUtils.mkdir_p(@attachments_parent_dir.join('001'))
+    FileUtils.mkdir_p(@attachments_parent_dir.join('002'))
+
+    @migrator = stub('migrator', perform: nil)
+    MigrateAssetsToAssetManager.stubs(:new).returns(@migrator)
+  end
+
+  test 'migrates attachment directory 001 and sets attachments as draft' do
+    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/001', true).returns(@migrator)
+    @migrator.expects(:perform)
+
+    MigrateAssetsToAssetManager.migrate_attachments
+  end
+
+  test 'migrates attachment directory 002 and sets attachments as draft' do
+    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/002', true).returns(@migrator)
+    @migrator.expects(:perform)
+
+    MigrateAssetsToAssetManager.migrate_attachments
+  end
+end
+
 class AssetFilePathsTest < ActiveSupport::TestCase
   setup do
     FileUtils.mkdir_p(organisation_logo_dir)


### PR DESCRIPTION
I'm adding this so that we can migrate all existing Whitehall attachments to Asset Manager (see https://github.com/alphagov/asset-manager/issues/441).

We want to mark these attachment assets as draft in Asset Manager to avoid the possibility of exposing potentially sensitive data.

I've tried this in my dev-vm and confirmed that calling the Rake task with the additional `draft` parameter set to `true` results in assets being created in Asset Manager in the draft state.