### PR TITLE
Rake tasks to delete non database backed assets from file system

### DIFF
--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -1,4 +1,39 @@
 class AssetRemover
+  def remove_attachment_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'attachment', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_consultation_response_form_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'consultation_response_form', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_edition_organisation_image_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'edition_organisation_image_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_edition_world_location_image_data_file
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'edition_world_location_image_data', 'file')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_news_article_featuring_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'news_article', 'featuring_image')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_news_article_image
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'news_article', 'image')
+    remove_asset_dir(target_dir)
+  end
+
+  def remove_topical_event_logo
+    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'topical_event', 'logo')
+    remove_asset_dir(target_dir)
+  end
+
   def remove_government_uploads_system_uploads
     target_dir = File.join(Whitehall.clean_uploads_root, 'government', 'uploads', 'system', 'uploads')
     remove_asset_dir(target_dir)

--- a/lib/asset_remover.rb
+++ b/lib/asset_remover.rb
@@ -34,61 +34,6 @@ class AssetRemover
     remove_asset_dir(target_dir)
   end
 
-  def remove_government_uploads_system_uploads
-    target_dir = File.join(Whitehall.clean_uploads_root, 'government', 'uploads', 'system', 'uploads')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_uploaded_number10
-    target_dir = File.join(Whitehall.clean_uploads_root, 'uploaded', 'number10')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_organisation_logo
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_consultation_response_form_data_file
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'consultation_response_form_data', 'file')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_classification_featuring_image_data_file
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'classification_featuring_image_data', 'file')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_default_news_organisation_image_data_file
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'default_news_organisation_image_data', 'file')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_feature_image
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'feature', 'image')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_image_data_file
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'image_data', 'file')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_person_image
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'person', 'image')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_promotional_feature_item_image
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'promotional_feature_item', 'image')
-    remove_asset_dir(target_dir)
-  end
-
-  def remove_take_part_page_image
-    target_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'take_part_page', 'image')
-    remove_asset_dir(target_dir)
-  end
-
 private
 
   def remove_asset_dir(target_dir)

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,7 +7,14 @@ namespace :asset_manager do
     migrator.perform
   end
 
-  %i(remove_government_uploads_system_uploads
+  %i(remove_attachment_file
+     remove_consultation_response_form_file
+     remove_edition_organisation_image_data_file
+     remove_edition_world_location_image_data_file
+     remove_news_article_featuring_image
+     remove_news_article_image
+     remove_topical_event_logo
+     remove_government_uploads_system_uploads
      remove_uploaded_number10
      remove_organisation_logo
      remove_consultation_response_form_data_file

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -13,18 +13,7 @@ namespace :asset_manager do
      remove_edition_world_location_image_data_file
      remove_news_article_featuring_image
      remove_news_article_image
-     remove_topical_event_logo
-     remove_government_uploads_system_uploads
-     remove_uploaded_number10
-     remove_organisation_logo
-     remove_consultation_response_form_data_file
-     remove_classification_featuring_image_data_file
-     remove_default_news_organisation_image_data_file
-     remove_feature_image
-     remove_image_data_file
-     remove_person_image
-     remove_promotional_feature_item_image
-     remove_take_part_page_image).each do |method|
+     remove_topical_event_logo).each do |method|
     desc "Calls AssetRemover##{method}."
     task method => :environment do
       files = AssetRemover.new.send(method)

--- a/test/unit/asset_remover_test.rb
+++ b/test/unit/asset_remover_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AssetRemoverTest < ActiveSupport::TestCase
   setup do
-    @logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'organisation', 'logo')
+    @logo_dir = File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'topical_event', 'logo')
     @logo_path = File.join(@logo_dir, '960x640_jpeg.jpg')
     fixture_asset_path = Rails.root.join('test', 'fixtures', 'images', '960x640_jpeg.jpg')
 
@@ -16,24 +16,24 @@ class AssetRemoverTest < ActiveSupport::TestCase
     FileUtils.remove_dir(@logo_dir, true)
   end
 
-  test '#remove_organisation_logo removes all logos' do
+  test '#remove_topical_event_logo removes all logos' do
     assert File.exist?(@logo_path)
 
-    @subject.remove_organisation_logo
+    @subject.remove_topical_event_logo
 
     refute File.exist?(@logo_path)
   end
 
-  test '#remove_organisation_logo removes the containing directory' do
+  test '#remove_topical_event_logo removes the containing directory' do
     assert Dir.exist?(@logo_dir)
 
-    @subject.remove_organisation_logo
+    @subject.remove_topical_event_logo
 
     refute Dir.exist?(@logo_dir)
   end
 
-  test '#remove_organisation_logo returns an array of the files remaining after removal' do
-    files = @subject.remove_organisation_logo
+  test '#remove_topical_event_logo returns an array of the files remaining after removal' do
+    files = @subject.remove_topical_event_logo
 
     assert_equal [], files
   end


### PR DESCRIPTION
See: alphagov/asset-manager#216

There are a number of assets under `system/uploads/` that are associated with mounted carrierwave uploaders that have subsequently been deleted from the code base. The assets however still have public URLs. We are migrating those assets to Asset Manager and once complete, the rake tasks added in this PR can be run to remove the files from NFS. 

I've also removed some of the rake tasks that have already been run. 