### PR TITLE
[DO NOT MERGE] Spike to import HMCTS forms

### DIFF
--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -1,0 +1,71 @@
+module Import
+  class HmctsCsvParser
+    CSV_HEADERS = %i(
+      publication_page_id
+      artefact_code
+      category
+      artefact_file_name
+      artefact_type
+      artefact_title
+      artefact_link
+      artefact_url
+      publication_type
+      publication_title
+      publication_summary
+      publication_body
+      published_before
+      has_images
+      alternative_format_email
+      policy
+      policy_areas
+      lead_organisations
+      supporting_organisations
+      excluded_nations
+      access_limiting
+      schedule_publishing
+      attachment_accessible
+      new_publication_url
+      new_attachment_url
+    ).freeze
+
+    PUBLICATION_TYPE_SLUGS = {
+      "Form" => "forms",
+      "Guidance" => "guidance",
+    }.freeze
+
+    def self.publications(path)
+      csv = CSV.read(path, headers: CSV_HEADERS)
+
+      Enumerator.new do |yielder|
+        page_id = nil
+        publication_details = {}
+
+        # Skip the header row
+        csv[1..-1].each do |row|
+          if row[:publication_page_id] == page_id
+
+          else
+            yielder << publication_details unless page_id.nil?
+
+            publication_details = {
+              publication_type: publication_type_slug(row[:publication_type]),
+              title: row[:publication_title],
+              summary: row[:publication_summary],
+              body: row[:publication_body],
+              # TODO: Handle multiple policy areas. Will they comma-separate these?
+              policy_area: row[:policy_areas],
+            }
+
+            page_id = row[:publication_page_id]
+          end
+        end
+
+        yielder << publication_details
+      end
+    end
+
+    def self.publication_type_slug(name)
+      PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
+    end
+  end
+end

--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -43,7 +43,7 @@ module Import
         # Skip the header row
         csv[1..-1].each do |row|
           if row[:publication_page_id] == page_id
-
+            publication_details[:attachments] << attachment_details(row)
           else
             yielder << publication_details unless page_id.nil?
 
@@ -54,7 +54,10 @@ module Import
               body: row[:publication_body],
               # TODO: Handle multiple policy areas. Will they comma-separate these?
               policy_area: row[:policy_areas],
+              attachments: [],
             }
+
+            publication_details[:attachments] << attachment_details(row)
 
             page_id = row[:publication_page_id]
           end
@@ -66,6 +69,14 @@ module Import
 
     def self.publication_type_slug(name)
       PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
+    end
+
+    def self.attachment_details(row)
+      {
+        title: row[:artefact_title],
+        file_name: row[:artefact_file_name],
+        url: row[:artefact_url],
+      }
     end
   end
 end

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -31,20 +31,41 @@ module Import
         publication.save!
         puts "Created publication with ID #{publication.id}"
 
-        # TODO: Add attachments
-        attachment_data = AttachmentData.new(file: File.new("/tmp/hello.txt"))
-        file_attachment = FileAttachment.new(
-          title: "Another attachment title",
-          attachment_data: attachment_data,
-          attachable: publication)
-        file_attachment.save!
-
-        puts "Added attachments"
+        create_attachments(publication_data[:attachments], publication)
       end
     end
 
     def self.default_organisation
       @_default_organisation ||= Organisation.find_by(name: "Ministry of Justice")
+    end
+
+    def self.create_attachments(attachments, publication)
+      temp_directory = "/tmp/#{SecureRandom.uuid}"
+      Dir.mkdir(temp_directory)
+      puts "Saving temporary files to #{temp_directory}"
+
+      attachments.each do |attachment|
+        create_attachment(attachment, publication, temp_directory)
+      end
+    end
+
+    def self.create_attachment(attachment, publication, temp_directory)
+      # TODO: Download attachment
+      temp_file_path = "#{temp_directory}/#{attachment[:file_name]}"
+      attachment_file = File.open(temp_file_path, "w") do |file|
+        file.write("Test attachment\n")
+        file.write(attachment[:title])
+      end
+
+      attachment_data = AttachmentData.new(file: File.new(temp_file_path))
+      file_attachment = FileAttachment.new(
+        title: attachment[:title],
+        attachment_data: attachment_data,
+        attachable: publication,
+      )
+      file_attachment.save!
+
+      puts "Added attachment #{temp_file_path}"
     end
   end
 end

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -1,0 +1,40 @@
+module Import
+  class HmctsImporter
+    def self.import(csv_path)
+      importer_user = User.find_by(name: "Automatic Data Importer")
+      raise "Could not find 'Automatic Data Importer' user" unless importer_user
+
+      HmctsCsvParser.publications(csv_path).each do |publication_data|
+        puts publication_data
+
+        publication = Publication.new
+        publication.publication_type = PublicationType.find_by_slug(publication_data[:publication_type])
+        publication.title = publication_data[:title]
+        publication.summary = publication_data[:summary]
+        publication.body = publication_data[:body]
+        # TODO: Handle multiple policy areas
+        publication.topics = [Topic.find_by(name: publication_data[:policy_area])]
+        # TODO: Get from spreadsheet once it is always populated
+        # TODO: Handle multiple lead organisations
+        publication.lead_organisations = [default_organisation]
+        publication.creator = importer_user
+
+        # TODO: Populate "published before" date
+        # TODO: Set "published before" to true if there is a date
+        # TODO: Populate policy
+        # TODO: Populate supporting organisations
+        # TODO: Populate excluded nations
+        # TODO: Populate access limiting flag
+
+        # TODO: Add attachments
+
+        publication.save!
+        puts "Created publication with ID #{publication.id}"
+      end
+    end
+
+    def self.default_organisation
+      @_default_organisation ||= Organisation.find_by(name: "Ministry of Justice")
+    end
+  end
+end

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -18,6 +18,8 @@ module Import
         # TODO: Handle multiple lead organisations
         publication.lead_organisations = [default_organisation]
         publication.creator = importer_user
+        # TODO: Should be HMCTS? Or another org with the email address provided in the CSV.
+        publication.alternative_format_provider = default_organisation
 
         # TODO: Populate "published before" date
         # TODO: Set "published before" to true if there is a date
@@ -26,10 +28,18 @@ module Import
         # TODO: Populate excluded nations
         # TODO: Populate access limiting flag
 
-        # TODO: Add attachments
-
         publication.save!
         puts "Created publication with ID #{publication.id}"
+
+        # TODO: Add attachments
+        attachment_data = AttachmentData.new(file: File.new("/tmp/hello.txt"))
+        file_attachment = FileAttachment.new(
+          title: "Another attachment title",
+          attachment_data: attachment_data,
+          attachable: publication)
+        file_attachment.save!
+
+        puts "Added attachments"
       end
     end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,5 @@
+namespace :import do
+  task :hmcts, [:csv_path] => :environment do |_, args|
+    Import::HmctsImporter.import(args[:csv_path])
+  end
+end


### PR DESCRIPTION
The code is a bit messy and full of TODOs - I'm just opening this PR to get some feedback on the approach, which is:

- Developer exports the spreadsheet as a CSV and copies it to a whitehall machine
- A new whitehall rake task reads the CSV
- For each form in the CSV, it creates a new draft publication
- It downloads all the forms for the publication
- It saves each form as a `FileAttachment` linked to the publication which, as far as I can tell on my dev VM, uploads them to asset-manager for virus scanning

It doesn't yet save all the publication data from the CSV. I concentrated on the attachments and the mandatory fields.

My main question is whether it's OK to download the attachments directly to the whitehall machine.

https://trello.com/c/ZLzjhOhB/57-spike-into-how-we-might-bulk-creating-draft-whitehall-content-based-on-a-spreadsheet-from-hmcts-1-day