### PR TITLE
Add size to AssetManagerAndQuarantinedFileStorage

### DIFF
--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -12,7 +12,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   class File
-    delegate :empty?, :path, :content_type, :filename, to: :@quarantined_file
+    delegate :empty?, :path, :content_type, :filename, :size, to: :@quarantined_file
 
     def initialize(asset_manager_file, quarantined_file)
       @asset_manager_file = asset_manager_file

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -86,6 +86,12 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
     assert_equal 'quarantined-file-empty?', @file.empty?
   end
 
+  test '#size delegates to the quarantined file' do
+    @quarantined_file.stubs(:size).returns('quarantined-file-size')
+
+    assert_equal 'quarantined-file-size', @file.size
+  end
+
   test '#delete calls delete on both asset manager file and quarantined file' do
     @asset_manager_file.expects(:delete)
     @quarantined_file.expects(:delete)


### PR DESCRIPTION
To avoid the following exception when calling `AttachmentData#file_is_not_empty`.

    NoMethodError
    undefined method `size' for
    #<Whitehall::AssetManagerAndQuarantinedFileStorage::File:0x00007f185b9de250>

This should fix the [exceptions we've been seeing in production][1] since deploying the changes in
https://github.com/alphagov/whitehall/pull/3734.

[1]: https://sentry.io/govuk/app-whitehall/issues/446471956/events/13256559568/
