### PR TITLE
Resolve action controller parameters hash method deprecation warnings

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -24,7 +24,7 @@ private
 
   def update_ordering(key, column)
     return unless params.include?(key)
-    params[key].each_key do |id|
+    params[key].keys.each do |id| # rubocop:disable Performance/HashEachMethods
       Role.where(id: id).update_all(
         column => params[key][id.to_s]["ordering"],
       )

--- a/app/controllers/admin/consultations_controller.rb
+++ b/app/controllers/admin/consultations_controller.rb
@@ -8,15 +8,15 @@ private
   end
 
   def cope_with_consultation_response_form_data_action_params
+    return if edition_params.empty?
     # NOTE: this is slightly different to what happens above in that
     # replace here will not create a new onbject and set up a replaced_by
     # but just does a simple attribute value overwrite (e.g. a normal
     # update). This is because consultation_participation objects are not
     # (yet) versioned with their editions like attachments are.
-    return unless params[:edition] &&
-        params[:edition][:consultation_participation_attributes] &&
-        params[:edition][:consultation_participation_attributes][:consultation_response_form_attributes]
-    response_form_params = params[:edition][:consultation_participation_attributes][:consultation_response_form_attributes]
+    return unless edition_params[:consultation_participation_attributes] &&
+        edition_params[:consultation_participation_attributes][:consultation_response_form_attributes]
+    response_form_params = edition_params[:consultation_participation_attributes][:consultation_response_form_attributes]
 
     if response_form_params[:id]
       case response_form_params.delete(:attachment_action).to_s.downcase

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -60,7 +60,7 @@ private
   end
 
   def destroy_blank_contact_numbers
-    (params[:contact][:contact_numbers_attributes] || {}).each_value do |attributes|
+    (params[:contact][:contact_numbers_attributes] || {}).each_pair do |_key, attributes|
       if attributes.except(:id).values.all?(&:blank?)
         attributes[:_destroy] = "1"
       end

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -37,7 +37,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
   def delete; end
 
   def update_memberships
-    params[:groups].each_value do |group_params|
+    params[:groups].each_pair do |_key, group_params|
       group = @collection.groups.find(group_params[:id])
       group.ordering = group_params[:order]
       group.set_document_ids_in_order! group_params.fetch(:document_ids, []).map(&:to_i).uniq

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -323,7 +323,7 @@ private
 
   def clear_scheduled_publication_if_not_activated
     if params[:scheduled_publication_active] && params[:scheduled_publication_active].to_i.zero?
-      edition_params.each_key do |key|
+      edition_params.keys.each do |key| # rubocop:disable Performance/HashEachMethods
         if key.match?(/^scheduled_publication(\([0-9]i\))?/)
           edition_params.delete(key)
         end

--- a/app/controllers/admin/feature_lists_controller.rb
+++ b/app/controllers/admin/feature_lists_controller.rb
@@ -6,7 +6,7 @@ class Admin::FeatureListsController < Admin::BaseController
   end
 
   def reorder
-    new_order = (params[:ordering] || []).sort_by { |_k, v| v.to_i }.map(&:first)
+    new_order = ordering_params.to_h.sort_by { |_k, v| v.to_i }.map(&:first)
     message = if @feature_list.reorder!(new_order)
                 { notice: "Feature order updated" }
               else
@@ -16,6 +16,14 @@ class Admin::FeatureListsController < Admin::BaseController
   end
 
 private
+
+  def ordering_params
+    # keys in ordering should be the ids of objects so that means they should be
+    # integers, we can't permit them based on an allow list, but we can pick
+    # only those keys that are integers and permit the whole param object after
+    # that
+    params.fetch(:ordering, {}).select { |k, _v| k =~ /\A\d+\Z/ }.permit!
+  end
 
   def find_feature_list
     @feature_list = FeatureList.find(params[:id] || params[:feature_list_id])

--- a/app/controllers/admin/link_check_reports_controller.rb
+++ b/app/controllers/admin/link_check_reports_controller.rb
@@ -1,5 +1,5 @@
 class Admin::LinkCheckReportsController < Admin::BaseController
-  before_filter :find_reportable
+  before_action :find_reportable
 
   def create
     @report = LinkCheckerApiService.check_links(

--- a/app/controllers/admin/speeches_controller.rb
+++ b/app/controllers/admin/speeches_controller.rb
@@ -8,8 +8,8 @@ private
   end
 
   def clear_role_appointment_param_on_override
-    if params[:person_override_active] == "1" || params[:edition][:person_override].present?
-      params[:edition][:role_appointment_id] = nil
+    if params[:person_override_active] == "1" || edition_params[:person_override].present?
+      edition_params[:role_appointment_id] = nil
       true
     end
   end

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -27,7 +27,7 @@ private
 
   def destroy_blank_social_media_accounts
     if params[:topical_event][:social_media_accounts_attributes]
-      params[:topical_event][:social_media_accounts_attributes].each_value do |account|
+      params[:topical_event][:social_media_accounts_attributes].each_pair do |_key, account|
         if account[:social_media_service_id].blank? && account[:url].blank?
           account[:_destroy] = "1"
         end

--- a/test/functional/admin/link_check_reports_controller_test.rb
+++ b/test/functional/admin/link_check_reports_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
   should_be_an_admin_controller
 
   test "AJAX POST :create saves a LinkCheckReport" do
-    xhr :post, :create, edition_id: @publication.id
+    post :create, params: { edition_id: @publication.id }, xhr: true
 
     assert_response :success
     assert_template :create
@@ -34,7 +34,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves a LinkCheckReport and redirects back to the edition" do
-    post :create, edition_id: @publication.id
+    post :create, params: { edition_id: @publication.id }
 
     assert_redirected_to admin_publication_url(@publication)
 
@@ -43,7 +43,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
 
   test "AJAX GET :show renders assigns the LinkCheckReport and renders the template" do
     link_check_report = create(:link_checker_api_report, link_reportable: @publication)
-    xhr :get, :show, id: link_check_report, edition_id: @publication
+    get :show, params: { id: link_check_report, edition_id: @publication }, xhr: true
 
     assert_response :success
     assert_template :show
@@ -53,7 +53,7 @@ class Admin::LinkCheckReportsControllerTest < ActionController::TestCase
 
   test "GET :show redirects back to the edition" do
     link_check_report = create(:link_checker_api_report, link_reportable: @publication)
-    get :show, id: link_check_report, edition_id: @publication
+    get :show, params: { id: link_check_report, edition_id: @publication }
 
     assert_redirected_to admin_publication_url(@publication)
   end


### PR DESCRIPTION
While working on #3747 I noticed lots of deprecation warnings about calling `Hash` methods on  params in the test output.  This makes it hard to see what's going on with any errors, so I decided to remove them.

This is best reviewed commit-by-commit as there's some nuance in how we avoid some of the deprecation warnings.  In particular the `each_key` in the editions controller and the `sort_by` in the feature lists controller prompted me to move fully towards using permitted params rather than accessing `params` directly and this may have some consequences I haven't thought about.  The rest are pretty straight forward though.