### PR TITLE
Redirect invalid email signups to root

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -1,5 +1,10 @@
 class EmailSignupsController < PublicFacingController
   def new
+    unless params[:email_signup].present?
+      redirect_to '/'
+      return
+    end
+
     @email_signup = EmailSignup.new(email_signup_params)
   end
 

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -5,6 +5,12 @@ class EmailSignupsControllerTest < ActionController::TestCase
   include FeedHelper
   include GdsApi::TestHelpers::EmailAlertApi
 
+  test 'GET :new without an email_signup param redirects to root' do
+    get :new
+
+    assert_redirected_to '/'
+  end
+
   view_test 'GET :new with a valid field displays the subscription form' do
     topic = create(:topic)
     get :new, params: { email_signup: { feed: atom_feed_url_for(topic) } }


### PR DESCRIPTION
The motivation is to avoid the [`ActionController::ParameterMissing` exceptions being caught in Sentry][1].

This means that requesting https://www.gov.uk/government/email-signup/new will result in a redirect to www.gov.uk, instead of the current 400 Bad Request response. This mirrors the redirect we send in response to requests for https://www.gov.uk/government/email-signup (although that's handled in routes.rb).

I'm not sure how best to avoid these exceptions. It would seem reasonable to display some kind of useful information if someone were to request /government/email-signup/new but that's more work than I have time for. Another option is to ignore these `ActionController::ParameterMissing` exceptions in Sentry (there's precedent for this as they're [ignored by default by HoneyBadger][2]) but it feels like that might have other consequences I'm not aware of.

[1]: https://sentry.io/govuk/app-whitehall/issues/343728660/
[2]: https://docs.honeybadger.io/ruby/getting-started/ignoring-errors.html