### PR TITLE
Revert "Reduce n+1 queries on document index"

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -302,17 +302,7 @@ private
   end
 
   def filter
-    @filter ||= Admin::EditionFilter.new(edition_class, current_user, edition_filter_options) if params_filters.any?
-  end
-
-  def edition_filter_options
-    params_filters_with_default_state.
-      symbolize_keys.
-      merge(
-        include_unpublishing: true,
-        include_link_check_reports: true,
-        include_last_author: true
-      )
+    @filter ||= Admin::EditionFilter.new(edition_class, current_user, params_filters_with_default_state.symbolize_keys) if params_filters.any?
   end
 
   def detect_other_active_editors

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -112,15 +112,12 @@ module Admin
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_broken_links if only_broken_links
 
-      editions = editions.includes(:unpublishing) if include_unpublishing?
-      editions = editions.includes(:link_check_reports) if include_link_check_reports?
-      editions = editions.includes(:last_author) if include_last_author?
-
       @unpaginated_editions = editions
     end
 
     def editions_with_translations(locale = nil)
       editions_without_translations = unpaginated_editions.
+                                        includes(:unpublishing).
                                         order("editions.updated_at DESC")
 
       if locale
@@ -229,18 +226,6 @@ module Admin
 
     def only_broken_links
       options[:only_broken_links].present?
-    end
-
-    def include_unpublishing?
-      options.fetch(:include_unpublishing, false)
-    end
-
-    def include_link_check_reports?
-      options.fetch(:include_link_check_reports, false)
-    end
-
-    def include_last_author?
-      options.fetch(:include_last_author, false)
     end
   end
 end

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -17,7 +17,7 @@ private
   end
 
   def create_filter(filter_options, user)
-    Admin::EditionFilter.new(Edition, user, filter_options.symbolize_keys.merge(include_unpublishing: true))
+    Admin::EditionFilter.new(Edition, user, filter_options.symbolize_keys)
   end
 
   def generate_csv(filter, csv_file)

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -7,58 +7,6 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     @current_user = build(:gds_editor)
   end
 
-  test "can preload unpublishing data if asked to" do
-    news_article = create(:news_article)
-    create(:unpublishing, edition: news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user, include_unpublishing: true).editions
-    assert_equal news_article, editions.first
-    assert editions.first.association(:unpublishing).loaded?
-  end
-
-  test "does not preload unpublishing data unless asked to" do
-    news_article = create(:news_article)
-    create(:unpublishing, edition: news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user).editions
-    assert_equal news_article, editions.first
-    refute editions.first.association(:unpublishing).loaded?
-  end
-
-  test "can preload last author data if asked to" do
-    news_article = create(:news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user, include_last_author: true).editions
-    assert_equal news_article, editions.first
-    assert editions.first.association(:last_author).loaded?
-  end
-
-  test "does not preload last author data unless asked to" do
-    news_article = create(:news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user).editions
-    assert_equal news_article, editions.first
-    refute editions.first.association(:last_author).loaded?
-  end
-
-  test "can preload link check report data if asked to" do
-    news_article = create(:news_article)
-    create(:link_checker_api_report, link_reportable: news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user, include_link_check_reports: true).editions
-    assert_equal news_article, editions.first
-    assert editions.first.association(:link_check_reports).loaded?
-  end
-
-  test "does not preload link check report data unless asked to" do
-    news_article = create(:news_article)
-    create(:link_checker_api_report, link_reportable: news_article)
-
-    editions = Admin::EditionFilter.new(Edition, @current_user).editions
-    assert_equal news_article, editions.first
-    refute editions.first.association(:last_author).loaded?
-  end
-
   test "ignores invalid state scopes" do
     news_article = create(:draft_news_article)
 

--- a/test/unit/workers/document_list_export_worker_test.rb
+++ b/test/unit/workers/document_list_export_worker_test.rb
@@ -7,7 +7,7 @@ class DocumentListExportWorkerTest < ActiveSupport::TestCase
   end
 
   test 'instantiates an EditionFilter with passed options converted to symbols' do
-    Admin::EditionFilter.expects(:new).with(Edition, @user, state: "draft", include_unpublishing: true)
+    Admin::EditionFilter.expects(:new).with(Edition, @user, state: "draft")
     @worker.stubs(:generate_csv)
     @worker.stubs(:send_mail)
     @worker.perform({ "state" => "draft" }, @user.id)


### PR DESCRIPTION
Reverts alphagov/whitehall#3747

We're seeing degraded performance on the admin/editions#index and this PR is a recent change to that action so it may be the cause.  We'll revert for now and re-investigate the n+1 thing later.