### PR TITLE
[WIP] Spike update draft status of assets in Asset Manager

### DIFF
--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -8,7 +8,7 @@ module ServiceListeners
 
     def update!
       if edition.allows_attachments?
-        edition.attachments.each do |attachment|
+        edition.attachments.select(&:file?).each do |attachment|
           attachment_data = attachment.attachment_data
           legacy_url_path = attachment_data.file.path
           draft = !AttachmentVisibility.new(attachment_data, nil).visible?

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -10,11 +10,11 @@ module ServiceListeners
       if edition.allows_attachments?
         edition.attachments.select(&:file?).each do |attachment|
           attachment_data = attachment.attachment_data
-          legacy_url_path = attachment_data.file.path
+          legacy_url_path = attachment_data.file.asset_manager_path
           draft = !AttachmentVisibility.new(attachment_data, nil).visible?
           AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft)
           attachment_data.file.versions.each_value do |uploader|
-            legacy_url_path = uploader.file.path
+            legacy_url_path = uploader.asset_manager_path
             AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft)
           end
         end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -245,6 +245,10 @@ class AttachmentUploader < WhitehallUploader
     raise CarrierWave::IntegrityError, problem.failure_message if problem
   end
 
+  def asset_manager_path
+    file.asset_manager_path
+  end
+
 private
 
   def use_fallback_pdf_thumbnail

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class AttachmentUploader < WhitehallUploader
-  storage :asset_manager_and_quarantined_file_storage
+  storage :asset_manager
 
   PDF_CONTENT_TYPE = 'application/pdf'.freeze
   INDEXABLE_TYPES = %w(csv doc docx ods odp odt pdf ppt pptx rdf rtf txt xls xlsx xml).freeze

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class AttachmentUploader < WhitehallUploader
-  storage :asset_manager
+  storage :asset_manager_and_quarantined_file_storage
 
   PDF_CONTENT_TYPE = 'application/pdf'.freeze
   INDEXABLE_TYPES = %w(csv doc docx ods odp odt pdf ppt pptx rdf rtf txt xls xlsx xml).freeze

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,11 +1,10 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
   def perform(legacy_url_path, draft)
     gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
-    asset_url = gds_api_response['id']
-    asset_id = asset_url[/\/assets\/(.*)/, 1]
-
-    # TODO: We could optimise this by working out whether the draft status
-    # has changed and only update it in the Asset Manager if it has.
-    Services.asset_manager.update_asset(asset_id, draft: draft)
+    unless gds_api_response['draft'] == draft
+      asset_url = gds_api_response['id']
+      asset_id = asset_url[/\/assets\/(.*)/, 1]
+      Services.asset_manager.update_asset(asset_id, draft: draft)
+    end
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,0 +1,11 @@
+class AssetManagerUpdateAssetWorker < WorkerBase
+  def perform(legacy_url_path, draft)
+    gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
+    asset_url = gds_api_response['id']
+    asset_id = asset_url[/\/assets\/(.*)/, 1]
+
+    # TODO: We could optimise this by working out whether the draft status
+    # has changed and only update it in the Asset Manager if it has.
+    Services.asset_manager.update_asset(asset_id, draft: draft)
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -6,6 +6,14 @@ Whitehall.edition_services.tap do |coordinator|
       .push(event: event, options: options)
   end
 
+  # TODO: we could optimise this by working out which events might affect
+  # the visibility of an attachment and only subscribing to those events
+  coordinator.subscribe do |_event, edition, _options|
+    ServiceListeners::AttachmentDraftStatusUpdater
+      .new(edition)
+      .update!
+  end
+
   coordinator.subscribe('unpublish') do |_event, edition, _options|
     # handling edition's dependency on other content
     edition.edition_dependencies.destroy_all

--- a/features/support/asset_manager_helper.rb
+++ b/features/support/asset_manager_helper.rb
@@ -1,3 +1,4 @@
 Before do
   Services.stubs(:asset_manager).returns(stub_everything('asset-manager'))
+  AssetManagerUpdateAssetWorker.stubs(:perform_async)
 end

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -23,6 +23,10 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
       @quarantined_file.url
     end
 
+    def asset_manager_path
+      @asset_manager_file.path
+    end
+
     def delete
       @quarantined_file.delete
       @asset_manager_file.delete

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -1,7 +1,9 @@
 class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    Whitehall::AssetManagerStorage.new(uploader).store!(file)
-    Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
+    asset_manager_file = Whitehall::AssetManagerStorage.new(uploader).store!(file)
+    quarantined_file = Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
+
+    File.new(asset_manager_file, quarantined_file)
   end
 
   def retrieve!(identifier)

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -3,25 +3,81 @@ require 'test_helper'
 class AttachmentDraftStatusTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  context 'when draft document with file attachment is published' do
-    test 'attachment & its thumbnail are marked as published in Asset Manager' do
-      edition = create(:news_article, :with_file_attachment)
+  context 'when draft document with file attachments is published' do
+    test 'attachments & their thumbnails are marked as published in Asset Manager' do
+      edition = create(:news_article)
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('greenpaper.pdf'))
+      )
       # ensure CarrierWave uploader returns instance of correct File class
       edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
+        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
         .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => true)
 
-      Services.asset_manager.expects(:update_asset)
-        .with('asset-1', draft: false)
-      Services.asset_manager.expects(:update_asset)
-        .with('asset-2', draft: false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => true)
 
-      Whitehall.edition_services.force_publisher(edition).perform!
+      Services.asset_manager.expects(:update_asset).with('asset-1', draft: false)
+      Services.asset_manager.expects(:update_asset).with('asset-2', draft: false)
+
+      Services.asset_manager.expects(:update_asset).with('asset-3', draft: false)
+      Services.asset_manager.expects(:update_asset).with('asset-4', draft: false)
+
+      assert Whitehall.edition_services.force_publisher(edition).perform!
+    end
+  end
+
+  context 'when published document with file attachments is unpublished' do
+    test 'attachments & their thumbnails are marked as draft in Asset Manager' do
+      edition = create(:published_news_article)
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('greenpaper.pdf'))
+      )
+      # ensure CarrierWave uploader returns instance of correct File class
+      edition.reload
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => false)
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
+
+      Services.asset_manager.expects(:update_asset).with('asset-1', draft: true)
+      Services.asset_manager.expects(:update_asset).with('asset-2', draft: true)
+
+      Services.asset_manager.expects(:update_asset).with('asset-3', draft: true)
+      Services.asset_manager.expects(:update_asset).with('asset-4', draft: true)
+
+      assert Whitehall.edition_services.unpublisher(edition, unpublishing: {
+        unpublishing_reason: UnpublishingReason::PublishedInError
+      }).perform!
     end
   end
 end

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -3,127 +3,61 @@ require 'test_helper'
 class AttachmentDraftStatusTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  context 'when draft document with file attachments is published' do
+  context 'when draft document with file attachment is published' do
     before do
       @edition = create(:news_article)
       @edition.attachments << FactoryBot.build(
         :file_attachment,
+        attachable: @edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
-      @edition.attachments << FactoryBot.build(
-        :file_attachment,
-        file: File.open(fixture_path.join('greenpaper.pdf'))
       )
       # ensure CarrierWave uploader returns instance of correct File class
       @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
         .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => true)
-
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
-        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
-        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => true)
     end
 
-    test 'attachments & their thumbnails are marked as published in Asset Manager' do
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
       Services.asset_manager.expects(:update_asset).with('asset-1', draft: false)
       Services.asset_manager.expects(:update_asset).with('asset-2', draft: false)
-
-      Services.asset_manager.expects(:update_asset).with('asset-3', draft: false)
-      Services.asset_manager.expects(:update_asset).with('asset-4', draft: false)
 
       force_publisher = Whitehall.edition_services.force_publisher(@edition)
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
-  context 'when published document with file attachments is unpublished' do
+  context 'when published document with file attachment is unpublished' do
     before do
       @edition = create(:published_news_article)
       @edition.attachments << FactoryBot.build(
         :file_attachment,
+        attachable: @edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
-      @edition.attachments << FactoryBot.build(
-        :file_attachment,
-        file: File.open(fixture_path.join('greenpaper.pdf'))
       )
       # ensure CarrierWave uploader returns instance of correct File class
       @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
         .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => false)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => false)
-
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
-        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => false)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
-        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
     end
 
-    test 'attachments & their thumbnails are marked as draft in Asset Manager' do
+    test 'attachment & its thumbnail are marked as draft in Asset Manager' do
       Services.asset_manager.expects(:update_asset).with('asset-1', draft: true)
       Services.asset_manager.expects(:update_asset).with('asset-2', draft: true)
-
-      Services.asset_manager.expects(:update_asset).with('asset-3', draft: true)
-      Services.asset_manager.expects(:update_asset).with('asset-4', draft: true)
 
       unpublisher = Whitehall.edition_services.unpublisher(@edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::PublishedInError
       })
       assert unpublisher.perform!, unpublisher.failure_reason
-    end
-  end
-
-  context 'when published document with file attachments is withdrawn' do
-    before do
-      @edition = create(:published_news_article)
-      @edition.attachments << FactoryBot.build(
-        :file_attachment,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
-      @edition.attachments << FactoryBot.build(
-        :file_attachment,
-        file: File.open(fixture_path.join('greenpaper.pdf'))
-      )
-      # ensure CarrierWave uploader returns instance of correct File class
-      @edition.reload
-
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
-        .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => false)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
-        .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => false)
-
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
-        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => false)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
-        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
-    end
-
-    test 'attachments & their thumbnails are not marked as draft in Asset Manager' do
-      Services.asset_manager.expects(:update_asset).never
-
-      withdrawer = Whitehall.edition_services.withdrawer(@edition, unpublishing: {
-        unpublishing_reason: UnpublishingReason::Withdrawn,
-        explanation: 'withdrawal-reason'
-      })
-      assert withdrawer.perform!, withdrawer.failure_reason
     end
   end
 end

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AttachmentDraftStatusTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  context 'when draft document with file attachment is published' do
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
+      edition = create(:news_article, :with_file_attachment)
+      # ensure CarrierWave uploader returns instance of correct File class
+      edition.reload
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => true)
+
+      Services.asset_manager.expects(:update_asset)
+        .with('asset-1', draft: false)
+      Services.asset_manager.expects(:update_asset)
+        .with('asset-2', draft: false)
+
+      Whitehall.edition_services.force_publisher(edition).perform!
+    end
+  end
+end

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -37,7 +37,8 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-3', draft: false)
       Services.asset_manager.expects(:update_asset).with('asset-4', draft: false)
 
-      assert Whitehall.edition_services.force_publisher(edition).perform!
+      force_publisher = Whitehall.edition_services.force_publisher(edition)
+      assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
@@ -75,9 +76,48 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-3', draft: true)
       Services.asset_manager.expects(:update_asset).with('asset-4', draft: true)
 
-      assert Whitehall.edition_services.unpublisher(edition, unpublishing: {
+      unpublisher = Whitehall.edition_services.unpublisher(edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::PublishedInError
-      }).perform!
+      })
+      assert unpublisher.perform!, unpublisher.failure_reason
+    end
+  end
+
+  context 'when published document with file attachments is withdrawn' do
+    test 'attachments & their thumbnails are not marked as draft in Asset Manager' do
+      edition = create(:published_news_article)
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+      edition.attachments << FactoryBot.build(
+        :file_attachment,
+        file: File.open(fixture_path.join('greenpaper.pdf'))
+      )
+      # ensure CarrierWave uploader returns instance of correct File class
+      edition.reload
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-1', 'draft' => false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-2', 'draft' => false)
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/greenpaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-3', 'draft' => false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
+
+      Services.asset_manager.expects(:update_asset).never
+
+      withdrawer = Whitehall.edition_services.withdrawer(edition, unpublishing: {
+        unpublishing_reason: UnpublishingReason::Withdrawn,
+        explanation: 'withdrawal-reason'
+      })
+      assert withdrawer.perform!, withdrawer.failure_reason
     end
   end
 end

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -11,8 +11,6 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
         attachable: @edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      # ensure CarrierWave uploader returns instance of correct File class
-      @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{whitepaper\.pdf$}))
@@ -39,8 +37,6 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
         attachable: @edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      # ensure CarrierWave uploader returns instance of correct File class
-      @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{whitepaper\.pdf$}))

--- a/test/integration/attachment_draft_status_test.rb
+++ b/test/integration/attachment_draft_status_test.rb
@@ -4,18 +4,18 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   context 'when draft document with file attachments is published' do
-    test 'attachments & their thumbnails are marked as published in Asset Manager' do
-      edition = create(:news_article)
-      edition.attachments << FactoryBot.build(
+    before do
+      @edition = create(:news_article)
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      edition.attachments << FactoryBot.build(
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('greenpaper.pdf'))
       )
       # ensure CarrierWave uploader returns instance of correct File class
-      edition.reload
+      @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
@@ -30,31 +30,33 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => true)
+    end
 
+    test 'attachments & their thumbnails are marked as published in Asset Manager' do
       Services.asset_manager.expects(:update_asset).with('asset-1', draft: false)
       Services.asset_manager.expects(:update_asset).with('asset-2', draft: false)
 
       Services.asset_manager.expects(:update_asset).with('asset-3', draft: false)
       Services.asset_manager.expects(:update_asset).with('asset-4', draft: false)
 
-      force_publisher = Whitehall.edition_services.force_publisher(edition)
+      force_publisher = Whitehall.edition_services.force_publisher(@edition)
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
   context 'when published document with file attachments is unpublished' do
-    test 'attachments & their thumbnails are marked as draft in Asset Manager' do
-      edition = create(:published_news_article)
-      edition.attachments << FactoryBot.build(
+    before do
+      @edition = create(:published_news_article)
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      edition.attachments << FactoryBot.build(
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('greenpaper.pdf'))
       )
       # ensure CarrierWave uploader returns instance of correct File class
-      edition.reload
+      @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
@@ -69,14 +71,16 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
+    end
 
+    test 'attachments & their thumbnails are marked as draft in Asset Manager' do
       Services.asset_manager.expects(:update_asset).with('asset-1', draft: true)
       Services.asset_manager.expects(:update_asset).with('asset-2', draft: true)
 
       Services.asset_manager.expects(:update_asset).with('asset-3', draft: true)
       Services.asset_manager.expects(:update_asset).with('asset-4', draft: true)
 
-      unpublisher = Whitehall.edition_services.unpublisher(edition, unpublishing: {
+      unpublisher = Whitehall.edition_services.unpublisher(@edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::PublishedInError
       })
       assert unpublisher.perform!, unpublisher.failure_reason
@@ -84,18 +88,18 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
   end
 
   context 'when published document with file attachments is withdrawn' do
-    test 'attachments & their thumbnails are not marked as draft in Asset Manager' do
-      edition = create(:published_news_article)
-      edition.attachments << FactoryBot.build(
+    before do
+      @edition = create(:published_news_article)
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      edition.attachments << FactoryBot.build(
+      @edition.attachments << FactoryBot.build(
         :file_attachment,
         file: File.open(fixture_path.join('greenpaper.pdf'))
       )
       # ensure CarrierWave uploader returns instance of correct File class
-      edition.reload
+      @edition.reload
 
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/whitepaper\.pdf$}))
@@ -110,10 +114,12 @@ class AttachmentDraftStatusTest < ActiveSupport::TestCase
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{attachment_data/file/\d+/thumbnail_greenpaper\.pdf\.png$}))
         .returns('id' => 'http://asset-manager/assets/asset-4', 'draft' => false)
+    end
 
+    test 'attachments & their thumbnails are not marked as draft in Asset Manager' do
       Services.asset_manager.expects(:update_asset).never
 
-      withdrawer = Whitehall.edition_services.withdrawer(edition, unpublishing: {
+      withdrawer = Whitehall.edition_services.withdrawer(@edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::Withdrawn,
         explanation: 'withdrawal-reason'
       })


### PR DESCRIPTION
This is my first stab at how this might work. I've tested this on my development VM with the appropriate asset route setup for Whitehall attachments being served from Asset Manager and it appears to work:

1. Create draft publication
2. Add a PDF attachment
3. Preview publication on draft stack
4. Confirm that links to attachment and its thumbnail image require that the user is signed in
5. Publish publication
6. View publication on website
7. Confirm that links to attachment and its thumbnail image do not require that the user is signed in

I haven't tried anything funky like un-publishing / withdrawing, but I _think_ it should work.

/cc @chrislo, @chrisroos