### PR TITLE
Migrate attachments in batches

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -7,8 +7,10 @@ namespace :asset_manager do
     migrator.perform
   end
 
-  task migrate_attachments: :environment do
-    MigrateAssetsToAssetManager.migrate_attachments
+  desc "Migrate assets under system/uploads/attachment_data/file to Asset Manager"
+  task :migrate_attachments, %i(batch_start batch_end) => :environment do |_, args|
+    abort(migrate_attachments_usage_string) unless args[:batch_start] && args[:batch_end]
+    MigrateAssetsToAssetManager.migrate_attachments(args[:batch_start].to_i, args[:batch_end].to_i)
   end
 
   %i(remove_attachment_file
@@ -31,6 +33,13 @@ namespace :asset_manager do
     %{Usage: asset_manager:migrate_assets[<path>]
 
       Where <path> is a subdirectory under Whitehall.clean_uploads_root e.g. `system/uploads/organisation/logo`
+    }
+  end
+
+  def migrate_attachments_usage_string
+    %{Usage: asset_manager:migrate_attachments[<batch_start>,<batch_end>]
+
+      Where <batch_start> and <batch_end> are integers corresponding to the directory names under `system/uploads/attachment_data/file`. e.g. `system/uploads/attachment_data/file/100` will be migrated if <batch_start> <= 100 and <batch_end> >= 100.
     }
   end
 end

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -100,22 +100,22 @@ class MigrateAttachmentsToAssetManagerTest < ActiveSupport::TestCase
   setup do
     @attachments_parent_dir = Pathname.new(File.join(Whitehall.clean_uploads_root, 'system', 'uploads', 'attachment_data', 'file'))
 
-    FileUtils.mkdir_p(@attachments_parent_dir.join('001'))
-    FileUtils.mkdir_p(@attachments_parent_dir.join('002'))
+    FileUtils.mkdir_p(@attachments_parent_dir.join('100'))
+    FileUtils.mkdir_p(@attachments_parent_dir.join('200'))
 
     @migrator = stub('migrator', perform: nil)
     MigrateAssetsToAssetManager.stubs(:new).returns(@migrator)
   end
 
-  test 'migrates attachment directory 001 and sets attachments as draft' do
-    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/001', true).returns(@migrator)
+  test 'migrates attachment directory 100 and sets attachments as draft' do
+    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/100', true).returns(@migrator)
     @migrator.expects(:perform)
 
     MigrateAssetsToAssetManager.migrate_attachments
   end
 
-  test 'migrates attachment directory 002 and sets attachments as draft' do
-    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/002', true).returns(@migrator)
+  test 'migrates attachment directory 200 and sets attachments as draft' do
+    MigrateAssetsToAssetManager.stubs(:new).with('system/uploads/attachment_data/file/200', true).returns(@migrator)
     @migrator.expects(:perform)
 
     MigrateAssetsToAssetManager.migrate_attachments

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -120,6 +120,19 @@ class MigrateAttachmentsToAssetManagerTest < ActiveSupport::TestCase
 
     MigrateAssetsToAssetManager.migrate_attachments
   end
+
+  test 'specifying a start and end range' do
+    MigrateAssetsToAssetManager.expects(:new).with('system/uploads/attachment_data/file/100', true).never
+    MigrateAssetsToAssetManager.expects(:new).with('system/uploads/attachment_data/file/200', true).returns(@migrator)
+    @migrator.expects(:perform)
+
+    MigrateAssetsToAssetManager.migrate_attachments(150, 250)
+  end
+
+  test '.directory_number_from_attachment_dir' do
+    attachment_dir = Pathname.new('system/uploads/attachment_data/file/100')
+    assert_equal 100, MigrateAssetsToAssetManager.directory_number_from_attachment_dir(attachment_dir)
+  end
 end
 
 class AssetFilePathsTest < ActiveSupport::TestCase


### PR DESCRIPTION
See: https://github.com/alphagov/asset-manager/issues/441

There are around 1.5m assets under `attachment_data/file`. When we attempted to queue up jobs to migrate all of these assets we ran into issues with redis running out of memory. This PR allows us to specify a "batch" of assets to be migrated so that we hopefully avoid this problem again. 