### PR TITLE
Improvements to AssetManagerAndQuarantinedFileStorage

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -245,6 +245,10 @@ class AttachmentUploader < WhitehallUploader
     raise CarrierWave::IntegrityError, problem.failure_message if problem
   end
 
+  def asset_manager_path
+    file.asset_manager_path
+  end
+
 private
 
   def use_fallback_pdf_thumbnail

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -25,6 +25,10 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
       @quarantined_file.url
     end
 
+    def asset_manager_path
+      @asset_manager_file.path
+    end
+
     def delete
       @quarantined_file.delete
       @asset_manager_file.delete

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -1,7 +1,9 @@
 class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::Abstract
   def store!(file)
-    Whitehall::AssetManagerStorage.new(uploader).store!(file)
-    Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
+    asset_manager_file = Whitehall::AssetManagerStorage.new(uploader).store!(file)
+    quarantined_file = Whitehall::QuarantinedFileStorage.new(uploader).store!(file)
+
+    File.new(asset_manager_file, quarantined_file)
   end
 
   def retrieve!(identifier)

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -150,6 +150,13 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
     end
   end
 
+  test 'returns Asset Manager version of path' do
+    uploader = AttachmentUploader.new(stub('AR Model', id: 1), 'mounted-as')
+    uploader.store!(fixture_file_upload('simple.pdf'))
+    expected_path = '/government/uploads/system/uploads/mocha/mock/mounted-as/1/simple.pdf'
+    assert_equal expected_path, uploader.file.asset_manager_path
+  end
+
   def required_arcgis_file_list
     %w(london.shp london.shx london.dbf)
   end

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -95,6 +95,12 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
     assert_equal 'quarantined-file-size', @file.size
   end
 
+  test '#asset_manager_path delegates to path on asset manager file' do
+    @asset_manager_file.stubs(:path).returns('asset-manager-file-path')
+
+    assert_equal 'asset-manager-file-path', @file.asset_manager_path
+  end
+
   test '#delete calls delete on both asset manager file and quarantined file' do
     @asset_manager_file.expects(:delete)
     @quarantined_file.expects(:delete)

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -28,10 +28,13 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
   end
 
   test 'returns the value returned from the quarantined file store' do
-    @asset_manager_storage.stubs(:store!)
-    @quarantined_file_storage.stubs(:store!).with(@file).returns('stored-file')
+    @quarantined_file_storage.stubs(:store!).with(@file).returns('stored-quarantined-file')
+    @asset_manager_storage.stubs(:store!).with(@file).returns('stored-asset-manager-file')
 
-    assert_equal 'stored-file', @storage.store!(@file)
+    composite_file = stub(:composite_file)
+    Whitehall::AssetManagerAndQuarantinedFileStorage::File.stubs(:new).with('stored-asset-manager-file', 'stored-quarantined-file').returns(composite_file)
+
+    assert_equal composite_file, @storage.store!(@file)
   end
 
   test 'returns the composite asset manager and quarantined file' do

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -31,7 +31,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     @quarantined_file_storage.stubs(:store!).with(@file).returns('stored-quarantined-file')
     @asset_manager_storage.stubs(:store!).with(@file).returns('stored-asset-manager-file')
 
-    composite_file = stub(:composite_file)
+    composite_file = stub('composite_file')
     Whitehall::AssetManagerAndQuarantinedFileStorage::File.stubs(:new).with('stored-asset-manager-file', 'stored-quarantined-file').returns(composite_file)
 
     assert_equal composite_file, @storage.store!(@file)
@@ -41,7 +41,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorageTest < ActiveSupport::Test
     @quarantined_file_storage.stubs(:retrieve!).with('identifier').returns('retrieved-quarantined-file')
     @asset_manager_storage.stubs(:retrieve!).with('identifier').returns('retrieved-asset-manager-file')
 
-    composite_file = stub(:composite_file)
+    composite_file = stub('composite_file')
     Whitehall::AssetManagerAndQuarantinedFileStorage::File.stubs(:new).with('retrieved-asset-manager-file', 'retrieved-quarantined-file').returns(composite_file)
 
     assert_equal composite_file, @storage.retrieve!('identifier')
@@ -50,8 +50,8 @@ end
 
 class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport::TestCase
   setup do
-    @asset_manager_file = stub(:asset_manager_file)
-    @quarantined_file = stub(:quarantined_file)
+    @asset_manager_file = stub('asset_manager_file')
+    @quarantined_file = stub('quarantined_file')
     @file = Whitehall::AssetManagerAndQuarantinedFileStorage::File.new(@asset_manager_file, @quarantined_file)
   end
 


### PR DESCRIPTION
This PR contains a couple of changes which will make it easier to add functionality to update the draft status of existing attachment assets in Asset Manager:

1. Fix the return value for `AssetManagerAndQuarantinedFileStorage#store!`
  * Previously this was returning an instance of `CarrierWave::SanitizedFile` rather than `Whitehall::AssetManagerAndQuarantinedFileStorage::File`.
  * This was inconsistent and confusing.
  * It also caused problems in some tests I was writing where I wanted access to the relevant `File` instance from the `AttachmentUploader` after `#store!` had been called, but before `#retrieve!` had been called.

2. Make Asset Manager version of path available when using composite storage
  * I want to add some functionality to update the draft status of an attachment asset in Asset Manager.
  * This will need to operate outside the realms of `CarrierWave` and so I need to make this method available.
  * We should be able to remove it again once we switch the `AttachmentUploader` to use the `Whitehall::AssetManagerStorage` class instead of the `Whitehall::AssetManagerAndQuarantinedFileStorage` class.

I've also made some minor improvements to one of the tests.
