### PR TITLE
Fix consultation redirect params

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -1,6 +1,6 @@
 class ConsultationsController < DocumentsController
   def index
     filter_params = params.permit!.except(:controller, :action, :format, :_, :host)
-    redirect_to publications_path(filter_params.merge(publication_filter_option: 'consultations'))
+    redirect_to publications_path(filter_params.merge(publication_filter_option: 'consultations').to_h)
   end
 end

--- a/test/functional/consultations_controller_test.rb
+++ b/test/functional/consultations_controller_test.rb
@@ -6,7 +6,7 @@ class ConsultationsControllerTest < ActionController::TestCase
   test 'index redirects to the publications index filtering consultations, retaining any other filter params' do
     get :index, params: { topics: ["a-topic-slug"], departments: ['an-org-slug'] }
     assert_redirected_to(
-      "http://test.host/government/publications.departments%255B%255D=an-org-slug&publication_filter_option=consultations&topics%255B%255D=a-topic-slug"
+      "http://test.host/government/publications?departments%5B%5D=an-org-slug&publication_filter_option=consultations&topics%5B%5D=a-topic-slug"
     )
   end
 end


### PR DESCRIPTION
This commit fixes the current implementation where the paramenters of the url were being separated by a "." (dot) instead of a "?" (question mark). 

It also replaced the ascii code "%255B" & "%255D" to the appropriate ones which are ""%5B" & "%5D" (both mean "[" & "]") which are used to represent an array of the attribute in cause.

This was brought to our attention in the Zendesk Ticket:
https://govuk.zendesk.com/agent/tickets/2576393