### PR TITLE
Update draft status of attachment assets

### DIFF
--- a/app/controllers/admin/policy_groups_controller.rb
+++ b/app/controllers/admin/policy_groups_controller.rb
@@ -12,6 +12,7 @@ class Admin::PolicyGroupsController < Admin::BaseController
   def create
     @policy_group = PolicyGroup.new(policy_group_params)
     if @policy_group.save
+      Whitehall.policy_group_notifier.publish('create', @policy_group)
       redirect_to admin_policy_groups_path, notice: %{"#{@policy_group.name}" created.}
     else
       render action: "new"
@@ -25,6 +26,7 @@ class Admin::PolicyGroupsController < Admin::BaseController
   def update
     @policy_group = PolicyGroup.friendly.find(params[:id])
     if @policy_group.update_attributes(policy_group_params)
+      Whitehall.policy_group_notifier.publish('update', @policy_group)
       redirect_to admin_policy_groups_path, notice: %{"#{@policy_group.name}" saved.}
     else
       render action: "edit"

--- a/app/controllers/admin/responses_controller.rb
+++ b/app/controllers/admin/responses_controller.rb
@@ -13,6 +13,7 @@ class Admin::ResponsesController < Admin::BaseController
     @response = response_class.new(response_params)
     @response.consultation = @edition
     if @response.save
+      Whitehall.consultation_response_notifier.publish('create', @response)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} saved"
     else
       render :show
@@ -23,6 +24,7 @@ class Admin::ResponsesController < Admin::BaseController
 
   def update
     if @response.update_attributes(response_params)
+      Whitehall.consultation_response_notifier.publish('update', @response)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} updated"
     else
       render :edit

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -12,6 +12,9 @@ module ServiceListeners
         attachment_data = attachment.attachment_data
         draft = !visibility_for(attachment_data).visible?
         enqueue_job(attachment_data.file, draft)
+        attachment_data.file.versions.each_value do |uploader|
+          enqueue_job(uploader, draft) if uploader.present?
+        end
       end
     end
 

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -1,0 +1,29 @@
+module ServiceListeners
+  class AttachmentDraftStatusUpdater
+    attr_reader :attachable
+
+    def initialize(attachable)
+      @attachable = attachable
+    end
+
+    def update!
+      return unless attachable.allows_attachments?
+      attachable.attachments.select(&:file?).each do |attachment|
+        attachment_data = attachment.attachment_data
+        draft = !visibility_for(attachment_data).visible?
+        enqueue_job(attachment_data.file, draft)
+      end
+    end
+
+  private
+
+    def visibility_for(attachment_data)
+      AttachmentVisibility.new(attachment_data, _anonymous_user = nil)
+    end
+
+    def enqueue_job(uploader, draft)
+      legacy_url_path = uploader.asset_manager_path
+      AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft: draft)
+    end
+  end
+end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,8 +1,10 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
   def perform(legacy_url_path, attributes = {})
     gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
-    asset_url = gds_api_response['id']
-    asset_id = asset_url[/\/assets\/(.*)/, 1]
-    Services.asset_manager.update_asset(asset_id, attributes)
+    unless gds_api_response['draft'] == attributes['draft']
+      asset_url = gds_api_response['id']
+      asset_id = asset_url[/\/assets\/(.*)/, 1]
+      Services.asset_manager.update_asset(asset_id, attributes)
+    end
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,0 +1,8 @@
+class AssetManagerUpdateAssetWorker < WorkerBase
+  def perform(legacy_url_path, attributes = {})
+    gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
+    asset_url = gds_api_response['id']
+    asset_id = asset_url[/\/assets\/(.*)/, 1]
+    Services.asset_manager.update_asset(asset_id, attributes)
+  end
+end

--- a/config/initializers/consultation_response_notifier.rb
+++ b/config/initializers/consultation_response_notifier.rb
@@ -1,0 +1,7 @@
+Whitehall.consultation_response_notifier.tap do |notifier|
+  notifier.subscribe do |_event, response|
+    ServiceListeners::AttachmentDraftStatusUpdater
+      .new(response)
+      .update!
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -11,10 +11,17 @@ Whitehall.edition_services.tap do |coordinator|
       .new(edition)
       .update!
 
-    if edition.is_a?(Consultation) && edition.outcome.present?
-      ServiceListeners::AttachmentDraftStatusUpdater
-        .new(edition.outcome)
-        .update!
+    if edition.is_a?(Consultation)
+      if edition.outcome.present?
+        ServiceListeners::AttachmentDraftStatusUpdater
+          .new(edition.outcome)
+          .update!
+      end
+      if edition.public_feedback.present?
+        ServiceListeners::AttachmentDraftStatusUpdater
+          .new(edition.public_feedback)
+          .update!
+      end
     end
   end
 

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -10,6 +10,12 @@ Whitehall.edition_services.tap do |coordinator|
     ServiceListeners::AttachmentDraftStatusUpdater
       .new(edition)
       .update!
+
+    if edition.is_a?(Consultation) && edition.outcome.present?
+      ServiceListeners::AttachmentDraftStatusUpdater
+        .new(edition.outcome)
+        .update!
+    end
   end
 
   coordinator.subscribe('unpublish') do |_event, edition, _options|

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -6,6 +6,12 @@ Whitehall.edition_services.tap do |coordinator|
       .push(event: event, options: options)
   end
 
+  coordinator.subscribe do |_event, edition, _options|
+    ServiceListeners::AttachmentDraftStatusUpdater
+      .new(edition)
+      .update!
+  end
+
   coordinator.subscribe('unpublish') do |_event, edition, _options|
     # handling edition's dependency on other content
     edition.edition_dependencies.destroy_all

--- a/config/initializers/policy_group_notifier.rb
+++ b/config/initializers/policy_group_notifier.rb
@@ -1,0 +1,7 @@
+Whitehall.policy_group_notifier.tap do |notifier|
+  notifier.subscribe do |_event, policy_group|
+    ServiceListeners::AttachmentDraftStatusUpdater
+      .new(policy_group)
+      .update!
+  end
+end

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -36,8 +36,6 @@ When(/^I add a new promotional feature with a single item$/) do
 end
 
 When(/^I delete the promotional feature$/) do
-  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
   visit admin_organisation_path(@executive_office)
   click_link 'Promotional features'
 
@@ -58,8 +56,6 @@ When(/^I edit the promotional item, set the summary to "([^"]*)"$/) do |new_summ
 end
 
 When(/^I delete the promotional item$/) do
-  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
   visit admin_organisation_path(@executive_office)
   click_link 'Promotional features'
   click_link @promotional_feature.title

--- a/features/step_definitions/take_part_pages_steps.rb
+++ b/features/step_definitions/take_part_pages_steps.rb
@@ -44,8 +44,6 @@ Then(/^I see the take part pages in my specified order including the new page on
 end
 
 When(/^I remove one of the take part pages because it's not something we want to promote$/) do
-  Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
   visit admin_get_involved_path
   click_on 'Take part pages'
 

--- a/features/support/asset_manager_helper.rb
+++ b/features/support/asset_manager_helper.rb
@@ -1,3 +1,6 @@
 Before do
-  Services.stubs(:asset_manager).returns(stub_everything('asset-manager'))
+  asset_manager = stub_everything('asset-manager')
+  asset_details = { 'id' => 'http://asset-manager/assets/asset-id' }
+  asset_manager.stubs(:whitehall_asset).returns(asset_details)
+  Services.stubs(:asset_manager).returns(asset_manager)
 end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -153,6 +153,10 @@ module Whitehall
     @edition_actions ||= EditionServiceCoordinator.new
   end
 
+  def self.consultation_response_notifier
+    @consultation_response_notifier ||= ActiveSupport::Notifications::Fanout.new
+  end
+
   def self.organisations_in_tagging_beta
     @taggable_organisations ||=
       YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")["organisations_in_tagging_beta"]

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -157,6 +157,10 @@ module Whitehall
     @consultation_response_notifier ||= ActiveSupport::Notifications::Fanout.new
   end
 
+  def self.policy_group_notifier
+    @policy_group_notifier ||= ActiveSupport::Notifications::Fanout.new
+  end
+
   def self.organisations_in_tagging_beta
     @taggable_organisations ||=
       YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")["organisations_in_tagging_beta"]

--- a/test/functional/admin/policy_groups_controller_test.rb
+++ b/test/functional/admin/policy_groups_controller_test.rb
@@ -30,6 +30,18 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
     assert_equal 'Policy Forum', PolicyGroup.last.name
   end
 
+  test "POST :create with valid params publishes event to policy_group_notifier" do
+    Whitehall.policy_group_notifier.expects(:publish).with('create', is_a(PolicyGroup))
+
+    post :create, params: { policy_group: { name: 'Policy Forum' } }
+  end
+
+  test "POST :create with invalid params does not publish event to policy_group_notifier" do
+    Whitehall.policy_group_notifier.expects(:publish).never
+
+    post :create, params: { policy_group: { name: '' } }
+  end
+
   view_test "GET :edit" do
     group = create(:policy_group)
 
@@ -47,6 +59,20 @@ class Admin::PolicyGroupsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_redirected_to admin_policy_groups_path
     assert_equal 'Policy Board', group.reload.name
+  end
+
+  test "PUT :update with valid params publishes event to policy_group_notifier" do
+    group = create(:policy_group, name: 'Policy Forum')
+    Whitehall.policy_group_notifier.expects(:publish).with('update', group)
+
+    put :update, params: { id: group, policy_group: { name: 'Policy Board' } }
+  end
+
+  test "PUT :update with invalid params does not publish event to policy_group_notifier" do
+    group = create(:policy_group, name: 'Policy Forum')
+    Whitehall.policy_group_notifier.expects(:publish).never
+
+    put :update, params: { id: group, policy_group: { name: '' } }
   end
 
   test "DELETE :destroy is forbidden for writers" do

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -110,4 +110,30 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
+
+  context 'when file attachment is added to outcome belonging to published consultation' do
+    before do
+      edition = create(:published_consultation)
+      @outcome = edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+    end
+
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
+
+      @outcome.attachments << FactoryBot.build(
+        :file_attachment,
+        attachable: @outcome,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+      Whitehall.consultation_response_notifier.publish('update', @outcome)
+    end
+  end
 end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -15,10 +15,14 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{whitepaper\.pdf$}))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
-    test 'attachment is marked as published in Asset Manager' do
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
       force_publisher = Whitehall.edition_services.force_publisher(@edition)
       assert force_publisher.perform!, force_publisher.failure_reason
@@ -37,10 +41,14 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.stubs(:whitehall_asset)
         .with(regexp_matches(%r{whitepaper\.pdf$}))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => false)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => false)
     end
 
-    test 'attachment is marked as draft in Asset Manager' do
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' =>true)
+    test 'attachment & its thumbnail are marked as draft in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true)
+      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => true)
 
       unpublisher = Whitehall.edition_services.unpublisher(@edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::PublishedInError

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -4,11 +4,12 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   context 'when draft document with file attachment is published' do
+    let(:edition) { create(:news_article) }
+
     before do
-      @edition = create(:news_article)
-      @edition.attachments << FactoryBot.build(
+      edition.attachments << FactoryBot.build(
         :file_attachment,
-        attachable: @edition,
+        attachable: edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
@@ -20,17 +21,18 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      force_publisher = Whitehall.edition_services.force_publisher(edition)
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
   context 'when published document with file attachment is unpublished' do
+    let(:edition) { create(:published_news_article) }
+
     before do
-      @edition = create(:published_news_article)
-      @edition.attachments << FactoryBot.build(
+      edition.attachments << FactoryBot.build(
         :file_attachment,
-        attachable: @edition,
+        attachable: edition,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
@@ -42,7 +44,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => true)
 
-      unpublisher = Whitehall.edition_services.unpublisher(@edition, unpublishing: {
+      unpublisher = Whitehall.edition_services.unpublisher(edition, unpublishing: {
         unpublishing_reason: UnpublishingReason::PublishedInError
       })
       assert unpublisher.perform!, unpublisher.failure_reason
@@ -50,9 +52,11 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
   end
 
   context 'when draft consultation with outcome with file attachment is published' do
+    let(:edition) { create(:draft_consultation) }
+    let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+    let(:outcome) { edition.create_outcome!(outcome_attributes) }
+
     before do
-      @edition = create(:draft_consultation)
-      outcome = @edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
       outcome.attachments << FactoryBot.build(
         :file_attachment,
         attachable: outcome,
@@ -67,15 +71,17 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      force_publisher = Whitehall.edition_services.force_publisher(edition)
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
   context 'when draft consultation with feedback with file attachment is published' do
+    let(:edition) { create(:draft_consultation) }
+    let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
+    let(:feedback) { edition.create_public_feedback!(feedback_attributes) }
+
     before do
-      @edition = create(:draft_consultation)
-      feedback = @edition.create_public_feedback!(FactoryBot.attributes_for(:consultation_public_feedback))
       feedback.attachments << FactoryBot.build(
         :file_attachment,
         attachable: feedback,
@@ -90,16 +96,17 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      force_publisher = Whitehall.edition_services.force_publisher(edition)
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
 
   context 'when file attachment is added to outcome belonging to published consultation' do
-    before do
-      edition = create(:published_consultation)
-      @outcome = edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
+    let(:edition) { create(:published_consultation) }
+    let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+    let(:outcome) { edition.create_outcome!(outcome_attributes) }
 
+    before do
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
@@ -108,19 +115,19 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      @outcome.attachments << FactoryBot.build(
+      outcome.attachments << FactoryBot.build(
         :file_attachment,
-        attachable: @outcome,
+        attachable: outcome,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      Whitehall.consultation_response_notifier.publish('update', @outcome)
+      Whitehall.consultation_response_notifier.publish('update', outcome)
     end
   end
 
   context 'when file attachment is added to policy group' do
-    before do
-      @policy_group = create(:policy_group)
+    let(:policy_group) { create(:policy_group) }
 
+    before do
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
@@ -129,12 +136,12 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      @policy_group.attachments << FactoryBot.build(
+      policy_group.attachments << FactoryBot.build(
         :file_attachment,
-        attachable: @policy_group,
+        attachable: policy_group,
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
-      Whitehall.policy_group_notifier.publish('update', @policy_group)
+      Whitehall.policy_group_notifier.publish('update', policy_group)
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -56,4 +56,31 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       assert unpublisher.perform!, unpublisher.failure_reason
     end
   end
+
+  context 'when draft consultation with outcome with file attachment is published' do
+    before do
+      @edition = create(:draft_consultation)
+      outcome = @edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
+      outcome.attachments << FactoryBot.build(
+        :file_attachment,
+        attachable: outcome,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+    end
+
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
+
+      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      assert force_publisher.perform!, force_publisher.failure_reason
+    end
+  end
 end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -12,12 +12,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
 
     test 'attachment & its thumbnail are marked as published in Asset Manager' do
@@ -38,12 +34,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => false)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => false)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: false)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: false)
     end
 
     test 'attachment & its thumbnail are marked as draft in Asset Manager' do
@@ -67,12 +59,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
 
     test 'attachment & its thumbnail are marked as published in Asset Manager' do
@@ -94,12 +82,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
         file: File.open(fixture_path.join('whitepaper.pdf'))
       )
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
 
     test 'attachment & its thumbnail are marked as published in Asset Manager' do
@@ -116,12 +100,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       edition = create(:published_consultation)
       @outcome = edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
 
     test 'attachment & its thumbnail are marked as published in Asset Manager' do
@@ -141,12 +121,8 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
     before do
       @policy_group = create(:policy_group)
 
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('whitepaper.pdf'))
-        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
-      Services.asset_manager.stubs(:whitehall_asset)
-        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
-        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
+      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
     end
 
     test 'attachment & its thumbnail are marked as published in Asset Manager' do
@@ -166,5 +142,11 @@ private
 
   def ends_with(expected)
     ->(actual) { actual.end_with?(expected) }
+  end
+
+  def stub_whitehall_asset(filename, id:, draft:)
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns('id' => "http://asset-manager/assets/#{id}", 'draft' => draft)
   end
 end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -13,10 +13,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       )
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
@@ -39,10 +39,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       )
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => false)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => false)
     end
 
@@ -68,10 +68,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       )
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
@@ -95,10 +95,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       )
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
@@ -117,10 +117,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       @outcome = edition.create_outcome!(FactoryBot.attributes_for(:consultation_outcome))
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
@@ -142,10 +142,10 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       @policy_group = create(:policy_group)
 
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .with(&ends_with('whitepaper.pdf'))
         .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
       Services.asset_manager.stubs(:whitehall_asset)
-        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .with(&ends_with('thumbnail_whitepaper.pdf.png'))
         .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
     end
 
@@ -160,5 +160,11 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       )
       Whitehall.policy_group_notifier.publish('update', @policy_group)
     end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
   end
 end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  context 'when draft document with file attachment is published' do
+    before do
+      @edition = create(:news_article)
+      @edition.attachments << FactoryBot.build(
+        :file_attachment,
+        attachable: @edition,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
+    end
+
+    test 'attachment is marked as published in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+
+      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      assert force_publisher.perform!, force_publisher.failure_reason
+    end
+  end
+
+  context 'when published document with file attachment is unpublished' do
+    before do
+      @edition = create(:published_news_article)
+      @edition.attachments << FactoryBot.build(
+        :file_attachment,
+        attachable: @edition,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => false)
+    end
+
+    test 'attachment is marked as draft in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' =>true)
+
+      unpublisher = Whitehall.edition_services.unpublisher(@edition, unpublishing: {
+        unpublishing_reason: UnpublishingReason::PublishedInError
+      })
+      assert unpublisher.perform!, unpublisher.failure_reason
+    end
+  end
+end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -7,11 +7,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
     let(:edition) { create(:news_article) }
 
     before do
-      edition.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: edition,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: edition)
 
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
@@ -30,11 +26,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
     let(:edition) { create(:published_news_article) }
 
     before do
-      edition.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: edition,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: edition)
 
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: false)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: false)
@@ -57,11 +49,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
     let(:outcome) { edition.create_outcome!(outcome_attributes) }
 
     before do
-      outcome.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: outcome,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: outcome)
 
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
@@ -82,11 +70,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
     let(:feedback) { edition.create_public_feedback!(feedback_attributes) }
 
     before do
-      feedback.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: feedback,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: feedback)
 
       stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
       stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
@@ -115,11 +99,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      outcome.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: outcome,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: outcome)
       Whitehall.consultation_response_notifier.publish('update', outcome)
     end
   end
@@ -136,11 +116,7 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
       Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
-      policy_group.attachments << FactoryBot.build(
-        :file_attachment,
-        attachable: policy_group,
-        file: File.open(fixture_path.join('whitepaper.pdf'))
-      )
+      add_file_attachment('whitepaper.pdf', to: policy_group)
       Whitehall.policy_group_notifier.publish('update', policy_group)
     end
   end
@@ -149,6 +125,14 @@ private
 
   def ends_with(expected)
     ->(actual) { actual.end_with?(expected) }
+  end
+
+  def add_file_attachment(filename, to:)
+    to.attachments << FactoryBot.build(
+      :file_attachment,
+      attachable: to,
+      file: File.open(fixture_path.join(filename))
+    )
   end
 
   def stub_whitehall_asset(filename, id:, draft:)

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -83,4 +83,31 @@ class AttachmentDraftStatusIntegrationTest < ActiveSupport::TestCase
       assert force_publisher.perform!, force_publisher.failure_reason
     end
   end
+
+  context 'when draft consultation with feedback with file attachment is published' do
+    before do
+      @edition = create(:draft_consultation)
+      feedback = @edition.create_public_feedback!(FactoryBot.attributes_for(:consultation_public_feedback))
+      feedback.attachments << FactoryBot.build(
+        :file_attachment,
+        attachable: feedback,
+        file: File.open(fixture_path.join('whitepaper.pdf'))
+      )
+
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{whitepaper\.pdf$}))
+        .returns('id' => 'http://asset-manager/assets/asset-id', 'draft' => true)
+      Services.asset_manager.stubs(:whitehall_asset)
+        .with(regexp_matches(%r{thumbnail_whitepaper\.pdf\.png$}))
+        .returns('id' => 'http://asset-manager/assets/thumbnail-asset-id', 'draft' => true)
+    end
+
+    test 'attachment & its thumbnail are marked as published in Asset Manager' do
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
+
+      force_publisher = Whitehall.edition_services.force_publisher(@edition)
+      assert force_publisher.perform!, force_publisher.failure_reason
+    end
+  end
 end

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+
+    let(:edition) { create(:news_article) }
+    let(:updater) { AttachmentDraftStatusUpdater.new(edition) }
+    let(:visibility) { stub('visibility', visible?: visible) }
+    let(:visible) { false }
+
+    before do
+      AttachmentVisibility.stubs(:new).returns(visibility)
+    end
+
+    context 'when edition does not allow attachments' do
+      let(:edition) { create(:speech) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when edition has only non-file attachments' do
+      before do
+        edition.attachments << FactoryBot.build(:html_attachment)
+        edition.attachments << FactoryBot.build(:external_attachment)
+      end
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when edition has non-pdf attachments' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:sample_docx) { File.open(fixture_path.join('sample.docx')) }
+      let(:rtf_attachment) { FactoryBot.build(:file_attachment, file: sample_rtf) }
+      let(:docx_attachment) { FactoryBot.build(:file_attachment, file: sample_docx) }
+
+      before do
+        edition.attachments << rtf_attachment
+        edition.attachments << docx_attachment
+      end
+
+      it 'updates draft status of asset for each attachment' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(rtf_attachment.file.asset_manager_path, draft: true)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(docx_attachment.file.asset_manager_path, draft: true)
+
+        updater.update!
+      end
+    end
+
+    context 'when edition has pdf attachment' do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:pdf_attachment) { FactoryBot.build(:file_attachment, file: simple_pdf) }
+
+      before do
+        edition.attachments << pdf_attachment
+      end
+
+      it 'updates draft status of asset for attachment' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(pdf_attachment.file.asset_manager_path, draft: true)
+
+        updater.update!
+      end
+
+      context 'and attachment should be visible, i.e. not draft' do
+        let(:visible) { true }
+
+        it 'updates draft status of asset for attachment' do
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(pdf_attachment.file.asset_manager_path, draft: false)
+
+          updater.update!
+        end
+      end
+    end
+  end
+end

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -65,9 +65,11 @@ module ServiceListeners
         edition.attachments << pdf_attachment
       end
 
-      it 'updates draft status of asset for attachment' do
+      it 'updates draft status of asset for attachment & its thumbnail' do
         AssetManagerUpdateAssetWorker.expects(:perform_async)
           .with(pdf_attachment.file.asset_manager_path, draft: true)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(pdf_attachment.file.thumbnail.asset_manager_path, draft: true)
 
         updater.update!
       end
@@ -75,9 +77,11 @@ module ServiceListeners
       context 'and attachment should be visible, i.e. not draft' do
         let(:visible) { true }
 
-        it 'updates draft status of asset for attachment' do
+        it 'updates draft status of asset for attachment & its thumbnail' do
           AssetManagerUpdateAssetWorker.expects(:perform_async)
             .with(pdf_attachment.file.asset_manager_path, draft: false)
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(pdf_attachment.file.thumbnail.asset_manager_path, draft: false)
 
           updater.update!
         end

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
+  setup do
+    @asset_id = 'asset-id'
+    @asset_url = "http://asset-manager/assets/#{@asset_id}"
+    @legacy_url_path = 'legacy-url-path'
+    @worker = AssetManagerUpdateAssetWorker.new
+  end
+
+  test 'marks draft asset as published' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns('id' => @asset_url)
+    Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => false)
+
+    @worker.perform(@legacy_url_path, 'draft' => false)
+  end
+
+  test 'mark published asset as draft' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns('id' => @asset_url)
+    Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => true)
+
+    @worker.perform(@legacy_url_path, 'draft' => true)
+  end
+end

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -10,16 +10,32 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
 
   test 'marks draft asset as published' do
     Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns('id' => @asset_url)
+      .returns('id' => @asset_url, 'draft' => true)
     Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => false)
+
+    @worker.perform(@legacy_url_path, 'draft' => false)
+  end
+
+  test 'does not mark asset as published if already published' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns('id' => @asset_url, 'draft' => false)
+    Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'draft' => false)
   end
 
   test 'mark published asset as draft' do
     Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns('id' => @asset_url)
+      .returns('id' => @asset_url, 'draft' => false)
     Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => true)
+
+    @worker.perform(@legacy_url_path, 'draft' => true)
+  end
+
+  test 'does not mark asset as draft if already draft' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns('id' => @asset_url, 'draft' => true)
+    Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'draft' => true)
   end


### PR DESCRIPTION
The Asset Manager assets for attachments are currently being created in the draft state by default. The changes in this pull request aim to update the draft status of attachment assets as their parent models change state. Hopefully the following gives a decent overview of the changes, but please see the individual commit notes for more detailed info.

There are three subclasses of the `Attachment` class, `FileAttachment`, `HtmlAttachment` & `ExternalAttachment`, but we are only concerned with `FileAttachment`, because they are the only ones stored in the Asset Manager.

I've used the existing `AttachmentVisibilty` class and its `#visible?` method to determine whether the public is allowed access to an attachment.

### Model Types

#### Editions

Models inheriting directly or indirectly from the `Edition` class may support attachments depending on whether they include the `Attachable` module. Whether or not a model supports attachments can be determined by calling the `#allows_attachments?` method.

I've used the existing `EditionServiceCoordinator` mechanism to hook a new service listener into `Edition` lifecycle events in `config/initializers/edition_services.rb`. `Admin::EditionWorkflowController` actions seem to use instances of `EditionService` to make all significant changes in `Edition` state and thus the new `ServiceListeners::AttachmentDraftStatusUpdater` should receive events for all these changes.

#### (Consultation) Responses

The terminology around these models is quite confusing. There is a base class, `Response`, with two subclasses, `ConsultationOutcome` & `ConsultationPublicFeedback` and these can both be (independently) associated with a `Consultation` via the `outcome` & `public_feedback` associations respectively. Anyway, the important thing for this pull request is that both subclasses of `Response` support attachments despite the fact they do not inherit from `Edition`.

The visibility of attachments on a `Response` is determined by the state of its `Consultation`. In order to keep the draft status of the corresponding assets up-to-date I've made the following changes:

1. Extended the logic in `config/initializers/edition_services.rb` to detect changes in the state of a `Consultation` and update the draft status of attachments on any associated `Response`.

2. Introduced a new `Whitehall.consultation_response_notifier` in order to detect the creation or updating of a `Response`. An instance of `ServiceListeners::AttachmentDraftStatusUpdater` is again used to handle events for this notifier and update the draft status of assets accordingly. This is needed, because e.g. an attachment can be added to a `Response` which is already associated with a published `Consultation`.

#### PolicyGroup

This model class also supports attachments despite the fact that it doesn't inherit from `Edition` either.

The visibility of attachments on a `PolicyGroup` is solely determined by their existence, i.e. a `PolicyGroup` is always public and so any attachments on it are also immediately public.

In order to keep the draft status of the associated assets up-to-date, I've introduced a new `Whitehall.policy_group_notifier` to detect the creation or updating of a `PolicyGroup`. An instance of  `ServiceListeners::AttachmentDraftStatusUpdater` is again used to handle events from this notifier and update the draft status of assets accordingly.

### Testing

I've added unit tests and an integration test, `AttachmentDraftStatusIntegrationTest`, but I decided not to add any Cucumber features, because the change in behaviour is not visible via the user interface. Also the integration test only covers a subset of the possible scenarios in order to avoid a combinatorial explosion - it's intended mainly to check that everything is wired up correctly.

### Risks

* It's possible that some important changes in `Edition` state happen without generating events from the `EditionServiceCoordinator` notifier. However, I'm pretty confident that they don't.
* Similarly it's possible that a new `Edition` state change might be added without making use of the `EditionServiceCoordinator` services.
* It's also possible that a new non-`Edition` model might be added with support for attachments.

However, in all these cases the consequence would be that the relevant attachments would always be in the draft state, i.e. their draft status would never be updated. Although this wouldn't be ideal, it would be considerably better than if attachments were inadvertently made public when they shouldn't be.


