### PR TITLE
Allow exclusion of england

### DIFF
--- a/app/models/edition/national_applicability.rb
+++ b/app/models/edition/national_applicability.rb
@@ -12,6 +12,7 @@ module Edition::NationalApplicability
   included do
     has_many :nation_inapplicabilities, foreign_key: :edition_id, dependent: :destroy, autosave: true
     validates_associated :nation_inapplicabilities
+    validates :nation_inapplicabilities, length: { maximum: Nation.all.count - 1, message: 'can not exclude all nations' }
 
     add_trait Trait
   end

--- a/app/models/nation.rb
+++ b/app/models/nation.rb
@@ -25,7 +25,7 @@ class Nation
   end
 
   def self.potentially_inapplicable
-    [Scotland, Wales, NorthernIreland]
+    [England, Scotland, Wales, NorthernIreland]
   end
 
   def self.find_by_name!(name)

--- a/app/views/admin/editions/_nation_fields.html.erb
+++ b/app/views/admin/editions/_nation_fields.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="excluded_nations">
+<fieldset class="excluded_nations <% if edition.errors[:nation_inapplicabilities].any? %>alert-danger form-errors field_with_errors<% end %>" >
   <legend>Excluded nations</legend>
 
   <% Nation.potentially_inapplicable.each do |nation| %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -427,6 +427,8 @@ ar:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -18,6 +18,8 @@ az:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -325,6 +325,8 @@ be:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -225,6 +225,8 @@ bg:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -223,6 +223,8 @@ bn:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -274,6 +274,8 @@ cs:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -427,6 +427,8 @@ cy:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -223,6 +223,8 @@ de:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -223,6 +223,8 @@ dr:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -223,6 +223,8 @@ el:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,8 @@ en:
         <<: *nested_attachment_field_names
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         <<: *nested_attachment_data_field_names
+      edition:
+        nation_inapplicabilities: 'Excluded nations'
       policy_group/policy_group_attachments/attachment/attachment_data:
         <<: *nested_attachment_data_field_names
       response/consultation_response_attachments/attachment:
@@ -489,7 +491,7 @@ en:
     authored_article: See all our authored articles
   broken_links:
     title: Broken links
-    broken: 
+    broken:
       subheading: We’ve found links in this document that may be broken
     caution:
       subheading: We’ve found some issues with links that may indicate problems, you should apply caution in linking to them

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -223,6 +223,8 @@ es-419:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -223,6 +223,8 @@ es:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -223,6 +223,8 @@ et:
         unnumbered_hoc_paper: Nummerdamata Parlamendi alamkoja dokument
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file: Manus
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: Manus
       response/consultation_response_attachments/attachment:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -18,6 +18,8 @@ fa:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -223,6 +223,8 @@ fr:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -223,6 +223,8 @@ he:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -223,6 +223,8 @@ hi:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -18,6 +18,8 @@ hu:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -223,6 +223,8 @@ hy:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -18,6 +18,8 @@ id:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -223,6 +223,8 @@ it:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,8 @@ ja:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -18,6 +18,8 @@ ka:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -18,6 +18,8 @@ ko:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -274,6 +274,8 @@ lt:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -223,6 +223,8 @@ lv:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -18,6 +18,8 @@ ms:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -325,6 +325,8 @@ pl:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -223,6 +223,8 @@ ps:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -223,6 +223,8 @@ pt:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -274,6 +274,8 @@ ro:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -325,6 +325,8 @@ ru:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -223,6 +223,8 @@ si:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -274,6 +274,8 @@ sk:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -223,6 +223,8 @@ so:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -223,6 +223,8 @@ sq:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -325,6 +325,8 @@ sr:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -223,6 +223,8 @@ sw:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -223,6 +223,8 @@ ta:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -18,6 +18,8 @@ th:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -223,6 +223,8 @@ tk:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -18,6 +18,8 @@ tr:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -325,6 +325,8 @@ uk:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -223,6 +223,8 @@ ur:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -223,6 +223,8 @@ uz:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -18,6 +18,8 @@ vi:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -18,6 +18,8 @@ zh-hk:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -18,6 +18,8 @@ zh-tw:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -18,6 +18,8 @@ zh:
         unnumbered_hoc_paper:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file:
+      edition:
+        nation_inapplicabilities:
       policy_group/policy_group_attachments/attachment/attachment_data:
         file:
       response/consultation_response_attachments/attachment:

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -66,9 +66,10 @@ module TestsForNationalApplicability
       }
 
       assert_nation_inapplicability_fields_exist
-      assert_nation_inapplicability_fields_set_as(index: 0, checked: true, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: true, alternative_url: "http://www.scotland.com/")
       assert_nation_inapplicability_fields_set_as(index: 2, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: false)
     end
 
     view_test 'creating with invalid nation inapplicability data should not lose the nation inapplicability fields or values' do
@@ -80,9 +81,10 @@ module TestsForNationalApplicability
       }
 
       assert_nation_inapplicability_fields_exist
-      assert_nation_inapplicability_fields_set_as(index: 0, checked: true, alternative_url: "invalid-url")
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: true, alternative_url: "invalid-url")
       assert_nation_inapplicability_fields_set_as(index: 2, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: false)
     end
 
     view_test 'edit displays edition form with nation inapplicability fields and values' do
@@ -95,7 +97,8 @@ module TestsForNationalApplicability
         assert_nation_inapplicability_fields_exist
         assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
         assert_nation_inapplicability_fields_set_as(index: 1, checked: false)
-        assert_nation_inapplicability_fields_set_as(index: 2, checked: true, alternative_url: "http://www.discovernorthernireland.com/")
+        assert_nation_inapplicability_fields_set_as(index: 2, checked: false)
+        assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.discovernorthernireland.com/")
       end
     end
 
@@ -123,9 +126,10 @@ module TestsForNationalApplicability
       put :update, params: { id: edition, edition: attributes }
 
       assert_nation_inapplicability_fields_exist
-      assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.wales.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: true, alternative_url: "http://www.northernireland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.northernireland.com/")
     end
 
     view_test 'updating with invalid nation inapplicability data should not lose the nation inapplicability fields or values' do
@@ -141,9 +145,10 @@ module TestsForNationalApplicability
       ) }
 
       assert_nation_inapplicability_fields_exist
-      assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.wales.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: true, alternative_url: "invalid-url")
+      assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "invalid-url")
     end
 
     view_test 'updating a stale edition should not lose the nation inapplicability fields or values' do
@@ -158,9 +163,10 @@ module TestsForNationalApplicability
       put :update, params: { id: edition, edition: attributes }
 
       assert_nation_inapplicability_fields_exist
-      assert_nation_inapplicability_fields_set_as(index: 0, checked: false, alternative_url: "http://www.scotland.com/")
-      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.wales.com/")
-      assert_nation_inapplicability_fields_set_as(index: 2, checked: true, alternative_url: "http://www.northernireland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 0, checked: false)
+      assert_nation_inapplicability_fields_set_as(index: 1, checked: false, alternative_url: "http://www.scotland.com/")
+      assert_nation_inapplicability_fields_set_as(index: 2, checked: false, alternative_url: "http://www.wales.com/")
+      assert_nation_inapplicability_fields_set_as(index: 3, checked: true, alternative_url: "http://www.northernireland.com/")
     end
   end
 

--- a/test/unit/edition/nation_inapplicability_test.rb
+++ b/test/unit/edition/nation_inapplicability_test.rb
@@ -50,6 +50,22 @@ class Edition::NationInapplicabilityTest < ActiveSupport::TestCase
     refute @edition.nation_inapplicabilities[0].excluded?
   end
 
+  test "mass-assignment making all nations inapplicable is invalid" do
+    assert @edition.nation_inapplicabilities.first.excluded?
+
+    nation_inapplicabilities_attributes = nation_inapplicability_attributes_for(
+      { nation_id: '1', alternative_url: 'http://england.org' },
+      { nation_id: '2', id: @nation_inapplicability.to_param, alternative_url: 'http://scotland.org' },
+      { nation_id: '3', alternative_url: 'http://wales.org' },
+      nation_id: '4', alternative_url: 'http://northern-ireland.org'
+    )
+
+    @edition.nation_inapplicabilities_attributes = nation_inapplicabilities_attributes
+
+    refute @edition.valid?
+    assert_includes @edition.errors.full_messages, "Excluded nations can not exclude all nations"
+  end
+
   def nation_inapplicability_attributes_for(*attributes)
     # Turns a hash of attributes (or an array of hashes of attributes) into a hash that resembles the equivelant
     # form field params, e.g. { '0' => { param1: 'val', param2: 'val2'}, '1' => { param3: 'val'} }

--- a/test/unit/nation_test.rb
+++ b/test/unit/nation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NationTest < ActiveSupport::TestCase
-  test "England is never inapplicable" do
-    refute Nation.potentially_inapplicable.include?(Nation.england)
-  end
-end


### PR DESCRIPTION
Currently, when adding a publication you can indicate it to not be relevant to Scotland, NI or Wales, it is always however relevant to England. For some Stats publications, the document is actually only relevant to Scotland, This PR makes it possible to make a document not relevant to England.

Add error validation to ensure at least one nation is applicable:

<img width="782" alt="screenshot 2018-02-15 12 41 20" src="https://user-images.githubusercontent.com/63736/36257325-4d6527e0-124e-11e8-82c2-f5fe73acf883.png">

And highlight in the form:

<img width="786" alt="screenshot 2018-02-15 12 41 30" src="https://user-images.githubusercontent.com/63736/36257332-5484e95c-124e-11e8-8bec-0fd06827785a.png">

This change allows documents to not be application to England.

Before:

<img width="635" alt="screenshot 2018-02-15 11 14 13" src="https://user-images.githubusercontent.com/63736/36257363-6e1c0cba-124e-11e8-8079-94c438326aff.png">

After:

<img width="628" alt="screenshot 2018-02-15 11 15 10" src="https://user-images.githubusercontent.com/63736/36257365-71fd48d0-124e-11e8-8240-507f9e909bf3.png">

https://trello.com/c/ukIxMUVM/66-scotland-report-shows-this-applies-to-england-and-wales