### PR TITLE
Send access_limited data to Asset Manager

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -26,6 +26,9 @@ class Admin::AttachmentsController < Admin::BaseController
 
   def update
     attachment.attributes = attachment_params
+    if attachment.is_a?(FileAttachment)
+      attachment.attachment_data.attachable = attachable
+    end
     if save_attachment
       message = "Attachment '#{attachment.title}' updated"
       redirect_to attachable_attachments_path(attachable), notice: message
@@ -100,6 +103,7 @@ private
   def build_file_attachment
     FileAttachment.new(attachment_params).tap do |file_attachment|
       file_attachment.build_attachment_data unless file_attachment.attachment_data
+      file_attachment.attachment_data.attachable = attachable
     end
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -48,6 +48,14 @@ class Attachment < ApplicationRecord
     end
   end
 
+  def attachable_is_access_limited?
+    attachable && attachable.access_limited?
+  end
+
+  def access_limited_object
+    attachable && attachable.access_limited_object
+  end
+
   def price
     if @price
       @price

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -19,18 +19,7 @@ class AttachmentData < ApplicationRecord
 
   OPENDOCUMENT_EXTENSIONS = %w(ODT ODP ODS).freeze
 
-  def attachable
-    return unless attachments.any?
-    attachments.order(:created_at).last.attachable
-  end
-
-  def attachable_is_access_limited?
-    attachable && attachable.access_limited?
-  end
-
-  def access_limited_object
-    attachable.access_limited_object
-  end
+  attr_accessor :attachable
 
   def filename
     url && File.basename(url)

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -19,6 +19,19 @@ class AttachmentData < ApplicationRecord
 
   OPENDOCUMENT_EXTENSIONS = %w(ODT ODP ODS).freeze
 
+  def attachable
+    return unless attachments.any?
+    attachments.order(:created_at).last.attachable
+  end
+
+  def attachable_is_access_limited?
+    attachable && attachable.access_limited?
+  end
+
+  def access_limited_object
+    attachable.access_limited_object
+  end
+
   def filename
     url && File.basename(url)
   end

--- a/app/models/edition/limited_access.rb
+++ b/app/models/edition/limited_access.rb
@@ -49,6 +49,10 @@ module Edition::LimitedAccess
     end
   end
 
+  def access_limited_object
+    self
+  end
+
   def access_limited?
     read_attribute(:access_limited)
   end

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -9,6 +9,14 @@ class PolicyGroup < ApplicationRecord
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :description
 
+  def access_limited_object
+    nil
+  end
+
+  def access_limited?
+    false
+  end
+
   def published_policies
     Whitehall.search_client.search(
       filter_policy_groups: [slug],

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -8,6 +8,14 @@ class Response < ApplicationRecord
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :summary
 
+  def access_limited_object
+    consultation
+  end
+
+  def access_limited?
+    consultation.access_limited?
+  end
+
   def alternative_format_contact_email
     consultation.alternative_format_contact_email
   end

--- a/app/services/service_listeners/attachment_access_limited_updater.rb
+++ b/app/services/service_listeners/attachment_access_limited_updater.rb
@@ -1,0 +1,38 @@
+module ServiceListeners
+  class AttachmentAccessLimitedUpdater
+    attr_reader :attachment, :queue
+
+    def initialize(attachment, queue: nil)
+      @attachment = attachment
+      @queue = queue
+    end
+
+    def update!
+      return unless attachment.file?
+      attachment_data = attachment.attachment_data
+      return unless attachment_data.present?
+
+      access_limited = []
+      if attachment.attachable_is_access_limited?
+        access_limited = AssetManagerAccessLimitation.for(attachment.access_limited_object)
+      end
+
+      enqueue_job(attachment_data.file, access_limited)
+      if attachment_data.pdf?
+        enqueue_job(attachment_data.file.thumbnail, access_limited)
+      end
+    end
+
+  private
+
+    def enqueue_job(uploader, access_limited)
+      legacy_url_path = uploader.asset_manager_path
+      worker.perform_async(legacy_url_path, access_limited: access_limited)
+    end
+
+    def worker
+      worker = AssetManagerUpdateAssetWorker
+      queue.present? ? worker.set(queue: queue) : worker
+    end
+  end
+end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -6,9 +6,9 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
 
     if model_class && model_id
       model = model_class.constantize.find(model_id)
-      if model.respond_to?(:attachable_is_access_limited?)
-        if model.attachable_is_access_limited?
-          authorised_user_uids = AssetManagerAccessLimitation.for(model.access_limited_object)
+      if model.respond_to?(:access_limited?)
+        if model.access_limited?
+          authorised_user_uids = AssetManagerAccessLimitation.for(model)
           asset_options[:access_limited] = authorised_user_uids
         end
       end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,8 +1,21 @@
 class AssetManagerCreateWhitehallAssetWorker < WorkerBase
-  def perform(file_path, legacy_url_path, draft = false)
+  def perform(file_path, legacy_url_path, draft = false, model_class = nil, model_id = nil)
     file = File.open(file_path)
     asset_options = { file: file, legacy_url_path: legacy_url_path }
     asset_options[:draft] = true if draft
+
+    if model_class && model_id
+      model = model_class.constantize.find(model_id)
+      if model.respond_to?(:attachable_is_access_limited?)
+        if model.attachable_is_access_limited?
+          object = model.access_limited_object
+          access_limited_hash = PublishingApi::PayloadBuilder::AccessLimitation.for(object)
+          authorised_user_uids = access_limited_hash[:access_limited][:users]
+          asset_options[:access_limited] = authorised_user_uids
+        end
+      end
+    end
+
     Services.asset_manager.create_whitehall_asset(asset_options)
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -8,9 +8,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
       model = model_class.constantize.find(model_id)
       if model.respond_to?(:attachable_is_access_limited?)
         if model.attachable_is_access_limited?
-          object = model.access_limited_object
-          access_limited_hash = PublishingApi::PayloadBuilder::AccessLimitation.for(object)
-          authorised_user_uids = access_limited_hash[:access_limited][:users]
+          authorised_user_uids = AssetManagerAccessLimitation.for(model.access_limited_object)
           asset_options[:access_limited] = authorised_user_uids
         end
       end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -17,6 +17,14 @@ Whitehall.edition_services.tap do |coordinator|
     end
   end
 
+  coordinator.subscribe('update_draft') do |_event, edition, _options|
+    edition.attachables.flat_map(&:attachments).each do |attachment|
+      ServiceListeners::AttachmentAccessLimitedUpdater
+        .new(attachment)
+        .update!
+    end
+  end
+
   coordinator.subscribe('unpublish') do |_event, edition, _options|
     # handling edition's dependency on other content
     edition.edition_dependencies.destroy_all

--- a/lib/asset_manager_access_limitation.rb
+++ b/lib/asset_manager_access_limitation.rb
@@ -1,0 +1,6 @@
+class AssetManagerAccessLimitation
+  def self.for(item)
+    access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
+    access_limitation[:access_limited][:users]
+  end
+end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -11,8 +11,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = ::File.join('/government/uploads', uploader.store_path)
     draft = uploader.assets_protected?
-    model_class = uploader.model && uploader.model.class.to_s
-    model_id = uploader.model && uploader.model.id
+    if uploader.model.respond_to?(:attachable)
+      model_class = uploader.model.attachable && uploader.model.attachable.class.to_s
+      model_id = uploader.model.attachable && uploader.model.attachable.id
+    end
     AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft, model_class, model_id)
     File.new(uploader.store_path)
   end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -11,7 +11,9 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     FileUtils.cp(original_file, temporary_location)
     legacy_url_path = ::File.join('/government/uploads', uploader.store_path)
     draft = uploader.assets_protected?
-    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft)
+    model_class = uploader.model && uploader.model.class.to_s
+    model_id = uploader.model && uploader.model.id
+    AssetManagerCreateWhitehallAssetWorker.perform_async(temporary_location, legacy_url_path, draft, model_class, model_id)
     File.new(uploader.store_path)
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -32,6 +32,7 @@ class AssetManagerIntegrationTest
         user = FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
         consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
         @attachment.attachable = consultation
+        @attachment.attachment_data.attachable = consultation
         @attachment.save!
 
         Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -25,6 +25,20 @@ class AssetManagerIntegrationTest
         @attachment.save!
       end
     end
+
+    test 'sends the user ids of authorised users to Asset Manager' do
+      Sidekiq::Testing.fake! do
+        organisation = FactoryBot.create(:organisation)
+        user = FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
+        consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
+        @attachment.attachable = consultation
+        @attachment.save!
+
+        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+
+        AssetManagerCreateWhitehallAssetWorker.drain
+      end
+    end
   end
 
   class CreatingAnOrganisationLogo < ActiveSupport::TestCase

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+
+  let(:organisation) { create(:organisation) }
+  let(:managing_editor) { create(:managing_editor, organisation: organisation, uid: 'user-uid') }
+
+  before do
+    login_as managing_editor
+  end
+
+  context 'given a draft document with file attachment' do
+    let(:edition) { create(:news_article, organisations: [organisation]) }
+
+    before do
+      setup_publishing_api_for(edition)
+      publishing_api_has_linkables([], document_type: "topic")
+
+      add_file_attachment('logo.png', to: edition)
+      VirusScanHelpers.simulate_virus_scan(include_versions: true)
+
+      stub_whitehall_asset('logo.png', id: 'asset-id', draft: true)
+    end
+
+    it 'marks attachment as access limited in Asset Manager when document is marked as access limited in Whitehall' do
+      visit edit_admin_news_article_path(edition)
+      check 'Limit access to producing organisations prior to publication'
+
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'access_limited' => ['user-uid'])
+
+      click_button 'Save'
+      AssetManagerUpdateAssetWorker.drain
+    end
+  end
+
+private
+
+  def setup_publishing_api_for(edition)
+    publishing_api_has_links(
+      content_id: edition.document.content_id,
+      links: {}
+    )
+  end
+
+  def add_file_attachment(filename, to:)
+    to.attachments << FactoryBot.build(
+      :file_attachment,
+      attachable: to,
+      file: File.open(path_to_attachment(filename))
+    )
+  end
+
+  def path_to_attachment(filename)
+    fixture_path.join(filename)
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+end

--- a/test/unit/asset_manager_access_limitation_test.rb
+++ b/test/unit/asset_manager_access_limitation_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class AssetManagerAccessLimitationTest < ActiveSupport::TestCase
+  test 'delegates to PublishingApi::PayloadBuilder::AccessLimitation to ask for users that can access item' do
+    edition = FactoryBot.build(:edition)
+    access_limitation = { access_limited: { users: ['uid-1'] } }
+    PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
+    assert_equal ['uid-1'], AssetManagerAccessLimitation.for(edition)
+  end
+end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -227,4 +227,42 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_equal replacer, to_be_replaced.replaced_by
     assert_equal replacer, replaced.reload.replaced_by
   end
+
+  test "#attachable returns nil if there aren't any attachments" do
+    attachment_data = FactoryBot.build(:attachment_data)
+
+    assert_nil attachment_data.attachable
+  end
+
+  test '#attachable returns the attachable object associated with the most recently created attachment' do
+    newer_consultation = FactoryBot.build(:consultation, created_at: 1.day.ago)
+    older_consultation = FactoryBot.build(:consultation, created_at: 1.week.ago)
+    newer_attachment = FactoryBot.build(:file_attachment, attachable: newer_consultation, created_at: 1.day.ago)
+    older_attachment = FactoryBot.build(:file_attachment, attachable: older_consultation, created_at: 1.week.ago)
+    attachment_data = FactoryBot.create(:attachment_data, attachments: [newer_attachment, older_attachment])
+
+    assert_equal newer_consultation, attachment_data.attachable
+  end
+
+  test "#attachable_is_access_limited? returns nil if there's no associated attachable object" do
+    attachment_data = FactoryBot.build(:attachment_data)
+
+    assert_nil attachment_data.attachable_is_access_limited?
+  end
+
+  test "#attachable_is_access_limited? delegates to the associated attachable object" do
+    attachment_data = FactoryBot.build(:attachment_data)
+    attachable = stub('attachable', access_limited?: 'access-limited')
+    attachment_data.stubs(:attachable).returns(attachable)
+
+    assert_equal 'access-limited', attachment_data.attachable_is_access_limited?
+  end
+
+  test '#access_limited_object delegates to the associated attachable object' do
+    attachment_data = FactoryBot.build(:attachment_data)
+    attachable = stub('attachable', access_limited_object: 'access-limited-object')
+    attachment_data.stubs(:attachable).returns(attachable)
+
+    assert_equal 'access-limited-object', attachment_data.access_limited_object
+  end
 end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -227,42 +227,4 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_equal replacer, to_be_replaced.replaced_by
     assert_equal replacer, replaced.reload.replaced_by
   end
-
-  test "#attachable returns nil if there aren't any attachments" do
-    attachment_data = FactoryBot.build(:attachment_data)
-
-    assert_nil attachment_data.attachable
-  end
-
-  test '#attachable returns the attachable object associated with the most recently created attachment' do
-    newer_consultation = FactoryBot.build(:consultation, created_at: 1.day.ago)
-    older_consultation = FactoryBot.build(:consultation, created_at: 1.week.ago)
-    newer_attachment = FactoryBot.build(:file_attachment, attachable: newer_consultation, created_at: 1.day.ago)
-    older_attachment = FactoryBot.build(:file_attachment, attachable: older_consultation, created_at: 1.week.ago)
-    attachment_data = FactoryBot.create(:attachment_data, attachments: [newer_attachment, older_attachment])
-
-    assert_equal newer_consultation, attachment_data.attachable
-  end
-
-  test "#attachable_is_access_limited? returns nil if there's no associated attachable object" do
-    attachment_data = FactoryBot.build(:attachment_data)
-
-    assert_nil attachment_data.attachable_is_access_limited?
-  end
-
-  test "#attachable_is_access_limited? delegates to the associated attachable object" do
-    attachment_data = FactoryBot.build(:attachment_data)
-    attachable = stub('attachable', access_limited?: 'access-limited')
-    attachment_data.stubs(:attachable).returns(attachable)
-
-    assert_equal 'access-limited', attachment_data.attachable_is_access_limited?
-  end
-
-  test '#access_limited_object delegates to the associated attachable object' do
-    attachment_data = FactoryBot.build(:attachment_data)
-    attachable = stub('attachable', access_limited_object: 'access-limited-object')
-    attachment_data.stubs(:attachable).returns(attachable)
-
-    assert_equal 'access-limited-object', attachment_data.access_limited_object
-  end
 end

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -224,4 +224,28 @@ class AttachmentTest < ActiveSupport::TestCase
     attachment.destroy
     assert attachment.deleted?
   end
+
+  test '#attachable_is_access_limited? is falsey if there is no attachable' do
+    attachment = FactoryBot.build(:file_attachment, attachable: nil)
+    refute attachment.attachable_is_access_limited?
+  end
+
+  test '#attachable_is_access_limited? delegates to the attachable' do
+    attachable = FactoryBot.build(:consultation)
+    attachable.stubs(:access_limited?).returns('access-limited')
+    attachment = FactoryBot.build(:file_attachment, attachable: attachable)
+    assert_equal 'access-limited', attachment.attachable_is_access_limited?
+  end
+
+  test '#access_limited_object returns nil if there is no attachable' do
+    attachment = FactoryBot.build(:file_attachment, attachable: nil)
+    assert_nil attachment.access_limited_object
+  end
+
+  test '#access_limited_object delegates to the attachable' do
+    attachable = FactoryBot.build(:consultation)
+    attachable.stubs(:access_limited_object).returns('access-limited-object')
+    attachment = FactoryBot.build(:file_attachment, attachable: attachable)
+    assert_equal 'access-limited-object', attachment.access_limited_object
+  end
 end

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -35,16 +35,14 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test "should store uploads in a directory that persists across deploys" do
-    model = stub("AR Model", id: 1)
-    uploader = AttachmentUploader.new(model, "mounted-as")
+    uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
     assert_match %r[^system], uploader.store_dir
   end
 
   test "should not generate thumbnail versions of non pdf files" do
     AttachmentUploader.enable_processing = true
 
-    model = stub("AR Model", id: 1)
-    uploader = AttachmentUploader.new(model, "mounted-as")
+    uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
     uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
 
     assert_nil uploader.thumbnail.path
@@ -204,8 +202,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
 
   setup do
     AttachmentUploader.enable_processing = true
-    model = stub("AR Model", id: 1)
-    @uploader = AttachmentUploader.new(model, "mounted-as")
+    @uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
 
     @uploader.store!(fixture_file_upload('two-pages-with-content.pdf'))
   end
@@ -240,8 +237,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   end
 
   test "should use a generic thumbnail if conversion fails" do
-    model = stub("AR Model", id: 1)
-    @uploader = AttachmentUploader.new(model, "mounted-as")
+    @uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
     @uploader.thumbnail.stubs(:pdf_thumbnail_command).returns("false")
 
     @uploader.store!(fixture_file_upload('two-pages-with-content.pdf'))
@@ -250,8 +246,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   end
 
   test "should use a generic thumbnail if conversion takes longer than 10 seconds to complete" do
-    model = stub("AR Model", id: 1)
-    @uploader = AttachmentUploader.new(model, "mounted-as")
+    @uploader = AttachmentUploader.new(stub("AR Model", id: 1), "mounted-as")
     @uploader.thumbnail.stubs(:pdf_thumbnail_command).raises(Timeout::Error)
 
     @uploader.store!(fixture_file_upload('two-pages-with-content.pdf'))

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -42,7 +42,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   test "should not generate thumbnail versions of non pdf files" do
     AttachmentUploader.enable_processing = true
 
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
 
     assert_nil uploader.thumbnail.path
@@ -53,7 +53,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   test "should be able to attach a xsd file" do
     AttachmentUploader.enable_processing = true
 
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     uploader.store!(fixture_file_upload("sample.xsd"))
     assert uploader.file.present?
 
@@ -61,7 +61,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test "should be able to attach a zip file" do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     uploader.store!(fixture_file_upload('sample_attachment.zip'))
     assert uploader.file.present?
   end
@@ -74,7 +74,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test "zip file containing SHOUTED whitelisted format files should not be rejected" do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     AttachmentUploader::ZipFile.any_instance.stubs(:filenames).returns(['README.TXT', 'ImportantDocument.PDF', 'dIRE-sTRAITS.jPG'])
     assert_nothing_raised do
       uploader.store!(fixture_file_upload('sample_attachment.zip'))
@@ -98,7 +98,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test 'zip file that looks like a minimal ArcGIS file should be allowed' do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), 'mounted-as')
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), 'mounted-as')
     AttachmentUploader::ZipFile.any_instance.stubs(:filenames).returns(required_arcgis_file_list)
     assert_nothing_raised do
       uploader.store!(fixture_file_upload('sample_attachment.zip'))
@@ -107,7 +107,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test 'zip file that looks like a comprehensive ArcGIS file should be allowed' do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), 'mounted-as')
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), 'mounted-as')
     AttachmentUploader::ZipFile.any_instance.stubs(:filenames).returns(comprehensive_arcgis_file_list)
     assert_nothing_raised do
       uploader.store!(fixture_file_upload('sample_attachment.zip'))
@@ -132,7 +132,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test 'zip file that looks like an ArcGIS file with multiple sets of shapes is allowed' do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), 'mounted-as')
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), 'mounted-as')
     AttachmentUploader::ZipFile.any_instance.stubs(:filenames).returns(multiple_shape_arcgis_file_list)
     assert_nothing_raised do
       uploader.store!(fixture_file_upload('sample_attachment.zip'))
@@ -149,7 +149,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
   end
 
   test 'returns Asset Manager version of path' do
-    uploader = AttachmentUploader.new(AttachmentData.new(id: 1), 'mounted-as')
+    uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), 'mounted-as')
     uploader.store!(fixture_file_upload('simple.pdf'))
     expected_path = '/government/uploads/system/uploads/attachment_data/mounted-as/1/simple.pdf'
     assert_equal expected_path, uploader.file.asset_manager_path
@@ -237,7 +237,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   end
 
   test "should use a generic thumbnail if conversion fails" do
-    @uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    @uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     @uploader.thumbnail.stubs(:pdf_thumbnail_command).returns("false")
 
     @uploader.store!(fixture_file_upload('two-pages-with-content.pdf'))
@@ -246,7 +246,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
   end
 
   test "should use a generic thumbnail if conversion takes longer than 10 seconds to complete" do
-    @uploader = AttachmentUploader.new(AttachmentData.new(id: 1), "mounted-as")
+    @uploader = AttachmentUploader.new(FactoryBot.create(:attachment_data), "mounted-as")
     @uploader.thumbnail.stubs(:pdf_thumbnail_command).raises(Timeout::Error)
 
     @uploader.store!(fixture_file_upload('two-pages-with-content.pdf'))

--- a/test/unit/consultation_outcome_test.rb
+++ b/test/unit/consultation_outcome_test.rb
@@ -2,4 +2,19 @@ require 'test_helper'
 
 class ConsultationOutcomeTest < ActiveSupport::TestCase
   should_not_accept_footnotes_in :summary
+
+  test '#access_limited_object returns the parent consultation' do
+    consultation = FactoryBot.build(:consultation)
+    outcome = FactoryBot.build(:consultation_outcome, consultation: consultation)
+
+    assert_equal consultation, outcome.access_limited_object
+  end
+
+  test '#access_limited? delegates to the parent consultation' do
+    consultation = FactoryBot.build(:consultation)
+    consultation.stubs(:access_limited?).returns('access-limited')
+    outcome = FactoryBot.build(:consultation_outcome, consultation: consultation)
+
+    assert_equal 'access-limited', outcome.access_limited?
+  end
 end

--- a/test/unit/consultation_public_feedback_test.rb
+++ b/test/unit/consultation_public_feedback_test.rb
@@ -2,4 +2,19 @@ require 'test_helper'
 
 class ConsultationPublicFeedbackTest < ActiveSupport::TestCase
   should_not_accept_footnotes_in :summary
+
+  test '#access_limited_object returns the parent consultation' do
+    consultation = FactoryBot.build(:consultation)
+    public_feedback = FactoryBot.build(:consultation_public_feedback, consultation: consultation)
+
+    assert_equal consultation, public_feedback.access_limited_object
+  end
+
+  test '#access_limited? delegates to the parent consultation' do
+    consultation = FactoryBot.build(:consultation)
+    consultation.stubs(:access_limited?).returns('access-limited')
+    public_feedback = FactoryBot.build(:consultation_public_feedback, consultation: consultation)
+
+    assert_equal 'access-limited', public_feedback.access_limited?
+  end
 end

--- a/test/unit/edition/limited_access_test.rb
+++ b/test/unit/edition/limited_access_test.rb
@@ -77,4 +77,10 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
       refute Edition.accessible_to(user).include?(edition), "doc #{i} should not be accessible"
     end
   end
+
+  test '#access_limited_object returns self' do
+    edition = LimitedAccessEdition.new
+
+    assert_equal edition, edition.access_limited_object
+  end
 end

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -21,7 +21,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should send correctly resized versions of a bitmap image to asset manager" do
-    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
+    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with do |value|
@@ -40,7 +40,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should store all the versions of a bitmap image in asset manager" do
-    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
+    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
@@ -57,7 +57,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should store the original version only of a svg image in asset manager" do
-    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
+    @uploader = ImageUploader.new(FactoryBot.create(:person), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -21,8 +21,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should send correctly resized versions of a bitmap image to asset manager" do
-    model = stub("AR Model", id: 1)
-    @uploader = ImageUploader.new(model, "mounted-as")
+    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with do |value|
@@ -36,14 +35,12 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should store uploads in a directory that persists across deploys" do
-    model = stub("AR Model", id: 1)
-    uploader = ImageUploader.new(model, "mounted-as")
+    uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
     assert_match %r[^system], uploader.store_dir
   end
 
   test "should store all the versions of a bitmap image in asset manager" do
-    model = stub("AR Model", id: 1)
-    @uploader = ImageUploader.new(model, "mounted-as")
+    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/minister-of-funk.960x640.jpg/))
@@ -60,8 +57,7 @@ class ImageUploaderTest < ActiveSupport::TestCase
   end
 
   test "should store the original version only of a svg image in asset manager" do
-    model = stub("AR Model", id: 1)
-    @uploader = ImageUploader.new(model, "mounted-as")
+    @uploader = ImageUploader.new(Person.new(id: 1), "mounted-as")
 
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -39,4 +39,14 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group = create(:policy_group)
     assert_published_policies_returns_all_tagged_policies(policy_group)
   end
+
+  test '#access_limited? returns false' do
+    policy_group = FactoryBot.build(:policy_group)
+    refute policy_group.access_limited?
+  end
+
+  test '#access_limited_object returns nil' do
+    policy_group = FactoryBot.build(:policy_group)
+    assert_nil policy_group.access_limited_object
+  end
 end

--- a/test/unit/services/service_listeners/attachment_access_limited_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_access_limited_updater_test.rb
@@ -1,0 +1,121 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+
+    let(:updater) { AttachmentAccessLimitedUpdater.new(attachment, queue: queue) }
+    let(:queue) { nil }
+
+    context 'when attachment is not a file attachment' do
+      let(:attachment) { FactoryBot.create(:html_attachment) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment has no associated attachment data' do
+      let(:attachment) { FileAttachment.new(attachment_data: nil) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context "when attachment's attachable is access limited and the attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      before do
+        access_limited_object = stub('access-limited-object')
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(['user-uid'])
+
+        attachment.stubs(:attachable_is_access_limited?).returns(true)
+        attachment.stubs(:access_limited_object).returns(access_limited_object)
+      end
+
+      it 'updates the access limited state of the asset' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, access_limited: ['user-uid'])
+
+        updater.update!
+      end
+    end
+
+    context "when attachment's attachable is access limited and the attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+      before do
+        access_limited_object = stub('access-limited-object')
+        AssetManagerAccessLimitation.stubs(:for).with(access_limited_object).returns(['user-uid'])
+
+        attachment.stubs(:attachable_is_access_limited?).returns(true)
+        attachment.stubs(:access_limited_object).returns(access_limited_object)
+      end
+
+      it "updates the access limited state of the asset and it's thumbnail" do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, access_limited: ['user-uid'])
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, access_limited: ['user-uid'])
+
+        updater.update!
+      end
+    end
+
+    context "when attachment's attachable is not access limited and the attachment is not a PDF" do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      before do
+        attachment.stubs(:attachable_is_access_limited?).returns(false)
+      end
+
+      it 'updates the asset to have an empty access_limited array' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, access_limited: [])
+
+        updater.update!
+      end
+    end
+
+    context "when attachment's attachable is not access limited and the attachment is a PDF" do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+      before do
+        attachment.stubs(:attachable_is_access_limited?).returns(false)
+      end
+
+      it 'updates the asset to have an empty access_limited array' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, access_limited: [])
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, access_limited: [])
+
+        updater.update!
+      end
+    end
+
+    context 'when a different queue is specified' do
+      let(:queue) { 'alternative-queue' }
+      let(:worker) { stub('worker', perform_async: nil) }
+      let(:attachment) { FactoryBot.create(:file_attachment) }
+
+      it 'uses that queue' do
+        AssetManagerUpdateAssetWorker.expects(:set)
+          .with(queue: queue).at_least_once.returns(worker)
+        worker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, anything)
+
+        updater.update!
+      end
+    end
+  end
+end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -36,7 +36,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
     expected_filename = File.basename(@file.path)
     expected_path = File.join('/government/uploads/store-dir', expected_filename)
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, expected_path, anything, anything, anything)
 
     @uploader.store!(@file)
   end
@@ -44,7 +44,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   test "creates a sidekiq job and sets draft to false if the uploader's assets_protected? returns false" do
     @uploader.assets_protected = false
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, false)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, false, anything, anything)
 
     @uploader.store!(@file)
   end
@@ -52,7 +52,15 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
   test "creates a sidekiq job and sets draft to true if the uploader's assets_protected? returns true" do
     @uploader.assets_protected = true
 
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, true)
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, true, anything, anything)
+
+    @uploader.store!(@file)
+  end
+
+  test "creates a sidekiq job and sets model class and id based on the model associated with the uploader" do
+    @uploader.stubs(:model).returns(Consultation.new(id: 1))
+
+    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, 'Consultation', 1)
 
     @uploader.store!(@file)
   end

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -48,10 +48,11 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     user = FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
     consultation = FactoryBot.create(:consultation, organisations: [organisation], access_limited: true)
     attachment = FactoryBot.create(:file_attachment, attachable: consultation)
+    attachment.attachment_data.attachable = consultation
 
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
 
-    @worker.perform(@file.path, @legacy_url_path, true, attachment.attachment_data.class.to_s, attachment.attachment_data.id)
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end
 
   test 'marks attachments belonging to consultation responses as access limited' do
@@ -60,10 +61,11 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     consultation = FactoryBot.create(:consultation, organisations: [organisation], access_limited: true)
     response = FactoryBot.create(:consultation_outcome, consultation: consultation)
     attachment = FactoryBot.create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
 
     Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
 
-    @worker.perform(@file.path, @legacy_url_path, true, attachment.attachment_data.class.to_s, attachment.attachment_data.id)
+    @worker.perform(@file.path, @legacy_url_path, true, consultation.class.to_s, consultation.id)
   end
 
   test 'does not mark attachments belonging to policy groups as access limited' do


### PR DESCRIPTION
Certain documents in Whitehall can be marked as access limited; which means that they're only accessible to users within the same organisation(s) that the document belongs to. Any attachments belonging to those documents are subject to the same restrictions in Whitehall so we need to mirror that behaviour when serving them from Asset Manager.

The changes in this branch mean that we send an array of user UIDs in the `access_limited` array when creating Whitehall assets in Asset Manager. The functionality to make use of this `access_limited` data was added to Asset Manager in https://github.com/alphagov/asset-manager/pull/471 and is based on similar functionality in the Content Store.

The access restrictions only apply to attachments (i.e. files modelled using `AttachmentData` and uploaded using the `AttachmentUploader`). Attachments can belong to an `Attachable` (one of `Edition`, `Response` or `PolicyGroup`) and the access restrictions are dependent on the type of `Attachable` they belong to:

* Attachments belonging to `Edition`s should respect the access restrictions of the `Edition`.
* Attachments belonging to `Response`s should respect the access restrictions of the `Response`'s `Edition`.
* Attachments belonging to `PolicyGroup`s should not be access limited.

It's not entirely trivial to get hold of the relevant `Attachable` object in the `AssetManagerCreateWhitehallAssetWorker#perform` method because there's no guarantee that an `Attachment` has been persisted to link the `Attachable` with the `AttachmentData` at the time the job runs. This is because the job is queued on the `after_save` of the `AttachmentData` and could feasibly run immediately. We considered failing fast in `AssetManagerCreateWhitehallAssetWorker#perform` if we determine that we don't have all the required information but that doesn't feel quite right. The approach I've gone with (after discussions with @floehopper), in the final commit of this branch, is to pass the `Attachable` object to the `AttachmentData` so that it can pass the `Attachable`'s class and ID at the point the job is queued up. This seems OK for now given that we only create attachments in the `Admin::AttachmentsController` but we should look to improve it in future given that this behaviour is somewhat surprising.
