### PR TITLE
Update draft status of existing attachment assets

### DIFF
--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -42,6 +42,21 @@ module ServiceListeners
 
         updater.update!
       end
+
+      context 'and queue is specified' do
+        let(:queue) { 'alternative_queue' }
+        let(:updater) { AttachmentDraftStatusUpdater.new(attachment, queue: queue) }
+        let(:worker) { stub('worker') }
+
+        it 'updates draft status of corresponding asset using specified queue' do
+          AssetManagerUpdateAssetWorker.expects(:set)
+            .with(queue: queue).returns(worker)
+          worker.expects(:perform_async)
+            .with(attachment.file.asset_manager_path, draft: true)
+
+          updater.update!
+        end
+      end
     end
 
     context 'when attachment is a PDF' do


### PR DESCRIPTION
This is based on the changes in #3768 which keeps the draft status of assets for attachments up-to-date on an *on-going* basis, including new ones. This PR adds a Rake task to allow us to update the draft status of assets for all *existing* attachments.

Only the last two commits are unique to this branch - I plan to rebase this branch against the branch in #3768 before merging this PR.

The new `asset_manager:attachments:update_draft_status` Rake task iterates over a range of attachments and invokes `ServiceListeners::AttachmentDraftStatusUpdater#update!` to queue up jobs to update the draft status of the corresponding assets in Asset Manager. Note that I've tweaked this `AttachmentDraftStatusUpdater` class slightly to allow the Rake task to specify the (lower priority) `asset_migration` Sidekiq queue in order to avoid blocking up business-as-usual activity in the app.

Like some of the other asset migration Rake tasks, this new Rake task allows a range of attachment IDs to be specified so we can process the attachments in manageable batches.

We're probably going to need to do something similar for the following issues:

* https://github.com/alphagov/asset-manager/issues/467
* https://github.com/alphagov/asset-manager/issues/466
* https://github.com/alphagov/asset-manager/issues/469 (maybe)

I wonder what the rate-limiting step was when we migrated the attachment files, because if running the new Rake task for all attachments is going to take a similar amount of time, we might want to consider either (a) combining the work from all the above issues into a single migration job; or (b) investigating increasing the throughput of the Whitehall/Asset Manager queueing mechanism.

@chrisroos, @chrislo: Do you have any thoughts on the latter?
