### PR TITLE
Add superseeding & superseeded relationships to API

### DIFF
--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -7,7 +7,8 @@ class Api::OrganisationsController < PublicFacingController
   def index
     respond_with Api::OrganisationPresenter.paginate(
       # Need to order by something for pagination to be deterministic:
-      Organisation.includes(:parent_organisations, :child_organisations, :translations).order(:id),
+      Organisation.includes(:parent_organisations, :child_organisations, :translations,
+        :superseding_organisations, :superseded_organisations).order(:id),
       view_context
     )
   end

--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -19,6 +19,8 @@ class Api::OrganisationPresenter < Api::BasePresenter
       analytics_identifier: model.analytics_identifier,
       parent_organisations: parent_organisations,
       child_organisations: child_organisations,
+      superseded_organisations: superseded_organisations,
+      superseding_organisations: superseding_organisations
     }
   end
 
@@ -29,6 +31,22 @@ class Api::OrganisationPresenter < Api::BasePresenter
   end
 
 private
+
+  def superseded_organisations
+    model.superseded_organisations.map do |organisation|
+      {
+        id: context.api_organisation_url(organisation),
+        web_url: Whitehall.url_maker.organisation_url(organisation)
+      }
+  end
+
+  def superseding_organisations
+    model.superseding_organisations.map do |organisation|
+      {
+        id: context.api_organisation_url(organisation),
+        web_url: Whitehall.url_maker.organisation_url(organisation)
+      }
+  end
 
   def parent_organisations
     model.parent_organisations.map do |parent|


### PR DESCRIPTION
The superseding & superseeded relationships should be added to the API (alongside the existing parent & child organisation relationships).

This would enable these types of organisation history charts to be generated: https://twitter.com/ad_greenway/status/964199485340602371