### PR TITLE
Only consider FileAttachments in asset_manager:attachments:update_draft_status Rake task

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -35,7 +35,7 @@ namespace :asset_manager do
       abort(update_draft_status_usage_string) unless first_id && last_id
       options = { start: first_id, finish: last_id }
       updater = ServiceListeners::AttachmentDraftStatusUpdater
-      Attachment.includes(:attachment_data).find_each(options) do |attachment|
+      FileAttachment.includes(:attachment_data).find_each(options) do |attachment|
         updater.new(attachment, queue: 'asset_migration').update!
       end
     end


### PR DESCRIPTION
Neither `HtmlAttachment` nor `ExternalAttachment` have any Asset Manager assets associated with them, so there's no need to include them in the query.