### PR TITLE
Only update draft status of attachments with underlying file in asset_manager:attachments:update_draft_status Rake task

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -36,7 +36,9 @@ namespace :asset_manager do
       options = { start: first_id, finish: last_id }
       updater = ServiceListeners::AttachmentDraftStatusUpdater
       FileAttachment.includes(:attachment_data).find_each(options) do |attachment|
-        updater.new(attachment, queue: 'asset_migration').update!
+        if File.exist?(attachment.attachment_data.file.path)
+          updater.new(attachment, queue: 'asset_migration').update!
+        end
       end
     end
   end


### PR DESCRIPTION
I discovered that there are `AttachmentData` instances in integration (and therefore presumably staging & production) with no underlying file on the filesystem. This means that they have no corresponding asset in Asset Manager and the asset lookup in `AssetManagerUpdateAssetWorker#perform` would raise a `GdsApi::HTTPNotFound` exception and the job would then be re-tried many times with no chance of success.

Since we haven't yet deleted the files from the Whitehall part of the NFS mount, we can take advantage of this by not attempting to update the asset draft status for attachments which have no underlying file and thereby avoiding a bunch of failing jobs.
