### PR TITLE
Expose govuk_closed_status in api

### DIFF
--- a/app/presenters/api/organisation_presenter.rb
+++ b/app/presenters/api/organisation_presenter.rb
@@ -14,6 +14,7 @@ class Api::OrganisationPresenter < Api::BasePresenter
         organisation_logo_type_class_name: model.organisation_logo_type.try(:class_name),
         closed_at: model.closed_at,
         govuk_status: model.govuk_status,
+        govuk_closed_status: model.govuk_closed_status,
         content_id: model.content_id,
       },
       analytics_identifier: model.analytics_identifier,

--- a/test/unit/presenters/api/organisation_presenter_test.rb
+++ b/test/unit/presenters/api/organisation_presenter_test.rb
@@ -66,6 +66,11 @@ class Api::OrganisationPresenterTest < PresenterTestCase
     assert_equal "live", @presenter.as_json[:details][:govuk_status]
   end
 
+  test "json includes govuk_closed_status in details hash" do
+    @organisation.stubs(:govuk_closed_status).returns("split")
+    assert_equal "split", @presenter.as_json[:details][:govuk_closed_status]
+  end
+
   test "json includes analytics_identifier in details hash" do
     @organisation.stubs(:analytics_identifier).returns("O123")
     assert_equal "O123", @presenter.as_json[:analytics_identifier]


### PR DESCRIPTION
Following on from #3781 this will give some valuable contextual
information in interpreting `superseded_organisations` and
`superseding_organisations`.