### PR TITLE
Improvements to AttachmentDraftStatusIntegrationTest

### DIFF
--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -30,6 +30,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
       click_button 'Force publish'
+      assert_text "The document #{edition.title} has been published"
     end
   end
 
@@ -54,6 +55,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       within '#js-published-in-error-form' do
         click_button 'Unpublish'
       end
+      assert_text 'This document has been unpublished'
     end
   end
 
@@ -79,6 +81,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
       click_button 'Force publish'
+      assert_text "The document #{edition.title} has been published"
     end
   end
 
@@ -104,6 +107,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
       click_button 'Force publish'
+      assert_text "The document #{edition.title} has been published"
     end
   end
 
@@ -120,6 +124,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
       click_button 'Save'
+      assert_text "Attachment 'Attachment Title' uploaded"
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -10,7 +10,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     login_as create(:managing_editor)
   end
 
-  context 'when draft document with file attachment is published' do
+  context 'given a draft document with file attachment' do
     let(:edition) { create(:news_article) }
 
     before do
@@ -22,7 +22,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager when document is published' do
       visit admin_news_article_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
@@ -33,7 +33,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context 'when published document with file attachment is unpublished' do
+  context 'given a published document with file attachment' do
     let(:edition) { create(:published_news_article) }
 
     before do
@@ -45,7 +45,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: false)
     end
 
-    it 'marks attachment as draft in Asset Manager' do
+    it 'marks attachment as draft in Asset Manager when document is unpublished' do
       visit admin_news_article_path(edition)
       click_link 'Withdraw or unpublish'
 
@@ -57,7 +57,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context 'when draft consultation with outcome with file attachment is published' do
+  context 'given a draft consultation with outcome with file attachment' do
     let(:edition) { create(:draft_consultation) }
     let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
     let(:outcome) { edition.create_outcome!(outcome_attributes) }
@@ -71,7 +71,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager when consultation is published' do
       visit admin_consultation_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
@@ -82,7 +82,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context 'when draft consultation with feedback with file attachment is published' do
+  context 'given a draft consultation with feedback with file attachment' do
     let(:edition) { create(:draft_consultation) }
     let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
     let(:feedback) { edition.create_public_feedback!(feedback_attributes) }
@@ -96,7 +96,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager when consultation is published' do
       visit admin_consultation_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
@@ -107,14 +107,11 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context 'when file attachment is added to policy group' do
+  context 'given a policy group' do
     let(:policy_group) { create(:policy_group) }
 
-    before do
+    it 'marks attachment as published in Asset Manager when added to policy group' do
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
-    end
-
-    it 'marks attachment as published in Asset Manager' do
       visit admin_policy_group_attachments_path(policy_group)
       click_link 'Upload new file attachment'
       fill_in 'Title', with: 'Attachment Title'

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -16,20 +16,18 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     before do
       setup_publishing_api_for(edition)
 
-      add_file_attachment('whitepaper.pdf', to: edition)
-      VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      add_file_attachment('sample.docx', to: edition)
+      VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
-      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment & its thumbnail as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager' do
       visit admin_news_article_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
-      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
       click_button 'Force publish'
     end
@@ -41,19 +39,17 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     before do
       setup_publishing_api_for(edition)
 
-      add_file_attachment('whitepaper.pdf', to: edition)
-      VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      add_file_attachment('sample.docx', to: edition)
+      VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: false)
-      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: false)
+      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: false)
     end
 
-    it 'marks attachment & its thumbnail as draft in Asset Manager' do
+    it 'marks attachment as draft in Asset Manager' do
       visit admin_news_article_path(edition)
       click_link 'Withdraw or unpublish'
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true)
-      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => true)
 
       within '#js-published-in-error-form' do
         click_button 'Unpublish'
@@ -69,20 +65,18 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     before do
       setup_publishing_api_for(edition)
 
-      add_file_attachment('whitepaper.pdf', to: outcome)
-      VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      add_file_attachment('sample.docx', to: outcome)
+      VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
-      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment & its thumbnail as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager' do
       visit admin_consultation_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
-      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
       click_button 'Force publish'
     end
@@ -96,20 +90,18 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     before do
       setup_publishing_api_for(edition)
 
-      add_file_attachment('whitepaper.pdf', to: feedback)
-      VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      add_file_attachment('sample.docx', to: feedback)
+      VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
-      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment & its thumbnail as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager' do
       visit admin_consultation_path(edition)
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
-      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
       click_button 'Force publish'
     end
@@ -119,18 +111,16 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     let(:policy_group) { create(:policy_group) }
 
     before do
-      stub_whitehall_asset('whitepaper.pdf', id: 'asset-id', draft: true)
-      stub_whitehall_asset('thumbnail_whitepaper.pdf.png', id: 'thumbnail-asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
     end
 
-    it 'marks attachment & its thumbnail as published in Asset Manager' do
+    it 'marks attachment as published in Asset Manager' do
       visit admin_policy_group_attachments_path(policy_group)
       click_link 'Upload new file attachment'
       fill_in 'Title', with: 'Attachment Title'
-      attach_file 'File', path_to_attachment('whitepaper.pdf')
+      attach_file 'File', path_to_attachment('sample.docx')
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
-      Services.asset_manager.expects(:update_asset).with('thumbnail-asset-id', 'draft' => false)
 
       click_button 'Save'
     end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -148,9 +148,10 @@ private
     fixture_path.join(filename)
   end
 
-  def stub_whitehall_asset(filename, id:, draft:)
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
     Services.asset_manager.stubs(:whitehall_asset)
       .with(&ends_with(filename))
-      .returns('id' => "http://asset-manager/assets/#{id}", 'draft' => draft)
+      .returns(attributes.merge(id: url_id).stringify_keys)
   end
 end


### PR DESCRIPTION
This is an attempt to simplify and improve the test bearing in mind that we're about to add a bunch more similar tests. See the individual commit notes for details.