### PR TITLE
Update asset draft status for attachment events for non-editions

### DIFF
--- a/config/initializers/attachment_notifier.rb
+++ b/config/initializers/attachment_notifier.rb
@@ -1,7 +1,9 @@
 Whitehall.attachment_notifier.tap do |notifier|
   notifier.subscribe do |_event, attachment|
-    ServiceListeners::AttachmentDraftStatusUpdater
-      .new(attachment)
-      .update!
+    unless attachment.attachable.is_a?(Edition)
+      ServiceListeners::AttachmentDraftStatusUpdater
+        .new(attachment)
+        .update!
+    end
   end
 end


### PR DESCRIPTION
[Originally][1] we had this only handling attachment events for policy groups, but then we [changed it][2] to handle all attachment events as a belt and braces approach. However, I'm now more convinced that the only scenarios where these events might be important is for policy groups and (possibly†) for consultation responses, i.e. where the attachable is not an edition.

So by making this change, we can reduce the number of Asset Manager API related jobs we create. This is particularly relevant, because I think these events generate `AssetManagerUpdateAssetWorker` jobs immediately after `AssetManagerCreateWhitehallAssetWorker` jobs and if the latter takes a while to complete, the former will raise an exception due to the asset not being found in Asset Manager. Although the job will then retry, it feels better to avoid this happening as much as possible.

[1]:
https://github.com/alphagov/whitehall/commit/3c05f68d503caee6038994a272c2e818c472c140
[2]:
https://github.com/alphagov/whitehall/commit/a0bc6c606e17eb70f5c1940f70d094e0c7d8df19

† I don't think this is actually necessary with the current user interface, but this change means we're more robust against this possibility.