### PR TITLE
Import HMCTS forms

### DIFF
--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -1,0 +1,71 @@
+module Import
+  class HmctsCsvParser
+    CSV_HEADERS = %i(
+      publication_page_id
+      artefact_code
+      category
+      artefact_file_name
+      artefact_type
+      artefact_title
+      artefact_link
+      artefact_url
+      publication_type
+      publication_title
+      publication_summary
+      publication_body
+      published_before
+      has_images
+      alternative_format_email
+      policy
+      policy_areas
+      lead_organisations
+      supporting_organisations
+      excluded_nations
+      access_limiting
+      schedule_publishing
+      attachment_accessible
+      new_publication_url
+      new_attachment_url
+    ).freeze
+
+    PUBLICATION_TYPE_SLUGS = {
+      "Form" => "forms",
+      "Guidance" => "guidance",
+    }.freeze
+
+    def self.publications(path)
+      csv = CSV.read(path, headers: CSV_HEADERS)
+
+      Enumerator.new do |yielder|
+        page_id = nil
+        publication_details = {}
+
+        # Skip the header row
+        csv[1..-1].each do |row|
+          if row[:publication_page_id] == page_id
+
+          else
+            yielder << publication_details unless page_id.nil?
+
+            publication_details = {
+              publication_type: publication_type_slug(row[:publication_type]),
+              title: row[:publication_title],
+              summary: row[:publication_summary],
+              body: row[:publication_body],
+              # TODO: Handle multiple policy areas. Will they comma-separate these?
+              policy_area: row[:policy_areas],
+            }
+
+            page_id = row[:publication_page_id]
+          end
+        end
+
+        yielder << publication_details
+      end
+    end
+
+    def self.publication_type_slug(name)
+      PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
+    end
+  end
+end

--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -22,7 +22,7 @@ module Import
       lead_organisations
       supporting_organisations
       excluded_nations
-      access_limiting
+      access_limited
       schedule_publishing
       attachment_accessible
       new_publication_url
@@ -52,8 +52,12 @@ module Import
               title: row[:publication_title],
               summary: row[:publication_summary],
               body: row[:publication_body],
-              # TODO: Handle multiple policy areas. We've asked HMCTS to semicolon-separate these
-              policy_area: row[:policy_areas],
+              policy_areas: parse_multiple(row, :policy_areas),
+              lead_organisations: parse_multiple(row, :lead_organisations),
+              supporting_organisations: parse_multiple(row, :supporting_organisations),
+              previous_publishing_date: row[:previous_publishing_date],
+              access_limited: (row[:access_limited] || "").strip.casecmp("yes").zero?,
+              excluded_nations: parse_multiple(row, :excluded_nations),
               attachments: [],
             }
 
@@ -71,6 +75,12 @@ module Import
         file_name: row[:artefact_file_name],
         url: row[:artefact_url],
       }
+    end
+
+    def self.parse_multiple(row, field)
+      return [] unless row[field]
+
+      row[field].split(";").map(&:strip)
     end
   end
 end

--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -38,15 +38,13 @@ module Import
 
         # Skip the header row
         csv[1..-1].each_with_index do |row, index|
-          if row[:publication_page_id] == page_id
-            publication_details[:attachments] << attachment_details(row)
-          else
+          unless row[:publication_page_id] == page_id
             yielder << publication_details unless page_id.nil?
 
             page_id = row[:publication_page_id]
 
             publication_details = {
-              csv_row: index + 2, # Add 1 because Google Sheets is 1-indexed, and another 1 because we skipped the header row
+
               page_id: page_id,
               publication_type: row[:publication_type],
               title: row[:publication_title],
@@ -59,10 +57,12 @@ module Import
               access_limited: (row[:access_limited] || "").strip.casecmp("yes").zero?,
               excluded_nations: parse_multiple(row, :excluded_nations),
               attachments: [],
+              csv_rows: [],
             }
-
-            publication_details[:attachments] << attachment_details(row)
           end
+
+          publication_details[:attachments] << attachment_details(row)
+          publication_details[:csv_rows] << index + 2 # Add 1 because Google Sheets is 1-indexed, and another 1 because we skipped the header row
         end
 
         yielder << publication_details

--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -21,9 +21,9 @@ module Import
       policy_areas
       lead_organisations
       supporting_organisations
-      excluded_nations
       access_limited
       schedule_publishing
+      excluded_nations
       attachment_accessible
       new_publication_url
       new_attachment_url

--- a/lib/import/hmcts_csv_parser.rb
+++ b/lib/import/hmcts_csv_parser.rb
@@ -43,7 +43,7 @@ module Import
         # Skip the header row
         csv[1..-1].each do |row|
           if row[:publication_page_id] == page_id
-
+            publication_details[:attachments] << attachment_details(row)
           else
             yielder << publication_details unless page_id.nil?
 
@@ -54,7 +54,10 @@ module Import
               body: row[:publication_body],
               # TODO: Handle multiple policy areas. Will they comma-separate these?
               policy_area: row[:policy_areas],
+              attachments: [],
             }
+
+            publication_details[:attachments] << attachment_details(row)
 
             page_id = row[:publication_page_id]
           end
@@ -66,6 +69,14 @@ module Import
 
     def self.publication_type_slug(name)
       PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
+    end
+
+    def self.attachment_details(row)
+      {
+        title: row[:artefact_title],
+        file_name: row[:artefact_file_name],
+        url: row[:artefact_url],
+      }
     end
   end
 end

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -10,7 +10,7 @@ module Import
     end
 
     def import(csv_path)
-      importer_user = User.find_by(name: "Automatic Data Importer")
+      importer_user = User.find_by!(name: "Automatic Data Importer")
       raise "Could not find 'Automatic Data Importer' user" unless importer_user
 
       publication_ids = []

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -38,7 +38,8 @@ module Import
           publication.validate!
 
           unless dry_run?
-            publication.save! unless dry_run?
+            publication.save!
+            Whitehall.edition_services.draft_updater(publication).perform!
             publication_ids << publication.id
           end
 

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -1,44 +1,58 @@
 module Import
   class HmctsImporter
+    PUBLICATION_TYPE_SLUGS = {
+      "Form" => "forms",
+      "Guidance" => "guidance",
+    }.freeze
+
     def self.import(csv_path)
       importer_user = User.find_by(name: "Automatic Data Importer")
       raise "Could not find 'Automatic Data Importer' user" unless importer_user
 
       HmctsCsvParser.publications(csv_path).each do |publication_data|
-        puts publication_data
+        # puts publication_data
 
-        publication = Publication.new
-        publication.publication_type = PublicationType.find_by_slug(publication_data[:publication_type])
-        publication.title = publication_data[:title]
-        publication.summary = publication_data[:summary]
-        publication.body = publication_data[:body]
-        # TODO: Handle multiple policy areas
-        publication.topics = [Topic.find_by(name: publication_data[:policy_area])]
-        # TODO: Get from spreadsheet once it is always populated
-        # TODO: Handle multiple lead organisations
-        publication.lead_organisations = [default_organisation]
-        publication.creator = importer_user
-        # TODO: Should be HMCTS? Or another org with the email address provided in the CSV.
-        publication.alternative_format_provider = default_organisation
+        begin
+          publication = Publication.new
+          publication.publication_type = PublicationType.find_by_slug(publication_type_slug(publication_data[:publication_type]))
+          publication.title = publication_data[:title]
+          publication.summary = publication_data[:summary]
+          publication.body = publication_data[:body]
+          # TODO: Handle multiple policy areas
+          publication.topics = [Topic.find_by(name: publication_data[:policy_area])]
+          # TODO: Get from spreadsheet once it is always populated
+          # TODO: Handle multiple lead organisations
+          publication.lead_organisations = [default_organisation]
+          publication.creator = importer_user
+          # TODO: Should be HMCTS? Or another org with the email address provided in the CSV.
+          publication.alternative_format_provider = default_organisation
 
-        # TODO: Populate "published before" date
-        # TODO: Set "published before" to true if there is a date
-        # TODO: Populate policy
-        # TODO: Populate supporting organisations
-        # TODO: Populate excluded nations
-        # TODO: Populate access limiting flag
+          # TODO: Populate "published before" date
+          # TODO: Set "published before" to true if there is a date
+          # TODO: Populate supporting organisations
+          # TODO: Populate excluded nations
+          # TODO: Populate access limiting flag
 
-        publication.save!
-        puts "Created publication with ID #{publication.id}"
+          publication.save!
+          # puts "Created publication with ID #{publication.id}"
 
-        publication_data[:attachments].each do |attachment|
-          create_attachment(attachment, publication)
+          publication_data[:attachments].each do |attachment|
+            create_attachment(attachment, publication)
+          end
+        rescue StandardError => error
+          # TODO: Fix row output: error may be from subsequent row because it's from a translated version
+          puts "Error for form #{publication_data[:page_id]} in row #{publication_data[:csv_row]}"
+          puts error
         end
       end
     end
 
     def self.default_organisation
       @_default_organisation ||= Organisation.find_by(name: "Ministry of Justice")
+    end
+
+    def self.publication_type_slug(name)
+      PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
     end
 
     def self.create_attachment(attachment, publication)
@@ -53,7 +67,7 @@ module Import
       )
       file_attachment.save!
 
-      puts "Added attachment #{temp_file_path}"
+      # puts "Added attachment #{temp_file_path}"
     end
 
     def self.download_attachment(hmcts_url, file_path)
@@ -65,7 +79,7 @@ module Import
       end
     end
 
-    def temp_directory
+    def self.temp_directory
       @_temp_directory ||= Dir.mktmpdir
     end
   end

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -1,9 +1,5 @@
 module Import
   class HmctsImporter
-    PUBLICATION_TYPE_SLUGS = {
-      "Form" => "forms",
-      "Guidance" => "guidance",
-    }.freeze
     TITLE_MAX_LENGTH = 255
 
     def initialize(dry_run)
@@ -23,7 +19,7 @@ module Import
 
         begin
           publication = Publication.new
-          publication.publication_type = PublicationType.find_by_slug(publication_type_slug(publication_data[:publication_type]))
+          publication.publication_type = default_publication_type
           publication.title = format_title(publication_data[:title])
           publication.summary = publication_data[:summary]
           publication.body = publication_data[:body]
@@ -119,8 +115,8 @@ module Import
       @_hmcts_organisation ||= Organisation.find_by!(name: "HM Courts & Tribunals Service")
     end
 
-    def publication_type_slug(name)
-      PUBLICATION_TYPE_SLUGS[name] || raise("Unknown publication type '#{name}'")
+    def default_publication_type
+      @_publication_type ||= PublicationType.find_by_slug("forms")
     end
 
     def format_title(title)

--- a/lib/import/hmcts_importer.rb
+++ b/lib/import/hmcts_importer.rb
@@ -1,0 +1,40 @@
+module Import
+  class HmctsImporter
+    def self.import(csv_path)
+      importer_user = User.find_by(name: "Automatic Data Importer")
+      raise "Could not find 'Automatic Data Importer' user" unless importer_user
+
+      HmctsCsvParser.publications(csv_path).each do |publication_data|
+        puts publication_data
+
+        publication = Publication.new
+        publication.publication_type = PublicationType.find_by_slug(publication_data[:publication_type])
+        publication.title = publication_data[:title]
+        publication.summary = publication_data[:summary]
+        publication.body = publication_data[:body]
+        # TODO: Handle multiple policy areas
+        publication.topics = [Topic.find_by(name: publication_data[:policy_area])]
+        # TODO: Get from spreadsheet once it is always populated
+        # TODO: Handle multiple lead organisations
+        publication.lead_organisations = [default_organisation]
+        publication.creator = importer_user
+
+        # TODO: Populate "published before" date
+        # TODO: Set "published before" to true if there is a date
+        # TODO: Populate policy
+        # TODO: Populate supporting organisations
+        # TODO: Populate excluded nations
+        # TODO: Populate access limiting flag
+
+        # TODO: Add attachments
+
+        publication.save!
+        puts "Created publication with ID #{publication.id}"
+      end
+    end
+
+    def self.default_organisation
+      @_default_organisation ||= Organisation.find_by(name: "Ministry of Justice")
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,5 +1,5 @@
 namespace :import do
   task :hmcts, [:csv_path] => :environment do |_, args|
-    Import::HmctsImporter.import(args[:csv_path])
+    Import::HmctsImporter.new(ENV["DRY_RUN"]).import(args[:csv_path])
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,5 @@
+namespace :import do
+  task :hmcts, [:csv_path] => :environment do |_, args|
+    Import::HmctsImporter.import(args[:csv_path])
+  end
+end


### PR DESCRIPTION
This picks up from the spike in #3746. It adds the remaining optional fields as well as a `DRY_RUN` parameter to let us test the data without creating any new drafts.

I haven't added tests because we're only going to run this once, and we'll review everything on integration before the final import.

https://trello.com/c/uEgpFGfV/71-2-hmcts-step-2-extend-functionality-for-bulk-import

Marked as "do not merge" until we sort out the final few TODOs.