### PR TITLE
Use Sidekiq's fake mode by default in test environment

### DIFF
--- a/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/deleting_documents_test.rb
@@ -68,11 +68,13 @@ class Admin::GenericEditionsController::DeletingDocumentsTest < ActionController
   end
 
   test "destroy notifies the publishing API of the deleted document" do
-    draft_edition = create(:draft_edition, translated_into: %i[es fr])
-    delete :destroy, params: { id: draft_edition }
+    Sidekiq::Testing.inline! do
+      draft_edition = create(:draft_edition, translated_into: %i[es fr])
+      delete :destroy, params: { id: draft_edition }
 
-    %w[en es fr].each do |locale|
-      assert_publishing_api_discard_draft(draft_edition.content_id, locale: locale)
+      %w[en es fr].each do |locale|
+        assert_publishing_api_discard_draft(draft_edition.content_id, locale: locale)
+      end
     end
   end
 end

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -23,14 +23,16 @@ class StatisticsControllerTest < ActionController::TestCase
   end
 
   view_test "#index only displays *published* statistics" do
-    superseded_statistics = create(:superseded_publication, :statistics)
-    published_statistics = create(:published_statistics)
-    draft_statistics = create(:draft_statistics)
-    get :index
+    Sidekiq::Testing.inline! do
+      superseded_statistics = create(:superseded_publication, :statistics)
+      published_statistics = create(:published_statistics)
+      draft_statistics = create(:draft_statistics)
+      get :index
 
-    assert_select_object(published_statistics)
-    refute_select_object(superseded_statistics)
-    refute_select_object(draft_statistics)
+      assert_select_object(published_statistics)
+      refute_select_object(superseded_statistics)
+      refute_select_object(draft_statistics)
+    end
   end
 
   test "#index sets Cache-Control: max-age to the time of the next scheduled publication" do
@@ -93,12 +95,14 @@ class StatisticsControllerTest < ActionController::TestCase
   end
 
   view_test "#index orders statistics by publication date by default" do
-    statistics = 5.times.map { |i| create(:published_statistics, first_published_at: (10 - i).days.ago) }
+    Sidekiq::Testing.inline! do
+      statistics = 5.times.map { |i| create(:published_statistics, first_published_at: (10 - i).days.ago) }
 
-    get :index
+      get :index
 
-    assert_equal "publication_#{statistics.last.id}", css_select(".filter-results .document-row").first['id']
-    assert_equal "publication_#{statistics.first.id}", css_select(".filter-results .document-row").last['id']
+      assert_equal "publication_#{statistics.last.id}", css_select(".filter-results .document-row").first['id']
+      assert_equal "publication_#{statistics.first.id}", css_select(".filter-results .document-row").last['id']
+    end
   end
 
   view_test "#index should show a helpful message if there are no matching statistics" do
@@ -129,121 +133,131 @@ class StatisticsControllerTest < ActionController::TestCase
   end
 
   view_test "#index requested as JSON includes data for statistics" do
-    organisation_1 = create(:organisation, name: "org-name")
-    organisation_2 = create(:organisation, name: "other-org")
-    statistics_publication = create(:published_statistics, title: "statistics-title",
-                                                           organisations: [organisation_1, organisation_2],
-                                                           first_published_at: Date.parse("2012-03-14"))
+    Sidekiq::Testing.inline! do
+      organisation_1 = create(:organisation, name: "org-name")
+      organisation_2 = create(:organisation, name: "other-org")
+      statistics_publication = create(:published_statistics, title: "statistics-title",
+                                                             organisations: [organisation_1, organisation_2],
+                                                             first_published_at: Date.parse("2012-03-14"))
 
-    get :index, format: :json
+      get :index, format: :json
 
-    results = ActiveSupport::JSON.decode(response.body)["results"]
-    assert_equal 1, results.length
-    json = results.first['result']
-    assert_equal "statistics-title", json["title"]
-    assert_equal statistics_publication.id, json["id"]
-    assert_equal statistic_path(statistics_publication.document), json["url"]
-    assert_equal "org-name and other-org", json["organisations"]
-    assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
-    assert_equal "Official Statistics", json["display_type"]
+      results = ActiveSupport::JSON.decode(response.body)["results"]
+      assert_equal 1, results.length
+      json = results.first['result']
+      assert_equal "statistics-title", json["title"]
+      assert_equal statistics_publication.id, json["id"]
+      assert_equal statistic_path(statistics_publication.document), json["url"]
+      assert_equal "org-name and other-org", json["organisations"]
+      assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
+      assert_equal "Official Statistics", json["display_type"]
+    end
   end
 
   view_test '#index should show relevant document collection information' do
-    create(:departmental_editor)
-    statistics = create(:draft_statistics)
-    collection = create(:document_collection, :with_group)
-    collection.groups.first.documents = [statistics.document]
-    stub_publishing_api_registration_for([collection, statistics])
+    Sidekiq::Testing.inline! do
+      create(:departmental_editor)
+      statistics = create(:draft_statistics)
+      collection = create(:document_collection, :with_group)
+      collection.groups.first.documents = [statistics.document]
+      stub_publishing_api_registration_for([collection, statistics])
 
-    Whitehall.edition_services.force_publisher(collection).perform!
-    Whitehall.edition_services.force_publisher(statistics).perform!
-    get :index
+      Whitehall.edition_services.force_publisher(collection).perform!
+      Whitehall.edition_services.force_publisher(statistics).perform!
+      get :index
 
-    assert_select_object(statistics) do
-      assert_select ".document-collections a[href=?]", public_document_path(collection)
+      assert_select_object(statistics) do
+        assert_select ".document-collections a[href=?]", public_document_path(collection)
+      end
     end
   end
 
   view_test '#index requested as JSON includes document collection information' do
-    create(:departmental_editor)
-    statistics = create(:draft_statistics)
-    collection = create(:document_collection, :with_group)
-    collection.groups.first.documents = [statistics.document]
-    stub_publishing_api_registration_for([collection, statistics])
-    Whitehall.edition_services.force_publisher(collection).perform!
-    Whitehall.edition_services.force_publisher(statistics).perform!
+    Sidekiq::Testing.inline! do
+      create(:departmental_editor)
+      statistics = create(:draft_statistics)
+      collection = create(:document_collection, :with_group)
+      collection.groups.first.documents = [statistics.document]
+      stub_publishing_api_registration_for([collection, statistics])
+      Whitehall.edition_services.force_publisher(collection).perform!
+      Whitehall.edition_services.force_publisher(statistics).perform!
 
-    get :index, format: :json
+      get :index, format: :json
 
-    json = ActiveSupport::JSON.decode(response.body)
-    result = json['results'].first['result']
+      json = ActiveSupport::JSON.decode(response.body)
+      result = json['results'].first['result']
 
-    path = public_document_path(collection)
-    link = %{<a href="#{path}">#{collection.title}</a>}
-    assert_equal %{Part of a collection: #{link}}, result['publication_collections']
+      path = public_document_path(collection)
+      link = %{<a href="#{path}">#{collection.title}</a>}
+      assert_equal %{Part of a collection: #{link}}, result['publication_collections']
+    end
   end
 
   view_test "index generates an atom feed with entries for statistics matching the current filter" do
-    organisation_1 = create(:organisation, name: "org-name")
-    organisation_2 = create(:organisation, name: "other-org")
-    statistics_publication = create(:published_statistics, title: "statistics-title",
-                                                           organisations: [organisation_1, organisation_2],
-                                                           first_published_at: Date.parse("2012-03-14"))
+    Sidekiq::Testing.inline! do
+      organisation_1 = create(:organisation, name: "org-name")
+      organisation_2 = create(:organisation, name: "other-org")
+      statistics_publication = create(:published_statistics, title: "statistics-title",
+                                                             organisations: [organisation_1, organisation_2],
+                                                             first_published_at: Date.parse("2012-03-14"))
 
-    get :index, params: { departments: [organisation_1.to_param] }, format: :atom
+      get :index, params: { departments: [organisation_1.to_param] }, format: :atom
 
-    assert_select_atom_feed do
-      assert_select_atom_entries([statistics_publication])
+      assert_select_atom_feed do
+        assert_select_atom_entries([statistics_publication])
+      end
     end
   end
 
   view_test 'index includes tracking details on all links' do
-    published_statistics = create(:published_statistics)
+    Sidekiq::Testing.inline! do
+      published_statistics = create(:published_statistics)
 
-    get :index
+      get :index
 
-    assert_select_object(published_statistics) do
-      results_list = css_select('ol.document-list').first
+      assert_select_object(published_statistics) do
+        results_list = css_select('ol.document-list').first
 
-      assert_equal(
-        'track-click',
-        results_list.attributes['data-module'].value,
-        "Expected the document list to have the 'track-click' module"
-      )
+        assert_equal(
+          'track-click',
+          results_list.attributes['data-module'].value,
+          "Expected the document list to have the 'track-click' module"
+        )
 
-      statistics_link = css_select('li.document-row a').first
+        statistics_link = css_select('li.document-row a').first
 
-      assert_equal(
-        'navStatisticLinkClicked',
-        statistics_link.attributes['data-category'].value,
-        "Expected the data category attribute to be 'navStatisticLinkClicked'"
-      )
+        assert_equal(
+          'navStatisticLinkClicked',
+          statistics_link.attributes['data-category'].value,
+          "Expected the data category attribute to be 'navStatisticLinkClicked'"
+        )
 
-      assert_equal(
-        '1',
-        statistics_link.attributes['data-action'].value,
-        "Expected the data action attribute to be the 1st position on the list"
-      )
+        assert_equal(
+          '1',
+          statistics_link.attributes['data-action'].value,
+          "Expected the data action attribute to be the 1st position on the list"
+        )
 
-      assert_equal(
-        public_document_path(published_statistics),
-        statistics_link.attributes['data-label'].value,
-        "Expected the data label attribute to be the link of the published statistic"
-      )
+        assert_equal(
+          public_document_path(published_statistics),
+          statistics_link.attributes['data-label'].value,
+          "Expected the data label attribute to be the link of the published statistic"
+        )
 
-      options = JSON.parse(statistics_link.attributes['data-options'].value)
+        options = JSON.parse(statistics_link.attributes['data-options'].value)
 
-      assert_equal(
-        '1',
-        options['dimension28'],
-        "Expected the custom dimension 28 to have the total number of published statistics"
-      )
+        assert_equal(
+          '1',
+          options['dimension28'],
+          "Expected the custom dimension 28 to have the total number of published statistics"
+        )
 
-      assert_equal(
-        published_statistics.title,
-        options['dimension29'],
-        "Expected the custom dimension 29 to have the title of the published statistic"
-      )
+        assert_equal(
+          published_statistics.title,
+          options['dimension29'],
+          "Expected the custom dimension 29 to have the title of the published statistic"
+        )
+      end
     end
   end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -13,13 +13,17 @@ class AssetManagerIntegrationTest
     test 'sends the attachment to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
 
-      @attachment.save!
+      Sidekiq::Testing.inline! do
+        @attachment.save!
+      end
     end
 
     test 'marks the attachment as draft in Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(draft: true))
 
-      @attachment.save!
+      Sidekiq::Testing.inline! do
+        @attachment.save!
+      end
     end
   end
 
@@ -36,13 +40,17 @@ class AssetManagerIntegrationTest
     test 'sends the logo to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
 
-      @organisation.save!
+      Sidekiq::Testing.inline! do
+        @organisation.save!
+      end
     end
 
     test 'does not mark the logo as draft in Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
-      @organisation.save!
+      Sidekiq::Testing.inline! do
+        @organisation.save!
+      end
     end
   end
 
@@ -61,7 +69,9 @@ class AssetManagerIntegrationTest
 
       Services.asset_manager.expects(:delete_asset).with(logo_asset_id)
 
-      organisation.remove_logo!
+      Sidekiq::Testing.inline! do
+        organisation.remove_logo!
+      end
     end
   end
 
@@ -81,7 +91,10 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset).with(old_logo_asset_id)
 
       organisation.logo = File.open(fixture_path.join('images', '960x640_gif.gif'))
-      organisation.save!
+
+      Sidekiq::Testing.inline! do
+        organisation.save!
+      end
     end
   end
 
@@ -99,13 +112,17 @@ class AssetManagerIntegrationTest
     test 'sends the person image to Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/#{@filename}/))
 
-      @person.save!
+      Sidekiq::Testing.inline! do
+        @person.save!
+      end
     end
 
     test 'does not mark the image as draft in Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
-      @person.save!
+      Sidekiq::Testing.inline! do
+        @person.save!
+      end
     end
 
     test 'sends each version of the person image to Asset Manager' do
@@ -115,7 +132,9 @@ class AssetManagerIntegrationTest
         )
       end
 
-      @person.save!
+      Sidekiq::Testing.inline! do
+        @person.save!
+      end
     end
   end
 
@@ -141,7 +160,9 @@ class AssetManagerIntegrationTest
       expected_number_of_versions = @person.image.versions.size + 1
       Services.asset_manager.expects(:delete_asset).with(@asset_id).times(expected_number_of_versions)
 
-      @person.remove_image!
+      Sidekiq::Testing.inline! do
+        @person.remove_image!
+      end
     end
   end
 
@@ -162,14 +183,20 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:create_whitehall_asset).times(expected_number_of_versions)
 
       @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
+
+      Sidekiq::Testing.inline! do
+        @person.save!
+      end
     end
 
     test 'does not remove the original images from asset manager' do
       Services.asset_manager.expects(:delete_asset).never
 
       @person.image = File.open(fixture_path.join('big-cheese.960x640.jpg'))
-      @person.save!
+
+      Sidekiq::Testing.inline! do
+        @person.save!
+      end
     end
   end
 
@@ -187,13 +214,17 @@ class AssetManagerIntegrationTest
         file_and_legacy_url_path_matching(/#{@filename}/)
       )
 
-      @consultation_response_form_data.save!
+      Sidekiq::Testing.inline! do
+        @consultation_response_form_data.save!
+      end
     end
 
     test 'does not mark the consultation response form data as draft in Asset Manager' do
       Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:draft)))
 
-      @consultation_response_form_data.save!
+      Sidekiq::Testing.inline! do
+        @consultation_response_form_data.save!
+      end
     end
   end
 
@@ -218,7 +249,9 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:delete_asset)
         .with(@consultation_response_form_asset_id)
 
-      @consultation_response_form_data.remove_file!
+      Sidekiq::Testing.inline! do
+        @consultation_response_form_data.remove_file!
+      end
     end
   end
 
@@ -244,7 +277,10 @@ class AssetManagerIntegrationTest
         .with(@consultation_response_form_asset_id)
 
       @consultation_response_form_data.file = File.open(fixture_path.join('whitepaper.pdf'))
-      @consultation_response_form_data.save!
+
+      Sidekiq::Testing.inline! do
+        @consultation_response_form_data.save!
+      end
     end
   end
 end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -29,7 +29,10 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
-      click_button 'Force publish'
+      Sidekiq::Testing.inline! do
+        click_button 'Force publish'
+      end
+
       assert_text "The document #{edition.title} has been published"
     end
   end
@@ -52,9 +55,12 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true)
 
-      within '#js-published-in-error-form' do
-        click_button 'Unpublish'
+      Sidekiq::Testing.inline! do
+        within '#js-published-in-error-form' do
+          click_button 'Unpublish'
+        end
       end
+
       assert_text 'This document has been unpublished'
     end
   end
@@ -80,7 +86,10 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
-      click_button 'Force publish'
+      Sidekiq::Testing.inline! do
+        click_button 'Force publish'
+      end
+
       assert_text "The document #{edition.title} has been published"
     end
   end
@@ -106,7 +115,10 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
-      click_button 'Force publish'
+      Sidekiq::Testing.inline! do
+        click_button 'Force publish'
+      end
+
       assert_text "The document #{edition.title} has been published"
     end
   end
@@ -123,7 +135,10 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
 
       Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
 
-      click_button 'Save'
+      Sidekiq::Testing.inline! do
+        click_button 'Save'
+      end
+
       assert_text "Attachment 'Attachment Title' uploaded"
     end
   end

--- a/test/integration/contact_test.rb
+++ b/test/integration/contact_test.rb
@@ -25,7 +25,9 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "When a contact is saved, a 'contact' content item is published to the Publishing API" do
-    @contact.save!
+    Sidekiq::Testing.inline! do
+      @contact.save!
+    end
 
     assert_publishing_api_put_content(@contact.content_id,
                                       request_json_includes(

--- a/test/integration/operational_field_publishing_test.rb
+++ b/test/integration/operational_field_publishing_test.rb
@@ -11,18 +11,20 @@ class OperationalFieldPublishingTest < ActiveSupport::TestCase
   end
 
   test "OperationalField is published to the Publishing API on save" do
-    operational_field = build(:operational_field)
-    operational_field.save!
+    Sidekiq::Testing.inline! do
+      operational_field = build(:operational_field)
+      operational_field.save!
 
-    assert_publishing_api_put_content(
-      operational_field.content_id,
-      PublishingApiPresenters.presenter_for(operational_field).content
-    )
+      assert_publishing_api_put_content(
+        operational_field.content_id,
+        PublishingApiPresenters.presenter_for(operational_field).content
+      )
 
-    assert_publishing_api_publish(
-      operational_field.content_id,
-      { update_type: 'major', locale: 'en' },
-      1
-    )
+      assert_publishing_api_publish(
+        operational_field.content_id,
+        { update_type: 'major', locale: 'en' },
+        1
+      )
+    end
   end
 end

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -16,7 +16,9 @@ class PublishingTest < ActiveSupport::TestCase
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
-    perform_force_publishing_for(@draft_edition)
+    Sidekiq::Testing.inline! do
+      perform_force_publishing_for(@draft_edition)
+    end
 
     assert_all_requested(requests)
   end
@@ -39,7 +41,9 @@ class PublishingTest < ActiveSupport::TestCase
 
     links_request = stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links)
 
-    perform_force_publishing_for(@draft_edition)
+    Sidekiq::Testing.inline! do
+      perform_force_publishing_for(@draft_edition)
+    end
 
     assert_all_requested(english_requests)
     assert_all_requested(french_requests)

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -2,10 +2,17 @@ require "test_helper"
 
 class RequestTracingTest < ActionDispatch::IntegrationTest
   setup do
+    @sidekiq_test_mode = Sidekiq::Testing.__test_mode
+    Sidekiq::Testing.inline!
+
     @govuk_request_id = "12345-67890"
     @draft_edition = create(:draft_publication)
     @presenter = PublishingApiPresenters.presenter_for(@draft_edition)
     login_as(create(:gds_admin))
+  end
+
+  teardown do
+    Sidekiq::Testing.__test_mode = @sidekiq_test_mode
   end
 
   def force_publish(edition, headers = {})

--- a/test/integration/scheduling_test.rb
+++ b/test/integration/scheduling_test.rb
@@ -15,88 +15,98 @@ class SchedulingTest < ActiveSupport::TestCase
   end
 
   test "scheduling a first-edition publishes a publish intent and 'coming_soon' content item to the Publishing API" do
-    path = Whitehall.url_maker.public_document_path(@submitted_edition)
-    schedule(@submitted_edition)
-    assert_publishing_api_put_content(@submitted_edition.content_id,
-                                      request_json_includes(schema_name: 'coming_soon'))
-    assert_publishing_api_put_intent(path, publish_time: @submitted_edition.scheduled_publication.as_json)
+    Sidekiq::Testing.inline! do
+      path = Whitehall.url_maker.public_document_path(@submitted_edition)
+      schedule(@submitted_edition)
+      assert_publishing_api_put_content(@submitted_edition.content_id,
+                                        request_json_includes(schema_name: 'coming_soon'))
+      assert_publishing_api_put_intent(path, publish_time: @submitted_edition.scheduled_publication.as_json)
+    end
   end
 
   test "scheduling a subsequent edition publishes a publish intent to the Publishing API" do
-    published_edition = nil
-    new_draft = nil
-    user = nil
+    Sidekiq::Testing.inline! do
+      published_edition = nil
+      new_draft = nil
+      user = nil
 
-    disable_publishes_to_publishing_api do
-      published_edition = create(:published_publication)
-      new_draft = published_edition.create_draft(published_edition.creator)
-      new_draft.change_note = 'changed'
-      new_draft.scheduled_publication = 1.day.from_now
-      new_draft.save!
-      new_draft.submit!
+      disable_publishes_to_publishing_api do
+        published_edition = create(:published_publication)
+        new_draft = published_edition.create_draft(published_edition.creator)
+        new_draft.change_note = 'changed'
+        new_draft.scheduled_publication = 1.day.from_now
+        new_draft.save!
+        new_draft.submit!
 
-      user = create(:user)
+        user = create(:user)
+      end
+
+      path = Whitehall.url_maker.public_document_path(new_draft)
+
+      acting_as(user) { schedule(new_draft) }
+
+      assert_not_requested(:put, %r{#{PUBLISHING_API_V2_ENDPOINT}/content.*})
+      assert_publishing_api_put_intent(path, publish_time: new_draft.scheduled_publication.as_json)
     end
-
-    path = Whitehall.url_maker.public_document_path(new_draft)
-
-    acting_as(user) { schedule(new_draft) }
-
-    assert_not_requested(:put, %r{#{PUBLISHING_API_V2_ENDPOINT}/content.*})
-    assert_publishing_api_put_intent(path, publish_time: new_draft.scheduled_publication.as_json)
   end
 
   test "scheduling a translated edition publishes a publish intent for each translation" do
-    I18n.with_locale :fr do
-      @submitted_edition.title = "French title"
-      @submitted_edition.save!
+    Sidekiq::Testing.inline! do
+      I18n.with_locale :fr do
+        @submitted_edition.title = "French title"
+        @submitted_edition.save!
+      end
+
+      english_path = Whitehall.url_maker.public_document_path(@submitted_edition)
+      french_path  = Whitehall.url_maker.public_document_path(@submitted_edition, locale: :fr)
+      publish_time = @submitted_edition.scheduled_publication.as_json
+
+      schedule(@submitted_edition)
+
+      assert_publishing_api_put_intent(english_path, publish_time: publish_time)
+      assert_publishing_api_put_intent(french_path, publish_time: publish_time)
     end
-
-    english_path = Whitehall.url_maker.public_document_path(@submitted_edition)
-    french_path  = Whitehall.url_maker.public_document_path(@submitted_edition, locale: :fr)
-    publish_time = @submitted_edition.scheduled_publication.as_json
-
-    schedule(@submitted_edition)
-
-    assert_publishing_api_put_intent(english_path, publish_time: publish_time)
-    assert_publishing_api_put_intent(french_path, publish_time: publish_time)
   end
 
   test "unscheduling a scheduled first-edition removes the publish intent and deletes the 'coming_soon' item" do
-    gone_uuid = SecureRandom.uuid
-    SecureRandom.stubs(uuid: gone_uuid)
-    scheduled_edition = create(:scheduled_case_study)
-    unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-    base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
+    Sidekiq::Testing.inline! do
+      gone_uuid = SecureRandom.uuid
+      SecureRandom.stubs(uuid: gone_uuid)
+      scheduled_edition = create(:scheduled_case_study)
+      unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
+      base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
 
-    destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
-    gone_request = stub_publishing_api_unpublish(
-      scheduled_edition.content_id,
-      body: {
-        type: "vanish",
-        locale: "en",
-      }
-    )
+      destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
+      gone_request = stub_publishing_api_unpublish(
+        scheduled_edition.content_id,
+        body: {
+          type: "vanish",
+          locale: "en",
+        }
+      )
 
-    unscheduler.perform!
+      unscheduler.perform!
 
-    assert_requested destroy_intent_request
-    assert_requested gone_request
+      assert_requested destroy_intent_request
+      assert_requested gone_request
+    end
   end
 
   test "unscheduling a scheduled subsequent edition removes the publish intent but doesn't delete the original item" do
-    published_edition = create(:published_case_study)
-    scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
+    Sidekiq::Testing.inline! do
+      published_edition = create(:published_case_study)
+      scheduled_edition = create(:scheduled_case_study, document: published_edition.document)
 
-    unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
-    base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
+      unscheduler       = Whitehall.edition_services.unscheduler(scheduled_edition)
+      base_path         = Whitehall.url_maker.public_document_path(scheduled_edition)
 
-    destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
+      destroy_intent_request = stub_publishing_api_destroy_intent(base_path)
 
-    unscheduler.perform!
+      unscheduler.perform!
 
-    assert_requested destroy_intent_request
-    assert_not_requested(:put, %r{#{PUBLISHING_API_ENDPOINT}/content.*})
+      assert_requested destroy_intent_request
+      assert_not_requested(:put, %r{#{PUBLISHING_API_ENDPOINT}/content.*})
+    end
   end
 
 private

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -12,63 +12,69 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
   end
 
   test "TopicalEventAboutPage is published to the Publishing API on save" do
-    presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
+    Sidekiq::Testing.inline! do
+      presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
 
-    @topical_event_about_page.save!
+      @topical_event_about_page.save!
 
-    expected_json = presenter.content.merge(
-      # This is to simulate what the time public timestamp will be after the
-      # page has been published
-      public_updated_at: Time.zone.now.as_json
-    )
+      expected_json = presenter.content.merge(
+        # This is to simulate what the time public timestamp will be after the
+        # page has been published
+        public_updated_at: Time.zone.now.as_json
+      )
 
-    assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
-    assert_publishing_api_publish(
-      @topical_event_about_page.content_id,
-      {
-        update_type: 'major',
-        locale: 'en'
-      },
-      1
-    )
+      assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
+      assert_publishing_api_publish(
+        @topical_event_about_page.content_id,
+        {
+          update_type: 'major',
+          locale: 'en'
+        },
+        1
+      )
+    end
   end
 
   test "TopicalEventAboutPage publishes gone route to the Publishing API on destroy" do
-    @topical_event_about_page.save!
+    Sidekiq::Testing.inline! do
+      @topical_event_about_page.save!
 
-    gone_request = stub_publishing_api_unpublish(
-      @topical_event_about_page.content_id,
-      body: {
-        type: "gone",
-        locale: "en",
-        discard_drafts: true,
-      }
-    )
+      gone_request = stub_publishing_api_unpublish(
+        @topical_event_about_page.content_id,
+        body: {
+          type: "gone",
+          locale: "en",
+          discard_drafts: true,
+        }
+      )
 
-    @topical_event_about_page.destroy
-    assert_requested gone_request
+      @topical_event_about_page.destroy
+      assert_requested gone_request
+    end
   end
 
   test "TopicalEventAboutPage is published to the Publishing API when updated" do
-    @topical_event_about_page.save!
-    @topical_event_about_page.read_more_link_text = "New read more link text"
-    @topical_event_about_page.save!
-    presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
+    Sidekiq::Testing.inline! do
+      @topical_event_about_page.save!
+      @topical_event_about_page.read_more_link_text = "New read more link text"
+      @topical_event_about_page.save!
+      presenter = PublishingApiPresenters.presenter_for(@topical_event_about_page)
 
-    expected_json = presenter.content.merge(
-      # This is to simulate what the time public timestamp will be after the
-      # page has been published
-      public_updated_at: Time.zone.now.as_json
-    )
+      expected_json = presenter.content.merge(
+        # This is to simulate what the time public timestamp will be after the
+        # page has been published
+        public_updated_at: Time.zone.now.as_json
+      )
 
-    assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
-    assert_publishing_api_publish(
-      @topical_event_about_page.content_id,
-      {
-        update_type: 'major',
-        locale: 'en'
-      },
-      2
-    )
+      assert_publishing_api_put_content(@topical_event_about_page.content_id, expected_json)
+      assert_publishing_api_publish(
+        @topical_event_about_page.content_id,
+        {
+          update_type: 'major',
+          locale: 'en'
+        },
+        2
+      )
+    end
   end
 end

--- a/test/integration/unpublishing_test.rb
+++ b/test/integration/unpublishing_test.rb
@@ -22,7 +22,9 @@ class UnpublishingTest < ActiveSupport::TestCase
   end
 
   test "When an edition is unpublished, it is unpublished to the Publishing API" do
-    unpublish(@published_edition, unpublishing_params)
+    Sidekiq::Testing.inline! do
+      unpublish(@published_edition, unpublishing_params)
+    end
 
     assert_publishing_api_unpublish(
       @published_edition.document.content_id,
@@ -33,7 +35,9 @@ class UnpublishingTest < ActiveSupport::TestCase
   test "When an edition is unpublished, a job is queued to republish the draft to the draft stack" do
     Whitehall::PublishingApi.expects(:save_draft_async).once
 
-    unpublish(@published_edition, unpublishing_params)
+    Sidekiq::Testing.inline! do
+      unpublish(@published_edition, unpublishing_params)
+    end
   end
 
   test "when a translated edition is unpublished, an request is made for each locale" do
@@ -43,7 +47,9 @@ class UnpublishingTest < ActiveSupport::TestCase
       @published_edition.save!(validate: false)
     end
 
-    unpublish(@published_edition, unpublishing_params)
+    Sidekiq::Testing.inline! do
+      unpublish(@published_edition, unpublishing_params)
+    end
 
     %w(en fr).each do |locale|
       assert_publishing_api_unpublish(
@@ -74,7 +80,9 @@ class UnpublishingTest < ActiveSupport::TestCase
                                        alternative_url: alternative_url
                                      )
 
-    unpublish(@published_edition, unpublishing_redirect_params)
+    Sidekiq::Testing.inline! do
+      unpublish(@published_edition, unpublishing_redirect_params)
+    end
 
     %w(en fr).each do |locale|
       assert_publishing_api_unpublish(

--- a/test/integration/withdrawing_test.rb
+++ b/test/integration/withdrawing_test.rb
@@ -3,23 +3,25 @@ require "gds_api/test_helpers/publishing_api"
 
 class WithdrawingTest < ActiveSupport::TestCase
   test "When an edition is withdrawn, it gets republished to the Publishing API with an withdrawn notice" do
-    edition = create(:published_case_study)
-    edition.build_unpublishing(explanation: 'Old information',
-      unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
+    Sidekiq::Testing.inline! do
+      edition = create(:published_case_study)
+      edition.build_unpublishing(explanation: 'Old information',
+        unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
 
-    request = stub_publishing_api_unpublish(
-      edition.content_id,
-      body: {
-        type: "withdrawal",
-        locale: "en",
-        explanation: "<div class=\"govspeak\"><p>Old information</p>\n</div>",
-        unpublished_at: edition.updated_at.utc.iso8601,
-      }
-    )
+      request = stub_publishing_api_unpublish(
+        edition.content_id,
+        body: {
+          type: "withdrawal",
+          locale: "en",
+          explanation: "<div class=\"govspeak\"><p>Old information</p>\n</div>",
+          unpublished_at: edition.updated_at.utc.iso8601,
+        }
+      )
 
-    perform_withdrawal(edition)
+      perform_withdrawal(edition)
 
-    assert_requested request
+      assert_requested request
+    end
   end
 
 private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require 'factories'
 require 'webmock/minitest'
 require 'whitehall/not_quite_as_fake_search'
 require 'whitehall/search_index'
-require 'sidekiq/testing/inline'
+require 'sidekiq/testing'
 require 'govuk-content-schema-test-helpers/test_unit'
 require 'parallel_tests/test/runtime_logger'
 
@@ -68,6 +68,7 @@ class ActiveSupport::TestCase
     Edition::AuditTrail.whodunnit = nil
     Timecop.return
     DatabaseCleaner.clean_with(:truncation, pre_count: true, reset_ids: false)
+    Sidekiq::Worker.clear_all
   end
 
   def acting_as(actor, &block)

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -44,7 +44,9 @@ module OrganisationResluggerTest
         stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
       ]
 
-      @reslugger.run!
+      Sidekiq::Testing.inline! do
+        @reslugger.run!
+      end
 
       assert_all_requested expected_publish_requests
     end

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -40,7 +40,9 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
-    @reslugger.run!
+    Sidekiq::Testing.inline! do
+      @reslugger.run!
+    end
 
     assert_all_requested(expected_publish_requests)
   end

--- a/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
@@ -12,7 +12,9 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 
-    DataHygiene::PublishingApiDocumentRepublisher.new(CaseStudy, NullLogger.instance).perform
+    Sidekiq::Testing.inline! do
+      DataHygiene::PublishingApiDocumentRepublisher.new(CaseStudy, NullLogger.instance).perform
+    end
 
     assert_all_requested(expected_requests)
   end
@@ -37,6 +39,8 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
     PublishingApiUnpublishingWorker.expects(:new).returns(worker = mock)
     worker.expects(:perform).with(unpublishing.id, true)
 
-    DataHygiene::PublishingApiDocumentRepublisher.new(edition.class, NullLogger.instance).perform
+    Sidekiq::Testing.inline! do
+      DataHygiene::PublishingApiDocumentRepublisher.new(edition.class, NullLogger.instance).perform
+    end
   end
 end

--- a/test/unit/data_hygiene/publishing_api_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_republisher_test.rb
@@ -16,7 +16,9 @@ class DataHygiene::PublishingApiRepublisherTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
     ]
 
-    DataHygiene::PublishingApiRepublisher.new(@scope, NullLogger.instance).perform
+    Sidekiq::Testing.inline! do
+      DataHygiene::PublishingApiRepublisher.new(@scope, NullLogger.instance).perform
+    end
 
     assert_all_requested(expected_requests)
   end

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -38,7 +38,9 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
-    @reslugger.run!
+    Sidekiq::Testing.inline! do
+      @reslugger.run!
+    end
 
     assert_all_requested(expected_publish_requests)
   end

--- a/test/unit/html_attachment_test.rb
+++ b/test/unit/html_attachment_test.rb
@@ -4,11 +4,13 @@ require 'test_helper'
 
 class HtmlAttachmentTest < ActiveSupport::TestCase
   test '#govspeak_content_body_html returns the computed HTML as an HTML safe string' do
-    attachment = create(:html_attachment, body: 'Some govspeak')
+    Sidekiq::Testing.inline! do
+      attachment = create(:html_attachment, body: 'Some govspeak')
 
-    assert attachment.reload.govspeak_content_body_html.html_safe?
-    assert_equivalent_html "<div class=\"govspeak\"><p>Some govspeak</p></div>",
-      attachment.govspeak_content_body_html
+      assert attachment.reload.govspeak_content_body_html.html_safe?
+      assert_equivalent_html "<div class=\"govspeak\"><p>Some govspeak</p></div>",
+        attachment.govspeak_content_body_html
+    end
   end
 
   test 'associated govspeak content is deleted with the html attachment' do

--- a/test/unit/image_uploader_test.rb
+++ b/test/unit/image_uploader_test.rb
@@ -30,7 +30,9 @@ class ImageUploaderTest < ActiveSupport::TestCase
       assert_image_has_correct_size image_path
     end
 
-    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+    Sidekiq::Testing.inline! do
+      @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+    end
   end
 
   test "should store uploads in a directory that persists across deploys" do
@@ -52,7 +54,9 @@ class ImageUploaderTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s300_minister-of-funk.960x640.jpg/))
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/s216_minister-of-funk.960x640.jpg/))
 
-    @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+    Sidekiq::Testing.inline! do
+      @uploader.store!(fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+    end
   end
 
   test "should store the original version only of a svg image in asset manager" do
@@ -62,7 +66,9 @@ class ImageUploaderTest < ActiveSupport::TestCase
     Services.asset_manager.stubs(:create_whitehall_asset)
     Services.asset_manager.expects(:create_whitehall_asset).with(file_and_legacy_url_path_matching(/test-svg.svg/))
 
-    @uploader.store!(fixture_file_upload('images/test-svg.svg', 'image/svg+xml'))
+    Sidekiq::Testing.inline! do
+      @uploader.store!(fixture_file_upload('images/test-svg.svg', 'image/svg+xml'))
+    end
   end
 
 private

--- a/test/unit/migrate_assets_to_asset_manager_test.rb
+++ b/test/unit/migrate_assets_to_asset_manager_test.rb
@@ -18,7 +18,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_whitehall_asset)
       .with(has_entry(:file, responds_with(:read, File.read(organisation_logo_path))))
 
-    @subject.perform
+    Sidekiq::Testing.inline! do
+      @subject.perform
+    end
   end
 
   test 'it calls create_whitehall_asset with the legacy file path' do
@@ -26,7 +28,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
       has_entry(:legacy_url_path, '/government/uploads/system/uploads/organisation/logo/1/logo.jpg')
     )
 
-    @subject.perform
+    Sidekiq::Testing.inline! do
+      @subject.perform
+    end
   end
 
   test 'it calls create_whitehall_asset with the legacy last modified time' do
@@ -36,7 +40,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
       has_entry(:legacy_last_modified, expected_last_modified)
     )
 
-    @subject.perform
+    Sidekiq::Testing.inline! do
+      @subject.perform
+    end
   end
 
   test 'it calls create_whitehall_asset with the legacy etag' do
@@ -49,7 +55,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
       has_entry(:legacy_etag, expected_etag)
     )
 
-    @subject.perform
+    Sidekiq::Testing.inline! do
+      @subject.perform
+    end
   end
 
   test 'it calls create_whitehall_asset with the draft flag set to false by default' do
@@ -57,7 +65,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
       has_entry(:draft, false)
     )
 
-    @subject.perform
+    Sidekiq::Testing.inline! do
+      @subject.perform
+    end
   end
 
   test 'it calls create_whitehall_asset with the draft flag set to true if explicitly set' do
@@ -67,7 +77,9 @@ class MigrateAssetsToAssetManagerTest < ActiveSupport::TestCase
       has_entry(:draft, true)
     )
 
-    subject.perform
+    Sidekiq::Testing.inline! do
+      subject.perform
+    end
   end
 
   test 'it does not call create_whitehall_asset if the asset already exists in asset manager' do

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -28,7 +28,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
       stub_publications_pusher(edition, "update_draft")
-      PublishingApiPusher.new(edition).push(event: "update_draft")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "update_draft")
+      end
     end
 
     test "saves attachments draft" do
@@ -40,7 +42,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:save_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "update_draft")
       stub_publications_pusher(edition, "update_draft")
-      PublishingApiPusher.new(edition).push(event: "update_draft")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "update_draft")
+      end
     end
 
     test "publish publishes" do
@@ -48,7 +52,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "publish")
       stub_publications_pusher(edition, "publish")
-      PublishingApiPusher.new(edition).push(event: "publish")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "publish")
+      end
     end
 
     test "force_publish publishes" do
@@ -56,7 +62,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:publish_async).with(edition)
       stub_html_attachment_pusher(edition, "force_publish")
       stub_publications_pusher(edition, "force_publish")
-      PublishingApiPusher.new(edition).push(event: "force_publish")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "force_publish")
+      end
     end
 
     test "update_draft_translation saves draft translation" do
@@ -64,7 +72,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:save_draft_translation_async).with(edition, 'en')
       stub_html_attachment_pusher(edition, "update_draft_translation")
       stub_publications_pusher(edition, "update_draft_translation")
-      PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
+      end
     end
 
     test "withdraw republishes" do
@@ -78,7 +88,9 @@ module ServiceListeners
       stub_html_attachment_pusher(edition, "withdraw")
       stub_publications_pusher(edition, "withdraw")
 
-      PublishingApiPusher.new(edition).push(event: "withdraw")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "withdraw")
+      end
     end
 
     test "unpublish publishes the unpublishing" do
@@ -86,7 +98,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
       stub_html_attachment_pusher(edition, "unpublish")
       stub_publications_pusher(edition, "unpublish")
-      PublishingApiPusher.new(edition).push(event: "unpublish")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "unpublish")
+      end
     end
 
     test "force_schedule schedules the edition" do
@@ -94,7 +108,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "force_schedule")
       stub_publications_pusher(edition, "force_schedule")
-      PublishingApiPusher.new(edition).push(event: "force_schedule")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "force_schedule")
+      end
     end
 
     test "schedule schedules the edition" do
@@ -102,7 +118,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
       stub_html_attachment_pusher(edition, "schedule")
       stub_publications_pusher(edition, "schedule")
-      PublishingApiPusher.new(edition).push(event: "schedule")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "schedule")
+      end
     end
 
     test "unschedule unschedules the edition" do
@@ -110,7 +128,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
       stub_html_attachment_pusher(edition, "unschedule")
       stub_publications_pusher(edition, "unschedule")
-      PublishingApiPusher.new(edition).push(event: "unschedule")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "unschedule")
+      end
     end
 
     test "delete discards draft" do
@@ -118,7 +138,9 @@ module ServiceListeners
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
       stub_html_attachment_pusher(edition, "delete")
       stub_publications_pusher(edition, "delete")
-      PublishingApiPusher.new(edition).push(event: "delete")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: "delete")
+      end
     end
 
     def draft_edition_with_deleted_translation(type)
@@ -162,7 +184,9 @@ module ServiceListeners
         fr.locale
       )
 
-      PublishingApiPusher.new(new_edition).push(event: "publish")
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(new_edition).push(event: "publish")
+      end
     end
 
     test 'handles corporate information pages' do
@@ -171,7 +195,9 @@ module ServiceListeners
       stub_corporate_information_pages_pusher(edition, 'update_draft')
       stub_html_attachment_pusher(edition, 'update_draft')
 
-      PublishingApiPusher.new(edition).push(event: 'update_draft')
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: 'update_draft')
+      end
     end
 
     test 'handles publications' do
@@ -180,7 +206,9 @@ module ServiceListeners
       stub_publications_pusher(edition, 'update_draft')
       stub_html_attachment_pusher(edition, 'update_draft')
 
-      PublishingApiPusher.new(edition).push(event: 'update_draft')
+      Sidekiq::Testing.inline! do
+        PublishingApiPusher.new(edition).push(event: 'update_draft')
+      end
     end
   end
 end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -272,16 +272,18 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   end
 
   test 'publishes to publishing api with a minor update type' do
-    edition = create(:statistics_announcement)
+    Sidekiq::Testing.inline! do
+      edition = create(:statistics_announcement)
 
-    presenter = PublishingApiPresenters.presenter_for(edition)
-    requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, update_type: "minor", locale: "en")
-    ]
+      presenter = PublishingApiPresenters.presenter_for(edition)
+      requests = [
+        stub_publishing_api_put_content(presenter.content_id, presenter.content),
+        stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
+        stub_publishing_api_publish(presenter.content_id, update_type: "minor", locale: "en")
+      ]
 
-    requests.each { |request| assert_requested request }
+      requests.each { |request| assert_requested request }
+    end
   end
 
 private

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -26,7 +26,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Whitehall::PublishingApi.publish_async(edition)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_async(edition)
+    end
 
     assert_all_requested(requests)
   end
@@ -41,7 +43,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Whitehall::PublishingApi.publish_async(organisation)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_async(organisation)
+    end
 
     assert_all_requested(requests)
   end
@@ -56,7 +60,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Whitehall::PublishingApi.publish_async(edition)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_async(edition)
+    end
 
     assert_all_requested(requests)
   end
@@ -83,7 +89,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
-    Whitehall::PublishingApi.publish_async(organisation)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_async(organisation)
+    end
 
     assert_all_requested(french_requests)
     assert_all_requested(english_requests)
@@ -114,7 +122,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
-    Whitehall::PublishingApi.republish_async(take_part_page)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.republish_async(take_part_page)
+    end
 
     assert_all_requested(requests)
   end
@@ -141,7 +151,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
-    Whitehall::PublishingApi.republish_async(organisation)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.republish_async(organisation)
+    end
 
     assert_all_requested(french_requests)
     assert_all_requested(english_requests)
@@ -166,7 +178,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
-    Whitehall::PublishingApi.bulk_republish_async(take_part_page)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.bulk_republish_async(take_part_page)
+    end
 
     assert_all_requested(requests)
   end
@@ -196,7 +210,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(html_attachment_content_id, locale: presenter.content[:locale], update_type: 'republish')
     ]
 
-    Whitehall::PublishingApi.republish_document_async(edition.document)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.republish_document_async(edition.document)
+    end
 
     assert_all_requested(requests)
   end
@@ -314,7 +330,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     payload = PublishingApiPresenters.presenter_for(draft_edition)
     request = stub_publishing_api_put_content(payload.content_id, payload.content)
 
-    Whitehall::PublishingApi.save_draft_async(draft_edition)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.save_draft_async(draft_edition)
+    end
 
     assert_requested request
   end
@@ -345,7 +363,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       }
     )
 
-    Whitehall::PublishingApi.publish_redirect_async(redirect_uuid, destination)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_redirect_async(redirect_uuid, destination)
+    end
 
     assert_requested redirect_request
   end
@@ -362,7 +382,9 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       }
     )
 
-    Whitehall::PublishingApi.publish_gone_async(gone_uuid, nil, nil)
+    Sidekiq::Testing.inline! do
+      Whitehall::PublishingApi.publish_gone_async(gone_uuid, nil, nil)
+    end
 
     assert_requested gone_request
   end

--- a/test/unit/workers/check_all_organisations_links_worker_test.rb
+++ b/test/unit/workers/check_all_organisations_links_worker_test.rb
@@ -25,7 +25,9 @@ class CheckAllOrganisationsLinksWorkerTest < ActiveSupport::TestCase
     stub_published_publication
     stub_news_article
 
-    CheckAllOrganisationsLinksWorker.new.perform
+    Sidekiq::Testing.inline! do
+      CheckAllOrganisationsLinksWorker.new.perform
+    end
 
     assert_equal 2, LinkCheckerApiReport.count
   end

--- a/test/unit/workers/publishing_api_html_attachments_worker_test.rb
+++ b/test/unit/workers/publishing_api_html_attachments_worker_test.rb
@@ -187,7 +187,9 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
         "en"
       )
 
-      call(publication)
+      Sidekiq::Testing.inline! do
+        call(publication)
+      end
     end
   end
 
@@ -326,7 +328,9 @@ class PublishingApiHtmlAttachmentsWorkerTest < ActiveSupport::TestCase
         attachment.content_id,
         "en"
       )
-      call(publication)
+      Sidekiq::Testing.inline! do
+        call(publication)
+      end
     end
 
     test "for a withdrawn publicaton with an attachment withdraws the attachment" do

--- a/test/unit/workers/worker_base_test.rb
+++ b/test/unit/workers/worker_base_test.rb
@@ -12,7 +12,9 @@ class WorkerBaseTest < ActiveSupport::TestCase
 
   test ".perform_async runs the job" do
     self.class.expects(:worker_has_run!)
-    MyWorker.perform_async
+    Sidekiq::Testing.inline! do
+      MyWorker.perform_async
+    end
   end
 
   test ".perform_async_in_queue runs the job in the specified queue" do


### PR DESCRIPTION
Sidekiq's [`fake` mode][1] is its default mode for testing. It appends jobs to a `jobs` array for inspection/processing instead of immediately executing the worker as with the `inline` mode. I think this is preferable because it forces us to be explicit in any tests that are relying on Sidekiq jobs to be processed. The tests requiring the Sidekiq jobs to be processed were updated in the previous commits in this branch.

The first commits in this branch explicitly enable Sidekiq's `inline` mode for those tests that rely on Sidekiq jobs being processed and the final commit contains the switch to using `fake` mode by default.

Note that I've chosen to clear all Sidekiq queues in the `teardown` block of `ActiveSupport::TestCase` in test_helper.rb. This isn't necessary for the tests to pass but the Sidekiq wiki suggests we do it to avoid jobs remaining in the queue between tests.

Note that the default mode for Cucumber tests is still `inline`.

Note that Sidekiq's `inline` mode was enabled in b3001c6e038dab9804d436a1971fcfdefb58bfd2 (PR #893) but it's not obvious why.

I think it's possible that we might see a speed improvement in the tests with this change as there'll be less code being executed.

[1]: https://github.com/mperham/sidekiq/wiki/Testing#testing-worker-queueing-fake
