### PR TITLE
Redirect requests for attachments on unpublished consultation outcomes & public feedback

### DIFF
--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -41,7 +41,8 @@ class AttachmentVisibility
   end
 
   def unpublished_edition
-    if (unpublishing = Unpublishing.where(edition_id: edition_ids).first)
+    attachable_ids = edition_ids + consultation_ids
+    if (unpublishing = Unpublishing.where(edition_id: attachable_ids).first)
       Edition.unscoped.find(unpublishing.edition_id)
     end
   end

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -1,0 +1,221 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+
+  let(:filename) { 'sample.docx' }
+  let(:file) { File.open(path_to_attachment(filename)) }
+  let(:attachment) { build(:file_attachment, attachable: attachable, file: file) }
+  let(:attachable) { edition }
+  let(:redirect_url) { Whitehall.url_maker.public_document_path(edition) }
+
+  before do
+    login_as create(:managing_editor)
+    setup_publishing_api_for(edition)
+    attachable.attachments << attachment
+    VirusScanHelpers.simulate_virus_scan
+    stub_whitehall_asset(filename, id: 'asset-id')
+  end
+
+  context 'given a published document with file attachment' do
+    let(:edition) { create(:published_news_article) }
+
+    it 'redirects attachment requests when document is unpublished' do
+      visit admin_news_article_path(edition)
+      unpublish_document_published_in_error
+      logout
+      get attachment.url
+      assert_redirected_to redirect_url
+    end
+
+    it 'redirects attachment requests when document is consolidated' do
+      visit admin_news_article_path(edition)
+      consolidate_document
+      logout
+      get attachment.url
+      assert_redirected_to redirect_url
+    end
+
+    it 'does not redirect attachment requests when document is withdrawn' do
+      visit admin_news_article_path(edition)
+      withdraw_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given a published consultation with outcome with file attachment' do
+    let(:edition) { create(:published_consultation) }
+    let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+    let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+    # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
+    it 'does not redirect attachment requests when document is unpublished' do
+    # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
+    # it 'redirects attachment requests when document is unpublished' do
+      visit admin_consultation_path(edition)
+      unpublish_document_published_in_error
+      logout
+      get attachment.url
+      # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
+      assert_response :not_found
+      # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
+      # assert_redirected_to redirect_url
+    end
+
+    it 'does not redirect attachment requests when document is withdrawn' do
+      visit admin_consultation_path(edition)
+      withdraw_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given a published consultation with feedback with file attachment' do
+    let(:edition) { create(:published_consultation) }
+    let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
+    let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
+
+    # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
+    it 'does not redirect attachment requests when document is unpublished' do
+    # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
+    # it 'redirects attachment requests when document is unpublished' do
+      visit admin_consultation_path(edition)
+      unpublish_document_published_in_error
+      logout
+      get attachment.url
+      # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
+      assert_response :not_found
+      # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
+      # assert_redirected_to redirect_url
+    end
+
+    it 'does not redirect attachment requests when document is withdrawn' do
+      visit admin_consultation_path(edition)
+      withdraw_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given an unpublished document with file attachment' do
+    let(:edition) { create(:news_article, :unpublished) }
+
+    it 'does not redirect attachment requests when document is published' do
+      visit admin_news_article_path(edition)
+      force_publish_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given an unpublished consultation with outcome with file attachment' do
+    let(:edition) { create(:consultation, :unpublished) }
+    let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+    let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+    it 'does not redirect attachment requests when document is published' do
+      visit admin_consultation_path(edition)
+      force_publish_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given a withdrawn document with file attachment' do
+    let(:edition) { create(:news_article, :published, :withdrawn) }
+
+    it 'does not redirect attachment requests when document is unwithdrawn' do
+      visit admin_news_article_path(edition)
+      unwithdraw_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+  context 'given a withdrawn consultation with outcome with file attachment' do
+    let(:edition) { create(:consultation, :published, :withdrawn) }
+    let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+    let(:attachable) { edition.create_outcome!(outcome_attributes) }
+
+    it 'does not redirect attachment requests when document is unwithdrawn' do
+      visit admin_consultation_path(edition)
+      unwithdraw_document
+      logout
+      get attachment.url
+      assert_response :success
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def setup_publishing_api_for(edition)
+    publishing_api_has_links(
+      content_id: edition.document.content_id,
+      links: {}
+    )
+  end
+
+  def path_to_attachment(filename)
+    fixture_path.join(filename)
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+
+  def unpublish_document_published_in_error
+    click_link 'Withdraw or unpublish'
+    within '#js-published-in-error-form' do
+      click_button 'Unpublish'
+    end
+    assert_text 'This document has been unpublished'
+  end
+
+  def consolidate_document
+    click_link 'Withdraw or unpublish'
+    within '#js-consolidated-form' do
+      fill_in 'consolidated_alternative_url', with: 'https://www.test.gov.uk/example'
+      click_button 'Unpublish'
+    end
+    assert_text 'This document has been unpublished'
+  end
+
+  def withdraw_document
+    click_link 'Withdraw or unpublish'
+    within '#js-withdraw-form' do
+      fill_in 'withdrawal_explanation', with: 'testing'
+      click_button 'Withdraw'
+    end
+    assert_text 'This document has been marked as withdrawn'
+  end
+
+  def force_publish_document
+    click_link 'Force publish'
+    fill_in 'Reason for force publishing', with: 'testing'
+    click_button 'Force publish'
+    assert_text %r{The document .* has been published}
+  end
+
+  def unwithdraw_document
+    click_link 'Unwithdraw'
+    click_button 'Unwithdraw'
+    assert_text 'This document has been unwithdrawn'
+  end
+end

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -53,18 +53,12 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:outcome_attributes) { attributes_for(:consultation_outcome) }
     let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-    # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
-    it 'does not redirect attachment requests when document is unpublished' do
-    # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
-    # it 'redirects attachment requests when document is unpublished' do
+    it 'redirects attachment requests when document is unpublished' do
       visit admin_consultation_path(edition)
       unpublish_document_published_in_error
       logout
       get attachment.url
-      # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
-      assert_response :not_found
-      # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
-      # assert_redirected_to redirect_url
+      assert_redirected_to redirect_url
     end
 
     it 'does not redirect attachment requests when document is withdrawn' do
@@ -81,18 +75,12 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
     let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
 
-    # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
-    it 'does not redirect attachment requests when document is unpublished' do
-    # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
-    # it 'redirects attachment requests when document is unpublished' do
+    it 'redirects attachment requests when document is unpublished' do
       visit admin_consultation_path(edition)
       unpublish_document_published_in_error
       logout
       get attachment.url
-      # TODO: Remove when bug in AttachmentVisibility#unpublished_edition fixed
-      assert_response :not_found
-      # TODO: Uncomment when bug in AttachmentVisibility#unpublished_edition fixed
-      # assert_redirected_to redirect_url
+      assert_redirected_to redirect_url
     end
 
     it 'does not redirect attachment requests when document is withdrawn' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -232,13 +232,20 @@ end
 
 class ActionDispatch::IntegrationTest
   include LocalisedUrlPathHelper
+  include Warden::Test::Helpers
 
   def login_as(user)
     GDS::SSO.test_user = user
+    super
   end
 
   def login_as_admin
     login_as(create(:user, name: "user-name", email: "user@example.com"))
+  end
+
+  def logout
+    GDS::SSO.test_user = nil
+    super
   end
 
   teardown do

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -162,6 +162,38 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     assert_equal deleted_edition, attachment_visibility.unpublished_edition
   end
 
+  test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation outcome' do
+    unpublished_consultation = create(:consultation, :unpublished)
+    outcome = unpublished_consultation.create_outcome!(attributes_for(:consultation_outcome))
+    file_attachment = build(:file_attachment, attachable: outcome)
+    outcome.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+
+    assert_equal unpublished_consultation, attachment_visibility.unpublished_edition
+  end
+
+  test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation feedback' do
+    unpublished_consultation = create(:consultation, :unpublished)
+    feedback = unpublished_consultation.create_public_feedback!(attributes_for(:consultation_public_feedback))
+    file_attachment = build(:file_attachment, attachable: feedback)
+    feedback.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+
+    assert_equal unpublished_consultation, attachment_visibility.unpublished_edition
+  end
+
+  test '#unpublished_edition returns nil for an attachment associated with a policy group' do
+    policy_group = create(:policy_group)
+    file_attachment = build(:file_attachment, attachable: policy_group)
+    policy_group.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+
+    assert_nil attachment_visibility.unpublished_edition
+  end
+
   test "#visible returns false for deleted attachment on a publication" do
     Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
 


### PR DESCRIPTION
Previously `AttachmentsController#show` was responding with a `404 Not Found` for attachments belonging to an unpublished consultation outcome/feedback rather than a `302 Redirect` to the parent document which is what happens for attachments belonging to an unpublished edition directly and I think the latter is the intended behaviour.

This was due to a bug in `AttachmentVisibility#unpublished_edition` which didn't handle the case when an attachment belongs to a consultation outcome/feedback, i.e. a non-edition class which includes the `Attachable` module.

I've added a fairly exhaustive integration test which uses the admin UI to trigger some document state transitions and then checks what behaviour an anonymous user would see when requesting an attachment. In the "Add AttachmentRedirectDueToUnpublishingIntegrationTest" commit I've added some `TODO` comments to highlight the incorrect behaviour. The "Fix redirects for attachment on consultation outcome/feedback" commit where the bug is fixed then allows me to remove the `TODO` comments.

My motivation for making this change is that it will make it easier to re-implement the same behaviour when the attachment assets are being served by Asset Manager.
