### PR TITLE
Update redirect URL of attachment assets in Asset Manager

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -41,7 +41,7 @@ private
 
   def fail
     if (edition = attachment_visibility.unpublished_edition)
-      redirect_to public_document_path(edition, id: edition.unpublishing.slug)
+      redirect_to edition.unpublishing.document_path
     elsif (replacement = attachment_data.replaced_by)
       expires_headers
       redirect_to replacement.url, status: 301

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -11,7 +11,8 @@ module ServiceListeners
       return unless attachment.file?
       attachment_data = attachment.attachment_data
       return unless attachment_data.present?
-      draft = !visibility_for(attachment_data).visible?
+      visibility = visibility_for(attachment_data)
+      draft = !(visibility.visible? || visibility.unpublished_edition)
       enqueue_job(attachment_data.file, draft)
       if attachment_data.pdf?
         enqueue_job(attachment_data.file.thumbnail, draft)

--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -1,0 +1,44 @@
+module ServiceListeners
+  class AttachmentRedirectUrlUpdater
+    include Rails.application.routes.url_helpers
+    include PublicDocumentRoutesHelper
+
+    attr_reader :attachment, :queue
+
+    def initialize(attachment, queue: nil)
+      @attachment = attachment
+      @queue = queue
+    end
+
+    def update!
+      return unless attachment.file?
+      attachment_data = attachment.attachment_data
+      return unless attachment_data.present?
+      visibility = visibility_for(attachment_data)
+      redirect_url = nil
+      if !visibility.visible? && (edition = visibility.unpublished_edition)
+        redirect_url = edition.unpublishing.document_path
+      end
+      enqueue_job(attachment_data.file, redirect_url)
+      if attachment_data.pdf?
+        enqueue_job(attachment_data.file.thumbnail, redirect_url)
+      end
+    end
+
+  private
+
+    def visibility_for(attachment_data)
+      AttachmentVisibility.new(attachment_data, _anonymous_user = nil)
+    end
+
+    def enqueue_job(uploader, redirect_url)
+      legacy_url_path = uploader.asset_manager_path
+      worker.perform_async(legacy_url_path, redirect_url: redirect_url)
+    end
+
+    def worker
+      worker = AssetManagerUpdateAssetWorker
+      queue.present? ? worker.set(queue: queue) : worker
+    end
+  end
+end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,7 +1,8 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
   def perform(legacy_url_path, attributes = {})
     gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
-    unless gds_api_response['draft'] == attributes['draft']
+    keys = attributes.keys
+    unless gds_api_response.slice(*keys) == attributes.slice(*keys)
       asset_url = gds_api_response['id']
       asset_id = asset_url[/\/assets\/(.*)/, 1]
       Services.asset_manager.update_asset(asset_id, attributes)

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -11,6 +11,9 @@ Whitehall.edition_services.tap do |coordinator|
       ServiceListeners::AttachmentDraftStatusUpdater
         .new(attachment)
         .update!
+      ServiceListeners::AttachmentRedirectUrlUpdater
+        .new(attachment)
+        .update!
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -46,11 +46,11 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       stub_whitehall_asset('sample.docx', id: 'asset-id', draft: false)
     end
 
-    it 'marks attachment as draft in Asset Manager when document is unpublished' do
+    it 'does not mark attachment as draft in Asset Manager when document is unpublished' do
       visit admin_news_article_path(edition)
       click_link 'Withdraw or unpublish'
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true)
+      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true).never
 
       within '#js-published-in-error-form' do
         click_button 'Unpublish'

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -18,6 +18,13 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     attachable.attachments << attachment
     VirusScanHelpers.simulate_virus_scan
     stub_whitehall_asset(filename, id: 'asset-id')
+
+    @test_mode = Sidekiq::Testing.__test_mode
+    Sidekiq::Testing.fake!
+  end
+
+  after do
+    Sidekiq::Testing.__test_mode = @test_mode
   end
 
   context 'given a published document with file attachment' do

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -10,6 +10,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
   let(:file) { File.open(path_to_attachment(filename)) }
   let(:attachment) { build(:file_attachment, attachable: attachable, file: file) }
   let(:attachable) { edition }
+  let(:asset_id) { 'asset-id' }
   let(:redirect_url) { Whitehall.url_maker.public_document_path(edition) }
 
   before do
@@ -17,7 +18,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     setup_publishing_api_for(edition)
     attachable.attachments << attachment
     VirusScanHelpers.simulate_virus_scan
-    stub_whitehall_asset(filename, id: 'asset-id')
+    stub_whitehall_asset(filename, id: asset_id)
 
     @test_mode = Sidekiq::Testing.__test_mode
     Sidekiq::Testing.fake!
@@ -30,28 +31,31 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
   context 'given a published document with file attachment' do
     let(:edition) { create(:published_news_article) }
 
-    it 'redirects attachment requests when document is unpublished' do
+    it 'sets redirect URL for attachment in Asset Manager when document is unpublished' do
       visit admin_news_article_path(edition)
       unpublish_document_published_in_error
       logout
       get attachment.url
       assert_redirected_to redirect_url
+      assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'redirects attachment requests when document is consolidated' do
+    it 'sets redirect URL for attachment in Asset Manager when document is consolidated' do
       visit admin_news_article_path(edition)
       consolidate_document
       logout
       get attachment.url
       assert_redirected_to redirect_url
+      assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'does not redirect attachment requests when document is withdrawn' do
+    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_news_article_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
@@ -60,20 +64,22 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:outcome_attributes) { attributes_for(:consultation_outcome) }
     let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-    it 'redirects attachment requests when document is unpublished' do
+    it 'sets redirect URL for attachment in Asset Manager when document is unpublished' do
       visit admin_consultation_path(edition)
       unpublish_document_published_in_error
       logout
       get attachment.url
       assert_redirected_to redirect_url
+      assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'does not redirect attachment requests when document is withdrawn' do
+    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_consultation_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
@@ -82,32 +88,35 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:feedback_attributes) { attributes_for(:consultation_public_feedback) }
     let(:attachable) { edition.create_public_feedback!(feedback_attributes) }
 
-    it 'redirects attachment requests when document is unpublished' do
+    it 'sets redirect URL for attachment in Asset Manager when document is unpublished' do
       visit admin_consultation_path(edition)
       unpublish_document_published_in_error
       logout
       get attachment.url
       assert_redirected_to redirect_url
+      assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'does not redirect attachment requests when document is withdrawn' do
+    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_consultation_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
   context 'given an unpublished document with file attachment' do
     let(:edition) { create(:news_article, :unpublished) }
 
-    it 'does not redirect attachment requests when document is published' do
+    it 'resets redirect URI for attachment in Asset Manager when document is published' do
       visit admin_news_article_path(edition)
       force_publish_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
@@ -116,24 +125,26 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:outcome_attributes) { attributes_for(:consultation_outcome) }
     let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-    it 'does not redirect attachment requests when document is published' do
+    it 'resets redirect URI for attachment in Asset Manager when document is published' do
       visit admin_consultation_path(edition)
       force_publish_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
   context 'given a withdrawn document with file attachment' do
     let(:edition) { create(:news_article, :published, :withdrawn) }
 
-    it 'does not redirect attachment requests when document is unwithdrawn' do
+    it 'resets redirect URI for attachment in Asset Manager when document is unwithdrawn' do
       visit admin_news_article_path(edition)
       unwithdraw_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
@@ -142,12 +153,13 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     let(:outcome_attributes) { attributes_for(:consultation_outcome) }
     let(:attachable) { edition.create_outcome!(outcome_attributes) }
 
-    it 'does not redirect attachment requests when document is unwithdrawn' do
+    it 'resets redirect URI for attachment in Asset Manager when document is unwithdrawn' do
       visit admin_consultation_path(edition)
       unwithdraw_document
       logout
       get attachment.url
       assert_response :success
+      assert_sets_redirect_url_in_asset_manager_to nil
     end
   end
 
@@ -173,6 +185,12 @@ private
     Services.asset_manager.stubs(:whitehall_asset)
       .with(&ends_with(filename))
       .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+
+  def assert_sets_redirect_url_in_asset_manager_to redirect_url
+    Services.asset_manager.expects(:update_asset)
+      .with(asset_id, 'redirect_url' => redirect_url)
+    AssetManagerUpdateAssetWorker.drain
   end
 
   def unpublish_document_published_in_error

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+    include Rails.application.routes.url_helpers
+    include PublicDocumentRoutesHelper
+
+    let(:updater) { AttachmentRedirectUrlUpdater.new(attachment) }
+    let(:visibility) { stub('visibility', visible?: visible, unpublished_edition: edition) }
+    let(:visible) { false }
+    let(:edition) { FactoryBot.create(:unpublished_edition) }
+    let(:redirect_url) { Whitehall.url_maker.public_document_path(edition) }
+
+    before do
+      AttachmentVisibility.stubs(:new).returns(visibility)
+    end
+
+    context 'when attachment is not a file attachment' do
+      let(:attachment) { FactoryBot.create(:html_attachment) }
+
+      it 'does not update redirect URL of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment has no associated attachment data' do
+      let(:attachment) { FileAttachment.new(attachment_data: nil) }
+
+      it 'does not update redirect URL of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment is not a PDF' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      it 'updates redirect URL of corresponding asset' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
+
+        updater.update!
+      end
+
+      context 'and queue is specified' do
+        let(:queue) { 'alternative_queue' }
+        let(:updater) { AttachmentRedirectUrlUpdater.new(attachment, queue: queue) }
+        let(:worker) { stub('worker') }
+
+        it 'updates redirect URL of corresponding asset using specified queue' do
+          AssetManagerUpdateAssetWorker.expects(:set)
+            .with(queue: queue).returns(worker)
+          worker.expects(:perform_async)
+            .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
+
+          updater.update!
+        end
+      end
+    end
+
+    context 'when attachment is a PDF' do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+      it 'updates redirect URL of asset for attachment & its thumbnail' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, redirect_url: redirect_url)
+
+        updater.update!
+      end
+
+      context 'and attachment is visible, e.g. associated with withdrawn edition' do
+        let(:visible) { true }
+
+        it 'resets redirect URL of asset for attachment & its thumbnail' do
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment.file.asset_manager_path, redirect_url: nil)
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment.file.thumbnail.asset_manager_path, redirect_url: nil)
+
+          updater.update!
+        end
+      end
+
+      context 'and attachment is not associated with an unpublished edition' do
+        let(:edition) { nil }
+
+        it 'resets redirect URL of asset for attachment & its thumbnail' do
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment.file.asset_manager_path, redirect_url: nil)
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment.file.thumbnail.asset_manager_path, redirect_url: nil)
+
+          updater.update!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new service listener which queues jobs to set the redirect URL for attachment assets in Asset Manager when the attachments parent document is unpublished/withdrawn and similarly unset the redirect URL when the parent document is re-published/un-withdrawn.

In combination with [these changes to Asset Manager][1], this will replace the behaviour [currently implemented in `AttachmentsController#fail`][2] when we start serving Whitehall attachment assets from Asset Manager.

I've enhanced `AttachmentRedirectDueToUnpublishingIntegrationTest` which I added in [a previous pull request][3] so that it now also sets expectations for the updates which need to be sent to the Asset Manager API. For the moment, I've left the assertions for the original behaviour, because I think it makes things a bit clearer. We'll need to remove those assertions before we remove the AttachmentsController when we start serving attachment assets from Asset Manager.

Note that I've also had to make a small change to `ServiceListeners::AttachmentDraftStatusUpdater` so that assets related to an unpublished document are no longer marked as draft in Asset Manager. In Asset Manager the draft status is used to decide whether to redirect requests via the `draft-assets` host which requires authentication. The fact that `AttachmentVisibility#visible?` returns `false` for attachments associated with an unpublished document is a bit of an aberration, because the attachment URL should in some sense be "visible", i.e. it should be accessible without authentication, it's just that requests to it will be redirected to the URL of the parent document which will have a public page explaining why the document has been unpublished.

See individual commit notes for more details.

[1]: https://github.com/alphagov/asset-manager/pull/481
[2]: https://github.com/alphagov/whitehall/blob/1db688fb3d795ae0e83d5490f0cb24202cc2e132/app/controllers/attachments_controller.rb#L43-L44
[3]: https://github.com/alphagov/whitehall/pull/3794
