### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
-
 RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME whitehall
 ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
@@ -29,4 +29,4 @@ RUN GOVUK_ASSET_ROOT=https://assets.publishing.service.gov.uk \
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'dalli', '~> 2.7'
 gem 'deprecated_columns', '~> 0.1.1'
 gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'faraday'
-gem 'foreman', '~> 0.84'
 gem 'friendly_id', '~> 5.2.1'
 gem 'gds-sso', '~> 13.6'
 gem 'globalize', '5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,6 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.21)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     friendly_id (5.2.3)
       activerecord (>= 4.0.0)
     gds-api-adapters (51.1.1)
@@ -490,7 +488,7 @@ GEM
     teaspoon-qunit (1.20.0)
       teaspoon (>= 1.0.0)
     test-queue (0.2.13)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
@@ -553,7 +551,6 @@ DEPENDENCIES
   equivalent-xml (~> 0.6.0)
   factory_bot
   faraday
-  foreman (~> 0.84)
   friendly_id (~> 5.2.1)
   gds-api-adapters
   gds-sso (~> 13.6)

--- a/startup.sh
+++ b/startup.sh
@@ -14,4 +14,4 @@ fi
 export STATIC_DEV
 echo
 bundle install
-bundle exec foreman run web
+bundle exec rails s -p 3020


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via `gem install` in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.