### PR TITLE
Redirect dounreay-site-restoration-ltd

### DIFF
--- a/db/data_migration/2018022112030805_reslug_dounreay_site_restoration_ltd.rb
+++ b/db/data_migration/2018022112030805_reslug_dounreay_site_restoration_ltd.rb
@@ -1,0 +1,10 @@
+require "data_hygiene/organisation_reslugger"
+
+old_slug = "dounreay-site-restoration-ltd"
+new_slug = "dounreay"
+
+organisation = Organisation.find_by(slug: old_slug)
+
+if organisation
+  DataHygiene::OrganisationReslugger.new(organisation, new_slug).run!
+end


### PR DESCRIPTION
- A request was made to redirect
  'https://www.gov.uk/government/organisations/dounreay-site-restoration-ltd'
to 'https://www.gov.uk/government/organisations/dounreay'. This commit
covers the change.

[https://govuk.zendesk.com/agent/tickets/2582049](url)

Solo: @suthagarht