### PR TITLE
Upgrade to govspeak 5.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ end
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '~> 5.4.0'
+  gem 'govspeak', '~> 5.5.0'
 end
 
 if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       activemodel (>= 4.2, < 5.2)
       activerecord (>= 4.2, < 5.2)
       request_store (~> 1.0)
-    govspeak (5.4.0)
+    govspeak (5.5.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -558,7 +558,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso (~> 13.6)
   globalize (= 5.1.0)
-  govspeak (~> 5.4.0)
+  govspeak (~> 5.5.0)
   govuk-content-schema-test-helpers
   govuk-lint (~> 3.6.0)
   govuk_ab_testing (~> 2.4x)


### PR DESCRIPTION
For: https://trello.com/c/8mDzHj8g/84-1-links-without-href-break-whitehall

This brings in a fix that stops the link extractor from breaking when a
link has no href, or a blank href.

All the context is in the fix to the govspeak gem: alphagov/govspeak#124