### PR TITLE
Implement asset manager storage file method

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -120,7 +120,7 @@ private
   end
 
   def file_is_not_empty
-    errors.add(:file, "is an empty file") if file.present? && file.file.size && file.file.size.to_i.zero?
+    errors.add(:file, "is an empty file") if file.present? && file.file.size.to_i.zero?
   end
 
   def virus_scan_pending?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -120,7 +120,7 @@ private
   end
 
   def file_is_not_empty
-    errors.add(:file, "is an empty file") if file.present? && file.file.size.to_i.zero?
+    errors.add(:file, "is an empty file") if file.present? && file.file.size && file.file.size.to_i.zero?
   end
 
   def virus_scan_pending?

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -14,7 +14,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   class File
-    delegate :empty?, :path, :content_type, :filename, :size, to: :@quarantined_file
+    delegate :empty?, :path, :content_type, :filename, to: :@quarantined_file
 
     def initialize(asset_manager_file, quarantined_file)
       @asset_manager_file = asset_manager_file
@@ -32,6 +32,10 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
     def delete
       @quarantined_file.delete
       @asset_manager_file.delete
+    end
+
+    def size
+      @asset_manager_file.size
     end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -52,7 +52,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
       else
         false
       end
-    rescue StandardError => e
+    rescue GdsApi::BaseError => e
       GovukError.notify(e)
       false
     end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -44,5 +44,17 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     def content_type
       MIME::Types.type_for(filename).first.to_s
     end
+
+    def size
+      response = Services.asset_manager.whitehall_asset(path)
+      if response.has_key?('size') && !response['size'].nil?
+        Integer(response['size'])
+      else
+        false
+      end
+    rescue StandardError => e
+      GovukError.notify(e)
+      false
+    end
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -47,14 +47,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
 
     def size
       response = Services.asset_manager.whitehall_asset(path)
-      if response.has_key?('size') && !response['size'].nil?
-        Integer(response['size'])
-      else
-        false
-      end
+      response['size'].to_i
     rescue GdsApi::BaseError => e
       GovukError.notify(e)
-      false
+      0
     end
   end
 end

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -90,9 +90,9 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
   end
 
   test '#size delegates to the quarantined file' do
-    @quarantined_file.stubs(:size).returns('quarantined-file-size')
+    @asset_manager_file.stubs(:size).returns('asset-manager-file-size')
 
-    assert_equal 'quarantined-file-size', @file.size
+    assert_equal 'asset-manager-file-size', @file.size
   end
 
   test '#asset_manager_path delegates to path on asset manager file' do

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -128,22 +128,22 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     assert_equal 100, @file.size
   end
 
-  test '#file_size returns false if response lacks size key' do
+  test '#file_size returns 0 if response lacks size key' do
     Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns({})
 
-    assert_equal false, @file.size
+    assert_equal 0, @file.size
   end
 
-  test '#file_size returns false if response has a nil size key' do
+  test '#file_size returns 0 if response has a nil size key' do
     Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns('size' => nil)
 
-    assert_equal false, @file.size
+    assert_equal 0, @file.size
   end
 
-  test '#file_size returns false if API request throws any GdsApi exception' do
+  test '#file_size returns 0 if API request throws any GdsApi exception' do
     Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises(GdsApi::TimedOutException, 'Error!')
 
-    assert_equal false, @file.size
+    assert_equal 0, @file.size
   end
 
   test '#file_size reports if API request throws any GdsApi exception' do

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -140,14 +140,14 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     assert_equal false, @file.size
   end
 
-  test '#file_size returns false if API request throws exception' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises('Error!')
+  test '#file_size returns false if API request throws any GdsApi exception' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises(GdsApi::TimedOutException, 'Error!')
 
     assert_equal false, @file.size
   end
 
-  test '#file_size reports if API request throws exception' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises('Error!')
+  test '#file_size reports if API request throws any GdsApi exception' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises(GdsApi::TimedOutException, 'Error!')
     GovukError.expects(:notify).with do |exception|
       assert_equal 'Error!', exception.message
     end

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -121,4 +121,37 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
 
     assert_equal 'http://assets-host/government/uploads/path/to/%C3%A4sset.png', file.url
   end
+
+  test '#file_size fetches the size from Asset Manager' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns('size' => 100)
+
+    assert_equal 100, @file.size
+  end
+
+  test '#file_size returns false if response lacks size key' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns({})
+
+    assert_equal false, @file.size
+  end
+
+  test '#file_size returns false if response has a nil size key' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).returns('size' => nil)
+
+    assert_equal false, @file.size
+  end
+
+  test '#file_size returns false if API request throws exception' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises('Error!')
+
+    assert_equal false, @file.size
+  end
+
+  test '#file_size reports if API request throws exception' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@asset_url_path).raises('Error!')
+    GovukError.expects(:notify).with do |exception|
+      assert_equal 'Error!', exception.message
+    end
+
+    @file.size
+  end
 end


### PR DESCRIPTION
See: https://github.com/alphagov/asset-manager/issues/482

We want to switch the AttachmentUploader to store files exclusively in Asset Manager by using the `AssetManagerStorage` engine instead of the `AssetManagerAndQuarantinedFileStorage` engine. The former doesn't currently implement `size` which makes the switch difficult. 

This PR implements a `size` method which fetches the value from the Asset Manager API (and returns `false` in error cases). 

Note that the size displayed to the public on pages with PDF attachments ([example](https://www.gov.uk/government/publications/technology-code-of-practice)) is actually stored in the whitehall database at the time the attachment is uploaded. I think this might end up being confusing as other asset types in Whitehall don't do this - eventually it would be good to use this new method to consistently fetch the size and other metadata. I think that can wait until after we've switched over the storage engine and have been able to simplify the code. 