### PR TITLE
Configurable log path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,8 @@ module Whitehall
       generate.test_framework :test_unit, fixture: false
     end
 
+    config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
+
     # Raise an exception when parameters are used without filtering
     # This will be mandatory in Rails 5.1
     config.action_controller.raise_on_unfiltered_parameters = true


### PR DESCRIPTION
This allows an env var to specify different paths when the app is used
in multiple contexts (e.g. running as whitehall admin, frontend or
draft-frontend). This is useful for [Publishing end-to-end tests][1]
which run the same container in different contexts.

[1]: https://github.com/alphagov/publishing-e2e-tests