### PR TITLE
Make document change conflict detection scenario more realistic

### DIFF
--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -55,8 +55,13 @@ Given(/^a submitted (publication|news article|consultation|speech|detailed guide
 end
 
 Given(/^another user edits the (publication|news article|consultation|speech) "([^"]*)" changing the title to "([^"]*)"$/) do |document_type, original_title, new_title|
-  edition = document_class(document_type).find_by!(title: original_title)
-  edition.update_attributes!(title: new_title)
+  as_user(create(:writer)) do
+    Capybara.using_session('another_user') do
+      begin_editing_document original_title
+      fill_in 'Title', with: new_title
+      click_button 'Save'
+    end
+  end
 end
 
 Given(/^a published (publication|news article|consultation|speech) "([^"]*)" that's the responsibility of:$/) do |document_type, title, table|


### PR DESCRIPTION
The "Trying to save a speech that has been changed by another user" scenario at `features/speeches.feature:19` has been failing on & off for some time now which has been making development frustratingly difficult.

The symptom was a `Capybara::ElementNotFound` exception being raised at `features/step_definitions/document_steps.rb:221`. This seemed to be happening, because the expected document title conflict was not detected and therefore the expected HTML element was not present.

In turn this seems to have been caused by the `edition.update_attributes!(title: new_title)` not always updating the `lock_version` as per [`ActiveRecord::Locking::Optimistic`][1]. Unfortunately due to lack of time and the fact the problem isn't very easily reproducible, I haven't managed to get to the bottom of why this sometimes happens.

However, I've decided to change the relevant Cucumber step so that instead of manipulating the model directly, it uses a separate Capybara session to login as another user and use the user interface to make the same change.

This makes the test more realistic and I'm hoping it has fixed the intermittent CI build failure; a branch with this fix has passed 6 times in a row and has never failed. At least it seems promising enough to
give it a go.

[1]:
http://api.rubyonrails.org/v5.0.6/classes/ActiveRecord/Locking/Optimistic.html