### PR TITLE
Improvements to attachment integration tests

### DIFF
--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -12,96 +12,98 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     login_as create(:managing_editor)
   end
 
-  context 'given a draft document with file attachment' do
-    let(:edition) { create(:news_article) }
+  context 'given a file attachment' do
+    context 'on a draft document' do
+      let(:edition) { create(:news_article) }
 
-    before do
-      setup_publishing_api_for(edition)
+      before do
+        setup_publishing_api_for(edition)
 
-      add_file_attachment('sample.docx', to: edition)
-      VirusScanHelpers.simulate_virus_scan
+        add_file_attachment('sample.docx', to: edition)
+        VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
-    end
-
-    it 'marks attachment as published in Asset Manager when document is published' do
-      visit admin_news_article_path(edition)
-      click_link 'Force publish'
-      fill_in 'Reason for force publishing', with: 'testing'
-      click_button 'Force publish'
-      assert_text "The document #{edition.title} has been published"
-      assert_sets_draft_status_in_asset_manager_to false
-    end
-  end
-
-  context 'given a published document with file attachment' do
-    let(:edition) { create(:published_news_article) }
-
-    before do
-      setup_publishing_api_for(edition)
-
-      add_file_attachment('sample.docx', to: edition)
-      VirusScanHelpers.simulate_virus_scan
-
-      stub_whitehall_asset('sample.docx', id: asset_id, draft: false)
-    end
-
-    it 'does not mark attachment as draft in Asset Manager when document is unpublished' do
-      visit admin_news_article_path(edition)
-      click_link 'Withdraw or unpublish'
-      within '#js-published-in-error-form' do
-        click_button 'Unpublish'
+        stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
       end
-      assert_text 'This document has been unpublished'
-      refute_sets_draft_status_in_asset_manager_to true
-    end
-  end
 
-  context 'given a draft consultation with outcome with file attachment' do
-    let(:edition) { create(:draft_consultation) }
-    let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
-    let(:outcome) { edition.create_outcome!(outcome_attributes) }
-
-    before do
-      setup_publishing_api_for(edition)
-
-      add_file_attachment('sample.docx', to: outcome)
-      VirusScanHelpers.simulate_virus_scan
-
-      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
+      it 'marks attachment as published in Asset Manager when document is published' do
+        visit admin_news_article_path(edition)
+        click_link 'Force publish'
+        fill_in 'Reason for force publishing', with: 'testing'
+        click_button 'Force publish'
+        assert_text "The document #{edition.title} has been published"
+        assert_sets_draft_status_in_asset_manager_to false
+      end
     end
 
-    it 'marks attachment as published in Asset Manager when consultation is published' do
-      visit admin_consultation_path(edition)
-      click_link 'Force publish'
-      fill_in 'Reason for force publishing', with: 'testing'
-      click_button 'Force publish'
-      assert_text "The document #{edition.title} has been published"
-      assert_sets_draft_status_in_asset_manager_to false
+    context 'on a published document' do
+      let(:edition) { create(:published_news_article) }
+
+      before do
+        setup_publishing_api_for(edition)
+
+        add_file_attachment('sample.docx', to: edition)
+        VirusScanHelpers.simulate_virus_scan
+
+        stub_whitehall_asset('sample.docx', id: asset_id, draft: false)
+      end
+
+      it 'does not mark attachment as draft in Asset Manager when document is unpublished' do
+        visit admin_news_article_path(edition)
+        click_link 'Withdraw or unpublish'
+        within '#js-published-in-error-form' do
+          click_button 'Unpublish'
+        end
+        assert_text 'This document has been unpublished'
+        refute_sets_draft_status_in_asset_manager_to true
+      end
     end
-  end
 
-  context 'given a draft consultation with feedback with file attachment' do
-    let(:edition) { create(:draft_consultation) }
-    let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
-    let(:feedback) { edition.create_public_feedback!(feedback_attributes) }
+    context 'on an outcome on a draft consultation' do
+      let(:edition) { create(:draft_consultation) }
+      let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+      let(:outcome) { edition.create_outcome!(outcome_attributes) }
 
-    before do
-      setup_publishing_api_for(edition)
+      before do
+        setup_publishing_api_for(edition)
 
-      add_file_attachment('sample.docx', to: feedback)
-      VirusScanHelpers.simulate_virus_scan
+        add_file_attachment('sample.docx', to: outcome)
+        VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
+        stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
+      end
+
+      it 'marks attachment as published in Asset Manager when consultation is published' do
+        visit admin_consultation_path(edition)
+        click_link 'Force publish'
+        fill_in 'Reason for force publishing', with: 'testing'
+        click_button 'Force publish'
+        assert_text "The document #{edition.title} has been published"
+        assert_sets_draft_status_in_asset_manager_to false
+      end
     end
 
-    it 'marks attachment as published in Asset Manager when consultation is published' do
-      visit admin_consultation_path(edition)
-      click_link 'Force publish'
-      fill_in 'Reason for force publishing', with: 'testing'
-      click_button 'Force publish'
-      assert_text "The document #{edition.title} has been published"
-      assert_sets_draft_status_in_asset_manager_to false
+    context 'on a feedback on a draft consultation' do
+      let(:edition) { create(:draft_consultation) }
+      let(:feedback_attributes) { FactoryBot.attributes_for(:consultation_public_feedback) }
+      let(:feedback) { edition.create_public_feedback!(feedback_attributes) }
+
+      before do
+        setup_publishing_api_for(edition)
+
+        add_file_attachment('sample.docx', to: feedback)
+        VirusScanHelpers.simulate_virus_scan
+
+        stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
+      end
+
+      it 'marks attachment as published in Asset Manager when consultation is published' do
+        visit admin_consultation_path(edition)
+        click_link 'Force publish'
+        fill_in 'Reason for force publishing', with: 'testing'
+        click_button 'Force publish'
+        assert_text "The document #{edition.title} has been published"
+        assert_sets_draft_status_in_asset_manager_to false
+      end
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -6,6 +6,8 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Rails.application.routes.url_helpers
 
+  let(:asset_id) { 'asset-id' }
+
   before do
     login_as create(:managing_editor)
   end
@@ -19,7 +21,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       add_file_attachment('sample.docx', to: edition)
       VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
     end
 
     it 'marks attachment as published in Asset Manager when document is published' do
@@ -27,7 +29,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with(asset_id, 'draft' => false)
 
       Sidekiq::Testing.inline! do
         click_button 'Force publish'
@@ -46,14 +48,14 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       add_file_attachment('sample.docx', to: edition)
       VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: false)
+      stub_whitehall_asset('sample.docx', id: asset_id, draft: false)
     end
 
     it 'does not mark attachment as draft in Asset Manager when document is unpublished' do
       visit admin_news_article_path(edition)
       click_link 'Withdraw or unpublish'
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => true).never
+      Services.asset_manager.expects(:update_asset).with(asset_id, 'draft' => true).never
 
       Sidekiq::Testing.inline! do
         within '#js-published-in-error-form' do
@@ -76,7 +78,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       add_file_attachment('sample.docx', to: outcome)
       VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
     end
 
     it 'marks attachment as published in Asset Manager when consultation is published' do
@@ -84,7 +86,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with(asset_id, 'draft' => false)
 
       Sidekiq::Testing.inline! do
         click_button 'Force publish'
@@ -105,7 +107,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       add_file_attachment('sample.docx', to: feedback)
       VirusScanHelpers.simulate_virus_scan
 
-      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
     end
 
     it 'marks attachment as published in Asset Manager when consultation is published' do
@@ -113,7 +115,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       click_link 'Force publish'
       fill_in 'Reason for force publishing', with: 'testing'
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with(asset_id, 'draft' => false)
 
       Sidekiq::Testing.inline! do
         click_button 'Force publish'
@@ -127,13 +129,13 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     let(:policy_group) { create(:policy_group) }
 
     it 'marks attachment as published in Asset Manager when added to policy group' do
-      stub_whitehall_asset('sample.docx', id: 'asset-id', draft: true)
+      stub_whitehall_asset('sample.docx', id: asset_id, draft: true)
       visit admin_policy_group_attachments_path(policy_group)
       click_link 'Upload new file attachment'
       fill_in 'Title', with: 'Attachment Title'
       attach_file 'File', path_to_attachment('sample.docx')
 
-      Services.asset_manager.expects(:update_asset).with('asset-id', 'draft' => false)
+      Services.asset_manager.expects(:update_asset).with(asset_id, 'draft' => false)
 
       Sidekiq::Testing.inline! do
         click_button 'Save'

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -19,13 +19,6 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     attachable.attachments << attachment
     VirusScanHelpers.simulate_virus_scan
     stub_whitehall_asset(filename, id: asset_id)
-
-    @test_mode = Sidekiq::Testing.__test_mode
-    Sidekiq::Testing.fake!
-  end
-
-  after do
-    Sidekiq::Testing.__test_mode = @test_mode
   end
 
   context 'given a published document with file attachment' do

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -180,7 +180,7 @@ private
       .returns(attributes.merge(id: url_id).stringify_keys)
   end
 
-  def assert_sets_redirect_url_in_asset_manager_to redirect_url
+  def assert_sets_redirect_url_in_asset_manager_to(redirect_url)
     Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'redirect_url' => redirect_url)
     AssetManagerUpdateAssetWorker.drain


### PR DESCRIPTION
This is just a bit of tidying up of the integration tests concerned with keeping Asset Manager up-to-date with the state of Whitehall attachments. It consolidates work from a number of different pull requests and brings the following two integration tests more into line:

* `AttachmentDraftStatusIntegrationTest`
* `AttachmentRedirectDueToUnpublishingIntegrationTest`

The changes remove a bunch of duplication, but there is still duplication *between* the two tests. I think I'm going to leave it a bit longer before going to the effort of removing this, because we have more work to do along these lines, so I can imagine some more integration tests of this kind being added in the near future.