### PR TITLE
Disabled scheduled links checking

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,7 +13,9 @@
   - sync_checks
   - link_checks
   - asset_migration
-:schedule:
-  check_all_organisations_links_worker:
-    cron: '0 1 * * *' # Runs at 1 a.m every day
-    class: CheckAllOrganisationsLinksWorker
+# Disable scheduled link checking as it uses too much CPU and affects publishers as the job is overrunning.
+#
+# :schedule:
+#   check_all_organisations_links_worker:
+#     cron: '0 1 * * *' # Runs at 1 a.m every day
+#     class: CheckAllOrganisationsLinksWorker


### PR DESCRIPTION
This process is over-running and affecting publishers ability to use whitehall admin

https://trello.com/c/aqGcNwFT/90-2-whitehall-link-checker-pegs-mysql-at-400-cpu-every-morning