### PR TITLE
Add some logging and timing to link checker process

### DIFF
--- a/app/workers/check_all_organisations_links_worker.rb
+++ b/app/workers/check_all_organisations_links_worker.rb
@@ -5,8 +5,12 @@ class CheckAllOrganisationsLinksWorker
   include Sidekiq::Worker
 
   def perform
-    organisations.each do |organisation|
-      CheckOrganisationLinksWorker.perform_async(organisation.id)
+    GovukStatsd.time('link-checking-debug.check-all-organisations-worker') do
+      logger.info("[link-checking-debug][job_#{self.jid}]: Queuing #{organisations.count} jobs to check organisations")
+      organisations.each do |organisation|
+        CheckOrganisationLinksWorker.perform_async(organisation.id)
+      end
+      logger.info("[link-checking-debug][job_#{self.jid}]: Done queuing #{organisations.count} jobs to check organisations")
     end
   end
 


### PR DESCRIPTION
For: https://trello.com/c/aqGcNwFT/90-2-whitehall-link-checker-pegs-mysql-at-400-cpu-every-morning

We want to get some more data about how long various parts of the link
checking process are taking, and when they are triggered.  We use statsd
timing to get the length of time, and we log some start/end messages to
get when things are happening.  It may not be enough, but hopefully it'll
tell us something.