### PR TITLE
DRY up Asset Manager workers

### DIFF
--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerCreateWhitehallAssetWorker < WorkerBase
+  include AssetManagerWorkerHelper
+
   def perform(file_path, legacy_url_path, draft = false, model_class = nil, model_id = nil)
     file = File.open(file_path)
     asset_options = { file: file, legacy_url_path: legacy_url_path }
@@ -17,11 +19,5 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     asset_manager.create_whitehall_asset(asset_options)
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
-  end
-
-private
-
-  def asset_manager
-    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -14,8 +14,14 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
       end
     end
 
-    Services.asset_manager.create_whitehall_asset(asset_options)
+    asset_manager.create_whitehall_asset(asset_options)
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
+  end
+
+private
+
+  def asset_manager
+    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,9 +1,15 @@
 class AssetManagerDeleteAssetWorker < WorkerBase
   def perform(legacy_url_path)
-    gds_api_response = Services.asset_manager.whitehall_asset(legacy_url_path)
+    gds_api_response = asset_manager.whitehall_asset(legacy_url_path)
     asset_url = gds_api_response['id']
     asset_id = asset_url[/\/assets\/(.*)/, 1]
 
-    Services.asset_manager.delete_asset(asset_id)
+    asset_manager.delete_asset(asset_id)
+  end
+
+private
+
+  def asset_manager
+    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -2,10 +2,7 @@ class AssetManagerDeleteAssetWorker < WorkerBase
   include AssetManagerWorkerHelper
 
   def perform(legacy_url_path)
-    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
-    asset_url = attributes['id']
-    asset_id = asset_url[/\/assets\/(.*)/, 1]
-
-    asset_manager.delete_asset(asset_id)
+    attributes = find_asset_by(legacy_url_path)
+    asset_manager.delete_asset(attributes['id'])
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,15 +1,11 @@
 class AssetManagerDeleteAssetWorker < WorkerBase
+  include AssetManagerWorkerHelper
+
   def perform(legacy_url_path)
     attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
     asset_url = attributes['id']
     asset_id = asset_url[/\/assets\/(.*)/, 1]
 
     asset_manager.delete_asset(asset_id)
-  end
-
-private
-
-  def asset_manager
-    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,7 +1,7 @@
 class AssetManagerDeleteAssetWorker < WorkerBase
   def perform(legacy_url_path)
-    gds_api_response = asset_manager.whitehall_asset(legacy_url_path)
-    asset_url = gds_api_response['id']
+    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
+    asset_url = attributes['id']
     asset_id = asset_url[/\/assets\/(.*)/, 1]
 
     asset_manager.delete_asset(asset_id)

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,9 +1,9 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
   def perform(legacy_url_path, new_attributes = {})
-    gds_api_response = asset_manager.whitehall_asset(legacy_url_path).to_hash
+    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
     keys = new_attributes.keys
-    unless gds_api_response.slice(*keys) == new_attributes.slice(*keys)
-      asset_url = gds_api_response['id']
+    unless attributes.slice(*keys) == new_attributes.slice(*keys)
+      asset_url = attributes['id']
       asset_id = asset_url[/\/assets\/(.*)/, 1]
       asset_manager.update_asset(asset_id, new_attributes)
     end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,12 +1,17 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
   def perform(legacy_url_path, new_attributes = {})
-    asset_manager = Services.asset_manager
     gds_api_response = asset_manager.whitehall_asset(legacy_url_path).to_hash
     keys = new_attributes.keys
     unless gds_api_response.slice(*keys) == new_attributes.slice(*keys)
       asset_url = gds_api_response['id']
       asset_id = asset_url[/\/assets\/(.*)/, 1]
-      Services.asset_manager.update_asset(asset_id, new_attributes)
+      asset_manager.update_asset(asset_id, new_attributes)
     end
+  end
+
+private
+
+  def asset_manager
+    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
+  include AssetManagerWorkerHelper
+
   def perform(legacy_url_path, new_attributes = {})
     attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
     keys = new_attributes.keys
@@ -7,11 +9,5 @@ class AssetManagerUpdateAssetWorker < WorkerBase
       asset_id = asset_url[/\/assets\/(.*)/, 1]
       asset_manager.update_asset(asset_id, new_attributes)
     end
-  end
-
-private
-
-  def asset_manager
-    Services.asset_manager
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -2,12 +2,10 @@ class AssetManagerUpdateAssetWorker < WorkerBase
   include AssetManagerWorkerHelper
 
   def perform(legacy_url_path, new_attributes = {})
-    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
+    attributes = find_asset_by(legacy_url_path)
     keys = new_attributes.keys
     unless attributes.slice(*keys) == new_attributes.slice(*keys)
-      asset_url = attributes['id']
-      asset_id = asset_url[/\/assets\/(.*)/, 1]
-      asset_manager.update_asset(asset_id, new_attributes)
+      asset_manager.update_asset(attributes['id'], new_attributes)
     end
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,12 +1,12 @@
 class AssetManagerUpdateAssetWorker < WorkerBase
-  def perform(legacy_url_path, attributes = {})
+  def perform(legacy_url_path, new_attributes = {})
     asset_manager = Services.asset_manager
     gds_api_response = asset_manager.whitehall_asset(legacy_url_path).to_hash
-    keys = attributes.keys
-    unless gds_api_response.slice(*keys) == attributes.slice(*keys)
+    keys = new_attributes.keys
+    unless gds_api_response.slice(*keys) == new_attributes.slice(*keys)
       asset_url = gds_api_response['id']
       asset_id = asset_url[/\/assets\/(.*)/, 1]
-      Services.asset_manager.update_asset(asset_id, attributes)
+      Services.asset_manager.update_asset(asset_id, new_attributes)
     end
   end
 end

--- a/app/workers/asset_manager_worker_helper.rb
+++ b/app/workers/asset_manager_worker_helper.rb
@@ -1,0 +1,6 @@
+module AssetManagerWorkerHelper
+  def asset_manager
+    Services.asset_manager
+  end
+  private :asset_manager
+end

--- a/app/workers/asset_manager_worker_helper.rb
+++ b/app/workers/asset_manager_worker_helper.rb
@@ -3,4 +3,12 @@ module AssetManagerWorkerHelper
     Services.asset_manager
   end
   private :asset_manager
+
+  def find_asset_by(legacy_url_path)
+    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
+    url = attributes['id']
+    id = url[/\/assets\/(.*)/, 1]
+    attributes.merge('id' => id, 'url' => url)
+  end
+  private :find_asset_by
 end

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -18,40 +18,40 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
   end
 
   test 'marks draft asset as published' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'draft' => true))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'draft' => true)
     Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => false)
 
     @worker.perform(@legacy_url_path, 'draft' => false)
   end
 
   test 'does not mark asset as published if already published' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'draft' => false))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'draft' => false)
     Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'draft' => false)
   end
 
   test 'mark published asset as draft' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'draft' => false))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'draft' => false)
     Services.asset_manager.expects(:update_asset).with(@asset_id, 'draft' => true)
 
     @worker.perform(@legacy_url_path, 'draft' => true)
   end
 
   test 'does not mark asset as draft if already draft' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'draft' => true))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'draft' => true)
     Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'draft' => true)
   end
 
   test 'sets redirect_url on asset if not already set' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id)
     Services.asset_manager.expects(:update_asset)
       .with(@asset_id, 'redirect_url' => @redirect_url)
 
@@ -59,8 +59,8 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
   end
 
   test 'sets redirect_url on asset if already set to different value' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'redirect_url' => "#{@redirect_url}-another"))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'redirect_url' => "#{@redirect_url}-another")
     Services.asset_manager.expects(:update_asset)
       .with(@asset_id, 'redirect_url' => @redirect_url)
 
@@ -68,33 +68,26 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
   end
 
   test 'does not set redirect_url on asset if already set' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns(gds_api_response('id' => @asset_url, 'redirect_url' => @redirect_url))
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'redirect_url' => @redirect_url)
     Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'redirect_url' => @redirect_url)
   end
 
   test 'marks asset as access-limited' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns('id' => @asset_url)
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id)
     Services.asset_manager.expects(:update_asset).with(@asset_id, 'access_limited' => ['uid-1'])
 
     @worker.perform(@legacy_url_path, 'access_limited' => ['uid-1'])
   end
 
   test 'does not mark asset as access-limited if already set' do
-    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
-      .returns('id' => @asset_url, 'access_limited' => ['uid-1'])
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_id, 'access_limited' => ['uid-1'])
     Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@legacy_url_path, 'access_limited' => ['uid-1'])
-  end
-
-private
-
-  def gds_api_response(attributes = {})
-    http_response = stub('http_response', body: attributes.to_json)
-    GdsApi::Response.new(http_response)
   end
 end

--- a/test/unit/workers/asset_manager_worker_helper_test.rb
+++ b/test/unit/workers/asset_manager_worker_helper_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class AssetManagerWorkerHelperTest < ActiveSupport::TestCase
+  setup do
+    @asset_id = 'asset-id'
+    @asset_url = "http://asset-manager/assets/#{@asset_id}"
+    @legacy_url_path = 'legacy-url-path'
+    @worker = Object.new
+    @worker.extend(AssetManagerWorkerHelper)
+  end
+
+  test 'returns attributes including asset ID' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns(gds_api_response('id' => @asset_url))
+
+    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+
+    assert_equal @asset_id, attributes['id']
+  end
+
+  test 'returns attributes including asset URL' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns(gds_api_response('id' => @asset_url))
+
+    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+
+    assert_equal @asset_url, attributes['url']
+  end
+
+  test 'returns other attributes' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .returns(gds_api_response('id' => @asset_url, 'key' => 'value'))
+
+    attributes = @worker.send(:find_asset_by, @legacy_url_path)
+
+    assert_equal 'value', attributes['key']
+  end
+
+private
+
+  def gds_api_response(attributes = {})
+    http_response = stub('http_response', body: attributes.to_json)
+    GdsApi::Response.new(http_response)
+  end
+end


### PR DESCRIPTION
This reduces the duplication and simplifies the code in the Asset Manager workers.

My motivation for making these changes is that I'm about to make some changes to `AssetManagerUpdateAssetWorker` and this will make them easier.
