### PR TITLE
Set access_limited state when bulk uploading attachments

### DIFF
--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -23,6 +23,9 @@ class Admin::BulkUploadsController < Admin::BaseController
   def create
     @bulk_upload = BulkUpload.new(@edition)
     @bulk_upload.attachments_attributes = create_params[:attachments_attributes]
+    @bulk_upload.attachments.each do |attachment|
+      attachment.attachment_data.attachable = @edition
+    end
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)
     else

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -111,4 +111,13 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select '.form-errors', text: /enter missing fields/
   end
+
+  test "POST :create associates the attachment's attachment_data object with the edition" do
+    post :create, params: { edition_id: @edition, bulk_upload: valid_create_params }
+
+    bulk_upload = assigns(:bulk_upload)
+    bulk_upload.attachments.each do |attachment|
+      assert_equal @edition, attachment.attachment_data.attachable
+    end
+  end
 end

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -54,10 +54,12 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       fill_in "Title", with: 'asset-title'
       attach_file 'File', path_to_attachment('logo.png')
 
-      Services.asset_manager.expects(:create_whitehall_asset).with do |params|
-        params[:legacy_url_path] =~ /logo\.png/ &&
-          params[:access_limited] == ['user-uid']
-      end
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        has_entries(
+          legacy_url_path: regexp_matches(/logo\.png/),
+          access_limited: ['user-uid']
+        )
+      )
 
       click_button 'Save'
       AssetManagerCreateWhitehallAssetWorker.drain
@@ -72,14 +74,18 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       fill_in 'Title', with: 'file-title'
       click_button 'Save'
 
-      Services.asset_manager.expects(:create_whitehall_asset).with do |params|
-        params[:legacy_url_path] =~ /greenpaper\.pdf/ &&
-          params[:access_limited] == ['user-uid']
-      end
-      Services.asset_manager.expects(:create_whitehall_asset).with do |params|
-        params[:legacy_url_path] =~ /thumbnail_greenpaper\.pdf\.png/ &&
-          params[:access_limited] == ['user-uid']
-      end
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        has_entries(
+          legacy_url_path: regexp_matches(/greenpaper\.pdf/),
+          access_limited: ['user-uid']
+        )
+      )
+      Services.asset_manager.expects(:create_whitehall_asset).with(
+        has_entries(
+          legacy_url_path: regexp_matches(/thumbnail_greenpaper\.pdf\.png/),
+          access_limited: ['user-uid']
+        )
+      )
 
       AssetManagerCreateWhitehallAssetWorker.drain
     end


### PR DESCRIPTION
This ensures we're setting the access_limited state in Asset Manager when Whitehall attachments are created using the bulk upload functionality. The equivalent functionality for setting it when attachments are created was in https://github.com/alphagov/whitehall/pull/3767.