### PR TITLE
Create new versions of the link checker api reports tables

### DIFF
--- a/db/migrate/20180228161807_create_new_link_checker_api_reports_tables.rb
+++ b/db/migrate/20180228161807_create_new_link_checker_api_reports_tables.rb
@@ -1,0 +1,45 @@
+class CreateNewLinkCheckerApiReportsTables < ActiveRecord::Migration[5.0]
+  def change
+    create_table :new_link_checker_api_reports do |t|
+      t.integer     :batch_id, null: false, index: { unique: true }
+      t.string      :status, null: false
+      t.references  :link_reportable, polymorphic: true, index: { name: 'index_link_checker_api_reportable' }
+      t.timestamp   :completed_at
+      t.timestamps  null: false
+    end
+
+    create_table :new_link_checker_api_report_links do |t|
+      t.references  :link_checker_api_report,
+                    index: { name: "index_link_checker_api_report_id" },
+                    foreign_key: { to_table: :new_link_checker_api_reports }
+      t.text        :uri, null: false
+      t.string      :status, null: false
+      t.timestamp   :checked
+      t.text        :check_warnings
+      t.text        :check_errors
+      t.integer     :ordering, null: false
+      t.text        :problem_summary
+      t.text        :suggested_fix
+
+      t.timestamps  null: false
+    end
+
+    rename_table :link_checker_api_reports, :old_link_checker_api_reports
+    rename_table :new_link_checker_api_reports, :link_checker_api_reports
+    reversible do |dir|
+      dir.up do
+        max_id = ActiveRecord::Base.connection.execute('select max(`id`) from old_link_checker_api_reports').first.first
+        execute "alter table link_checker_api_reports auto_increment = #{(max_id || 0)+ 1000}"
+      end
+    end
+
+    rename_table :link_checker_api_report_links, :old_link_checker_api_report_links
+    rename_table :new_link_checker_api_report_links, :link_checker_api_report_links
+    reversible do |dir|
+      dir.up do
+        max_id = ActiveRecord::Base.connection.execute('select max(`id`) from old_link_checker_api_report_links').first.first
+        execute "alter table link_checker_api_report_links auto_increment = #{(max_id || 0)+ 1000}"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116144233) do
+ActiveRecord::Schema.define(version: 20180228161807) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -664,10 +664,10 @@ ActiveRecord::Schema.define(version: 20180116144233) do
     t.text     "check_warnings",             limit: 65535
     t.text     "check_errors",               limit: 65535
     t.integer  "ordering",                                 null: false
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
     t.text     "problem_summary",            limit: 65535
     t.text     "suggested_fix",              limit: 65535
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id", using: :btree
   end
 
@@ -680,6 +680,7 @@ ActiveRecord::Schema.define(version: 20180116144233) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.index ["batch_id"], name: "index_link_checker_api_reports_on_batch_id", unique: true, using: :btree
+    t.index ["link_reportable_type", "link_reportable_id"], name: "index_link_checker_api_reportable", using: :btree
   end
 
   create_table "nation_inapplicabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -702,6 +703,32 @@ ActiveRecord::Schema.define(version: 20180116144233) do
     t.datetime "date"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+  end
+
+  create_table "old_link_checker_api_report_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "link_checker_api_report_id"
+    t.text     "uri",                        limit: 65535, null: false
+    t.string   "status",                                   null: false
+    t.datetime "checked"
+    t.text     "check_warnings",             limit: 65535
+    t.text     "check_errors",               limit: 65535
+    t.integer  "ordering",                                 null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.text     "problem_summary",            limit: 65535
+    t.text     "suggested_fix",              limit: 65535
+    t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id", using: :btree
+  end
+
+  create_table "old_link_checker_api_reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "batch_id",             null: false
+    t.string   "status",               null: false
+    t.string   "link_reportable_type"
+    t.integer  "link_reportable_id"
+    t.datetime "completed_at"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.index ["batch_id"], name: "index_old_link_checker_api_reports_on_batch_id", unique: true, using: :btree
   end
 
   create_table "operational_fields", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -1197,12 +1224,13 @@ ActiveRecord::Schema.define(version: 20180116144233) do
   end
 
   create_table "worldwide_services", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",            null: false
-    t.integer  "service_type_id", null: false
+    t.string   "name",            default: "", null: false
+    t.integer  "service_type_id",              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
+  add_foreign_key "old_link_checker_api_report_links", "old_link_checker_api_reports", column: "link_checker_api_report_id"
   add_foreign_key "related_mainstreams", "editions"
 end


### PR DESCRIPTION
For: https://trello.com/c/aqGcNwFT/90-2-whitehall-link-checker-pegs-mysql-at-400-cpu-every-morning

The existing link_checker_api_reports table currently has ~900,000 rows
and no index on the link_reportable_id and link_reportable_type columns.
This makes joining on it expensive.  We'd like to add an index on those
columns, but doing so would take a long time and block the application
because we show link check information on edition show pages.  However,
this data is:

1. quite new - we only turned on this version of the link checking code
   in the middle of january 2018.
2. quite transient - when we re-enable the overnight link checker we'll
   quickly generate link check reports for all the editions.

So it doesn't actually feel that useful to keep it around and go through
the effort of using a tool like [lhm][lhm] or [percona][percona] to peform
this change directly on the data.  We haven't removed the old version of
the table yet, because we want to apply the indexes to it so we can test
out if having those indexes on a table of that size would actually speed
things up.  We'll add those indexes manually in the console and do
some testing, and then follow up with a new migration that removes the
old tables.  We may decide to back port the existing data if we do decide
it's useful, which is why we've set the auto increment on the new versions
of the tables to start at the max id of the old versions (with a +1000 to
give us some wiggle room for any rows that get inserted after the table
rename, but before the auto increment change.

[lhm]: https://github.com/soundcloud/lhm
[percona]: https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html