### PR TITLE
Set parent_document_url when updating attachments

### DIFF
--- a/app/services/service_listeners/attachment_link_header_updater.rb
+++ b/app/services/service_listeners/attachment_link_header_updater.rb
@@ -1,0 +1,40 @@
+module ServiceListeners
+  class AttachmentLinkHeaderUpdater
+    attr_reader :attachment, :queue
+
+    def initialize(attachment, queue: nil)
+      @attachment = attachment
+      @queue = queue
+    end
+
+    def update!
+      return unless attachment.file?
+      attachment_data = attachment.attachment_data
+      return unless attachment_data.present?
+      return unless attachment.attachable.is_a?(Edition)
+
+      parent_document_url = Whitehall.url_maker.public_document_url(attachment.attachable)
+
+      enqueue_job(attachment_data.file, parent_document_url)
+      if attachment_data.pdf?
+        enqueue_job(attachment_data.file.thumbnail, parent_document_url)
+      end
+    end
+
+  private
+
+    def visibility_for(attachment_data)
+      AttachmentVisibility.new(attachment_data, _anonymous_user = nil)
+    end
+
+    def enqueue_job(uploader, parent_document_url)
+      legacy_url_path = uploader.asset_manager_path
+      worker.perform_async(legacy_url_path, parent_document_url: parent_document_url)
+    end
+
+    def worker
+      worker = AssetManagerUpdateAssetWorker
+      queue.present? ? worker.set(queue: queue) : worker
+    end
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -14,6 +14,11 @@ Whitehall.edition_services.tap do |coordinator|
       ServiceListeners::AttachmentRedirectUrlUpdater
         .new(attachment)
         .update!
+    end
+  end
+
+  coordinator.subscribe(/^(force_publish|publish)$/) do |_event, edition, options|
+    edition.attachables.flat_map(&:attachments).each do |attachment|
       ServiceListeners::AttachmentLinkHeaderUpdater
         .new(attachment)
         .update!

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -14,6 +14,9 @@ Whitehall.edition_services.tap do |coordinator|
       ServiceListeners::AttachmentRedirectUrlUpdater
         .new(attachment)
         .update!
+      ServiceListeners::AttachmentLinkHeaderUpdater
+        .new(attachment)
+        .update!
     end
   end
 

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+  include PublicDocumentRoutesHelper
+
+  let(:filename) { 'sample.docx' }
+  let(:asset_id) { 'asset-id' }
+
+  before do
+    login_as create(:managing_editor)
+    stub_whitehall_asset(filename, id: asset_id, draft: asset_initially_draft)
+  end
+
+  context 'given a file attachment' do
+    let(:file) { File.open(path_to_attachment(filename)) }
+    let(:attachment) { build(:file_attachment, attachable: attachable, file: file) }
+    let(:attachable) { edition }
+
+    before do
+      setup_publishing_api_for(edition)
+      attachable.attachments << attachment
+      VirusScanHelpers.simulate_virus_scan
+    end
+
+    context 'on a draft document' do
+      let(:edition) { create(:news_article) }
+      let(:asset_initially_draft) { true }
+
+      it 'sets link to parent document in Asset Manager when document is published' do
+        visit admin_news_article_path(edition)
+        force_publish_document
+
+        parent_document_url = Whitehall.url_maker.public_document_url(edition)
+
+        Services.asset_manager.expects(:update_asset)
+          .with(asset_id, 'parent_document_url' => parent_document_url)
+
+        AssetManagerUpdateAssetWorker.drain
+      end
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def setup_publishing_api_for(edition)
+    publishing_api_has_links(
+      content_id: edition.document.content_id,
+      links: {}
+    )
+  end
+
+  def path_to_attachment(filename)
+    fixture_path.join(filename)
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+
+  def assert_sets_draft_status_in_asset_manager_to(draft, never: false)
+    expectation = Services.asset_manager.expects(:update_asset)
+      .with(asset_id, 'draft' => draft)
+    expectation.never if never
+    AssetManagerUpdateAssetWorker.drain
+  end
+
+  def refute_sets_draft_status_in_asset_manager_to(draft)
+    assert_sets_draft_status_in_asset_manager_to(draft, never: true)
+  end
+
+  def force_publish_document
+    click_link 'Force publish'
+    fill_in 'Reason for force publishing', with: 'testing'
+    click_button 'Force publish'
+    assert_text %r{The document .* has been published}
+  end
+
+  def unpublish_document_published_in_error
+    click_link 'Withdraw or unpublish'
+    within '#js-published-in-error-form' do
+      click_button 'Unpublish'
+    end
+    assert_text 'This document has been unpublished'
+  end
+
+  def add_attachment(filename)
+    click_link 'Upload new file attachment'
+    fill_in 'Title', with: 'Attachment Title'
+    attach_file 'File', path_to_attachment(filename)
+    click_button 'Save'
+    assert_text "Attachment 'Attachment Title' uploaded"
+  end
+end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+    include Rails.application.routes.url_helpers
+    include PublicDocumentRoutesHelper
+
+    let(:updater) { AttachmentLinkHeaderUpdater.new(attachment) }
+    let(:edition) { FactoryBot.create(:edition) }
+    let(:parent_document_url) { Whitehall.url_maker.public_document_url(edition) }
+
+    context 'when attachment is not a file attachment' do
+      let(:attachment) { FactoryBot.create(:html_attachment) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment has no associated attachment data' do
+      let(:attachment) { FileAttachment.new(attachment_data: nil) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context "when attachment doesn't belong to an edition" do
+      let(:attachment) { FileAttachment.new(attachable: PolicyGroup.new) }
+
+      it 'does not update draft status of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment is not a PDF' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+
+      it 'sets parent_document_url of corresponding asset' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
+
+        updater.update!
+      end
+
+      context 'and queue is specified' do
+        let(:queue) { 'alternative_queue' }
+        let(:updater) { AttachmentLinkHeaderUpdater.new(attachment, queue: queue) }
+        let(:worker) { stub('worker') }
+
+        it 'sets parent_document_url of corresponding asset using specified queue' do
+          AssetManagerUpdateAssetWorker.expects(:set)
+            .with(queue: queue).returns(worker)
+          worker.expects(:perform_async)
+            .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
+
+          updater.update!
+        end
+      end
+    end
+
+    context 'when attachment is a PDF' do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+
+      it 'sets parent_document_url for attachment & its thumbnail' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, parent_document_url: parent_document_url)
+
+        updater.update!
+      end
+    end
+  end
+end


### PR DESCRIPTION
Send parent_document_url to AM on publication of docs

A `Link` header, containing the URL of an attachment's parent document,
was added to Whitehall attachments in
https://github.com/alphagov/whitehall/pull/2202, so that:

> the cover sheet for an attachment is easily discoverable by crawlers and
> other clients, we should surface the attachment edition's public URL via
> HTTP headers.

We need to send the value of the attachment's parent URL to to Asset
Manager so that we can continue setting the `Link` header once we're
serving Whitehall attachments from Asset Manager.

My implementation differs slightly from that in Whitehall. In Whitehall
the `Link` header will be set irrespective of whether a document (and
therefore its attachments) is draft or public. My interpretation of PR
 #2202 is that it's unnecessary to set it for draft documents as they're
not publicly accessible to clients such as web crawlers. As such, I've
decided to send the `parent_document_url` to Asset Manager at the time a
document is published in Whitehall.

It's not obvious that it's possible to change the URL of a published
document but if it is, and if the change in URL doesn't result in a
redirect from the old to the new, then we might need to add something to
handle that.