### PR TITLE
Fetch CSV data for previews from public url

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -15,7 +15,7 @@ class CsvPreviewController < ApplicationController
         end
       end
     end
-  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError
+  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError
     render layout: 'html_attachments'
   rescue ActionController::UnknownFormat
     render status: :not_acceptable, plain: "Request format #{request.format} not handled."

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -6,7 +6,9 @@ class CsvPreviewController < ApplicationController
           expires_headers
           @edition = attachment_visibility.visible_edition
           @attachment = attachment_visibility.visible_attachment
-          @csv_preview = CsvPreview.new(upload_path)
+          CsvFileFromPublicHost.new(@attachment.file.file.asset_manager_path) do |file|
+            @csv_preview = CsvPreview.new(file.path)
+          end
           render layout: 'html_attachments'
         else
           fail

--- a/features/step_definitions/attachment_preview_steps.rb
+++ b/features/step_definitions/attachment_preview_steps.rb
@@ -7,6 +7,12 @@ Given(/^there is a publicly visible CSV attachment on the site$/) do
 end
 
 When(/^I preview the contents of the attachment$/) do
+  fn = File.join(Whitehall.clean_uploads_root, @attachment.file.store_path)
+
+  stub_request(:get, "https://www.test.gov.uk/government/uploads/system/uploads/attachment_data/file/#{@attachment.id}/sample.csv")
+    .with(headers: {'Range'=>'bytes=0-30000'})
+    .to_return(status: 206, body: File.read(fn))
+
   visit csv_preview_path(
     id: @attachment.attachment_data.id,
     file: @attachment.filename_without_extension,

--- a/features/step_definitions/attachment_preview_steps.rb
+++ b/features/step_definitions/attachment_preview_steps.rb
@@ -10,7 +10,7 @@ When(/^I preview the contents of the attachment$/) do
   fn = File.join(Whitehall.clean_uploads_root, @attachment.file.store_path)
 
   stub_request(:get, "https://www.test.gov.uk/government/uploads/system/uploads/attachment_data/file/#{@attachment.id}/sample.csv")
-    .with(headers: {'Range'=>'bytes=0-30000'})
+    .with(headers: {'Range'=>'bytes=0-300000'})
     .to_return(status: 206, body: File.read(fn))
 
   visit csv_preview_path(

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -1,0 +1,40 @@
+class CsvFileFromPublicHost
+  class ConnectionError < StandardError; end
+
+  MAXIMUM_RANGE_BYTES = '30000'.freeze
+
+  def initialize(path)
+    @path = path
+
+    Tempfile.create(temp_fn, temp_dir) do |tmp_file|
+      tmp_file.write(csv_file)
+      tmp_file.rewind
+      yield(tmp_file)
+    end
+  end
+
+private
+
+  def connection
+    Faraday.new(url: Whitehall.public_root)
+  end
+
+  def response
+    connection.get(@path) do |req|
+      req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
+    end
+  end
+
+  def csv_file
+    raise ConnectionError unless response.status == 206
+    response.body
+  end
+
+  def temp_dir
+    File.join(Rails.root, 'tmp')
+  end
+
+  def temp_fn
+    CGI.escape(@path)
+  end
+end

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -1,7 +1,7 @@
 class CsvFileFromPublicHost
   class ConnectionError < StandardError; end
 
-  MAXIMUM_RANGE_BYTES = '30000'.freeze
+  MAXIMUM_RANGE_BYTES = '300000'.freeze
 
   def initialize(path)
     @path = path

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -16,7 +16,9 @@ class CsvFileFromPublicHost
 private
 
   def connection
-    Faraday.new(url: Whitehall.public_root)
+    conn = Faraday.new(url: Whitehall.public_root)
+    conn.basic_auth(basic_auth_user, basic_auth_password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
+    conn
   end
 
   def response
@@ -36,5 +38,17 @@ private
 
   def temp_fn
     CGI.escape(@path)
+  end
+
+  def basic_auth_user
+    basic_auth_credentials[0]
+  end
+
+  def basic_auth_password
+    basic_auth_credentials[1]
+  end
+
+  def basic_auth_credentials
+    ENV["BASIC_AUTH_CREDENTIALS"].split(":")
   end
 end

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -9,12 +9,19 @@ class CsvPreviewControllerTest < ActionController::TestCase
     File.basename(attachment_data.filename, '.' + attachment_data.file_extension)
   end
 
+  def stub_csv_file_from_public_host(attachment)
+    file_path = File.join(Whitehall.clean_uploads_root, attachment.attachment_data.file.store_path)
+    public_url_path = attachment.file.file.asset_manager_path
+    CsvFileFromPublicHost.stubs(:new).with(public_url_path).yields(stub(path: file_path))
+  end
+
   view_test "GET #show for a CSV attachment on a public edition renders the CSV preview" do
     visible_edition = create(:published_publication, :with_file_attachment, attachments: [
       attachment = build(:csv_attachment)
     ])
     attachment_data = attachment.attachment_data
 
+    stub_csv_file_from_public_host(attachment)
     get_show attachment_data
 
     assert_equal visible_edition, assigns(:edition)
@@ -34,6 +41,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     create(:published_publication, :with_file_attachment, attachments: [attachment], organisations: [org_1, org_2, org_3])
 
+    stub_csv_file_from_public_host(attachment)
     get_show attachment_data
 
     assert_select 'a[href=?]', organisation_path(org_1)
@@ -76,6 +84,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     CsvPreview.expects(:new).raises(CsvPreview::FileEncodingError)
 
+    stub_csv_file_from_public_host(attachment)
     get_show attachment_data
 
     assert_equal visible_edition, assigns(:edition)
@@ -114,6 +123,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
     create(:published_publication, :with_file_attachment, attachments: [attachment])
 
+    stub_csv_file_from_public_host(attachment)
     get_show attachment_data
 
     assert_response :success
@@ -136,6 +146,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
+    stub_csv_file_from_public_host(attachment)
     get_show attachment_data
 
     assert_response :success

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -93,6 +93,22 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_select 'p.preview-error', text: /This file could not be previewed/
   end
 
+  view_test "GET #show handles CsvFileFromPublicHost::ConnectionError errors" do
+    visible_edition = create(:published_publication, :with_file_attachment, attachments: [
+      attachment = build(:csv_attachment)
+    ])
+    attachment_data = attachment.attachment_data
+
+    CsvFileFromPublicHost.expects(:new).raises(CsvFileFromPublicHost::ConnectionError)
+
+    get_show attachment_data
+
+    assert_equal visible_edition, assigns(:edition)
+    assert_equal attachment, assigns(:attachment)
+    assert_response :success
+    assert_select 'p.preview-error', text: /This file could not be previewed/
+  end
+
   test "GET #show for attachments that aren't visible and have been replaced permanently redirects to the replacement attachment" do
     replacement = create(:csv_attachment)
     attachment_data = create(:attachment_data, replaced_by: replacement.attachment_data)

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class CsvFileFromPublicHostTest < ActiveSupport::TestCase
   def stub_csv_request(status: 206, body: '')
     stub_request(:get, "#{Whitehall.public_root}/some-path")
-      .with(headers: { 'Range' => 'bytes=0-30000' })
+      .with(headers: { 'Range' => 'bytes=0-300000' })
       .to_return(status: status, body: body)
   end
 

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -29,4 +29,18 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
       assert_raises(CsvFileFromPublicHost::ConnectionError) { CsvFileFromPublicHost.new('some-path') }
     end
   end
+
+  test 'uses basic authentication if set in the environment' do
+    ENV.stubs(:[]).with('BASIC_AUTH_CREDENTIALS').returns('user:password')
+    ENV.stubs(:has_key?).with('BASIC_AUTH_CREDENTIALS').returns(true)
+    mock_response = mock('response')
+    mock_response.stubs(status: 206, body: '')
+    mock_connection = mock('connection')
+    mock_connection.stubs(get: mock_response)
+    Faraday.stubs(:new).returns(mock_connection)
+
+    mock_connection.expects(:basic_auth).at_least_once.with('user', 'password')
+
+    CsvFileFromPublicHost.new('some-path') {}
+  end
 end

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class CsvFileFromPublicHostTest < ActiveSupport::TestCase
+  def stub_csv_request(status: 206, body: '')
+    stub_request(:get, "#{Whitehall.public_root}/some-path")
+      .with(headers: { 'Range' => 'bytes=0-30000' })
+      .to_return(status: status, body: body)
+  end
+
+  test '#new yields a temporary file' do
+    stub_csv_request
+
+    CsvFileFromPublicHost.new('some-path') do |file|
+      assert File.exist?(file.path)
+    end
+  end
+
+  test '#new yields a temporary file that contains the contents of the request body' do
+    stub_csv_request(body: 'csv,file')
+
+    CsvFileFromPublicHost.new('some-path') do |file|
+      assert_equal 'csv,file', file.read
+    end
+  end
+
+  test '#new raises an exception if the request status is anything other than 206' do
+    [404, 502, 503].each do |status|
+      stub_csv_request(status: status)
+      assert_raises(CsvFileFromPublicHost::ConnectionError) { CsvFileFromPublicHost.new('some-path') }
+    end
+  end
+end


### PR DESCRIPTION
When we switch to storing all attachments exclusively in Asset Manager, the CsvPreview class will no longer be able to read CSV data from the local NFS mount to generate the previews presented to the
user[1].

Instead we can generate the CSV previews by fetching the CSV file served at the public host. Currently that will in effect by reading the file from the NFS mount, but when we do change over to serving from Asset Manager it will fetch the CSV file from there.

Some CSV file attachments are almost 200Mb[2] so it is not practical to fetch the entire file as part of the preview request. Fortunately the preview functionality is configured to present at most 1,000 rows
and 50 columns to the user.

I've configured the Range request to request the first 30,000 bytes of the file. This is somewhat arbitrary at the moment, and I could do some work to set this to a limit that ensures 1000 lines of every currently uploaded csv attachment is fetched.

[1] For example: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/675936/Q4_2017_csv.csv/preview
[2]
https://www.gov.uk//government/uploads/system/uploads/attachment_data/file/399850/mappings-2015-01-27T10_26_13_00_00.csv/preview