### PR TITLE
Update Asset Manager when attachment is replaced

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -98,6 +98,7 @@ class AttachmentData < ApplicationRecord
     cant_be_replaced_by_self
     raise ActiveRecord::RecordInvalid, self if self.errors.any?
     self.update_column(:replaced_by_id, replacement.id)
+    Whitehall.attachment_data_notifier.publish('replace', self)
     AttachmentData.where(replaced_by_id: self.id).each do |ad|
       ad.replace_with!(replacement)
     end

--- a/app/services/service_listeners/attachment_replacement_id_updater.rb
+++ b/app/services/service_listeners/attachment_replacement_id_updater.rb
@@ -18,7 +18,11 @@ module ServiceListeners
 
       enqueue_job(attachment_data.file, replacement.file)
       if attachment_data.pdf?
-        enqueue_job(attachment_data.file.thumbnail, replacement.file.thumbnail)
+        if replacement.pdf?
+          enqueue_job(attachment_data.file.thumbnail, replacement.file.thumbnail)
+        else
+          enqueue_job(attachment_data.file.thumbnail, replacement.file)
+        end
       end
     end
 

--- a/app/services/service_listeners/attachment_replacement_id_updater.rb
+++ b/app/services/service_listeners/attachment_replacement_id_updater.rb
@@ -1,0 +1,38 @@
+module ServiceListeners
+  class AttachmentReplacementIdUpdater
+    include Rails.application.routes.url_helpers
+    include PublicDocumentRoutesHelper
+
+    attr_reader :attachment_data, :queue
+
+    def initialize(attachment_data, queue: nil)
+      @attachment_data = attachment_data
+      @queue = queue
+    end
+
+    def update!
+      return unless attachment_data.present?
+
+      return unless attachment_data.replaced_by.present?
+      replacement = attachment_data.replaced_by
+
+      enqueue_job(attachment_data.file, replacement.file)
+      if attachment_data.pdf?
+        enqueue_job(attachment_data.file.thumbnail, replacement.file.thumbnail)
+      end
+    end
+
+  private
+
+    def enqueue_job(uploader, replacement_uploader)
+      legacy_url_path = uploader.asset_manager_path
+      replacement_legacy_url_path = replacement_uploader.asset_manager_path
+      worker.perform_async(legacy_url_path, replacement_legacy_url_path: replacement_legacy_url_path)
+    end
+
+    def worker
+      worker = AssetManagerUpdateAssetWorker
+      queue.present? ? worker.set(queue: queue) : worker
+    end
+  end
+end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -3,6 +3,11 @@ class AssetManagerUpdateAssetWorker < WorkerBase
 
   def perform(legacy_url_path, new_attributes = {})
     attributes = find_asset_by(legacy_url_path)
+
+    if (replacement_path = new_attributes.delete('replacement_legacy_url_path'))
+      new_attributes['replacement_id'] = find_asset_by(replacement_path)['id']
+    end
+
     keys = new_attributes.keys
     unless attributes.slice(*keys) == new_attributes.slice(*keys)
       asset_manager.update_asset(attributes['id'], new_attributes)

--- a/config/initializers/attachment_data_notifier.rb
+++ b/config/initializers/attachment_data_notifier.rb
@@ -1,0 +1,7 @@
+Whitehall.attachment_data_notifier.tap do |notifier|
+  notifier.subscribe('replace') do |_event, attachment_data|
+    ServiceListeners::AttachmentReplacementIdUpdater
+      .new(attachment_data)
+      .update!
+  end
+end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -162,6 +162,10 @@ module Whitehall
     @attachment_notifier ||= ActiveSupport::Notifications::Fanout.new
   end
 
+  def self.attachment_data_notifier
+    @attachment_data_notifier ||= ActiveSupport::Notifications::Fanout.new
+  end
+
   def self.organisations_in_tagging_beta
     @taggable_organisations ||=
       YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")["organisations_in_tagging_beta"]

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -30,6 +30,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     login_as :gds_editor
     @edition = create(:consultation)
     Whitehall.attachment_notifier.stubs(:publish)
+    Whitehall.attachment_data_notifier.stubs(:publish)
   end
 
   def self.supported_attachable_types

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -15,6 +15,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     let(:asset_id) { 'asset-id' }
 
     let(:replacement_filename) { 'sample.rtf' }
+    let(:replacement_asset_id) { 'replacement-asset-id' }
 
     let(:edition) { create(:news_article) }
 
@@ -40,6 +41,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
         assert_text "Attachment 'Attachment Title' updated"
 
         VirusScanHelpers.simulate_virus_scan
+        stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
       end
 
       it 'redirects requests for attachment to replacement' do
@@ -51,6 +53,12 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
 
         get @attachment_url
         assert_redirected_to replacement_url
+      end
+
+      it 'updates replacement_id for attachment in Asset Manager' do
+        Services.asset_manager.expects(:update_asset)
+          .with(asset_id, 'replacement_id' => replacement_asset_id)
+        AssetManagerUpdateAssetWorker.drain
       end
     end
   end

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+
+  context 'given a draft document with a file attachment' do
+    let(:managing_editor) { create(:managing_editor) }
+
+    let(:filename) { 'sample.docx' }
+    let(:file) { File.open(path_to_attachment(filename)) }
+    let(:attachment) { build(:file_attachment, attachable: edition, file: file) }
+    let(:asset_id) { 'asset-id' }
+
+    let(:replacement_filename) { 'sample.rtf' }
+
+    let(:edition) { create(:news_article) }
+
+    before do
+      login_as(managing_editor)
+      edition.attachments << attachment
+      setup_publishing_api_for(edition)
+      stub_whitehall_asset(filename, id: asset_id)
+      VirusScanHelpers.simulate_virus_scan
+    end
+
+    context 'when attachment is replaced' do
+      before do
+        visit admin_news_article_path(edition)
+        click_link 'Modify attachments'
+        @attachment_url = find('.existing-attachments a', text: filename)[:href]
+        within '.existing-attachments' do
+          click_link 'Edit'
+        end
+        fill_in 'Title', with: 'Attachment Title'
+        attach_file 'Replace file', path_to_attachment(replacement_filename)
+        click_button 'Save'
+        assert_text "Attachment 'Attachment Title' updated"
+
+        VirusScanHelpers.simulate_virus_scan
+      end
+
+      it 'redirects requests for attachment to replacement' do
+        visit admin_news_article_path(edition)
+        click_link 'Modify attachments'
+        replacement_url = find('.existing-attachments a', text: replacement_filename)[:href]
+
+        logout
+
+        get @attachment_url
+        assert_redirected_to replacement_url
+      end
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def setup_publishing_api_for(edition)
+    publishing_api_has_links(
+      content_id: edition.document.content_id,
+      links: {}
+    )
+  end
+
+  def path_to_attachment(filename)
+    fixture_path.join(filename)
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -5,6 +5,8 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
   setup do
     AttachmentUploader.enable_processing = true
+    @notifier = stub_everything('notifier')
+    Whitehall.stubs(:attachment_data_notifier).returns(@notifier)
   end
 
   teardown do
@@ -226,5 +228,14 @@ class AttachmentDataTest < ActiveSupport::TestCase
     to_be_replaced.replace_with!(replacer)
     assert_equal replacer, to_be_replaced.replaced_by
     assert_equal replacer, replaced.reload.replaced_by
+  end
+
+  test 'replace_with! published a replace event to the attachment data notifier' do
+    attachment_data = create(:attachment_data)
+    replacement = create(:attachment_data)
+
+    @notifier.expects(:publish).with('replace', attachment_data)
+
+    attachment_data.replace_with!(replacement)
   end
 end

--- a/test/unit/services/service_listeners/attachment_replacement_id_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_replacement_id_updater_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+
+    let(:updater) { AttachmentReplacementIdUpdater.new(attachment_data) }
+
+    context 'when attachment data is nil' do
+      let(:attachment_data) { nil }
+
+      it 'does not update replacement ID of any assets' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+        updater.update!
+      end
+    end
+
+    context 'when attachment data is not a PDF' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:sample_docx) { File.open(fixture_path.join('sample.docx')) }
+      let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+      let(:replacement) { AttachmentData.create!(file: sample_docx) }
+      let(:key) { :replacement_legacy_url_path }
+      let(:attributes) { { key => replacement.file.asset_manager_path } }
+
+      it 'updates replacement ID of corresponding asset' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment_data.file.asset_manager_path, attributes)
+
+        updater.update!
+      end
+
+      context 'and queue is specified' do
+        let(:queue) { 'alternative_queue' }
+        let(:updater) { AttachmentReplacementIdUpdater.new(attachment_data, queue: queue) }
+        let(:worker) { stub('worker') }
+
+        it 'updates replacement ID of corresponding asset using specified queue' do
+          AssetManagerUpdateAssetWorker.expects(:set)
+            .with(queue: queue).returns(worker)
+          worker.expects(:perform_async)
+            .with(attachment_data.file.asset_manager_path, attributes)
+
+          updater.update!
+        end
+      end
+    end
+
+    context 'when attachment data is a PDF' do
+      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+      let(:whitepaper_pdf) { File.open(fixture_path.join('whitepaper.pdf')) }
+      let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
+      let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
+      let(:key) { :replacement_legacy_url_path }
+      let(:attributes) { { key => replacement.file.asset_manager_path } }
+      let(:thumbnail_attributes) { { key => replacement.file.thumbnail.asset_manager_path } }
+
+      it 'updates replacement ID of asset for attachment & its thumbnail' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment_data.file.asset_manager_path, attributes)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+
+        updater.update!
+      end
+    end
+  end
+end

--- a/test/unit/services/service_listeners/attachment_replacement_id_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_replacement_id_updater_test.rb
@@ -53,8 +53,10 @@ module ServiceListeners
       let(:attachment_data) { AttachmentData.create!(file: simple_pdf, replaced_by: replacement) }
       let(:replacement) { AttachmentData.create!(file: whitepaper_pdf) }
       let(:key) { :replacement_legacy_url_path }
-      let(:attributes) { { key => replacement.file.asset_manager_path } }
-      let(:thumbnail_attributes) { { key => replacement.file.thumbnail.asset_manager_path } }
+      let(:replacement_url_path) { replacement.file.asset_manager_path }
+      let(:attributes) { { key => replacement_url_path } }
+      let(:replacement_thumbnail_url_path) { replacement.file.thumbnail.asset_manager_path }
+      let(:thumbnail_attributes) { { key => replacement_thumbnail_url_path } }
 
       it 'updates replacement ID of asset for attachment & its thumbnail' do
         AssetManagerUpdateAssetWorker.expects(:perform_async)
@@ -63,6 +65,21 @@ module ServiceListeners
           .with(attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
         updater.update!
+      end
+
+      context 'but replacement is not a PDF' do
+        let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+        let(:replacement) { AttachmentData.create!(file: sample_rtf) }
+        let(:thumbnail_attributes) { { key => replacement_url_path } }
+
+        it 'updates replacement ID of asset for attachment & its thumbnail' do
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment_data.file.asset_manager_path, attributes)
+          AssetManagerUpdateAssetWorker.expects(:perform_async)
+            .with(attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+
+          updater.update!
+        end
       end
     end
   end


### PR DESCRIPTION
The admin part of this app includes functionality to _replace_ an existing attachment. When an attachment is replaced, a request for the original attachment is redirected to the new attachment.

When we start serving Whitehall attachments from Asset Manager we'll want the attachment replacement functionality to continue to work. I added the ability to replace an asset in Asset Manager in https://github.com/alphagov/asset-manager/pull/499. This PR hooks into Whitehall at the point where an asset is replaced and queues up a job (or jobs) to update the relevant asset(s) in Asset Manager with the appropriate `replacement_id`.

I've chosen to hook into `AttachmentData#replace_with!` rather than in `AttachmentsController#update`, because it was more straightforward and I feel as if it's more robust against user interface changes.

The logic in `AttachmentVisibility` is really quite complicated and when considered in combination with the way `Attachment` instances are duplicated onto new editions, `AttachmentData` instances are shared between zero-many `Attachment` instances, and old editions are "quietly" marked as "superseded", and so I found it really hard to work out what was going on.

Consequently I'm slightly wary that `AttachmentVisibility#visible?` might return `false` for a replaced attachment in cases where you might expect it to return `true`. This would mean that `ServiceListeners::AttachmentDraftStatusUpdater#update!` might incorrectly try to change the draft status of an asset associated with a published, but replaced, attachment to `true`, which would mean that the redirect to the replacement asset would not be publicly available.

To protect against this problem, I've added some validation in Asset Manager in https://github.com/alphagov/asset-manager/pull/503. If we start seeing exceptions in Whitehall because of this we might need to revisit this PR.

I'm increasingly feeling as if we might be better merging the generic functionality in `AssetManagerUpdateAssetWorker` into the various attachment updater classes and converting those into more specialist workers, but that can wait for now.

I'm also starting to think we should've added new Asset Manager API endpoints for things like un-publishing/withdrawing an asset or, in this case, replacing an asset, rather than re-using the existing generic update endpoint, but again that can wait for now.

Note that the new updater class, `AttachmentReplacementIdUpdater`, operates on an instance of an `AttachmentData` rather than an instance of `Attachment`. This was because the former is actually what we care about in the updater and since we're hooking into `AttachmentData#replace_with!`, we already know the instance we want to operate on. We might want to consider changing all the updater classes to work the same way.

It might also make sense to combine the existing `Whitehall.attachment_notifier` with the `Whitehall.attachment_data_notifier` introduced in this PR, but that can also wait for now.

Note that I've left [the code which optimises out multiple redirects][1] in Whitehall for now. We might want to consider moving that to Asset Manager.

[1]: https://github.com/alphagov/whitehall/blob/c78b00f489276ba67411f688475329e3c4f9f449/app/models/attachment_data.rb#L101-L103
