### PR TITLE
 Only show taxons with flag visible_to_departmental_editors

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -4,21 +4,20 @@ module Taxonomy
 
     def draft_taxon_data
       @_draft_data ||= begin
-        expand_taxon_array only_visible_taxons(draft_taxons_data)
+        expand_taxon_array draft_taxons_data
       end
     end
 
     def published_taxon_data
       @_published_data ||= begin
-        taxons = get_level_one_taxons(with_drafts: false)
-        expand_taxon_array(taxons)
+        expand_taxon_array get_level_one_taxons(with_drafts: false)
       end
     end
 
   private
 
     def only_visible_taxons(taxons)
-      taxons.select { |taxon_hash| taxon_hash.fetch('details', {})['visible_to_departmental_editors'] }
+      taxons.select { |taxon_hash| taxon_hash.dig('details', 'visible_to_departmental_editors') }
     end
 
     def expand_taxon_array(taxons)
@@ -48,9 +47,10 @@ module Taxonomy
     end
 
     def get_level_one_taxons(with_drafts:)
-      get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
+      all_results = get_expanded_links_hash(HOMEPAGE_CONTENT_ID, with_drafts: with_drafts)
         .fetch('expanded_links', {})
         .fetch('level_one_taxons', [])
+      only_visible_taxons all_results
     end
 
     def get_expanded_links_hash(content_id, with_drafts:)

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -6,72 +6,72 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
   end
 
   test "#published_taxon_data" do
-    setup_published_taxons([published_taxon])
+    setup_taxons([visible_published_taxon, not_visible_published_taxon], with_drafts: false)
+    setup_taxons([visible_draft_taxon, not_visible_draft_taxon, visible_published_taxon, not_visible_published_taxon], with_drafts: true)
     result = subject.published_taxon_data
-    assert_equal result, [published_taxon_tree]
+    assert_same_elements result, [taxon_tree(visible_published_taxon), taxon_tree(not_visible_published_taxon)]
   end
 
   test "#draft_taxon_data" do
-    setup_published_taxons([published_taxon])
-    setup_draft_taxons([visible_draft_taxon, draft_taxon])
+    setup_taxons([visible_published_taxon, not_visible_published_taxon], with_drafts: false)
+    setup_taxons([visible_draft_taxon, not_visible_draft_taxon, visible_published_taxon, not_visible_published_taxon], with_drafts: true)
     result = subject.draft_taxon_data
-    assert_equal [visible_draft_taxon_tree], result
+    assert_same_elements [taxon_tree(visible_draft_taxon)], result
   end
 
-  def published_taxon_tree
-    published_taxon.tap do |taxon|
-      taxon['expanded_links_hash'] = published_taxon
+  def taxon_tree(taxon)
+    taxon.tap do |t|
+      t['expanded_links_hash'] = taxon.dup
     end
   end
 
-  def published_taxon
-    { "content_id" => "published" }
-  end
-
-  def draft_taxon
-    { "content_id" => "draft" }
-  end
-
-  def visible_draft_taxon_tree
-    visible_draft_taxon.tap do |taxon|
-      taxon['expanded_links_hash'] = visible_draft_taxon
-    end
-  end
-
-  def visible_draft_taxon
+  def visible_published_taxon
     {
-      "content_id" => "visible_and_draft",
+      "content_id" => "published_visible",
       "details" => {
         "visible_to_departmental_editors" => true
       }
     }
   end
 
-  def setup_published_taxons(level_one_taxons)
-    homepage_expanded_links = {
-      "content_id" => Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID,
-      "expanded_links" => {
-        "level_one_taxons" => level_one_taxons
+  def not_visible_published_taxon
+    {
+      "content_id" => "published",
+      "details" => {
+        "visible_to_departmental_editors" => false
       }
     }
-    publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: false)
-
-    level_one_taxons.each do |taxon|
-      publishing_api_has_expanded_links(taxon, with_drafts: true)
-    end
   end
 
-  def setup_draft_taxons(level_one_taxons)
+  def not_visible_draft_taxon
+    {
+      "content_id" => "draft",
+      "details" => {
+        "visible_to_departmental_editors" => false
+      }
+    }
+  end
+
+  def visible_draft_taxon
+    {
+      "content_id" => "draft_visible",
+      "details" => {
+        "visible_to_departmental_editors" => true
+      }
+    }
+  end
+
+  def setup_taxons(level_one_taxons, with_drafts: false)
     homepage_expanded_links = {
       "content_id" => Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID,
       "expanded_links" => {
         "level_one_taxons" => level_one_taxons
       }
     }
-    publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: true)
+    publishing_api_has_expanded_links(homepage_expanded_links, with_drafts: with_drafts)
 
     level_one_taxons.each do |taxon|
-      publishing_api_has_expanded_links(taxon, with_drafts: true)
+      publishing_api_has_expanded_links(taxon, with_drafts: with_drafts)
     end
   end
 end

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -9,7 +9,7 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
     setup_taxons([visible_published_taxon, not_visible_published_taxon], with_drafts: false)
     setup_taxons([visible_draft_taxon, not_visible_draft_taxon, visible_published_taxon, not_visible_published_taxon], with_drafts: true)
     result = subject.published_taxon_data
-    assert_same_elements result, [taxon_tree(visible_published_taxon), taxon_tree(not_visible_published_taxon)]
+    assert_same_elements result, [taxon_tree(visible_published_taxon)]
   end
 
   test "#draft_taxon_data" do


### PR DESCRIPTION
This change will show draft and published taxons in the 'edit editions tags'
interface, only when the 'visible_to_departmental_editors' flag has been set
in the level one taxons.

Previously all published taxons, regardless of the 'visible_to_departmental_editors' 
flag would be show.

Trello: https://trello.com/c/pzbqjfTU/159-spike-investigate-impact-on-education-world-and-transport-tagging-interfaces-in-whitehall

