### PR TITLE
Don't include govuk_toolkit in application.js

### DIFF
--- a/app/assets/javascripts/all.js
+++ b/app/assets/javascripts/all.js
@@ -1,8 +1,8 @@
-// This is a manifest file that'll be compiled into including all the files listed below.
-// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
-// be included in the compiled file accessible from http://example.com/assets/application.js
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// the compiled file.
+// This is a manifest file used by the runner for JavaScript unit tests.
+// It is not used in the main application. If you add something to
+// application.js (for whitehall-frontend) or admin.js (for whitehall-admin)
+// make sure to add it here.  Or if you remove something from application.js
+// that you get from static when deployed, then make sure to add it in here.
 //
 //= require govuk-admin-template
 //= require jquery.ui.all

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 //= require vendor/sorttable
 //= require vendor/object-create-polyfill
 //
-//= require govuk_toolkit
 //= require shared_mustache
 //= require templates
 //


### PR DESCRIPTION
For: https://trello.com/c/AK6V1hHg/103-sort-out-govuktoolkit-use-in-frontend-apps-to-avoid-object-object-in-ga

When the application is deployed we get the govuk_toolkit js files from
static, if we also include them in our own JS bundle we:

1. make users effectively download the same code twice
2. run the risk of delivering two different versions of the code and
   causing errors in how things interact
3. run the risk of delivering two versions of the code that interact
   strangely because they end up redefininig things and cause things
   like type-checks to fail

Of course, if we rely on static to deliver this JS we won't have it in
test environments, but luckily we already have `all.js` which is loaded
in our testing environments and does include it.  We've added a comment
to the top of that file making it clearer what its purpose is.

It's worth noting that 2. and 3. are not hypothetical.  When we added PII
stripping functionality to govuk_frontend_toolkit and delivered it via
static we saw both of these problems.  1st: the version of the JS included
in the frontend apps was out of sync with the version delivered by static
so it didn't understand the PIISafe object at all and would raise errors
when trying to call that function, resulting in no analytics being sent.
2nd: after updating the govuk_frontend_toolkit version in the apps so it
was in sync with that delivered by static, we saw custom dimension values
of `[object Object]` being sent to analytics because the two versions on
the page disagreed about the type of `Analytics.PIISafe` instances and
didn't extract the value correctly.

Removing the govuk_toolkit reqire from our application.js avoids this
entirely.