### PR TITLE
Add index on link_reportable to link_checker_api_reports

### DIFF
--- a/db/migrate/20180302165453_add_index_on_link_checker_reportable_to_link_checker_api_reports.rb
+++ b/db/migrate/20180302165453_add_index_on_link_checker_reportable_to_link_checker_api_reports.rb
@@ -1,0 +1,5 @@
+class AddIndexOnLinkCheckerReportableToLinkCheckerApiReports < ActiveRecord::Migration[5.0]
+  def change
+    add_index :link_checker_api_reports, [:link_reportable_type, :link_reportable_id], name: 'index_link_checker_api_reportable'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116144233) do
+ActiveRecord::Schema.define(version: 20180302165453) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -680,6 +680,7 @@ ActiveRecord::Schema.define(version: 20180116144233) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.index ["batch_id"], name: "index_link_checker_api_reports_on_batch_id", unique: true, using: :btree
+    t.index ["link_reportable_type", "link_reportable_id"], name: "index_link_checker_api_reportable", using: :btree
   end
 
   create_table "nation_inapplicabilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
For: https://trello.com/c/aqGcNwFT/90-2-whitehall-link-checker-pegs-mysql-at-400-cpu-every-morning

This index will speed up all access to link checker reports that starts
from an edition.  That means the documents index, edition show, and check
organisation links worker job.  This table is very large and the join is
very slow without an index on the link reportable type and id columns.
For example, with the table at ~850,000 rows it took ~15minutes on staging
to fetch 500 editions for a single org and join that list against their
link checker api reports.  Adding the index reduces this to less than a
second.  This is one of the queries that the check organistion links
worker job performs. With the index the total time to run all the check
organisation links worker jobs went from ~15 hours on staging to ~10
minutes.

Usually adding an index to a large table directly is something we'd like
to avoid, because it will lock the table for the duration.  However we
tested this on staging and it only took 3 seconds to add, so we're going
to bite the bullet and just do it.  We'll deploy this during a period of
relative minor use in the app to avoid disruption, but it's a lot easier
to apply the index directly compared to using online-schema-change tools
like [lhm][] or [percona][] to do this for us.

[lhm]:https://github.com/soundcloud/lhm
[percona]:https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html

Note: this is an alternative to #3824 because after testing we realised we could
get away with creating the index directly, rather than moving things around.