### PR TITLE
Remove unused Asset Manager stubs

### DIFF
--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -167,8 +167,6 @@ class AttachmentsControllerTest < ActionController::TestCase
   end
 
   test 'deleted attachments policy groups return 404' do
-    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
     attachment = create(:file_attachment, attachable: create(:policy_group))
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -47,8 +47,6 @@ class AttachmentDataTest < ActiveSupport::TestCase
   end
 
   test "should save content type and file size on update" do
-    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
     greenpaper_pdf = fixture_file_upload('greenpaper.pdf', 'application/pdf')
     whitepaper_pdf = fixture_file_upload('whitepaper.pdf', 'application/pdf')
     attachment = create(:attachment_data, file: greenpaper_pdf)
@@ -95,8 +93,6 @@ class AttachmentDataTest < ActiveSupport::TestCase
   end
 
   test "should set page count for PDF on update" do
-    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
     two_pages_pdf = fixture_file_upload('two-pages.pdf')
     three_pages_pdf = fixture_file_upload('three-pages.pdf')
     attachment = create(:attachment_data, file: two_pages_pdf)

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -195,8 +195,6 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
   end
 
   test "#visible returns false for deleted attachment on a publication" do
-    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
     publication = create(:published_publication, :with_file_attachment)
     attachment = publication.attachments.last
     attachment.destroy
@@ -219,8 +217,6 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
   end
 
   test "#visible returns false for deleted attachment on a PolicyGroup" do
-    Services.asset_manager.stubs(:whitehall_asset).returns('id' => 'http://asset-manager/assets/asset-id')
-
     policy_group = create(:policy_group, :with_file_attachment)
     attachment = policy_group.attachments.last
     attachment.destroy


### PR DESCRIPTION
These stubs were all introduced in [this commit][1] in connection with deleting attachments. However, they haven't been necessary since the tests were switched to use Sidekiq's fake mode in [this PR][2], which means `AssetManagerDeleteAssetWorker#perform` is no longer executed.

[1]:
https://github.com/alphagov/whitehall/commit/dbff284870c7ae5e9e893b5df9faf92c90d4bab3
[2]: https://github.com/alphagov/whitehall/pull/3793
