### PR TITLE
Do not destroy instances of AttachmentData for attachments marked as deleted

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -124,7 +124,7 @@ module Attachable
   end
 
   def delete_all_attachments
-    attachments.each { |attachment| attachment.update(deleted: true) }
+    attachments.each(&:destroy)
   end
 
   def reorder_attachments(ordered_attachment_ids)

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -6,8 +6,6 @@ class FileAttachment < Attachment
     :number_of_pages, :file, :filename, :filename_without_extension, :virus_status,
     to: :attachment_data
 
-  after_destroy :destroy_unused_attachment_data
-
   accepts_nested_attributes_for :attachment_data, reject_if: ->(attributes) { attributes[:file].blank? && attributes[:file_cache].blank? }
 
   validate :filename_is_unique
@@ -29,13 +27,6 @@ class FileAttachment < Attachment
   end
 
 private
-
-  # Only destroy the associated attachment_data record if no other attachments are using it
-  def destroy_unused_attachment_data
-    if attachment_data && Attachment.not_deleted.where(attachment_data_id: attachment_data.id).empty?
-      attachment_data.destroy
-    end
-  end
 
   def filename_is_unique
     if attachable && attachable.attachments.any? { |a| a.file? && a != self && a.filename.downcase == filename.try(:downcase) }

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -82,7 +82,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
       assert_response :redirect
       assert Attachment.find(attachment.id).deleted?, 'attachment should have been soft-deleted'
-      assert AttachmentData.find_by(id: attachment_data.id).nil?, 'attachment data should have been deleted'
     end
   end
 

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -174,8 +174,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
     attachment.destroy
 
-    assert_raises(ActiveRecord::RecordNotFound) do
-      get_show attachment_data
-    end
+    get_show attachment_data
+    assert_response :not_found
   end
 end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -147,7 +147,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment = new_edition.attachments.last
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
-    attachment.update_column(:deleted, true)
+    attachment.destroy
 
     get :show, params: { id: attachment_data.to_param, file: basename(attachment_data), extension: attachment_data.file_extension }
 
@@ -159,7 +159,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment = visible_edition.attachments.first
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
-    attachment.update_column(:deleted, true)
+    attachment.destroy
 
     get_show attachment_data
 

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+
+  context 'given a draft document with a file attachment' do
+    let(:managing_editor) { create(:managing_editor) }
+
+    let(:filename) { 'sample.docx' }
+    let(:file) { File.open(path_to_attachment(filename)) }
+    let(:attachment) { build(:file_attachment, attachable: edition, file: file) }
+    let(:asset_id) { 'asset-id' }
+
+    let(:edition) { create(:news_article) }
+
+    before do
+      login_as(managing_editor)
+      edition.attachments << attachment
+      setup_publishing_api_for(edition)
+      stub_whitehall_asset(filename, id: asset_id)
+      VirusScanHelpers.simulate_virus_scan
+
+      visit admin_news_article_path(edition)
+      click_link 'Modify attachments'
+      @attachment_url = find('.existing-attachments a', text: filename)[:href]
+    end
+
+    context 'when attachment is deleted' do
+      before do
+        visit admin_news_article_path(edition)
+        click_link 'Modify attachments'
+        within '.existing-attachments' do
+          click_link 'Delete'
+        end
+        assert_text 'Attachment deleted'
+      end
+
+      it 'responds with 404 Not Found for attachment URL' do
+        logout
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get @attachment_url
+        end
+      end
+
+      it 'deletes attachment in Asset Manager' do
+        Services.asset_manager.expects(:delete_asset)
+          .with(asset_id)
+        AssetManagerDeleteAssetWorker.drain
+      end
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def setup_publishing_api_for(edition)
+    publishing_api_has_links(
+      content_id: edition.document.content_id,
+      links: {}
+    )
+  end
+
+  def path_to_attachment(filename)
+    fixture_path.join(filename)
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+      .with(&ends_with(filename))
+      .returns(attributes.merge(id: url_id).stringify_keys)
+  end
+end

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -41,15 +41,8 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       it 'responds with 404 Not Found for attachment URL' do
         logout
 
-        assert_raises(ActiveRecord::RecordNotFound) do
-          get @attachment_url
-        end
-      end
-
-      it 'deletes attachment in Asset Manager' do
-        Services.asset_manager.expects(:delete_asset)
-          .with(asset_id)
-        AssetManagerDeleteAssetWorker.drain
+        get @attachment_url
+        assert_response :not_found
       end
     end
 

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -52,6 +52,20 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
         AssetManagerDeleteAssetWorker.drain
       end
     end
+
+    context 'when draft document is discarded' do
+      before do
+        visit admin_news_article_path(edition)
+        click_button 'Discard draft'
+      end
+
+      it 'responds with 404 Not Found for attachment URL' do
+        logout
+
+        get @attachment_url
+        assert_response :not_found
+      end
+    end
   end
 
 private

--- a/test/unit/file_attachment_test.rb
+++ b/test/unit/file_attachment_test.rb
@@ -41,23 +41,6 @@ class FileAttachmentTest < ActiveSupport::TestCase
     assert_match %r(can't be blank), attachment.errors[:"attachment_data.file"].first
   end
 
-  test "does not destroy attachment_data when more attachments are associated" do
-    saved_attachment = create(:file_attachment)
-    attachment_data = saved_attachment.attachment_data
-    _other_attachment = create(:file_attachment, attachment_data: attachment_data)
-
-    attachment_data.expects(:destroy).never
-    saved_attachment.destroy
-  end
-
-  test "destroys attachment_data when no attachments are associated" do
-    saved_attachment = create(:file_attachment)
-    attachment_data = saved_attachment.attachment_data
-
-    attachment_data.expects(:destroy)
-    saved_attachment.destroy
-  end
-
   test "update with empty nested attachment data attributes still works" do
     attachment = create(:file_attachment)
 


### PR DESCRIPTION
There are two ways that `AttachmentsController#show` can respond with a `404 Not Found` for a deleted attachment:

A. If the `AttachmentData` does not exist the call to `AttachmentData.find` raises an `ActiveRecord::RecordNotFound` exception which is [translated into a `404 Not Found` in production][1].

B. If the `Attachment` is marked as deleted, its edition is not included in [`AttachmentVisibility#edition_ids`][2] and thus `AttachmentVisibility#visible?` will return `false` and [this line][3] in `AttachmentsController#fail` will be invoked.

Previously, for scenarios involving deleted attachments†, the application was only relying on mechanism A when a single attachment was deleted from a document which had never been published. Even in the very similar scenario when a document which has never been published is discarded, the AttachmentData instances associated with its attachments are not destroyed.

The changes in this commit mean that the application now relies on mechanism B for *all* scenarios involving deleted attachments, i.e. it makes things more consistent.

I did consider using mechanism A in all scenarios, but this would've meant a lot more changes and it would mean we were potentially deleting useful data.

In some ways this is a step backwards in terms of marking attachment assets as deleted in Asset Manager, but there was already work to do on that front and now it can start from a more consistent starting point.

† Mechanism A is still used if the `AttachmentData` ID in the URL path does not exist.

[1]:
http://guides.rubyonrails.org/v5.0.6/action_controller_overview.html#rescue
[2]:
https://github.com/alphagov/whitehall/blob/32bb13cf3ae3ae9ca71fa14bd4c620c631660419/app/models/attachment_visibility.rb#L116-L118
[3]:
https://github.com/alphagov/whitehall/blob/32bb13cf3ae3ae9ca71fa14bd4c620c631660419/app/controllers/attachments_controller.rb#L31