### PR TITLE
Handle CSV file encoding correctly when fetching from the public URL

### DIFF
--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class CsvFileFromPublicHostTest < ActiveSupport::TestCase
+  def encoding_fixture(encoding)
+    File.open(Rails.root.join("test/fixtures/csv_encodings/#{encoding}.csv"))
+  end
+
   def stub_csv_request(status: 206, body: '')
     stub_request(:get, "#{Whitehall.public_root}/some-path")
       .with(headers: { 'Range' => 'bytes=0-300000' })
@@ -9,6 +13,30 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
 
   test '#new yields a temporary file' do
     stub_csv_request
+
+    CsvFileFromPublicHost.new('some-path') do |file|
+      assert File.exist?(file.path)
+    end
+  end
+
+  test '#new handles utf-8 encoding' do
+    stub_csv_request(body: encoding_fixture('utf-8'))
+
+    CsvFileFromPublicHost.new('some-path') do |file|
+      assert File.exist?(file.path)
+    end
+  end
+
+  test '#new handles iso-8859-1 encoded files' do
+    stub_csv_request(body: encoding_fixture('iso-8859-1'))
+
+    CsvFileFromPublicHost.new('some-path') do |file|
+      assert File.exist?(file.path)
+    end
+  end
+
+  test '#new handles windows-1252 encoded files' do
+    stub_csv_request(body: encoding_fixture('windows-1252'))
 
     CsvFileFromPublicHost.new('some-path') do |file|
       assert File.exist?(file.path)


### PR DESCRIPTION
We need to detect the encoding of the CSV before trying to write it to
a temporary file, so that we open the file with the correct encoding
mode.

The detection code here is borrowed from the `CsvPreview` class.