### PR TITLE
Respond with 404 Not Found for attachments on an edition which is both unpublished & deleted

### DIFF
--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -43,7 +43,7 @@ class AttachmentVisibility
   def unpublished_edition
     attachable_ids = edition_ids + consultation_ids
     if (unpublishing = Unpublishing.where(edition_id: attachable_ids).first)
-      Edition.unscoped.find(unpublishing.edition_id)
+      Edition.find_by(id: unpublishing.edition_id)
     end
   end
 

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -42,10 +42,8 @@ class Unpublishing < ApplicationRecord
     unpublishing_reason.as_sentence
   end
 
-  # Because the edition may have been deleted, we override the slug in case it
-  # has bee pre-fixed with 'deleted-'
   def document_path
-    Whitehall.url_maker.public_document_path(edition, id: slug)
+    Whitehall.url_maker.public_document_path(edition)
   end
 
   def document_url

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -176,13 +176,13 @@ class AttachmentsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
-  test '#show redirects to the edition if the edition has been unpublished and deleted' do
+  test '#show responds with 404 if the edition has been unpublished and deleted' do
     edition = create(:unpublished_publication, :with_file_attachment, :deleted)
     attachment = edition.attachments.first
     attachment_data = attachment.attachment_data
     VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
     get_show attachment_data
-    assert_redirected_to publication_url(edition.document)
+    assert_response :not_found
   end
 end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -175,4 +175,14 @@ class AttachmentsControllerTest < ActionController::TestCase
     get_show attachment_data
     assert_response :not_found
   end
+
+  test '#show redirects to the edition if the edition has been unpublished and deleted' do
+    edition = create(:unpublished_publication, :with_file_attachment, :deleted)
+    attachment = edition.attachments.first
+    attachment_data = attachment.attachment_data
+    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+
+    get_show attachment_data
+    assert_redirected_to publication_url(edition.document)
+  end
 end

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -152,16 +152,6 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     assert_equal unpublished_edition, attachment_visibility.unpublished_edition
   end
 
-  test '#unpublished_edition returns the edition, even if it is deleted' do
-    deleted_edition = create(:deleted_publication, :with_file_attachment)
-    create(:unpublishing, edition: deleted_edition)
-    attachment_data = deleted_edition.attachments.first.attachment_data
-    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
-
-    refute attachment_visibility.visible?
-    assert_equal deleted_edition, attachment_visibility.unpublished_edition
-  end
-
   test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation outcome' do
     unpublished_consultation = create(:consultation, :unpublished)
     outcome = unpublished_consultation.create_outcome!(attributes_for(:consultation_outcome))

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -130,40 +130,11 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal original_path, unpublishing.document_path
   end
 
-  test '#document_path returns the URL path for a deleted unpublished edition' do
-    edition = create(:detailed_guide)
-    original_path = Whitehall.url_maker.public_document_path(edition)
-    unpublishing = create(:unpublishing, edition: edition,
-                          unpublishing_reason: UnpublishingReason::PublishedInError)
-
-
-    EditionDeleter.new(edition).perform!
-    # The default scope on Edition stops deleted editions being found when an
-    # unpublishing is loaded. To trigger the bug we need to reload.
-    unpublishing.reload
-
-    assert_equal original_path, unpublishing.document_path
-  end
-
   test '#document_url returns the URL for the unpublished edition' do
     edition = create(:detailed_guide, :draft)
     original_url = Whitehall.url_maker.public_document_url(edition)
     unpublishing = create(:unpublishing, edition: edition,
                           unpublishing_reason: UnpublishingReason::PublishedInError)
-
-    assert_equal original_url, unpublishing.document_url
-  end
-
-  test '#document_url returns the URL for a deleted unpublished edition' do
-    edition = create(:detailed_guide)
-    original_url = Whitehall.url_maker.public_document_url(edition)
-    unpublishing = create(:unpublishing, edition: edition,
-                          unpublishing_reason: UnpublishingReason::PublishedInError)
-
-    EditionDeleter.new(edition).perform!
-    # The default scope on Edition stops deleted editions being found when an
-    # unpublishing is loaded. To trigger the bug we need to reload.
-    unpublishing.reload
 
     assert_equal original_url, unpublishing.document_url
   end


### PR DESCRIPTION
Previously a request for an attachment on an edition which was both unpublished & deleted resulted in a redirect to the document page, which then responded with a `404 Not Found`.

This PR changes the behaviour so the attachment request itself responds with `404 Not Found`. I think this is more consistent and easier to understand. It should also help with some refactoring of `AttachmentVisibility` that I'm doing separately.