### PR TITLE
Set asset redirect_url to the URL of the parent document

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -48,6 +48,10 @@ class Unpublishing < ApplicationRecord
     Whitehall.url_maker.public_document_path(edition, id: slug)
   end
 
+  def document_url
+    Whitehall.url_maker.public_document_url(edition, id: slug)
+  end
+
   # Because the edition may have been deleted, we need to find it unscoped to
   # get around the default scope.
   def edition

--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -17,7 +17,7 @@ module ServiceListeners
       visibility = visibility_for(attachment_data)
       redirect_url = nil
       if !visibility.visible? && (edition = visibility.unpublished_edition)
-        redirect_url = edition.unpublishing.document_path
+        redirect_url = edition.unpublishing.document_url
       end
       enqueue_job(attachment_data.file, redirect_url)
       if attachment_data.pdf?

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -11,7 +11,8 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
   let(:attachment) { build(:file_attachment, attachable: attachable, file: file) }
   let(:attachable) { edition }
   let(:asset_id) { 'asset-id' }
-  let(:redirect_url) { Whitehall.url_maker.public_document_path(edition) }
+  let(:redirect_path) { Whitehall.url_maker.public_document_path(edition) }
+  let(:redirect_url) { Whitehall.url_maker.public_document_url(edition) }
 
   before do
     login_as create(:managing_editor)
@@ -29,7 +30,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       unpublish_document_published_in_error
       logout
       get attachment.url
-      assert_redirected_to redirect_url
+      assert_redirected_to redirect_path
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
@@ -38,7 +39,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       consolidate_document
       logout
       get attachment.url
-      assert_redirected_to redirect_url
+      assert_redirected_to redirect_path
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
@@ -62,7 +63,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       unpublish_document_published_in_error
       logout
       get attachment.url
-      assert_redirected_to redirect_url
+      assert_redirected_to redirect_path
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
@@ -86,7 +87,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       unpublish_document_published_in_error
       logout
       get attachment.url
-      assert_redirected_to redirect_url
+      assert_redirected_to redirect_path
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -10,7 +10,7 @@ module ServiceListeners
     let(:visibility) { stub('visibility', visible?: visible, unpublished_edition: edition) }
     let(:visible) { false }
     let(:edition) { FactoryBot.create(:unpublished_edition) }
-    let(:redirect_url) { Whitehall.url_maker.public_document_path(edition) }
+    let(:redirect_url) { Whitehall.url_maker.public_document_url(edition) }
 
     before do
       AttachmentVisibility.stubs(:new).returns(visibility)

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -121,7 +121,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal ['must be provided when withdrawing'], unpublishing.errors[:explanation]
   end
 
-  test '#document_path returns the URL for the unpublished edition' do
+  test '#document_path returns the URL path for the unpublished edition' do
     edition = create(:detailed_guide, :draft)
     original_path = Whitehall.url_maker.public_document_path(edition)
     unpublishing = create(:unpublishing, edition: edition,
@@ -130,7 +130,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal original_path, unpublishing.document_path
   end
 
-  test '#document_path returns the URL for a deleted unpublished edition' do
+  test '#document_path returns the URL path for a deleted unpublished edition' do
     edition = create(:detailed_guide)
     original_path = Whitehall.url_maker.public_document_path(edition)
     unpublishing = create(:unpublishing, edition: edition,
@@ -143,6 +143,29 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing.reload
 
     assert_equal original_path, unpublishing.document_path
+  end
+
+  test '#document_url returns the URL for the unpublished edition' do
+    edition = create(:detailed_guide, :draft)
+    original_url = Whitehall.url_maker.public_document_url(edition)
+    unpublishing = create(:unpublishing, edition: edition,
+                          unpublishing_reason: UnpublishingReason::PublishedInError)
+
+    assert_equal original_url, unpublishing.document_url
+  end
+
+  test '#document_url returns the URL for a deleted unpublished edition' do
+    edition = create(:detailed_guide)
+    original_url = Whitehall.url_maker.public_document_url(edition)
+    unpublishing = create(:unpublishing, edition: edition,
+                          unpublishing_reason: UnpublishingReason::PublishedInError)
+
+    EditionDeleter.new(edition).perform!
+    # The default scope on Edition stops deleted editions being found when an
+    # unpublishing is loaded. To trigger the bug we need to reload.
+    unpublishing.reload
+
+    assert_equal original_url, unpublishing.document_url
   end
 
   test '#translated_locales is delegated to the edition' do


### PR DESCRIPTION
Instead of a relative path to the parent document.

We need to specify the full URL so that the redirect works as expected
when the asset is requested via either draft-assets or assets-origin.

I've added the `Unpublishing#document_url` method (to complement the
`Unpublishing#document_path` method) but it's not entirely clear that
this is better than calling `Whitehall.url_maker.public_document_url`
directly from within `AttachmentRedirectUrlUpdater`.