### PR TITLE
Reduce duplication in attachment-related controllers

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -38,10 +38,6 @@ private
     end
   end
 
-  def analytics_format
-    @edition.type.underscore.to_sym
-  end
-
   def set_slimmer_template
     slimmer_template 'chromeless'
   end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,4 +1,4 @@
-class AttachmentsController < ApplicationController
+class AttachmentsController < BaseAttachmentsController
   include PublicDocumentRoutesHelper
 
   def show
@@ -13,74 +13,10 @@ class AttachmentsController < ApplicationController
 
 private
 
-  def attachment_visible?
-    upload_exists?(upload_path) && attachment_visibility.visible?
-  end
-
-  def fail
-    if (edition = attachment_visibility.unpublished_edition)
-      redirect_to edition.unpublishing.document_path
-    elsif (replacement = attachment_data.replaced_by)
-      expires_headers
-      redirect_to replacement.url, status: 301
-    elsif image? upload_path
-      redirect_to view_context.path_to_image('thumbnail-placeholder.png')
-    elsif incoming_upload_exists? upload_path
-      redirect_to_placeholder
-    else
-      render plain: "Not found", status: :not_found
-    end
-  end
-
   def link_rel_headers
     if (edition = attachment_visibility.visible_edition)
       response.headers['Link'] = "<#{public_document_url(edition)}>; rel=\"up\""
     end
-  end
-
-  def set_slimmer_template
-    slimmer_template 'chromeless'
-  end
-
-  def attachment_data
-    @attachment_data ||= AttachmentData.find(params[:id])
-  end
-
-  def expires_headers
-    if current_user.nil?
-      expires_in(Whitehall.uploads_cache_max_age, public: true)
-    else
-      expires_now
-    end
-  end
-
-  def upload_path
-    File.join(Whitehall.clean_uploads_root, path_to_attachment_or_thumbnail)
-  end
-
-  def file_with_extensions
-    [params[:file], params[:extension], params[:format]].compact.join('.')
-  end
-
-  def path_to_attachment_or_thumbnail
-    attachment_data.file.store_path(file_with_extensions)
-  end
-
-  def attachment_visibility
-    @attachment_visibility ||= AttachmentVisibility.new(attachment_data, current_user)
-  end
-
-  def file_is_clean?(path)
-    path.starts_with?(Whitehall.clean_uploads_root)
-  end
-
-  def image?(path)
-    ['.jpg', '.jpeg', '.png', '.gif'].include?(File.extname(path))
-  end
-
-  def incoming_upload_exists?(path)
-    path = path.sub(Whitehall.clean_uploads_root, Whitehall.incoming_uploads_root)
-    File.exist?(path)
   end
 
   def mime_type_for(path)
@@ -91,22 +27,11 @@ private
     File.realpath(potentially_symlinked_path)
   end
 
-  def redirect_to_placeholder
-    # Cache is explicitly 1 minute to prevent the virus redirect beng
-    # cached by CDNs.
-    expires_in(1.minute, public: true)
-    redirect_to placeholder_url
-  end
-
   def send_file_for_mime_type
     if (mime_type = mime_type_for(upload_path))
       send_file real_path_for_x_accel_mapping(upload_path), type: mime_type, disposition: 'inline'
     else
       send_file real_path_for_x_accel_mapping(upload_path), disposition: 'inline'
     end
-  end
-
-  def upload_exists?(path)
-    File.exist?(path) && file_is_clean?(path)
   end
 end

--- a/app/controllers/base_attachments_controller.rb
+++ b/app/controllers/base_attachments_controller.rb
@@ -1,0 +1,78 @@
+class BaseAttachmentsController < ApplicationController
+protected
+
+  def attachment_visible?
+    upload_exists?(upload_path) && attachment_visibility.visible?
+  end
+
+  def fail
+    if (edition = attachment_visibility.unpublished_edition)
+      redirect_to edition.unpublishing.document_path
+    elsif (replacement = attachment_data.replaced_by)
+      expires_headers
+      redirect_to replacement.url, status: 301
+    elsif image? upload_path
+      redirect_to view_context.path_to_image('thumbnail-placeholder.png')
+    elsif incoming_upload_exists? upload_path
+      redirect_to_placeholder
+    else
+      render plain: "Not found", status: :not_found
+    end
+  end
+
+  def set_slimmer_template
+    slimmer_template 'chromeless'
+  end
+
+  def attachment_data
+    @attachment_data ||= AttachmentData.find(params[:id])
+  end
+
+  def expires_headers
+    if current_user.nil?
+      expires_in(Whitehall.uploads_cache_max_age, public: true)
+    else
+      expires_now
+    end
+  end
+
+  def upload_path
+    File.join(Whitehall.clean_uploads_root, path_to_attachment_or_thumbnail)
+  end
+
+  def file_with_extensions
+    [params[:file], params[:extension], params[:format]].compact.join('.')
+  end
+
+  def path_to_attachment_or_thumbnail
+    attachment_data.file.store_path(file_with_extensions)
+  end
+
+  def attachment_visibility
+    @attachment_visibility ||= AttachmentVisibility.new(attachment_data, current_user)
+  end
+
+  def file_is_clean?(path)
+    path.starts_with?(Whitehall.clean_uploads_root)
+  end
+
+  def image?(path)
+    ['.jpg', '.jpeg', '.png', '.gif'].include?(File.extname(path))
+  end
+
+  def incoming_upload_exists?(path)
+    path = path.sub(Whitehall.clean_uploads_root, Whitehall.incoming_uploads_root)
+    File.exist?(path)
+  end
+
+  def redirect_to_placeholder
+    # Cache is explicitly 1 minute to prevent the virus redirect beng
+    # cached by CDNs.
+    expires_in(1.minute, public: true)
+    redirect_to placeholder_url
+  end
+
+  def upload_exists?(path)
+    File.exist?(path) && file_is_clean?(path)
+  end
+end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -1,4 +1,4 @@
-class CsvPreviewController < ApplicationController
+class CsvPreviewController < BaseAttachmentsController
   def show
     respond_to do |format|
       format.html do
@@ -19,76 +19,5 @@ class CsvPreviewController < ApplicationController
     render layout: 'html_attachments'
   rescue ActionController::UnknownFormat
     render status: :not_acceptable, plain: "Request format #{request.format} not handled."
-  end
-
-private
-
-  def attachment_visible?
-    upload_exists?(upload_path) && attachment_visibility.visible?
-  end
-
-  def fail
-    if (edition = attachment_visibility.unpublished_edition)
-      redirect_to edition.unpublishing.document_path
-    elsif (replacement = attachment_data.replaced_by)
-      expires_headers
-      redirect_to replacement.url, status: 301
-    elsif incoming_upload_exists? upload_path
-      redirect_to_placeholder
-    else
-      render plain: "Not found", status: :not_found
-    end
-  end
-
-  def set_slimmer_template
-    slimmer_template 'chromeless'
-  end
-
-  def redirect_to_placeholder
-    # Cache is explicitly 1 minute to prevent the virus redirect beng
-    # cached by CDNs.
-    expires_in(1.minute, public: true)
-    redirect_to placeholder_url
-  end
-
-  def attachment_data
-    @attachment_data ||= AttachmentData.find(params[:id])
-  end
-
-  def expires_headers
-    if current_user.nil?
-      expires_in(Whitehall.uploads_cache_max_age, public: true)
-    else
-      expires_now
-    end
-  end
-
-  def upload_path
-    File.join(Whitehall.clean_uploads_root, path_to_attachment_or_thumbnail)
-  end
-
-  def file_with_extensions
-    [params[:file], params[:extension], params[:format]].compact.join('.')
-  end
-
-  def path_to_attachment_or_thumbnail
-    attachment_data.file.store_path(file_with_extensions)
-  end
-
-  def attachment_visibility
-    @attachment_visibility ||= AttachmentVisibility.new(attachment_data, current_user)
-  end
-
-  def file_is_clean?(path)
-    path.starts_with?(Whitehall.clean_uploads_root)
-  end
-
-  def incoming_upload_exists?(path)
-    path = path.sub(Whitehall.clean_uploads_root, Whitehall.incoming_uploads_root)
-    File.exist?(path)
-  end
-
-  def upload_exists?(path)
-    File.exist?(path) && file_is_clean?(path)
   end
 end


### PR DESCRIPTION
I'm planning to do some significant refactoring of the `AttachmentsController`, but I didn't want to have to duplicate my efforts in the `CsvPreviewController`. This change will mean I can do the refactoring in one place.

I've also taken the opportunity to remove an unused method from `AttachmentsController`.
