### PR TITLE
Allow tabs in CSV files

### DIFF
--- a/app/models/csv_preview.rb
+++ b/app/models/csv_preview.rb
@@ -98,7 +98,7 @@ private
     preview_rows.force_encoding('windows-1252')
     # This regexp checks for the presence of ASCII control characters, which
     # would indicate we have the wrong encoding.
-    preview_rows.valid_encoding? && !preview_rows.match(/[\x00-\x09\x0b\x0c\x0e-\x1f]/)
+    preview_rows.valid_encoding? && !preview_rows.match(/[\x00-\x08\x0b\x0c\x0e-\x1f]/)
   end
 
   def ensure_csv_data_is_well_formed

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -76,6 +76,6 @@ private
     body.force_encoding('windows-1252')
     # This regexp checks for the presence of ASCII control characters, which
     # would indicate we have the wrong encoding.
-    body.valid_encoding? && !body.match(/[\x00-\x09\x0b\x0c\x0e-\x1f]/)
+    body.valid_encoding? && !body.match(/[\x00-\x08\x0b\x0c\x0e-\x1f]/)
   end
 end

--- a/test/fixtures/csv_encodings/windows-1252.csv
+++ b/test/fixtures/csv_encodings/windows-1252.csv
@@ -1,2 +1,2 @@
 name,address1,address2,town,postcode,access_notes,general_notes,url,email,phone,fax,text_phone
-1 Stop Instrüction™,Power League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420
+1 Stop Instrüction™,Power	League,Forest Road,Ilford (Fairlop),IG6 3HJ,Some access notes,Some general notes,http://www.1stopinstruction.com,info@1stopinstruction.com,0800 848 8418,0800 848 8419,0800 848 8420


### PR DESCRIPTION
Some CSVs have tabs in their values, but aren’t used as delimiters. We
shouldn’t match on tab characters, we should allow them to be
displayed.