### PR TITLE
Re-enable scheduled links checking

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,9 +13,7 @@
   - sync_checks
   - link_checks
   - asset_migration
-# Disable scheduled link checking as it uses too much CPU and affects publishers as the job is overrunning.
-#
-# :schedule:
-#   check_all_organisations_links_worker:
-#     cron: '0 1 * * *' # Runs at 1 a.m every day
-#     class: CheckAllOrganisationsLinksWorker
+:schedule:
+  check_all_organisations_links_worker:
+    cron: '0 1 * * *' # Runs at 1 a.m every day
+    class: CheckAllOrganisationsLinksWorker


### PR DESCRIPTION
For: https://trello.com/c/aqGcNwFT/90-2-whitehall-link-checker-pegs-mysql-at-400-cpu-every-morning

Reverts alphagov/whitehall#3810

Now that we've applied #3832 the links checker process takes about 20 minutes to process all the jobs on whitehall, and about 3 hours for all the link checks to complete and be reported back to whitehall.  It still consumes a lot of CPU while processing the jobs (not fully 400% though, it's more like 350%), but the short duration of this step means it won't impact users significantly so we're happy to turn the scheduled job back on.