### PR TITLE
Implement AttachmentData methods as alternative to AttachmentVisibility methods

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -104,6 +104,14 @@ class AttachmentData < ApplicationRecord
     end
   end
 
+  def deleted?
+    if attachments.one? || attachments[-1].attachable.publicly_visible?
+      attachments[-1].deleted?
+    else
+      attachments[-2].deleted?
+    end
+  end
+
 private
 
   def cant_be_replaced_by_self

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -129,6 +129,10 @@ class AttachmentData < ApplicationRecord
     replaced_by.present?
   end
 
+  def visible_to?(user)
+    !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
+  end
+
 private
 
   class NullAttachable

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -121,6 +121,10 @@ class AttachmentData < ApplicationRecord
     last_attachment.attachable.unpublished?
   end
 
+  def unpublished_edition
+    last_attachment.attachable.unpublished_edition
+  end
+
   def replaced?
     replaced_by.present?
   end
@@ -138,6 +142,10 @@ private
 
     def unpublished?
       false
+    end
+
+    def unpublished_edition
+      nil
     end
   end
 

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -133,6 +133,15 @@ class AttachmentData < ApplicationRecord
     !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
   end
 
+  def visible_attachable_for(user)
+    visible_to?(user) ? significant_attachable : nil
+  end
+
+  def visible_edition_for(user)
+    visible_attachable = visible_attachable_for(user)
+    visible_attachable.is_a?(Edition) ? visible_attachable : nil
+  end
+
 private
 
   class NullAttachable

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -106,35 +106,23 @@ class AttachmentData < ApplicationRecord
 
   def deleted?
     return false if attachments.none?
-    if attachments.one? || attachments[-1].attachable.publicly_visible?
-      attachments[-1].deleted?
-    else
-      attachments[-2].deleted?
-    end
+    significant_attachment.deleted?
   end
 
   def draft?
     return false if unpublished?
     return true if attachments.none?
-    if attachments.one? || attachments[-1].attachable.publicly_visible?
-      !attachments[-1].attachable.publicly_visible?
-    else
-      !attachments[-2].attachable.publicly_visible?
-    end
+    !significant_attachment.attachable.publicly_visible?
   end
 
   def accessible_to?(user)
     return false if attachments.none?
-    if attachments.one? || attachments[-1].attachable.publicly_visible?
-      attachments[-1].attachable.accessible_to?(user)
-    else
-      attachments[-2].attachable.accessible_to?(user)
-    end
+    significant_attachment.attachable.accessible_to?(user)
   end
 
   def unpublished?
     return false if attachments.none?
-    attachments[-1].attachable.unpublished?
+    last_attachment.attachable.unpublished?
   end
 
   def replaced?
@@ -142,6 +130,22 @@ class AttachmentData < ApplicationRecord
   end
 
 private
+
+  def significant_attachment
+    if attachments.one? || last_attachment.attachable.publicly_visible?
+      last_attachment
+    else
+      penultimate_attachment
+    end
+  end
+
+  def last_attachment
+    attachments[-1]
+  end
+
+  def penultimate_attachment
+    attachments[-2]
+  end
 
   def cant_be_replaced_by_self
     return if replaced_by.nil?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -112,6 +112,14 @@ class AttachmentData < ApplicationRecord
     end
   end
 
+  def draft?
+    if attachments.one? || attachments[-1].attachable.publicly_visible?
+      !attachments[-1].attachable.publicly_visible?
+    else
+      !attachments[-2].attachable.publicly_visible?
+    end
+  end
+
 private
 
   def cant_be_replaced_by_self

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -113,11 +113,16 @@ class AttachmentData < ApplicationRecord
   end
 
   def draft?
+    return false if unpublished?
     if attachments.one? || attachments[-1].attachable.publicly_visible?
       !attachments[-1].attachable.publicly_visible?
     else
       !attachments[-2].attachable.publicly_visible?
     end
+  end
+
+  def unpublished?
+    attachments[-1].attachable.unpublished?
   end
 
 private

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -123,6 +123,15 @@ class AttachmentData < ApplicationRecord
     end
   end
 
+  def accessible_to?(user)
+    return false if attachments.none?
+    if attachments.one? || attachments[-1].attachable.publicly_visible?
+      attachments[-1].attachable.accessible_to?(user)
+    else
+      attachments[-2].attachable.accessible_to?(user)
+    end
+  end
+
   def unpublished?
     return false if attachments.none?
     attachments[-1].attachable.unpublished?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -105,6 +105,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def deleted?
+    return false if attachments.none?
     if attachments.one? || attachments[-1].attachable.publicly_visible?
       attachments[-1].deleted?
     else
@@ -114,6 +115,7 @@ class AttachmentData < ApplicationRecord
 
   def draft?
     return false if unpublished?
+    return true if attachments.none?
     if attachments.one? || attachments[-1].attachable.publicly_visible?
       !attachments[-1].attachable.publicly_visible?
     else
@@ -122,7 +124,12 @@ class AttachmentData < ApplicationRecord
   end
 
   def unpublished?
+    return false if attachments.none?
     attachments[-1].attachable.unpublished?
+  end
+
+  def replaced?
+    replaced_by.present?
   end
 
 private

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -3,7 +3,7 @@ require 'pdf-reader'
 class AttachmentData < ApplicationRecord
   mount_uploader :file, AttachmentUploader, mount_on: :carrierwave_file
 
-  has_many :attachments, inverse_of: :attachment_data
+  has_many :attachments, -> { order(:attachable_id) }, inverse_of: :attachment_data
 
   delegate :url, :path, to: :file, allow_nil: true
 

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -118,11 +118,11 @@ class AttachmentData < ApplicationRecord
   end
 
   def unpublished?
-    last_attachment.attachable.unpublished?
+    last_attachable.unpublished?
   end
 
   def unpublished_edition
-    last_attachment.attachable.unpublished_edition
+    last_attachable.unpublished_edition
   end
 
   def replaced?
@@ -178,6 +178,10 @@ private
 
   def significant_attachable
     significant_attachment.attachable || NullAttachable.new
+  end
+
+  def last_attachable
+    last_attachment.attachable || NullAttachable.new
   end
 
   def significant_attachment

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -110,11 +110,11 @@ class AttachmentData < ApplicationRecord
 
   def draft?
     return false if unpublished?
-    !significant_attachment.attachable.publicly_visible?
+    !significant_attachable.publicly_visible?
   end
 
   def accessible_to?(user)
-    significant_attachment.attachable.accessible_to?(user)
+    significant_attachable.accessible_to?(user)
   end
 
   def unpublished?
@@ -161,6 +161,10 @@ private
     def attachable
       NullAttachable.new
     end
+  end
+
+  def significant_attachable
+    significant_attachment.attachable || NullAttachable.new
   end
 
   def significant_attachment

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -133,6 +133,10 @@ class AttachmentData < ApplicationRecord
     !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
   end
 
+  def visible_attachment_for(user)
+    visible_to?(user) ? significant_attachment : nil
+  end
+
   def visible_attachable_for(user)
     visible_to?(user) ? significant_attachable : nil
   end

--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -37,83 +37,30 @@ class AttachmentVisibility
   end
 
   def visible?
-    visible_edition? || visible_policy_group? || visible_consultation_response?
+    attachment_data.visible_to?(user)
   end
 
   def unpublished_edition
-    attachable_ids = edition_ids + consultation_ids
-    if (unpublishing = Unpublishing.where(edition_id: attachable_ids).first)
-      Edition.find_by(id: unpublishing.edition_id)
-    end
+    attachment_data.unpublished_edition
   end
 
   def visible_attachment
-    if visible_attachable
-      (visible_attachable.attachments & attachment_data.attachments).first
-    end
+    attachment_data.visible_attachment_for(user)
   end
 
   def visible_attachable
-    visible_edition || visible_consultation_response || visible_policy_group
+    attachment_data.visible_attachable_for(user)
   end
 
   def visible_edition
-    visible_edition_scope.last
+    attachment_data.visible_edition_for(user)
   end
 
   def visible_consultation_response
-    if visible_consultation_response?
-      Response.where(edition_id: consultation_ids).last
-    end
+    attachment_data.visible_attachable_for(user)
   end
 
   def visible_policy_group
-    visible_policy_group_scope.last
-  end
-
-private
-
-  def id
-    attachment_data.id
-  end
-
-  def visible_edition?
-    visible_edition_scope.exists?
-  end
-
-  def visible_policy_group?
-    visible_policy_group_scope.exists?
-  end
-
-  def visible_consultation_response?
-    visible_consultation_scope.exists?
-  end
-
-  def visible_edition_scope
-    if user
-      Edition.accessible_to(user).where(id: edition_ids)
-    else
-      Edition.publicly_visible.where(id: edition_ids)
-    end
-  end
-
-  def visible_consultation_scope
-    if user
-      Edition.accessible_to(user).where(id: consultation_ids)
-    else
-      Edition.publicly_visible.where(id: consultation_ids)
-    end
-  end
-
-  def visible_policy_group_scope
-    PolicyGroup.joins(:attachments).where(attachments: { attachment_data_id: id })
-  end
-
-  def consultation_ids
-    @consultation_ids ||= Response.joins(:attachments).where(attachments: { attachment_data_id: id }).pluck(:edition_id)
-  end
-
-  def edition_ids
-    @edition_ids ||= Attachment.not_deleted.where(attachment_data_id: id).where(attachable_type: 'Edition').pluck(:attachable_id)
+    attachment_data.visible_attachable_for(user)
   end
 end

--- a/app/models/edition/limited_access.rb
+++ b/app/models/edition/limited_access.rb
@@ -66,4 +66,8 @@ module Edition::LimitedAccess
       self.access_limited = self.access_limited_by_default?
     end
   end
+
+  def accessible_to?(user)
+    user.present? && self.class.accessible_to(user).where(id: id).any?
+  end
 end

--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -94,4 +94,8 @@ module Edition::Publishing
   def unpublished?
     !publicly_visible? && unpublishing.present?
   end
+
+  def unpublished_edition
+    unpublished? ? unpublishing.edition : nil
+  end
 end

--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -90,4 +90,8 @@ module Edition::Publishing
     self.published_major_version = previous_edition.try(:published_major_version)
     self.published_minor_version = previous_edition.try(:published_minor_version)
   end
+
+  def unpublished?
+    !publicly_visible? && unpublishing.present?
+  end
 end

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -21,6 +21,10 @@ class PolicyGroup < ApplicationRecord
     true
   end
 
+  def accessible_to?(*)
+    true
+  end
+
   def unpublished?
     false
   end

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -21,6 +21,10 @@ class PolicyGroup < ApplicationRecord
     true
   end
 
+  def unpublished?
+    false
+  end
+
   def published_policies
     Whitehall.search_client.search(
       filter_policy_groups: [slug],

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -29,6 +29,10 @@ class PolicyGroup < ApplicationRecord
     false
   end
 
+  def unpublished_edition
+    nil
+  end
+
   def published_policies
     Whitehall.search_client.search(
       filter_policy_groups: [slug],

--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -17,6 +17,10 @@ class PolicyGroup < ApplicationRecord
     false
   end
 
+  def publicly_visible?
+    true
+  end
+
   def published_policies
     Whitehall.search_client.search(
       filter_policy_groups: [slug],

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -24,6 +24,10 @@ class Response < ApplicationRecord
     consultation.publicly_visible?
   end
 
+  def unpublished?
+    consultation.unpublished?
+  end
+
   def can_order_attachments?
     true
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -20,6 +20,10 @@ class Response < ApplicationRecord
     consultation.alternative_format_contact_email
   end
 
+  def publicly_visible?
+    consultation.publicly_visible?
+  end
+
   def can_order_attachments?
     true
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -32,6 +32,10 @@ class Response < ApplicationRecord
     consultation.unpublished?
   end
 
+  def unpublished_edition
+    consultation.unpublished_edition
+  end
+
   def can_order_attachments?
     true
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -24,6 +24,10 @@ class Response < ApplicationRecord
     consultation.publicly_visible?
   end
 
+  def accessible_to?(user)
+    consultation.accessible_to?(user)
+  end
+
   def unpublished?
     consultation.unpublished?
   end

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -234,4 +234,16 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     attachment_data.replace_with!(replacement)
   end
+
+  test 'order attachments by attachable ID' do
+    attachment_data = create(:attachment_data)
+    edition_1 = create(:edition)
+    edition_2 = create(:edition)
+    attachment_1 = build(:file_attachment, attachable: edition_2)
+    attachment_2 = build(:file_attachment, attachable: edition_1)
+    attachment_data.attachments << attachment_1
+    attachment_data.attachments << attachment_2
+
+    assert_equal [attachment_2, attachment_1], attachment_data.attachments.to_a
+  end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -48,6 +48,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         refute attachment_data.reload.unpublished?
       end
 
+      it 'has no unpublished edition' do
+        assert_nil attachment_data.reload.unpublished_edition
+      end
+
       it 'is not replaced' do
         refute attachment_data.reload.replaced?
       end
@@ -138,6 +142,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.unpublished?
         end
 
+        it 'has no unpublished edition' do
+          assert_nil attachment_data.reload.unpublished_edition
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { edition.create_draft(user) }
           let(:new_attachable) { new_edition }
@@ -157,6 +165,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
           it 'is not unpublished' do
             refute attachment_data.reload.unpublished?
+          end
+
+          it 'has no unpublished edition' do
+            assert_nil attachment_data.reload.unpublished_edition
           end
 
           context 'new edition is access-limited' do
@@ -244,6 +256,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           it 'is is unpublished' do
             assert attachment_data.reload.unpublished?
           end
+
+          it 'returns edition as unpublished edition' do
+            assert_equal edition, attachment_data.reload.unpublished_edition
+          end
         end
 
         context 'and edition is withdrawn' do
@@ -263,6 +279,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
           it 'is is not unpublished' do
             refute attachment_data.reload.unpublished?
+          end
+
+          it 'has no unpublished edition' do
+            assert_nil attachment_data.reload.unpublished_edition
           end
         end
       end
@@ -296,6 +316,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       it 'is not unpublished' do
         refute attachment_data.reload.unpublished?
+      end
+
+      it 'has no unpublished edition' do
+        assert_nil attachment_data.reload.unpublished_edition
       end
 
       context 'consultation is access-limited' do
@@ -344,6 +368,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.unpublished?
         end
 
+        it 'has no unpublished edition' do
+          assert_nil attachment_data.reload.unpublished_edition
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { consultation.create_draft(user) }
           let(:new_attachable) { new_edition.outcome }
@@ -363,6 +391,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
           it 'is not unpublished' do
             refute attachment_data.reload.unpublished?
+          end
+
+          it 'has no unpublished edition' do
+            assert_nil attachment_data.reload.unpublished_edition
           end
 
           context 'and attachment is deleted' do
@@ -410,6 +442,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           it 'is unpublished' do
             assert attachment_data.reload.unpublished?
           end
+
+          it 'returns consultation as unpublished edition' do
+            assert_equal consultation, attachment_data.reload.unpublished_edition
+          end
         end
       end
     end
@@ -428,6 +464,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       it 'is not unpublished' do
         refute attachment_data.reload.unpublished?
+      end
+
+      it 'has no unpublished edition' do
+        assert_nil attachment_data.reload.unpublished_edition
       end
 
       it 'is accessible to anonymous user' do

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -1,0 +1,171 @@
+require 'test_helper'
+
+class AttachmentDataVisibilityTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:user) { create(:writer) }
+
+  context 'given an attachment' do
+    let(:file) { File.open(fixture_path.join('simple.pdf')) }
+    let(:attachment) { build(:file_attachment, attachable: attachable, file: file) }
+    let(:attachment_data) { attachment.attachment_data }
+
+    before do
+      attachable.attachments << attachment
+      VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+    end
+
+    context 'on a draft edition' do
+      let(:edition) { create(:news_article) }
+      let(:attachable) { edition }
+
+      it 'is not deleted' do
+        refute attachment_data.reload.deleted?
+      end
+
+      context 'when attachment is deleted' do
+        before do
+          attachment.destroy!
+        end
+
+        it 'is deleted' do
+          assert attachment_data.reload.deleted?
+        end
+      end
+
+      context 'when edition is published' do
+        before do
+          edition.major_change_published_at = Time.zone.now
+          edition.force_publish!
+        end
+
+        it 'is not deleted' do
+          refute attachment_data.reload.deleted?
+        end
+
+        context 'and new edition is created' do
+          let(:new_edition) { edition.create_draft(user) }
+          let(:new_attachable) { new_edition }
+          let(:new_attachment) { new_attachable.attachments.first }
+
+          before do
+            new_edition.reload
+          end
+
+          it 'is not deleted' do
+            refute attachment_data.reload.deleted?
+          end
+
+          context 'and attachment is deleted' do
+            before do
+              new_attachment.destroy!
+            end
+
+            it 'is not deleted, because available on published edition' do
+              refute attachment_data.reload.deleted?
+            end
+
+            context 'and new edition is published' do
+              before do
+                new_edition.major_change_published_at = Time.zone.now
+                new_edition.change_note = 'change-note'
+                new_edition.force_publish!
+              end
+
+              it 'is deleted, because not available on published edition' do
+                assert attachment_data.reload.deleted?
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'on a draft consultation response' do
+      let(:consultation) { create(:consultation) }
+      let(:outcome_attributes) { attributes_for(:consultation_outcome) }
+      let(:outcome) { consultation.create_outcome!(outcome_attributes) }
+      let(:attachable) { outcome }
+
+      it 'is not deleted' do
+        refute attachment_data.reload.deleted?
+      end
+
+      context 'when attachment is deleted' do
+        before do
+          attachment.destroy!
+        end
+
+        it 'is deleted' do
+          assert attachment_data.reload.deleted?
+        end
+      end
+
+      context 'when consultation is published' do
+        before do
+          consultation.major_change_published_at = Time.zone.now
+          consultation.force_publish!
+        end
+
+        it 'is not deleted' do
+          refute attachment_data.reload.deleted?
+        end
+
+        context 'and new edition is created' do
+          let(:new_edition) { consultation.create_draft(user) }
+          let(:new_attachable) { new_edition.outcome }
+          let(:new_attachment) { new_attachable.attachments.first }
+
+          before do
+            new_edition.reload
+          end
+
+          it 'is not deleted' do
+            refute attachment_data.reload.deleted?
+          end
+
+          context 'and attachment is deleted' do
+            before do
+              new_attachment.destroy!
+            end
+
+            it 'is not deleted, because available on published edition' do
+              refute attachment_data.reload.deleted?
+            end
+
+            context 'and new edition is published' do
+              before do
+                new_edition.major_change_published_at = Time.zone.now
+                new_edition.change_note = 'change-note'
+                new_edition.force_publish!
+              end
+
+              it 'is deleted, because not available on published edition' do
+                assert attachment_data.reload.deleted?
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'on a policy group' do
+      let(:policy_group) { create(:policy_group) }
+      let(:attachable) { policy_group }
+
+      it 'is not deleted' do
+        refute attachment_data.reload.deleted?
+      end
+
+      context 'when attachment is deleted' do
+        before do
+          attachment.destroy!
+        end
+
+        it 'is deleted' do
+          assert attachment_data.reload.deleted?
+        end
+      end
+    end
+  end
+end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -23,6 +23,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         refute attachment_data.reload.deleted?
       end
 
+      it 'is draft' do
+        assert attachment_data.reload.draft?
+      end
+
       context 'when attachment is deleted' do
         before do
           attachment.destroy!
@@ -43,6 +47,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.deleted?
         end
 
+        it 'is not draft' do
+          refute attachment_data.reload.draft?
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { edition.create_draft(user) }
           let(:new_attachable) { new_edition }
@@ -56,6 +64,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             refute attachment_data.reload.deleted?
           end
 
+          it 'is not draft' do
+            refute attachment_data.reload.draft?
+          end
+
           context 'and attachment is deleted' do
             before do
               new_attachment.destroy!
@@ -63,6 +75,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
             it 'is not deleted, because available on published edition' do
               refute attachment_data.reload.deleted?
+            end
+
+            it 'is not draft, because available on published edition' do
+              refute attachment_data.reload.draft?
             end
 
             context 'and new edition is published' do
@@ -91,6 +107,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         refute attachment_data.reload.deleted?
       end
 
+      it 'is draft' do
+        assert attachment_data.reload.draft?
+      end
+
       context 'when attachment is deleted' do
         before do
           attachment.destroy!
@@ -111,6 +131,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.deleted?
         end
 
+        it 'is not draft' do
+          refute attachment_data.reload.draft?
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { consultation.create_draft(user) }
           let(:new_attachable) { new_edition.outcome }
@@ -124,6 +148,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             refute attachment_data.reload.deleted?
           end
 
+          it 'is not draft' do
+            refute attachment_data.reload.draft?
+          end
+
           context 'and attachment is deleted' do
             before do
               new_attachment.destroy!
@@ -131,6 +159,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
             it 'is not deleted, because available on published edition' do
               refute attachment_data.reload.deleted?
+            end
+
+            it 'is not draft, because available on published edition' do
+              refute attachment_data.reload.draft?
             end
 
             context 'and new edition is published' do
@@ -155,6 +187,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       it 'is not deleted' do
         refute attachment_data.reload.deleted?
+      end
+
+      it 'is not draft' do
+        refute attachment_data.reload.draft?
       end
 
       context 'when attachment is deleted' do

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -611,5 +611,33 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context '#visible_attachment_for' do
+      let(:attachable) { build(:news_article) }
+      let(:significant_attachment) { stub('significant-attachment') }
+
+      before do
+        attachment_data.stubs(:visible_to?).with(user).returns(visible)
+        attachment_data.stubs(:significant_attachment)
+          .returns(significant_attachment)
+      end
+
+      context 'when attachment data is not visible' do
+        let(:visible) { false }
+
+        it 'returns nil' do
+          assert_nil attachment_data.visible_attachment_for(user)
+        end
+      end
+
+      context 'when attachment data is visible' do
+        let(:visible) { true }
+
+        it 'returns significant attachment' do
+          result = attachment_data.visible_attachment_for(user)
+          assert_equal significant_attachment, result
+        end
+      end
+    end
   end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -558,5 +558,58 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context '#visible_attachable_for' do
+      let(:attachable) { build(:news_article) }
+      let(:significant_attachable) { stub('significant-attachable') }
+
+      before do
+        attachment_data.stubs(:visible_to?).with(user).returns(visible)
+        attachment_data.stubs(:significant_attachable)
+          .returns(significant_attachable)
+      end
+
+      context 'when attachment data is not visible' do
+        let(:visible) { false }
+
+        it 'returns nil' do
+          assert_nil attachment_data.visible_attachable_for(user)
+        end
+      end
+
+      context 'when attachment data is visible' do
+        let(:visible) { true }
+
+        it 'returns attachable for significant attachment' do
+          result = attachment_data.visible_attachable_for(user)
+          assert_equal significant_attachable, result
+        end
+      end
+    end
+
+    context '#visible_edition_for' do
+      let(:visible_attachable) { attachable }
+
+      before do
+        attachment_data.stubs(:visible_attachable_for).with(user)
+          .returns(visible_attachable)
+      end
+
+      context 'when visible attachable is not an edition' do
+        let(:attachable) { build(:policy_group) }
+
+        it 'returns nil' do
+          assert_nil attachment_data.visible_edition_for(user)
+        end
+      end
+
+      context 'when visible attachable is an edition' do
+        let(:attachable) { build(:edition) }
+
+        it 'returns visible attachable' do
+          assert_equal visible_attachable, attachment_data.visible_edition_for(user)
+        end
+      end
+    end
   end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -27,6 +27,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         assert attachment_data.reload.draft?
       end
 
+      it 'is not unpublished' do
+        refute attachment_data.reload.unpublished?
+      end
+
       context 'when attachment is deleted' do
         before do
           attachment.destroy!
@@ -51,6 +55,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.draft?
         end
 
+        it 'is not unpublished' do
+          refute attachment_data.reload.unpublished?
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { edition.create_draft(user) }
           let(:new_attachable) { new_edition }
@@ -66,6 +74,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
           it 'is not draft' do
             refute attachment_data.reload.draft?
+          end
+
+          it 'is not unpublished' do
+            refute attachment_data.reload.unpublished?
           end
 
           context 'and attachment is deleted' do
@@ -94,6 +106,46 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             end
           end
         end
+
+        context 'and edition is unpublished' do
+          before do
+            attributes = attributes_for(:unpublishing, edition: edition)
+            edition.build_unpublishing(attributes)
+            edition.unpublish!
+          end
+
+          it 'is not deleted' do
+            refute attachment_data.reload.deleted?
+          end
+
+          it 'is not draft' do
+            refute attachment_data.reload.draft?
+          end
+
+          it 'is is unpublished' do
+            assert attachment_data.reload.unpublished?
+          end
+        end
+
+        context 'and edition is withdrawn' do
+          before do
+            attributes = attributes_for(:unpublishing, edition: edition)
+            edition.build_unpublishing(attributes)
+            edition.withdraw!
+          end
+
+          it 'is not deleted' do
+            refute attachment_data.reload.deleted?
+          end
+
+          it 'is not draft' do
+            refute attachment_data.reload.draft?
+          end
+
+          it 'is is not unpublished' do
+            refute attachment_data.reload.unpublished?
+          end
+        end
       end
     end
 
@@ -109,6 +161,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       it 'is draft' do
         assert attachment_data.reload.draft?
+      end
+
+      it 'is not unpublished' do
+        refute attachment_data.reload.unpublished?
       end
 
       context 'when attachment is deleted' do
@@ -135,6 +191,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
           refute attachment_data.reload.draft?
         end
 
+        it 'is not unpublished' do
+          refute attachment_data.reload.unpublished?
+        end
+
         context 'and new edition is created' do
           let(:new_edition) { consultation.create_draft(user) }
           let(:new_attachable) { new_edition.outcome }
@@ -150,6 +210,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
           it 'is not draft' do
             refute attachment_data.reload.draft?
+          end
+
+          it 'is not unpublished' do
+            refute attachment_data.reload.unpublished?
           end
 
           context 'and attachment is deleted' do
@@ -178,6 +242,26 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             end
           end
         end
+
+        context 'and consultation is unpublished' do
+          before do
+            attributes = attributes_for(:unpublishing, edition: consultation)
+            consultation.build_unpublishing(attributes)
+            consultation.unpublish!
+          end
+
+          it 'is not deleted' do
+            refute attachment_data.reload.deleted?
+          end
+
+          it 'is not draft' do
+            refute attachment_data.reload.draft?
+          end
+
+          it 'is unpublished' do
+            assert attachment_data.reload.unpublished?
+          end
+        end
       end
     end
 
@@ -191,6 +275,10 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       it 'is not draft' do
         refute attachment_data.reload.draft?
+      end
+
+      it 'is not unpublished' do
+        refute attachment_data.reload.unpublished?
       end
 
       context 'when attachment is deleted' do

--- a/test/unit/edition/limited_access_test.rb
+++ b/test/unit/edition/limited_access_test.rb
@@ -83,4 +83,36 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert_equal edition, edition.access_limited_object
   end
+
+  test 'is not accessible if no user specified' do
+    edition = LimitedAccessEdition.new
+
+    refute edition.accessible_to?(nil)
+  end
+
+  test 'is not accessible if edition is not accessible to user' do
+    user = build(:user)
+    edition_id = 123
+    edition = LimitedAccessEdition.new(id: edition_id)
+    accessible_scope = stub('accessible-scope')
+    LimitedAccessEdition.stubs(:accessible_to).with(user)
+      .returns(accessible_scope)
+
+    accessible_scope.stubs(:where).with(id: edition_id).returns([])
+
+    refute edition.accessible_to?(user)
+  end
+
+  test 'is accessible if edition is accessible to user' do
+    user = build(:user)
+    edition_id = 123
+    edition = LimitedAccessEdition.new(id: edition_id)
+    accessible_scope = stub('accessible-scope')
+    LimitedAccessEdition.stubs(:accessible_to).with(user)
+      .returns(accessible_scope)
+
+    accessible_scope.stubs(:where).with(id: edition_id).returns([edition_id])
+
+    assert edition.accessible_to?(user)
+  end
 end

--- a/test/unit/edition/publishing_test.rb
+++ b/test/unit/edition/publishing_test.rb
@@ -124,4 +124,23 @@ class Edition::PublishingTest < ActiveSupport::TestCase
     refute edition.approve_retrospectively
     assert edition.errors[:base].include?('This document has not been force-published')
   end
+
+  test '#unpublished? returns false if publicly visible' do
+    published_edition = build(:published_edition)
+
+    refute published_edition.unpublished?
+  end
+
+  test '#unpublished? returns false if no unpublishing exists' do
+    draft_edition = build(:draft_edition)
+
+    refute draft_edition.unpublished?
+  end
+
+  test '#unpublished? returns true if not publicly visible and unpublishing exists' do
+    unpublishing = build(:unpublishing)
+    draft_edition_with_unpublishing = build(:draft_edition, unpublishing: unpublishing)
+
+    assert draft_edition_with_unpublishing.unpublished?
+  end
 end

--- a/test/unit/edition/publishing_test.rb
+++ b/test/unit/edition/publishing_test.rb
@@ -143,4 +143,17 @@ class Edition::PublishingTest < ActiveSupport::TestCase
 
     assert draft_edition_with_unpublishing.unpublished?
   end
+
+  test '#unpublished_edition returns nil if not unpublished' do
+    edition = build(:published_edition)
+
+    assert_nil edition.unpublished_edition
+  end
+
+  test '#unpublished_edition returns unpublished edition if unpublished' do
+    edition = create(:draft_edition, :with_document)
+    edition.build_unpublishing(edition: edition)
+
+    assert_equal edition, edition.unpublished_edition
+  end
 end

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -54,4 +54,9 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group = FactoryBot.build(:policy_group)
     assert policy_group.publicly_visible?
   end
+
+  test 'is never unpublished' do
+    policy_group = FactoryBot.build(:policy_group)
+    refute policy_group.unpublished?
+  end
 end

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -60,6 +60,11 @@ class PolicyGroupTest < ActiveSupport::TestCase
     refute policy_group.unpublished?
   end
 
+  test 'never has unpublished edition' do
+    policy_group = FactoryBot.build(:policy_group)
+    assert_nil policy_group.unpublished_edition
+  end
+
   test 'is always accessible' do
     policy_group = FactoryBot.build(:policy_group)
     assert policy_group.accessible_to?(nil)

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -49,4 +49,9 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group = FactoryBot.build(:policy_group)
     assert_nil policy_group.access_limited_object
   end
+
+  test 'is always publicly visible' do
+    policy_group = FactoryBot.build(:policy_group)
+    assert policy_group.publicly_visible?
+  end
 end

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -59,4 +59,9 @@ class PolicyGroupTest < ActiveSupport::TestCase
     policy_group = FactoryBot.build(:policy_group)
     refute policy_group.unpublished?
   end
+
+  test 'is always accessible' do
+    policy_group = FactoryBot.build(:policy_group)
+    assert policy_group.accessible_to?(nil)
+  end
 end

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -48,4 +48,12 @@ class ResponseTest < ActiveSupport::TestCase
 
     refute response.unpublished?
   end
+
+  test 'returns unpublished edition from its consultation' do
+    consultation = build(:consultation)
+    consultation.stubs(:unpublished_edition).returns(consultation)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert_equal consultation, response.unpublished_edition
+  end
 end

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -32,4 +32,20 @@ class ResponseTest < ActiveSupport::TestCase
 
     refute response.publicly_visible?
   end
+
+  test 'is unpublished if its consultation is unpublished' do
+    consultation = build(:consultation)
+    consultation.stubs(:unpublished?).returns(true)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert response.unpublished?
+  end
+
+  test 'is not unpublished if its consultation is not unpublished' do
+    consultation = build(:consultation)
+    consultation.stubs(:unpublished?).returns(false)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    refute response.unpublished?
+  end
 end

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -16,4 +16,20 @@ class ResponseTest < ActiveSupport::TestCase
 
     assert_equal consultation.alternative_format_contact_email, response.alternative_format_contact_email
   end
+
+  test 'is publicly visible if its consultation is publicly visible' do
+    consultation = build(:consultation)
+    consultation.stubs(:publicly_visible?).returns(true)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert response.publicly_visible?
+  end
+
+  test 'is not publicly visible if its consultation is not publicly visible' do
+    consultation = build(:consultation)
+    consultation.stubs(:publicly_visible?).returns(false)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    refute response.publicly_visible?
+  end
 end


### PR DESCRIPTION
`AttachmentVisibility#visible?` conflates a number of concepts, e.g. whether the attachment is deleted, draft, unpublished or replaced. Also the tests for AttachmentVisibility#visible? are patchy and not very logically organised.

The commits in this PR test-drive a *new* implementation of the logic in `AttachmentVisibility#visible` via lower level predicate methods. The tests in `AttachmentDataVisibilityTest` were used to drive out the implementation of the new methods in `AttachmentData`.

I felt that the implementation of `AttachmentVisibility` was overly focussed on performance versus readability. I've aimed to do the reverse with the new methods on `AttachmentData`, e.g. using model associations and polymorphism in preference to more sophisticated SQL queries.

This is one stage in a bigger refactoring where we're aiming to the same methods on `AttachmentData` for the logic in `AttachmentsController` and the various attachment-related service listener classes. We're also aiming to make the logic in `AttachmentsController` more similar to the related logic in Asset Manager's media controller `download` actions.

I'm hoping that eventually we'll be able to use the lower-level (and easier to understand) `AttachmentData` predicate methods in preference to `AttachmentVisibility#visible?`.

I should add that my original motivation for doing this was because I was struggling to understand the interplay between the deleted and visible status of an attachment when trying to implement code to delete Asset Manager assets for Whitehall attachments.