### PR TITLE
Extract AttachmentRedirectUrlUpdater logic into worker

### DIFF
--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -11,21 +11,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      redirect_url = nil
-      if attachment_data.unpublished?
-        redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
-      end
-      enqueue_job(attachment_data.file, redirect_url)
-      if attachment_data.pdf?
-        enqueue_job(attachment_data.file.thumbnail, redirect_url)
-      end
-    end
-
-  private
-
-    def enqueue_job(uploader, redirect_url)
-      legacy_url_path = uploader.asset_manager_path
-      AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, redirect_url: redirect_url)
+      AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment_data)
     end
   end
 end

--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -11,7 +11,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment_data)
+      AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment_data.id)
     end
   end
 end

--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -11,7 +11,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment_data.id)
+      AssetManagerAttachmentRedirectUrlUpdateWorker.perform_async(attachment_data.id)
     end
   end
 end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -1,6 +1,7 @@
 class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
   def perform(attachment_data_id)
-    attachment_data = AttachmentData.find(attachment_data_id)
+    attachment_data = AttachmentData.find_by(id: attachment_data_id)
+    return unless attachment_data.present?
     redirect_url = nil
     if attachment_data.unpublished?
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -15,6 +15,6 @@ private
 
   def enqueue_job(uploader, redirect_url)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, redirect_url: redirect_url)
+    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'redirect_url' => redirect_url)
   end
 end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -1,0 +1,19 @@
+class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
+  def perform(attachment_data)
+    redirect_url = nil
+    if attachment_data.unpublished?
+      redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
+    end
+    enqueue_job(attachment_data.file, redirect_url)
+    if attachment_data.pdf?
+      enqueue_job(attachment_data.file.thumbnail, redirect_url)
+    end
+  end
+
+private
+
+  def enqueue_job(uploader, redirect_url)
+    legacy_url_path = uploader.asset_manager_path
+    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, redirect_url: redirect_url)
+  end
+end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -1,5 +1,6 @@
 class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
-  def perform(attachment_data)
+  def perform(attachment_data_id)
+    attachment_data = AttachmentData.find(attachment_data_id)
     redirect_url = nil
     if attachment_data.unpublished?
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -184,6 +184,7 @@ private
   def assert_sets_redirect_url_in_asset_manager_to(redirect_url)
     Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'redirect_url' => redirect_url)
+    AssetManagerAttachmentRedirectUrlUpdateWorker.drain
     AssetManagerUpdateAssetWorker.drain
   end
 

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -185,7 +185,6 @@ private
     Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'redirect_url' => redirect_url)
     AssetManagerAttachmentRedirectUrlUpdateWorker.drain
-    AssetManagerUpdateAssetWorker.drain
   end
 
   def unpublish_document_published_in_error

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -6,18 +6,13 @@ module ServiceListeners
 
     let(:updater) { AttachmentRedirectUrlUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
-    let(:worker) { mock('asset-manager-attachment-redirect-url-update-worker') }
-
-    before do
-      AssetManagerAttachmentRedirectUrlUpdateWorker.stubs(:new).returns(worker)
-    end
 
     context 'when attachment has associated attachment data' do
       let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
       let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
       it 'updates the redirect URL of any assets' do
-        worker.expects(:perform).with(attachment_data.id)
+        AssetManagerAttachmentRedirectUrlUpdateWorker.expects(:perform_async).with(attachment_data.id)
 
         updater.update!
       end
@@ -27,7 +22,7 @@ module ServiceListeners
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
       it 'does not update redirect URL of any assets' do
-        worker.expects(:perform).never
+        AssetManagerAttachmentRedirectUrlUpdateWorker.expects(:perform_async).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -3,14 +3,9 @@ require 'test_helper'
 module ServiceListeners
   class AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
     extend Minitest::Spec::DSL
-    include Rails.application.routes.url_helpers
-    include PublicDocumentRoutesHelper
 
     let(:updater) { AttachmentRedirectUrlUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
-    let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
-    let(:redirect_url) { Whitehall.url_maker.public_document_url(unpublished_edition) }
-    let(:unpublished) { true }
 
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
@@ -19,56 +14,6 @@ module ServiceListeners
         AssetManagerUpdateAssetWorker.expects(:perform_async).never
 
         updater.update!
-      end
-    end
-
-    context 'when attachment is not a PDF' do
-      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-
-      before do
-        attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-      end
-
-      it 'updates redirect URL of corresponding asset' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
-
-        updater.update!
-      end
-    end
-
-    context 'when attachment is a PDF' do
-      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-
-      before do
-        attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-      end
-
-      it 'updates redirect URL of asset for attachment & its thumbnail' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.thumbnail.asset_manager_path, redirect_url: redirect_url)
-
-        updater.update!
-      end
-
-      context 'and attachment is not unpublished' do
-        let(:unpublished) { false }
-        let(:unpublished_edition) { nil }
-
-        it 'resets redirect URL of asset for attachment & its thumbnail' do
-          AssetManagerUpdateAssetWorker.expects(:perform_async)
-            .with(attachment.file.asset_manager_path, redirect_url: nil)
-          AssetManagerUpdateAssetWorker.expects(:perform_async)
-            .with(attachment.file.thumbnail.asset_manager_path, redirect_url: nil)
-
-          updater.update!
-        end
       end
     end
   end

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -6,12 +6,17 @@ module ServiceListeners
 
     let(:updater) { AttachmentRedirectUrlUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
+    let(:worker) { mock('asset-manager-attachment-redirect-url-update-worker') }
+
+    before do
+      AssetManagerAttachmentRedirectUrlUpdateWorker.stubs(:new).returns(worker)
+    end
 
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
       it 'does not update redirect URL of any assets' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+        worker.expects(:perform).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_redirect_url_updater_test.rb
@@ -12,6 +12,17 @@ module ServiceListeners
       AssetManagerAttachmentRedirectUrlUpdateWorker.stubs(:new).returns(worker)
     end
 
+    context 'when attachment has associated attachment data' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      it 'updates the redirect URL of any assets' do
+        worker.expects(:perform).with(attachment_data.id)
+
+        updater.update!
+      end
+    end
+
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 

--- a/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include Rails.application.routes.url_helpers
+  include PublicDocumentRoutesHelper
+
+  let(:worker) { AssetManagerAttachmentRedirectUrlUpdateWorker.new }
+  let(:attachment_data) { attachment.attachment_data }
+  let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
+  let(:redirect_url) { Whitehall.url_maker.public_document_url(unpublished_edition) }
+  let(:unpublished) { true }
+
+  context 'when attachment is not a PDF' do
+    let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+    before do
+      attachment_data.stubs(:unpublished?).returns(unpublished)
+      attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+    end
+
+    it 'updates redirect URL of corresponding asset' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
+
+      worker.perform(attachment_data)
+    end
+  end
+
+  context 'when attachment is a PDF' do
+    let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+
+    before do
+      attachment_data.stubs(:unpublished?).returns(unpublished)
+      attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+    end
+
+    it 'updates redirect URL of asset for attachment & its thumbnail' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.thumbnail.asset_manager_path, redirect_url: redirect_url)
+
+      worker.perform(attachment_data)
+    end
+
+    context 'and attachment is not unpublished' do
+      let(:unpublished) { false }
+      let(:unpublished_edition) { nil }
+
+      it 'resets redirect URL of asset for attachment & its thumbnail' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, redirect_url: nil)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, redirect_url: nil)
+
+        worker.perform(attachment_data)
+      end
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -18,13 +18,14 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     before do
       attachment_data.stubs(:unpublished?).returns(unpublished)
       attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+      AttachmentData.stubs(:find).with(attachment_data.id).returns(attachment_data)
     end
 
     it 'updates redirect URL of corresponding asset' do
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.asset_manager_path, redirect_url: redirect_url)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
     end
   end
 
@@ -35,6 +36,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     before do
       attachment_data.stubs(:unpublished?).returns(unpublished)
       attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
+      AttachmentData.stubs(:find).with(attachment_data.id).returns(attachment_data)
     end
 
     it 'updates redirect URL of asset for attachment & its thumbnail' do
@@ -43,7 +45,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.thumbnail.asset_manager_path, redirect_url: redirect_url)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
     end
 
     context 'and attachment is not unpublished' do
@@ -56,7 +58,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
         AssetManagerUpdateAssetWorker.expects(:perform_async)
           .with(attachment.file.thumbnail.asset_manager_path, redirect_url: nil)
 
-        worker.perform(attachment_data)
+        worker.perform(attachment_data.id)
       end
     end
   end

--- a/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -16,6 +16,14 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     AssetManagerUpdateAssetWorker.stubs(:new).returns(update_worker)
   end
 
+  context 'when attachment cannot be found' do
+    it 'does not update the redirect URL' do
+      update_worker.expects(:perform).never
+
+      worker.perform('no-such-id')
+    end
+  end
+
   context 'when attachment is not a PDF' do
     let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
     let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
@@ -23,7 +31,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     before do
       attachment_data.stubs(:unpublished?).returns(unpublished)
       attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-      AttachmentData.stubs(:find).with(attachment_data.id).returns(attachment_data)
+      AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
     end
 
     it 'updates redirect URL of corresponding asset' do
@@ -41,7 +49,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     before do
       attachment_data.stubs(:unpublished?).returns(unpublished)
       attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
-      AttachmentData.stubs(:find).with(attachment_data.id).returns(attachment_data)
+      AttachmentData.stubs(:find_by).with(id: attachment_data.id).returns(attachment_data)
     end
 
     it 'updates redirect URL of asset for attachment & its thumbnail' do


### PR DESCRIPTION
This PR extracts the logic from the AttachmentRedirectUrlUpdater service listener into a new worker. The motivation for this is to ensure that the data required to do the work is fetched at the time the work is done rather than when the job is added to the queue. This is best practice in general for asynchronous jobs and it also means that we can use the worker to help migrate the metadata for existing whitehall assets to asset manager (where we anticipate adding a lot of jobs to the queue). 