### PR TITLE
Delete assets in Asset Manager when attachments are deleted

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -8,6 +8,7 @@ class Attachment < ApplicationRecord
   before_save :set_ordering, if: -> { ordering.blank? }
   before_save :nilify_locale_if_blank
   before_save :prevent_saving_of_abstract_base_class
+  after_destroy :publish_destroy_event
 
   VALID_COMMAND_PAPER_NUMBER_PREFIXES = ['C.', 'Cd.', 'Cmd.', 'Cmnd.', 'Cm.'].freeze
 
@@ -148,5 +149,9 @@ private
     if type.nil? || type == "Attachment"
       raise RuntimeError, "Attempted to save abstract base class Attachment"
     end
+  end
+
+  def publish_destroy_event
+    Whitehall.attachment_notifier.publish('destroy', self)
   end
 end

--- a/app/services/service_listeners/attachment_deleter.rb
+++ b/app/services/service_listeners/attachment_deleter.rb
@@ -1,0 +1,15 @@
+module ServiceListeners
+  class AttachmentDeleter
+    attr_reader :attachment_data
+
+    def initialize(attachment_data)
+      @attachment_data = attachment_data
+    end
+
+    def delete!
+      return unless attachment_data.present?
+
+      AssetManagerAttachmentDeleteWorker.perform_async(attachment_data.id)
+    end
+  end
+end

--- a/app/workers/asset_manager_attachment_delete_worker.rb
+++ b/app/workers/asset_manager_attachment_delete_worker.rb
@@ -1,0 +1,16 @@
+class AssetManagerAttachmentDeleteWorker < WorkerBase
+  def perform(attachment_data_id)
+    attachment_data = AttachmentData.find_by(id: attachment_data_id)
+    return unless attachment_data.present?
+    return unless attachment_data.deleted?
+
+    delete_asset_for(attachment_data.file)
+    if attachment_data.pdf?
+      delete_asset_for(attachment_data.file.thumbnail)
+    end
+  end
+
+  def delete_asset_for(uploader)
+    AssetManagerDeleteAssetWorker.new.perform(uploader.asset_manager_path)
+  end
+end

--- a/config/initializers/attachment_notifier.rb
+++ b/config/initializers/attachment_notifier.rb
@@ -6,4 +6,9 @@ Whitehall.attachment_notifier.tap do |notifier|
         .update!
     end
   end
+  notifier.subscribe('destroy') do |_event, attachment|
+    ServiceListeners::AttachmentDeleter
+      .new(attachment.attachment_data)
+      .delete!
+  end
 end

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -44,6 +44,11 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
         get @attachment_url
         assert_response :not_found
       end
+
+      it 'deletes corresponding asset(s) in Asset Manager' do
+        Services.asset_manager.expects(:delete_asset).with(asset_id)
+        AssetManagerAttachmentDeleteWorker.drain
+      end
     end
 
     context 'when draft document is discarded' do
@@ -57,6 +62,11 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
 
         get @attachment_url
         assert_response :not_found
+      end
+
+      it 'deletes corresponding asset(s) in Asset Manager' do
+        Services.asset_manager.expects(:delete_asset).with(asset_id)
+        AssetManagerAttachmentDeleteWorker.drain
       end
     end
   end

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class AttachmentTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
+  setup do
+    Whitehall.attachment_notifier.stubs(:publish)
+  end
+
   test 'should be invalid without an attachable' do
     refute build(:file_attachment, attachable: nil).valid?
   end
@@ -223,5 +227,12 @@ class AttachmentTest < ActiveSupport::TestCase
     attachment = create(:file_attachment)
     attachment.destroy
     assert attachment.deleted?
+  end
+
+  test 'destroy publishes destroy event to attachment notifier' do
+    attachment = create(:file_attachment)
+    Whitehall.attachment_notifier.expects(:publish).with('destroy', attachment)
+
+    attachment.destroy
   end
 end

--- a/test/unit/services/service_listeners/attachment_deleter_test.rb
+++ b/test/unit/services/service_listeners/attachment_deleter_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module ServiceListeners
+  class AttachmentDeleterTest < ActiveSupport::TestCase
+    extend Minitest::Spec::DSL
+
+    let(:deleter) { AttachmentDeleter.new(attachment_data) }
+
+    context 'when attachment data is not nil' do
+      let(:id) { 123 }
+      let(:attachment_data) { AttachmentData.new(id: id) }
+
+      it 'deletes related assets in Asset Manager' do
+        AssetManagerAttachmentDeleteWorker.expects(:perform_async).with(id)
+
+        deleter.delete!
+      end
+    end
+
+    context 'when attachment data is nil' do
+      let(:attachment_data) { nil }
+
+      it 'does not delete any assets in Asset Manager' do
+        AssetManagerAttachmentDeleteWorker.expects(:perform_async).never
+
+        deleter.delete!
+      end
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_delete_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_delete_worker_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class AssetManagerAttachmentDeleteWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:worker) { AssetManagerAttachmentDeleteWorker.new }
+  let(:attachment_data) { nil }
+  let(:delete_worker) { mock('delete-worker') }
+
+  before do
+    AttachmentData.stubs(:find_by).with(id: id).returns(attachment_data)
+    AssetManagerDeleteAssetWorker.stubs(:new).returns(delete_worker)
+  end
+
+  context 'when attachment data does not exist' do
+    let(:id) { 'no-such-id' }
+
+    it 'does not delete any assets from Asset Manager' do
+      delete_worker.expects(:perform).never
+
+      worker.perform(id)
+    end
+  end
+
+  context 'when attachment data exists' do
+    let(:attachment_data) { create(:attachment_data, file: file) }
+    let(:id) { attachment_data.id }
+
+    before do
+      attachment_data.stubs(:deleted?).returns(deleted)
+    end
+
+    context 'when attachment data is not a PDF' do
+      let(:file) { File.open(fixture_path.join('sample.rtf')) }
+
+      context 'and attachment data is deleted' do
+        let(:deleted) { true }
+
+        it 'deletes corresponding asset in Asset Manager' do
+          delete_worker.expects(:perform)
+            .with(attachment_data.file.asset_manager_path)
+
+          worker.perform(id)
+        end
+      end
+
+      context 'and attachment data is not deleted' do
+        let(:deleted) { false }
+
+        it 'does not delete any assets from Asset Manager' do
+          delete_worker.expects(:perform).never
+
+          assert AssetManagerDeleteAssetWorker.jobs.empty?
+        end
+      end
+    end
+
+    context 'when attachment data is a PDF' do
+      let(:file) { File.open(fixture_path.join('simple.pdf')) }
+
+      context 'and attachment data is deleted' do
+        let(:deleted) { true }
+
+        it 'deletes attachment & thumbnail asset in Asset Manager' do
+          delete_worker.expects(:perform)
+            .with(attachment_data.file.asset_manager_path)
+          delete_worker.expects(:perform)
+            .with(attachment_data.file.thumbnail.asset_manager_path)
+
+          worker.perform(id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This wires up an instance of `ServiceListeners::AttachmentDeleter` so that the Asset Manager assets corresponding to an `AttachmentData` are deleted via a Sidekiq worker.

This will mark the relevant assets as deleted in Asset Manager. While there is functionality in the Asset Manager API to restore a deleted asset, there doesn't appear to be any such functionality in Whitehall.

Note that the Asset Manager assets will only be deleted if no other non-deleted Attachment instances are still referencing the `AttachmentData`, i.e. where `AttachmentData#deleted?` is `true`.

Also note that it looks as if when a (consultation) `Response` or a `PolicyGroup` is destroyed, the associated attachments are not destroyed. While it's not obvious that it's possible to delete a `Response` via the user interface, it does appear to be possible to delete a `PolicyGroup`.

While it doesn't feel appropriate to address this here, I'd recommend that for consistency and completeness, both of these problems should be fixed by calling `Attachable#delete_all_attachments` from a before/after destroy callback on `Response` and `PolicyGroup`. This would mean a 'destroy' event would be published to the attachment notifier for each attachment and the relevant assets would be deleted in Asset Manager.
