### PR TITLE
Fix AttachmentData#significant_attachment

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -201,7 +201,7 @@ private
   end
 
   def significant_attachment
-    if attachments.one? || last_attachment.attachable.publicly_visible?
+    if attachments.one? || last_attachable.publicly_visible?
       last_attachment
     else
       penultimate_attachment

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -171,6 +171,17 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             assert_nil attachment_data.reload.unpublished_edition
           end
 
+          context 'when new edition is discarded' do
+            before do
+              new_edition.delete
+              new_edition.save!
+            end
+
+            it 'is not deleted' do
+              refute attachment_data.reload.deleted?
+            end
+          end
+
           context 'new edition is access-limited' do
             before do
               new_edition.change_note = 'change-note'


### PR DESCRIPTION
@kevindew pointed out that `NoMethodError` exceptions like [this one][1] were occurring in the staging environment.

I discovered that this is possible if the attachment data belongs to a deleted edition which in turn has a previous edition. I've added this scenario to `AttachmentDataVisiblityTest` and called `AttachmentData#deleted?` to trigger the exception.

I've fixed the problem by using the existing `AttachmentData#last_attachable` method which uses the Null Object pattern to avoid ever returning `nil`. In hindsight, I should probably have done this in [this earlier commit][2].

While I was at it I looked through the other similar methods on `AttachmentData` to see if I could spot any possibility of a similar problem occurring, but it all looks OK to me.

[1]: https://sentry.io/govuk/app-whitehall/issues/491623681/
[2]:
https://github.com/alphagov/whitehall/commit/2256a57c603d61a0e71d69e4e7b167dd0ad1040f