### PR TITLE
Use Unpublishing#slug in Unpublishing#document_path

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -43,7 +43,7 @@ class Unpublishing < ApplicationRecord
   end
 
   def document_path
-    Whitehall.url_maker.public_document_path(edition)
+    Whitehall.url_maker.public_document_path(edition, id: slug)
   end
 
   def document_url

--- a/test/unit/unpublishing_test.rb
+++ b/test/unit/unpublishing_test.rb
@@ -130,6 +130,15 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal original_path, unpublishing.document_path
   end
 
+  test '#document_path returns the URL path using the slug from the unpublishing' do
+    edition = create(:detailed_guide, :draft)
+    unpublishing = create(:unpublishing, edition: edition,
+                          unpublishing_reason: UnpublishingReason::PublishedInError)
+    unpublishing.update_attribute(:slug, 'a-different-slug')
+
+    assert_equal '/guidance/a-different-slug', unpublishing.document_path
+  end
+
   test '#document_url returns the URL for the unpublished edition' do
     edition = create(:detailed_guide, :draft)
     original_url = Whitehall.url_maker.public_document_url(edition)
@@ -137,6 +146,15 @@ class UnpublishingTest < ActiveSupport::TestCase
                           unpublishing_reason: UnpublishingReason::PublishedInError)
 
     assert_equal original_url, unpublishing.document_url
+  end
+
+  test '#document_url returns the URL using the slug from the unpublishing' do
+    edition = create(:detailed_guide, :draft)
+    unpublishing = create(:unpublishing, edition: edition,
+                          unpublishing_reason: UnpublishingReason::PublishedInError)
+    unpublishing.update_attribute(:slug, 'a-different-slug')
+
+    assert_match '/guidance/a-different-slug', unpublishing.document_url
   end
 
   test '#translated_locales is delegated to the edition' do


### PR DESCRIPTION
This partially reverts https://github.com/alphagov/whitehall/pull/3840/commits/7ea19016cd9c1366d1e6a306e4355c8d92b15a0d (PR #3840).

After deploying PR #3840 we saw a failure in the "Whitehall assets are served" scenario of the Whitehall feature in Smokey. The test was getting a 404 instead of a 200. This is because we redirect to the `Unpublishing#document_path` and the removal of the `id` option meant that this was now redirecting to a page that didn't exist. This is demonstrated in the curl requests below:

    # Before PR #3840
    $ curl -v \
      https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/32409/11-944-higher-education-students-at-heart-of-system.pdf \
      > /dev/null
    <snipped>
    < HTTP/2 302
    < location: https://www.gov.uk/government/publications/higher-education-students-at-the-heart-of-the-system--2

    $ curl -v \
      https://www.gov.uk/government/publications/higher-education-students-at-the-heart-of-the-system--2 \
      > /dev/null
    <snipped>
    < HTTP/2 301
    < location: /government/consultations/higher-education-white-paper-students-at-the-heart-of-the-system

    $ curl -v \
      https://www.gov.uk/government/consultations/higher-education-white-paper-students-at-the-heart-of-the-system \
      > /dev/null
    <snipped>
    < HTTP/2 200

    ---

    # After PR #3840
    $ curl -v \
      https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/32409/11-944-higher-education-students-at-heart-of-system.pdf \
      > /dev/null
    <snipped>
    < HTTP/1.1 302 Found
    < Location: https://www.gov.uk/government/publications/higher-education-students-at-the-heart-of-the-system

    $ curl -v \
      https://www.gov.uk/government/publications/higher-education-students-at-the-heart-of-the-system \
      > /dev/null
    <snipped>
    < HTTP/1.1 404 Not Found

I've checked the `Unpublishing` data in integration and can see that there are 4617 Unpublishing instances that are associated with an Edition with attachments where the Unpublishing has a different slug to the slug of its parent Document.

    > Unpublishing.count
    => 28083

    > mismatch_slug_count = 0; Unpublishing.all.each { |u|
        mismatch_slug_count += 1 if (u.slug != u.edition.document.slug)
      }; mismatch_slug_count
    => 5930

    > mismatch_slug_count = 0; Unpublishing.all.each { |u|
        mismatch_slug_count += 1 if (
          u.edition.respond_to?(:attachments) &&
          u.edition.attachments.any? &&
          u.slug != u.edition.document.slug
        )
      }; mismatch_slug_count
    => 4617

I think the change highlighted by the Smokey failure might also apply to these 4617 documents which is we I've chosen to revert the behaviour for now.

As an aside: the test failure in Smokey highlighted that it was previously returning a false positive response. [Smokey PR 345][1] attempts to avoid such false positives in future.

[1]: https://github.com/alphagov/smokey/pull/345