### PR TITLE
Inline attachment link header updater logic into worker

### DIFF
--- a/app/services/service_listeners/attachment_link_header_updater.rb
+++ b/app/services/service_listeners/attachment_link_header_updater.rb
@@ -9,7 +9,7 @@ module ServiceListeners
     def update!
       return unless attachment_data.present?
 
-      AssetManagerAttachmentLinkHeaderUpdateWorker.new.perform(attachment_data)
+      AssetManagerAttachmentLinkHeaderUpdateWorker.new.perform(attachment_data.id)
     end
   end
 end

--- a/app/services/service_listeners/attachment_link_header_updater.rb
+++ b/app/services/service_listeners/attachment_link_header_updater.rb
@@ -9,22 +9,7 @@ module ServiceListeners
     def update!
       return unless attachment_data.present?
 
-      visible_edition = attachment_data.visible_edition_for(nil)
-      return unless visible_edition.present?
-
-      parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
-
-      enqueue_job(attachment_data.file, parent_document_url)
-      if attachment_data.pdf?
-        enqueue_job(attachment_data.file.thumbnail, parent_document_url)
-      end
-    end
-
-  private
-
-    def enqueue_job(uploader, parent_document_url)
-      legacy_url_path = uploader.asset_manager_path
-      AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, parent_document_url: parent_document_url)
+      AssetManagerAttachmentLinkHeaderUpdateWorker.new.perform(attachment_data)
     end
   end
 end

--- a/app/services/service_listeners/attachment_link_header_updater.rb
+++ b/app/services/service_listeners/attachment_link_header_updater.rb
@@ -9,7 +9,7 @@ module ServiceListeners
     def update!
       return unless attachment_data.present?
 
-      AssetManagerAttachmentLinkHeaderUpdateWorker.new.perform(attachment_data.id)
+      AssetManagerAttachmentLinkHeaderUpdateWorker.perform_async(attachment_data.id)
     end
   end
 end

--- a/app/workers/asset_manager_attachment_link_header_update_worker.rb
+++ b/app/workers/asset_manager_attachment_link_header_update_worker.rb
@@ -1,0 +1,20 @@
+class AssetManagerAttachmentLinkHeaderUpdateWorker < WorkerBase
+  def perform(attachment_data)
+    visible_edition = attachment_data.visible_edition_for(nil)
+    return unless visible_edition.present?
+
+    parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
+
+    enqueue_job(attachment_data.file, parent_document_url)
+    if attachment_data.pdf?
+      enqueue_job(attachment_data.file.thumbnail, parent_document_url)
+    end
+  end
+
+private
+
+  def enqueue_job(uploader, parent_document_url)
+    legacy_url_path = uploader.asset_manager_path
+    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, parent_document_url: parent_document_url)
+  end
+end

--- a/app/workers/asset_manager_attachment_link_header_update_worker.rb
+++ b/app/workers/asset_manager_attachment_link_header_update_worker.rb
@@ -17,6 +17,6 @@ private
 
   def enqueue_job(uploader, parent_document_url)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, parent_document_url: parent_document_url)
+    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'parent_document_url' => parent_document_url)
   end
 end

--- a/app/workers/asset_manager_attachment_link_header_update_worker.rb
+++ b/app/workers/asset_manager_attachment_link_header_update_worker.rb
@@ -1,5 +1,7 @@
 class AssetManagerAttachmentLinkHeaderUpdateWorker < WorkerBase
-  def perform(attachment_data)
+  def perform(attachment_data_id)
+    attachment_data = AttachmentData.find_by(id: attachment_data_id)
+    return unless attachment_data.present?
     visible_edition = attachment_data.visible_edition_for(nil)
     return unless visible_edition.present?
 

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -68,36 +68,10 @@ private
       .returns(attributes.merge(id: url_id).stringify_keys)
   end
 
-  def assert_sets_draft_status_in_asset_manager_to(draft, never: false)
-    expectation = Services.asset_manager.expects(:update_asset)
-      .with(asset_id, 'draft' => draft)
-    expectation.never if never
-  end
-
-  def refute_sets_draft_status_in_asset_manager_to(draft)
-    assert_sets_draft_status_in_asset_manager_to(draft, never: true)
-  end
-
   def force_publish_document
     click_link 'Force publish'
     fill_in 'Reason for force publishing', with: 'testing'
     click_button 'Force publish'
     assert_text %r{The document .* has been published}
-  end
-
-  def unpublish_document_published_in_error
-    click_link 'Withdraw or unpublish'
-    within '#js-published-in-error-form' do
-      click_button 'Unpublish'
-    end
-    assert_text 'This document has been unpublished'
-  end
-
-  def add_attachment(filename)
-    click_link 'Upload new file attachment'
-    fill_in 'Title', with: 'Attachment Title'
-    attach_file 'File', path_to_attachment(filename)
-    click_button 'Save'
-    assert_text "Attachment 'Attachment Title' uploaded"
   end
 end

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -40,7 +40,6 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
           .with(asset_id, 'parent_document_url' => parent_document_url)
 
         AssetManagerAttachmentLinkHeaderUpdateWorker.drain
-        AssetManagerUpdateAssetWorker.drain
       end
     end
   end
@@ -73,7 +72,6 @@ private
     expectation = Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'draft' => draft)
     expectation.never if never
-    AssetManagerUpdateAssetWorker.drain
   end
 
   def refute_sets_draft_status_in_asset_manager_to(draft)

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -39,6 +39,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
         Services.asset_manager.expects(:update_asset)
           .with(asset_id, 'parent_document_url' => parent_document_url)
 
+        AssetManagerAttachmentLinkHeaderUpdateWorker.drain
         AssetManagerUpdateAssetWorker.drain
       end
     end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -22,7 +22,7 @@ module ServiceListeners
     end
 
     context "when attachment doesn't belong to an edition" do
-      let(:attachment) { FileAttachment.new(attachable: PolicyGroup.new) }
+      let(:attachment) { FactoryBot.create(:file_attachment) }
 
       it 'does not update draft status of any assets' do
         AssetManagerUpdateAssetWorker.expects(:perform_async).never

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -17,7 +17,7 @@ module ServiceListeners
       let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
       it 'calls the worker' do
-        worker.expects(:perform).with(attachment_data)
+        worker.expects(:perform).with(attachment_data.id)
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -3,55 +3,15 @@ require 'test_helper'
 module ServiceListeners
   class AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
     extend Minitest::Spec::DSL
-    include Rails.application.routes.url_helpers
-    include PublicDocumentRoutesHelper
 
     let(:updater) { AttachmentLinkHeaderUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
-    let(:edition) { FactoryBot.create(:published_edition) }
-    let(:parent_document_url) { Whitehall.url_maker.public_document_url(edition) }
 
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
       it 'does not update draft status of any assets' do
         AssetManagerUpdateAssetWorker.expects(:perform_async).never
-
-        updater.update!
-      end
-    end
-
-    context "when attachment doesn't belong to an edition" do
-      let(:attachment) { FactoryBot.create(:file_attachment) }
-
-      it 'does not update draft status of any assets' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async).never
-
-        updater.update!
-      end
-    end
-
-    context 'when attachment is not a PDF' do
-      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
-
-      it 'sets parent_document_url of corresponding asset' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
-
-        updater.update!
-      end
-    end
-
-    context 'when attachment is a PDF' do
-      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
-
-      it 'sets parent_document_url for attachment & its thumbnail' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.thumbnail.asset_manager_path, parent_document_url: parent_document_url)
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -6,12 +6,17 @@ module ServiceListeners
 
     let(:updater) { AttachmentLinkHeaderUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
+    let(:worker) { mock('asset-manager-attachment-link-header-update-worker') }
+
+    setup do
+      AssetManagerAttachmentLinkHeaderUpdateWorker.stubs(:new).returns(worker)
+    end
 
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
-      it 'does not update draft status of any assets' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+      it 'does not call the worker' do
+        worker.expects(:perform).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -6,18 +6,13 @@ module ServiceListeners
 
     let(:updater) { AttachmentLinkHeaderUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
-    let(:worker) { mock('asset-manager-attachment-link-header-update-worker') }
-
-    setup do
-      AssetManagerAttachmentLinkHeaderUpdateWorker.stubs(:new).returns(worker)
-    end
 
     context 'when attachment has associated attachment data' do
       let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
       let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
       it 'calls the worker' do
-        worker.expects(:perform).with(attachment_data.id)
+        AssetManagerAttachmentLinkHeaderUpdateWorker.expects(:perform_async).with(attachment_data.id)
 
         updater.update!
       end
@@ -27,7 +22,7 @@ module ServiceListeners
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
       it 'does not call the worker' do
-        worker.expects(:perform).never
+        AssetManagerAttachmentLinkHeaderUpdateWorker.expects(:perform_async).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_link_header_updater_test.rb
@@ -12,6 +12,17 @@ module ServiceListeners
       AssetManagerAttachmentLinkHeaderUpdateWorker.stubs(:new).returns(worker)
     end
 
+    context 'when attachment has associated attachment data' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      it 'calls the worker' do
+        worker.expects(:perform).with(attachment_data)
+
+        updater.update!
+      end
+    end
+
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 

--- a/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include Rails.application.routes.url_helpers
+  include PublicDocumentRoutesHelper
+
+  let(:worker) { AssetManagerAttachmentLinkHeaderUpdateWorker.new }
+  let(:attachment_data) { attachment.attachment_data }
+  let(:edition) { FactoryBot.create(:published_edition) }
+  let(:parent_document_url) { Whitehall.url_maker.public_document_url(edition) }
+
+  context "when attachment doesn't belong to an edition" do
+    let(:attachment) { FactoryBot.create(:file_attachment) }
+
+    it 'does not update draft status of any assets' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+      worker.perform(attachment_data)
+    end
+  end
+
+  context 'when attachment is not a PDF' do
+    let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf, attachable: edition) }
+
+    it 'sets parent_document_url of corresponding asset' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
+
+      worker.perform(attachment_data)
+    end
+  end
+
+  context 'when attachment is a PDF' do
+    let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: edition) }
+
+    it 'sets parent_document_url for attachment & its thumbnail' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.thumbnail.asset_manager_path, parent_document_url: parent_document_url)
+
+      worker.perform(attachment_data)
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
@@ -16,7 +16,15 @@ class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
     it 'does not update draft status of any assets' do
       AssetManagerUpdateAssetWorker.expects(:perform_async).never
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
+    end
+  end
+
+  context "when the attachment cannot be found" do
+    it 'does not update draft status of any assets' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+      worker.perform('no-such-id')
     end
   end
 
@@ -28,7 +36,7 @@ class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.asset_manager_path, parent_document_url: parent_document_url)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
     end
   end
 
@@ -42,7 +50,7 @@ class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.thumbnail.asset_manager_path, parent_document_url: parent_document_url)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
     end
   end
 end


### PR DESCRIPTION
The motivation for this change is to avoid any issues with data or code changing between the time link updater worker is queued and when the job is executed. As well as being good practice this is especially important as we want to use this worker to perform bulk update of data in Asset Manager from Whitehall and expect the individual jobs to wait on the queue for some time. 