### PR TITLE
Fix NoMethodError in consultation Response methods

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -26,6 +26,32 @@ module Attachable
     end
   end
 
+  class Null
+    def publicly_visible?
+      false
+    end
+
+    def accessible_to?(_user)
+      false
+    end
+
+    def access_limited?
+      false
+    end
+
+    def access_limited_object
+      nil
+    end
+
+    def unpublished?
+      false
+    end
+
+    def unpublished_edition
+      nil
+    end
+  end
+
   def attachables
     [self]
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -41,6 +41,16 @@ class Attachment < ApplicationRecord
   scope :not_deleted, -> { where(deleted: false) }
   scope :deleted, -> { where(deleted: true) }
 
+  class Null
+    def deleted?
+      false
+    end
+
+    def attachable
+      Attachable::Null.new
+    end
+  end
+
   def self.parliamentary_sessions
     (1951..Time.zone.now.year).to_a.reverse.map do |year|
       starts = Date.new(year).strftime('%Y')

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -156,16 +156,6 @@ class AttachmentData < ApplicationRecord
 
 private
 
-  class NullAttachment
-    def deleted?
-      false
-    end
-
-    def attachable
-      Attachable::Null.new
-    end
-  end
-
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end
@@ -183,11 +173,11 @@ private
   end
 
   def last_attachment
-    attachments[-1] || NullAttachment.new
+    attachments[-1] || Attachment::Null.new
   end
 
   def penultimate_attachment
-    attachments[-2] || NullAttachment.new
+    attachments[-2] || Attachment::Null.new
   end
 
   def cant_be_replaced_by_self

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -156,48 +156,22 @@ class AttachmentData < ApplicationRecord
 
 private
 
-  class NullAttachable
-    def publicly_visible?
-      false
-    end
-
-    def accessible_to?(_user)
-      false
-    end
-
-    def access_limited?
-      false
-    end
-
-    def access_limited_object
-      nil
-    end
-
-    def unpublished?
-      false
-    end
-
-    def unpublished_edition
-      nil
-    end
-  end
-
   class NullAttachment
     def deleted?
       false
     end
 
     def attachable
-      NullAttachable.new
+      Attachable::Null.new
     end
   end
 
   def significant_attachable
-    significant_attachment.attachable || NullAttachable.new
+    significant_attachment.attachable || Attachable::Null.new
   end
 
   def last_attachable
-    last_attachment.attachable || NullAttachable.new
+    last_attachment.attachable || Attachable::Null.new
   end
 
   def significant_attachment

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -13,7 +13,7 @@ class Response < ApplicationRecord
   end
 
   def access_limited?
-    consultation.access_limited?
+    parent_attachable.access_limited?
   end
 
   def alternative_format_contact_email
@@ -21,19 +21,19 @@ class Response < ApplicationRecord
   end
 
   def publicly_visible?
-    consultation.publicly_visible?
+    parent_attachable.publicly_visible?
   end
 
   def accessible_to?(user)
-    consultation.accessible_to?(user)
+    parent_attachable.accessible_to?(user)
   end
 
   def unpublished?
-    consultation.unpublished?
+    parent_attachable.unpublished?
   end
 
   def unpublished_edition
-    consultation.unpublished_edition
+    parent_attachable.unpublished_edition
   end
 
   def can_order_attachments?
@@ -44,5 +44,9 @@ private
 
   def has_attachments
     attachments.any?
+  end
+
+  def parent_attachable
+    consultation || AttachmentData::NullAttachable.new
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -47,6 +47,6 @@ private
   end
 
   def parent_attachable
-    consultation || AttachmentData::NullAttachable.new
+    consultation || Attachable::Null.new
   end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -408,6 +408,17 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             assert_nil attachment_data.reload.unpublished_edition
           end
 
+          context 'when new edition is discarded' do
+            before do
+              new_edition.delete
+              new_edition.save!
+            end
+
+            it 'is not deleted' do
+              refute attachment_data.reload.deleted?
+            end
+          end
+
           context 'and attachment is deleted' do
             before do
               new_attachment.destroy!

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -33,6 +33,12 @@ class ResponseTest < ActiveSupport::TestCase
     refute response.publicly_visible?
   end
 
+  test 'is not publicly visible if its consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    refute response.publicly_visible?
+  end
+
   test 'is unpublished if its consultation is unpublished' do
     consultation = build(:consultation)
     consultation.stubs(:unpublished?).returns(true)
@@ -49,11 +55,83 @@ class ResponseTest < ActiveSupport::TestCase
     refute response.unpublished?
   end
 
+  test 'is not unpublished if its consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    refute response.unpublished?
+  end
+
   test 'returns unpublished edition from its consultation' do
     consultation = build(:consultation)
     consultation.stubs(:unpublished_edition).returns(consultation)
     response = build(:consultation_outcome, consultation: consultation)
 
     assert_equal consultation, response.unpublished_edition
+  end
+
+  test 'returns no unpublished edition if its consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    assert_nil response.unpublished_edition
+  end
+
+  test 'is accessible to user if consultation is accessible to user' do
+    user = build(:user)
+    consultation = build(:consultation)
+    consultation.stubs(:accessible_to?).with(user).returns(true)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert response.accessible_to?(user)
+  end
+
+  test 'is not accessible to user if consultation is not accessible to user' do
+    user = build(:user)
+    consultation = build(:consultation)
+    consultation.stubs(:accessible_to?).with(user).returns(false)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    refute response.accessible_to?(user)
+  end
+
+  test 'is not accessible to user if consultation is nil' do
+    user = build(:user)
+    response = build(:consultation_outcome, consultation: nil)
+
+    refute response.accessible_to?(user)
+  end
+
+  test 'is access limited if its consultation is access limited' do
+    consultation = build(:consultation)
+    consultation.stubs(:access_limited?).returns(true)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert response.access_limited?
+  end
+
+  test 'is not access limited if its consultation is not access limited' do
+    consultation = build(:consultation)
+    consultation.stubs(:access_limited?).returns(false)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    refute response.access_limited?
+  end
+
+  test 'is not access limited if its consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    refute response.access_limited?
+  end
+
+  test 'returns consultation as its access limited object' do
+    consultation = build(:consultation)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert_equal consultation, response.access_limited_object
+  end
+
+  test 'returns no access limited object if its consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    assert_nil response.access_limited_object
   end
 end


### PR DESCRIPTION
I noticed that exceptions like [this one][1] were occurring on staging.

I discovered that this is possible if the attachment data belongs to a consultation response which in turn belongs to a deleted consultation which in turn has a previous edition. I've added this scenario to `AttachmentDataVisiblityTest` and called AttachmentData#deleted? to trigger the exception.

In fixing the problem, I noticed a bunch more methods on `Response` which I've added recently are susceptible to the same problem. I've driven out fixes for them by adding tests to ResponseTest rather than making `AttachmentDataVisiblityTest` even longer.

I've reused `AttachmentData::NullAttachable` to avoid duplicating the default return values.

Note that `Response#access_limited_object` is not vulnerable to the same problem, because unlike the others, it doesn't call a method on the parent consultation. The same is true of all the equivalent methods on `PolicyGroup`.

I've also moved the following Null Object classes:

* `AttachmentData::NullAttachment` -> `Attachment::Null`
* `AttachmentData::NullAttachable` -> `Attachable::Null`

[1]: https://sentry.io/govuk/app-whitehall/issues/491627163/
