### PR TITLE
Move AttachmentDraftStatusUpdater logic to worker

### DIFF
--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -8,7 +8,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      AssetManagerAttachmentDraftStatusUpdateWorker.new.perform(attachment_data)
+      AssetManagerAttachmentDraftStatusUpdateWorker.new.perform(attachment_data.id)
     end
   end
 end

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -8,7 +8,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      AssetManagerAttachmentDraftStatusUpdateWorker.new.perform(attachment_data.id)
+      AssetManagerAttachmentDraftStatusUpdateWorker.perform_async(attachment_data.id)
     end
   end
 end

--- a/app/services/service_listeners/attachment_draft_status_updater.rb
+++ b/app/services/service_listeners/attachment_draft_status_updater.rb
@@ -8,18 +8,7 @@ module ServiceListeners
 
     def update!
       return unless attachment_data.present?
-      draft = attachment_data.draft?
-      enqueue_job(attachment_data.file, draft)
-      if attachment_data.pdf?
-        enqueue_job(attachment_data.file.thumbnail, draft)
-      end
-    end
-
-  private
-
-    def enqueue_job(uploader, draft)
-      legacy_url_path = uploader.asset_manager_path
-      AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft: draft)
+      AssetManagerAttachmentDraftStatusUpdateWorker.new.perform(attachment_data)
     end
   end
 end

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -13,6 +13,6 @@ private
 
   def enqueue_job(uploader, draft)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft: draft)
+    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'draft' => draft)
   end
 end

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -1,0 +1,16 @@
+class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
+  def perform(attachment_data)
+    draft = attachment_data.draft?
+    enqueue_job(attachment_data.file, draft)
+    if attachment_data.pdf?
+      enqueue_job(attachment_data.file.thumbnail, draft)
+    end
+  end
+
+private
+
+  def enqueue_job(uploader, draft)
+    legacy_url_path = uploader.asset_manager_path
+    AssetManagerUpdateAssetWorker.perform_async(legacy_url_path, draft: draft)
+  end
+end

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -1,5 +1,7 @@
 class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
-  def perform(attachment_data)
+  def perform(attachment_data_id)
+    attachment_data = AttachmentData.find_by(id: attachment_data_id)
+    return unless attachment_data.present?
     draft = attachment_data.draft?
     enqueue_job(attachment_data.file, draft)
     if attachment_data.pdf?

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -113,6 +113,7 @@ private
     expectation = Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'draft' => draft)
     expectation.never if never
+    AssetManagerAttachmentDraftStatusUpdateWorker.drain
     AssetManagerUpdateAssetWorker.drain
   end
 

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -12,6 +12,17 @@ module ServiceListeners
       AssetManagerAttachmentDraftStatusUpdateWorker.stubs(:new).returns(worker)
     end
 
+    context 'when the attachment has associated attachment data' do
+      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+
+      it 'call the worker' do
+        worker.expects(:perform).with(attachment_data)
+
+        updater.update!
+      end
+    end
+
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -6,12 +6,17 @@ module ServiceListeners
 
     let(:updater) { AttachmentDraftStatusUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
+    let(:worker) { mock('asset-manager-attachment-draft-status-update-worker') }
+
+    setup do
+      AssetManagerAttachmentDraftStatusUpdateWorker.stubs(:new).returns(worker)
+    end
 
     context 'when attachment has no associated attachment data' do
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
-      it 'does not update draft status of any assets' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async).never
+      it 'does not call the worker' do
+        worker.expects(:perform).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -6,18 +6,13 @@ module ServiceListeners
 
     let(:updater) { AttachmentDraftStatusUpdater.new(attachment_data) }
     let(:attachment_data) { attachment.attachment_data }
-    let(:worker) { mock('asset-manager-attachment-draft-status-update-worker') }
-
-    setup do
-      AssetManagerAttachmentDraftStatusUpdateWorker.stubs(:new).returns(worker)
-    end
 
     context 'when the attachment has associated attachment data' do
       let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
       let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
       it 'call the worker' do
-        worker.expects(:perform).with(attachment_data.id)
+        AssetManagerAttachmentDraftStatusUpdateWorker.expects(:perform_async).with(attachment_data.id)
 
         updater.update!
       end
@@ -27,7 +22,7 @@ module ServiceListeners
       let(:attachment) { FactoryBot.create(:html_attachment) }
 
       it 'does not call the worker' do
-        worker.expects(:perform).never
+        AssetManagerAttachmentDraftStatusUpdateWorker.expects(:perform_async).never
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -17,7 +17,7 @@ module ServiceListeners
       let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
 
       it 'call the worker' do
-        worker.expects(:perform).with(attachment_data)
+        worker.expects(:perform).with(attachment_data.id)
 
         updater.update!
       end

--- a/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/service_listeners/attachment_draft_status_updater_test.rb
@@ -16,54 +16,5 @@ module ServiceListeners
         updater.update!
       end
     end
-
-    context 'when attachment is not a PDF' do
-      let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
-      let(:draft) { true }
-
-      before do
-        attachment_data.stubs(:draft?).returns(draft)
-      end
-
-      it 'marks corresponding asset as draft' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, draft: true)
-
-        updater.update!
-      end
-    end
-
-    context 'when attachment is a PDF' do
-      let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
-      let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
-      let(:draft) { true }
-
-      before do
-        attachment_data.stubs(:draft?).returns(draft)
-      end
-
-      it 'marks asset for attachment & its thumbnail as draft' do
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.asset_manager_path, draft: true)
-        AssetManagerUpdateAssetWorker.expects(:perform_async)
-          .with(attachment.file.thumbnail.asset_manager_path, draft: true)
-
-        updater.update!
-      end
-
-      context 'and attachment should not be draft' do
-        let(:draft) { false }
-
-        it 'marks corresponding assets as not draft' do
-          AssetManagerUpdateAssetWorker.expects(:perform_async)
-            .with(attachment.file.asset_manager_path, draft: false)
-          AssetManagerUpdateAssetWorker.expects(:perform_async)
-            .with(attachment.file.thumbnail.asset_manager_path, draft: false)
-
-          updater.update!
-        end
-      end
-    end
   end
 end

--- a/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:worker) { AssetManagerAttachmentDraftStatusUpdateWorker.new }
+  let(:attachment_data) { attachment.attachment_data }
+
+  context 'when attachment is not a PDF' do
+    let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: sample_rtf) }
+    let(:draft) { true }
+
+    before do
+      attachment_data.stubs(:draft?).returns(draft)
+    end
+
+    it 'marks corresponding asset as draft' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, draft: true)
+
+      worker.perform(attachment_data)
+    end
+  end
+
+  context 'when attachment is a PDF' do
+    let(:simple_pdf) { File.open(fixture_path.join('simple.pdf')) }
+    let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf) }
+    let(:draft) { true }
+
+    before do
+      attachment_data.stubs(:draft?).returns(draft)
+    end
+
+    it 'marks asset for attachment & its thumbnail as draft' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.asset_manager_path, draft: true)
+      AssetManagerUpdateAssetWorker.expects(:perform_async)
+        .with(attachment.file.thumbnail.asset_manager_path, draft: true)
+
+      worker.perform(attachment_data)
+    end
+
+    context 'and attachment should not be draft' do
+      let(:draft) { false }
+
+      it 'marks corresponding assets as not draft' do
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.asset_manager_path, draft: false)
+        AssetManagerUpdateAssetWorker.expects(:perform_async)
+          .with(attachment.file.thumbnail.asset_manager_path, draft: false)
+
+        worker.perform(attachment_data)
+      end
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
@@ -12,6 +12,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
     let(:draft) { true }
 
     before do
+      AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
       attachment_data.stubs(:draft?).returns(draft)
     end
 
@@ -19,7 +20,15 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.asset_manager_path, draft: true)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
+    end
+  end
+
+  context 'when attachment cannot be found' do
+    it 'does not mark anything as draft' do
+      AssetManagerUpdateAssetWorker.expects(:perform_async).never
+
+      worker.perform('no-such-id')
     end
   end
 
@@ -29,6 +38,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
     let(:draft) { true }
 
     before do
+      AttachmentData.stubs(:find_by).with(id: attachment.id).returns(attachment_data)
       attachment_data.stubs(:draft?).returns(draft)
     end
 
@@ -38,7 +48,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
       AssetManagerUpdateAssetWorker.expects(:perform_async)
         .with(attachment.file.thumbnail.asset_manager_path, draft: true)
 
-      worker.perform(attachment_data)
+      worker.perform(attachment_data.id)
     end
 
     context 'and attachment should not be draft' do
@@ -50,7 +60,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
         AssetManagerUpdateAssetWorker.expects(:perform_async)
           .with(attachment.file.thumbnail.asset_manager_path, draft: false)
 
-        worker.perform(attachment_data)
+        worker.perform(attachment_data.id)
       end
     end
   end


### PR DESCRIPTION
The motivation for this change is to avoid any issues with data or code changing between the time link updater worker is queued and when the job is executed. As well as being good practice this is especially important as we want to use this worker to perform bulk update of data in Asset Manager from Whitehall and expect the individual jobs to wait on the queue for some time.