### PR TITLE
Remove redundant Sidekiq::Testing.fake! blocks from tests

### DIFF
--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -89,13 +89,11 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
   test 'schedule schedules the given edition on behalf of the current user' do
     editor = create(:departmental_editor)
     submitted_edition(submitter: editor, scheduled_publication: 1.day.from_now)
-    Sidekiq::Testing.fake! do
-      post :schedule, params: { id: submitted_edition, lock_version: submitted_edition.lock_version }
+    post :schedule, params: { id: submitted_edition, lock_version: submitted_edition.lock_version }
 
-      assert_redirected_to admin_editions_path(state: :scheduled)
-      assert submitted_edition.reload.scheduled?
-      assert_equal "The document #{submitted_edition.title} has been scheduled for publication", flash[:notice]
-    end
+    assert_redirected_to admin_editions_path(state: :scheduled)
+    assert submitted_edition.reload.scheduled?
+    assert_equal "The document #{submitted_edition.title} has been scheduled for publication", flash[:notice]
   end
 
   test 'schedule redirects back to the edition with an error message if scheduling reports a failure' do
@@ -123,24 +121,20 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
   end
 
   test 'POST :force_schedule force schedules the edition' do
-    Sidekiq::Testing.fake! do
-      draft_edition.update_attribute(:scheduled_publication, 1.day.from_now)
-      post :force_schedule, params: { id: draft_edition, lock_version: draft_edition.lock_version }
+    draft_edition.update_attribute(:scheduled_publication, 1.day.from_now)
+    post :force_schedule, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
-      assert_redirected_to admin_editions_path(state: :scheduled)
-      assert draft_edition.reload.scheduled?
-      assert draft_edition.force_published?
-    end
+    assert_redirected_to admin_editions_path(state: :scheduled)
+    assert draft_edition.reload.scheduled?
+    assert draft_edition.force_published?
   end
 
   test 'unschedule unschedules the given edition on behalf of the current user' do
-    Sidekiq::Testing.fake! do
-      scheduled_edition = create(:scheduled_publication)
-      post :unschedule, params: { id: scheduled_edition, lock_version: scheduled_edition.lock_version }
+    scheduled_edition = create(:scheduled_publication)
+    post :unschedule, params: { id: scheduled_edition, lock_version: scheduled_edition.lock_version }
 
-      assert_redirected_to admin_editions_path(state: :submitted)
-      assert scheduled_edition.reload.submitted?
-    end
+    assert_redirected_to admin_editions_path(state: :submitted)
+    assert scheduled_edition.reload.submitted?
   end
 
   test 'unschedule redirects back to the edition with an error message if unscheduling reports a failure' do

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -27,18 +27,16 @@ class AssetManagerIntegrationTest
     end
 
     test 'sends the user ids of authorised users to Asset Manager' do
-      Sidekiq::Testing.fake! do
-        organisation = FactoryBot.create(:organisation)
-        user = FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
-        consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
-        @attachment.attachable = consultation
-        @attachment.attachment_data.attachable = consultation
-        @attachment.save!
+      organisation = FactoryBot.create(:organisation)
+      user = FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
+      consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
+      @attachment.attachable = consultation
+      @attachment.attachment_data.attachable = consultation
+      @attachment.save!
 
-        Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
+      Services.asset_manager.expects(:create_whitehall_asset).with(has_entry(access_limited: [user.uid]))
 
-        AssetManagerCreateWhitehallAssetWorker.drain
-      end
+      AssetManagerCreateWhitehallAssetWorker.drain
     end
   end
 

--- a/test/unit/govspeak_content_test.rb
+++ b/test/unit/govspeak_content_test.rb
@@ -2,12 +2,10 @@ require 'test_helper'
 
 class GovspeakContentTest < ActiveSupport::TestCase
   test 'queues a job to compute the HTML on creation' do
-    Sidekiq::Testing.fake! do
-      govspeak_content = create(:html_attachment).govspeak_content
+    govspeak_content = create(:html_attachment).govspeak_content
 
-      assert job = GovspeakContentWorker.jobs.last
-      assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
-    end
+    assert job = GovspeakContentWorker.jobs.last
+    assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
   end
 
   test 'clears computed values and queues a job to re-compute the HTML when the body changes' do
@@ -15,16 +13,14 @@ class GovspeakContentTest < ActiveSupport::TestCase
                          body: "## A heading\nSome content").govspeak_content
     compute_govspeak(govspeak_content)
 
-    Sidekiq::Testing.fake! do
-      govspeak_content.body = "Updated body"
-      govspeak_content.save!
+    govspeak_content.body = "Updated body"
+    govspeak_content.save!
 
-      assert_nil govspeak_content.computed_body_html
-      assert_nil govspeak_content.computed_headers_html
+    assert_nil govspeak_content.computed_body_html
+    assert_nil govspeak_content.computed_headers_html
 
-      assert job = GovspeakContentWorker.jobs.last
-      assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
-    end
+    assert job = GovspeakContentWorker.jobs.last
+    assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
   end
 
   test "doesn't clear computed values and doesn't queue a job to re-compute the HTML when the body has not changed" do
@@ -33,14 +29,12 @@ class GovspeakContentTest < ActiveSupport::TestCase
                            body: "## A heading\nSome content").govspeak_content
       compute_govspeak(govspeak_content)
 
-      Sidekiq::Testing.fake! do
-        govspeak_content.save!
+      govspeak_content.save!
 
-        assert govspeak_content.computed_body_html.present?
-        assert govspeak_content.computed_headers_html.present?
+      assert govspeak_content.computed_body_html.present?
+      assert govspeak_content.computed_headers_html.present?
 
-        assert_empty GovspeakContentWorker.jobs
-      end
+      assert_empty GovspeakContentWorker.jobs
     end
   end
 
@@ -50,16 +44,14 @@ class GovspeakContentTest < ActiveSupport::TestCase
                         body: "## 1.0 A heading\nSome content").govspeak_content
     compute_govspeak(govspeak_content)
 
-    Sidekiq::Testing.fake! do
-      govspeak_content.manually_numbered_headings = true
-      govspeak_content.save!
+    govspeak_content.manually_numbered_headings = true
+    govspeak_content.save!
 
-      assert_nil govspeak_content.computed_body_html
-      assert_nil govspeak_content.computed_headers_html
+    assert_nil govspeak_content.computed_body_html
+    assert_nil govspeak_content.computed_headers_html
 
-      assert job = GovspeakContentWorker.jobs.last
-      assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
-    end
+    assert job = GovspeakContentWorker.jobs.last
+    assert_equal [govspeak_content.id, { "authenticated_user" => nil, "request_id" => nil }], job['args']
   end
 
   test "#render_govspeak sets computed_headers_html correctly" do

--- a/test/unit/services/edition_scheduler_test.rb
+++ b/test/unit/services/edition_scheduler_test.rb
@@ -4,14 +4,12 @@ class EditionSchedulerTest < ActiveSupport::TestCase
   test '#perform! with a valid (submitted) schedulable edition transitions the edition and queues a publish job' do
     edition = create(:submitted_edition, scheduled_publication: 1.day.from_now)
 
-    Sidekiq::Testing.fake! do
-      assert EditionScheduler.new(edition).perform!
-      assert edition.scheduled?
+    assert EditionScheduler.new(edition).perform!
+    assert edition.scheduled?
 
-      assert job = ScheduledPublishingWorker.jobs.last
-      assert_equal edition.id, job["args"].first
-      assert_equal edition.scheduled_publication.to_i, job["at"].to_i
-    end
+    assert job = ScheduledPublishingWorker.jobs.last
+    assert_equal edition.id, job["args"].first
+    assert_equal edition.scheduled_publication.to_i, job["at"].to_i
   end
 
   %w(published draft imported rejected superseded scheduled).each do |state|

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -229,27 +229,25 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     english_path = Whitehall.url_maker.public_document_path(edition)
     french_path  = Whitehall.url_maker.public_document_path(edition, locale: :fr)
 
-    Sidekiq::Testing.fake! do
-      Whitehall::PublishingApi.schedule_async(edition)
+    Whitehall::PublishingApi.schedule_async(edition)
 
-      first_job = PublishingApiScheduleWorker.jobs[0]['args']
-      second_job = PublishingApiScheduleWorker.jobs[1]['args']
+    first_job = PublishingApiScheduleWorker.jobs[0]['args']
+    second_job = PublishingApiScheduleWorker.jobs[1]['args']
 
-      assert_equal english_path, first_job[0]
-      assert_equal timestamp, first_job[1]
+    assert_equal english_path, first_job[0]
+    assert_equal timestamp, first_job[1]
 
-      assert_equal french_path, second_job[0]
-      assert_equal timestamp, second_job[1]
+    assert_equal french_path, second_job[0]
+    assert_equal timestamp, second_job[1]
 
-      first_job = PublishingApiComingSoonWorker.jobs[0]['args']
-      second_job = PublishingApiComingSoonWorker.jobs[1]['args']
+    first_job = PublishingApiComingSoonWorker.jobs[0]['args']
+    second_job = PublishingApiComingSoonWorker.jobs[1]['args']
 
-      assert_equal edition.id, first_job[0]
-      assert_equal 'en', first_job[1]
+    assert_equal edition.id, first_job[0]
+    assert_equal 'en', first_job[1]
 
-      assert_equal edition.id, second_job[0]
-      assert_equal 'fr', second_job[1]
-    end
+    assert_equal edition.id, second_job[0]
+    assert_equal 'fr', second_job[1]
   end
 
   test ".schedule_async for a subsequent edition served from the content store queues jobs to push publish intents, but not to publish 'coming_soon' items" do
@@ -265,20 +263,18 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     english_path = Whitehall.url_maker.public_document_path(updated_edition)
     spanish_path = Whitehall.url_maker.public_document_path(updated_edition, locale: :es)
 
-    Sidekiq::Testing.fake! do
-      Whitehall::PublishingApi.schedule_async(updated_edition)
+    Whitehall::PublishingApi.schedule_async(updated_edition)
 
-      first_job = PublishingApiScheduleWorker.jobs[0]['args']
-      second_job = PublishingApiScheduleWorker.jobs[1]['args']
+    first_job = PublishingApiScheduleWorker.jobs[0]['args']
+    second_job = PublishingApiScheduleWorker.jobs[1]['args']
 
-      assert_equal english_path, first_job[0]
-      assert_equal timestamp, first_job[1]
+    assert_equal english_path, first_job[0]
+    assert_equal timestamp, first_job[1]
 
-      assert_equal spanish_path, second_job[0]
-      assert_equal timestamp, second_job[1]
+    assert_equal spanish_path, second_job[0]
+    assert_equal timestamp, second_job[1]
 
-      assert_equal [], PublishingApiComingSoonWorker.jobs
-    end
+    assert_equal [], PublishingApiComingSoonWorker.jobs
   end
 
   test ".unschedule_async for a first edition served from the content store queues jobs to remove publish intents and delete 'coming_soon' items" do
@@ -292,15 +288,13 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     english_path = Whitehall.url_maker.public_document_path(edition)
     german_path = Whitehall.url_maker.public_document_path(edition, locale: :de)
 
-    Sidekiq::Testing.fake! do
-      Whitehall::PublishingApi.unschedule_async(edition)
+    Whitehall::PublishingApi.unschedule_async(edition)
 
-      assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
-      assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
+    assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
+    assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
 
-      assert_equal [edition.content_id, "de"], PublishingApiVanishWorker.jobs[0]["args"][0..1]
-      assert_equal [edition.content_id, "en"], PublishingApiVanishWorker.jobs[1]["args"][0..1]
-    end
+    assert_equal [edition.content_id, "de"], PublishingApiVanishWorker.jobs[0]["args"][0..1]
+    assert_equal [edition.content_id, "en"], PublishingApiVanishWorker.jobs[1]["args"][0..1]
   end
 
   test ".unschedule_async for a subsequent edition served from the content store queues jobs to remove publish intents, but not to delete original items" do
@@ -315,14 +309,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     english_path = Whitehall.url_maker.public_document_path(updated_edition)
     german_path = Whitehall.url_maker.public_document_path(updated_edition, locale: :de)
 
-    Sidekiq::Testing.fake! do
-      Whitehall::PublishingApi.unschedule_async(updated_edition)
+    Whitehall::PublishingApi.unschedule_async(updated_edition)
 
-      assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
-      assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
+    assert_equal german_path, PublishingApiUnscheduleWorker.jobs[0]['args'].first
+    assert_equal english_path, PublishingApiUnscheduleWorker.jobs[1]['args'].first
 
-      assert_equal [], PublishingApiVanishWorker.jobs
-    end
+    assert_equal [], PublishingApiVanishWorker.jobs
   end
 
   test ".save_draft_async publishes a draft edition" do

--- a/test/unit/whitehall/search_index_test.rb
+++ b/test/unit/whitehall/search_index_test.rb
@@ -8,25 +8,21 @@ module Whitehall
     test 'SearchIndex.add queues a search index add job for 10 seconds time to allow any transactions to complete' do
       searchable_thing = stub(class: SearchableClass, id: 'id')
 
-      Sidekiq::Testing.fake! do
-        SearchIndex.add(searchable_thing)
-        job = SearchIndexAddWorker.jobs.last
+      SearchIndex.add(searchable_thing)
+      job = SearchIndexAddWorker.jobs.last
 
-        assert_equal ['SearchableClass', 'id', { "authenticated_user" => nil, "request_id" => nil }], job['args']
-        assert_equal 10.seconds.from_now.to_i, job['at']
-      end
+      assert_equal ['SearchableClass', 'id', { "authenticated_user" => nil, "request_id" => nil }], job['args']
+      assert_equal 10.seconds.from_now.to_i, job['at']
     end
 
     test 'SearchIndex.delete queues a search index removal job for the instance based on its slug and rummager index' do
       searchable_thing = stub(search_index: { 'link' => 'full_slug' }, rummager_index: :index_name)
 
-      Sidekiq::Testing.fake! do
-        SearchIndex.delete(searchable_thing)
-        args = SearchIndexDeleteWorker.jobs.last['args']
+      SearchIndex.delete(searchable_thing)
+      args = SearchIndexDeleteWorker.jobs.last['args']
 
-        assert_equal 'full_slug', args[0]
-        assert_equal 'index_name', args[1]
-      end
+      assert_equal 'full_slug', args[0]
+      assert_equal 'index_name', args[1]
     end
   end
 end

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -36,13 +36,11 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
   test '.queue queues a job for a scheduled edition' do
     edition = create(:scheduled_edition)
 
-    Sidekiq::Testing.fake! do
-      ScheduledPublishingWorker.queue(edition)
+    ScheduledPublishingWorker.queue(edition)
 
-      assert job = ScheduledPublishingWorker.jobs.last
-      assert_equal edition.id, job["args"].first
-      assert_equal edition.scheduled_publication.to_i, job["at"].to_i
-    end
+    assert job = ScheduledPublishingWorker.jobs.last
+    assert_equal edition.id, job["args"].first
+    assert_equal edition.scheduled_publication.to_i, job["at"].to_i
   end
 
   test '.dequeue removes a job for a scheduled edition' do

--- a/test/unit/workers/sync_check_worker_test.rb
+++ b/test/unit/workers/sync_check_worker_test.rb
@@ -81,23 +81,19 @@ class SyncCheckWorkerTest < ActiveSupport::TestCase
   test "it schedules the job for 5 minutes time" do
     case_study = create(:published_case_study)
 
-    Sidekiq::Testing.fake! do
-      SyncCheckWorker.enqueue(case_study)
+    SyncCheckWorker.enqueue(case_study)
 
-      assert_equal 1, SyncCheckWorker.jobs.size
+    assert_equal 1, SyncCheckWorker.jobs.size
 
-      job = SyncCheckWorker.jobs.first
-      assert_equal SyncChecker::Formats::CaseStudyCheck.name, job["args"][0]
-      assert_equal case_study.document_id, job["args"][1]
-      assert_in_delta 5.minutes, job["at"] - job["created_at"], 1
-    end
+    job = SyncCheckWorker.jobs.first
+    assert_equal SyncChecker::Formats::CaseStudyCheck.name, job["args"][0]
+    assert_equal case_study.document_id, job["args"][1]
+    assert_in_delta 5.minutes, job["at"] - job["created_at"], 1
   end
 
   test "it doesn't schedule a job that a check doesn't exist for" do
-    Sidekiq::Testing.fake! do
-      SyncCheckWorker.enqueue(create(:user))
+    SyncCheckWorker.enqueue(create(:user))
 
-      assert_empty SyncCheckWorker.jobs
-    end
+    assert_empty SyncCheckWorker.jobs
   end
 end


### PR DESCRIPTION
In #3793, Sidekiq's testing mode was set to "fake" by default, so these blocks are unnecessary.

The diff is best viewed using the `--ignore-all-space` option, because of all the indentation changes.
