### PR TITLE
Fix NoMethodError in PublishingApi::PayloadBuilder::AccessLimitation.for

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -43,6 +43,10 @@ module Attachable
       nil
     end
 
+    def organisations
+      []
+    end
+
     def unpublished?
       false
     end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -16,6 +16,10 @@ class Response < ApplicationRecord
     parent_attachable.access_limited?
   end
 
+  def organisations
+    parent_attachable.organisations
+  end
+
   def alternative_format_contact_email
     consultation.alternative_format_contact_email
   end

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -18,7 +18,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
 
     before do
       setup_publishing_api_for(edition)
-      publishing_api_has_linkables([], document_type: "topic")
+      publishing_api_has_linkables([], document_type: 'topic')
 
       add_file_attachment('logo.png', to: edition)
       VirusScanHelpers.simulate_virus_scan(include_versions: true)
@@ -54,9 +54,9 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
     context 'when an attachment is added to the draft document' do
       before do
         visit admin_news_article_path(edition)
-        click_link "Modify attachments"
-        click_link "Upload new file attachment"
-        fill_in "Title", with: 'asset-title'
+        click_link 'Modify attachments'
+        click_link 'Upload new file attachment'
+        fill_in 'Title', with: 'asset-title'
         attach_file 'File', path_to_attachment('logo.png')
         click_button 'Save'
       end
@@ -75,8 +75,8 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
     context 'when bulk uploaded to draft document' do
       before do
         visit admin_news_article_path(edition)
-        click_link "Modify attachments"
-        click_link "Bulk upload from Zip file"
+        click_link 'Modify attachments'
+        click_link 'Bulk upload from Zip file'
         attach_file 'Zip file', path_to_attachment('sample_attachment.zip')
         click_button 'Upload zip'
         fill_in 'Title', with: 'file-title'
@@ -107,7 +107,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
 
     before do
       setup_publishing_api_for(edition)
-      publishing_api_has_linkables([], document_type: "topic")
+      publishing_api_has_linkables([], document_type: 'topic')
 
       add_file_attachment('logo.png', to: edition)
       VirusScanHelpers.simulate_virus_scan(include_versions: true)
@@ -132,8 +132,8 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
     context 'when attachment is replaced' do
       before do
         visit admin_news_article_path(edition)
-        click_link "Modify attachments"
-        click_link "Edit"
+        click_link 'Modify attachments'
+        click_link 'Edit'
         attach_file 'Replace file', path_to_attachment('big-cheese.960x640.jpg')
         click_button 'Save'
       end

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -31,6 +31,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
         visit edit_admin_news_article_path(edition)
         check 'Limit access to producing organisations prior to publication'
         click_button 'Save'
+        assert_text 'The document has been saved'
       end
 
       it 'marks attachment as access limited in Asset Manager' do
@@ -59,6 +60,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
         fill_in 'Title', with: 'asset-title'
         attach_file 'File', path_to_attachment('logo.png')
         click_button 'Save'
+        assert_text "Attachment 'asset-title' uploaded"
       end
 
       it 'marks attachment as access limited in Asset Manager' do
@@ -81,6 +83,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
         click_button 'Upload zip'
         fill_in 'Title', with: 'file-title'
         click_button 'Save'
+        assert find('.existing-attachments a', text: 'greenpaper.pdf')
       end
 
       it 'marks attachment as access limited in Asset Manager' do
@@ -120,6 +123,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
         visit edit_admin_news_article_path(edition)
         uncheck 'Limit access to producing organisations prior to publication'
         click_button 'Save'
+        assert_text 'The document has been saved'
       end
 
       it 'unmarks attachment as access limited in Asset Manager' do
@@ -136,6 +140,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
         click_link 'Edit'
         attach_file 'Replace file', path_to_attachment('big-cheese.960x640.jpg')
         click_button 'Save'
+        assert_text "Attachment 'logo.png' updated"
       end
 
       it 'marks replacement attachment as access limited in Asset Manager' do
@@ -162,6 +167,7 @@ private
     to.attachments << FactoryBot.build(
       :file_attachment,
       attachable: to,
+      title: filename,
       file: File.open(path_to_attachment(filename))
     )
   end

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -134,4 +134,18 @@ class ResponseTest < ActiveSupport::TestCase
 
     assert_nil response.access_limited_object
   end
+
+  test 'returns consultation organisations as its organisations' do
+    organisations = create_list(:organisation, 2)
+    consultation = create(:consultation, organisations: organisations)
+    response = build(:consultation_outcome, consultation: consultation)
+
+    assert_equal organisations, response.organisations
+  end
+
+  test 'returns no organisations if consultation is nil' do
+    response = build(:consultation_outcome, consultation: nil)
+
+    assert_equal [], response.organisations
+  end
 end


### PR DESCRIPTION
The first three commits are just improvements to the `AttachmentAccessLimitedIntegrationTest`. The significant changes are all in the final commit.

I've added a new scenario to `AttachmentAccessLimitedIntegrationTest` where an attachment is added to an outcome on an access-limited consultation triggered. This triggered a `NoMethodError` exception as described in [this comment][1]. As mentioned there, this root cause of this is similar to [an exception that's been seen in production][2], but has since been partially/accidentally fixed.

My naïve fix is to allow `PublishingApi::PayloadBuilder::AccessLimitation.for` to obtain the organisations for a (consultation) `Response` by delegating to its parent `Consultation`.

I'm really not very happy with the overall implementation of this access-limiting behaviour; I feel as if the logic is rather scattered around the codebase. And I've only made that worse with this fix. However, I'll leave that for another PR.

Note that a number of `AssetManagerCreateWhitehallAssetWorker` jobs have have failed in production, which means that assets will not have been created in Asset Manager for the relevant attachments. However, assuming the Sidekiq workers are restarted after a deployment, if any of the jobs are still on the retry queue, they should succeed after this change has been deployed. Although there's a slight question in my mind about how long the files will have hung around in the `Whitehall.asset_manager_tmp_dir` directory.

[1]:
alphagov/asset-manager#522 (comment)
[2]: https://sentry.io/govuk/app-whitehall/issues/490263226/