### PR TITLE
Bulk update attachment metadata in asset manager

### DIFF
--- a/lib/asset_manager_attachment_metadata_updater.rb
+++ b/lib/asset_manager_attachment_metadata_updater.rb
@@ -1,0 +1,16 @@
+class AssetManagerAttachmentMetadataUpdater
+  def self.update_range(start, finish)
+    AttachmentData.find_each(start: start, finish: finish) do |attachment_data|
+      [
+       AssetManagerAttachmentAccessLimitedWorker,
+       AssetManagerAttachmentDeleteWorker,
+       AssetManagerAttachmentDraftStatusUpdateWorker,
+       AssetManagerAttachmentLinkHeaderUpdateWorker,
+       AssetManagerAttachmentRedirectUrlUpdateWorker,
+       AssetManagerAttachmentReplacementIdUpdateWorker
+      ].each do |worker|
+        worker.perform_async(attachment_data.id)
+      end
+    end
+  end
+end

--- a/lib/asset_manager_attachment_metadata_updater.rb
+++ b/lib/asset_manager_attachment_metadata_updater.rb
@@ -9,7 +9,7 @@ class AssetManagerAttachmentMetadataUpdater
        AssetManagerAttachmentRedirectUrlUpdateWorker,
        AssetManagerAttachmentReplacementIdUpdateWorker
       ].each do |worker|
-        worker.perform_async(attachment_data.id)
+        worker.set(queue: 'asset_migration').perform_async(attachment_data.id)
       end
     end
   end

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -27,6 +27,11 @@ namespace :asset_manager do
     end
   end
 
+  task :update_attachment_metadata, %i(batch_start batch_end) => :environment do |_, args|
+    abort(update_attachment_metadata_usage_string) unless args[:batch_start] && args[:batch_end]
+    AssetManagerAttachmentMetadataUpdater.update_range(args[:batch_start].to_i, args[:batch_end].to_i)
+  end
+
   private
 
   def usage_string
@@ -40,6 +45,16 @@ namespace :asset_manager do
     %{Usage: asset_manager:migrate_attachments[<batch_start>,<batch_end>]
 
       Where <batch_start> and <batch_end> are integers corresponding to the directory names under `system/uploads/attachment_data/file`. e.g. `system/uploads/attachment_data/file/100` will be migrated if <batch_start> <= 100 and <batch_end> >= 100.
+    }
+  end
+
+  def update_attachment_metadata_usage_string
+    lowest_id = AttachmentData.order(:id).first.id
+    highest_id = AttachmentData.order(:id).last.id
+
+    %{Usage: asset_manager:update_attachment_metadata[<batch_start>,<batch_end>]
+
+      Where <batch_start> and <batch_end> are integers between #{lowest_id} and #{highest_id} corresponding to the primary key of the AttachmentData records in the database.
     }
   end
 end

--- a/test/unit/asset_manager_attachment_metadata_updater_test.rb
+++ b/test/unit/asset_manager_attachment_metadata_updater_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   test 'uses find_each with the range specified' do
     AttachmentData.expects(:find_each).with(start: 1, finish: 2)
 
@@ -15,8 +17,14 @@ class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
     AssetManagerAttachmentRedirectUrlUpdateWorker,
     AssetManagerAttachmentReplacementIdUpdateWorker
   ].each do |worker|
+    let(:attachment_data) { FactoryBot.create(:attachment_data) }
+
+    test "sets the #{worker} queue to 'asset_migration'" do
+      worker.expects(:set).with(queue: 'asset_migration').returns(worker)
+      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
+    end
+
     test "queues a job on the #{worker}" do
-      attachment_data = FactoryBot.create(:attachment_data)
       worker.expects(:perform_async).with(attachment_data.id)
       AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
     end

--- a/test/unit/asset_manager_attachment_metadata_updater_test.rb
+++ b/test/unit/asset_manager_attachment_metadata_updater_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
+  test 'uses find_each with the range specified' do
+    AttachmentData.expects(:find_each).with(start: 1, finish: 2)
+
+    AssetManagerAttachmentMetadataUpdater.update_range(1, 2)
+  end
+
+  [
+    AssetManagerAttachmentAccessLimitedWorker,
+    AssetManagerAttachmentDeleteWorker,
+    AssetManagerAttachmentDraftStatusUpdateWorker,
+    AssetManagerAttachmentLinkHeaderUpdateWorker,
+    AssetManagerAttachmentRedirectUrlUpdateWorker,
+    AssetManagerAttachmentReplacementIdUpdateWorker
+  ].each do |worker|
+    test "queues a job on the #{worker}" do
+      attachment_data = FactoryBot.create(:attachment_data)
+      worker.expects(:perform_async).with(attachment_data.id)
+      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a rake task which can be run on a batch of AttachmentData records and updates the metadata (access limited list, deleted flag, draft status, link header, redirect url and replacement) in Asset Manager for each record. 

We have taken a simple approach of queueing a single job for each of the 6 workers for each attachment data record (there are currenlty 523,122 in Whitehall in the integration environment). We hope that these jobs will run fast enough that we can enqueue a large number of them in each batch and process every AttachmentData record quickly. However we intend to verify this once this PR is merged and deployed by running a small batch and timing it. 