### PR TITLE
[WIP] Revert AttachmentVisibility changes

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -14,7 +14,7 @@ class AttachmentsController < BaseAttachmentsController
 private
 
   def link_rel_headers
-    if (edition = attachment_data.visible_edition_for(current_user))
+    if (edition = attachment_visibility.visible_edition)
       response.headers['Link'] = "<#{public_document_url(edition)}>; rel=\"up\""
     end
   end

--- a/app/controllers/base_attachments_controller.rb
+++ b/app/controllers/base_attachments_controller.rb
@@ -6,9 +6,8 @@ protected
   end
 
   def fail
-    if attachment_data.unpublished?
-      redirect_url = attachment_data.unpublished_edition.unpublishing.document_path
-      redirect_to redirect_url
+    if (edition = attachment_data.unpublished_edition)
+      redirect_to edition.unpublishing.document_path
     elsif attachment_data.replaced?
       expires_headers
       redirect_to attachment_data.replaced_by.url, status: 301

--- a/app/controllers/base_attachments_controller.rb
+++ b/app/controllers/base_attachments_controller.rb
@@ -8,9 +8,9 @@ protected
   def fail
     if (edition = attachment_data.unpublished_edition)
       redirect_to edition.unpublishing.document_path
-    elsif attachment_data.replaced?
+    elsif (replacement = attachment_data.replaced_by)
       expires_headers
-      redirect_to attachment_data.replaced_by.url, status: 301
+      redirect_to replacement.url, status: 301
     elsif image? upload_path
       redirect_to view_context.path_to_image('thumbnail-placeholder.png')
     elsif incoming_upload_exists? upload_path

--- a/app/controllers/base_attachments_controller.rb
+++ b/app/controllers/base_attachments_controller.rb
@@ -2,11 +2,11 @@ class BaseAttachmentsController < ApplicationController
 protected
 
   def attachment_visible?
-    upload_exists?(upload_path) && attachment_data.visible_to?(current_user)
+    upload_exists?(upload_path) && attachment_visibility.visible?
   end
 
   def fail
-    if (edition = attachment_data.unpublished_edition)
+    if (edition = attachment_visibility.unpublished_edition)
       redirect_to edition.unpublishing.document_path
     elsif (replacement = attachment_data.replaced_by)
       expires_headers
@@ -46,6 +46,10 @@ protected
 
   def path_to_attachment_or_thumbnail
     attachment_data.file.store_path(file_with_extensions)
+  end
+
+  def attachment_visibility
+    @attachment_visibility ||= AttachmentVisibility.new(attachment_data, current_user)
   end
 
   def file_is_clean?(path)

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -2,10 +2,10 @@ class CsvPreviewController < BaseAttachmentsController
   def show
     respond_to do |format|
       format.html do
-        if attachment_data.csv? && attachment_visible? && attachment_data.visible_edition_for(current_user)
+        if attachment_data.csv? && attachment_visible? && attachment_visibility.visible_edition
           expires_headers
-          @edition = attachment_data.visible_edition_for(current_user)
-          @attachment = attachment_data.visible_attachment_for(current_user)
+          @edition = attachment_visibility.visible_edition
+          @attachment = attachment_visibility.visible_attachment
           CsvFileFromPublicHost.new(@attachment.file.file.asset_manager_path) do |file|
             @csv_preview = CsvPreview.new(file.path)
           end

--- a/app/models/attachment_visibility.rb
+++ b/app/models/attachment_visibility.rb
@@ -1,0 +1,66 @@
+# Utility class used to identify the publically visible Attachments and
+# Attachable models that are associated with a given AttachmentData file.
+#
+# This class exists because of the way attachments are currently routed and
+# served using the file path to the attachment file, e.g.
+#
+# /government/uploads/system/uploads/attachment_data/file/123/file.csv
+#
+# Given an AttachmentData (identified by the ID in the above URL), this class
+# will identify the thing the file is associated with by following back up the
+# chain.
+#
+# Attachments are served like this because in the early days, files were served
+# directly by the webserver, bypassing the application entirely. Later, the app
+# was updated to handle these URLs so that we could do things like  show an
+# appropriate response if a file was being virus scanned, or redirect when it
+# had been replaced by another version.
+#
+# In an ideal world, attachments would be served with a sensible routing
+# structure that included the attachable thing in the path, e.g.
+#
+# /government/publications/slug-for-pub/attachments/file.csv
+#
+# or
+#
+# /government/publications/slug-for-pub/attachments/:id/file.csv
+#
+# This would friendlier for users, and would also greatly simplify the
+# attachment serving code, as the attachable model could be easily identified.
+#
+class AttachmentVisibility
+  attr_reader :attachment_data, :user
+
+  def initialize(attachment_data, user)
+    @attachment_data = attachment_data
+    @user = user
+  end
+
+  def visible?
+    attachment_data.visible_to?(user)
+  end
+
+  def unpublished_edition
+    attachment_data.unpublished_edition
+  end
+
+  def visible_attachment
+    attachment_data.visible_attachment_for(user)
+  end
+
+  def visible_attachable
+    attachment_data.visible_attachable_for(user)
+  end
+
+  def visible_edition
+    attachment_data.visible_edition_for(user)
+  end
+
+  def visible_consultation_response
+    attachment_data.visible_attachable_for(user)
+  end
+
+  def visible_policy_group
+    attachment_data.visible_attachable_for(user)
+  end
+end

--- a/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
+++ b/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
@@ -2,7 +2,7 @@ class AssetManagerAttachmentReplacementIdUpdateWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
-    return unless attachment_data.replaced?
+    return unless attachment_data.replaced_by.present?
     replacement = attachment_data.replaced_by
 
     replace_path(attachment_data.file.asset_manager_path, replacement.file.asset_manager_path)

--- a/lib/whitehall/exporters/mappings.rb
+++ b/lib/whitehall/exporters/mappings.rb
@@ -23,8 +23,8 @@ class Whitehall::Exporters::Mappings
         if attachment_source.attachment
           path = attachment_source.attachment.url
           attachment_url = "#{Whitehall.public_root}#{path}"
-          attachment_data = attachment_source.attachment.attachment_data
-          state = attachment_data.visible_to?(nil) ? 'published' : 'draft'
+          visibility = AttachmentVisibility.new(attachment_source.attachment.attachment_data, nil)
+          state = visibility.visible? ? 'published' : 'draft'
           target << [attachment_source.url, attachment_url, '', state]
         end
       rescue StandardError => e

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -180,6 +180,28 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             it 'is not deleted' do
               refute attachment_data.reload.deleted?
             end
+
+            context 'and another new edition is created' do
+              let(:another_new_edition) { edition.create_draft(user) }
+
+              before do
+                another_new_edition.reload
+              end
+
+              it 'is not deleted' do
+                refute attachment_data.reload.deleted?
+              end
+
+              it 'is not draft according to AttachmentData' do
+                skip 'AttachmentData#draft? is broken'
+                refute attachment_data.reload.draft?
+              end
+
+              it 'is visible according to AttachmentVisibility' do
+                visibility = AttachmentVisibility.new(attachment_data, nil)
+                assert visibility.visible?
+              end
+            end
           end
 
           context 'new edition is access-limited' do

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -1,0 +1,214 @@
+require 'test_helper'
+
+class AttachmentVisibilityTest < ActiveSupport::TestCase
+  test '#visible_to? returns true when attachment data is associated with a published edition' do
+    edition = create(:published_publication, :with_file_attachment_not_scanned)
+    attachment_data = edition.attachments.first.attachment_data
+
+    assert attachment_data.visible_to?(nil)
+    assert_nil attachment_data.unpublished_edition
+  end
+
+  test '#visible_to? returns false when edition is unpublished' do
+    edition = create(:draft_publication, :with_file_attachment_not_scanned)
+    attachment_data = edition.attachments.first.attachment_data
+
+    refute attachment_data.visible_to?(nil)
+  end
+
+  test '#visible_to? returns true when attachment is associated with a response on a published consultation' do
+    response = create(:consultation_with_outcome).outcome
+    response.attachments << build(:file_attachment)
+    attachment_data = response.attachments.first.attachment_data
+
+    assert attachment_data.visible_to?(nil)
+  end
+
+  test '#visible_edition_for returns a published edition that the attachment is assigned to' do
+    edition = create(:published_publication, :with_file_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+
+    assert_equal edition, attachment_data.visible_edition_for(nil)
+  end
+
+  test '#visible_edition_for returns a withdrawn edition that the attachment is assigned to' do
+    edition = create(:publication, :withdrawn, :with_file_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+
+    assert_equal edition, attachment_data.visible_edition_for(nil)
+  end
+
+  test '#visible_attachable_for a published response that the attachment is associated with' do
+    response = create(:consultation_with_outcome).outcome
+    response.attachments << attachment = build(:file_attachment)
+    attachment_data = attachment.attachment_data
+
+    assert_equal response, attachment_data.visible_attachable_for(nil)
+  end
+
+  test '#visible_attachable_for returns nil if the attachment is not associated with a response on a published consultation' do
+    response = create(:consultation_with_outcome, :draft).outcome
+    response.attachments << attachment = build(:file_attachment)
+    attachment_data = attachment.attachment_data
+
+    assert_equal :draft, response.consultation.current_state
+
+    assert_nil attachment_data.visible_attachable_for(nil)
+  end
+
+  test '#visible_attachable_for returns a draft response if it is accessible to the provided user' do
+    user = create(:writer)
+
+    response = create(:consultation_with_outcome, :draft).outcome
+    response.attachments << attachment = build(:file_attachment)
+    attachment_data = attachment.attachment_data
+
+    assert_equal :draft, response.consultation.current_state
+
+    assert_equal response, attachment_data.visible_attachable_for(user)
+  end
+
+  test '#visible_edition_for returns nil if the attachment is associated with a non-published edition' do
+    edition = create(:draft_publication, :with_file_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+
+    assert_nil attachment_data.visible_edition_for(nil)
+  end
+
+  test '#visible_edition_for will return a draft edition if it is accessible to the provided user' do
+    user = create(:writer)
+    edition = create(:draft_publication, :with_file_attachment)
+    attachment_data = edition.attachments.first.attachment_data
+
+    assert_equal edition, attachment_data.visible_edition_for(user)
+  end
+
+  test '#visible_edition_for returns nil if the attachment is associated with a non-Edition' do
+    info_page = create(:consultation_outcome, attachments: [
+      build(:file_attachment)
+    ])
+    attachment_data = info_page.attachments.first.attachment_data
+
+    assert_nil attachment_data.visible_edition_for(nil)
+  end
+
+  test '#visible_attachment_for returns the attachment associated with a published edition' do
+    edition               = create(:published_publication, :with_file_attachment)
+    _new_draft            = edition.create_draft(create(:writer))
+    attachment            = edition.attachments.first
+    attachment_data       = attachment.attachment_data
+
+    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+  end
+
+  test '#visible_attachment_for returns nil if the attachment_data is not associated with a publically visible attachment' do
+    edition               = create(:draft_publication, :with_file_attachment)
+    attachment            = edition.attachments.first
+    attachment_data       = attachment.attachment_data
+
+    assert_nil attachment_data.visible_attachment_for(nil)
+  end
+
+  test '#visible_attachment_for returns the attachment associated with the response of the published consultation' do
+    response = create(:consultation_with_outcome).outcome
+    response.attachments << attachment = build(:file_attachment)
+    attachment_data = attachment.attachment_data
+
+    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+  end
+
+  test '#visible_attachment_for returns the attachment associated with a policy group' do
+    create(:policy_group, attachments: [
+      attachment = build(:file_attachment)
+    ])
+    attachment_data = attachment.attachment_data
+
+    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+  end
+
+  test '#visible_attachment_for does not return the attachment if it is deleted' do
+    edition = create(:published_publication, :with_file_attachment)
+    edition.create_draft(create(:writer))
+    attachment = edition.attachments.first
+    attachment.destroy
+    attachment_data = attachment.attachment_data
+
+    assert_nil attachment_data.visible_attachment_for(nil)
+  end
+
+  test '#unpublished_edition returns the edition for an attachment associated with an unpublished edition' do
+    unpublished_edition = create(:publication, :unpublished, :with_file_attachment)
+    attachment_data = unpublished_edition.attachments.first.attachment_data
+
+    refute attachment_data.visible_to?(nil)
+    assert_equal unpublished_edition, attachment_data.unpublished_edition
+  end
+
+  test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation outcome' do
+    unpublished_consultation = create(:consultation, :unpublished)
+    outcome = unpublished_consultation.create_outcome!(attributes_for(:consultation_outcome))
+    file_attachment = build(:file_attachment, attachable: outcome)
+    outcome.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+
+    assert_equal unpublished_consultation, attachment_data.unpublished_edition
+  end
+
+  test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation feedback' do
+    unpublished_consultation = create(:consultation, :unpublished)
+    feedback = unpublished_consultation.create_public_feedback!(attributes_for(:consultation_public_feedback))
+    file_attachment = build(:file_attachment, attachable: feedback)
+    feedback.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+
+    assert_equal unpublished_consultation, attachment_data.unpublished_edition
+  end
+
+  test '#unpublished_edition returns nil for an attachment associated with a policy group' do
+    policy_group = create(:policy_group)
+    file_attachment = build(:file_attachment, attachable: policy_group)
+    policy_group.attachments << file_attachment
+    attachment_data = file_attachment.attachment_data
+
+    assert_nil attachment_data.unpublished_edition
+  end
+
+  test "#visible_to? returns false for deleted attachment on a publication" do
+    publication = create(:published_publication, :with_file_attachment)
+    attachment = publication.attachments.last
+    attachment.destroy
+
+    attachment_data = attachment.attachment_data
+    refute attachment_data.visible_to?(nil)
+  end
+
+  test "#visible_to? returns false for deleted attachment on a publication with more than one edition" do
+    publication = create(:draft_publication, :with_file_attachment)
+    new_edition = create(:published_publication)
+    new_edition.attachments = publication.attachments.map(&:deep_clone)
+    attachment = new_edition.attachments.last
+    attachment.destroy
+
+    attachment_data = attachment.attachment_data
+    refute attachment_data.visible_to?(nil)
+  end
+
+  test "#visible_to? returns false for deleted attachment on a PolicyGroup" do
+    policy_group = create(:policy_group, :with_file_attachment)
+    attachment = policy_group.attachments.last
+    attachment.destroy
+
+    attachment_data = attachment.attachment_data
+    refute attachment_data.visible_to?(nil)
+  end
+
+  test "#visible_to? returns false for deleted attachment on a Consultation Response" do
+    response = create(:consultation_with_outcome).outcome
+    response.attachments << build(:file_attachment)
+    attachment = response.attachments.first
+    attachment.destroy
+
+    attachment_data = attachment.attachment_data
+    refute attachment_data.visible_to?(nil)
+  end
+end

--- a/test/unit/attachment_visibility_test.rb
+++ b/test/unit/attachment_visibility_test.rb
@@ -1,147 +1,155 @@
 require 'test_helper'
 
 class AttachmentVisibilityTest < ActiveSupport::TestCase
-  test '#visible_to? returns true when attachment data is associated with a published edition' do
+  test '#visible? returns true when attachment data is associated with a published edition' do
     edition = create(:published_publication, :with_file_attachment_not_scanned)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert attachment_data.visible_to?(nil)
-    assert_nil attachment_data.unpublished_edition
+    assert attachment_visibility.visible?
+    assert_nil attachment_visibility.unpublished_edition
   end
 
-  test '#visible_to? returns false when edition is unpublished' do
+  test '#visible? returns false when edition is unpublished' do
     edition = create(:draft_publication, :with_file_attachment_not_scanned)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    refute attachment_data.visible_to?(nil)
+    refute attachment_visibility.visible?
   end
 
-  test '#visible_to? returns true when attachment is associated with a response on a published consultation' do
+  test '#visible? returns true when attachment is associated with a response on a published consultation' do
     response = create(:consultation_with_outcome).outcome
     response.attachments << build(:file_attachment)
     attachment_data = response.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert attachment_data.visible_to?(nil)
+    assert attachment_visibility.visible?
   end
 
-  test '#visible_edition_for returns a published edition that the attachment is assigned to' do
+  test '#visible_edition returns a published edition that the attachment is assigned to' do
     edition = create(:published_publication, :with_file_attachment)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_equal edition, attachment_data.visible_edition_for(nil)
+    assert_equal edition, attachment_visibility.visible_edition
   end
 
-  test '#visible_edition_for returns a withdrawn edition that the attachment is assigned to' do
+  test '#visible_edition returns a withdrawn edition that the attachment is assigned to' do
     edition = create(:publication, :withdrawn, :with_file_attachment)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_equal edition, attachment_data.visible_edition_for(nil)
+    assert_equal edition, attachment_visibility.visible_edition
   end
 
-  test '#visible_attachable_for a published response that the attachment is associated with' do
+  test '#visible_consultation_response a published response that the attachment is associated with' do
     response = create(:consultation_with_outcome).outcome
     response.attachments << attachment = build(:file_attachment)
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_equal response, attachment_data.visible_attachable_for(nil)
+    assert_equal response, attachment_visibility.visible_consultation_response
   end
 
-  test '#visible_attachable_for returns nil if the attachment is not associated with a response on a published consultation' do
+  test '#visible_consultation_response returns nil if the attachment is not associated with a response on a published consultation' do
     response = create(:consultation_with_outcome, :draft).outcome
     response.attachments << attachment = build(:file_attachment)
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
     assert_equal :draft, response.consultation.current_state
 
-    assert_nil attachment_data.visible_attachable_for(nil)
+    assert_nil attachment_visibility.visible_consultation_response
   end
 
-  test '#visible_attachable_for returns a draft response if it is accessible to the provided user' do
+  test '#visible_consultation_response returns a draft response if it is accessible to the provided user' do
     user = create(:writer)
 
     response = create(:consultation_with_outcome, :draft).outcome
     response.attachments << attachment = build(:file_attachment)
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, user)
 
     assert_equal :draft, response.consultation.current_state
 
-    assert_equal response, attachment_data.visible_attachable_for(user)
+    assert_equal response, attachment_visibility.visible_consultation_response
   end
 
-  test '#visible_edition_for returns nil if the attachment is associated with a non-published edition' do
+  test '#visible_edition returns nil if the attachment is associated with a non-published edition' do
     edition = create(:draft_publication, :with_file_attachment)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_nil attachment_data.visible_edition_for(nil)
+    assert_nil attachment_visibility.visible_edition
   end
 
-  test '#visible_edition_for will return a draft edition if it is accessible to the provided user' do
+  test '#visible_edition will return a draft edition if it is accessible to the provided user' do
     user = create(:writer)
     edition = create(:draft_publication, :with_file_attachment)
     attachment_data = edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, user)
 
-    assert_equal edition, attachment_data.visible_edition_for(user)
+    assert_equal edition, attachment_visibility.visible_edition
   end
 
-  test '#visible_edition_for returns nil if the attachment is associated with a non-Edition' do
+  test '#visible_edition returns nil if the attachment is associated with a non-Edition' do
     info_page = create(:consultation_outcome, attachments: [
       build(:file_attachment)
     ])
-    attachment_data = info_page.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(info_page.attachments.first.attachment_data, nil)
 
-    assert_nil attachment_data.visible_edition_for(nil)
+    assert_nil attachment_visibility.visible_edition
   end
 
-  test '#visible_attachment_for returns the attachment associated with a published edition' do
+  test '#visible_attachment returns the attachment associated with a published edition' do
     edition               = create(:published_publication, :with_file_attachment)
     _new_draft            = edition.create_draft(create(:writer))
     attachment            = edition.attachments.first
-    attachment_data       = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+    assert_equal attachment, attachment_visibility.visible_attachment
   end
 
-  test '#visible_attachment_for returns nil if the attachment_data is not associated with a publically visible attachment' do
+  test '#visible_attachment returns nil if the attachment_data is not associated with a publically visible attachment' do
     edition               = create(:draft_publication, :with_file_attachment)
     attachment            = edition.attachments.first
-    attachment_data       = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_nil attachment_data.visible_attachment_for(nil)
+    assert_nil attachment_visibility.visible_attachment
   end
 
-  test '#visible_attachment_for returns the attachment associated with the response of the published consultation' do
+  test '#visible_attachment returns the attachment associated with the response of the published consultation' do
     response = create(:consultation_with_outcome).outcome
     response.attachments << attachment = build(:file_attachment)
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+    assert_equal attachment, attachment_visibility.visible_attachment
   end
 
-  test '#visible_attachment_for returns the attachment associated with a policy group' do
+  test '#visible_attachment returns the attachment associated with a policy group' do
     create(:policy_group, attachments: [
       attachment = build(:file_attachment)
     ])
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_equal attachment, attachment_data.visible_attachment_for(nil)
+    assert_equal attachment, attachment_visibility.visible_attachment
   end
 
-  test '#visible_attachment_for does not return the attachment if it is deleted' do
+  test '#visible_attachment does not return the attachment if it is deleted' do
     edition = create(:published_publication, :with_file_attachment)
     edition.create_draft(create(:writer))
     attachment = edition.attachments.first
     attachment.destroy
-    attachment_data = attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment.attachment_data, nil)
 
-    assert_nil attachment_data.visible_attachment_for(nil)
+    assert_nil attachment_visibility.visible_attachment
   end
 
   test '#unpublished_edition returns the edition for an attachment associated with an unpublished edition' do
     unpublished_edition = create(:publication, :unpublished, :with_file_attachment)
     attachment_data = unpublished_edition.attachments.first.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    refute attachment_data.visible_to?(nil)
-    assert_equal unpublished_edition, attachment_data.unpublished_edition
+    refute attachment_visibility.visible?
+    assert_equal unpublished_edition, attachment_visibility.unpublished_edition
   end
 
   test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation outcome' do
@@ -150,8 +158,9 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     file_attachment = build(:file_attachment, attachable: outcome)
     outcome.attachments << file_attachment
     attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_equal unpublished_consultation, attachment_data.unpublished_edition
+    assert_equal unpublished_consultation, attachment_visibility.unpublished_edition
   end
 
   test '#unpublished_edition returns the consultation for an attachment associated with an unpublished consultation feedback' do
@@ -160,8 +169,9 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     file_attachment = build(:file_attachment, attachable: feedback)
     feedback.attachments << file_attachment
     attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_equal unpublished_consultation, attachment_data.unpublished_edition
+    assert_equal unpublished_consultation, attachment_visibility.unpublished_edition
   end
 
   test '#unpublished_edition returns nil for an attachment associated with a policy group' do
@@ -169,20 +179,22 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     file_attachment = build(:file_attachment, attachable: policy_group)
     policy_group.attachments << file_attachment
     attachment_data = file_attachment.attachment_data
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
 
-    assert_nil attachment_data.unpublished_edition
+    assert_nil attachment_visibility.unpublished_edition
   end
 
-  test "#visible_to? returns false for deleted attachment on a publication" do
+  test "#visible returns false for deleted attachment on a publication" do
     publication = create(:published_publication, :with_file_attachment)
     attachment = publication.attachments.last
     attachment.destroy
 
     attachment_data = attachment.attachment_data
-    refute attachment_data.visible_to?(nil)
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+    refute attachment_visibility.visible?
   end
 
-  test "#visible_to? returns false for deleted attachment on a publication with more than one edition" do
+  test "#visible returns false for deleted attachment on a publication with more than one edition" do
     publication = create(:draft_publication, :with_file_attachment)
     new_edition = create(:published_publication)
     new_edition.attachments = publication.attachments.map(&:deep_clone)
@@ -190,25 +202,28 @@ class AttachmentVisibilityTest < ActiveSupport::TestCase
     attachment.destroy
 
     attachment_data = attachment.attachment_data
-    refute attachment_data.visible_to?(nil)
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+    refute attachment_visibility.visible?
   end
 
-  test "#visible_to? returns false for deleted attachment on a PolicyGroup" do
+  test "#visible returns false for deleted attachment on a PolicyGroup" do
     policy_group = create(:policy_group, :with_file_attachment)
     attachment = policy_group.attachments.last
     attachment.destroy
 
     attachment_data = attachment.attachment_data
-    refute attachment_data.visible_to?(nil)
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+    refute attachment_visibility.visible?
   end
 
-  test "#visible_to? returns false for deleted attachment on a Consultation Response" do
+  test "#visible returns false for deleted attachment on a Consultation Response" do
     response = create(:consultation_with_outcome).outcome
     response.attachments << build(:file_attachment)
     attachment = response.attachments.first
     attachment.destroy
 
     attachment_data = attachment.attachment_data
-    refute attachment_data.visible_to?(nil)
+    attachment_visibility = AttachmentVisibility.new(attachment_data, nil)
+    refute attachment_visibility.visible?
   end
 end


### PR DESCRIPTION
This addresses the problem described in https://github.com/alphagov/asset-manager/issues/524 and should mean that `master` is deployable again.

It does this by reinstating the previous logic for deciding whether an attachment should be visible or not. This is achieved by reverting the following:

* Part of https://github.com/alphagov/whitehall/pull/3851
  * https://github.com/alphagov/whitehall/pull/3851/commits/8a3d9970c94bca20181cd58b13eb6eff6c50a1e0
  * https://github.com/alphagov/whitehall/pull/3851/commits/9b99739374b3d670fe8f38e5f913834f64b71b4a
  * https://github.com/alphagov/whitehall/pull/3851/commits/9a1be4071a0e9de4b60fedc7e3c493cb9d411c5b
  * https://github.com/alphagov/whitehall/pull/3851/commits/109689bf2537d88d42daa143f09d22e331d89dc9
  * https://github.com/alphagov/whitehall/pull/3851/commits/ffe4ac495e228d7ab9a897d36ee65783d811b7eb
  * https://github.com/alphagov/whitehall/pull/3851/commits/7779ba086d20a838fc9d2c047f89e02e677e9672

* Part of https://github.com/alphagov/whitehall/pull/3850
  * https://github.com/alphagov/whitehall/pull/3850/commits/b94cba90f42eff60db98292e6b183249fa4e1975

I've intentionally not reverted the changes to do with the attachment-related updaters/workers, because the data in Asset Manager is not yet being used and we're still planning to export this data for all attachments before we switch over.

I've added a final commit to demonstrate the problem described in https://github.com/alphagov/asset-manager/issues/524.

I've marked this as WIP, because I plan to review it again in the morning.

/cc @chrisroos 