### PR TITLE
Fix AttachmentData#significant_attachment bug

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -154,8 +154,6 @@ class AttachmentData < ApplicationRecord
     visible_attachable.is_a?(Edition) ? visible_attachable : nil
   end
 
-private
-
   def significant_attachable
     significant_attachment.attachable || Attachable::Null.new
   end
@@ -179,6 +177,8 @@ private
   def penultimate_attachment
     attachments[-2] || Attachment::Null.new
   end
+
+private
 
   def cant_be_replaced_by_self
     return if replaced_by.nil?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -163,19 +163,15 @@ class AttachmentData < ApplicationRecord
   end
 
   def significant_attachment
-    if attachments.one? || last_attachable.publicly_visible?
-      last_attachment
-    else
-      penultimate_attachment
-    end
+    last_publicly_visible_attachment || last_attachment
   end
 
   def last_attachment
-    attachments[-1] || Attachment::Null.new
+    attachments.last || Attachment::Null.new
   end
 
-  def penultimate_attachment
-    attachments[-2] || Attachment::Null.new
+  def last_publicly_visible_attachment
+    attachments.reverse.detect { |a| (a.attachable || Attachable::Null.new).publicly_visible? }
   end
 
 private

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -272,4 +272,45 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data.stubs(:last_attachable).returns(attachable)
     assert_equal 'access-limited-object', attachment_data.access_limited_object
   end
+
+  test '#last_publicly_visible_attachment returns publicly visible attachable' do
+    attachable = build(:edition)
+    attachable.stubs(:publicly_visible?).returns(true)
+    attachment = build(:file_attachment, attachable: attachable)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([attachment])
+
+    assert_equal attachment, attachment_data.last_publicly_visible_attachment
+  end
+
+  test '#last_publicly_visible_attachment returns latest publicly visible attachable' do
+    earliest_attachable = build(:edition)
+    earliest_attachable.stubs(:publicly_visible?).returns(true)
+    latest_attachable = build(:edition)
+    latest_attachable.stubs(:publicly_visible?).returns(true)
+    earliest_attachment = build(:file_attachment, attachable: earliest_attachable)
+    latest_attachment = build(:file_attachment, attachable: latest_attachable)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([earliest_attachment, latest_attachment])
+
+    assert_equal latest_attachment, attachment_data.last_publicly_visible_attachment
+  end
+
+  test '#last_publicly_visible_attachment returns nil if there are no publicly visible attachables' do
+    attachable = build(:edition)
+    attachable.stubs(:publicly_visible?).returns(false)
+    attachment = build(:file_attachment, attachable: attachable)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([attachment])
+
+    assert_nil attachment_data.last_publicly_visible_attachment
+  end
+
+  test '#last_publicly_visible_attachment returns nil if there are no attachables' do
+    attachment = build(:file_attachment, attachable: nil)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([attachment])
+
+    assert_nil attachment_data.last_publicly_visible_attachment
+  end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -180,6 +180,22 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             it 'is not deleted' do
               refute attachment_data.reload.deleted?
             end
+
+            context 'and another new edition is created' do
+              let(:another_new_edition) { edition.create_draft(user) }
+
+              before do
+                another_new_edition.reload
+              end
+
+              it 'is not deleted' do
+                refute attachment_data.reload.deleted?
+              end
+
+              it 'is not draft' do
+                refute attachment_data.reload.draft?
+              end
+            end
           end
 
           context 'new edition is access-limited' do


### PR DESCRIPTION
In order to fix [this issue][1], we should be ignoring attachments with no attachable, i.e. attachments associated with deleted editions.

We've added a realistic/representative scenario to `AttachmentDataVisibilityTest` and more thorough & more unit-y tests in `AttachmentDataTest` to drive out the changes.

We compared the difference between `AttachmentVisibility#visible?` and `AttachmentData#visible_to?` for all `AttachmentData` records in integration (about 500,000). There were a number of differences before this change, and no differences after so we're confident we're mirroring the previous behaviour provided by `AttachmentVisibility`.

[1]: https://github.com/alphagov/asset-manager/issues/524