### PR TITLE
Fix AttachmentData#last_attachable bug

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -105,7 +105,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def deleted?
-    significant_attachment.deleted?
+    significant_attachment(include_deleted_attachables: true).deleted?
   end
 
   def draft?
@@ -162,12 +162,12 @@ class AttachmentData < ApplicationRecord
     last_attachment.attachable || Attachable::Null.new
   end
 
-  def significant_attachment
-    last_publicly_visible_attachment || last_attachment
+  def significant_attachment(**args)
+    last_publicly_visible_attachment || last_attachment(**args)
   end
 
-  def last_attachment
-    attachments.last || Attachment::Null.new
+  def last_attachment(**args)
+    filtered_attachments(**args).last || Attachment::Null.new
   end
 
   def last_publicly_visible_attachment
@@ -175,6 +175,14 @@ class AttachmentData < ApplicationRecord
   end
 
 private
+
+  def filtered_attachments(include_deleted_attachables: false)
+    if include_deleted_attachables
+      attachments
+    else
+      attachments.select { |attachment| attachment.attachable.present? }
+    end
+  end
 
   def cant_be_replaced_by_self
     return if replaced_by.nil?

--- a/test/unit/attachment_data_test.rb
+++ b/test/unit/attachment_data_test.rb
@@ -313,4 +313,68 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     assert_nil attachment_data.last_publicly_visible_attachment
   end
+
+  test '#last_attachment returns attachment for latest attachable' do
+    earliest_attachable = build(:edition)
+    latest_attachable = build(:edition)
+    earliest_attachment = build(:file_attachment, attachable: earliest_attachable)
+    latest_attachment = build(:file_attachment, attachable: latest_attachable)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([earliest_attachment, latest_attachment])
+
+    assert_equal latest_attachment, attachment_data.last_attachment
+  end
+
+  test '#last_attachment ignores attachments without attachable' do
+    earliest_attachable = build(:edition)
+    earliest_attachment = build(:file_attachment, attachable: earliest_attachable)
+    latest_attachment = build(:file_attachment, attachable: nil)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([earliest_attachment, latest_attachment])
+
+    assert_equal earliest_attachment, attachment_data.last_attachment
+  end
+
+  test '#last_attachment returns null attachment if no attachments' do
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([])
+
+    assert_instance_of Attachment::Null, attachment_data.last_attachment
+  end
+
+  test '#deleted? returns true if attachment is deleted' do
+    attachable = build(:edition)
+    attachable.stubs(:publicly_visible?).returns(false)
+    deleted_attachment = build(:file_attachment, attachable: attachable, deleted: true)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([deleted_attachment])
+
+    assert attachment_data.deleted?
+  end
+
+  test '#deleted? returns false if attachment is not deleted' do
+    attachable = build(:edition)
+    attachable.stubs(:publicly_visible?).returns(false)
+    deleted_attachment = build(:file_attachment, attachable: attachable, deleted: false)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([deleted_attachment])
+
+    refute attachment_data.deleted?
+  end
+
+  test '#deleted? returns true if attachment is deleted even if attachable is nil' do
+    deleted_attachment = build(:file_attachment, attachable: nil, deleted: true)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([deleted_attachment])
+
+    assert attachment_data.deleted?
+  end
+
+  test '#deleted? returns false if attachment is not deleted even if attachable is nil' do
+    deleted_attachment = build(:file_attachment, attachable: nil, deleted: false)
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:attachments).returns([deleted_attachment])
+
+    refute attachment_data.deleted?
+  end
 end

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -73,6 +73,40 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         it 'is not accessible to user in another organisation' do
           refute attachment_data.reload.accessible_to?(user_in_another_organisation)
         end
+
+        context 'when edition is published' do
+          before do
+            edition.major_change_published_at = Time.zone.now
+            edition.force_publish!
+          end
+
+          context 'and new edition is created' do
+            let(:new_edition) { edition.create_draft(user) }
+
+            before do
+              new_edition.reload
+            end
+
+            context 'new edition is access-limited' do
+              before do
+                new_edition.change_note = 'change-note'
+                new_edition.access_limited = true
+                new_edition.save!
+              end
+
+              context 'discard new edition' do
+                before do
+                  new_edition.delete
+                  new_edition.save!
+                end
+
+                it 'is access limited' do
+                  assert attachment_data.reload.access_limited?
+                end
+              end
+            end
+          end
+        end
       end
 
       context 'when attachment is deleted' do


### PR DESCRIPTION
This is closely related to #3866.

Previously `AttachmentData#last_attachment` was always considering attachments with no attachable. The main (or only?) scenario where an attachment has no attachable is when the attachable is a deleted edition, thanks to [the `default_scope` on `Edition::Workflow`][1].

In this case, `Attachment#attachable` returns `nil` and so, given that `AttachmentData#last_attachment` was including the attachment, `AttachmentData#last_attachable` was falling back to returning `Attachable::Null`. In most scenarios it turns out that the methods on this return the correct values, but we felt it was happening more by accident than design.

We've added a realistic† scenario to `AttachmentDataVisibilityTest` which failed with the original implementation and forced us to drive out the new implementation.

We've added unit tests to AttachmentDataTest to give more complete coverage.

Note that we still need to consider attachments with no attachable in `AttachmentData#deleted?`, because of the scenario where an edition is deleted and marks all its attachments as deleted. Hence the optional keyword argument, `include_deleted_attachables`.

† Although the scenario is realistic, the incorrect return value from `AttachmentData#access_limited?` doesn't actually matter, because in this case the attachment is published and therefore access-limiting doesn't come into play. Having said that, I'm sure there are scenarios in which it (or other predicate methods on `AttachmentData`) might have returned a more consequential incorrect value before the fix.

[1]:
https://github.com/alphagov/whitehall/blob/fc62edcd5a9b1ba8bfb22911f69f128083535127/app/models/edition/workflow.rb#L21