### PR TITLE
Fix bug in AttachmentData#visible_to? for replaced attachments

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -138,7 +138,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def visible_to?(user)
-    !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
+    !deleted? && !unpublished? && !replaced? && (!draft? || (draft? && accessible_to?(user)))
   end
 
   def visible_attachment_for(user)

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -24,6 +24,10 @@ class AttachmentsControllerTest < ActionController::TestCase
   test "attachments that aren't visible and have been replaced are permanently redirected to the replacement attachment" do
     replacement = create(:attachment_data)
     attachment_data = create(:attachment_data, replaced_by: replacement)
+    attachment_data.stubs(:draft?).returns(false)
+    controller.stubs(:attachment_data).returns(attachment_data)
+    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+
     get_show attachment_data
 
     assert_redirected_to replacement.url

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -110,8 +110,14 @@ class CsvPreviewControllerTest < ActionController::TestCase
   end
 
   test "GET #show for attachments that aren't visible and have been replaced permanently redirects to the replacement attachment" do
+    attachment = create(:csv_attachment)
+    attachment_data = attachment.attachment_data
     replacement = create(:csv_attachment)
-    attachment_data = create(:attachment_data, replaced_by: replacement.attachment_data)
+    attachment_data.update_attributes!(replaced_by: replacement.attachment_data)
+    attachment_data.stubs(:draft?).returns(false)
+    attachment_data.stubs(:visible_edition_for).returns(build(:edition))
+    controller.stubs(:attachment_data).returns(attachment_data)
+    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
 
     get_show attachment_data
 

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -536,12 +536,14 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       let(:deleted) { false }
       let(:unpublished) { false }
+      let(:replaced) { false }
       let(:draft) { false }
 
       before do
         attachment_data.stubs(
           deleted?: deleted,
           unpublished?: unpublished,
+          replaced?: replaced,
           draft?: draft
         )
       end
@@ -560,6 +562,14 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       context 'when unpublished' do
         let(:unpublished) { true }
+
+        it 'is not visible' do
+          refute attachment_data.visible_to?(nil)
+        end
+      end
+
+      context 'when replaced' do
+        let(:replaced) { true }
 
         it 'is not visible' do
           refute attachment_data.visible_to?(nil)


### PR DESCRIPTION
This bug meant that unless there was some reason why an `AttachmentData` was considered not "visible", requests for a replaced attachment would've resulted in the original attachment being served.

Thus a replaced attachment on a draft edition was redirected correctly, because being draft meant that it was not visible. But a replaced attachment on a published edition was not redirected, because being published meant that it was visible.

I believe this has been the case for a long time, because `AttachmentVisiblity#visible?` did not take into account whether an `AttachmentData` had been replaced or not.

Both `AttachchmentsController#show` & `CsvPreviewController#show` use `BaseAttachmentsController#attachment_visible?` and thence `BaseAttachmentsController#upload_exists?` and `AttachmentData#visible_to?` to decide whether to render the attachment/preview or to call `BaseAttachmentsController#fail`. It is the latter which contains the condition to redirect requests for replaced attachments.

Unfortunately the controller tests for replaced attachments were only passing by accident, because `BaseAttachmentsController#upload_exists?` and/or `AttachmentData#visible_to?` were returning false for a number of reasons; whereas `BaseAttachmentsController#upload_exists?` should've been
returning `true` and `AttachmentData#visible_to?` should've only been returning `false`, because `AttachmentData#replaced?` was returning `true`.

These tests were also faulty when `AttachmentVisibility` was in place, for similar reasons. `BaseAttachmentsController#upload_exists?` was again returning `false`, because the attachment file had not been virus-scanned and `AttachmentVisibility#visible?` was only returning `false`, because the `AttachmentData` was an orphan and had no parent edition.

I've updated the controller tests so that they're more realistic and they forced me to add the dependency on `AttachmentData#replaced?` in the implementation of `AttachmentData#visible_to?`. I'm not completely happy with the amount of stubbing I've had to do, but I'm hoping I can clear
it up later.

Interestingly this bug actually only came to light when I was doing some refactoring of the attachment controllers in which I break the nested `if`/`else` statements down into guard conditions and use lower-level predicate methods on `AttachmentData` like `#deleted?`, `#draft?`, etc.
