### PR TITLE
Ignore missing files when updating metadata in Asset Manager

### DIFF
--- a/lib/asset_manager_attachment_metadata_updater.rb
+++ b/lib/asset_manager_attachment_metadata_updater.rb
@@ -1,6 +1,8 @@
 class AssetManagerAttachmentMetadataUpdater
   def self.update_range(start, finish)
     AttachmentData.find_each(start: start, finish: finish) do |attachment_data|
+      next unless File.exist?(attachment_data.file.path)
+
       [
        AssetManagerAttachmentAccessLimitedWorker,
        AssetManagerAttachmentDeleteWorker,

--- a/test/unit/asset_manager_attachment_metadata_updater_test.rb
+++ b/test/unit/asset_manager_attachment_metadata_updater_test.rb
@@ -19,6 +19,10 @@ class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
   ].each do |worker|
     let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
+    before do
+      VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+    end
+
     test "sets the #{worker} queue to 'asset_migration'" do
       worker.expects(:set).with(queue: 'asset_migration').returns(worker)
       AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
@@ -26,6 +30,12 @@ class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
 
     test "queues a job on the #{worker}" do
       worker.expects(:perform_async).with(attachment_data.id)
+      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
+    end
+
+    test "does not queue a job on the #{worker} if the file doesn't exist" do
+      FileUtils.rm(attachment_data.reload.file.path)
+      worker.expects(:perform_async).never
       AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
     end
   end


### PR DESCRIPTION
When testing `AssetManagerAttachmentMetadataUpdater.update_range` in integration we ran into some problems where `AttachmentData` objects didn't have a corresponding file on the file system. The lack of file meant that the asset hadn't been created in Asset Manager (because we populated Asset Manager using the files on disk) and so we saw exceptions when trying to retrieve the asset from Asset Manager (in `AssetManagerWorkerHelper#find_asset_by`).

Some of these attachments have been replaced which means that, despite not having a file on disk, requests for them are redirected to their replacement. We've identified these attachments and are creating assets for them in Asset Manager as part of https://github.com/alphagov/asset-manager/issues/525. Once these records have been created we're confident that it's safe to ignore any remaining `AttachmentData` records that don't have files.