### PR TITLE
Move asset manager attachment metadata migration to a worker

### DIFF
--- a/app/workers/asset_manager_attachment_metadata_update_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_update_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentMetadataUpdateWorker < WorkerBase
+  sidekiq_options queue: 'asset_migration'
+
   def perform(attachment_data_id)
     [
       AssetManagerAttachmentAccessLimitedWorker,
@@ -8,7 +10,7 @@ class AssetManagerAttachmentMetadataUpdateWorker < WorkerBase
       AssetManagerAttachmentRedirectUrlUpdateWorker,
       AssetManagerAttachmentReplacementIdUpdateWorker
     ].each do |worker|
-      worker.set(queue: 'asset_migration').perform_async(attachment_data_id)
+      worker.perform_async(attachment_data_id)
     end
   end
 end

--- a/app/workers/asset_manager_attachment_metadata_update_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_update_worker.rb
@@ -2,15 +2,19 @@ class AssetManagerAttachmentMetadataUpdateWorker < WorkerBase
   sidekiq_options queue: 'asset_migration'
 
   def perform(attachment_data_id)
+    workers.each do |worker|
+      worker.new.perform(attachment_data_id)
+    end
+  end
+
+  def workers
     [
       AssetManagerAttachmentAccessLimitedWorker,
-      AssetManagerAttachmentDeleteWorker,
       AssetManagerAttachmentDraftStatusUpdateWorker,
       AssetManagerAttachmentLinkHeaderUpdateWorker,
       AssetManagerAttachmentRedirectUrlUpdateWorker,
-      AssetManagerAttachmentReplacementIdUpdateWorker
-    ].each do |worker|
-      worker.new.perform(attachment_data_id)
-    end
+      AssetManagerAttachmentReplacementIdUpdateWorker,
+      AssetManagerAttachmentDeleteWorker
+    ]
   end
 end

--- a/app/workers/asset_manager_attachment_metadata_update_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_update_worker.rb
@@ -10,7 +10,7 @@ class AssetManagerAttachmentMetadataUpdateWorker < WorkerBase
       AssetManagerAttachmentRedirectUrlUpdateWorker,
       AssetManagerAttachmentReplacementIdUpdateWorker
     ].each do |worker|
-      worker.perform_async(attachment_data_id)
+      worker.new.perform(attachment_data_id)
     end
   end
 end

--- a/app/workers/asset_manager_attachment_metadata_update_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_update_worker.rb
@@ -1,0 +1,14 @@
+class AssetManagerAttachmentMetadataUpdateWorker < WorkerBase
+  def perform(attachment_data_id)
+    [
+      AssetManagerAttachmentAccessLimitedWorker,
+      AssetManagerAttachmentDeleteWorker,
+      AssetManagerAttachmentDraftStatusUpdateWorker,
+      AssetManagerAttachmentLinkHeaderUpdateWorker,
+      AssetManagerAttachmentRedirectUrlUpdateWorker,
+      AssetManagerAttachmentReplacementIdUpdateWorker
+    ].each do |worker|
+      worker.set(queue: 'asset_migration').perform_async(attachment_data_id)
+    end
+  end
+end

--- a/lib/asset_manager_attachment_metadata_updater.rb
+++ b/lib/asset_manager_attachment_metadata_updater.rb
@@ -3,16 +3,7 @@ class AssetManagerAttachmentMetadataUpdater
     AttachmentData.find_each(start: start, finish: finish) do |attachment_data|
       next unless File.exist?(attachment_data.file.path)
 
-      [
-       AssetManagerAttachmentAccessLimitedWorker,
-       AssetManagerAttachmentDeleteWorker,
-       AssetManagerAttachmentDraftStatusUpdateWorker,
-       AssetManagerAttachmentLinkHeaderUpdateWorker,
-       AssetManagerAttachmentRedirectUrlUpdateWorker,
-       AssetManagerAttachmentReplacementIdUpdateWorker
-      ].each do |worker|
-        worker.set(queue: 'asset_migration').perform_async(attachment_data.id)
-      end
+      AssetManagerAttachmentMetadataUpdateWorker.perform_async(attachment_data.id)
     end
   end
 end

--- a/test/unit/asset_manager_attachment_metadata_updater_test.rb
+++ b/test/unit/asset_manager_attachment_metadata_updater_test.rb
@@ -3,40 +3,28 @@ require 'test_helper'
 class AssetManagerAttachmentMetadataUpdaterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
+  let(:attachment_data) { FactoryBot.create(:attachment_data) }
+
+  setup do
+    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+  end
+
   test 'uses find_each with the range specified' do
     AttachmentData.expects(:find_each).with(start: 1, finish: 2)
 
     AssetManagerAttachmentMetadataUpdater.update_range(1, 2)
   end
 
-  [
-    AssetManagerAttachmentAccessLimitedWorker,
-    AssetManagerAttachmentDeleteWorker,
-    AssetManagerAttachmentDraftStatusUpdateWorker,
-    AssetManagerAttachmentLinkHeaderUpdateWorker,
-    AssetManagerAttachmentRedirectUrlUpdateWorker,
-    AssetManagerAttachmentReplacementIdUpdateWorker
-  ].each do |worker|
-    let(:attachment_data) { FactoryBot.create(:attachment_data) }
+  test "calls the worker if the file exists" do
+    AssetManagerAttachmentMetadataUpdateWorker.expects(:perform_async).with(attachment_data.id)
 
-    before do
-      VirusScanHelpers.simulate_virus_scan(attachment_data.file)
-    end
+    AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
+  end
 
-    test "sets the #{worker} queue to 'asset_migration'" do
-      worker.expects(:set).with(queue: 'asset_migration').returns(worker)
-      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
-    end
+  test "does not call the worker if the file doesn't exist" do
+    FileUtils.rm(attachment_data.reload.file.path)
+    AssetManagerAttachmentMetadataUpdateWorker.expects(:perform_async).never
 
-    test "queues a job on the #{worker}" do
-      worker.expects(:perform_async).with(attachment_data.id)
-      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
-    end
-
-    test "does not queue a job on the #{worker} if the file doesn't exist" do
-      FileUtils.rm(attachment_data.reload.file.path)
-      worker.expects(:perform_async).never
-      AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
-    end
+    AssetManagerAttachmentMetadataUpdater.update_range(attachment_data.id, attachment_data.id)
   end
 end

--- a/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
@@ -43,6 +43,10 @@ class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
     subject.perform(attachment_data.id)
   end
 
+  test 'calls AssetManagerAttachmentDeleteWorker last' do
+    assert_equal AssetManagerAttachmentDeleteWorker, subject.workers.last
+  end
+
   test 'calls AssetManagerAttachmentDraftStatusUpdateWorker#perform with the attachment_data id' do
     mock_draft_status_update_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)

--- a/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
@@ -4,24 +4,39 @@ class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   let(:subject) { AssetManagerAttachmentMetadataUpdateWorker.new }
+  let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
   test 'it uses the asset_migration queue' do
     assert_equal 'asset_migration', subject.class.queue
   end
 
-  [
-    AssetManagerAttachmentAccessLimitedWorker,
-    AssetManagerAttachmentDeleteWorker,
-    AssetManagerAttachmentDraftStatusUpdateWorker,
-    AssetManagerAttachmentLinkHeaderUpdateWorker,
-    AssetManagerAttachmentRedirectUrlUpdateWorker,
-    AssetManagerAttachmentReplacementIdUpdateWorker
-  ].each do |worker|
-    let(:attachment_data) { FactoryBot.create(:attachment_data) }
+  test 'queues a job on the AssetManagerAttachmentMetadataUpdateWorker' do
+    AssetManagerAttachmentAccessLimitedWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
+  end
 
-    test "queues a job on the #{worker}" do
-      worker.expects(:perform_async).with(attachment_data.id)
-      subject.perform(attachment_data.id)
-    end
+  test 'queues a job on the AssetManagerAttachmentDeleteWorker' do
+    AssetManagerAttachmentDeleteWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
+  end
+
+  test 'queues a job on the AssetManagerAttachmentDraftStatusUpdateWorker' do
+    AssetManagerAttachmentDraftStatusUpdateWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
+  end
+
+  test 'queues a job on the AssetManagerAttachmentLinkHeaderUpdateWorker' do
+    AssetManagerAttachmentLinkHeaderUpdateWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
+  end
+
+  test 'queues a job on the AssetManagerAttachmentRedirectUrlUpdateWorker' do
+    AssetManagerAttachmentRedirectUrlUpdateWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
+  end
+
+  test 'queues a job on the AssetManagerAttachmentReplacementIdUpdateWorker' do
+    AssetManagerAttachmentReplacementIdUpdateWorker.expects(:perform_async).with(attachment_data.id)
+    subject.perform(attachment_data.id)
   end
 end

--- a/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
@@ -6,37 +6,60 @@ class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
   let(:subject) { AssetManagerAttachmentMetadataUpdateWorker.new }
   let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
+  let(:mock_access_limited_worker) { mock('access_limited_worker') }
+  let(:mock_delete_worker) { mock('delete_worker') }
+  let(:mock_draft_status_update_worker) { mock('draft_status_update_worker') }
+  let(:mock_link_header_update_worker) { mock('link_header_update_worker') }
+  let(:mock_redirect_url_update_worker) { mock('redirect_url_update_worker') }
+  let(:mock_replacement_id_update_worker) { mock('replacement_id_update_worker') }
+
+  setup do
+    mock_access_limited_worker.stubs(:perform)
+    mock_delete_worker.stubs(:perform)
+    mock_draft_status_update_worker.stubs(:perform)
+    mock_link_header_update_worker.stubs(:perform)
+    mock_redirect_url_update_worker.stubs(:perform)
+    mock_replacement_id_update_worker.stubs(:perform)
+
+    AssetManagerAttachmentAccessLimitedWorker.stubs(:new).returns(mock_access_limited_worker)
+    AssetManagerAttachmentDeleteWorker.stubs(:new).returns(mock_delete_worker)
+    AssetManagerAttachmentDraftStatusUpdateWorker.stubs(:new).returns(mock_draft_status_update_worker)
+    AssetManagerAttachmentLinkHeaderUpdateWorker.stubs(:new).returns(mock_link_header_update_worker)
+    AssetManagerAttachmentRedirectUrlUpdateWorker.stubs(:new).returns(mock_redirect_url_update_worker)
+    AssetManagerAttachmentReplacementIdUpdateWorker.stubs(:new).returns(mock_replacement_id_update_worker)
+  end
+
   test 'it uses the asset_migration queue' do
     assert_equal 'asset_migration', subject.class.queue
   end
 
-  test 'queues a job on the AssetManagerAttachmentMetadataUpdateWorker' do
-    AssetManagerAttachmentAccessLimitedWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentAccessLimitedWorker#perform with the attachment_data id' do
+    mock_access_limited_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 
-  test 'queues a job on the AssetManagerAttachmentDeleteWorker' do
-    AssetManagerAttachmentDeleteWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentDeleteWorker#perform with the attachment_data id' do
+    mock_delete_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 
-  test 'queues a job on the AssetManagerAttachmentDraftStatusUpdateWorker' do
-    AssetManagerAttachmentDraftStatusUpdateWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentDraftStatusUpdateWorker#perform with the attachment_data id' do
+    mock_draft_status_update_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 
-  test 'queues a job on the AssetManagerAttachmentLinkHeaderUpdateWorker' do
-    AssetManagerAttachmentLinkHeaderUpdateWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentLinkHeaderUpdateWorker#perform with the attachment_data id' do
+    mock_link_header_update_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 
-  test 'queues a job on the AssetManagerAttachmentRedirectUrlUpdateWorker' do
-    AssetManagerAttachmentRedirectUrlUpdateWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentRedirectUrlUpdateWorker#perform with the attachment_data id' do
+    mock_redirect_url_update_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 
-  test 'queues a job on the AssetManagerAttachmentReplacementIdUpdateWorker' do
-    AssetManagerAttachmentReplacementIdUpdateWorker.expects(:perform_async).with(attachment_data.id)
+  test 'calls AssetManagerAttachmentReplacementIdUpdateWorker#perform with the attachment_data id' do
+    mock_replacement_id_update_worker.expects(:perform).with(attachment_data.id)
     subject.perform(attachment_data.id)
   end
 end

--- a/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:subject) { AssetManagerAttachmentMetadataUpdateWorker.new }
+
+  [
+    AssetManagerAttachmentAccessLimitedWorker,
+    AssetManagerAttachmentDeleteWorker,
+    AssetManagerAttachmentDraftStatusUpdateWorker,
+    AssetManagerAttachmentLinkHeaderUpdateWorker,
+    AssetManagerAttachmentRedirectUrlUpdateWorker,
+    AssetManagerAttachmentReplacementIdUpdateWorker
+  ].each do |worker|
+    let(:attachment_data) { FactoryBot.create(:attachment_data) }
+
+    test "sets the #{worker} queue to 'asset_migration'" do
+      worker.expects(:set).with(queue: 'asset_migration').returns(worker)
+      subject.perform(attachment_data.id)
+    end
+
+    test "queues a job on the #{worker}" do
+      worker.expects(:perform_async).with(attachment_data.id)
+      subject.perform(attachment_data.id)
+    end
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_update_worker_test.rb
@@ -5,6 +5,10 @@ class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
 
   let(:subject) { AssetManagerAttachmentMetadataUpdateWorker.new }
 
+  test 'it uses the asset_migration queue' do
+    assert_equal 'asset_migration', subject.class.queue
+  end
+
   [
     AssetManagerAttachmentAccessLimitedWorker,
     AssetManagerAttachmentDeleteWorker,
@@ -14,11 +18,6 @@ class AssetManagerAttachmentMetadataUpdateWorkerTest < ActiveSupport::TestCase
     AssetManagerAttachmentReplacementIdUpdateWorker
   ].each do |worker|
     let(:attachment_data) { FactoryBot.create(:attachment_data) }
-
-    test "sets the #{worker} queue to 'asset_migration'" do
-      worker.expects(:set).with(queue: 'asset_migration').returns(worker)
-      subject.perform(attachment_data.id)
-    end
 
     test "queues a job on the #{worker}" do
       worker.expects(:perform_async).with(attachment_data.id)


### PR DESCRIPTION
This PR changes `AssetManagerAttachmentMetadataUpdater` so that it puts a single job on the `asset_migration` queue for each `AttachmentData` in the batch. The new worker in turn calls the various asset metadata update workers synchronously. 

The motivation for this changes is that previously we queued a single job for each of the update workers for each `AttachmentData`. The problem with this is that we have no control over the execution order for these jobs and in the case where the `AssetManagerAttachmentDeleteWorker` was called to mark an Asset as deleted in Asset Manager any of the other jobs that needed to fetch this asset would fail when a GET to Asset Manager for the asset in question returned 404. 

Making this change allows us to execute the work in the background and also to specify the execution order. The final commit in this PR calls the delete worker last. 