### PR TITLE
Revert "Fix bug in AttachmentData#visible_to? for replaced attachments"

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -138,7 +138,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def visible_to?(user)
-    !deleted? && !unpublished? && !replaced? && (!draft? || (draft? && accessible_to?(user)))
+    !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
   end
 
   def visible_attachment_for(user)

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -24,10 +24,6 @@ class AttachmentsControllerTest < ActionController::TestCase
   test "attachments that aren't visible and have been replaced are permanently redirected to the replacement attachment" do
     replacement = create(:attachment_data)
     attachment_data = create(:attachment_data, replaced_by: replacement)
-    attachment_data.stubs(:draft?).returns(false)
-    controller.stubs(:attachment_data).returns(attachment_data)
-    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
-
     get_show attachment_data
 
     assert_redirected_to replacement.url

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -110,14 +110,8 @@ class CsvPreviewControllerTest < ActionController::TestCase
   end
 
   test "GET #show for attachments that aren't visible and have been replaced permanently redirects to the replacement attachment" do
-    attachment = create(:csv_attachment)
-    attachment_data = attachment.attachment_data
     replacement = create(:csv_attachment)
-    attachment_data.update_attributes!(replaced_by: replacement.attachment_data)
-    attachment_data.stubs(:draft?).returns(false)
-    attachment_data.stubs(:visible_edition_for).returns(build(:edition))
-    controller.stubs(:attachment_data).returns(attachment_data)
-    VirusScanHelpers.simulate_virus_scan(attachment_data.file)
+    attachment_data = create(:attachment_data, replaced_by: replacement.attachment_data)
 
     get_show attachment_data
 

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -570,14 +570,12 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       let(:deleted) { false }
       let(:unpublished) { false }
-      let(:replaced) { false }
       let(:draft) { false }
 
       before do
         attachment_data.stubs(
           deleted?: deleted,
           unpublished?: unpublished,
-          replaced?: replaced,
           draft?: draft
         )
       end
@@ -596,14 +594,6 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       context 'when unpublished' do
         let(:unpublished) { true }
-
-        it 'is not visible' do
-          refute attachment_data.visible_to?(nil)
-        end
-      end
-
-      context 'when replaced' do
-        let(:replaced) { true }
 
         it 'is not visible' do
           refute attachment_data.visible_to?(nil)


### PR DESCRIPTION
Reverts alphagov/whitehall#3874

This PR introduced a bug in production where requests for attachments which had been replaced, but whose replacement was not accessible (e.g. on a draft edition), resulted in a `301 Moved Permanently` redirect to the replacement attachment which then resulted in a `404 Not Found`; whereas the original attachment should have been served with a `200 OK`.

We're reverting #3874 to fix the above problem in `master`.