### PR TITLE
Add scenarios to AttachmentReplacementIntegrationTest

### DIFF
--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -6,28 +6,27 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Rails.application.routes.url_helpers
 
+  let(:managing_editor) { create(:managing_editor) }
+  let(:filename) { 'sample.docx' }
+  let(:file) { File.open(path_to_attachment(filename)) }
+  let(:attachment) { build(:file_attachment, attachable: edition, file: file) }
+  let(:asset_id) { 'asset-id' }
+
+  before do
+    login_as(managing_editor)
+    edition.attachments << attachment
+    setup_publishing_api_for(edition)
+    stub_whitehall_asset(filename, id: asset_id)
+    VirusScanHelpers.simulate_virus_scan
+  end
+
   context 'given a draft document with a file attachment' do
-    let(:managing_editor) { create(:managing_editor) }
-
-    let(:filename) { 'sample.docx' }
-    let(:file) { File.open(path_to_attachment(filename)) }
-    let(:attachment) { build(:file_attachment, attachable: edition, file: file) }
-    let(:asset_id) { 'asset-id' }
-
-    let(:replacement_filename) { 'sample.rtf' }
-    let(:replacement_asset_id) { 'replacement-asset-id' }
-
     let(:edition) { create(:news_article) }
 
-    before do
-      login_as(managing_editor)
-      edition.attachments << attachment
-      setup_publishing_api_for(edition)
-      stub_whitehall_asset(filename, id: asset_id)
-      VirusScanHelpers.simulate_virus_scan
-    end
-
     context 'when attachment is replaced' do
+      let(:replacement_filename) { 'sample.rtf' }
+      let(:replacement_asset_id) { 'replacement-asset-id' }
+
       before do
         visit admin_news_article_path(edition)
         click_link 'Modify attachments'

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -9,10 +9,14 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
   let(:managing_editor) { create(:managing_editor) }
   let(:filename) { 'sample.docx' }
   let(:file) { File.open(path_to_attachment(filename)) }
-  let(:attachment) { build(:file_attachment, attachable: edition, file: file) }
+  let(:attachment) { build(:file_attachment, title: 'attachment-title', attachable: edition, file: file) }
   let(:asset_id) { 'asset-id' }
 
+  let(:replacement_filename) { 'sample.rtf' }
+  let(:replacement_asset_id) { 'replacement-asset-id' }
+
   before do
+    create(:government)
     login_as(managing_editor)
     edition.attachments << attachment
     setup_publishing_api_for(edition)
@@ -24,9 +28,6 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     let(:edition) { create(:news_article) }
 
     context 'when attachment is replaced' do
-      let(:replacement_filename) { 'sample.rtf' }
-      let(:replacement_asset_id) { 'replacement-asset-id' }
-
       before do
         visit admin_news_article_path(edition)
         click_link 'Modify attachments'
@@ -54,10 +55,80 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
         assert_redirected_to replacement_url
       end
 
+      # We rely on Asset Manager to do the redirect immediately in this case,
+      # because the replacement is visible to the user.
       it 'updates replacement_id for attachment in Asset Manager' do
         Services.asset_manager.expects(:update_asset)
           .with(asset_id, 'replacement_id' => replacement_asset_id)
         AssetManagerAttachmentReplacementIdUpdateWorker.drain
+      end
+    end
+  end
+
+  context 'given a published document with file attachment' do
+    let(:edition) { create(:published_news_article) }
+
+    context 'when new draft is created and attachment is replaced' do
+      before do
+        publishing_api_has_linkables([], document_type: 'topic')
+        visit admin_news_article_path(edition)
+        click_button 'Create new edition to edit'
+        click_link 'Attachments 1'
+        @attachment_url = find('.existing-attachments a', text: filename)[:href]
+        within '.existing-attachments' do
+          click_link 'Edit'
+        end
+        attach_file 'Replace file', path_to_attachment(replacement_filename)
+        click_button 'Save'
+        assert_text "Attachment 'attachment-title' updated"
+        VirusScanHelpers.simulate_virus_scan
+        stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
+      end
+
+      it 'does not redirect requests for attachment to replacement' do
+        logout
+
+        get @attachment_url
+        assert_response :ok
+      end
+
+      # We rely on Asset Manager *not* to do the redirect, even though the
+      # asset is marked as replaced, because the replacement is not yet
+      # visible to the user.
+      it 'updates replacement_id for attachment in Asset Manager' do
+        Services.asset_manager.expects(:update_asset)
+          .with(asset_id, 'replacement_id' => replacement_asset_id)
+        AssetManagerAttachmentReplacementIdUpdateWorker.drain
+      end
+
+      context 'and draft edition is published' do
+        before do
+          AssetManagerAttachmentReplacementIdUpdateWorker.drain
+
+          click_link 'Document'
+          fill_in 'Public change note', with: 'attachment replaced'
+          click_button 'Save'
+          assert_text 'The document has been saved'
+
+          click_link 'Modify attachments'
+          @replacement_url = find('.existing-attachments a', text: replacement_filename)[:href]
+
+          visit admin_news_article_path(edition.latest_edition)
+          click_link 'Force publish'
+          fill_in 'Reason for force publishing', with: 'testing'
+          click_button 'Force publish'
+          assert_text %r{The document .* has been published}
+        end
+
+        it 'redirects requests for attachment to replacement' do
+          logout
+
+          get @attachment_url
+          assert_redirected_to @replacement_url
+        end
+
+        # We rely on Asset Manager to do the redirect setup previously
+        # (see above), now that the asset *is* publicly available.
       end
     end
   end


### PR DESCRIPTION
This would've caught the problem that was accidentally introduced in [this PR][1] and reverted in [this PR][2]. More specifically the assertion on line 92 would've failed, because the response would've incorrectly been a `301 Moved Permanently` redirect rather than `200 OK`.

These tests also serves to illustrate how the attachment replacement functionality will work once we switch over to serving Whitehall attachments from Asset Manager. In particular it highlights how we will be dependent on the functionality introduced into Asset Manager in [this PR][3], i.e. Whitehall will mark the relevant Asset Manager assets as replaced at the time where the attachment is replaced, even though in some circumstances the redirect to the replacement should not happen.

[1]: https://github.com/alphagov/whitehall/pull/3874
[2]: https://github.com/alphagov/whitehall/pull/3894
[3]: https://github.com/alphagov/asset-manager/pull/531