### PR TITLE
Decouple AttachmentData#draft? from AttachmentData#unpublished?

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -109,7 +109,6 @@ class AttachmentData < ApplicationRecord
   end
 
   def draft?
-    return false if unpublished?
     !significant_attachable.publicly_visible?
   end
 
@@ -138,7 +137,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def visible_to?(user)
-    !deleted? && !unpublished? && (!draft? || (draft? && accessible_to?(user)))
+    !deleted? && (!draft? || (draft? && accessible_to?(user)))
   end
 
   def visible_attachment_for(user)

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -2,7 +2,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
-    draft = attachment_data.draft?
+    draft = attachment_data.draft? && !attachment_data.unpublished?
     enqueue_job(attachment_data.file, draft)
     if attachment_data.pdf?
       enqueue_job(attachment_data.file.thumbnail, draft)

--- a/test/unit/attachment_data_visibility_test.rb
+++ b/test/unit/attachment_data_visibility_test.rb
@@ -310,8 +310,8 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             refute attachment_data.reload.deleted?
           end
 
-          it 'is not draft' do
-            refute attachment_data.reload.draft?
+          it 'is draft' do
+            assert attachment_data.reload.draft?
           end
 
           it 'is is unpublished' do
@@ -507,8 +507,8 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             refute attachment_data.reload.deleted?
           end
 
-          it 'is not draft' do
-            refute attachment_data.reload.draft?
+          it 'is draft' do
+            assert attachment_data.reload.draft?
           end
 
           it 'is unpublished' do
@@ -569,13 +569,11 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
       let(:attachable) { build(:news_article) }
 
       let(:deleted) { false }
-      let(:unpublished) { false }
       let(:draft) { false }
 
       before do
         attachment_data.stubs(
           deleted?: deleted,
-          unpublished?: unpublished,
           draft?: draft
         )
       end
@@ -586,14 +584,6 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
       context 'when deleted' do
         let(:deleted) { true }
-
-        it 'is not visible' do
-          refute attachment_data.visible_to?(nil)
-        end
-      end
-
-      context 'when unpublished' do
-        let(:unpublished) { true }
 
         it 'is not visible' do
           refute attachment_data.visible_to?(nil)


### PR DESCRIPTION
The fact that `AttachmentData#draft?` depended on
`AttachmentData#unpublished?` was based on a faulty assumption, i.e.
that `AttachmentVisibility#visible?` always returned `false` if the
`AttachmentData` was unpublished. The reason it always returned `false`
for an `AttachmentData` on an unpublished edition was purely because its
edition was not in a publicly visible state.

Another (faulty) reason for implementing `AttachmentData#draft?` this
way was so that `AssetManagerAttachmentDraftStatusUpdateWorker#perform`
would only need to call this predicate method to decide whether to set
the corresponding Asset Manager assets to be draft or not.

As Asset Manager currently stands, we need to ensure that an asset with
a redirect URL due to a document being unpublished is still marked as
*not* draft even though its corresponding `AttachmentData` in Whitehall
will be draft. This is so that the redirect is visible on the live stack
and thus anonymous users are redirected. However, this is really an
Asset Manager concern and not anything to do with Whitehall.

So I think it's less confusing if `AttachmentData#draft?` is independent
of `AttachmentData#unpublished?` and the fact that an unpublished asset
in Asset Manager needs to be marked as not draft is encapsulated in
`AssetManagerAttachmentDraftStatusUpdateWorker#process`. This also
brings `AttachmentData#visible_to?` into line with how
`AttachmentVisibility#visible?` used to work.

Note that this is just a refactoring as evidenced by no changes being
necessary in the integration tests.

I can imagine it might make sense to change Asset Manager so that an
unpublished asset (i.e. one with a redirect URL) is always assumed to be
not draft - that way we could remove the extra condition in
`AssetManagerAttachmentDraftStatusUpdateWorker#process`. However, I'm
not going to address that in this PR.

Supersedes https://github.com/alphagov/whitehall/pull/3901.