### PR TITLE
Prepare to switch AttachmentUploader to use AssetManagerStorage

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -200,7 +200,7 @@ private
   end
 
   def file_is_not_empty
-    errors.add(:file, "is an empty file") if file.present? && file.file.size.to_i.zero?
+    errors.add(:file, "is an empty file") if file.present? && file.file.zero_size?
   end
 
   def virus_scan_pending?

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -33,5 +33,9 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
       @quarantined_file.delete
       @asset_manager_file.delete
     end
+
+    def zero_size?
+      @asset_manager_file.zero_size?
+    end
   end
 end

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -14,7 +14,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   class File
-    delegate :path, :content_type, :filename, :size, to: :@quarantined_file
+    delegate :path, :content_type, :filename, to: :@quarantined_file
 
     def initialize(asset_manager_file, quarantined_file)
       @asset_manager_file = asset_manager_file

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -14,7 +14,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   class File
-    delegate :empty?, :path, :content_type, :filename, :size, to: :@quarantined_file
+    delegate :path, :content_type, :filename, :size, to: :@quarantined_file
 
     def initialize(asset_manager_file, quarantined_file)
       @asset_manager_file = asset_manager_file

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -45,6 +45,10 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
       @legacy_url_path
     end
 
+    def asset_manager_path
+      path
+    end
+
     def content_type
       MIME::Types.type_for(filename).first.to_s
     end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -48,5 +48,9 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
     def content_type
       MIME::Types.type_for(filename).first.to_s
     end
+
+    def zero_size?
+      false
+    end
   end
 end

--- a/lib/whitehall/carrier_wave/sanitized_file.rb
+++ b/lib/whitehall/carrier_wave/sanitized_file.rb
@@ -16,6 +16,10 @@ module CarrierWave
       CarrierWaveFilePath.new(path).to_public_path
     end
 
+    def zero_size?
+      size.to_i.zero?
+    end
+
     class CarrierWaveFilePath
       def initialize(path)
         @path = path

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -83,12 +83,6 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
     assert_equal 'quarantined-file-content-type', @file.content_type
   end
 
-  test '#size delegates to the quarantined file' do
-    @quarantined_file.stubs(:size).returns('quarantined-file-size')
-
-    assert_equal 'quarantined-file-size', @file.size
-  end
-
   test '#asset_manager_path delegates to path on asset manager file' do
     @asset_manager_file.stubs(:path).returns('asset-manager-file-path')
 

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -83,12 +83,6 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
     assert_equal 'quarantined-file-content-type', @file.content_type
   end
 
-  test '#empty? delegates to the quarantined file' do
-    @quarantined_file.stubs(:empty?).returns('quarantined-file-empty?')
-
-    assert_equal 'quarantined-file-empty?', @file.empty?
-  end
-
   test '#size delegates to the quarantined file' do
     @quarantined_file.stubs(:size).returns('quarantined-file-size')
 

--- a/test/unit/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_storage_test.rb
@@ -127,6 +127,10 @@ class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase
     assert_equal @asset_url_path, @file.path
   end
 
+  test 'delegates asset_manager_path to path' do
+    assert_equal @file.path, @file.asset_manager_path
+  end
+
   test '#content_type returns the first element of the content type array' do
     assert_equal 'image/png', @file.content_type
   end


### PR DESCRIPTION
In #3811 we are planning to switch the storage engine used in the `AttachmentUploader` from `AssetManagerAndQuanantinedFileStorage` to `AssetManagerStorage`. 

These are some commits that are safe to land on master before we make that change and will help to make the changeset in #3811 smaller. 

