### PR TITLE
Gracefully handle CSV encoding errors

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -15,7 +15,7 @@ class CsvPreviewController < BaseAttachmentsController
         end
       end
     end
-  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError
+  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
     render layout: 'html_attachments'
   rescue ActionController::UnknownFormat
     render status: :not_acceptable, plain: "Request format #{request.format} not handled."


### PR DESCRIPTION
Previously, encoding errors would only be raised in the `CsvPreview`
class, but they can now be raised in `CsvFileFromPublicHost`. If this
happens, we should still show the friendly error message.