### PR TITLE
Remove GdsApi::BaseError#raven_context

### DIFF
--- a/config/initializers/gds_api_base_error.rb
+++ b/config/initializers/gds_api_base_error.rb
@@ -1,0 +1,5 @@
+require 'gds_api/exceptions'
+
+class GdsApi::BaseError
+  remove_method :raven_context
+end

--- a/test/unit/gds_api_base_error_test.rb
+++ b/test/unit/gds_api_base_error_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GdsApiBaseErrorTest < ActiveSupport::TestCase
+  test 'removes raven_context method to avoid grouping unrelated exceptions' do
+    refute GdsApi::BaseError.new.respond_to?(:raven_context)
+  end
+end


### PR DESCRIPTION
To avoid grouping unrelated exceptions in Sentry.

This essentially undoes [commit cadedca67c1f431132503f65279c7a49ae89d303 of gds-api-adapters][1].

I think this grouping of exceptions is a little too aggressive and I think it'll be better to remove it until we can come up with something a little better. I created [PR 821 to remove the grouping in gds-api-adapters][2] but it's not obvious that it makes sense for all clients of the adapters, hence this change to undo it in Whitehall.

To illustrate the grouping problem: we currently have about [12,000 instances of the `GdsApi::HTTPUnprocessableEntity` exception in Whitehall][3]. These 12,000 exceptions will be a combination of requests to different services (at least asset-manager, publishing-api and rummager - there may be others but they're hard to find in the noise), for different reasons (e.g. an asset isn't in the expected state in asset-manager or there's a base_path conflict in publishing-api), from Rails and from Sidekiq, and for different environments (integration, staging and production).

All of which means that I don't think viewing these exceptions in Sentry is particularly useful. My preference would be for each URL to appear as a separate exception (which is the default behaviour, I believe) and for us to use Sentry's merging functionality to group them if they really are the same. [Sentry makes it easy to merge issues but impossible to unmerge][4].

[1]: https://github.com/alphagov/gds-api-adapters/commit/cadedca67c1f431132503f65279c7a49ae89d303
[2]: https://github.com/alphagov/gds-api-adapters/pull/821
[3]: https://sentry.io/govuk/app-whitehall/issues/343661139/
[4]: https://help.sentry.io/hc/en-us/articles/115000151633-Can-I-unmerge-if-I-have-accidentally-merged-issues-together-