### PR TITLE
Avoid CsvPreviewController depending on attachments being on the filesystem

### DIFF
--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -14,4 +14,24 @@ class CsvPreviewController < BaseAttachmentsController
       end
     end
   end
+
+private
+
+  def fail
+    if attachment_data.unpublished?
+      redirect_url = attachment_data.unpublished_edition.unpublishing.document_path
+      redirect_to redirect_url
+    elsif attachment_data.replaced?
+      expires_headers
+      redirect_to attachment_data.replaced_by.url, status: 301
+    elsif incoming_upload_exists? upload_path
+      if image? upload_path
+        redirect_to view_context.path_to_image('thumbnail-placeholder.png')
+      else
+        redirect_to_placeholder
+      end
+    else
+      render plain: "Not found", status: :not_found
+    end
+  end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -6,7 +6,8 @@ class CsvPreviewController < BaseAttachmentsController
           expires_headers
           @edition = visible_edition
           @attachment = attachment_data.visible_attachment_for(current_user)
-          @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
+          csv_response = CsvFileFromPublicHost.csv_response(attachment_data.file.asset_manager_path)
+          @csv_preview = CsvFileFromPublicHost.csv_preview_from(csv_response)
           render layout: 'html_attachments'
         else
           fail

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -6,15 +6,16 @@ class CsvPreviewController < BaseAttachmentsController
           expires_headers
           @edition = attachment_data.visible_edition_for(current_user)
           @attachment = attachment_data.visible_attachment_for(current_user)
-          @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
+          begin
+            @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
+          rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
+          end
           render layout: 'html_attachments'
         else
           fail
         end
       end
     end
-  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
-    render layout: 'html_attachments'
   rescue ActionController::UnknownFormat
     render status: :not_acceptable, plain: "Request format #{request.format} not handled."
   end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -34,4 +34,13 @@ private
   def visible_edition
     @visible_edition ||= attachment_data.visible_edition_for(current_user)
   end
+
+  def incoming_upload_exists?(path)
+    path = path.sub(Whitehall.clean_uploads_root, Whitehall.incoming_uploads_root)
+    File.exist?(path)
+  end
+
+  def upload_exists?(path)
+    File.exist?(path) && file_is_clean?(path)
+  end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -36,12 +36,11 @@ private
     @visible_edition ||= attachment_data.visible_edition_for(current_user)
   end
 
-  def incoming_upload_exists?(path)
-    path = path.sub(Whitehall.clean_uploads_root, Whitehall.incoming_uploads_root)
-    File.exist?(path)
+  def incoming_upload_exists?(*)
+    (@csv_response.status == 302) && (@csv_response.headers['Location'] == placeholder_url)
   end
 
-  def upload_exists?(path)
-    File.exist?(path) && file_is_clean?(path)
+  def upload_exists?(*)
+    @csv_response.status == 206
   end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -2,9 +2,9 @@ class CsvPreviewController < BaseAttachmentsController
   def show
     respond_to do |format|
       format.html do
-        if attachment_data.csv? && attachment_visible? && attachment_data.visible_edition_for(current_user)
+        if attachment_data.csv? && attachment_visible? && visible_edition
           expires_headers
-          @edition = attachment_data.visible_edition_for(current_user)
+          @edition = visible_edition
           @attachment = attachment_data.visible_attachment_for(current_user)
           @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
           render layout: 'html_attachments'
@@ -29,5 +29,9 @@ private
     else
       render plain: "Not found", status: :not_found
     end
+  end
+
+  def visible_edition
+    @visible_edition ||= attachment_data.visible_edition_for(current_user)
   end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -37,7 +37,11 @@ private
   end
 
   def incoming_upload_exists?(*)
-    (@csv_response.status == 302) && (@csv_response.headers['Location'] == placeholder_url)
+    (@csv_response.status == 302) && redirect_path_matches_placeholder_path
+  end
+
+  def redirect_path_matches_placeholder_path
+    URI.parse(@csv_response.headers['Location']).path == placeholder_path
   end
 
   def upload_exists?(*)

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -2,12 +2,12 @@ class CsvPreviewController < BaseAttachmentsController
   def show
     respond_to do |format|
       format.html do
+        @csv_response = CsvFileFromPublicHost.csv_response(attachment_data.file.asset_manager_path)
         if attachment_data.csv? && attachment_visible? && visible_edition
           expires_headers
           @edition = visible_edition
           @attachment = attachment_data.visible_attachment_for(current_user)
-          csv_response = CsvFileFromPublicHost.csv_response(attachment_data.file.asset_manager_path)
-          @csv_preview = CsvFileFromPublicHost.csv_preview_from(csv_response)
+          @csv_preview = CsvFileFromPublicHost.csv_preview_from(@csv_response)
           render layout: 'html_attachments'
         else
           fail

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -13,7 +13,5 @@ class CsvPreviewController < BaseAttachmentsController
         end
       end
     end
-  rescue ActionController::UnknownFormat
-    render status: :not_acceptable, plain: "Request format #{request.format} not handled."
   end
 end

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -6,10 +6,7 @@ class CsvPreviewController < BaseAttachmentsController
           expires_headers
           @edition = attachment_data.visible_edition_for(current_user)
           @attachment = attachment_data.visible_attachment_for(current_user)
-          begin
-            @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
-          rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
-          end
+          @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
           render layout: 'html_attachments'
         else
           fail

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -6,9 +6,7 @@ class CsvPreviewController < BaseAttachmentsController
           expires_headers
           @edition = attachment_data.visible_edition_for(current_user)
           @attachment = attachment_data.visible_attachment_for(current_user)
-          CsvFileFromPublicHost.new(attachment_data.file.asset_manager_path) do |file|
-            @csv_preview = CsvPreview.new(file.path)
-          end
+          @csv_preview = CsvFileFromPublicHost.csv_preview(attachment_data.file.asset_manager_path)
           render layout: 'html_attachments'
         else
           fail

--- a/app/controllers/csv_preview_controller.rb
+++ b/app/controllers/csv_preview_controller.rb
@@ -25,11 +25,7 @@ private
       expires_headers
       redirect_to attachment_data.replaced_by.url, status: 301
     elsif incoming_upload_exists? upload_path
-      if image? upload_path
-        redirect_to view_context.path_to_image('thumbnail-placeholder.png')
-      else
-        redirect_to_placeholder
-      end
+      redirect_to_placeholder
     else
       render plain: "Not found", status: :not_found
     end

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -18,9 +18,6 @@ class CsvFileFromPublicHost
   def initialize(path)
     @path = path
 
-    temp_fn = CGI.escape(@path).truncate(50)
-    temp_dir = File.join(Rails.root, 'tmp')
-
     response = connection.get(@path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
     end
@@ -31,6 +28,9 @@ class CsvFileFromPublicHost
       set_encoding!(body)
       body
     end
+
+    temp_fn = CGI.escape(@path).truncate(50)
+    temp_dir = File.join(Rails.root, 'tmp')
 
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|
       tmp_file.write(csv_file)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -16,6 +16,9 @@ class CsvFileFromPublicHost
   end
 
   def initialize(path)
+    connection = Faraday.new(url: Whitehall.public_root)
+    connection.basic_auth(basic_auth_user, basic_auth_password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
+
     response = connection.get(path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
     end
@@ -38,12 +41,6 @@ class CsvFileFromPublicHost
   end
 
 private
-
-  def connection
-    conn = Faraday.new(url: Whitehall.public_root)
-    conn.basic_auth(basic_auth_user, basic_auth_password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
-    conn
-  end
 
   def basic_auth_user
     basic_auth_credentials[0]

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -5,11 +5,6 @@ class CsvFileFromPublicHost
 
   MAXIMUM_RANGE_BYTES = '300000'.freeze
 
-  def self.csv_preview(path)
-    response = csv_response(path)
-    csv_preview_from(response)
-  end
-
   def self.csv_response(path)
     connection = Faraday.new(url: Whitehall.public_root)
 

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -19,6 +19,8 @@ class CsvFileFromPublicHost
     @path = path
 
     temp_fn = CGI.escape(@path).truncate(50)
+    temp_dir = File.join(Rails.root, 'tmp')
+
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|
       tmp_file.write(csv_file)
       tmp_file.rewind
@@ -47,10 +49,6 @@ private
       set_encoding!(body)
       body
     end
-  end
-
-  def temp_dir
-    File.join(Rails.root, 'tmp')
   end
 
   def basic_auth_user

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -18,6 +18,7 @@ class CsvFileFromPublicHost
   def initialize(path)
     @path = path
 
+    temp_fn = CGI.escape(@path).truncate(50)
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|
       tmp_file.write(csv_file)
       tmp_file.rewind
@@ -50,10 +51,6 @@ private
 
   def temp_dir
     File.join(Rails.root, 'tmp')
-  end
-
-  def temp_fn
-    CGI.escape(@path).truncate(50)
   end
 
   def basic_auth_user

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -11,6 +11,8 @@ class CsvFileFromPublicHost
       csv_preview = CsvPreview.new(file.path)
     end
     csv_preview
+  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
+    nil
   end
 
   def initialize(path)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -6,12 +6,8 @@ class CsvFileFromPublicHost
   MAXIMUM_RANGE_BYTES = '300000'.freeze
 
   def self.csv_preview(path)
-    csv_preview = nil
     response = csv_response(path)
-    new(response) do |file|
-      csv_preview = CsvPreview.new(file.path)
-    end
-    csv_preview
+    csv_preview_from(response)
   rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
     nil
   end
@@ -29,6 +25,14 @@ class CsvFileFromPublicHost
     connection.get(path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
     end
+  end
+
+  def self.csv_preview_from(response)
+    csv_preview = nil
+    new(response) do |file|
+      csv_preview = CsvPreview.new(file.path)
+    end
+    csv_preview
   end
 
   def initialize(response)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -16,9 +16,7 @@ class CsvFileFromPublicHost
   end
 
   def initialize(path)
-    @path = path
-
-    response = connection.get(@path) do |req|
+    response = connection.get(path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
     end
 
@@ -29,7 +27,7 @@ class CsvFileFromPublicHost
       body
     end
 
-    temp_fn = CGI.escape(@path).truncate(50)
+    temp_fn = CGI.escape(path).truncate(50)
     temp_dir = File.join(Rails.root, 'tmp')
 
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -5,6 +5,14 @@ class CsvFileFromPublicHost
 
   MAXIMUM_RANGE_BYTES = '300000'.freeze
 
+  def self.csv_preview(path)
+    csv_preview = nil
+    new(path) do |file|
+      csv_preview = CsvPreview.new(file.path)
+    end
+    csv_preview
+  end
+
   def initialize(path)
     @path = path
 

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -5,11 +5,11 @@ class CsvFileFromPublicHost
 
   MAXIMUM_RANGE_BYTES = '300000'.freeze
 
-  def self.csv_response(path)
+  def self.csv_response(path, env: ENV)
     connection = Faraday.new(url: Whitehall.public_root)
 
-    if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
-      basic_auth_credentials = ENV["BASIC_AUTH_CREDENTIALS"].split(":")
+    if env.has_key?("BASIC_AUTH_CREDENTIALS")
+      basic_auth_credentials = env["BASIC_AUTH_CREDENTIALS"].split(":")
       basic_auth_user = basic_auth_credentials[0]
       basic_auth_password = basic_auth_credentials[1]
       connection.basic_auth(basic_auth_user, basic_auth_password)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -17,7 +17,13 @@ class CsvFileFromPublicHost
 
   def initialize(path)
     connection = Faraday.new(url: Whitehall.public_root)
-    connection.basic_auth(basic_auth_user, basic_auth_password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
+
+    if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
+      basic_auth_credentials = ENV["BASIC_AUTH_CREDENTIALS"].split(":")
+      basic_auth_user = basic_auth_credentials[0]
+      basic_auth_password = basic_auth_credentials[1]
+      connection.basic_auth(basic_auth_user, basic_auth_password)
+    end
 
     response = connection.get(path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
@@ -41,18 +47,6 @@ class CsvFileFromPublicHost
   end
 
 private
-
-  def basic_auth_user
-    basic_auth_credentials[0]
-  end
-
-  def basic_auth_password
-    basic_auth_credentials[1]
-  end
-
-  def basic_auth_credentials
-    ENV["BASIC_AUTH_CREDENTIALS"].split(":")
-  end
 
   def set_encoding!(body)
     if utf_8_encoding?(body)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -21,6 +21,10 @@ class CsvFileFromPublicHost
     temp_fn = CGI.escape(@path).truncate(50)
     temp_dir = File.join(Rails.root, 'tmp')
 
+    response = connection.get(@path) do |req|
+      req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
+    end
+
     csv_file = begin
       raise ConnectionError unless response.status == 206
       body = response.body
@@ -41,12 +45,6 @@ private
     conn = Faraday.new(url: Whitehall.public_root)
     conn.basic_auth(basic_auth_user, basic_auth_password) if ENV.has_key?("BASIC_AUTH_CREDENTIALS")
     conn
-  end
-
-  def response
-    connection.get(@path) do |req|
-      req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
-    end
   end
 
   def basic_auth_user

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -21,6 +21,13 @@ class CsvFileFromPublicHost
     temp_fn = CGI.escape(@path).truncate(50)
     temp_dir = File.join(Rails.root, 'tmp')
 
+    csv_file = begin
+      raise ConnectionError unless response.status == 206
+      body = response.body
+      set_encoding!(body)
+      body
+    end
+
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|
       tmp_file.write(csv_file)
       tmp_file.rewind
@@ -39,15 +46,6 @@ private
   def response
     connection.get(@path) do |req|
       req.headers['Range'] = "bytes=0-#{MAXIMUM_RANGE_BYTES}"
-    end
-  end
-
-  def csv_file
-    @csv_file ||= begin
-      raise ConnectionError unless response.status == 206
-      body = response.body
-      set_encoding!(body)
-      body
     end
   end
 

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -8,8 +8,6 @@ class CsvFileFromPublicHost
   def self.csv_preview(path)
     response = csv_response(path)
     csv_preview_from(response)
-  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
-    nil
   end
 
   def self.csv_response(path)
@@ -33,6 +31,8 @@ class CsvFileFromPublicHost
       csv_preview = CsvPreview.new(file.path)
     end
     csv_preview
+  rescue CsvPreview::FileEncodingError, CSV::MalformedCSVError, CsvFileFromPublicHost::ConnectionError, CsvFileFromPublicHost::FileEncodingError
+    nil
   end
 
   def initialize(response)

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -27,7 +27,7 @@ class CsvFileFromPublicHost
       body
     end
 
-    temp_fn = CGI.escape(path).truncate(50)
+    temp_fn = 'csv-file-from-public-host'
     temp_dir = File.join(Rails.root, 'tmp')
 
     Tempfile.create(temp_fn, temp_dir, encoding: csv_file.encoding) do |tmp_file|

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -376,6 +376,15 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_template 'show'
   end
 
+  test 'renders template even if CsvFileFromPublicHost::FileEncodingError is raised' do
+    setup_stubs
+    CsvFileFromPublicHost.stubs(:new).raises(CsvFileFromPublicHost::FileEncodingError)
+
+    get :show, params: params
+
+    assert_template 'show'
+  end
+
   test 'responds with 406 Not Acceptable if format is unknown' do
     setup_stubs
 

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -350,20 +350,20 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_template 'show', layout: 'html_attachments'
   end
 
-  test 'responds with 406 Not Acceptable if format is unknown' do
+  test 'raises ActionController::UnknownFormat if format is unknown' do
     setup_stubs
 
-    get :show, params: params.merge(format: 'pdf')
-
-    assert_response :not_acceptable
+    assert_raises(ActionController::UnknownFormat) do
+      get :show, params: params.merge(format: 'pdf')
+    end
   end
 
-  test 'responds with 406 Not Acceptable for XHR request if format is unknown' do
+  test 'raises ActionController::UnknownFormat for XHR request if format is unknown' do
     setup_stubs
 
-    get :show, params: params.merge(format: 'pdf'), xhr: true
-
-    assert_response :not_acceptable
+    assert_raises(ActionController::UnknownFormat) do
+      get :show, params: params.merge(format: 'pdf'), xhr: true
+    end
   end
 
   test 'assigns edition for template' do

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -384,6 +384,14 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_response :not_acceptable
   end
 
+  test 'responds with 406 Not Acceptable for XHR request if format is unknown' do
+    setup_stubs
+
+    get :show, params: params.merge(format: 'pdf'), xhr: true
+
+    assert_response :not_acceptable
+  end
+
   test 'assigns edition for template' do
     setup_stubs
 

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -496,7 +496,13 @@ private
     attributes.delete(:visible_attachment)
 
     csv_preview = attributes.fetch(:csv_preview, CsvPreview.new(file))
-    stub_csv_file_from_public_host(csv_preview)
+    csv_response = stub('csv-response')
+    CsvFileFromPublicHost.stubs(:csv_response)
+      .with(attachment_data.file.asset_manager_path)
+      .returns(csv_response)
+    CsvFileFromPublicHost.stubs(:csv_preview_from)
+      .with(csv_response)
+      .returns(csv_preview)
     attributes.delete(:csv_preview)
 
     defaults = {
@@ -510,15 +516,5 @@ private
     }
 
     attachment_data.stubs(defaults.merge(attributes))
-  end
-
-  def stub_csv_file_from_public_host(csv_preview)
-    csv_response = stub('csv-response')
-    CsvFileFromPublicHost.stubs(:csv_response)
-      .with(attachment_data.file.asset_manager_path)
-      .returns(csv_response)
-    CsvFileFromPublicHost.stubs(:csv_preview_from)
-      .with(csv_response)
-      .returns(csv_preview)
   end
 end

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -513,8 +513,12 @@ private
   end
 
   def stub_csv_file_from_public_host(csv_preview)
-    CsvFileFromPublicHost.stubs(:csv_preview)
+    csv_response = stub('csv-response')
+    CsvFileFromPublicHost.stubs(:csv_response)
       .with(attachment_data.file.asset_manager_path)
+      .returns(csv_response)
+    CsvFileFromPublicHost.stubs(:csv_preview_from)
+      .with(csv_response)
       .returns(csv_preview)
   end
 end

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -497,7 +497,7 @@ private
       csv_response.stubs(:status).returns(404)
     when :unscanned
       csv_response.stubs(:status).returns(302)
-      csv_response.stubs(:headers).returns('Location' => placeholder_url)
+      csv_response.stubs(:headers).returns('Location' => 'http://www.example.com/government/placeholder')
     end
 
     CsvFileFromPublicHost.stubs(:csv_response)

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -69,6 +69,16 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_redirected_to unpublished_edition.unpublishing.document_path
   end
 
+  test 'redirects to unpublished edition if attachment data is unpublished & not a CSV' do
+    unpublished_edition = create(:unpublished_edition)
+    setup_stubs(csv?: false, unpublished?: true, unpublished_edition: unpublished_edition)
+
+    get :show, params: params
+
+    assert_response :found
+    assert_redirected_to unpublished_edition.unpublishing.document_path
+  end
+
   test 'redirects to unpublished edition if attachment data is unpublished, draft & not accessible' do
     unpublished_edition = create(:unpublished_edition)
     setup_stubs(draft?: true, accessible_to?: false, unpublished?: true, unpublished_edition: unpublished_edition)
@@ -132,6 +142,16 @@ class CsvPreviewControllerTest < ActionController::TestCase
     assert_redirected_to replacement.url
   end
 
+  test 'permanently redirects to replacement if attachment data is replaced & not CSV' do
+    replacement = create(:attachment_data)
+    setup_stubs(csv?: false, replaced?: true, replaced_by: replacement)
+
+    get :show, params: params
+
+    assert_response :moved_permanently
+    assert_redirected_to replacement.url
+  end
+
   test 'permanently redirects to replacement if attachment data is replaced, draft & not accessible' do
     replacement = create(:attachment_data)
     setup_stubs(draft?: true, accessible_to?: false, replaced?: true, replaced_by: replacement)
@@ -183,6 +203,15 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   test 'redirects to placeholder page if file is unscanned non-image even if deleted' do
     setup_stubs(file_state: :unscanned, deleted?: true)
+
+    get :show, params: params
+
+    assert_response :found
+    assert_redirected_to placeholder_url
+  end
+
+  test 'redirects to placeholder page if file is unscanned non-image even if not CSV' do
+    setup_stubs(file_state: :unscanned, csv?: false)
 
     get :show, params: params
 

--- a/test/functional/csv_preview_controller_test.rb
+++ b/test/functional/csv_preview_controller_test.rb
@@ -7,6 +7,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
   attr_reader :organisation_2
   attr_reader :edition
   attr_reader :attachment
+  attr_reader :csv_preview
 
   setup do
     file = File.open(fixture_path.join('sample.csv'))
@@ -22,6 +23,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
     @organisation_2 = create(:organisation)
     @edition = create(:publication, organisations: [organisation_1, organisation_2])
     @attachment = build(:file_attachment)
+    @csv_preview = CsvPreview.new(file)
 
     controller.stubs(:attachment_data).returns(attachment_data)
   end
@@ -351,7 +353,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   test 'renders template even if CsvPreview::FileEncodingError is raised' do
     setup_stubs
-    CsvPreview.stubs(:new).raises(CsvPreview::FileEncodingError)
+    CsvFileFromPublicHost.stubs(:csv_preview).raises(CsvPreview::FileEncodingError)
 
     get :show, params: params
 
@@ -360,7 +362,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   test 'renders template even if CSV::MalformedCSVError is raised' do
     setup_stubs
-    CsvPreview.stubs(:new).raises(CSV::MalformedCSVError)
+    CsvFileFromPublicHost.stubs(:csv_preview).raises(CSV::MalformedCSVError)
 
     get :show, params: params
 
@@ -369,7 +371,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   test 'renders template even if CsvFileFromPublicHost::ConnectionError is raised' do
     setup_stubs
-    CsvFileFromPublicHost.stubs(:new).raises(CsvFileFromPublicHost::ConnectionError)
+    CsvFileFromPublicHost.stubs(:csv_preview).raises(CsvFileFromPublicHost::ConnectionError)
 
     get :show, params: params
 
@@ -378,7 +380,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   test 'renders template even if CsvFileFromPublicHost::FileEncodingError is raised' do
     setup_stubs
-    CsvFileFromPublicHost.stubs(:new).raises(CsvFileFromPublicHost::FileEncodingError)
+    CsvFileFromPublicHost.stubs(:csv_preview).raises(CsvFileFromPublicHost::FileEncodingError)
 
     get :show, params: params
 
@@ -464,7 +466,7 @@ class CsvPreviewControllerTest < ActionController::TestCase
 
   view_test 'renders error message if CSV::MalformedCSVError is raised' do
     setup_stubs
-    CsvPreview.stubs(:new).raises(CSV::MalformedCSVError)
+    CsvFileFromPublicHost.stubs(:csv_preview).raises(CSV::MalformedCSVError)
 
     get :show, params: params
 
@@ -518,8 +520,8 @@ private
   end
 
   def stub_csv_file_from_public_host
-    CsvFileFromPublicHost.stubs(:new)
+    CsvFileFromPublicHost.stubs(:csv_preview)
       .with(attachment_data.file.asset_manager_path)
-      .yields(stub(path: attachment_data.clean_path))
+      .returns(csv_preview)
   end
 end

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -19,15 +19,6 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new handles a very long filename' do
-    filename = 'a-long-filename' * 1000
-    stub_csv_request(path: filename)
-
-    CsvFileFromPublicHost.new(filename) do |file|
-      assert File.exist?(file.path)
-    end
-  end
-
   test '.new handles utf-8 encoding' do
     stub_csv_request(body: encoding_fixture('utf-8'))
 

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -11,7 +11,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
       .to_return(status: status, body: body)
   end
 
-  test '#new yields a temporary file' do
+  test '.new yields a temporary file' do
     stub_csv_request
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -28,7 +28,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new handles utf-8 encoding' do
+  test '.new handles utf-8 encoding' do
     stub_csv_request(body: encoding_fixture('utf-8'))
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -36,7 +36,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new handles iso-8859-1 encoded files' do
+  test '.new handles iso-8859-1 encoded files' do
     stub_csv_request(body: encoding_fixture('iso-8859-1'))
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -44,7 +44,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new handles windows-1252 encoded files' do
+  test '.new handles windows-1252 encoded files' do
     stub_csv_request(body: encoding_fixture('windows-1252'))
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -52,7 +52,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new yields a temporary file that contains the contents of the request body' do
+  test '.new yields a temporary file that contains the contents of the request body' do
     stub_csv_request(body: 'csv,file')
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -60,7 +60,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '#new raises an exception if the request status is anything other than 206' do
+  test '.new raises an exception if the request status is anything other than 206' do
     [404, 502, 503].each do |status|
       stub_csv_request(status: status)
       assert_raises(CsvFileFromPublicHost::ConnectionError) { CsvFileFromPublicHost.new('some-path') }

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -66,62 +66,52 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '.csv_preview builds and returns a CsvPreview using response body' do
+  test '.csv_preview_from builds and returns a CsvPreview using response body' do
     response = stub('response')
-    CsvFileFromPublicHost.stubs(:csv_response).with('some-path')
-      .returns(response)
     file = stub('file', path: 'some-path')
     CsvFileFromPublicHost.stubs(:new).with(response).yields(file)
     csv_preview = stub('csv-preview')
     CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
 
-    assert_equal csv_preview, CsvFileFromPublicHost.csv_preview('some-path')
+    assert_equal csv_preview, CsvFileFromPublicHost.csv_preview_from(response)
   end
 
-  test '.csv_preview returns nil if CsvPreview::FileEncodingError is raised' do
+  test '.csv_preview_from returns nil if CsvPreview::FileEncodingError is raised' do
     response = stub('response')
-    CsvFileFromPublicHost.stubs(:csv_response).with('some-path')
-      .returns(response)
     file = stub('file', path: 'some-path')
     CsvFileFromPublicHost.stubs(:new).with(response).yields(file)
     CsvPreview.stubs(:new).with('some-path').raises(CsvPreview::FileEncodingError)
 
-    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+    assert_nil CsvFileFromPublicHost.csv_preview_from(response)
   end
 
-  test '.csv_preview returns nil if CSV::MalformedCSVError is raised' do
+  test '.csv_preview_from returns nil if CSV::MalformedCSVError is raised' do
     response = stub('response')
-    CsvFileFromPublicHost.stubs(:csv_response).with('some-path')
-      .returns(response)
     file = stub('file', path: 'some-path')
     CsvFileFromPublicHost.stubs(:new).with(response).yields(file)
     CsvPreview.stubs(:new).with('some-path').raises(CSV::MalformedCSVError)
 
-    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+    assert_nil CsvFileFromPublicHost.csv_preview_from(response)
   end
 
-  test '.csv_preview returns nil if CsvFileFromPublicHost::ConnectionError is raised' do
+  test '.csv_preview_from returns nil if CsvFileFromPublicHost::ConnectionError is raised' do
     response = stub('response')
-    CsvFileFromPublicHost.stubs(:csv_response).with('some-path')
-      .returns(response)
     CsvFileFromPublicHost.stubs(:new).with(response)
       .raises(CsvFileFromPublicHost::ConnectionError)
     csv_preview = stub('csv-preview')
     CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
 
-    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+    assert_nil CsvFileFromPublicHost.csv_preview_from(response)
   end
 
-  test '.csv_preview returns nil if CsvFileFromPublicHost::FileEncodingError is raised' do
+  test '.csv_preview_from returns nil if CsvFileFromPublicHost::FileEncodingError is raised' do
     response = stub('response')
-    CsvFileFromPublicHost.stubs(:csv_response).with('some-path')
-      .returns(response)
     CsvFileFromPublicHost.stubs(:new).with(response)
       .raises(CsvFileFromPublicHost::FileEncodingError)
     csv_preview = stub('csv-preview')
     CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
 
-    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+    assert_nil CsvFileFromPublicHost.csv_preview_from(response)
   end
 
   test '#csv_response uses basic authentication if set in the environment' do

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -52,7 +52,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '.new yields a temporary file that contains the contents of the request body' do
+  test '.new yields a temporary file that contains the contents of the response body' do
     stub_csv_request(body: 'csv,file')
 
     CsvFileFromPublicHost.new('some-path') do |file|
@@ -60,7 +60,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
-  test '.new raises an exception if the request status is anything other than 206' do
+  test '.new raises an exception if the response status is anything other than 206' do
     [404, 502, 503].each do |status|
       stub_csv_request(status: status)
       assert_raises(CsvFileFromPublicHost::ConnectionError) { CsvFileFromPublicHost.new('some-path') }

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -67,6 +67,15 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     end
   end
 
+  test '.csv_preview builds and returns a CsvPreview using response body' do
+    file = stub('file', path: 'some-path')
+    CsvFileFromPublicHost.stubs(:new).with('some-path').yields(file)
+    csv_preview = stub('csv-preview')
+    CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
+
+    assert_equal csv_preview, CsvFileFromPublicHost.csv_preview('some-path')
+  end
+
   test 'uses basic authentication if set in the environment' do
     ENV.stubs(:[]).with('BASIC_AUTH_CREDENTIALS').returns('user:password')
     ENV.stubs(:has_key?).with('BASIC_AUTH_CREDENTIALS').returns(true)

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -115,16 +115,10 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
   end
 
   test '#csv_response uses basic authentication if set in the environment' do
-    ENV.stubs(:[]).with('BASIC_AUTH_CREDENTIALS').returns('user:password')
-    ENV.stubs(:has_key?).with('BASIC_AUTH_CREDENTIALS').returns(true)
-    mock_response = mock('response')
-    mock_response.stubs(status: 206, body: '')
-    mock_connection = mock('connection')
-    mock_connection.stubs(get: mock_response)
-    Faraday.stubs(:new).returns(mock_connection)
+    stub_csv_request.with(basic_auth: %w(user password))
+    env = { 'BASIC_AUTH_CREDENTIALS' => 'user:password' }
 
-    mock_connection.expects(:basic_auth).at_least_once.with('user', 'password')
-
-    CsvFileFromPublicHost.csv_response('some-path')
+    response = CsvFileFromPublicHost.csv_response('some-path', env: env)
+    assert_equal 206, response.status
   end
 end

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -76,6 +76,40 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     assert_equal csv_preview, CsvFileFromPublicHost.csv_preview('some-path')
   end
 
+  test '.csv_preview returns nil if CsvPreview::FileEncodingError is raised' do
+    file = stub('file', path: 'some-path')
+    CsvFileFromPublicHost.stubs(:new).with('some-path').yields(file)
+    CsvPreview.stubs(:new).with('some-path').raises(CsvPreview::FileEncodingError)
+
+    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+  end
+
+  test '.csv_preview returns nil if CSV::MalformedCSVError is raised' do
+    file = stub('file', path: 'some-path')
+    CsvFileFromPublicHost.stubs(:new).with('some-path').yields(file)
+    CsvPreview.stubs(:new).with('some-path').raises(CSV::MalformedCSVError)
+
+    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+  end
+
+  test '.csv_preview returns nil if CsvFileFromPublicHost::ConnectionError is raised' do
+    CsvFileFromPublicHost.stubs(:new).with('some-path')
+      .raises(CsvFileFromPublicHost::ConnectionError)
+    csv_preview = stub('csv-preview')
+    CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
+
+    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+  end
+
+  test '.csv_preview returns nil if CsvFileFromPublicHost::FileEncodingError is raised' do
+    CsvFileFromPublicHost.stubs(:new).with('some-path')
+      .raises(CsvFileFromPublicHost::FileEncodingError)
+    csv_preview = stub('csv-preview')
+    CsvPreview.stubs(:new).with('some-path').returns(csv_preview)
+
+    assert_nil CsvFileFromPublicHost.csv_preview('some-path')
+  end
+
   test 'uses basic authentication if set in the environment' do
     ENV.stubs(:[]).with('BASIC_AUTH_CREDENTIALS').returns('user:password')
     ENV.stubs(:has_key?).with('BASIC_AUTH_CREDENTIALS').returns(true)


### PR DESCRIPTION
The motivation to do this is to make it easier to switch over to use `AssetManagerStorage` in `AttachmentUploader`.

This PR does the following:

* Simplifies/improves `CsvPreviewController` and its tests
* Splits `CsvFileFromPublicHost.new` into two methods so controller has access to HTTP response from range request
* Uses HTTP response from `CsvFileFromPublicHost` to implement `CsvPreviewController#incoming_upload_exists?` and `#upload_exists?` without accessing file system

I'm not very happy with how this leaves the implementation of `CsvFileFromPublicHost`, but I think it'll do for now.

Things still left to do:

* [x] Test on development VM and/or integration
* [x] The comparison of the placeholder URL in `CsvPreviewController#incoming_upload_exists?` might be wrong because of host differences

/cc @chrisroos @chrislo 