### PR TITLE
Cope with long filenames in the CSV preview

### DIFF
--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -43,7 +43,7 @@ private
   end
 
   def temp_fn
-    CGI.escape(@path)
+    CGI.escape(@path).truncate(50)
   end
 
   def basic_auth_user

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -5,8 +5,8 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     File.open(Rails.root.join("test/fixtures/csv_encodings/#{encoding}.csv"))
   end
 
-  def stub_csv_request(status: 206, body: '')
-    stub_request(:get, "#{Whitehall.public_root}/some-path")
+  def stub_csv_request(status: 206, body: '', path: 'some-path')
+    stub_request(:get, "#{Whitehall.public_root}/#{path}")
       .with(headers: { 'Range' => 'bytes=0-300000' })
       .to_return(status: status, body: body)
   end
@@ -15,6 +15,15 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
     stub_csv_request
 
     CsvFileFromPublicHost.new('some-path') do |file|
+      assert File.exist?(file.path)
+    end
+  end
+
+  test '#new handles a very long filename' do
+    filename = 'a-long-filename' * 1000
+    stub_csv_request(path: filename)
+
+    CsvFileFromPublicHost.new(filename) do |file|
       assert File.exist?(file.path)
     end
   end


### PR DESCRIPTION
This truncates the input we give to `Tempfile` to ensure the filenames don't end up being too long.