### PR TITLE
Redirect attachment requests to asset host

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -2,6 +2,12 @@ class AttachmentsController < BaseAttachmentsController
   include PublicDocumentRoutesHelper
 
   def show
+    asset_host = URI.parse(Plek.new.public_asset_host).host
+    unless request.host == asset_host
+      redirect_to host: asset_host
+      return
+    end
+
     if attachment_visible?
       expires_headers
       send_file_for_mime_type

--- a/features/step_definitions/attachment_preview_steps.rb
+++ b/features/step_definitions/attachment_preview_steps.rb
@@ -9,7 +9,8 @@ end
 When(/^I preview the contents of the attachment$/) do
   fn = File.join(Whitehall.clean_uploads_root, @attachment.file.store_path)
 
-  stub_request(:get, "https://www.test.gov.uk/government/uploads/system/uploads/attachment_data/file/#{@attachment.id}/sample.csv")
+  asset_host = URI.parse(Plek.new.public_asset_host).host
+  stub_request(:get, "https://#{asset_host}/government/uploads/system/uploads/attachment_data/file/#{@attachment.id}/sample.csv")
     .with(headers: {'Range'=>'bytes=0-300000'})
     .to_return(status: 206, body: File.read(fn))
 

--- a/lib/csv_file_from_public_host.rb
+++ b/lib/csv_file_from_public_host.rb
@@ -6,7 +6,7 @@ class CsvFileFromPublicHost
   MAXIMUM_RANGE_BYTES = '300000'.freeze
 
   def self.csv_response(path, env: ENV)
-    connection = Faraday.new(url: Whitehall.public_root)
+    connection = Faraday.new(url: Plek.new.public_asset_host)
 
     if env.has_key?("BASIC_AUTH_CREDENTIALS")
       basic_auth_credentials = env["BASIC_AUTH_CREDENTIALS"].split(":")

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -21,10 +21,31 @@ class AttachmentsControllerTest < ActionController::TestCase
     @edition = create(:publication)
 
     controller.stubs(:attachment_data).returns(attachment_data)
+
+    request.host = 'asset-host.com'
+    Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
   end
 
   teardown do
     AttachmentUploader.enable_processing = false
+  end
+
+  test "redirects asset requests that aren't made via the asset host" do
+    request.host = 'not-asset-host.com'
+
+    get :show, params: params
+
+    assert_redirected_to "http://asset-host.com#{attachment_data.file.asset_manager_path}"
+  end
+
+  test 'does not redirect asset requests that are made via the asset host' do
+    setup_stubs
+
+    request.host = 'asset-host.com'
+
+    get :show, params: params
+
+    assert_response 200
   end
 
   # Unpublished

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -26,6 +26,9 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       visit admin_news_article_path(edition)
       click_link 'Modify attachments'
       @attachment_url = find('.existing-attachments a', text: filename)[:href]
+
+      asset_host = URI.parse(Plek.new.public_asset_host).host
+      host! asset_host
     end
 
     context 'when attachment is deleted' do

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -20,6 +20,9 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     attachable.attachments << attachment
     VirusScanHelpers.simulate_virus_scan
     stub_whitehall_asset(filename, id: asset_id)
+
+    asset_host = URI.parse(Plek.new.public_asset_host).host
+    host! asset_host
   end
 
   context 'given a published document with file attachment' do

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -22,6 +22,9 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
     setup_publishing_api_for(edition)
     stub_whitehall_asset(filename, id: asset_id)
     VirusScanHelpers.simulate_virus_scan
+
+    asset_host = URI.parse(Plek.new.public_asset_host).host
+    host! asset_host
   end
 
   context 'given a draft document with a file attachment' do

--- a/test/unit/csv_file_from_public_host_test.rb
+++ b/test/unit/csv_file_from_public_host_test.rb
@@ -6,7 +6,7 @@ class CsvFileFromPublicHostTest < ActiveSupport::TestCase
   end
 
   def stub_csv_request(status: 206, body: '', path: 'some-path')
-    stub_request(:get, "#{Whitehall.public_root}/#{path}")
+    stub_request(:get, "#{Plek.new.public_asset_host}/#{path}")
       .with(headers: { 'Range' => 'bytes=0-300000' })
       .to_return(status: status, body: body)
   end


### PR DESCRIPTION
It's currently possible to request Whitehall attachments at /government/uploads/attachment_data/file via both www.gov.uk and the asset host (e.g.  assets.publishing.gov.uk). We want all asset requests to go via the asset host so that we can make changes to the config in a single place.

I'm using `Plek#public_asset_host` as [it returns "The public-facing asset base URL"][1]. I've tested this on integration and confirmed that it returns 'https://assets-origin.integration.publishing.service.gov.uk'.

This is very similar to the redirect added in 0aa298afeb19a55dc56954712729af585ee2568c.

[1]: https://github.com/alphagov/plek/blob/4d63a574ab36e9e8833ff14471482d1cbb110e61/lib/plek.rb#L97