### PR TITLE
Avoid exceptions for deleted attachments

### DIFF
--- a/app/workers/asset_manager_attachment_access_limited_worker.rb
+++ b/app/workers/asset_manager_attachment_access_limited_worker.rb
@@ -7,16 +7,16 @@ class AssetManagerAttachmentAccessLimitedWorker < WorkerBase
       access_limited = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
     end
 
-    enqueue_job(attachment_data.file, access_limited)
+    enqueue_job(attachment_data, attachment_data.file, access_limited)
     if attachment_data.pdf?
-      enqueue_job(attachment_data.file.thumbnail, access_limited)
+      enqueue_job(attachment_data, attachment_data.file.thumbnail, access_limited)
     end
   end
 
 private
 
-  def enqueue_job(uploader, access_limited)
+  def enqueue_job(attachment_data, uploader, access_limited)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'access_limited' => access_limited)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'access_limited' => access_limited)
   end
 end

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -3,16 +3,16 @@ class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
     draft = attachment_data.draft? && !attachment_data.unpublished?
-    enqueue_job(attachment_data.file, draft)
+    enqueue_job(attachment_data, attachment_data.file, draft)
     if attachment_data.pdf?
-      enqueue_job(attachment_data.file.thumbnail, draft)
+      enqueue_job(attachment_data, attachment_data.file.thumbnail, draft)
     end
   end
 
 private
 
-  def enqueue_job(uploader, draft)
+  def enqueue_job(attachment_data, uploader, draft)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'draft' => draft)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'draft' => draft)
   end
 end

--- a/app/workers/asset_manager_attachment_link_header_update_worker.rb
+++ b/app/workers/asset_manager_attachment_link_header_update_worker.rb
@@ -7,16 +7,16 @@ class AssetManagerAttachmentLinkHeaderUpdateWorker < WorkerBase
 
     parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
 
-    enqueue_job(attachment_data.file, parent_document_url)
+    enqueue_job(attachment_data, attachment_data.file, parent_document_url)
     if attachment_data.pdf?
-      enqueue_job(attachment_data.file.thumbnail, parent_document_url)
+      enqueue_job(attachment_data, attachment_data.file.thumbnail, parent_document_url)
     end
   end
 
 private
 
-  def enqueue_job(uploader, parent_document_url)
+  def enqueue_job(attachment_data, uploader, parent_document_url)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'parent_document_url' => parent_document_url)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'parent_document_url' => parent_document_url)
   end
 end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -6,16 +6,16 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
     if attachment_data.unpublished?
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
     end
-    enqueue_job(attachment_data.file, redirect_url)
+    enqueue_job(attachment_data, attachment_data.file, redirect_url)
     if attachment_data.pdf?
-      enqueue_job(attachment_data.file.thumbnail, redirect_url)
+      enqueue_job(attachment_data, attachment_data.file.thumbnail, redirect_url)
     end
   end
 
 private
 
-  def enqueue_job(uploader, redirect_url)
+  def enqueue_job(attachment_data, uploader, redirect_url)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'redirect_url' => redirect_url)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'redirect_url' => redirect_url)
   end
 end

--- a/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
+++ b/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
@@ -5,17 +5,17 @@ class AssetManagerAttachmentReplacementIdUpdateWorker < WorkerBase
     return unless attachment_data.replaced?
     replacement = attachment_data.replaced_by
 
-    replace_path(attachment_data.file.asset_manager_path, replacement.file.asset_manager_path)
+    replace_path(attachment_data, attachment_data.file.asset_manager_path, replacement.file.asset_manager_path)
     if attachment_data.pdf?
       if replacement.pdf?
-        replace_path(attachment_data.file.thumbnail.asset_manager_path, replacement.file.thumbnail.asset_manager_path)
+        replace_path(attachment_data, attachment_data.file.thumbnail.asset_manager_path, replacement.file.thumbnail.asset_manager_path)
       else
-        replace_path(attachment_data.file.thumbnail.asset_manager_path, replacement.file.asset_manager_path)
+        replace_path(attachment_data, attachment_data.file.thumbnail.asset_manager_path, replacement.file.asset_manager_path)
       end
     end
   end
 
-  def replace_path(legacy_url_path, replacement_legacy_url_path)
-    AssetManagerUpdateAssetWorker.new.perform(legacy_url_path, 'replacement_legacy_url_path' => replacement_legacy_url_path)
+  def replace_path(attachment_data, legacy_url_path, replacement_legacy_url_path)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'replacement_legacy_url_path' => replacement_legacy_url_path)
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,4 +1,4 @@
-class AssetManagerUpdateAssetWorker < WorkerBase
+class AssetManagerUpdateAssetWorker
   include AssetManagerWorkerHelper
 
   def perform(legacy_url_path, new_attributes = {})

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -114,7 +114,6 @@ private
       .with(asset_id, 'draft' => draft)
     expectation.never if never
     AssetManagerAttachmentDraftStatusUpdateWorker.drain
-    AssetManagerUpdateAssetWorker.drain
   end
 
   def refute_sets_draft_status_in_asset_manager_to(draft)

--- a/test/unit/workers/asset_manager_attachment_access_limited_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_access_limited_worker_test.rb
@@ -35,7 +35,7 @@ class AssetManagerAttachmentAccessLimitedWorkerTest < ActiveSupport::TestCase
 
     it 'updates the access limited state of the asset' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'access_limited' => ['user-uid'])
+        .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => ['user-uid'])
 
       worker.perform(attachment_data.id)
     end
@@ -57,9 +57,9 @@ class AssetManagerAttachmentAccessLimitedWorkerTest < ActiveSupport::TestCase
 
     it "updates the access limited state of the asset and it's thumbnail" do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'access_limited' => ['user-uid'])
+        .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => ['user-uid'])
       update_worker.expects(:perform)
-        .with(attachment.file.thumbnail.asset_manager_path, 'access_limited' => ['user-uid'])
+        .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'access_limited' => ['user-uid'])
 
       worker.perform(attachment_data.id)
     end
@@ -75,7 +75,7 @@ class AssetManagerAttachmentAccessLimitedWorkerTest < ActiveSupport::TestCase
 
     it 'updates the asset to have an empty access_limited array' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'access_limited' => [])
+        .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => [])
 
       worker.perform(attachment_data.id)
     end
@@ -91,9 +91,9 @@ class AssetManagerAttachmentAccessLimitedWorkerTest < ActiveSupport::TestCase
 
     it 'updates the asset to have an empty access_limited array' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'access_limited' => [])
+        .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => [])
       update_worker.expects(:perform)
-        .with(attachment.file.thumbnail.asset_manager_path, 'access_limited' => [])
+        .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'access_limited' => [])
 
       worker.perform(attachment_data.id)
     end

--- a/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_draft_status_update_worker_test.rb
@@ -23,7 +23,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
 
     it 'marks corresponding asset as draft' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'draft' => true)
+        .with(attachment_data, attachment.file.asset_manager_path, 'draft' => true)
 
       worker.perform(attachment_data.id)
     end
@@ -51,9 +51,9 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
 
     it 'marks asset for attachment & its thumbnail as draft' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'draft' => true)
+        .with(attachment_data, attachment.file.asset_manager_path, 'draft' => true)
       update_worker.expects(:perform)
-        .with(attachment.file.thumbnail.asset_manager_path, 'draft' => true)
+        .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => true)
 
       worker.perform(attachment_data.id)
     end
@@ -63,9 +63,9 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
 
       it 'marks corresponding assets as not draft' do
         update_worker.expects(:perform)
-          .with(attachment.file.asset_manager_path, 'draft' => false)
+          .with(attachment_data, attachment.file.asset_manager_path, 'draft' => false)
         update_worker.expects(:perform)
-          .with(attachment.file.thumbnail.asset_manager_path, 'draft' => false)
+          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => false)
 
         worker.perform(attachment_data.id)
       end
@@ -76,9 +76,9 @@ class AssetManagerAttachmentDraftStatusUpdateWorkerTest < ActiveSupport::TestCas
 
       it 'marks corresponding assets as not draft even though attachment is draft' do
         update_worker.expects(:perform)
-          .with(attachment.file.asset_manager_path, 'draft' => false)
+          .with(attachment_data, attachment.file.asset_manager_path, 'draft' => false)
         update_worker.expects(:perform)
-          .with(attachment.file.thumbnail.asset_manager_path, 'draft' => false)
+          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => false)
 
         worker.perform(attachment_data.id)
       end

--- a/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_link_header_update_worker_test.rb
@@ -39,7 +39,7 @@ class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
 
     it 'sets parent_document_url of corresponding asset' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'parent_document_url' => parent_document_url)
+        .with(attachment_data, attachment.file.asset_manager_path, 'parent_document_url' => parent_document_url)
 
       worker.perform(attachment_data.id)
     end
@@ -51,9 +51,9 @@ class AssetManagerAttachmentLinkHeaderUpdateWorkerTest < ActiveSupport::TestCase
 
     it 'sets parent_document_url for attachment & its thumbnail' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'parent_document_url' => parent_document_url)
+        .with(attachment_data, attachment.file.asset_manager_path, 'parent_document_url' => parent_document_url)
       update_worker.expects(:perform)
-        .with(attachment.file.thumbnail.asset_manager_path, 'parent_document_url' => parent_document_url)
+        .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'parent_document_url' => parent_document_url)
 
       worker.perform(attachment_data.id)
     end

--- a/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -36,7 +36,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
 
     it 'updates redirect URL of corresponding asset' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'redirect_url' => redirect_url)
+        .with(attachment_data, attachment.file.asset_manager_path, 'redirect_url' => redirect_url)
 
       worker.perform(attachment_data.id)
     end
@@ -54,9 +54,9 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
 
     it 'updates redirect URL of asset for attachment & its thumbnail' do
       update_worker.expects(:perform)
-        .with(attachment.file.asset_manager_path, 'redirect_url' => redirect_url)
+        .with(attachment_data, attachment.file.asset_manager_path, 'redirect_url' => redirect_url)
       update_worker.expects(:perform)
-        .with(attachment.file.thumbnail.asset_manager_path, 'redirect_url' => redirect_url)
+        .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'redirect_url' => redirect_url)
 
       worker.perform(attachment_data.id)
     end
@@ -67,9 +67,9 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
 
       it 'resets redirect URL of asset for attachment & its thumbnail' do
         update_worker.expects(:perform)
-          .with(attachment.file.asset_manager_path, 'redirect_url' => nil)
+          .with(attachment_data, attachment.file.asset_manager_path, 'redirect_url' => nil)
         update_worker.expects(:perform)
-          .with(attachment.file.thumbnail.asset_manager_path, 'redirect_url' => nil)
+          .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'redirect_url' => nil)
 
         worker.perform(attachment_data.id)
       end

--- a/test/unit/workers/asset_manager_attachment_replacement_id_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_replacement_id_update_worker_test.rb
@@ -20,7 +20,7 @@ class AssetManagerAttachmentReplacementIdUpdateWorkerTest < ActiveSupport::TestC
 
     it 'updates replacement ID of corresponding asset' do
       update_worker.expects(:perform)
-        .with(attachment_data.file.asset_manager_path, attributes)
+        .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
 
       worker.perform(attachment_data.id)
     end
@@ -58,9 +58,9 @@ class AssetManagerAttachmentReplacementIdUpdateWorkerTest < ActiveSupport::TestC
 
     it 'updates replacement ID of asset for attachment & its thumbnail' do
       update_worker.expects(:perform)
-        .with(attachment_data.file.asset_manager_path, attributes)
+        .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
       update_worker.expects(:perform)
-        .with(attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+        .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
       worker.perform(attachment_data.id)
     end
@@ -72,9 +72,9 @@ class AssetManagerAttachmentReplacementIdUpdateWorkerTest < ActiveSupport::TestC
 
       it 'updates replacement ID of asset for attachment & its thumbnail' do
         update_worker.expects(:perform)
-          .with(attachment_data.file.asset_manager_path, attributes)
+          .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
         update_worker.expects(:perform)
-          .with(attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
+          .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
         worker.perform(attachment_data.id)
       end


### PR DESCRIPTION
If we can't find the asset in Asset Manager (i.e. we get a `GdsApi::HTTPNotFound` exception) then it means that the asset has been deleted or that it never existed. In either case, if the asset has also been deleted from Whitehall then there's nothing to do as a request for the asset in either app will result in a 404 so the behaviour remains the same.

Note that it's theoretically possible for Whitehall to have marked an asset as deleted in Asset Manager before then trying to update some other metadata about it (e.g. its access-limited state). If this happens, and if we were then to undelete the asset in Asset Manager; it might not be in the state we'd expect. We're not worried about this at the moment as there's currently no way through the user-interface to undelete assets from Whitehall.
