### PR TITLE
Avoid setting draft to true on replaced assets in Asset Manager

### DIFF
--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -2,7 +2,7 @@ class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
-    draft = attachment_data.draft? && !attachment_data.unpublished?
+    draft = attachment_data.draft? && !attachment_data.unpublished? && !attachment_data.replaced?
     enqueue_job(attachment_data, attachment_data.file, draft)
     if attachment_data.pdf?
       enqueue_job(attachment_data, attachment_data.file.thumbnail, draft)


### PR DESCRIPTION
Currently we are seeing exceptions from the `AssetManagerAttachmentDraftStatusUpdateWorker` when we attempt to set `draft` to `true` on an asset that has already been replaced. This raises an `GdsApi::HTTPUnprocessableEntity` exception with the message (from Asset Manager) `"Draft cannot be true, because already replaced"`.

Assets in Whitehall that have public URLs that redirect to other assets can be "draft" in Whitehall as the code doesn't enforce this edge case. In Asset Manager however we are a bit stricter and raise the above exception to notify the clients.

This PR avoids raising the exception in the first place by setting the 'draft' flag to `false` in Asset Manager in this case.