### PR TITLE
Capitalise email subscription list titles correctly

### DIFF
--- a/app/models/email_signup/feed_url_validator.rb
+++ b/app/models/email_signup/feed_url_validator.rb
@@ -13,7 +13,7 @@ class EmailSignup
 
     def description
       if valid?
-        [leading_fragment, parameter_fragments, command_and_act_fragment].compact.join " "
+        [leading_fragment, parameter_fragments, command_and_act_fragment].compact.join(" ").upcase_first
       end
     end
 

--- a/test/unit/email_signup/feed_url_validator_test.rb
+++ b/test/unit/email_signup/feed_url_validator_test.rb
@@ -15,7 +15,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal "publications", validator.description
+    assert_equal "Publications", validator.description
   end
 
   test 'validates and describes a publication filter feed url with filter options' do
@@ -34,7 +34,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal "corporate reports related to The Cabinet Office, Arts and culture and Afghanistan which are command or act papers", validator.description
+    assert_equal "Corporate reports related to The Cabinet Office, Arts and culture and Afghanistan which are command or act papers", validator.description
   end
 
   test 'validates and describes an announcements filter feed url' do
@@ -51,7 +51,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal "announcements related to The Cabinet Office, Arts and culture and Afghanistan", validator.description
+    assert_equal "Announcements related to The Cabinet Office, Arts and culture and Afghanistan", validator.description
   end
 
   test 'validates and describes a statistics filter feed url with filter options' do
@@ -66,7 +66,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal "statistics related to The Cabinet Office and Arts and culture", validator.description
+    assert_equal "Statistics related to The Cabinet Office and Arts and culture", validator.description
   end
 
   test 'uses the announcement_filter_option when given' do
@@ -74,7 +74,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal "fatality notices", validator.description
+    assert_equal "Fatality notices", validator.description
   end
 
   test 'validates and describes an organisation feed url' do
@@ -83,7 +83,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal organisation.name, validator.description
+    assert_equal organisation.name.upcase_first, validator.description
   end
 
   test 'validates and describes a topic feed url' do
@@ -92,7 +92,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal topic.name, validator.description
+    assert_equal topic.name.upcase_first, validator.description
   end
 
   test 'validates and describes a topical event feed url' do
@@ -101,7 +101,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator     = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal topical_event.name, validator.description
+    assert_equal topical_event.name.upcase_first, validator.description
   end
 
   test 'validates and describes a world location feed url' do
@@ -110,7 +110,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator      = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal world_location.name, validator.description
+    assert_equal world_location.name.upcase_first, validator.description
   end
 
   test 'validates and describes a person feed url' do
@@ -128,7 +128,7 @@ class EmailSignup::FeedUrlValidatorTest < ActiveSupport::TestCase
     validator = klass.new(feed_url)
 
     assert validator.valid?
-    assert_equal role.name, validator.description
+    assert_equal role.name.upcase_first, validator.description
   end
 
   test 'does not validate a feed url for another host' do

--- a/test/unit/email_signup_test.rb
+++ b/test/unit/email_signup_test.rb
@@ -10,7 +10,7 @@ class EmailSignupTest < ActiveSupport::TestCase
 
     email_alert_api_does_not_have_subscriber_list("email_document_supertype" => "publications")
     email_alert_api_creates_subscriber_list(response).with do |request|
-      assert_equal "publications", JSON.parse(request.body)["title"]
+      assert_equal "Publications", JSON.parse(request.body)["title"]
     end
 
     assert email_signup.save
@@ -40,7 +40,7 @@ class EmailSignupTest < ActiveSupport::TestCase
   test "#description provides a human-readable description of the filters being applied" do
     feed_url = feed_url("publications.atom?official_document_status=command_and_act_papers")
 
-    expected = "publications which are command or act papers"
+    expected = "Publications which are command or act papers"
     assert_equal expected, EmailSignup.new(feed: feed_url).description
   end
 


### PR DESCRIPTION
This commit adds `upcase_first` to always uppercase descriptions for feeds, which are used in email subscription list titles.

Trello: https://trello.com/c/msKlizQT/641-make-subscription-titles-great-again