### PR TITLE
Generate missing thumbnails

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -32,6 +32,17 @@ namespace :asset_manager do
     AssetManagerAttachmentMetadataUpdater.update_range(args[:batch_start].to_i, args[:batch_end].to_i)
   end
 
+  task generate_missing_thumbnails: :environment do
+    [332963, 310979, 199066, 318696, 311266, 321710, 199068, 326576, 69897, 417180, 371318, 501885, 418558].each do |id|
+      begin
+        attachment_data = AttachmentData.find(id)
+        attachment_data.file.recreate_versions!
+      rescue ActiveRecord::RecordNotFound => e
+        puts e
+      end
+    end
+  end
+
   private
 
   def usage_string

--- a/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
+++ b/lib/whitehall/asset_manager_and_quarantined_file_storage.rb
@@ -14,7 +14,7 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage < CarrierWave::Storage::A
   end
 
   class File
-    delegate :path, :content_type, :filename, to: :@quarantined_file
+    delegate :read, :path, :content_type, :filename, to: :@quarantined_file
 
     def initialize(asset_manager_file, quarantined_file)
       @asset_manager_file = asset_manager_file

--- a/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
+++ b/test/unit/whitehall/asset_manager_and_quarantined_file_storage_test.rb
@@ -71,6 +71,12 @@ class Whitehall::AssetManagerAndQuarantinedFileStorage::FileTest < ActiveSupport
     assert_equal 'quarantined-file-path', @file.path
   end
 
+  test '#read delegates to the quarantined file' do
+    @quarantined_file.stubs(:read).returns('quarantined-file-read')
+
+    assert_equal 'quarantined-file-read', @file.read
+  end
+
   test '#filename delegates to the quarantined file' do
     @quarantined_file.stubs(:filename).returns('quarantined-file-filename')
 


### PR DESCRIPTION
When running the AssetManagerAttachmentMetadataUpdater task we encountered a number of exceptions that were due to thumbnail files not being found in Asset Manager. After investigation we noticed that these files are not present on the NFS mount for Whitehall.

Our migration of all files from Whitehall to Asset Manager was based on the files on disk so this explains why these are missing. Our best guess is that something either went wrong with the [thumbnail generation](https://github.com/alphagov/whitehall/blob/0545394231b8a028935116e1ca8740b96591af1c/app/uploaders/attachment_uploader.rb#L55) or these assets were added before the thumbnail generation code was made more robust. 

In either case it seems simplest to simply regenerate the missing thumbnails and allow them to be uploaded to Asset Manager. The rake task in this PR does that for the attachment ids extracted from the exceptions in [Sentry](https://sentry.io/govuk/app-whitehall/issues/504366848/) that were due to missing thumbnails.
