### PR TITLE
Fix redirect when filename contains multiple periods

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,6 +19,10 @@ class AttachmentsController < BaseAttachmentsController
 
 private
 
+  def file_with_extensions
+    [params[:file], params[:format]].compact.join('.')
+  end
+
   def link_rel_headers
     if (edition = attachment_data.visible_edition_for(current_user))
       response.headers['Link'] = "<#{public_document_url(edition)}>; rel=\"up\""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,7 +421,7 @@ Whitehall::Application.routes.draw do
   get '/guidance/:id(.:locale)', as: 'detailed_guide', to: 'detailed_guides#show', constraints: { id: /[A-z0-9\-]+/, locale: VALID_LOCALES_REGEX }
 
   get '/government/uploads/system/uploads/consultation_response_form/*path.:extension' => LongLifeRedirect.new('/government/uploads/system/uploads/consultation_response_form_data/')
-  get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension' => "attachments#show"
+  get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:format' => "attachments#show"
   get '/government/uploads/system/uploads/attachment_data/file/:id/*file.:extension/preview' => "csv_preview#show", as: :csv_preview
   get '/government/uploads/uploaded/hmrc/*path' => "hmrc_assets#show", format: true
   get '/government/uploads/*path' => "asset_manager_redirect#show", as: :asset_manager_redirect, format: true

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -15,7 +15,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     @params = {
       id: attachment_data,
       file: attachment_data.filename_without_extension,
-      extension: attachment_data.file_extension
+      format: attachment_data.file_extension
     }
 
     @edition = create(:publication)
@@ -189,7 +189,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data.update!(file: new_file)
     setup_stubs(file_state: :unscanned)
 
-    get :show, params: params.merge(file: 'minister-of-funk.960x640', extension: 'jpg')
+    get :show, params: params.merge(file: 'minister-of-funk.960x640', format: 'jpg')
 
     assert_response :found
     assert_redirected_to view_context.path_to_image('thumbnail-placeholder.png')
@@ -200,7 +200,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data.update!(file: new_file)
     setup_stubs(file_state: :unscanned, deleted?: true)
 
-    get :show, params: params.merge(file: 'minister-of-funk.960x640', extension: 'jpg')
+    get :show, params: params.merge(file: 'minister-of-funk.960x640', format: 'jpg')
 
     assert_response :found
     assert_redirected_to view_context.path_to_image('thumbnail-placeholder.png')
@@ -211,7 +211,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data.update!(file: new_file)
     setup_stubs(file_state: :unscanned, draft?: true, accessible_to?: false)
 
-    get :show, params: params.merge(file: 'minister-of-funk.960x640', extension: 'jpg')
+    get :show, params: params.merge(file: 'minister-of-funk.960x640', format: 'jpg')
 
     assert_response :found
     assert_redirected_to view_context.path_to_image('thumbnail-placeholder.png')
@@ -283,7 +283,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data.update!(file: new_file)
     setup_stubs(file_state: :infected)
 
-    get :show, params: params.merge(file: 'minister-of-funk.960x640', extension: 'jpg')
+    get :show, params: params.merge(file: 'minister-of-funk.960x640', format: 'jpg')
 
     assert_response :not_found
   end
@@ -362,7 +362,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     setup_stubs
 
     basename = File.basename(attachment_data.file.thumbnail.path, '.png')
-    get :show, params: params.merge(file: basename, extension: 'png')
+    get :show, params: params.merge(file: basename, format: 'png')
 
     assert_response :ok
   end
@@ -441,7 +441,7 @@ class AttachmentsControllerTest < ActionController::TestCase
     attachment_data.update!(file: new_file)
     setup_stubs
 
-    get :show, params: params.merge(file: 'sample', extension: 'chm')
+    get :show, params: params.merge(file: 'sample', format: 'chm')
 
     assert_equal 'application/octet-stream', response.headers['Content-Type']
   end

--- a/test/integration/attachments_test.rb
+++ b/test/integration/attachments_test.rb
@@ -35,4 +35,17 @@ class AttachmentsTest < ActionDispatch::IntegrationTest
       assert_no_text "need to be referenced"
     end
   end
+
+  test "redirects asset requests that aren't made via the asset host when the filename contains multiple periods" do
+    Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
+    host! 'not-asset-host.com'
+
+    filename_with_multiple_periods = 'big-cheese.960x640.jpg'
+    file = File.open(fixture_path.join(filename_with_multiple_periods))
+    attachment_data = FactoryBot.create(:attachment_data, file: file)
+
+    get "/government/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/#{filename_with_multiple_periods}"
+
+    assert_redirected_to "http://asset-host.com/government/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/big-cheese.960x640.jpg"
+  end
 end


### PR DESCRIPTION
We received numerous support requests about attachments not being accessible after deploying [PR 3918][1] earlier today.

The problem was caused by the explicit `:extension` segment in the routes. Its presence meant that filenames containing multiple periods (e.g. 'filename.foo.bar') would be parsed and result in:

* params[:path] being set to 'filename',
* params[:extension] being set to 'foo'
* params[:format] being set to 'bar'

I don't fully understand why but calling `redirect_to host: asset_host` when params contains both an `extension` and `format` results in the `format` being dropped. You can see this in the example below (note that the .pdf has been dropped):

    curl -v "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/637057/Rural_Land_and_Entitlements__RLE1__V1.0_2016.pdf"
    < HTTP/2 302
    < location: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/637057/Rural_Land_and_Entitlements__RLE1__V1.0_2016

I came across this previously when doing something similar with the non-attachment assets. That was fixed in [PR 3627][2].

I started out trying to write a functional test for the AttachmentsController but that wasn't easy because I have to specify the parameters individually. I've gone with an integration test as it allows me to request the path using a string.

[1]: https://github.com/alphagov/whitehall/pull/3918
[2]: https://github.com/alphagov/whitehall/pull/3627/commits/98bb15f5fed3c735f4f601227d331c0b41dcd924

