### PR TITLE
Reslug policy group government-property-unit-gpu

### DIFF
--- a/db/data_migration/20180404123238_reslug_ogp_policy_group.rb
+++ b/db/data_migration/20180404123238_reslug_ogp_policy_group.rb
@@ -1,0 +1,11 @@
+old_slug = "government-property-unit-gpu"
+new_slug = "office-of-government-property-ogp"
+
+group = PolicyGroup.find_by!(slug: old_slug)
+
+Whitehall::SearchIndex.delete(group)
+
+group.update_attributes!(slug: new_slug)
+
+Whitehall::PublishingApi.republish_async(group)
+Whitehall::SearchIndex.add(group)


### PR DESCRIPTION
reslug government-property-unit-gpu to office-of-government-property-ogp
see also: 20171012150638_reslug_nsi_policy_group.rb

Zendesk: https://govuk.zendesk.com/agent/tickets/2698880