### PR TITLE
Handle soft deleted assets in Asset Manager

### DIFF
--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -4,19 +4,12 @@ class AssetManagerUpdateAssetWorker
   class AssetManagerAssetMissing < StandardError; end
 
   def perform(attachment_data, legacy_url_path, new_attributes = {})
-    attributes = {}
-    asset_missing = false
-
-    begin
-      attributes = find_asset_by(legacy_url_path)
-    rescue GdsApi::HTTPNotFound
-      asset_missing = true
-    end
+    attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes['deleted']
 
-    if (asset_missing || asset_deleted) && attachment_data.deleted?
+    if asset_deleted && attachment_data.deleted?
       return
-    elsif (asset_missing || asset_deleted) && !attachment_data.deleted?
+    elsif asset_deleted && !attachment_data.deleted?
       error_message = "Asset corresponding to AttachmentData ID #{attachment_data.id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
       raise AssetManagerAssetMissing.new(error_message)
     end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -12,10 +12,11 @@ class AssetManagerUpdateAssetWorker
     rescue GdsApi::HTTPNotFound
       asset_missing = true
     end
+    asset_deleted = attributes['deleted']
 
-    if asset_missing && attachment_data.deleted?
+    if (asset_missing || asset_deleted) && attachment_data.deleted?
       return
-    elsif asset_missing && !attachment_data.deleted?
+    elsif (asset_missing || asset_deleted) && !attachment_data.deleted?
       error_message = "Asset corresponding to AttachmentData ID #{attachment_data.id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
       raise AssetManagerAssetMissing.new(error_message)
     end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -3,7 +3,7 @@ class AssetManagerUpdateAssetWorker
 
   class AssetManagerAssetDeleted < StandardError
     def initialize(attachment_data_id, legacy_url_path)
-      message = "Asset corresponding to AttachmentData ID #{attachment_data_id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
+      message = "Asset corresponding to AttachmentData ID #{attachment_data_id} and legacy URL path #{legacy_url_path} expected not to be deleted in Asset Manager"
       super(message)
     end
   end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,7 +1,12 @@
 class AssetManagerUpdateAssetWorker
   include AssetManagerWorkerHelper
 
-  class AssetManagerAssetDeleted < StandardError; end
+  class AssetManagerAssetDeleted < StandardError
+    def initialize(attachment_data_id, legacy_url_path)
+      message = "Asset corresponding to AttachmentData ID #{attachment_data_id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
+      super(message)
+    end
+  end
 
   def perform(attachment_data, legacy_url_path, new_attributes = {})
     attributes = find_asset_by(legacy_url_path)
@@ -10,8 +15,7 @@ class AssetManagerUpdateAssetWorker
     if asset_deleted && attachment_data.deleted?
       return
     elsif asset_deleted && !attachment_data.deleted?
-      error_message = "Asset corresponding to AttachmentData ID #{attachment_data.id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
-      raise AssetManagerAssetDeleted.new(error_message)
+      raise AssetManagerAssetDeleted.new(attachment_data.id, legacy_url_path)
     end
 
     if (replacement_path = new_attributes.delete('replacement_legacy_url_path'))

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -1,7 +1,7 @@
 class AssetManagerUpdateAssetWorker
   include AssetManagerWorkerHelper
 
-  class AssetManagerAssetMissing < StandardError; end
+  class AssetManagerAssetDeleted < StandardError; end
 
   def perform(attachment_data, legacy_url_path, new_attributes = {})
     attributes = find_asset_by(legacy_url_path)
@@ -11,7 +11,7 @@ class AssetManagerUpdateAssetWorker
       return
     elsif asset_deleted && !attachment_data.deleted?
       error_message = "Asset corresponding to AttachmentData ID #{attachment_data.id} and by legacy URL path #{legacy_url_path} expected to exist in Asset Manager"
-      raise AssetManagerAssetMissing.new(error_message)
+      raise AssetManagerAssetDeleted.new(error_message)
     end
 
     if (replacement_path = new_attributes.delete('replacement_legacy_url_path'))

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -21,9 +21,31 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
   end
 
+  test "no-op if the attachment_data has been deleted and the asset has been deleted in asset manager" do
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_url, 'deleted' => true)
+
+    @attachment_data.stubs(:deleted?).returns(true)
+
+    Services.asset_manager.expects(:update_asset).never
+
+    @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
+  end
+
   test "raises exception if asset can't be found and attachment_data isn't deleted" do
     exception = GdsApi::HTTPNotFound.new(404)
     @worker.stubs(:find_asset_by).with(@legacy_url_path).raises(exception)
+
+    @attachment_data.stubs(:deleted?).returns(false)
+
+    assert_raises(AssetManagerUpdateAssetWorker::AssetManagerAssetMissing) do
+      @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
+    end
+  end
+
+  test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
+    @worker.stubs(:find_asset_by).with(@legacy_url_path)
+      .returns('id' => @asset_url, 'deleted' => true)
 
     @attachment_data.stubs(:deleted?).returns(false)
 

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -10,17 +10,6 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     @attachment_data = FactoryBot.build(:attachment_data)
   end
 
-  test "no-op if the attachment_data has been deleted and we can't find the asset in asset manager" do
-    exception = GdsApi::HTTPNotFound.new(404)
-    @worker.stubs(:find_asset_by).with(@legacy_url_path).raises(exception)
-
-    @attachment_data.stubs(:deleted?).returns(true)
-
-    Services.asset_manager.expects(:update_asset).never
-
-    @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
-  end
-
   test "no-op if the attachment_data has been deleted and the asset has been deleted in asset manager" do
     @worker.stubs(:find_asset_by).with(@legacy_url_path)
       .returns('id' => @asset_url, 'deleted' => true)
@@ -30,17 +19,6 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:update_asset).never
 
     @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
-  end
-
-  test "raises exception if asset can't be found and attachment_data isn't deleted" do
-    exception = GdsApi::HTTPNotFound.new(404)
-    @worker.stubs(:find_asset_by).with(@legacy_url_path).raises(exception)
-
-    @attachment_data.stubs(:deleted?).returns(false)
-
-    assert_raises(AssetManagerUpdateAssetWorker::AssetManagerAssetMissing) do
-      @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
-    end
   end
 
   test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -27,7 +27,7 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
 
     @attachment_data.stubs(:deleted?).returns(false)
 
-    assert_raises(AssetManagerUpdateAssetWorker::AssetManagerAssetMissing) do
+    assert_raises(AssetManagerUpdateAssetWorker::AssetManagerAssetDeleted) do
       @worker.perform(@attachment_data, @legacy_url_path, 'draft' => false)
     end
   end


### PR DESCRIPTION
I was previously treating a `GdsApi::HTTPNotFound` exception as a proxy for an asset having been deleted in Asset Manager. The Asset Manager API was recently [updated so that the API responds to GET requests for deleted assets with a 200 instead of a 404][1] (it includes the deleted state in the JSON response) so I'm using that to make the code in `AssetManagerUpdateAssetWorker` more explicit.

[1]: https://github.com/alphagov/asset-manager/pull/542