### PR TITLE
Set the atom and email URLs for the statistics filter

### DIFF
--- a/app/presenters/announcement_filter_json_presenter.rb
+++ b/app/presenters/announcement_filter_json_presenter.rb
@@ -1,10 +1,20 @@
 class AnnouncementFilterJsonPresenter < DocumentFilterPresenter
   def as_json(options = nil)
-    super.merge atom_feed_url: context.filter_atom_feed_url,
-                email_signup_url: context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
+    super.merge(
+      atom_feed_url: atom_feed_url,
+      email_signup_url: email_signup_url,
+    )
   end
 
   def result_type
     "announcement"
+  end
+
+  def atom_feed_url
+    context.filter_atom_feed_url
+  end
+
+  def email_signup_url
+    context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
   end
 end

--- a/app/presenters/publication_filter_json_presenter.rb
+++ b/app/presenters/publication_filter_json_presenter.rb
@@ -3,13 +3,17 @@ class PublicationFilterJsonPresenter < DocumentFilterPresenter
 
   def as_json(options = nil)
     super.merge(
-      atom_feed_url: context.filter_atom_feed_url,
+      atom_feed_url: atom_feed_url,
       email_signup_url: email_signup_url,
     )
   end
 
   def result_type
     "publication"
+  end
+
+  def atom_feed_url
+    context.filter_atom_feed_url
   end
 
   def email_signup_url

--- a/app/presenters/statistics_filter_json_presenter.rb
+++ b/app/presenters/statistics_filter_json_presenter.rb
@@ -1,10 +1,20 @@
 class StatisticsFilterJsonPresenter < DocumentFilterPresenter
   def as_json(options = nil)
-    super.merge atom_feed_url: context.filter_atom_feed_url,
-                email_signup_url: context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
+    super.merge(
+      atom_feed_url: atom_feed_url,
+      email_signup_url: email_signup_url,
+    )
   end
 
   def result_type
     "statistic"
+  end
+
+  def atom_feed_url
+    context.filter_atom_feed_url
+  end
+
+  def email_signup_url
+    context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
   end
 end

--- a/app/presenters/statistics_filter_json_presenter.rb
+++ b/app/presenters/statistics_filter_json_presenter.rb
@@ -1,4 +1,9 @@
 class StatisticsFilterJsonPresenter < DocumentFilterPresenter
+  def as_json(options = nil)
+    super.merge atom_feed_url: context.filter_atom_feed_url,
+                email_signup_url: context.new_email_signups_path(email_signup: { feed: context.filter_atom_feed_url })
+  end
+
   def result_type
     "statistic"
   end


### PR DESCRIPTION
If you go to `/government/statistics`, set the filters, and click the email link, you will probably be taken to a page to subscribe for a different filter: usually the one *before*.  It's not just an off-by-one error, as sometimes you can go through several filter changes before the email link changes.

I haven't been able to figure out why.  However, setting the `atom_feed_url` and `email_signup_url` in the backend, like the announcements presenter does, solves the problem and makes the email and feed links consistently work.

---

It would be good to know what caused the strange behaviour (I suspected caching, but can replicate it locally, so that doesn't seem to be it), and how long it's done that, but for now we have a fix.