### PR TITLE
Add guidance on open formats to attachments admin pages

### DIFF
--- a/app/views/admin/attachments/_attachment_data_fields.html.erb
+++ b/app/views/admin/attachments/_attachment_data_fields.html.erb
@@ -5,6 +5,11 @@
   <% end %>
 
   <%= attachment_data_fields.label :file, (attachment_data_fields.object.filename ? 'Replace file' : nil), required: false %>
+
+  <p>
+    You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.
+  </p>
+
   <%= attachment_data_fields.file_field :file %>
 
   <%= form.check_box :accessible, label_text: "Attachment is accessible" %>

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -31,10 +31,14 @@
         <% end %>
       </ul>
 
-      <p class="alert alert-warning">
-        You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.<br/>
-        For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.
-      </p>
+      <div class="alert alert-warning">
+        <p>
+          You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.<br/>
+        </p>
+        <p>
+          For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.
+        </p>
+      </div>
 
       <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
     <% end %>

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -31,6 +31,11 @@
         <% end %>
       </ul>
 
+      <p class="alert alert-warning">
+        You must upload attachments in an <a href="https://www.gov.uk/guidance/content-design/planning-content#open-formats">open standards format</a>.<br/>
+        For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.
+      </p>
+
       <%= render('attachments', attachable: attachable) if attachable.attachments.any? %>
     <% end %>
   </section>

--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -9,7 +9,7 @@
       <p class="qa-helper-copy">
         <strong>Note:</strong>
         <%= attachment_note(attachment.attachable_model_name) %>
-      <p>
+      </p>
       <ul class="actions list-unstyled">
         <li>
           <%= link_to 'Upload new file attachment', new_polymorphic_path([:admin, typecast_for_attachable_routing(attachable), Attachment]) %>


### PR DESCRIPTION
<img width="792" alt="screen shot 2018-04-10 at 14 44 21" src="https://user-images.githubusercontent.com/75235/38561045-ecd7d8d6-3cce-11e8-93ea-3fce31aec208.png">
<img width="827" alt="screen shot 2018-04-10 at 14 44 23" src="https://user-images.githubusercontent.com/75235/38561046-ecf13f1a-3cce-11e8-80af-6374e4936e98.png">
<img width="819" alt="screen shot 2018-04-10 at 14 44 24" src="https://user-images.githubusercontent.com/75235/38561048-ed09e092-3cce-11e8-941f-daeb7023de60.png">

I used an `alert-warning` on the attachments list page as I think it should stand out, but having two `alert-info`s next to each other doesn't seem very good.

Links go directly to the `gov.uk` domain, rather than through any smart URL constructors, but that seems in keeping with other guidance links:

```
$ git grep www.gov.uk/guidance
...
app/views/admin/dashboard/index.html.erb:      <li><a href="https://www.gov.uk/guidance/style-guide">GOV.UK style guide</a></li>
app/views/admin/dashboard/index.html.erb:      <li><a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk">How to publish content on GOV.UK</a></li>
app/views/admin/dashboard/index.html.erb:      <li><a href="https://www.gov.uk/guidance/content-design">Planning, writing and managing content</a></li>
...
```