### PR TITLE
Permit "page" query parameter in paginator presenter

### DIFF
--- a/app/presenters/api/page_presenter.rb
+++ b/app/presenters/api/page_presenter.rb
@@ -44,7 +44,8 @@ private
       :controller,
       :format,
       :action,
-      :world_location_id
+      :world_location_id,
+      :page,
     ).merge(
       override_params.merge(only_path: false)
     ))


### PR DESCRIPTION
When running whitehall in the dev VM, this url works:

http://whitehall-admin.dev.gov.uk/api/world-locations

But this one does not:

http://whitehall-admin.dev.gov.uk/api/world-locations?page=2

The latter complains about the unpermitted `page` parameter.  This breaks anything using the world locations API, like smart answers which include a country selection.  So this PR permits it.

---

~We probably shouldn't merge this until we figure out why it doesn't seem to be required on production.~

This is because the dev and test environments set this: https://github.com/alphagov/whitehall/blob/af5393f0bc7df7920c9552fa01f166b17ebd873f/config/environments/development.rb#L21

Production does not.  So an unpermitted parameter on production is silently dropped, whereas on dev/test it triggers an exception.  The exception is raised from https://github.com/alphagov/whitehall/blob/af5393f0bc7df7920c9552fa01f166b17ebd873f/app/presenters/api/page_presenter.rb#L42-L51

So here's what happens if you visit `/api/world-locations?page=2` on production:

1. `url(page: 1)` is called by `previous_page_url`
2. The `page=2` query parameter is filtered out by the `permit!`
3. The url `/api/world-locations?page=1` is returned by `url_for`, because it takes the arguments of `url` as an override

But on dev/test, it never gets past step 2.

---

It's safe to permit `page` here, which solves the problem, because a `page` parameter is passed to `url` by everything which uses it: `links`, `previous_page_url`, and `next_page_url`.  So the current page will never "leak" anywhere it shouldn't.