### PR TITLE
Send corporate information page change history to Publishing API

### DIFF
--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -61,6 +61,7 @@ module PublishingApi
 
     def details
       base_details
+        .merge(change_history)
         .merge(CorporateInformationGroups.for(corporate_information_page))
         .merge(Organisation.for(corporate_information_page))
         .merge(PayloadBuilder::TagDetails.for(corporate_information_page))
@@ -79,6 +80,12 @@ module PublishingApi
                           end
 
       public_updated_at.rfc3339
+    end
+
+    def change_history
+      return {} unless corporate_information_page.change_history.present?
+
+      { change_history: corporate_information_page.change_history.as_json }
     end
 
     class CorporateInformationGroups


### PR DESCRIPTION
Trello: https://trello.com/c/dwniZAC4/71-investigate-change-note-lag-bug-in-emails

Prior to this the history was not provided for these pages which meant
that incorrect information was being sent out as part of the Email
Alert.

Do not merge until https://github.com/alphagov/govuk-content-schemas/pull/746 this is deployed