### PR TITLE
Ensure features are deleted with their docs

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,7 +37,7 @@ class Document < ApplicationRecord
   has_many :document_collection_group_memberships, inverse_of: :document, dependent: :delete_all
   has_many :document_collection_groups, through: :document_collection_group_memberships
   has_many :document_collections, through: :document_collection_groups
-  has_many :features, inverse_of: :document
+  has_many :features, inverse_of: :document, dependent: :destroy
 
   validates_presence_of :content_id
 

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -18,6 +18,8 @@ class OffsiteLink < ApplicationRecord
   end
 
   belongs_to :parent, polymorphic: true
+  has_many :features, inverse_of: :offsite_link, dependent: :destroy
+
   validates :title, :summary, :link_type, :url, presence: true, length: { maximum: 255 }
   validate :check_url_is_allowed
   validates :link_type, presence: true, inclusion: { in: LinkTypes.all }

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -39,6 +39,8 @@ class TopicalEvent < Classification
             class_name: "Consultation",
             source: :consultation
 
+  has_many :features, inverse_of: :topical_event, dependent: :destroy
+
   scope :active, -> { where("end_date > ?", Date.today) }
   scope :order_by_start_date, -> { order("start_date DESC") }
   scope :for_edition, ->(id) { joins(:classification_memberships).where(classification_memberships: { edition_id: id }) }

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -108,6 +108,20 @@ class DocumentTest < ActiveSupport::TestCase
     assert_empty DocumentCollectionGroupMembership.where(document_id: published_edition.document.id)
   end
 
+  test "#destroy also destroys 'featured document' associations" do
+    document = create(:document)
+    feature = create(:feature, document: document)
+    feature_list = create(:feature_list, features: [feature])
+
+    feature_list.reload
+    assert_equal 1, feature_list.features.size
+
+    document.destroy
+
+    feature_list.reload
+    assert_equal 0, feature_list.features.size
+  end
+
   test "should list a single change history when sole published edition is marked as a minor change" do
     edition = create(:published_publication, minor_change: true, change_note: nil)
 

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -104,4 +104,18 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     offsite_link = build(:offsite_link, link_type: 'nhs_content')
     assert offsite_link.valid?
   end
+
+  test "#destroy also destroys 'featured offsite link' associations" do
+    offsite_link = create(:offsite_link)
+    feature = create(:feature, offsite_link: offsite_link)
+    feature_list = create(:feature_list, features: [feature])
+
+    feature_list.reload
+    assert_equal 1, feature_list.features.size
+
+    offsite_link.destroy
+
+    feature_list.reload
+    assert_equal 0, feature_list.features.size
+  end
 end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -59,4 +59,18 @@ class TopicalEventTest < ActiveSupport::TestCase
     assert_equal start_date, rummager_payload["start_date"]
     assert_equal end_date, rummager_payload["end_date"]
   end
+
+  test "#destroy also destroys 'featured topical event' associations" do
+    topical_event = create(:topical_event)
+    feature = create(:feature, topical_event: topical_event)
+    feature_list = create(:feature_list, features: [feature])
+
+    feature_list.reload
+    assert_equal 1, feature_list.features.size
+
+    topical_event.destroy
+
+    feature_list.reload
+    assert_equal 0, feature_list.features.size
+  end
 end


### PR DESCRIPTION
It's rare to delete a Document, and presumably likewise for offsite links and topical events, but it does happen from time to time and we should ensure that these ghost docs are no longer considered featured.

Adds dependent destroy from Document, OffsiteLink, and TopicalEvent, to Feature.