### PR TITLE
Expand featured items for sub organisations to 6 from 5

### DIFF
--- a/app/presenters/organisation_feature_list_presenter.rb
+++ b/app/presenters/organisation_feature_list_presenter.rb
@@ -4,9 +4,6 @@ class OrganisationFeatureListPresenter < FeatureListPresenter
   def initialize(organisation, view_context)
     @organisation = organisation
     super(@organisation.feature_list_for_locale(I18n.locale), view_context)
-  end
-
-  def limit
-    @organisation.organisation_type.sub_organisation? ? 5 : 6
+    limit_to 6
   end
 end


### PR DESCRIPTION
Sub organisation pages used to be designed so that only 5
featured items would work well on the page. This has changed
(although it's unclear when), so we can remove the special
case for sub organisations.

Before:
![screen shot 2018-04-17 at 09 19 42](https://user-images.githubusercontent.com/18276/38871983-1a0580da-424a-11e8-8ada-2ce879adee9c.png)

After:
![screen shot 2018-04-17 at 14 15 24](https://user-images.githubusercontent.com/18276/38871992-1faf7f40-424a-11e8-9a32-dc958885eeb6.png)

Zendesk: https://govuk.zendesk.com/agent/tickets/2743316