### PR TITLE
Improve logging in rummager Sidekiq jobs

### DIFF
--- a/app/workers/search_index_add_worker.rb
+++ b/app/workers/search_index_add_worker.rb
@@ -6,11 +6,11 @@ class SearchIndexAddWorker < WorkerBase
     @id = id
 
     if searchable_instance.nil?
-      Rails.logger.warn("SearchIndexAddWorker: Could not find #{class_name} with id #{id} (#{Time.zone.now.utc}).")
+      logger.warn("SearchIndexAddWorker: Could not find #{class_name} with id #{id} (#{Time.zone.now.utc}).")
     elsif !searchable_instance.can_index_in_search?
-      Rails.logger.warn("SearchIndexAddWorker: Was asked to index #{class_name} with id #{id}, but it was unindexable (#{Time.zone.now.utc}).")
+      logger.warn("SearchIndexAddWorker: Was asked to index #{class_name} with id #{id}, but it was unindexable (#{Time.zone.now.utc}).")
     else
-      index = Whitehall::SearchIndex.for(searchable_instance.rummager_index)
+      index = Whitehall::SearchIndex.for(searchable_instance.rummager_index, logger: logger)
       index.add searchable_instance.search_index
     end
   end

--- a/app/workers/search_index_delete_worker.rb
+++ b/app/workers/search_index_delete_worker.rb
@@ -2,6 +2,6 @@ class SearchIndexDeleteWorker < WorkerBase
   attr_reader :link, :index
 
   def perform(link, index)
-    Whitehall::SearchIndex.for(index.to_sym).delete(link)
+    Whitehall::SearchIndex.for(index.to_sym, logger: logger).delete(link)
   end
 end

--- a/app/workers/world_location_news_page_worker.rb
+++ b/app/workers/world_location_news_page_worker.rb
@@ -34,7 +34,7 @@ private
   end
 
   def search_index
-    Whitehall::SearchIndex.for(:government)
+    Whitehall::SearchIndex.for(:government, logger: logger)
   end
 
   # We use the same content_id for all locales so that Publishing API knows

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -17,12 +17,12 @@ module Whitehall
       SearchIndexDeleteWorker.perform_async(instance.search_index['link'], instance.rummager_index)
     end
 
-    def self.for(type)
+    def self.for(type, options = {})
       path = {
         government: government_search_index_path,
         detailed_guides: detailed_search_index_path
       }.fetch(type)
-      indexer_class.new(rummager_host, path, logger: Rails.logger)
+      indexer_class.new(rummager_host, path, { logger: Rails.logger }.merge(options))
     end
 
     def self.government_search_index_path

--- a/test/unit/whitehall/rummageable_test.rb
+++ b/test/unit/whitehall/rummageable_test.rb
@@ -159,7 +159,7 @@ class RummageableTest < ActiveSupport::TestCase
     Whitehall::Rummageable::Index.any_instance.stubs(:sleep)
 
     logger = stub('logger', debug: true, info: true)
-    logger.expects(:info).once.with(regexp_matches(/result: UNKNOWN/))
+    logger.expects(:info).once.with(has_entry(:result, 'UNKNOWN'))
 
     index = Whitehall::Rummageable::Index.new(rummager_url, index_name, logger: logger)
     index.add(one_document)

--- a/test/unit/workers/search_index_add_worker_test.rb
+++ b/test/unit/workers/search_index_add_worker_test.rb
@@ -10,7 +10,7 @@ class SearchIndexAddWorkerTest < ActiveSupport::TestCase
   end
 
   test '#perform logs a warning if the instance does not exist' do
-    Rails.logger.expects(:warn).once
+    Sidekiq.logger.expects(:warn).once
     SearchIndexAddWorker.new.perform('Topic', 1)
   end
 
@@ -27,7 +27,7 @@ class SearchIndexAddWorkerTest < ActiveSupport::TestCase
     draft_publication = create(:draft_publication)
 
     Whitehall::SearchIndex.indexer_class.any_instance.expects(:add).never
-    Rails.logger.expects(:warn).once
+    Sidekiq.logger.expects(:warn).once
     SearchIndexAddWorker.new.perform(draft_publication.class.name, draft_publication.id)
   end
 end

--- a/test/unit/workers/search_index_delete_worker_test.rb
+++ b/test/unit/workers/search_index_delete_worker_test.rb
@@ -4,7 +4,7 @@ class SearchIndexDeleteWorkerTest < ActiveSupport::TestCase
   test '#perform deletes the instance from its index' do
     index = mock('search_index')
     index.expects(:delete).with('woo')
-    Whitehall::SearchIndex.expects(:for).with(:government).returns(index)
+    Whitehall::SearchIndex.expects(:for).with(:government, anything).returns(index)
 
     SearchIndexDeleteWorker.new.perform('woo', 'government')
   end


### PR DESCRIPTION
Fixes the search index & world locations jobs using the Rails logger rather than the Sidekiq logger, and logs more details about the requests sent to Rummager.