### PR TITLE
Do not remove ministerial role holders from the search index

### DIFF
--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -71,13 +71,8 @@ class RoleAppointment < ApplicationRecord
     where(started_at: start_time..end_time)
   end
 
-  #This is to prevent duplication of people by ministerial roles indexing
   def update_indexes
-    if person.current_ministerial_roles.any?
-      person.remove_from_search_index
-    else
-      person.update_in_search_index
-    end
+    person.update_in_search_index
   end
 
   attr_accessor :make_current

--- a/test/unit/role_appointment_test.rb
+++ b/test/unit/role_appointment_test.rb
@@ -1,41 +1,6 @@
 require "test_helper"
 
 class RoleAppointmentTest < ActiveSupport::TestCase
-  test "should should remove person from index when added as a minister" do
-    person = create(:person)
-    Whitehall::SearchIndex.expects(:delete).with(person)
-    create(:ministerial_role_appointment, person: person)
-  end
-
-  test "should should add person to index when removed as a minister" do
-    Whitehall::SearchIndex.stubs(:add)
-    person = create(:person)
-    role = create(:ministerial_role_appointment, person: person)
-    Whitehall::SearchIndex.expects(:add).with(person)
-    role.destroy
-  end
-
-  test "should add the person to the index when a they no longer hold a ministerial role" do
-    Whitehall::SearchIndex.stubs(:add)
-
-    role = create(:ministerial_role)
-    alice = create(:person, forename: "Alice")
-    bob = create(:person, forename: "Bob")
-
-    create(:role_appointment, role: role, person: alice, started_at: 3.days.ago, ended_at: nil)
-
-    Whitehall::SearchIndex.expects(:add).with(alice)
-
-    role.reload
-    alice.reload
-    bob.reload
-
-    create(:role_appointment, role: role, person: bob, started_at: 1.day.ago, ended_at: nil, make_current: true)
-
-    assert_equal bob, role.current_person
-    assert_equal alice.current_ministerial_roles.any?, false
-  end
-
   test "should be invalid with no started_at" do
     role_appointment = build(:role_appointment, started_at: nil)
     refute role_appointment.valid?


### PR DESCRIPTION
We have a problem where people sometimes disappear from the search, which we resolve by [republishing the person in whitehall](https://docs.publishing.service.gov.uk/manual/fix-blank-finder-filter-options.html).

I believe this is due to the bit of code which I remove in this PR, which removes a person from the search index when they are appointed to a ministerial role.  @bevanloon and I appointed a new minister in Integration, which caused the problem to manifest.

---

I don't have the historical context to know that if is a correct change.  I *suspect* that once upon a time, ministerial roles and person pages had exactly the same content.  So: once Theresa May became Prime Minister, these two pages would have been the same:

- https://www.gov.uk/government/ministers/prime-minister
- https://www.gov.uk/government/people/theresa-may

This is supported a little by the mention of a `past-prime-ministers` page in the whitehall code.  So if this *were* the case, then it makes sense to remove the person page from the search index, as it would effectively be a duplicate result.  In which case, the people-vanishing-from-search bug was probably introduced around the time the historical role pages were removed.

But this is just a guess.  It would be good if someone more familiar with whitehall could confirm.

---

[Trello card](https://trello.com/c/y1HPBN5q/69-peoples-names-go-missing-from-search-results-requiring-person-to-be-republished-in-rummager-3)