### PR TITLE
Send people to the publishing-api

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -21,17 +21,26 @@ module PublishingApi
 
       content.merge!(
         description: nil,
-        details: {},
-        document_type: item.class.name.underscore,
+        details: details,
+        document_type: "person",
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        schema_name: "placeholder",
+        schema_name: "person",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
     end
 
     def links
       {}
+    end
+
+    def details
+      {
+        image: {
+          url: item.image_url(:s465),
+          alt_text: item.name,
+        }
+      }
     end
   end
 end

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -1,19 +1,21 @@
 require 'test_helper'
 
 class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+
   def present(model_instance, options = {})
     PublishingApi::PersonPresenter.new(model_instance, options)
   end
 
   test 'presents a Person ready for adding to the publishing API' do
-    person = create(:person, forename: "Winston")
+    person = create(:person, forename: "Winston", image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
     public_path = Whitehall.url_maker.person_path(person)
 
     expected_hash = {
       base_path: public_path,
       title: "Winston",
       description: nil,
-      schema_name: "placeholder",
+      schema_name: "person",
       document_type: "person",
       locale: 'en',
       publishing_app: 'whitehall',
@@ -21,7 +23,12 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       public_updated_at: person.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
-      details: {},
+      details: {
+        image: {
+          url: person.image_url(:s465),
+          alt_text: "Winston",
+        }
+      },
       update_type: "major",
     }
     expected_links = {}
@@ -33,6 +40,6 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 
-    assert_valid_against_schema(presented_item.content, 'placeholder')
+    assert_valid_against_schema(presented_item.content, 'person')
   end
 end


### PR DESCRIPTION
This makes sure that we're sending people to the publishing-api with the `person` schema. The schema is a bit bare bones at the moment so we're only sending the persons image. The rest can be added later.

Needs https://github.com/alphagov/govuk-content-schemas/pull/749 to be deployed before the tests pass

https://trello.com/c/xebVLRcp