### PR TITLE
Send Organisation logo_url to rummager

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -185,7 +185,8 @@ class Organisation < ApplicationRecord
              organisation_type: :organisation_type_key,
              organisation_crest: :organisation_crest,
              organisation_brand: :organisation_brand,
-             logo_formatted_title: :logo_formatted_name
+             logo_formatted_title: :logo_formatted_name,
+             logo_url: :logo_url
 
   extend FriendlyId
   friendly_id
@@ -327,6 +328,10 @@ class Organisation < ApplicationRecord
     else
       govuk_status
     end
+  end
+
+  def logo_url
+    logo.try(:url)
   end
 
   def live?

--- a/app/models/searchable.rb
+++ b/app/models/searchable.rb
@@ -20,6 +20,7 @@ module Searchable
     :is_political,
     :latest_change_note,
     :link,
+    :logo_url,
     :logo_formatted_title,
     :metadata,
     :news_article_type,

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -388,6 +388,29 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [], organisation.search_index['organisations']
   end
 
+  test 'should return search index data suitable for Rummageable with a custom logo' do
+    organisation = build(:organisation,
+      slug: 'ministry-of-funk',
+      name: 'Ministry of Funk',
+      acronym: 'MoF',
+      logo: File.open(fixture_path.join('images', '960x640_gif.gif')),
+      organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+      organisation_brand_colour_id: OrganisationBrandColour::HomeOffice.id)
+
+    assert_equal 'Ministry of Funk', organisation.search_index['title']
+    assert_equal 'MoF', organisation.search_index['acronym']
+    assert_equal "/government/organisations/#{organisation.slug}", organisation.search_index['link']
+    assert_equal organisation.indexable_content, organisation.search_index['indexable_content']
+    assert_equal 'organisation', organisation.search_index['format']
+    assert_equal 'live', organisation.search_index['organisation_state']
+    assert_equal 'other', organisation.search_index['organisation_type'].to_s
+    assert_equal OrganisationLogoType::CustomLogo.class_name, organisation.search_index['organisation_crest']
+    assert_equal OrganisationBrandColour::HomeOffice.class_name, organisation.search_index['organisation_brand']
+    assert_equal "Ministry\nof\nFunk", organisation.search_index['logo_formatted_title']
+    assert organisation.search_index['logo_url'].include? '960x640_gif.gif'
+    assert_equal [], organisation.search_index['organisations']
+  end
+
   test 'should return a rendered summary as description' do
     organisation = create(:organisation, name: "HMRC")
 


### PR DESCRIPTION
We want to display search results for organisation as logos in the collections app for the Trello card [Show the department logo in the Organisations list](https://trello.com/c/wSDRcUwW/27-show-the-department-logo-in-the-organisations-list). 

This commit sends the following fields to rummager to allow this.

logo_url for the organisation

There is a related [PR in rummager](https://github.com/alphagov/rummager/pull/1230)
