### PR TITLE
Don't send `image` for people if there isn't one

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -35,12 +35,11 @@ module PublishingApi
     end
 
     def details
-      {
-        image: {
-          url: item.image_url(:s465),
-          alt_text: item.name,
-        }
-      }
+      {}.tap do |hash|
+        if item.image_url(:s465)
+          hash[:image] = { url: item.image_url(:s465), alt_text: item.name }
+        end
+      end
     end
   end
 end

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -42,4 +42,12 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
 
     assert_valid_against_schema(presented_item.content, 'person')
   end
+
+  test 'accepts people without an image' do
+    person = create(:person, forename: "Winston")
+
+    presented_item = present(person)
+
+    assert_valid_against_schema(presented_item.content, 'person')
+  end
 end


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/3973 I assumed that every person would have an image. That isn't so, so we need to account for it.