### PR TITLE
Handle pdf-reader errors more gracefully

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -195,7 +195,7 @@ private
 
   def calculate_number_of_pages
     PDF::Reader.new(path).page_count
-  rescue PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError
+  rescue PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError, OpenSSL::Cipher::CipherError
     return nil
   end
 


### PR DESCRIPTION
Pdf-readed was bumped to version 2.1.0
(https://github.com/alphagov/whitehall/pull/3890) which has changed the
error that is surfaced when a pdf has a password and `#page_count` is
sent.

Add OpenSSL::Cipher::CipherError to the rescue clasue so we continue to
allow these pdfs.

[Trello](https://trello.com/c/f2vfdrb9/102-fix-opensslcipher-error-on-whitehall-attachment-uploads)