### PR TITLE
[DO NOT MERGE] Reload attachment_data before checking if it is deleted

### DIFF
--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -12,6 +12,7 @@ class AssetManagerUpdateAssetWorker
     attributes = find_asset_by(legacy_url_path)
     asset_deleted = attributes['deleted']
 
+    attachment_data.reload
     if asset_deleted && attachment_data.deleted?
       return
     elsif asset_deleted && !attachment_data.deleted?

--- a/test/unit/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_update_asset_worker_test.rb
@@ -8,6 +8,7 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     @worker = AssetManagerUpdateAssetWorker.new
     @redirect_url = 'https://www.test.gov.uk/example'
     @attachment_data = FactoryBot.build(:attachment_data)
+    @attachment_data.stubs(:reload).returns(@attachment_data)
   end
 
   test "no-op if the attachment_data has been deleted and the asset has been deleted in asset manager" do


### PR DESCRIPTION
We're getting a lot of errors about files being present in whitehall, but not present in the asset manager (https://sentry.io/govuk/app-whitehall/issues/515774347/).  There's a tantalising comment in https://github.com/alphagov/whitehall/pull/3926:

> Note that it's theoretically possible for Whitehall to have marked an asset as deleted in Asset Manager before then trying to update some other metadata about it (e.g. its access-limited state). If this happens, and if we were then to undelete the asset in Asset Manager; it might not be in the state we'd expect. We're not worried about this at the moment as there's currently no way through the user-interface to undelete assets from Whitehall.

I haven't been able to find anywhere where assets are deleted from the asset manager and not also from whitehall.  Here's where things get deleted: https://github.com/alphagov/whitehall/blob/42b0803183ee918a2ae285729e7983c3da095456/lib/whitehall/asset_manager_and_quarantined_file_storage.rb#L32-L35

So... things get deleted from whitehall *and then* from the asset manager.  That should be safe.

Here's where the exception is raised: https://github.com/alphagov/whitehall/blob/42b0803183ee918a2ae285729e7983c3da095456/app/workers/asset_manager_update_asset_worker.rb#L12-L19

---

So here's my totally speculative hypothesis, supported by nothing more than a Ph.D which has trained me to see race conditions everywhere (even where they're not):

1. An asset is created, which both gets stored in whitehall and uploaded to the asset manager.
2. A Sidekiq job is created to do *something* with that asset.
3. The asset gets deleted.
4. The job does not reload the `attachment_data`, so it doesn't pick up that it's been deleted in whitehall, triggering an exception.

(I think 2 and 3 could happen in the other order, too)

Really, the fundamental problem is that we're trying to keep two bits of state in sync: what whitehall thinks the assets are, and what the asset manager thinks they are.  This is brittle, as state changes can't be atomically applied to both together.  There's a window in which the change can be reflected in one but not the other.  But if we reload the whitehall state after checking the asset manager state, this window should be pretty small.

Note: Sidekiq retries jobs which raise an exception, which could explain why we have seen so many instances of this.

I could be totally wrong, however.

---

[Trello card](https://trello.com/c/VybIxQvG/104-fix-assetmanagerupdateassetworkerassetmanagerassetmissing-error-in-whitehall)