### PR TITLE
Change slug to one that matches the page title

### DIFF
--- a/db/data_migration/20180426092205_rename_digital_data_and_technology_job_roles_in_government_to_new_url.rb
+++ b/db/data_migration/20180426092205_rename_digital_data_and_technology_job_roles_in_government_to_new_url.rb
@@ -1,0 +1,14 @@
+old_slug = 'digital-data-and-technology-job-roles-in-government'
+new_slug = 'digital-data-and-technology-profession-capability-framework'
+
+document = Document.find_by(slug: old_slug)
+
+if document
+  # remove the most recent edition from the search index
+  edition = document.editions.published.last
+  Whitehall::SearchIndex.delete(edition)
+
+  # change the slug of the document and create a redirect from the original
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+end


### PR DESCRIPTION
Due to a zendesk ticket being opened asking the slug of
'digital-data-and-technology-job-roles-in-government' to be changed
to 'digital-data-and-technology-profession-capability-framework'
so that the slug reflects the changed title of the page.

https://govuk.zendesk.com/agent/tickets/2762067