### PR TITLE
Less memory usage in broken link report

### DIFF
--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -6,7 +6,7 @@ class LinkReporterCsvService
   end
 
   def generate
-    public_editions.each do |edition|
+    public_editions.find_each do |edition|
       next unless broken_links(edition).any?
       csv_for_organisation(edition_organisation(edition)) << row_for_edition(edition)
     end

--- a/app/services/link_reporter_csv_service.rb
+++ b/app/services/link_reporter_csv_service.rb
@@ -6,9 +6,12 @@ class LinkReporterCsvService
   end
 
   def generate
-    public_editions.find_each do |edition|
-      next unless broken_links(edition).any?
-      csv_for_organisation(edition_organisation(edition)) << row_for_edition(edition)
+    total = public_editions.count
+    public_editions.find_each.with_index do |edition, index|
+      if broken_links(edition).any?
+        csv_for_organisation(edition_organisation(edition)) << row_for_edition(edition)
+      end
+      yield (index + 1), total if block_given?
     end
 
     close_reports

--- a/lib/tasks/broken_link_reporting.rake
+++ b/lib/tasks/broken_link_reporting.rake
@@ -6,23 +6,22 @@ task :generate_broken_link_reports, %i[reports_dir email_address organisation_sl
     organisation_slug = args[:organisation_slug]
     report_zip_name   = "broken-link-reports-#{Date.today.strftime}.zip"
     report_zip_path   = Pathname.new(reports_dir).join(report_zip_name)
-    logger            = Logger.new(Rails.root.join('log/broken_link_reporting.log'))
 
-    logger.info("Cleaning up any existing reports.")
+    puts "Cleaning up any existing reports."
     FileUtils.mkpath reports_dir
     FileUtils.rm Dir.glob(reports_dir + '/*_links_report.csv')
     FileUtils.rm(report_zip_path) if File.exist?(report_zip_path)
 
-    logger.info("Generating broken link reports...")
+    puts "Generating broken link reports..."
     organisation = Organisation.where(slug: organisation_slug).first if organisation_slug
     LinkReporterCsvService.new(reports_dir: reports_dir, organisation: organisation).generate
 
-    logger.info("Reports generated. Zipping...")
+    puts "Reports generated. Zipping..."
     system "zip #{report_zip_path} #{reports_dir}/*_links_report.csv --junk-paths"
 
-    logger.info("Reports zipped. Emailing to #{email_address}")
+    puts "Reports zipped. Emailing to #{email_address}"
     Notifications.broken_link_reports(report_zip_path, email_address).deliver_now
-    logger.info("Email sent.")
+    puts "Email sent."
   rescue StandardError => e
     GovukError.notify(e, extra: { error_message: "Exception raised during broken link report generation: '#{e.message}'" })
     raise

--- a/lib/tasks/broken_link_reporting.rake
+++ b/lib/tasks/broken_link_reporting.rake
@@ -23,12 +23,17 @@ task :generate_broken_link_reports, %i[reports_dir email_address organisation_sl
         puts "Processed #{processed_str} of #{total_str}" if (processed % 10000).zero?
       end
 
-    puts "Reports generated. Zipping..."
-    system "zip #{report_zip_path} #{reports_dir}/*_links_report.csv --junk-paths"
+    if Dir.glob("#{reports_dir}/*_links_report.csv").any?
+      puts "Reports generated. Zipping..."
+      system "zip #{report_zip_path} #{reports_dir}/*_links_report.csv --junk-paths"
 
-    puts "Reports zipped. Emailing to #{email_address}"
-    Notifications.broken_link_reports(report_zip_path, email_address).deliver_now
-    puts "Email sent."
+      puts "Reports zipped. Emailing to #{email_address}"
+      Notifications.broken_link_reports(report_zip_path, email_address).deliver_now
+      puts "Email sent."
+    else
+      puts "There are no broken link reports so hopefully this means there " \
+        "are no broken links 🎉"
+    end
   rescue StandardError => e
     GovukError.notify(e, extra: { error_message: "Exception raised during broken link report generation: '#{e.message}'" })
     raise


### PR DESCRIPTION
Trello: https://trello.com/c/ho81WTSs/110-fix-whitehall-monthly-link-checker-not-working-2

We've been seeing the Jenkins job for running the Whitehall Broken Link Checker fail regularly with the job being killed due to memory usage. The fix for this was surprisingly trivial and meant just switching an `each` on an ActiveRecord scope to a `find_each` to avoid loading most of the database in one query.

I've also updated the script to:
- No longer use a custom logger and instead writes to STDOUT (which will be output to Jenkins)
- Give some progress outputs
- Gracefully deal with situation where there are no links.

Further details in commits.

I did identify that there's scope here to remove the need to create directories and instead use a temp one that ruby creates - it would be a bit painful switching this as puppet would need changing also. Flagged as an optimisation if a problem arises.

Example of this job running in integration: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/498/console