### PR TITLE
Improve handling of draft admin links with link checker

### DIFF
--- a/app/assets/stylesheets/admin/helpers/_broken_links_report.scss
+++ b/app/assets/stylesheets/admin/helpers/_broken_links_report.scss
@@ -40,10 +40,14 @@
 
   .display-issue-details::before {
     content: '\25B6';
-    padding-right: 3px;  
+    padding-right: 3px;
   }
 
   details[open] > .display-issue-details::before {
     content: '\25BC';
+  }
+
+  .draft-admin-links {
+    margin-top: 15px;
   }
 }

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -102,7 +102,7 @@ class Admin::EditionsController < Admin::BaseController
     if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
 
-      if @edition.link_check_reports.last && LinkCheckerApiService.has_links?(@edition)
+      if @edition.link_check_reports.last
         LinkCheckerApiService.check_links(@edition, admin_link_checker_api_callback_url)
       end
 

--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -4,6 +4,15 @@ class LinkCheckerApiReport < ActiveRecord::Base
            -> { order(ordering: :asc) },
            class_name: LinkCheckerApiReport::Link
 
+  def self.create_noop_report(link_reportable)
+    create(
+      batch_id: nil,
+      completed_at: Time.zone.now,
+      link_reportable: link_reportable,
+      status: "completed",
+    )
+  end
+
   def self.create_from_batch_report(batch_report, link_reportable)
     CreateFromBatchReport.new(batch_report, link_reportable).create
   end

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -9,7 +9,7 @@ class LinkCheckerApiService
 
   def self.check_links(reportable, webhook_uri, checked_within: nil)
     uris = convert_admin_links(extract_links(reportable))
-    raise "Reportable has no links to check" if uris.empty?
+    return if uris.empty?
 
     batch_report = Whitehall.link_checker_api_client.create_batch(
       uris,
@@ -22,14 +22,15 @@ class LinkCheckerApiService
   end
 
   def self.convert_admin_links(links)
-    links.map do |link|
+    converted = links.map do |link|
       edition = Whitehall::AdminLinkLookup.find_edition(link)
       if edition
-        Whitehall.url_maker.public_document_url(edition)
+        Whitehall.url_maker.public_document_url(edition) if edition.published?
       else
         link
       end
     end
+    converted.compact
   end
 
   def self.webhook_secret_token

--- a/app/services/link_checker_api_service.rb
+++ b/app/services/link_checker_api_service.rb
@@ -1,6 +1,14 @@
 class LinkCheckerApiService
-  def self.has_links?(reportable)
-    !extract_links(reportable).empty?
+  def self.has_links?(reportable, convert_admin_links: true)
+    links = extract_links(reportable)
+    links = convert_admin_links(links) if convert_admin_links
+    links.any?
+  end
+
+  def self.has_admin_draft_links?(reportable)
+    links = extract_links(reportable)
+    converted = convert_admin_links(links)
+    links.count > converted.count
   end
 
   def self.extract_links(reportable)

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -38,7 +38,7 @@
           <%= render "govspeak_help", hide_inline_attachments_help: !@edition.allows_inline_attachments?,
                                       show_attachments_tab_help: true,
                                       govspeak_link_errors: force_publisher.govspeak_link_errors,
-                                      link_check_report: LinkCheckerApiService.has_links?(@edition) ? @edition.link_check_reports.last : nil %>
+                                      link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_reports.last : nil %>
 
           <%= render "words_to_avoid_guidance" %>
           <h3 class="style-title">Style</h3>

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -69,7 +69,7 @@
       <% end %>
     <% end %>
 
-    <% if LinkCheckerApiService.has_links?(@edition) %>
+    <% if LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) %>
       <%= render 'admin/link_check_reports/link_check_report', report: (@edition.link_check_reports.last || @edition.link_check_reports.build) %>
     <% end %>
 

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -34,11 +34,17 @@
           <% end %>
         </ul>
       <% end %>
+      <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
+        <p class="draft-admin-links">It also contains links to draft documents that weren't checked.</p>
+      <% end %>
       <%= render 'admin/link_check_reports/form', reportable: report.link_reportable, button_text: 'Check again' %>
     </section>
   <% else %>
     <section class='alert alert-success'>
       <p><span class="glyphicon glyphicon-ok add-right-margin"></span> This document contains no broken links.</p>
+      <% if LinkCheckerApiService.has_admin_draft_links?(report.link_reportable) %>
+        <p class="draft-admin-links">It also contains links to draft documents that weren't checked.</p>
+      <% end %>
       <%= render 'admin/link_check_reports/form', reportable: report.link_reportable, button_text: 'Check again' %>
     </section>
   <% end %>

--- a/db/migrate/20180424194943_link_checker_api_report_nil_batch_id.rb
+++ b/db/migrate/20180424194943_link_checker_api_report_nil_batch_id.rb
@@ -1,0 +1,5 @@
+class LinkCheckerApiReportNilBatchId < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :link_checker_api_reports, :batch_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180302165453) do
+ActiveRecord::Schema.define(version: 20180424194943) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "topical_event_id"
@@ -672,7 +672,7 @@ ActiveRecord::Schema.define(version: 20180302165453) do
   end
 
   create_table "link_checker_api_reports", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "batch_id",             null: false
+    t.integer  "batch_id"
     t.string   "status",               null: false
     t.string   "link_reportable_type"
     t.integer  "link_reportable_id"

--- a/test/unit/models/link_checker_api_report_test.rb
+++ b/test/unit/models/link_checker_api_report_test.rb
@@ -27,4 +27,12 @@ class LinkCheckerApiReportTest < ActiveSupport::TestCase
     report = LinkCheckerApiReport.find_by(batch_id: batch_id)
     assert_equal "completed", report.status
   end
+
+  test "creates a noop one for when there are no links" do
+    publication = create(:publication, body: "no links")
+
+    LinkCheckerApiReport.create_noop_report(publication)
+
+    assert publication.link_check_reports.last.completed?
+  end
 end

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -4,6 +4,29 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
   WEBHOOK_URI = "https://example.com/webhook_uri".freeze
   LINK_CHECKER_RESPONSE = { id: 123, completed_at: nil, status: "completed" }.to_json.freeze
 
+  test "it knows whether an edition has links" do
+    edition = Edition.new(body: "A doc with a link to [an external URL](https://example.com/some-page)")
+
+    assert LinkCheckerApiService.has_links?(edition)
+  end
+
+  test "it knows whether an edition has links excluding admin links" do
+    speech = create(:draft_speech)
+
+    edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
+
+    assert LinkCheckerApiService.has_links?(edition, convert_admin_links: false)
+    refute LinkCheckerApiService.has_links?(edition, convert_admin_links: true)
+  end
+
+  test "it knows whether there are draft admin links" do
+    speech = create(:draft_speech)
+
+    edition = Edition.new(body: "A doc with a link to [an admin URL](/government/admin/speeches/#{speech.id})")
+
+    assert LinkCheckerApiService.has_admin_draft_links?(edition)
+  end
+
   test "checks external URL" do
     edition = Edition.new(body: "A doc with a link to [an external URL](https://example.com/some-page)")
 

--- a/test/unit/services/link_checker_api_service_test.rb
+++ b/test/unit/services/link_checker_api_service_test.rb
@@ -58,9 +58,14 @@ class LinkCheckerApiServiceTest < ActiveSupport::TestCase
     assert_not_requested(link_check_request)
   end
 
-  test "returns nil if there are no URLs in the document" do
+  test "returns a completed LinkCheckerApiReport if there are no URLs in the document" do
     edition = Edition.new(body: "Some text")
 
-    assert_nil(LinkCheckerApiService.check_links(edition, WEBHOOK_URI))
+    link_check_request = stub_request(:post, "https://link-checker-api.test.gov.uk/batch")
+
+    report = LinkCheckerApiService.check_links(edition, WEBHOOK_URI)
+
+    assert_not_requested(link_check_request)
+    assert(report.completed?)
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/7960ISmj/111-whitehall-broken-link-checker-handles-full-admin-urls-badly-2

This doesn't send links to draft Whitehall documents to Link Checker API. It didn't seem intuitive to me whether doing this was the correct experience or not (as they are effectively broken links when they are drafts) but doing this does seem consistent with existing user expectations of the software (and the underlying story)

In an effort to improve consistency and surprises I have set up Link Checker Reports for editions that have no links that are just noops with no broken links. The presence of these means the last link checker report is valid for an edition rather than having the complexity of checking whether the document has editions. This doesn't feel like an ideal solution but seems best that can be done without remodelling the concept.

Finally I've added in some messages on link reports to indicate when there are draft links that weren't checked.

Screenshots:
<img width="378" alt="screen shot 2018-04-26 at 18 33 19" src="https://user-images.githubusercontent.com/282717/39321980-6520b14c-4980-11e8-812a-7ffb9f443ea3.png">
<img width="373" alt="screen shot 2018-04-26 at 18 33 38" src="https://user-images.githubusercontent.com/282717/39321982-675266ea-4980-11e8-8ddd-7e50c0a6e1e6.png">

More details in the commits.