### PR TITLE
Update bad link message

### DIFF
--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -10,7 +10,7 @@ class EditionPublisher < EditionService
 
     reasons = []
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
-    reasons << "This edition contains bad links" if govspeak_link_errors.any?
+    reasons << "This edition contains links which violate linking guidelines" if govspeak_link_errors.any?
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
 

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -19,7 +19,7 @@ class EditionScheduler < EditionService
                         elsif scheduled_publication_is_not_within_cache_limit?
                           "Scheduled publication date must be at least #{Whitehall.default_cache_max_age / 60} minutes from now"
                         elsif DataHygiene::GovspeakLinkValidator.new(edition.body).errors.any?
-                          "This edition contains bad links"
+                          "This edition contains links which violate linking guidelines"
                         end
   end
 

--- a/test/unit/services/edition_scheduler_test.rb
+++ b/test/unit/services/edition_scheduler_test.rb
@@ -55,6 +55,6 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     scheduler = EditionScheduler.new(edition)
 
     refute scheduler.can_perform?
-    assert_equal "This edition contains bad links", scheduler.failure_reason
+    assert_equal "This edition contains links which violate linking guidelines", scheduler.failure_reason
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/7960ISmj/111-whitehall-broken-link-checker-handles-full-admin-urls-badly-2

This update to the message is to try make it more distinct from the
message that can often proceed it of "This document contains no broken
links."

Hopefully a user will be able to interpret that the problem isn't that
their link is broken and that they have just not done something they
were expected to do in their link choices.

Prior to this change this message looked like this: 

<img width="388" alt="screen shot 2018-04-26 at 18 48 30" src="https://user-images.githubusercontent.com/282717/39322714-ab4a2a52-4982-11e8-9c0b-88d9fc51b99d.png">

Now it looks like:
<img width="372" alt="screen shot 2018-04-26 at 18 49 04" src="https://user-images.githubusercontent.com/282717/39322725-b0f31a90-4982-11e8-8ad9-96c4165abe57.png">

