### PR TITLE
Add a rake task for reslugging a document

### DIFF
--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -9,8 +9,7 @@ namespace :reslug do
   It performs the following steps:
   - changes the person's slug
   - reindexes the person for search
-  - republishes the person to Publishing API
-  - publishes a redirect content item to Publishing API
+  - republishes the person to Publishing API (automatically handles the redirect)
   - reindexes all dependent documents in search"
   task :person, %i[old_slug new_slug] => :environment do |_task, args|
     old_slug = args[:old_slug]
@@ -27,13 +26,28 @@ namespace :reslug do
   It performs the following steps:
   - changes the role's slug
   - reindexes the role for search
-  - republishes the role to Publishing API
-  - publishes a redirect content item to Publishing API"
+  - republishes the role to Publishing API (automatically handles the redirect)"
   task :role, %i[old_slug new_slug] => :environment do |_task, args|
     old_slug = args[:old_slug]
     new_slug = args[:new_slug]
     role = Role.find_by!(slug: old_slug)
 
     DataHygiene::RoleReslugger.new(role, new_slug).run!
+  end
+
+  desc "Change a document's slug in whitehall (DANGER!).\n
+  It performs the following steps:
+  - changes the documents slug
+  - reindexes the document with it's new slug
+  - republishes the document to Publishing API (automatically handles the redirect)"
+  task :document, %i[old_slug new_slug] => :environment do |_task, args|
+    document = Document.find_by(slug: args.old_slug)
+    # remove the most recent edition from the search index
+    edition = document.editions.published.last
+    Whitehall::SearchIndex.delete(edition)
+
+    # change the slug of the document and create a redirect from the original
+    document.update_attributes!(slug: args.new_slug)
+    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
 end


### PR DESCRIPTION
Instead of running data_migration to reslug a document, now a rake task
can be ran by inputting the old slug and the new desired slug. This
reindexes the document in elasticsearch, republishes to pub API and
publishes a redirect content item to pub API.