### PR TITLE
Require authors to check a box saying they've read consultation principles

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -184,6 +184,7 @@ private
       :primary_specialist_sector_tag,
       :corporate_information_page_type_id,
       :political,
+      :read_consultation_principles,
       secondary_specialist_sector_tags: [],
       lead_organisation_ids: [],
       supporting_organisation_ids: [],

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -12,6 +12,7 @@ class Consultation < Publicationesque
   validates :external_url, presence: true, if: :external?
   validates :external_url, uri: true, allow_blank: true
   validate :validate_closes_after_opens
+  validate :validate_consultation_principles, unless: ->(consultation) { Edition::PRE_PUBLICATION_STATES.include? consultation.state }
 
   has_one :outcome, class_name: 'ConsultationOutcome', foreign_key: :edition_id, dependent: :destroy
   has_one :public_feedback, class_name: 'ConsultationPublicFeedback', foreign_key: :edition_id, dependent: :destroy
@@ -168,6 +169,12 @@ private
   def validate_closes_after_opens
     if closing_at && opening_at && closing_at.to_date <= opening_at.to_date
       errors.add :closing_at, "must be after the opening on date"
+    end
+  end
+
+  def validate_consultation_principles
+    unless read_consultation_principles
+      errors.add :read_consultation_principles, "must be ticked"
     end
   end
 end

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -1,5 +1,7 @@
 <div class="format-advice">
   <p><strong>Use this format for:</strong> Consultations (officially “documents requiring collective agreement across government”, including calls for evidence).</p>
+
+  <p>Check you have read the current <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>.</p>
 </div>
 
 <%= consultation_editing_tabs(edition) do %>
@@ -60,6 +62,11 @@
 
       <%= render 'organisation_fields', form: form, edition: edition %>
       <%= render 'specialist_sector_fields', form: form, edition: edition %>
+    </fieldset>
+
+    <fieldset>
+      <legend>Consultation principles</legend>
+      <%= form.check_box :read_consultation_principles, label_text: 'We have considered the <a href="https://www.gov.uk/government/publications/consultation-principles-guidance">consultation principles</a>'.html_safe %>
     </fieldset>
   <% end %>
 <% end %>

--- a/db/migrate/20180427095027_add_read_consultation_principles_to_edition.rb
+++ b/db/migrate/20180427095027_add_read_consultation_principles_to_edition.rb
@@ -1,0 +1,5 @@
+class AddReadConsultationPrinciplesToEdition < ActiveRecord::Migration[5.0]
+  def change
+    add_column :editions, :read_consultation_principles, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424194943) do
+ActiveRecord::Schema.define(version: 20180427095027) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "topical_event_id"
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(version: 20180424194943) do
     t.string   "primary_locale",                                            default: "en",    null: false
     t.boolean  "political",                                                 default: false
     t.string   "logo_url"
+    t.boolean  "read_consultation_principles",                              default: false
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id", using: :btree
     t.index ["closing_at"], name: "index_editions_on_closing_at", using: :btree
     t.index ["document_id"], name: "index_editions_on_document_id", using: :btree

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -15,7 +15,8 @@ Scenario: Submitting a draft consultation to a second pair of eyes
 Scenario: Publishing a submitted consultation
   Given I am an editor
   And a submitted consultation "Beard Length Review" exists
-  When I publish the consultation "Beard Length Review"
+  When I check "Beard Length Review" adheres to the consultation principles
+  And I publish the consultation "Beard Length Review"
   Then I should see the consultation "Beard Length Review" in the list of published documents
 
 Scenario: Adding an outcome to a closed consultation

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -252,3 +252,9 @@ When(/^I edit the new edition$/) do
   fill_in 'Body', with: "New body"
   click_button 'Save'
 end
+
+When(/^I check "([^"]*)" adheres to the consultation principles$/) do |title|
+  edition = Edition.latest_edition.find_by!(title: title)
+  edition.read_consultation_principles = true
+  edition.save
+end

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -31,6 +31,7 @@ Scenario: Associating a publication with a topical event
 Scenario: Associating a consultation with a topical event
   Given a topical event called "An Event" with description "A topical event"
   When I draft a new consultation "A Consultation" relating it to topical event "An Event"
+  And I check "A Consultation" adheres to the consultation principles
   And I force publish the consultation "A Consultation"
   Then I should see the consultation "A Consultation" in the consultations section of the topical event "An Event"
 

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     body  "consultation-body"
     opening_at { 1.day.ago }
     closing_at { 6.weeks.from_now }
+    read_consultation_principles { true }
     transient do
       relevant_to_local_government { false }
     end


### PR DESCRIPTION
At the top of the page, link to the principles:

<img width="782" alt="screen shot 2018-04-27 at 16 48 51" src="https://user-images.githubusercontent.com/75235/39371942-052c1888-4a3b-11e8-968c-35c09fcb3788.png">

With a checkbox at the bottom:

<img width="794" alt="screen shot 2018-04-27 at 16 49 19" src="https://user-images.githubusercontent.com/75235/39371952-0af6afc6-4a3b-11e8-9621-65d445668725.png">

The consultation can be saved and updated without the box checked, as long as it's in a pre-publication state.  Trying to publish without checking the box gives you an error:

<img width="1032" alt="screen shot 2018-04-27 at 16 47 08" src="https://user-images.githubusercontent.com/75235/39372006-29075bbe-4a3b-11e8-9700-b0a15ddec538.png">

The error is a bit unsatisfying.

I'd prefer to get rid of the space or, even better, to use something like "Must have read the consultation principles", but that doesn't seem possible without subclassing `ActiveModel::Errors`.  Not passing the string at all gives "Read consultation principles is invalid", which is a terrible message.

---

[Trello card](https://trello.com/c/L9imzdp3/108-help-publishers-read-and-consider-consultation-principles-1)