### PR TITLE
Log obfuscated email addresses for consultation reminders

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -64,14 +64,14 @@ class Notifications < ActionMailer::Base
 
   def consultation_deadline_upcoming(consultation, weeks_left:)
     mail from: no_reply_email_address,
-      to: consultation.authors.map(&:email),
+      to: consultation.authors.uniq.map(&:email),
       subject: "Consultation response due in #{pluralize(weeks_left, 'week')}",
       body: %{Your consultation "#{consultation.title}" is closed and is due a response within #{pluralize(weeks_left, 'week')}}
   end
 
   def consultation_deadline_passed(consultation)
     mail from: no_reply_email_address,
-      to: consultation.authors.map(&:email),
+      to: consultation.authors.uniq.map(&:email),
       subject: "Consultation response deadline has passed",
       body: %{The consultation response deadline for "#{consultation.title}" has passed}
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -26,7 +26,7 @@ class Consultation < Publicationesque
   scope :opened_at_or_after, ->(time) { open.where('opening_at >= ?', time) }
   scope :upcoming, -> { where('opening_at > ?', Time.zone.now) }
   scope :responded, -> { joins(:outcome) }
-  scope :awaiting_response, -> { closed.where.not(id: responded.pluck(&:id)) }
+  scope :awaiting_response, -> { closed.where.not(id: responded.pluck(:id)) }
 
   add_trait do
     def process_associations_after_save(edition)

--- a/app/models/consultation_reminder.rb
+++ b/app/models/consultation_reminder.rb
@@ -13,14 +13,26 @@ class ConsultationReminder
 
     def send_deadline_reminder(weeks_left:)
       Consultation.awaiting_response.closed_on((PUBLISH_DEADLINE - weeks_left).weeks.ago.to_date).each do |consultation|
+        log(consultation)
         Notifications.consultation_deadline_upcoming(consultation, weeks_left: weeks_left).deliver_now
       end
     end
 
     def send_deadline_passed_notification
       Consultation.awaiting_response.closed_on((PUBLISH_DEADLINE.weeks + 1.day).ago.to_date).each do |consultation|
+        log(consultation)
         Notifications.consultation_deadline_passed(consultation).deliver_now
       end
+    end
+
+    def log(consultation)
+      Rails.logger.info("Sending reminder for consultation ##{consultation.id} '#{consultation.title}' to #{obfuscated_email_addresses(consultation)}")
+    end
+
+    def obfuscated_email_addresses(consultation)
+      consultation.authors.uniq.map { |author|
+        author.email.gsub(/^(.{2}).*(.{2})$/, '\1*****\2')
+      }.to_sentence
     end
   end
 end

--- a/test/unit/models/consultation_reminder_test.rb
+++ b/test/unit/models/consultation_reminder_test.rb
@@ -62,7 +62,8 @@ class ConsultationReminderTest < ActiveSupport::TestCase
   end
 
   test "#send_all doesn't send for consultations with a response" do
-    FactoryBot.create(:consultation_with_outcome,
+    FactoryBot.create(
+      :consultation_with_outcome,
       opening_at: 10.months.ago,
       closing_at: (12.weeks + 1.day).ago,
     )
@@ -74,7 +75,8 @@ class ConsultationReminderTest < ActiveSupport::TestCase
 
   test "#send_all only notifies authors once" do
     author = FactoryBot.create(:author)
-    consultation = FactoryBot.create(:consultation,
+    consultation = FactoryBot.create(
+      :consultation,
       opening_at: 10.months.ago,
       closing_at: (12.weeks + 1.day).ago,
     )

--- a/test/unit/models/consultation_reminder_test.rb
+++ b/test/unit/models/consultation_reminder_test.rb
@@ -72,6 +72,20 @@ class ConsultationReminderTest < ActiveSupport::TestCase
     assert ActionMailer::Base.deliveries.empty?
   end
 
+  test "#send_all only notifies authors once" do
+    author = FactoryBot.create(:author)
+    consultation = FactoryBot.create(:consultation,
+      opening_at: 10.months.ago,
+      closing_at: (12.weeks + 1.day).ago,
+    )
+    consultation.update(authors: [author, author])
+
+    ConsultationReminder.send_all
+
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_equal [author.email], ActionMailer::Base.deliveries.first.to
+  end
+
   def create_consultations(closed_at)
     FactoryBot.create(:consultation, opening_at: 10.months.ago, closing_at: closed_at + 1.day)
     FactoryBot.create(:consultation, opening_at: 10.months.ago, closing_at: closed_at - 1.day)

--- a/test/unit/models/consultation_reminder_test.rb
+++ b/test/unit/models/consultation_reminder_test.rb
@@ -61,6 +61,17 @@ class ConsultationReminderTest < ActiveSupport::TestCase
     end
   end
 
+  test "#send_all doesn't send for consultations with a response" do
+    FactoryBot.create(:consultation_with_outcome,
+      opening_at: 10.months.ago,
+      closing_at: (12.weeks + 1.day).ago,
+    )
+
+    ConsultationReminder.send_all
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
   def create_consultations(closed_at)
     FactoryBot.create(:consultation, opening_at: 10.months.ago, closing_at: closed_at + 1.day)
     FactoryBot.create(:consultation, opening_at: 10.months.ago, closing_at: closed_at - 1.day)


### PR DESCRIPTION
Logs elliot.crosby-mccullough@digital.cabinet-office.gov.uk as `el*****uk`.

Useful for monitoring and debugging.