### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -10,8 +10,7 @@
 
     <%= meta_description_tag %>
 
-    <%= render partial: 'govuk_component/analytics_meta_tags',
-      locals: { content_item: @content_item } %>
+    <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
 
     <title><%= page_title %></title>
     <%-

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -303,20 +303,6 @@ class AnnouncementsControllerTest < ActionController::TestCase
     refute_select '.filter-results-summary'
   end
 
-  view_test 'includes the analytics component' do
-    get :index
-
-    analytics_component = css_select(
-      'test-govuk-component[data-template=govuk_component-analytics_meta_tags]'
-    )
-
-    assert_match(
-      @content_item['title'],
-      analytics_component.text,
-      'Expected the analytics meta tag component to be initialized with the content item'
-    )
-  end
-
   view_test 'index includes tracking details on all links' do
     Sidekiq::Testing.inline! do
       news_article = create(:published_news_article)

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -617,18 +617,4 @@ private
       end
     end
   end
-
-  view_test 'includes the analytics component' do
-    get :index
-
-    analytics_component = css_select(
-      'test-govuk-component[data-template=govuk_component-analytics_meta_tags]'
-    )
-
-    assert_match(
-      @content_item['title'],
-      analytics_component.text,
-      'Expected the analytics meta tag component to be initialized with the content item'
-    )
-  end
 end

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -260,18 +260,4 @@ class StatisticsControllerTest < ActionController::TestCase
       end
     end
   end
-
-  view_test 'includes the analytics component' do
-    get :index
-
-    analytics_component = css_select(
-      'test-govuk-component[data-template=govuk_component-analytics_meta_tags]'
-    )
-
-    assert_match(
-      @content_item['title'],
-      analytics_component.text,
-      'Expected the analytics meta tag component to be initialized with the content item'
-    )
-  end
 end


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/2w1AKyuW