### PR TITLE
Update PersonPresenter

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -91,6 +91,10 @@ class Person < ApplicationRecord
     name_as_words(("The Rt Hon" if privy_counsellor?), title, forename, surname, letters)
   end
 
+  def full_name
+    name_as_words(title, forename, surname, letters)
+  end
+
   def name_without_privy_counsellor_prefix
     name_as_words(title, forename, surname, letters)
   end

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -35,11 +35,16 @@ module PublishingApi
     end
 
     def details
-      {}.tap do |hash|
-        if item.image_url(:s465)
-          hash[:image] = { url: item.image_url(:s465), alt_text: item.name }
-        end
+      details_hash = {}
+
+      if item.image_url(:s465)
+        details_hash[:image] = { url: item.image_url(:s465), alt_text: item.name }
       end
+
+      details_hash.merge(
+        full_name: item.full_name,
+        privy_counsellor: item.privy_counsellor?,
+      )
     end
   end
 end

--- a/lib/tasks/update_people_in_publishing_api.rake
+++ b/lib/tasks/update_people_in_publishing_api.rake
@@ -1,0 +1,8 @@
+namespace :publishing_api do
+  desc "Updates all people to Publishing API, async"
+  task update_all_people_in_publishing_api: :environment do
+    Person.find_each do |person|
+      Whitehall::PublishingApi.publish_async(person)
+    end
+  end
+end

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -8,12 +8,21 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
   end
 
   test 'presents a Person ready for adding to the publishing API' do
-    person = create(:person, forename: "Winston", image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg'))
+    person = create(
+      :person,
+      title: "Sir",
+      forename: "Winston",
+      surname: "Churchill",
+      letters: "PM",
+      privy_counsellor: true,
+      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+    )
+
     public_path = Whitehall.url_maker.person_path(person)
 
     expected_hash = {
       base_path: public_path,
-      title: "Winston",
+      title: "The Rt Hon Sir Winston Churchill PM",
       description: nil,
       schema_name: "person",
       document_type: "person",
@@ -24,9 +33,11 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
+        full_name: "Sir Winston Churchill PM",
+        privy_counsellor: true,
         image: {
           url: person.image_url(:s465),
-          alt_text: "Winston",
+          alt_text: "The Rt Hon Sir Winston Churchill PM",
         }
       },
       update_type: "major",
@@ -44,7 +55,14 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
   end
 
   test 'accepts people without an image' do
-    person = create(:person, forename: "Winston")
+    person = create(
+      :person,
+      title: "Sir",
+      forename: "Winston",
+      surname: "Churchill",
+      letters: "PM",
+      privy_counsellor: true,
+    )
 
     presented_item = present(person)
 


### PR DESCRIPTION
We want to pass to send two extra fields to publishing-api (`full_name` & `privy_counsellor`).

Uppon some research, we have noticed inconsistencies on how editors have been using the different fields (title, forename, surname and letters), some records had the title in the forename and others had the title, surname and letters into the surname.

To avoid future inconsistencies we have decided to have one field (full_name), this way we also are addressing the [Service Manual](https://www.gov.uk/service-manual/design/names#use-a-single-name-field-where-possible).

This is the beginning of that migration.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/755
Trello: https://trello.com/c/32LO2xT8