### PR TITLE
Update links on organisations index page

### DIFF
--- a/app/workers/update_organisations_list_worker.rb
+++ b/app/workers/update_organisations_list_worker.rb
@@ -1,0 +1,34 @@
+class UpdateOrganisationsListWorker < WorkerBase
+  def perform
+    PublishStaticPages.new.patch_links(
+      "fde62e52-dfb6-42ae-b336-2c4faf068101", # content_id for /government/organisations
+      links: links
+    )
+  end
+
+private
+
+  def links
+    {
+      ordered_executive_offices: organisation_content_ids(:executive_offices),
+      ordered_ministerial_departments: organisation_content_ids(:ministerial_departments),
+      ordered_non_ministerial_departments: organisation_content_ids(:non_ministerial_departments),
+      ordered_agencies_and_other_public_bodies: organisation_content_ids(:agencies_and_government_bodies),
+      ordered_high_profile_groups: organisation_content_ids(:high_profile_groups),
+      ordered_public_corporations: organisation_content_ids(:public_corporations),
+      ordered_devolved_administrations: organisation_content_ids(:devolved_administrations)
+    }
+  end
+
+  def organisation_content_ids(organisation_type_key)
+    presented_organisations.send(organisation_type_key).map(&:content_id)
+  end
+
+  def presented_organisations
+    @presented_organisations ||= OrganisationsIndexPresenter.new(all_organisations)
+  end
+
+  def all_organisations
+    @all_organisations ||= Organisation.excluding_courts_and_tribunals.listable.ordered_by_name_ignoring_prefix
+  end
+end

--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -120,6 +120,7 @@ class PublishStaticPages
         base_path: "/government/organisations",
         document_type: "finder",
         description: "Information from government departments, agencies and public bodies, including news, campaigns, policies and contact details.",
+        schema_name: "organisations_homepage",
       },
     ]
   end
@@ -154,7 +155,7 @@ class PublishStaticPages
         title: page[:title],
         description: page[:description],
         document_type: page[:document_type],
-        schema_name: "placeholder",
+        schema_name: page.fetch("schema_name", "placeholder"),
         locale: "en",
         base_path: page[:base_path],
         publishing_app: "whitehall",

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -995,6 +995,12 @@ class OrganisationTest < ActiveSupport::TestCase
     )
   end
 
+  test "#save triggers an update of the organisations index page links hash" do
+    organisation = build(:organisation)
+    UpdateOrganisationsListWorker.expects(:perform_async)
+    organisation.save!
+  end
+
   test "#save does not trigger organisation with a changed chart url to republish about page if it does not exist" do
     organisation = create(
       :organisation,

--- a/test/unit/services/service_listeners/edition_dependencies_test.rb
+++ b/test/unit/services/service_listeners/edition_dependencies_test.rb
@@ -63,7 +63,7 @@ class ServiceListeners::EditionDependenciesTest < ActiveSupport::TestCase
           expect_republishing(dependent_article)
           assert Whitehall.edition_services.send(service_name, dependable_speech).perform!
 
-          dependable_speech.unpublishing = create(:unpublishing)
+          dependable_speech.unpublishing = create(:unpublishing, edition: dependable_speech)
 
           #stub unpublishing worker to avoid the extra save draft calls
           PublishingApiUnpublishingWorker.stubs(:perform_async)

--- a/test/unit/workers/update_organisations_list_worker_test.rb
+++ b/test/unit/workers/update_organisations_list_worker_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class UpdateOrganisationsListWorkerTest < ActiveSupport::TestCase
+  test "sends to the publishing api" do
+    organisation = FactoryBot.create(:organisation)
+    links = {
+      ordered_executive_offices: [],
+      ordered_ministerial_departments: [],
+      ordered_non_ministerial_departments: [],
+      ordered_agencies_and_other_public_bodies: [organisation.content_id],
+      ordered_high_profile_groups: [],
+      ordered_public_corporations: [],
+      ordered_devolved_administrations: [],
+    }
+
+    Services.publishing_api.expects(:patch_links).with(
+      "fde62e52-dfb6-42ae-b336-2c4faf068101",
+      links: links
+    )
+
+    UpdateOrganisationsListWorker.new.perform
+  end
+end


### PR DESCRIPTION
This commit sets up a callback that updates the links to all organisations from the organisations index page at `/government/organisations` whenever a new organisation is created. Organisations that are updated or deleted will be changed automatically by publishing-api dependency resolution.

Trello: https://trello.com/c/kMgJ1gqF/56-link-to-all-organisations-from-the-organisation-list-content-item