### PR TITLE
Fix schema_name in PublishStaticPages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -155,7 +155,7 @@ class PublishStaticPages
         title: page[:title],
         description: page[:description],
         document_type: page[:document_type],
-        schema_name: page.fetch("schema_name", "placeholder"),
+        schema_name: page.fetch(:schema_name, "placeholder"),
         locale: "en",
         base_path: page[:base_path],
         publishing_app: "whitehall",

--- a/test/unit/publish_static_pages_test.rb
+++ b/test/unit/publish_static_pages_test.rb
@@ -10,11 +10,11 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
     PublishStaticPages.new.publish
   end
 
-  test 'static pages presented to the publishing api are valid placeholders' do
+  test 'static pages presented to the publishing api are valid according to the relevant schema' do
     publisher = PublishStaticPages.new
     publisher.pages.each do |page|
       presented = publisher.present_for_publishing_api(page)
-      expect_valid_placeholder(presented[:content])
+      expect_valid_for_schema(presented[:content])
     end
   end
 
@@ -25,7 +25,7 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
           page[:content_id],
           has_entries(
             document_type: page[:document_type],
-            schema_name: "placeholder",
+            schema_name: (page[:schema_name] || "placeholder"),
             base_path: page[:base_path],
             title: page[:title],
             update_type: "minor",
@@ -37,9 +37,9 @@ class PublishStaticPagesTest < ActiveSupport::TestCase
     end
   end
 
-  def expect_valid_placeholder(presented_page)
+  def expect_valid_for_schema(presented_page)
     validator = GovukContentSchemaTestHelpers::Validator.new(
-      "placeholder",
+      presented_page[:schema_name],
       "schema",
       presented_page
     )


### PR DESCRIPTION
This commit fixes the `PublishStaticPages` class to correctly fetch the schema name for the pages it publishes.