### PR TITLE
Add rake tasks for asset audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'graphviz_transitions'
   gem 'stackprof', require: false
+  gem 'mechanize'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,15 @@ GEM
       mini_mime (>= 0.1.1)
     maxitest (3.0.1)
       minitest (>= 5.0.0, < 5.12.0)
+    mechanize (2.7.5)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0)
+      mime-types (>= 1.17.2)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.6)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
     metaclass (0.0.4)
     method_source (0.9.0)
     mime-types (3.1)
@@ -301,10 +310,13 @@ GEM
     multipart-post (2.0.0)
     mustache (1.0.5)
     mysql2 (0.4.10)
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (2.9.4)
     netrc (0.11.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    ntlm-http (0.1.1)
     null_logger (0.0.1)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -532,6 +544,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    webrobots (0.1.2)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -589,6 +602,7 @@ DEPENDENCIES
   link_header
   logstasher (~> 1.2.1)
   maxitest
+  mechanize
   mime-types (~> 3.1)
   mini_magick (~> 4.8.0)
   minitest-fail-fast

--- a/lib/asset_audit.rb
+++ b/lib/asset_audit.rb
@@ -1,0 +1,74 @@
+class AssetAudit
+  def cache_bust
+    "cache_bust=#{rand(1e8)}"
+  end
+
+  def call(email, password, sample_size)
+    signon_url = Plek.new.external_url_for('signon')
+    whitehall_base_url = Plek.new.external_url_for('assets-origin')
+    asset_manager_base_url = Plek.new.external_url_for('draft-assets')
+
+    mechanize = Mechanize.new
+    mechanize.agent.allowed_error_codes = %w(404)
+    # mechanize.log = Logger.new($stdout)
+
+    sign_in_page = mechanize.get("#{signon_url}/users/sign_in")
+    signed_in_page = sign_in_page.form_with(id: 'new_user') do |form|
+      form['user[email]'] = email
+      form['user[password]'] = password
+    end.submit
+
+    message = (signed_in_page / '.alert-success').text
+    raise 'Failed to sign in' unless message == 'Signed in successfully.'
+
+    csv = CSV.new($stdout, col_sep: "\t")
+    csv << %w(
+      id
+      visible
+      whitehall_code
+      asset_manager_code
+      whitehall_location
+      asset_manager_location
+    )
+
+    samples = AttachmentData.order("RAND(123)").limit(sample_size)
+    samples.each do |attachment_data|
+      visible = attachment_data.visible_to?(nil)
+      unless visible
+        csv << [
+          attachment_data.id,
+          visible
+        ]
+        next
+      end
+
+      whitehall_path = attachment_data.file.url
+      asset_manager_path = attachment_data.file.asset_manager_path
+
+      whitehall_url = "#{whitehall_base_url}#{whitehall_path}"
+      asset_manager_url = "#{asset_manager_base_url}#{asset_manager_path}"
+
+      # Make request for asset from Whitehall
+      mechanize.redirect_ok = false
+      whitehall_response = mechanize.get("#{whitehall_url}?#{cache_bust}")
+
+      # Preparatory request for asset from Asset Manager following redirects
+      # in order to authenticate against Asset Manager if necessary
+      mechanize.redirect_ok = true
+      mechanize.get("#{asset_manager_url}?#{cache_bust}")
+
+      # Make request for asset from Asset Manager
+      mechanize.redirect_ok = false
+      asset_manager_response = mechanize.get("#{asset_manager_url}?#{cache_bust}")
+
+      csv << [
+        attachment_data.id,
+        visible,
+        whitehall_response.code,
+        asset_manager_response.code,
+        whitehall_response.header['location'],
+        asset_manager_response.header['location'],
+      ]
+    end
+  end
+end

--- a/lib/asset_audit.rb
+++ b/lib/asset_audit.rb
@@ -37,15 +37,21 @@ class AssetAudit
   end
 
   def ask_password
+    print "Password: "
     STDIN.noecho(&:gets).chomp
   end
 
-  def self.check_status(email, urls_filename)
-    new.check_status(email, urls_filename)
+  def self.check_status(*args)
+    new.check_status(*args)
   end
 
-  def check_status(email, urls_filename)
-    mechanize = Mechanize.new
+  def check_status(email, app_domain, urls_filename)
+    ENV["GOVUK_APP_DOMAIN"] = app_domain
+
+    mechanize = Mechanize.new { |agent|
+      agent.user_agent_alias = 'Mac Safari'
+    }
+
     mechanize.agent.allowed_error_codes = %w(404)
 
     sign_user_in(mechanize, email, ask_password)

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -47,8 +47,8 @@ namespace :asset_manager do
     AssetAudit.dump
   end
 
-  task :audit_check_status, %i(email filename) => :environment do |_, args|
-    AssetAudit.check_status(args[:email], args[:filename])
+  task :audit_check_status, %i(email app_domain filename) => :environment do |_, args|
+    AssetAudit.check_status(args[:email], args[:app_domain], args[:filename])
   end
 
   private

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -43,6 +43,13 @@ namespace :asset_manager do
     end
   end
 
+  task :audit, %i(sample_size) => :environment do |_, args|
+    auditor = AssetAudit.new
+    email = ENV.fetch("EMAIL")
+    password = ENV.fetch("PASSWORD")
+    auditor.call(email, password, args[:sample_size].to_i)
+  end
+
   private
 
   def usage_string

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -43,6 +43,10 @@ namespace :asset_manager do
     end
   end
 
+  task dump: :environment do
+    AssetAudit.dump
+  end
+
   task :audit, %i(sample_size) => :environment do |_, args|
     auditor = AssetAudit.new
     email = ENV.fetch("EMAIL")

--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -47,11 +47,8 @@ namespace :asset_manager do
     AssetAudit.dump
   end
 
-  task :audit, %i(sample_size) => :environment do |_, args|
-    auditor = AssetAudit.new
-    email = ENV.fetch("EMAIL")
-    password = ENV.fetch("PASSWORD")
-    auditor.call(email, password, args[:sample_size].to_i)
+  task :audit_check_status, %i(email filename) => :environment do |_, args|
+    AssetAudit.check_status(args[:email], args[:filename])
   end
 
   private


### PR DESCRIPTION
Adds rake tasks for auditing the assets:

- `asset_manager:dump`, gives (as a CSV) the URLs of every visible asset in Whitehall and its asset-manager path.
- `asset_manager:audit_check_status`, reads the CSV and prints a CSV of the status code, "location" header, "content-type" header, and "content-length" header.

[Trello Card](https://trello.com/c/0mGuSTyF/130-audit-whitehall-attachment-metadata-in-asset-manager-3)