### PR TITLE
Idempotent asset workers

### DIFF
--- a/app/workers/asset_manager_attachment_access_limited_worker.rb
+++ b/app/workers/asset_manager_attachment_access_limited_worker.rb
@@ -2,21 +2,21 @@ class AssetManagerAttachmentAccessLimitedWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
-    access_limited = []
+    access_limited_to_these_users = []
     if attachment_data.access_limited?
-      access_limited = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
+      access_limited_to_these_users = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
     end
 
-    enqueue_job(attachment_data, attachment_data.file, access_limited)
+    enqueue_job(attachment_data, attachment_data.file, access_limited_to_these_users)
     if attachment_data.pdf?
-      enqueue_job(attachment_data, attachment_data.file.thumbnail, access_limited)
+      enqueue_job(attachment_data, attachment_data.file.thumbnail, access_limited_to_these_users)
     end
   end
 
 private
 
-  def enqueue_job(attachment_data, uploader, access_limited)
+  def enqueue_job(attachment_data, uploader, access_limited_to_these_users)
     legacy_url_path = uploader.asset_manager_path
-    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'access_limited' => access_limited)
+    AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, "access_limited" => access_limited_to_these_users)
   end
 end

--- a/app/workers/asset_manager_attachment_delete_worker.rb
+++ b/app/workers/asset_manager_attachment_delete_worker.rb
@@ -1,8 +1,7 @@
 class AssetManagerAttachmentDeleteWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
-    return unless attachment_data.present?
-    return unless attachment_data.deleted?
+    return unless attachment_data.present? && attachment_data.deleted?
 
     delete_asset_for(attachment_data.file)
     if attachment_data.pdf?

--- a/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
+++ b/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
@@ -1,8 +1,7 @@
 class AssetManagerAttachmentReplacementIdUpdateWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
-    return unless attachment_data.present?
-    return unless attachment_data.replaced?
+    return unless attachment_data.present? && attachment_data.replaced?
     replacement = attachment_data.replaced_by
 
     replace_path(attachment_data, attachment_data.file.asset_manager_path, replacement.file.asset_manager_path)

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -2,6 +2,8 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
   include AssetManagerWorkerHelper
 
   def perform(file_path, legacy_url_path, draft = false, model_class = nil, model_id = nil)
+    return unless File.exist?(file_path)
+
     file = File.open(file_path)
     asset_options = { file: file, legacy_url_path: legacy_url_path }
     asset_options[:draft] = true if draft

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -3,6 +3,8 @@ class AssetManagerDeleteAssetWorker < WorkerBase
 
   def perform(legacy_url_path)
     attributes = find_asset_by(legacy_url_path)
+    return if attributes["deleted"]
+
     asset_manager.delete_asset(attributes['id'])
   end
 end

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -78,4 +78,13 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
 
     @worker.perform(@file.path, @legacy_url_path, true, attachment.attachment_data.class.to_s, attachment.attachment_data.id)
   end
+
+  test "doesn't run if the file is missing (e.g. job ran twice)" do
+    path = @file.path
+    FileUtils.rm(@file)
+
+    Services.asset_manager.expects(:create_whitehall_asset).never
+
+    @worker.perform(path, @legacy_url_path)
+  end
 end

--- a/test/unit/workers/asset_manager_delete_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_delete_asset_worker_test.rb
@@ -1,16 +1,16 @@
-require 'test_helper'
+require "test_helper"
 
 class AssetManagerDeleteAssetWorkerTest < ActiveSupport::TestCase
   setup do
-    @asset_id = 'asset-id'
+    @asset_id = "asset-id"
     @asset_url = "http://asset-manager/assets/#{@asset_id}"
-    @legacy_url_path = 'legacy-url-path'
+    @legacy_url_path = "legacy-url-path"
     @worker = AssetManagerDeleteAssetWorker.new
   end
 
-  test 'deletes file from asset manager' do
+  test "deletes file from asset manager" do
     @worker.stubs(:find_asset_by).with(@legacy_url_path)
-      .returns('id' => @asset_id)
+      .returns("id" => @asset_id)
     Services.asset_manager.expects(:delete_asset).with(@asset_id)
 
     @worker.perform(@legacy_url_path)

--- a/test/unit/workers/asset_manager_delete_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_delete_asset_worker_test.rb
@@ -15,4 +15,14 @@ class AssetManagerDeleteAssetWorkerTest < ActiveSupport::TestCase
 
     @worker.perform(@legacy_url_path)
   end
+
+  test "does not attempt a delete if the asset is already deleted" do
+    @worker.stubs(:find_asset_by).with(@legacy_url_path).returns(
+      "id" => @asset_id,
+      "deleted" => true,
+    )
+    Services.asset_manager.expects(:delete_asset).never
+
+    @worker.perform(@legacy_url_path)
+  end
 end


### PR DESCRIPTION
As per [this issue](https://github.com/alphagov/asset-manager/issues/545) Sidekiq operates on a "at least once" concurrency pattern, so our workers should be idempotent where possible.