### PR TITLE
Don’t publish crest for organisations with no identity

### DIFF
--- a/lib/publish_organisations_index_page.rb
+++ b/lib/publish_organisations_index_page.rb
@@ -61,7 +61,11 @@ private
   end
 
   def organisation_logo(organisation)
-    if organisation.organisation_crest == "custom"
+    if organisation.organisation_crest == "no-identity"
+      {
+        formatted_title: organisation.logo_formatted_name
+      }
+    elsif organisation.organisation_crest == "custom"
       {
         formatted_title: organisation.logo_formatted_name,
         image: {


### PR DESCRIPTION
This commit prevents the `PublishOrganisationsIndexPage` class from attempting to publish a `no-identity` crest for organisations with no logo.

Trello: https://trello.com/c/kMgJ1gqF/56-link-to-all-organisations-from-the-organisation-list-content-item