### PR TITLE
Rename cica slug

### DIFF
--- a/db/data_migration/20180508102221_rename_cica_notice.rb
+++ b/db/data_migration/20180508102221_rename_cica_notice.rb
@@ -1,0 +1,14 @@
+old_slug = 'cica-fair-processing-notice'
+new_slug = 'cica-privacy-notice'
+
+document = Document.find_by(slug: old_slug)
+
+if document
+  # remove the most recent edition from the search index
+  edition = document.editions.published.last
+  Whitehall::SearchIndex.delete(edition)
+
+  # change the slug of the document and create a redirect from the original
+  document.update_attributes!(slug: new_slug)
+  PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+end


### PR DESCRIPTION
As requested by Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2776357

We want to rename the following slug: /cica-fair-processing-notice to /cica-privacy-notice