### PR TITLE
Catch errors when trying to replace assets before they have synced

### DIFF
--- a/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
+++ b/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
@@ -16,5 +16,9 @@ class AssetManagerAttachmentReplacementIdUpdateWorker < WorkerBase
 
   def replace_path(attachment_data, legacy_url_path, replacement_legacy_url_path)
     AssetManagerUpdateAssetWorker.new.perform(attachment_data, legacy_url_path, 'replacement_legacy_url_path' => replacement_legacy_url_path)
+  rescue AssetManagerWorkerHelper::AssetManagerAssetNotFound
+    raise AssetNotFound.new('Asset unavailable, it may not have synced yet')
   end
+
+  class AssetNotFound < StandardError; end
 end

--- a/app/workers/asset_manager_worker_helper.rb
+++ b/app/workers/asset_manager_worker_helper.rb
@@ -5,7 +5,8 @@ module AssetManagerWorkerHelper
   private :asset_manager
 
   def find_asset_by(legacy_url_path)
-    attributes = asset_manager.whitehall_asset(legacy_url_path).to_hash
+    path = legacy_url_path.sub(/^\//, '')
+    attributes = asset_manager.whitehall_asset(path).to_hash
     url = attributes['id']
     id = url[/\/assets\/(.*)/, 1]
     attributes.merge('id' => id, 'url' => url)

--- a/app/workers/asset_manager_worker_helper.rb
+++ b/app/workers/asset_manager_worker_helper.rb
@@ -1,4 +1,11 @@
 module AssetManagerWorkerHelper
+  class AssetManagerAssetNotFound < StandardError
+    def initialize(legacy_url_path)
+      message = "Asset with legacy URL path #{legacy_url_path} is not on Asset Manager"
+      super(message)
+    end
+  end
+
   def asset_manager
     Services.asset_manager
   end
@@ -10,6 +17,9 @@ module AssetManagerWorkerHelper
     url = attributes['id']
     id = url[/\/assets\/(.*)/, 1]
     attributes.merge('id' => id, 'url' => url)
+  rescue GdsApi::HTTPNotFound
+    raise AssetManagerAssetNotFound.new(legacy_url_path)
   end
+
   private :find_asset_by
 end

--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.excluded_exceptions << 'AssetManagerAttachmentReplacementIdUpdateWorker::AssetNotFound'
+end

--- a/test/unit/workers/asset_manager_attachment_replacement_id_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_replacement_id_update_worker_test.rb
@@ -80,4 +80,22 @@ class AssetManagerAttachmentReplacementIdUpdateWorkerTest < ActiveSupport::TestC
       end
     end
   end
+
+  context 'when attachment is not synced with asset manager' do
+    let(:sample_rtf) { File.open(fixture_path.join('sample.rtf')) }
+    let(:sample_docx) { File.open(fixture_path.join('sample.docx')) }
+    let(:attachment_data) { AttachmentData.create!(file: sample_rtf, replaced_by: replacement) }
+    let(:replacement) { AttachmentData.create!(file: sample_docx) }
+
+    before do
+      update_worker.expects(:perform)
+        .raises(AssetManagerWorkerHelper::AssetManagerAssetNotFound.new('asset not found'))
+    end
+
+    it 'raises a AssetNotFound error' do
+      assert_raises(AssetManagerAttachmentReplacementIdUpdateWorker::AssetNotFound) do
+        worker.perform(attachment_data.id)
+      end
+    end
+  end
 end

--- a/test/unit/workers/asset_manager_worker_helper_test.rb
+++ b/test/unit/workers/asset_manager_worker_helper_test.rb
@@ -36,6 +36,15 @@ class AssetManagerWorkerHelperTest < ActiveSupport::TestCase
     assert_equal 'value', attributes['key']
   end
 
+  test 'raises AssetManagerAssetNotFound when an asset is not available' do
+    Services.asset_manager.stubs(:whitehall_asset).with(@legacy_url_path)
+      .raises(GdsApi::HTTPNotFound.new(404))
+
+    assert_raises AssetManagerWorkerHelper::AssetManagerAssetNotFound do
+      @worker.send(:find_asset_by, @legacy_url_path)
+    end
+  end
+
 private
 
   def gds_api_response(attributes = {})


### PR DESCRIPTION
Trello: https://trello.com/c/ACGX4n7d/129-fix-gdsapihttpnotfound-error-for-asset-manager-2

When an [AttachmentData](https://github.com/alphagov/whitehall/blob/master/app/models/attachment_data.rb) model is saved it runs a [callback](https://github.com/alphagov/whitehall/blob/master/app/models/attachment_data.rb#L193) to update any instances it replaces. This operation will often raise `GdsApi::HTTPNotFound` errors since it may well run before Whitehall has even told asset manager about the asset:

<img width="987" alt="screen shot 2018-05-08 at 18 10 27" src="https://user-images.githubusercontent.com/282717/39771752-2afdcc60-52eb-11e8-8aec-d50e38da6a7a.png">

This sets it up to throw specific exceptions that can be caught and have these be ignored by Sentry.

Ideally though it would be better if we could find a way to do this without things attempting to run before any synchronisation. However this feels like a big step outside of the eventual consistency that runs most of Whitehall.