### PR TITLE
Downgrade minitest to 5.10.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,8 @@ group :test do
   gem 'factory_bot'
   gem 'govuk-content-schema-test-helpers'
   gem 'maxitest'
+  # minitest 5.11.3 is incompatible with rails 5.0.6
+  # this is a temporary downgrade until rails is upgraded
   gem 'minitest', '5.10.3'
   gem 'minitest-fail-fast'
   gem 'minitest-stub-const'

--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ group :test do
   gem 'factory_bot'
   gem 'govuk-content-schema-test-helpers'
   gem 'maxitest'
+  gem 'minitest', '5.10.3'
   gem 'minitest-fail-fast'
   gem 'minitest-stub-const'
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     mini_magick (4.8.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.11.3)
+    minitest (5.10.3)
     minitest-fail-fast (0.1.0)
       minitest (~> 5)
     minitest-stub-const (0.6)
@@ -605,6 +605,7 @@ DEPENDENCIES
   mechanize
   mime-types (~> 3.1)
   mini_magick (~> 4.8.0)
+  minitest (= 5.10.3)
   minitest-fail-fast
   minitest-stub-const
   mlanett-redis-lock


### PR DESCRIPTION
Rails 5.0.6 is incompatible with the latest version of minitest (5.11.3)

This causes the test run to crash on the first error.
We need to be able to run the tests so downgrade is necessary until
whitehall is upgraded to rails > 5.1.

The error is documented [in this rails PR](https://github.com/rails/rails/pull/31624)