### PR TITLE
Update consultation reminder text

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -63,17 +63,20 @@ class Notifications < ActionMailer::Base
   end
 
   def consultation_deadline_upcoming(consultation, weeks_left:)
+    @title = consultation.title
+    @weeks_left = weeks_left
+
     mail from: no_reply_email_address,
       to: consultation.authors.uniq.map(&:email),
-      subject: "Consultation response due in #{pluralize(weeks_left, 'week')}",
-      body: %{Your consultation "#{consultation.title}" is closed and is due a response within #{pluralize(weeks_left, 'week')}}
+      subject: "Consultation response due in #{pluralize(weeks_left, 'week')}"
   end
 
   def consultation_deadline_passed(consultation)
+    @title = consultation.title
+
     mail from: no_reply_email_address,
       to: consultation.authors.uniq.map(&:email),
-      subject: "Consultation response deadline has passed",
-      body: %{The consultation response deadline for "#{consultation.title}" has passed}
+      subject: "Consultation deadline breached"
   end
 
 private

--- a/app/views/notifications/consultation_deadline_passed.text.erb
+++ b/app/views/notifications/consultation_deadline_passed.text.erb
@@ -1,0 +1,7 @@
+Publish the "<%= @title %>" response as soon as possible.
+
+Consultation responses must be published within 12 weeks of being closed, please see guidance here:
+https://www.gov.uk/government/publications/consultation-principles-guidance
+
+Read how to write good consultation pages here:
+https://www.gov.uk/guidance/content-design/content-types#consultation

--- a/app/views/notifications/consultation_deadline_upcoming.text.erb
+++ b/app/views/notifications/consultation_deadline_upcoming.text.erb
@@ -1,0 +1,7 @@
+Publish the government response for "<%= @title %>" within <%= pluralize(@weeks_left, "week") %>.
+
+Consultation responses must be published within 12 weeks of being closed, please see guidance here:
+https://www.gov.uk/government/publications/consultation-principles-guidance
+
+Read how to write good consultation pages here:
+https://www.gov.uk/guidance/content-design/content-types#consultation

--- a/test/functional/notifications_consultation_reminders_test.rb
+++ b/test/functional/notifications_consultation_reminders_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class NotificationsConsultationRemindersTest < ActionMailer::TestCase
+  setup do
+    @consultation = build(:consultation)
+  end
+
+  test "reminder emails should contain the title text and weeks remaining" do
+    @email = Notifications.consultation_deadline_upcoming(@consultation, weeks_left: 2)
+    assert_includes @email.body.to_s, %{Publish the government response for "#{@consultation.title}" within 2 weeks}
+  end
+
+  test "overdue notifications should contain the title text" do
+    @email = Notifications.consultation_deadline_passed(@consultation)
+    assert_includes @email.body.to_s, %{Publish the "#{@consultation.title}" response as soon as possible}
+  end
+end


### PR DESCRIPTION
This is the updated text from the content team, edited to accommodate text-only emails.

https://trello.com/c/OrQqkV8J/149-add-content-to-consultation-reminder-email-then-start-sending-these-emails-2