### PR TITLE
Move uncategorised publishing workers to publishing_api queue

### DIFF
--- a/app/workers/publishing_api_corporate_information_pages_worker.rb
+++ b/app/workers/publishing_api_corporate_information_pages_worker.rb
@@ -2,6 +2,8 @@ class PublishingApiCorporateInformationPagesWorker
   extend Forwardable
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'publishing_api'
+
   def perform(edition_id, event)
     self.corporate_information_page =
       CorporateInformationPage.unscoped.find(edition_id)

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -14,6 +14,8 @@
 class PublishingApiDocumentRepublishingWorker < WorkerBase
   attr_reader :published_edition, :pre_publication_edition
 
+  sidekiq_options queue: 'publishing_api'
+
   def perform(document_id)
     document = Document.find(document_id)
     #this the latest edition in a visible state ie: withdrawn, published

--- a/app/workers/publishing_api_html_attachments_worker.rb
+++ b/app/workers/publishing_api_html_attachments_worker.rb
@@ -4,6 +4,8 @@ class PublishingApiHtmlAttachmentsWorker
   attr_reader :edition
   private :edition
 
+  sidekiq_options queue: 'publishing_api'
+
   def perform(edition_id, event)
     @edition = Edition.unscoped.find(edition_id)
     send(event) if respond_to?(event) && edition.respond_to?(:html_attachments)

--- a/app/workers/publishing_api_publications_worker.rb
+++ b/app/workers/publishing_api_publications_worker.rb
@@ -2,6 +2,8 @@ class PublishingApiPublicationsWorker
   extend Forwardable
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'publishing_api'
+
   def perform(edition_id, event)
     self.publication =
       Publication.unscoped.find(edition_id)

--- a/app/workers/publishing_api_unpublishing_worker.rb
+++ b/app/workers/publishing_api_unpublishing_worker.rb
@@ -1,6 +1,8 @@
 class PublishingApiUnpublishingWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'publishing_api'
+
   def perform(unpublishing_id, allow_draft = false)
     unpublishing = Unpublishing.includes(:edition).find(unpublishing_id)
     edition = unpublishing.edition


### PR DESCRIPTION
We have a Sidekiq queue called "publishing_api", but some of the "publishing_api_*" workers do not use it, using the default queue instead.  I suspect that this is an oversight.