### PR TITLE
Add a separate Sidekiq queue for asset-manager tasks

### DIFF
--- a/app/workers/asset_manager_attachment_access_limited_worker.rb
+++ b/app/workers/asset_manager_attachment_access_limited_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentAccessLimitedWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?

--- a/app/workers/asset_manager_attachment_delete_worker.rb
+++ b/app/workers/asset_manager_attachment_delete_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentDeleteWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present? && attachment_data.deleted?

--- a/app/workers/asset_manager_attachment_draft_status_update_worker.rb
+++ b/app/workers/asset_manager_attachment_draft_status_update_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentDraftStatusUpdateWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?

--- a/app/workers/asset_manager_attachment_link_header_update_worker.rb
+++ b/app/workers/asset_manager_attachment_link_header_update_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentLinkHeaderUpdateWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?

--- a/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
+++ b/app/workers/asset_manager_attachment_replacement_id_update_worker.rb
@@ -1,4 +1,6 @@
 class AssetManagerAttachmentReplacementIdUpdateWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present? && attachment_data.replaced?

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -1,6 +1,8 @@
 class AssetManagerCreateWhitehallAssetWorker < WorkerBase
   include AssetManagerWorkerHelper
 
+  sidekiq_options queue: 'asset_manager'
+
   def perform(file_path, legacy_url_path, draft = false, model_class = nil, model_id = nil)
     return unless File.exist?(file_path)
 

--- a/app/workers/asset_manager_delete_asset_worker.rb
+++ b/app/workers/asset_manager_delete_asset_worker.rb
@@ -1,6 +1,8 @@
 class AssetManagerDeleteAssetWorker < WorkerBase
   include AssetManagerWorkerHelper
 
+  sidekiq_options queue: 'asset_manager'
+
   def perform(legacy_url_path)
     attributes = find_asset_by(legacy_url_path)
     return if attributes["deleted"]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,7 @@
   - scheduled_publishing
   - default
   - publishing_api
+  - asset_manager
   - email_alert_api_signup
   - bulk_republishing
   - sync_checks


### PR DESCRIPTION
Friday's incident solved itself, but it took a while.  This is directly because whitehall was spending all its time processing the backed-up asset-manager tasks before it got to any of the publishing tasks.

To mitigate this problem, this PR adds a new queue for asset-manager jobs, which is processed after the regular publishing jobs.