### PR TITLE
[DO NOT MERGE] Add a second Sidekiq worker for publishing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3020}
+worker: bundle exec sidekiq -C ./config/sidekiq_publishing.yml
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,11 +5,8 @@
 :concurrency: 1
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - scheduled_publishing
   - default
-  - publishing_api
   - email_alert_api_signup
-  - bulk_republishing
   - sync_checks
   - link_checks
   - asset_migration

--- a/config/sidekiq_publishing.yml
+++ b/config/sidekiq_publishing.yml
@@ -1,0 +1,10 @@
+:verbose: true
+# We set concurrency to 1 because parts of the publishing pipeline
+# are not threadsafe. Once we've removed instances of `I18n.with_locale`
+# from the workers, we can increase this again.
+:concurrency: 1
+:logfile: ./log/sidekiq_publishing.json.log
+:queues:
+  - scheduled_publishing
+  - publishing_api
+  - bulk_republishing


### PR DESCRIPTION
The visible part of Friday's incident (publication delay) was directly due to Whitehall spending all its time processing asset-manager jobs, which it does before publishing jobs.

To mitigate this problem, this PR adds a second Sidekiq worker for *just* publishing jobs.

---

Another thing to think about is: do we really want any one queue to be able to block the lower ones?  This has some discussion of weights: https://philsturgeon.uk/2016/11/16/tips-on-sidekiq-queues/

---

Tagging this with "DO NOT MERGE" pending the incident review.