### PR TITLE
Alter links for providing feedback on topic taxonomy

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -6,9 +6,6 @@
 <div class="row">
   <div class="col-md-12">
     <h2>Topics (new taxonomy)</h2>
-    <p>
-      <%= link_to "Send feedback about the new taxonomy", Whitehall.support_url, class: "feedback-link" %>
-    </p>
     <hr>
 
     <%= form_for @tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>
@@ -30,8 +27,17 @@
       </div>
 
       <%= form.hidden_field "invisible_draft_taxons", value: @tag_form.invisible_taxons.join(",") %>
+
       <p>
-        <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
+        <%= link_to "Suggest a new topic",
+          "#{Whitehall.support_url}/taxonomy_new_topic_request/new",
+          class: "feedback-link"
+        %>
+        or
+        <%= link_to "Suggest a change to a topic",
+          "#{Whitehall.support_url}/taxonomy_change_topic_request/new",
+          class: "feedback-link"
+        %>
       </p>
 
       <h2>Selected topics</h2>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -6,9 +6,6 @@
 <div class="row">
   <div class="col-md-12">
     <h2>Topics (new taxonomy)</h2>
-    <p>
-      <%= link_to "Send feedback about the new taxonomy", Whitehall.support_url, class: "feedback-link" %>
-    </p>
     <hr>
 
     <%= form_for @tag_form, url: admin_statistics_announcement_tags_path(@statistics_announcement), method: :put do |form| %>
@@ -30,7 +27,15 @@
       </div>
 
       <p>
-        <%= link_to "Report a missing topic", Whitehall.support_url, class: "feedback-link" %>
+        <%= link_to "Suggest a new topic",
+          "#{Whitehall.support_url}/taxonomy_new_topic_request/new",
+          class: "feedback-link"
+        %>
+        or
+        <%= link_to "Suggest a change to a topic",
+          "#{Whitehall.support_url}/taxonomy_change_topic_request/new",
+          class: "feedback-link"
+        %>
       </p>
 
       <h2>Selected topics</h2>


### PR DESCRIPTION
Remove vague links and replace with more specific ones, like,
'Suggest a new topic` takes the user to that actual form where they can
recommend a new topic. Previsously the feedback links would land the user
on the homepage of the support app with no real connection with what
the link text described.