### PR TITLE
Tell search engines to only index first page of a paginated set

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -3,7 +3,7 @@ module PaginationHelper
     link_content = "Next <span class=\"visuallyhidden\">page</span> <span class=\"page-numbers\">#{page} of #{of}</span>".html_safe
 
     content_tag :li, class: 'next' do
-      link_to link_content, url
+      link_to link_content, url, rel: "next"
     end
   end
 
@@ -11,7 +11,7 @@ module PaginationHelper
     link_content = "Previous <span class=\"visuallyhidden\">page</span> <span class=\"page-numbers\">#{page} of #{of}</span>".html_safe
 
     content_tag :li, class: 'previous' do
-      link_to link_content, url
+      link_to link_content, url, rel: "prev"
     end
   end
 end

--- a/app/views/documents/_filter_results.html.erb
+++ b/app/views/documents/_filter_results.html.erb
@@ -19,3 +19,6 @@
 <div class="filter-results-summary">
   <%= render_mustache('documents/filter_selections', context) %>
 </div>
+
+<%# This will be hoisted into <head> by Slimmer %>
+<% tag :meta, name: 'robots', content: 'noindex' unless filter.documents.first_page? %>

--- a/app/views/documents/_filter_table.mustache
+++ b/app/views/documents/_filter_table.mustache
@@ -40,12 +40,12 @@
       <ul class="previous-next-navigation">
         {{#prev_page?}}
           <li class="previous">
-            <a href="{{prev_page_web_url}}">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
+            <a href="{{prev_page_web_url}}" rel="prev">Previous <span class="visuallyhidden">page</span> <span class="page-numbers">{{prev_page}} of {{total_pages}}</span></a>
           </li>
         {{/prev_page?}}
         {{#next_page?}}
           <li class="next">
-            <a href="{{next_page_web_url}}">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
+            <a href="{{next_page_web_url}}" rel="next">Next <span class="visuallyhidden">page</span> <span class="page-numbers">{{next_page}} of {{total_pages}}</span></a>
           </li>
         {{/next_page?}}
       </ul>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,4 +7,4 @@
     remote:        data-remote
 -%>
 <% text = "Next <span class='visuallyhidden'>page</span> <span class='page-numbers'>#{current_page + 1} of #{total_pages}</span>".html_safe %>
-<li class="next"><%= link_to_unless current_page.last?, text, url %></li>
+<li class="next"><%= link_to_unless current_page.last?, text, url, rel: "next" %></li>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,4 +7,4 @@
     remote:        data-remote
 -%>
 <% text = "Previous <span class='visuallyhidden'>page</span> <span class='page-numbers'>#{current_page - 1} of #{total_pages}</span>".html_safe %>
-<li class="previous"><%= link_to_unless current_page.first?, text, url %></li>
+<li class="previous"><%= link_to_unless current_page.first?, text, url, rel: "prev" %></li>

--- a/app/views/statistics_announcements/_filter_results.html.erb
+++ b/app/views/statistics_announcements/_filter_results.html.erb
@@ -28,3 +28,6 @@
     </ul>
   </nav>
 <% end %>
+
+<%# This will be hoisted into <head> by Slimmer %>
+<% tag :meta, name: 'robots', content: 'noindex' if @filter.results.previous_page? %>

--- a/test/unit/helpers/pagination_helper_test.rb
+++ b/test/unit/helpers/pagination_helper_test.rb
@@ -10,6 +10,7 @@ class PaginationHelperTest < ActionView::TestCase
     link_tag = rendered.at_css('a')
     assert_equal '/somewhere?page=2', link_tag[:href]
     assert_equal "Next page 2 of 10", link_tag.text
+    assert_equal "next", link_tag[:rel]
   end
 
   test "previous_page_link should build a link inside an li with the given attributes" do
@@ -21,5 +22,6 @@ class PaginationHelperTest < ActionView::TestCase
     link_tag = rendered.at_css('a')
     assert_equal '/somewhere?page=2', link_tag[:href]
     assert_equal "Previous page 2 of 10", link_tag.text
+    assert_equal "prev", link_tag[:rel]
   end
 end


### PR DESCRIPTION
This will encourage search engines to index only the first page of a paginated set of pages meaning users should always end up at the first page.

[Trello Card](https://trello.com/c/PHjO8hP2/139-noindex-pagination-from-external-search-2)