### PR TITLE
Add rake tasks to delete attachments with an invalid attachable

### DIFF
--- a/lib/tasks/attachment.rake
+++ b/lib/tasks/attachment.rake
@@ -1,0 +1,20 @@
+namespace :attachment do
+  desc 'List and delete attachments with invalid attachables'
+  task delete_where_attachable_invalid: :environment do
+    # adding 'attachable: nil' to this 'where' doesn't work here:
+    # doing so only keeps those with a null attachable_id in the
+    # database; but if the attachable_id is invalid but non-null, the
+    # attachable will be nil:
+    #
+    # irb> Attachment.find(566845).attachable
+    # => nil
+    # irb> Attachment.find(566845).attachable_id
+    # => 330497
+    #
+    Attachment.where(deleted: false).find_each do |attachment|
+      next unless attachment.attachable == nil
+      puts attachment.attachment_data.file.asset_manager_path if attachment.attachment_data && attachment.attachment_data.file
+      attachment.destroy
+    end
+  end
+end


### PR DESCRIPTION
The audit we did was only against visible assets, so there's a task here to check all attachments.

~~I imagine the way we handle the full change (https://github.com/alphagov/asset-manager/pull/560) will be:~~

1. ~~Run `rake attachment:delete_where_attachable_invalid` in whitehall, which prints a list of legacy urls~~
2. ~~Run `rake govuk_assets:unreplace_whitehall_asset` in asset-manager for each one~~

I think we just need to run this on whitehall and wait for all the asset-manager jobs to complete.  Then we can run the audit again and see what happens.

---

[Trello card](https://trello.com/c/uIPJV2kI/150-fix-old-replaced-whitehall-attachments-on-discarded-editions-2)