### PR TITLE
Modify and organise Topic Taxonomy tagging page

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -17,13 +17,8 @@
         data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.live } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.ordered_taxons } %>
 
-        <h2>Alpha and Beta topics</h2>
-
-        <p>These topic pages are in development, and are not shown on GOV.UK</p>
-
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.alpha_beta } %>
       </div>
 
       <%= form.hidden_field "invisible_draft_taxons", value: @tag_form.invisible_taxons.join(",") %>

--- a/app/views/admin/statistics_announcement_tags/edit.html.erb
+++ b/app/views/admin/statistics_announcement_tags/edit.html.erb
@@ -17,13 +17,8 @@
         data-content-format="statistics_announcement"
         data-content-public-path="<%= @statistics_announcement.public_path %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.live } %>
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.ordered_taxons } %>
 
-        <h2>Draft topics</h2>
-
-        <p>These topic pages are in development, and are not shown on GOV.UK</p>
-
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @topic_taxonomy.alpha_beta } %>
       </div>
 
       <p>

--- a/lib/taxonomy/topic_taxonomy.rb
+++ b/lib/taxonomy/topic_taxonomy.rb
@@ -5,18 +5,8 @@ module Taxonomy
       @tree_builder_class = tree_builder_class
     end
 
-    def live
-      @_live ||= branches.select do |level_one_taxon|
-        level_one_taxon.phase == 'live' &&
-          level_one_taxon.visible_to_departmental_editors
-      end
-    end
-
-    def alpha_beta
-      @_alpha_beta ||= branches.select do |level_one_taxon|
-        level_one_taxon.phase != 'live' &&
-          level_one_taxon.visible_to_departmental_editors
-      end
+    def ordered_taxons
+      @_ordered_taxons ||= ordered_branches.select(&:visible_to_departmental_editors)
     end
 
     def all_taxons
@@ -33,6 +23,10 @@ module Taxonomy
       @_branches ||= @adapter.taxon_data.map do |taxon_hash|
         @tree_builder_class.new(taxon_hash).root_taxon
       end
+    end
+
+    def ordered_branches
+      @_ordered_branches ||= branches.sort_by(&:name)
     end
   end
 end

--- a/test/unit/taxonomy/topic_taxonomy_test.rb
+++ b/test/unit/taxonomy/topic_taxonomy_test.rb
@@ -7,19 +7,6 @@ class Taxonomy::TopicTaxonomyTest < ActiveSupport::TestCase
     Taxonomy::TopicTaxonomy.new
   end
 
-  test "#live" do
-    redis_cache_has_taxons([build(:taxon_hash, content_id: 'live_id', phase: 'live'),
-                            build(:taxon_hash, phase: 'alpha')])
-    assert_equal ['live_id'], subject.live.map(&:content_id)
-  end
-
-  test "#alpha_beta" do
-    redis_cache_has_taxons([build(:taxon_hash, phase: 'live'),
-                            build(:taxon_hash, content_id: 'alpha_id', phase: 'alpha'),
-                            build(:taxon_hash, content_id: 'beta_id', phase: 'beta')])
-    assert_equal %w[alpha_id beta_id], subject.alpha_beta.map(&:content_id)
-  end
-
   test "#all_taxons" do
     redis_cache_has_taxons([build(:taxon_hash, content_id: 'live_id', phase: 'live'),
                             build(:taxon_hash, content_id: 'alpha_id', phase: 'alpha'),
@@ -31,5 +18,15 @@ class Taxonomy::TopicTaxonomyTest < ActiveSupport::TestCase
     redis_cache_has_taxons([build(:taxon_hash, content_id: 'visible_id', visibility: true),
                             build(:taxon_hash, content_id: 'visible_id', visibility: false),])
     assert_equal ['visible_id'], subject.visible_taxons.map(&:content_id)
+  end
+
+  test "#ordered_taxons are ordered by name" do
+    redis_cache_has_taxons([build(:taxon_hash, title: 'Cow', phase: 'live'),
+                            build(:taxon_hash, title: 'Moose', phase: 'alpha'),
+                            build(:taxon_hash, title: 'Alpha', phase: 'alpha'),
+                            build(:taxon_hash, title: 'Donkey', phase: 'beta'),
+                            build(:taxon_hash, title: 'Zebra', phase: 'alpha'),
+                            build(:taxon_hash, title: 'Anteater', phase: 'beta')])
+    assert_equal %w[Alpha Anteater Cow Donkey Moose Zebra], subject.ordered_taxons.map(&:name)
   end
 end


### PR DESCRIPTION
Make all the taxon's that can be tagged to appear in one ordered list on
the Topic Taxonomy tagging interface. This can be done by merging the
alpha, beta and live lists together and ordering all the taxon's in
an alphabetical order.

This will ensure that the Topic tagging interface is easier to understand and
use.

<img width="1053" alt="screen shot 2018-05-31 at 10 29 55" src="https://user-images.githubusercontent.com/24479188/40774486-9e8caa46-64bd-11e8-8c06-963c6bd44212.png">
