### PR TITLE
Tweak the Topic Taxonomy tagging message

### DIFF
--- a/app/assets/stylesheets/admin/alerts.scss
+++ b/app/assets/stylesheets/admin/alerts.scss
@@ -69,6 +69,11 @@ p.warning {
   margin: 15px 0;
 }
 
+div.info {
+  font-size: 1.2em;
+  margin: 15px 0;
+}
+
 .required span {
   color: $orange;
   padding: 3px 5px;

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -40,10 +40,12 @@
       <div class="content content-bordered hidden" data-module="breadcrumb-preview">
       </div>
 
-      <p class="warning">
-        Warning: topic changes to published content appear instantly on the live site.
-      </p>
 
+      <div class="info alert alert-info" role="alert">
+        <strong>Info:</strong> Topics are applied to all editions of a
+        document. This means changes will be reflected on the live
+        site if there's a published edition.
+      </div>
       <div class="publishing-controls well">
         <%= form.form_actions(buttons: { save: 'Save topic changes', legacy_tags: 'Legacy tags' }, cancel: admin_edition_path(@edition)) %>
       </div>


### PR DESCRIPTION
I don't think this needs to be a warning, or so alarming, as Topic
Taxonomy tagging is done at the document level as the tagging should
be appropriate for any edition.

Therefore, use blue rather than red rather than colour, and update the
text to try to be more informative.

## Old
![old-warning](https://user-images.githubusercontent.com/1130010/40496754-6ac99e6c-5f72-11e8-9234-21a5cc9fc2d3.png)

## New
![new](https://user-images.githubusercontent.com/1130010/40496755-6d2f8824-5f72-11e8-9feb-d5873c1dba18.png)
