### PR TITLE
Split the Worldwide tagging interface out from the Topic Taxonomy tagging interface [DO NOT MERGE]

### DIFF
--- a/app/controllers/admin/edition_tags_controller.rb
+++ b/app/controllers/admin/edition_tags_controller.rb
@@ -12,7 +12,7 @@ class Admin::EditionTagsController < Admin::BaseController
     EditionTaxonLinkPatcher.new.call(
       content_id: @edition.content_id,
       selected_taxons: selected_taxons,
-      invisible_taxons: invisible_taxons,
+      invisible_taxons: invisible_taxons + previously_selected_world_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
     )
 
@@ -44,5 +44,10 @@ private
 
   def invisible_taxons
     params["taxonomy_tag_form"].fetch("invisible_taxons", "").split(",")
+  end
+
+  def previously_selected_world_taxons
+    world_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch_world_taxons
+    world_taxons.map(&:content_id)
   end
 end

--- a/app/controllers/admin/edition_world_tags_controller.rb
+++ b/app/controllers/admin/edition_world_tags_controller.rb
@@ -1,0 +1,43 @@
+class Admin::EditionWorldTagsController < Admin::BaseController
+  before_action :find_edition
+  before_action :enforce_permissions!
+  before_action :limit_edition_access!
+
+  def edit
+    @world_taxonomy = Taxonomy::WorldTaxonomy.new
+    @tag_form = WorldTaxonomyTagForm.load(@edition.content_id)
+  end
+
+  def update
+    EditionWorldTaxonLinkPatcher.new.call(
+      content_id: @edition.content_id,
+      selected_taxons: selected_taxons,
+      invisible_taxons: [],
+      previous_version: params["taxonomy_tag_form"]["previous_version"],
+    )
+    redirect_to admin_edition_path(@edition),
+      notice: "The tags have been updated."
+  rescue GdsApi::HTTPConflict
+    redirect_to edit_admin_edition_world_tags_path(@edition),
+      alert: "Somebody changed the tags before you could. Your changes have not been saved."
+  end
+
+private
+
+  def enforce_permissions!
+    unless @edition.can_be_tagged_to_taxonomy?
+      raise Whitehall::Authority::Errors::PermissionDenied.new(:update, @edition)
+    end
+
+    enforce_permission!(:update, @edition)
+  end
+
+  def find_edition
+    edition = Edition.find(params[:edition_id])
+    @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def selected_taxons
+    params["taxonomy_tag_form"].fetch("taxons", []).reject(&:blank?)
+  end
+end

--- a/app/controllers/admin/edition_world_tags_controller.rb
+++ b/app/controllers/admin/edition_world_tags_controller.rb
@@ -12,7 +12,7 @@ class Admin::EditionWorldTagsController < Admin::BaseController
     EditionWorldTaxonLinkPatcher.new.call(
       content_id: @edition.content_id,
       selected_taxons: selected_taxons,
-      invisible_taxons: [],
+      invisible_taxons: previously_selected_topic_taxons,
       previous_version: params["taxonomy_tag_form"]["previous_version"],
     )
     redirect_to admin_edition_path(@edition),
@@ -39,5 +39,10 @@ private
 
   def selected_taxons
     params["taxonomy_tag_form"].fetch("taxons", []).reject(&:blank?)
+  end
+
+  def previously_selected_topic_taxons
+    topic_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
+    topic_taxons.map(&:content_id)
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -74,6 +74,7 @@ class Admin::EditionsController < Admin::BaseController
 
     if @edition.can_be_tagged_to_taxonomy?
       @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
+      @edition_world_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch_world_taxons
     end
   end
 

--- a/app/models/world_taxonomy_tag_form.rb
+++ b/app/models/world_taxonomy_tag_form.rb
@@ -1,0 +1,26 @@
+class WorldTaxonomyTagForm
+  include ActiveModel::Model
+
+  attr_accessor :selected_taxons, :content_id, :previous_version
+
+  def self.load(content_id)
+    begin
+      content_item = Services.publishing_api.get_links(content_id)
+
+      selected_taxons = content_item["links"]["taxons"] || []
+      previous_version = content_item["version"] || 0
+    rescue GdsApi::HTTPNotFound
+      # TODO: This is a workaround, because Publishing API
+      # returns 404 when the document exists but there are no links.
+      # This can be removed when that changes.
+      selected_taxons = []
+      previous_version = 0
+    end
+
+    new(
+      selected_taxons: selected_taxons,
+      content_id: content_id,
+      previous_version: previous_version
+    )
+  end
+end

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -6,7 +6,15 @@ class EditionTaxonsFetcher
   end
 
   def fetch
-    taxons.select { |taxon| visible?(taxon) }
+    taxons.select do |taxon|
+      visible?(taxon) && topic_taxon?(taxon.content_id)
+    end
+  end
+
+  def fetch_world_taxons
+    taxons.select do |taxon|
+      visible?(taxon) && world_taxon?(taxon.content_id)
+    end
   end
 
 private
@@ -17,6 +25,15 @@ private
 
   def visible?(taxon)
     taxon.parent_node.nil? ? taxon.visible_to_departmental_editors : visible?(taxon.parent_node)
+  end
+
+  def topic_taxon?(content_id)
+    !world_taxon?(content_id)
+  end
+
+  def world_taxon?(content_id)
+    world_taxon_content_ids = all_world_taxons.map(&:content_id)
+    content_id.in?(world_taxon_content_ids)
   end
 
   def build_taxon(taxon_link)
@@ -48,7 +65,7 @@ private
     Services.publishing_api.get_expanded_links(content_id)
   end
 
-  def topic_taxonomy
-    Taxonomy::TopicTaxonomy.new
+  def all_world_taxons
+    Taxonomy::WorldTaxonomy.new.all_world_taxons.flat_map(&:taxon_list)
   end
 end

--- a/app/services/edition_world_taxon_link_patcher.rb
+++ b/app/services/edition_world_taxon_link_patcher.rb
@@ -1,0 +1,32 @@
+class EditionWorldTaxonLinkPatcher
+  def call(content_id:, previous_version:, selected_taxons:, invisible_taxons:)
+    Services
+      .publishing_api
+      .patch_links(
+        content_id,
+        links: { taxons: most_specific_taxons(selected_taxons) + invisible_taxons },
+        previous_version: previous_version
+      )
+  end
+
+private
+
+  def most_specific_taxons(selected_taxons)
+    all_world_taxons.each_with_object([]) do |taxon, list_of_taxons|
+      content_ids = taxon.descendants.map(&:content_id)
+
+      any_descendants_selected = selected_taxons.any? do |selected_taxon|
+        content_ids.include?(selected_taxon)
+      end
+
+      unless any_descendants_selected
+        content_id = taxon.content_id
+        list_of_taxons << content_id if selected_taxons.include?(content_id)
+      end
+    end
+  end
+
+  def all_world_taxons
+    Taxonomy::WorldTaxonomy.new.all_world_taxons.flat_map(&:taxon_list)
+  end
+end

--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -1,0 +1,36 @@
+<% page_title "Edit topics: " + @edition.title %>
+
+<div class="row">
+  <h1><%= @edition.title %></h1>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <h2>Worldwide</h2>
+    <hr>
+
+    <%= form_for @tag_form, url: admin_edition_world_tags_path(@edition), method: :put do |form| %>
+      <%= form.hidden_field :previous_version %>
+
+      <div class="form-group"
+        data-module="taxonomy-tree-checkboxes"
+        data-content-id="<%= @edition.content_id %>"
+        data-content-format="<%= @edition.content_store_document_type %>"
+        data-content-public-path="<%= public_document_path(@edition) %>">
+
+        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @world_taxonomy.all_world_taxons } %>
+      </div>
+
+      <h2>Selected topics</h2>
+      <div class="content content-bordered hidden" data-module="breadcrumb-preview">
+      </div>
+
+      <p class="warning">
+        Warning: topic changes to published content appear instantly on the live site.
+      </p>
+
+      <div class="publishing-controls well">
+        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -51,6 +51,12 @@
     selected_taxon_paths: @edition_taxons.map(&:full_path),
     no_topics_message: 'No topics - please add a topic before publishing'
   } %>
+
+  <%= render partial: '/admin/shared/tagging/show_world_topics_box', locals: {
+    path_to_edit_tags: edit_admin_edition_world_tags_path(@edition.id),
+    selected_taxon_paths: @edition_world_taxons.map(&:full_path),
+    no_topics_message: 'No worldwide related topics'
+  } %>
 <% end %>
 
 <% if @edition.translatable? %>

--- a/app/views/admin/shared/tagging/_show_world_topics_box.html.erb
+++ b/app/views/admin/shared/tagging/_show_world_topics_box.html.erb
@@ -1,0 +1,24 @@
+<section class="taxonomy-topics" id="world-taxonomy">
+  <h2>Worldwide
+    <%= link_to path_to_edit_tags, class:"btn btn-default pull-right" do %>
+      <% if selected_taxon_paths.any? %>
+        <span class="glyphicon glyphicon-edit"></span> Change topics
+      <% else %>
+        <span class="glyphicon glyphicon-plus-sign"></span> Add topic
+      <% end %>
+    <% end %>
+  </h2>
+  <% if selected_taxon_paths.any? %>
+    <div class="content content-bordered">
+      <% selected_taxon_paths.each do |path| %>
+        <%= render partial: '/admin/shared/tagging/taxon_breadcrumb', locals: {
+          breadcrumbs: path
+        } %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="no-content no-content-bordered">
+      <%= no_topics_message %>
+    </div>
+  <% end %>
+</section>

--- a/app/workers/rebuild_taxonomy_cache_worker.rb
+++ b/app/workers/rebuild_taxonomy_cache_worker.rb
@@ -3,5 +3,6 @@ class RebuildTaxonomyCacheWorker
 
   def perform
     Taxonomy::RedisCacheAdapter.new.rebuild_caches
+    Taxonomy::RedisCacheAdapter.new.rebuild_world_taxon_caches
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,7 @@ Whitehall::Application.routes.draw do
 
         resources :editions, only: [:index] do
           resource :tags, only: %i[edit update], controller: :edition_tags
+          resource :world_tags, only: %i[edit update], controller: :edition_world_tags
 
           collection do
             post :export

--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -5,7 +5,13 @@ module Taxonomy
 
     def taxon_data
       @_taxon_data = expand_taxon_array(
-        level_one_taxons + [world_taxon]
+        level_one_taxons
+      )
+    end
+
+    def world_taxon_data
+      @_world_taxon_data = expand_taxon_array(
+        [world_taxon]
       )
     end
 

--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -1,6 +1,7 @@
 module Taxonomy
   class RedisCacheAdapter
     TAXONS_CACHE_KEY = "topic_taxonomy_taxons".freeze
+    WORLD_TAXONS_CACHE_KEY = "world_taxonomy_taxons".freeze
 
     def initialize(redis_client: Redis.current, adapter: PublishingApiAdapter.new)
       @redis_client = redis_client
@@ -11,9 +12,18 @@ module Taxonomy
       JSON.parse @redis_client.get(TAXONS_CACHE_KEY)
     end
 
+    def world_taxon_data
+      JSON.parse @redis_client.get(WORLD_TAXONS_CACHE_KEY)
+    end
+
     def rebuild_caches
       data = @adapter.taxon_data
       @redis_client.set TAXONS_CACHE_KEY, JSON.dump(data)
+    end
+
+    def rebuild_world_taxon_caches
+      data = @adapter.world_taxon_data
+      @redis_client.set WORLD_TAXONS_CACHE_KEY, JSON.dump(data)
     end
   end
 end

--- a/lib/taxonomy/world_taxonomy.rb
+++ b/lib/taxonomy/world_taxonomy.rb
@@ -1,0 +1,20 @@
+module Taxonomy
+  class WorldTaxonomy
+    def initialize(adapter: RedisCacheAdapter.new, tree_builder_class: Tree)
+      @adapter = adapter
+      @tree_builder_class = tree_builder_class
+    end
+
+    def all_world_taxons
+      @_world_taxon_list ||= world_taxon_branches
+    end
+
+  private
+
+    def world_taxon_branches
+      @_branches ||= @adapter.world_taxon_data.map do |world_taxon_hash|
+        @tree_builder_class.new(world_taxon_hash).root_taxon
+      end
+    end
+  end
+end

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -10,6 +10,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
     @edition = create(:publication, organisations: [organisation])
     stub_taxonomy_with_all_taxons
+    stub_taxonomy_with_world_taxons
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)
@@ -22,7 +23,19 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
       )
   end
 
+  def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
+    publishing_api_has_expanded_links(
+      "content_id" => content_id,
+      "expanded_links" => {
+        "taxons" => taxons,
+      },
+      "version" => 1,
+      )
+  end
+
   test 'should return an error on a version conflict' do
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
+
     publishing_api_patch_request = stub_request(:patch, "#{@publishing_api_endpoint}/links/#{@edition.content_id}")
       .to_return(status: 409)
 
@@ -34,7 +47,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   end
 
   test 'should post taxons to publishing-api' do
-    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 
     put :update, params: { edition_id: @edition, taxonomy_tag_form: { taxons: [child_taxon_content_id], previous_version: 1 } }
 
@@ -48,7 +61,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   end
 
   test 'should post empty array to publishing api if no taxons are selected' do
-    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 
     put :update, params: { edition_id: @edition, taxonomy_tag_form: { previous_version: 1 } }
 
@@ -90,7 +103,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
   end
 
   test 'should post invisible draft taxons to publishing-api' do
-    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 
     put :update, params: {
       edition_id: @edition,
@@ -108,6 +121,29 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
           child_taxon_content_id,
           "invisible_draft_taxon_1_content_id"
         ]
+      },
+      previous_version: "1"
+    )
+  end
+
+  test 'should also post taxons tagged to the topic and world taxonomies' do
+    organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
+    @world_and_topic_edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [organisation])
+
+    stub_publishing_api_expanded_links_with_taxons(@world_and_topic_edition.content_id, [world_child_taxon])
+
+    put :update, params: {
+      edition_id: @world_and_topic_edition,
+      taxonomy_tag_form: {
+        taxons: [child_taxon_content_id],
+        previous_version: 1
+      }
+    }
+
+    assert_publishing_api_patch_links(
+      @world_and_topic_edition.content_id,
+      links: {
+        taxons: [child_taxon_content_id, world_child_taxon_content_id]
       },
       previous_version: "1"
     )

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -13,26 +13,6 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     stub_taxonomy_with_world_taxons
   end
 
-  def stub_publishing_api_links_with_taxons(content_id, taxons)
-    publishing_api_has_links(
-      "content_id" => content_id,
-      "links" => {
-        "taxons" => taxons,
-      },
-      "version" => 1,
-      )
-  end
-
-  def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
-    publishing_api_has_expanded_links(
-      "content_id" => content_id,
-      "expanded_links" => {
-        "taxons" => taxons,
-      },
-      "version" => 1,
-      )
-  end
-
   test 'should return an error on a version conflict' do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
 

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
+  should_be_an_admin_controller
+
+  setup do
+    @user = login_as(:departmental_editor)
+    @publishing_api_endpoint = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
+    organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
+    @edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [organisation])
+    stub_taxonomy_with_world_taxons
+  end
+
+  def stub_publishing_api_links_with_taxons(content_id, taxons)
+    publishing_api_has_links(
+      "content_id" => content_id,
+      "links" => {
+        "taxons" => taxons,
+      },
+      "version" => 1,
+      )
+  end
+
+  test 'should return an error on a version conflict' do
+    publishing_api_patch_request = stub_request(:patch, "#{@publishing_api_endpoint}/links/#{@edition.content_id}")
+      .to_return(status: 409)
+
+    put :update, params: { edition_id: @edition, taxonomy_tag_form: { previous_version: 1, taxons: [world_child_taxon_content_id] } }
+
+    assert_requested publishing_api_patch_request
+    assert_redirected_to edit_admin_edition_world_tags_path(@edition)
+    assert_equal "Somebody changed the tags before you could. Your changes have not been saved.", flash[:alert]
+  end
+
+  test 'should post world taxons to publishing-api' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+
+    put :update, params: { edition_id: @edition, taxonomy_tag_form: { taxons: [world_child_taxon_content_id], previous_version: 1 } }
+
+    assert_publishing_api_patch_links(
+      @edition.content_id,
+      links: {
+        taxons: [world_child_taxon_content_id]
+      },
+      previous_version: "1"
+    )
+  end
+
+  test 'should post empty array to publishing api if no world taxons are selected' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [])
+
+    put :update, params: { edition_id: @edition, taxonomy_tag_form: { previous_version: 1 } }
+
+    assert_publishing_api_patch_links(@edition.content_id, links: { taxons: [] }, previous_version: "1")
+  end
+
+  view_test 'should check a child taxon and its parents when only a child taxon is selected' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [world_grandchild_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select "input[value='#{world_child_taxon_content_id}'][checked='checked']"
+    assert_select "input[value='#{world_grandchild_taxon_content_id}'][checked='checked']"
+  end
+
+  view_test 'should check a parent taxon but not its children when only a parent taxon is selected' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [world_child_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select "input[value='#{world_child_taxon_content_id}'][checked='checked']"
+    refute_select "input[value='#{world_grandchild_taxon_content_id}'][checked='checked']"
+  end
+end

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -12,26 +12,6 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
     stub_taxonomy_with_world_taxons
   end
 
-  def stub_publishing_api_links_with_taxons(content_id, taxons)
-    publishing_api_has_links(
-      "content_id" => content_id,
-      "links" => {
-        "taxons" => taxons,
-      },
-      "version" => 1,
-      )
-  end
-
-  def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
-    publishing_api_has_expanded_links(
-      "content_id" => content_id,
-      "expanded_links" => {
-        "taxons" => taxons,
-      },
-      "version" => 1,
-      )
-  end
-
   test 'should return an error on a version conflict' do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [world_child_taxon])
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     @organisation = create(:organisation)
     @user = create(:writer, organisation: @organisation)
     login_as @user
+    stub_taxonomy_with_world_taxons
   end
 
   should_be_an_admin_controller
@@ -198,6 +199,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
 
     refute_select '.taxonomy-topics .content'
     assert_select '.taxonomy-topics .no-content', "No topics - please add a topic before publishing"
+    assert_select '.taxonomy-topics .no-content', "No worldwide related topics"
   end
 
   view_test "when edition is tagged to the new taxonomy" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -216,9 +216,30 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
 
     get :show, params: { id: publication }
 
-    refute_select '.taxonomy-topics .no-content'
+    refute_select '.taxonomy-topics#topic-new-taxonomy .no-content'
     assert_select '.taxonomy-topics .content li', "Education, Training and Skills"
     assert_select '.taxonomy-topics .content li', "Primary Education"
+    assert_select '.taxonomy-topics#world-taxonomy .no-content'
+  end
+
+  view_test "when edition is tagged to the world taxonomy" do
+    sfa_organisation = create(:organisation, content_id: "3e5a6924-b369-4eb3-8b06-3c0814701de4")
+
+    publication = create(
+      :publication,
+      organisations: [sfa_organisation]
+    )
+
+    login_as(create(:user, organisation: sfa_organisation))
+
+    publication_has_world_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    refute_select '.taxonomy-topics#world-taxonomy .no-content'
+    assert_select '.taxonomy-topics .content li', "World Child Taxon"
+    assert_select '.taxonomy-topics .content li', "World Grandchild Taxon"
+    assert_select '.taxonomy-topics#topic-new-taxonomy .no-content'
   end
 
 private
@@ -245,6 +266,33 @@ private
                 {
                   "title" => "Education, Training and Skills",
                   "content_id" => "bbbb",
+                  "base_path" => "i-am-a-parent-taxon",
+                  "details" => { "visible_to_departmental_editors" => true },
+                  "links" => {}
+                }
+              ]
+            }
+          }
+        ]
+      }
+    )
+  end
+
+  def publication_has_world_expanded_links(content_id)
+    publishing_api_has_expanded_links(
+      content_id:  content_id,
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => "World Grandchild Taxon",
+            "content_id" => world_grandchild_taxon_content_id,
+            "base_path" => "i-am-a-taxon",
+            "details" => { "visible_to_departmental_editors" => true },
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => "World Child Taxon",
+                  "content_id" => world_child_taxon_content_id,
                   "base_path" => "i-am-a-parent-taxon",
                   "details" => { "visible_to_departmental_editors" => true },
                   "links" => {}

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     @organisation = create(:organisation)
     @user = login_as create(:gds_editor, organisation: @organisation)
     @topic = create(:topic)
+    stub_taxonomy_with_world_taxons
   end
 
   view_test "GET :new renders a new announcement form" do

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -23,8 +23,16 @@ module TaxonomyHelper
     "grandparent"
   end
 
+  def world_child_taxon_content_id
+    "world_child"
+  end
+
   def stub_taxonomy_with_all_taxons
     redis_cache_has_taxons [root_taxon, draft_taxon_1, draft_taxon_2]
+  end
+
+  def stub_taxonomy_with_world_taxons
+    redis_cache_has_world_taxons([world_taxon])
   end
 
   def redis_cache_has_taxons(taxons)
@@ -93,5 +101,21 @@ private
                      title: "Parenting",
                      base_path: "/childcare-parenting",
                      content_id: draft_taxon_1_content_id)
+  end
+
+  def world_child_taxon
+    FactoryBot.build(:taxon_hash,
+                     title: "World Child Taxon",
+                     base_path: "/world/child",
+                     content_id: world_child_taxon_content_id,
+                     is_level_one_taxon: false)
+  end
+
+  def world_taxon
+    FactoryBot.build(:taxon_hash,
+                     title: "World",
+                     base_path: "/world/all",
+                     content_id: "world",
+                     children: [world_child_taxon])
   end
 end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -34,6 +34,13 @@ module TaxonomyHelper
       .returns(JSON.dump(taxons))
   end
 
+  def redis_cache_has_world_taxons(world_taxons)
+    redis_client
+      .stubs(:get)
+      .with(Taxonomy::RedisCacheAdapter::WORLD_TAXONS_CACHE_KEY)
+      .returns(JSON.dump(world_taxons))
+  end
+
 private
 
   def redis_client

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -57,6 +57,26 @@ module TaxonomyHelper
       .returns(JSON.dump(world_taxons))
   end
 
+  def stub_publishing_api_links_with_taxons(content_id, taxons)
+    publishing_api_has_links(
+      "content_id" => content_id,
+      "links" => {
+        "taxons" => taxons,
+      },
+      "version" => 1,
+      )
+  end
+
+  def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
+    publishing_api_has_expanded_links(
+      "content_id" => content_id,
+      "expanded_links" => {
+        "taxons" => taxons,
+      },
+      "version" => 1,
+      )
+  end
+
 private
 
   def redis_client

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -23,8 +23,16 @@ module TaxonomyHelper
     "grandparent"
   end
 
+  def world_taxon_content_id
+    "world"
+  end
+
   def world_child_taxon_content_id
     "world_child"
+  end
+
+  def world_grandchild_taxon_content_id
+    "world_grandchild"
   end
 
   def stub_taxonomy_with_all_taxons
@@ -103,19 +111,28 @@ private
                      content_id: draft_taxon_1_content_id)
   end
 
+  def world_grandchild_taxon
+    FactoryBot.build(:taxon_hash,
+                     title: "World Child Taxon",
+                     base_path: "/world/grand-child",
+                     content_id: world_grandchild_taxon_content_id,
+                     is_level_one_taxon: false)
+  end
+
   def world_child_taxon
     FactoryBot.build(:taxon_hash,
                      title: "World Child Taxon",
                      base_path: "/world/child",
                      content_id: world_child_taxon_content_id,
-                     is_level_one_taxon: false)
+                     is_level_one_taxon: false,
+                     children: [world_grandchild_taxon])
   end
 
   def world_taxon
     FactoryBot.build(:taxon_hash,
                      title: "World",
                      base_path: "/world/all",
-                     content_id: "world",
+                     content_id: world_taxon_content_id,
                      children: [world_child_taxon])
   end
 end

--- a/test/unit/models/world_taxonomy_tag_form_test.rb
+++ b/test/unit/models/world_taxonomy_tag_form_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class WorldTaxonomyTagFormTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
+  test "#load when publishing-api returns 404, selected_taxons should be '[]'" do
+    content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
+
+    body = {
+      "error" => {
+        "code" => 404,
+        "message" => "Could not find link set with content_id: #{content_id}"
+      }
+    }.to_json
+
+    stub_request(:get, %r{.*/v2/links/#{content_id}.*})
+      .to_return(body: body, status: 404)
+
+    form = WorldTaxonomyTagForm.load(content_id)
+
+    assert_equal form.selected_taxons, []
+  end
+
+  test '#load should request links to publishing-api' do
+    content_id = "64aadc14-9bca-40d9-abb6-4f21f9792a05"
+    taxons = ["c58fdadd-7743-46d6-9629-90bb3ccc4ef0"]
+
+    publishing_api_has_links(
+      "content_id" => "64aadc14-9bca-40d9-abb6-4f21f9792a05",
+      "links" => {
+        "taxons" => taxons,
+      },
+      "version" => 1
+    )
+
+    form = WorldTaxonomyTagForm.load(content_id)
+
+    assert_equal(form.content_id, content_id)
+    assert_equal(form.selected_taxons, taxons)
+    assert_equal(form.previous_version, 1)
+  end
+end

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   include TaxonomyHelper
 
+  setup do
+    stub_taxonomy_with_world_taxons
+  end
+
   test "it returns '[]' if there are no expanded_links" do
     content_id = "64aadc14-9bca-40d9-abb4-4f21f9792a05"
 
@@ -270,5 +274,55 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
 
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal %w[aaaa cccc], taxons.map(&:content_id)
+  end
+
+  test "it gets world taxons tagged to the edition" do
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
+        "taxons" => [
+          {
+            "title" => "I am the published taxon",
+            "content_id" => "published-taxon",
+            "base_path" => "/i-am-a-taxon",
+            "details" => { "visible_to_departmental_editors" => true },
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => "I am the parent of the published taxon",
+                  "content_id" => "bbbb",
+                  "base_path" => "/i-am-a-parent-taxon",
+                  "details" => { "visible_to_departmental_editors" => true },
+                  "links" => {}
+                },
+              ]
+            }
+          },
+          {
+            "title" => "I am the world taxon",
+            "content_id" => "world-taxon",
+            "base_path" => "/world/i-am-a-world-taxon",
+            "details" => { "visible_to_departmental_editors" => true },
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "title" => "I am the parent of the visible draft taxon",
+                  "content_id" => "dddd",
+                  "base_path" => "/world/all",
+                  "details" => { "visible_to_departmental_editors" => true },
+                  "links" => {}
+                },
+              ]
+            }
+          }
+        ]
+      }
+    )
+    redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
+
+    redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
+
+    taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch_world_taxons
+    assert_equal %w[world-taxon], taxons.map(&:content_id)
   end
 end

--- a/test/unit/services/edition_world_taxon_link_patcher_test.rb
+++ b/test/unit/services/edition_world_taxon_link_patcher_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class EditionWorldTaxonLinkPatcherTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
+  test 'sends patch links request to publishing api' do
+    stub_taxonomy_with_world_taxons
+
+    EditionWorldTaxonLinkPatcher.new.call(
+      content_id: "12345",
+      selected_taxons: [world_taxon, world_child_taxon_content_id],
+      invisible_taxons: [],
+      previous_version: "1",
+    )
+
+    assert_publishing_api_patch_links(
+      "12345",
+      links: {
+        taxons: [world_child_taxon_content_id]
+      },
+      previous_version: "1"
+    )
+  end
+end

--- a/test/unit/taxonomy/redis_cache_adapter_test.rb
+++ b/test/unit/taxonomy/redis_cache_adapter_test.rb
@@ -22,4 +22,11 @@ class Taxonomy::RedisCacheAdapterTest < ActiveSupport::TestCase
     redis_client.expects(:set).with("topic_taxonomy_taxons", JSON.dump(published_taxons))
     subject.rebuild_caches
   end
+
+  test "#rebuild_world_taxon_caches" do
+    published_world_taxons = { 'baz' => 'qux' }
+    publishing_api_adapter.stubs(:world_taxon_data).returns(published_world_taxons)
+    redis_client.expects(:set).with("world_taxonomy_taxons", JSON.dump(published_world_taxons))
+    subject.rebuild_world_taxon_caches
+  end
 end

--- a/test/unit/taxonomy/world_taxonomy_test.rb
+++ b/test/unit/taxonomy/world_taxonomy_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class Taxonomy::WorldTaxonomyTest < ActiveSupport::TestCase
+  include TaxonomyHelper
+
+  def subject
+    Taxonomy::WorldTaxonomy.new
+  end
+
+  test "#world_taxons" do
+    redis_cache_has_world_taxons(
+      [
+        build(:taxon_hash, content_id: 'content_id_1'),
+        build(:taxon_hash, content_id: 'content_id_2'),
+        build(:taxon_hash, content_id: 'content_id_3')
+      ]
+    )
+    assert_equal %w[content_id_1 content_id_2 content_id_3], subject.all_world_taxons.map(&:content_id)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/iNqKZBEq

## What's changed

Create a separate interface to tag documents to the worldwide taxonomy.

The departments that could tag documents to the worldwide taxonomy previously can still tag to it, they just have to do it in a different place.

## Why

These changes should allow for future improvements to the topic tagging interface without affecting worldwide tagging. It also allows us to more easily restrict access to the worldwide tagging interface in the future.

## Changes
### Before
![screen shot 2018-05-24 at 17 35 15](https://user-images.githubusercontent.com/5793815/40499202-2504b504-5f79-11e8-89e5-814e413e63ce.png)
![screen shot 2018-05-24 at 17 47 46](https://user-images.githubusercontent.com/5793815/40499688-9814288a-5f7a-11e8-99be-2208570b891c.png)

### After
![screen shot 2018-05-24 at 17 28 24](https://user-images.githubusercontent.com/5793815/40498994-85060dfa-5f78-11e8-9984-bb0046551d4a.png)
![screen shot 2018-05-24 at 17 28 45](https://user-images.githubusercontent.com/5793815/40498997-86fc786a-5f78-11e8-8df0-7464cf51c337.png)
![screen shot 2018-05-24 at 17 29 20](https://user-images.githubusercontent.com/5793815/40499009-898290e2-5f78-11e8-8d2f-776f9847a833.png)
![screen shot 2018-05-24 at 17 30 36](https://user-images.githubusercontent.com/5793815/40499014-8daa5ba0-5f78-11e8-9c51-64a5271b8982.png)

## Post-deployment tasks

Run `bundle exec rake taxonomy:rebuild_cache`