### PR TITLE
Hide legacy association section

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -670,6 +670,18 @@ class Edition < ApplicationRecord
     PublishingApiPresenters.presenter_for(self).content.fetch(:document_type)
   end
 
+  def has_legacy_tags?
+    has_policies? || has_policy_areas? || has_primary_sector? || has_secondary_sectors?
+  end
+
+  def has_policies?
+    false
+  end
+
+  def has_policy_areas?
+    false
+  end
+
 private
 
   def date_for_government

--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -68,4 +68,8 @@ module Edition::RelatedPolicies
   def can_be_related_to_policies?
     true
   end
+
+  def has_policies?
+    policy_content_ids.any?
+  end
 end

--- a/app/models/edition/specialist_sectors.rb
+++ b/app/models/edition/specialist_sectors.rb
@@ -9,15 +9,15 @@ module Edition::SpecialistSectors
   included do
     has_many :specialist_sectors, foreign_key: :edition_id, dependent: :destroy
     has_many :primary_specialist_sectors,
-             -> { where(primary: true) },
-             class_name: 'SpecialistSector',
-             foreign_key: :edition_id,
-             dependent: :destroy
+      -> { where(primary: true) },
+      class_name: 'SpecialistSector',
+      foreign_key: :edition_id,
+      dependent: :destroy
     has_many :secondary_specialist_sectors,
-             -> { where(primary: false) },
-             class_name: 'SpecialistSector',
-             foreign_key: :edition_id,
-             dependent: :destroy
+      -> { where(primary: false) },
+      class_name: 'SpecialistSector',
+      foreign_key: :edition_id,
+      dependent: :destroy
 
     add_trait do
       def process_associations_before_save(edition)
@@ -46,6 +46,14 @@ module Edition::SpecialistSectors
 
   def specialist_sector_tags
     specialist_sectors.order("specialist_sectors.primary DESC").map(&:topic_content_id)
+  end
+
+  def has_primary_sector?
+    !primary_specialist_sector_tag.blank?
+  end
+
+  def has_secondary_sectors?
+    secondary_specialist_sectors.any?
   end
 
 private

--- a/app/models/edition/topics.rb
+++ b/app/models/edition/topics.rb
@@ -17,6 +17,10 @@ module Edition::Topics
     true
   end
 
+  def has_policy_areas?
+    topics.any?
+  end
+
   def search_index
     # "Policy area" is the newer name for "topic"
     # (https://www.gov.uk/government/topics)

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -55,7 +55,7 @@
   <%= render partial: '/admin/shared/tagging/legacy_associations_box', locals: {
       path_to_edit_associations: edit_admin_edition_legacy_associations_path(@edition.id),
       edition: @edition,
-      no_policy_areas_message: 'No policy areas - please add a policy area before publishing'
+      no_associations_message: 'No associations'
   } %>
 <% end %>
 

--- a/app/views/admin/shared/tagging/_legacy_associations_box.html.erb
+++ b/app/views/admin/shared/tagging/_legacy_associations_box.html.erb
@@ -6,41 +6,39 @@
       <% end %>
     <% end %>
   </h2>
-  <div class="content content-bordered">
-    <% if edition.can_be_related_to_policies? && tagged_policy_names(edition.policy_content_ids).any? %>
-      <h4>Policies</h4>
-      <ul class="policies">
-        <% tagged_policy_names(edition.policy_content_ids).each do |name| %>
-          <li><%= name %></li>
-        <% end %>
-      </ul>
-    <% end %>
-    <% if edition.can_be_associated_with_topics? %>
-      <h4>Policy Areas</h4>
-      <% if edition.topics.any? %>
+  <% if edition.has_legacy_tags? %>
+    <div class="content content-bordered">
+      <% if edition.has_policies? %>
+        <h4>Policies</h4>
+        <ul class="policies">
+          <% tagged_policy_names(edition.policy_content_ids).each do |name| %>
+            <li><%= name %></li>
+          <% end %>
+        </ul>
+      <% end %>
+      <% if edition.has_policy_areas? %>
+        <h4>Policy Areas</h4>
         <ul class="policy-areas">
           <% edition.topics.each do |name| %>
             <li><%= name %></li>
           <% end %>
         </ul>
 
-      <% else %>
-        <p><%= no_policy_areas_message %> </p>
       <% end %>
-    <% end %>
-    <% unless specialist_sector_name(edition.primary_specialist_sector_tag).blank? %>
-      <h4>Primary Specialist Sector</h4>
-      <ul class="primary-specialist-sector">
-        <li><%= specialist_sector_name(edition.primary_specialist_sector_tag) %></li>
-      </ul>
-    <% end %>
-    <% unless specialist_sector_names(edition.secondary_specialist_sector_tags).empty? %>
-      <h4>Secondary Specialist Sectors</h4>
-      <ul class="secondary-specialist-sectors">
-        <% specialist_sector_names(edition.secondary_specialist_sector_tags).each do |name| %>
-          <li><%= name %></li>
-        <% end %>
-      </ul>
-    <% end %>
-  </div>
+      <% if edition.has_primary_sector? %>
+        <h4>Primary Specialist Sector</h4>
+        <ul class="primary-specialist-sector">
+          <li><%= specialist_sector_name(edition.primary_specialist_sector_tag) %></li>
+        </ul>
+      <% end %>
+      <% if edition.has_secondary_sectors? %>
+        <h4>Secondary Specialist Sectors</h4>
+        <ul class="secondary-specialist-sectors">
+          <% specialist_sector_names(edition.secondary_specialist_sector_tags).each do |name| %>
+            <li><%= name %></li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+  <% end %>
 </section>

--- a/app/views/admin/shared/tagging/_legacy_associations_box.html.erb
+++ b/app/views/admin/shared/tagging/_legacy_associations_box.html.erb
@@ -2,7 +2,11 @@
   <h2>Associations
     <% if edition.pre_publication? %>
       <%= link_to path_to_edit_associations, class: "btn btn-default pull-right" do %>
-        <span class="glyphicon glyphicon-edit"></span> Change Associations
+        <% if edition.has_legacy_tags? %>
+          <span class="glyphicon glyphicon-edit"></span> Change Associations
+        <% else %>
+          <span class="glyphicon glyphicon-plus-sign"></span> Add Associations
+        <% end %>
       <% end %>
     <% end %>
   </h2>
@@ -23,7 +27,6 @@
             <li><%= name %></li>
           <% end %>
         </ul>
-
       <% end %>
       <% if edition.has_primary_sector? %>
         <h4>Primary Specialist Sector</h4>
@@ -38,7 +41,12 @@
             <li><%= name %></li>
           <% end %>
         </ul>
+
       <% end %>
+    </div>
+  <% else %>
+    <div class="no-content no-content-bordered">
+      <%= no_associations_message %>
     </div>
   <% end %>
 </section>

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -59,6 +59,12 @@ FactoryBot.define do
     end
   end
 
+  factory :publication_without_policy_areas, parent: :edition, class: Publication, traits: %i[with_organisations] do
+    sequence(:title) { |index| "publication-title-#{index}" }
+    body "publication-body"
+    summary "publication-summary"
+    publication_type_id { PublicationType::PolicyPaper.id }
+  end
   factory :imported_publication, parent: :publication, traits: [:imported]
   factory :draft_publication, parent: :publication, traits: [:draft]
   factory :submitted_publication, parent: :publication, traits: [:submitted]

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -240,6 +240,28 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select ".policies li", policy_1['title']
     assert_select ".policy-areas li", policy_area.name
     assert_selected_specialist_sectors_are_displayed
+    assert_select "a[href='#{edit_admin_edition_legacy_associations_path(publication)}']", /Change Associations/
+    assert_select "a[href='#{edit_admin_edition_legacy_associations_path(publication)}'] .glyphicon-edit"
+  end
+
+  view_test "shows message when edition is not tagged to any legacy associations" do
+    stub_specialist_sectors
+    organisation = create(:organisation)
+    publication = create(
+      :publication_without_policy_areas,
+      organisations: [organisation],
+    )
+
+    login_as(create(:user, organisation: organisation))
+    get :show, params: { id: publication }
+
+    refute_select '.policies'
+    refute_select '.policy-areas'
+    refute_select '.primary-specialist-sector'
+    refute_select '.secondary-specialist-sectors'
+    assert_select '.no-content.no-content-bordered', 'No associations'
+    assert_select "a[href='#{edit_admin_edition_legacy_associations_path(publication)}']", /Add Associations/
+    assert_select "a[href='#{edit_admin_edition_legacy_associations_path(publication)}'] .glyphicon-plus-sign"
   end
 
 private

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -884,13 +884,13 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test 'when policies are supported but no policies' do
-    edition = create(:publication_without_topics, policy_content_ids: [])
+    edition = create(:publication_without_policy_areas, policy_content_ids: [])
     refute edition.has_policies?
     refute edition.has_legacy_tags?
   end
 
   test 'when policies exist' do
-    edition = create(:publication_without_topics, policy_content_ids: [policy_1['content_id']])
+    edition = create(:publication_without_policy_areas, policy_content_ids: [policy_1['content_id']])
     stub_publishing_api_policies
     assert edition.has_policies?
     assert edition.has_legacy_tags?
@@ -903,7 +903,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test 'when policy areas supported but no policy areas' do
-    edition = create(:publication_without_topics)
+    edition = create(:publication_without_policy_areas)
     refute edition.has_policy_areas?
     refute edition.has_legacy_tags?
   end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -876,4 +876,61 @@ class EditionTest < ActiveSupport::TestCase
     refute non_attachable_edition.allows_attachments?
     assert_equal [], non_attachable_edition.attachables
   end
+
+  test 'when policies not supported' do
+    edition = create(:edition)
+    refute edition.has_policies?
+    refute edition.has_legacy_tags?
+  end
+
+  test 'when policies are supported but no policies' do
+    edition = create(:publication_without_topics, policy_content_ids: [])
+    refute edition.has_policies?
+    refute edition.has_legacy_tags?
+  end
+
+  test 'when policies exist' do
+    edition = create(:publication_without_topics, policy_content_ids: [policy_1['content_id']])
+    stub_publishing_api_policies
+    assert edition.has_policies?
+    assert edition.has_legacy_tags?
+  end
+
+  test 'when policy areas are not supported' do
+    edition = create(:edition)
+    refute edition.has_policy_areas?
+    refute edition.has_legacy_tags?
+  end
+
+  test 'when policy areas supported but no policy areas' do
+    edition = create(:publication_without_topics)
+    refute edition.has_policy_areas?
+    refute edition.has_legacy_tags?
+  end
+
+  test 'when policy areas exist' do
+    topic = create(:topic)
+    edition = create(:publication, topic_ids: [topic.id])
+    assert edition.has_policy_areas?
+    assert edition.has_legacy_tags?
+  end
+
+  test 'when no specialist sectors' do
+    edition = create(:edition)
+    refute edition.has_primary_sector?
+    refute edition.has_secondary_sectors?
+    refute edition.has_legacy_tags?
+  end
+
+  test 'when a primary specialist sector exists' do
+    edition = create(:edition, primary_specialist_sector_tag: 'primary')
+    assert edition.has_primary_sector?
+    assert edition.has_legacy_tags?
+  end
+
+  test 'when a secondary specialist sector exists' do
+    edition = create(:edition, secondary_specialist_sector_tags: ['secondary'])
+    assert edition.has_secondary_sectors?
+    assert edition.has_legacy_tags?
+  end
 end


### PR DESCRIPTION
This PR implements the trello card [Hide the legacy associations section from the overview page when edition does not support any of them](https://trello.com/c/7xxP9Ij3/100-hide-the-legacy-associations-section-from-the-overview-page-when-edition-does-not-support-any-of-them)

## Before (when the edition hasn't been tagged)
<img width="786" alt="empty_section" src="https://user-images.githubusercontent.com/511319/40653471-2f07175a-6333-11e8-8a69-4a781fa6ae28.png">

## After 
<img width="790" alt="screen shot 2018-05-29 at 11 27 31" src="https://user-images.githubusercontent.com/511319/40653515-587212e8-6333-11e8-83df-936298ef4bc5.png">

