### PR TITLE
Separate topic and world tagging permissions

### DIFF
--- a/app/controllers/admin/edition_world_tags_controller.rb
+++ b/app/controllers/admin/edition_world_tags_controller.rb
@@ -25,7 +25,7 @@ class Admin::EditionWorldTagsController < Admin::BaseController
 private
 
   def enforce_permissions!
-    unless @edition.can_be_tagged_to_taxonomy?
+    unless @edition.can_be_tagged_to_worldwide_taxonomy?
       raise Whitehall::Authority::Errors::PermissionDenied.new(:update, @edition)
     end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -74,6 +74,9 @@ class Admin::EditionsController < Admin::BaseController
 
     if @edition.can_be_tagged_to_taxonomy?
       @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
+    end
+
+    if @edition.can_be_tagged_to_worldwide_taxonomy?
       @edition_world_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch_world_taxons
     end
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -439,6 +439,10 @@ class Edition < ApplicationRecord
     false
   end
 
+  def can_be_tagged_to_worldwide_taxonomy?
+    false
+  end
+
   def has_been_tagged?
     api_response = Services.publishing_api.get_links(content_id)
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -435,10 +435,6 @@ class Edition < ApplicationRecord
     false
   end
 
-  def must_be_tagged_to_taxonomy?
-    false
-  end
-
   def can_be_tagged_to_worldwide_taxonomy?
     false
   end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -55,6 +55,6 @@ private
   end
 
   def education_taggable_organisation_ids
-    Whitehall.organisations_in_tagging_beta["education_related"].to_a
+    Whitehall.organisations_in_tagging_beta.to_a
   end
 end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -11,17 +11,21 @@ module Edition::TaggableOrganisations
   # Only Education based organisations have validation to prevent publishing if
   # they have not been tagged
   def must_be_tagged_to_taxonomy?
-    education_taggable?
+    topic_taxonomy_taggable?
   end
 
   def can_be_tagged_to_taxonomy?
-    education_taggable? || world_taggable?
+    topic_taxonomy_taggable?
+  end
+
+  def can_be_tagged_to_worldwide_taxonomy?
+    world_taggable?
   end
 
 private
 
-  def education_taggable?
-    organisations_in_education_tagging_beta?
+  def topic_taxonomy_taggable?
+    organisations_in_topic_tagging_beta?
   end
 
   def world_taggable?
@@ -46,15 +50,15 @@ private
     (organisations_content_ids & worldwide_taggable_organisation_ids).present?
   end
 
-  def organisations_in_education_tagging_beta?
-    (organisations_content_ids & education_taggable_organisation_ids).present?
+  def organisations_in_topic_tagging_beta?
+    (organisations_content_ids & topic_taggable_organisation_ids).present?
   end
 
   def worldwide_taggable_organisation_ids
     Whitehall.worldwide_tagging_organisations.to_a
   end
 
-  def education_taggable_organisation_ids
+  def topic_taggable_organisation_ids
     Whitehall.organisations_in_tagging_beta.to_a
   end
 end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -8,12 +8,6 @@ module Edition::TaggableOrganisations
     PublicationType::Form,
   ].freeze
 
-  # Only Education based organisations have validation to prevent publishing if
-  # they have not been tagged
-  def must_be_tagged_to_taxonomy?
-    topic_taxonomy_taggable?
-  end
-
   def can_be_tagged_to_taxonomy?
     topic_taxonomy_taggable?
   end

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -51,7 +51,7 @@ private
   end
 
   def worldwide_taggable_organisation_ids
-    Whitehall.organisations_in_tagging_beta["worldwide_related"].to_a
+    Whitehall.worldwide_tagging_organisations.to_a
   end
 
   def education_taggable_organisation_ids

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -212,12 +212,12 @@ class StatisticsAnnouncement < ApplicationRecord
   def can_be_tagged_to_taxonomy?
     organisations_content_ids = organisations.map(&:content_id)
 
-    organisations_in_education_tagging_beta?(organisations_content_ids)
+    organisations_in_topic_tagging_beta?(organisations_content_ids)
   end
 
 private
 
-  def organisations_in_education_tagging_beta?(org_content_ids)
+  def organisations_in_topic_tagging_beta?(org_content_ids)
     (org_content_ids & Whitehall.organisations_in_tagging_beta).present?
   end
 

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -218,7 +218,7 @@ class StatisticsAnnouncement < ApplicationRecord
 private
 
   def organisations_in_education_tagging_beta?(org_content_ids)
-    (org_content_ids & Whitehall.organisations_in_tagging_beta["education_related"]).present?
+    (org_content_ids & Whitehall.organisations_in_tagging_beta).present?
   end
 
   def publication_has_been_published?

--- a/app/validators/taxon_validator.rb
+++ b/app/validators/taxon_validator.rb
@@ -11,6 +11,6 @@ class TaxonValidator < ActiveModel::Validator
 private
 
   def missing_taxons?(edition)
-    edition.must_be_tagged_to_taxonomy? && !edition.has_been_tagged?
+    edition.can_be_tagged_to_taxonomy? && !edition.has_been_tagged?
   end
 end

--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -51,7 +51,9 @@
     selected_taxon_paths: @edition_taxons.map(&:full_path),
     no_topics_message: 'No topics - please add a topic before publishing'
   } %>
+<% end %>
 
+<% if @edition.can_be_tagged_to_worldwide_taxonomy? %>
   <%= render partial: '/admin/shared/tagging/show_world_topics_box', locals: {
     path_to_edit_tags: edit_admin_edition_world_tags_path(@edition.id),
     selected_taxon_paths: @edition_world_taxons.map(&:full_path),

--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -1,6 +1,5 @@
 # This file has a list of organisation content_id's
-# that are allowed to have their documents tagged into the taxonomy
-# - This is part of the work performed by Finding Things team.
+# that are allowed tag their documents to the topic taxonomy
 
 organisations_in_tagging_beta:
   education_related:
@@ -17,7 +16,6 @@ organisations_in_tagging_beta:
     - "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
     - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
     - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
-  worldwide_related:
     - "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
     - "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
     - "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration

--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -1,23 +1,21 @@
 # This file has a list of organisation content_id's
 # that are allowed tag their documents to the topic taxonomy
 
-organisations_in_tagging_beta:
-  education_related:
-    - "71381a6e-aa5c-43ae-a982-be9bfd46ea5b" # Education & Skills Funding Agency
-    - "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
-    - "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education
-    - "60de9b00-a982-4449-a995-f2353e86fb95" # Higher Education Statistics Agency
-    - "a081cd5b-c41d-4389-ac65-982e7570680d" # Institute for Apprenticeships
-    - "e1cbab66-b0d3-4186-917c-afd4f3fb6967" # National College for Teaching and Leadership
-    - "e7f33769-a539-4fb4-b24f-f6c1cabc3f59" # Office of the Schools Adjudicator
-    - "83f6e93f-bb2c-46ab-9b02-394f972b7030" # Ofqual
-    - "ad5f6169-ac7b-4382-9eb6-e58af71a2f00" # Ofsted
-    - "3e5a6924-b369-4eb3-8b06-3c0814701de4" # Skills Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
-    - "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
-    - "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
-    - "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
-    - "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
-    - "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
-    - "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
-    - "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
-    - "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union
+- "71381a6e-aa5c-43ae-a982-be9bfd46ea5b" # Education & Skills Funding Agency
+- "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
+- "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education
+- "60de9b00-a982-4449-a995-f2353e86fb95" # Higher Education Statistics Agency
+- "a081cd5b-c41d-4389-ac65-982e7570680d" # Institute for Apprenticeships
+- "e1cbab66-b0d3-4186-917c-afd4f3fb6967" # National College for Teaching and Leadership
+- "e7f33769-a539-4fb4-b24f-f6c1cabc3f59" # Office of the Schools Adjudicator
+- "83f6e93f-bb2c-46ab-9b02-394f972b7030" # Ofqual
+- "ad5f6169-ac7b-4382-9eb6-e58af71a2f00" # Ofsted
+- "3e5a6924-b369-4eb3-8b06-3c0814701de4" # Skills Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
+- "863ffacd-d313-49c1-b856-58fe0799fd41" # Standards and Testing Agency
+- "9a9111aa-1db8-4025-8dd2-e08ec3175e72" # Student Loans Company
+- "30637a3a-bd24-4db6-b172-c49500bf50a5" # Schools Commissioners Group
+- "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
+- "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
+- "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
+- "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
+- "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union

--- a/config/worldwide_tagging_organisations.yml
+++ b/config/worldwide_tagging_organisations.yml
@@ -1,0 +1,8 @@
+# This file has a list of organisation content_id's
+# that are allowed to have their documents tagged into the worldwide taxonomy
+
+- "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
+- "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office
+- "04148522-b0c1-4137-b687-5f3c3bdd561a" # UK Visas and Immigration
+- "082092f1-656c-470e-b024-229dc6e750e9" # Department for International Trade
+- "f323e83c-868b-4bcb-b6e2-a8f9bb40397e" # Department for Exiting the European Union

--- a/config/worldwide_tagging_organisations.yml
+++ b/config/worldwide_tagging_organisations.yml
@@ -1,5 +1,5 @@
 # This file has a list of organisation content_id's
-# that are allowed to have their documents tagged into the worldwide taxonomy
+# that are allowed to tag their documents to the worldwide taxonomy
 
 - "db994552-7644-404d-a770-a2fe659c661f" # Department for International Development
 - "9adfc4ed-9f6c-4976-a6d8-18d34356367c" # Foreign & Commonwealth Office

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -171,6 +171,11 @@ module Whitehall
       YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")["organisations_in_tagging_beta"]
   end
 
+  def self.worldwide_tagging_organisations
+    @worldwide_taggable_organisations ||=
+      YAML.load_file(Rails.root + "config/worldwide_tagging_organisations.yml")
+  end
+
   def self.load_secrets
     if File.exist?(secrets_path)
       YAML.load_file(secrets_path)

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -168,7 +168,7 @@ module Whitehall
 
   def self.organisations_in_tagging_beta
     @taggable_organisations ||=
-      YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")["organisations_in_tagging_beta"]
+      YAML.load_file(Rails.root + "config/organisations_in_tagging_beta.yml")
   end
 
   def self.worldwide_tagging_organisations

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -63,7 +63,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
       "version" => 1
     )
 
-    Publication.any_instance.stubs(:must_be_tagged_to_taxonomy?).returns(true)
+    Publication.any_instance.stubs(:can_be_tagged_to_taxonomy?).returns(true)
 
     get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -7,8 +7,8 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
   setup do
     @user = login_as(:departmental_editor)
     @publishing_api_endpoint = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
-    organisation = create(:organisation, content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37")
-    @edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [organisation])
+    @organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
+    @edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [@organisation])
     stub_taxonomy_with_world_taxons
   end
 
@@ -66,13 +66,10 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
   end
 
   test 'should also post taxons tagged to the topic and world taxonomies' do
-    organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
-    @world_and_topic_edition = create(:publication, publication_type: PublicationType::Guidance, organisations: [organisation])
-
-    stub_publishing_api_expanded_links_with_taxons(@world_and_topic_edition.content_id, [child_taxon])
+    stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
 
     put :update, params: {
-      edition_id: @world_and_topic_edition,
+      edition_id: @edition,
       taxonomy_tag_form: {
         taxons: [world_child_taxon_content_id],
         previous_version: 1
@@ -80,7 +77,7 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
     }
 
     assert_publishing_api_patch_links(
-      @world_and_topic_edition.content_id,
+      @edition.content_id,
       links: {
         taxons: [world_child_taxon_content_id, child_taxon_content_id]
       },

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -185,32 +185,34 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "when edition is not tagged to the new taxonomy" do
-    sfa_organisation = create(:organisation, content_id: "3e5a6924-b369-4eb3-8b06-3c0814701de4")
+    world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 
     publication = create(
       :publication,
-      organisations: [sfa_organisation]
+      publication_type: PublicationType::Guidance,
+      organisations: [world_tagging_organisation]
     )
 
-    login_as(create(:user, organisation: sfa_organisation))
+    login_as(create(:user, organisation: world_tagging_organisation))
 
     publication_has_no_expanded_links(publication.content_id)
     get :show, params: { id: publication }
 
     refute_select '.taxonomy-topics .content'
-    assert_select '.taxonomy-topics .no-content', "No topics - please add a topic before publishing"
-    assert_select '.taxonomy-topics .no-content', "No worldwide related topics"
+    assert_select '.taxonomy-topics#topic-new-taxonomy .no-content'
+    assert_select '.taxonomy-topics#world-taxonomy .no-content'
   end
 
   view_test "when edition is tagged to the new taxonomy" do
-    sfa_organisation = create(:organisation, content_id: "3e5a6924-b369-4eb3-8b06-3c0814701de4")
+    world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 
     publication = create(
       :publication,
-      organisations: [sfa_organisation]
+      publication_type: PublicationType::Guidance,
+      organisations: [world_tagging_organisation]
     )
 
-    login_as(create(:user, organisation: sfa_organisation))
+    login_as(create(:user, organisation: world_tagging_organisation))
 
     publication_has_expanded_links(publication.content_id)
 
@@ -223,14 +225,15 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   end
 
   view_test "when edition is tagged to the world taxonomy" do
-    sfa_organisation = create(:organisation, content_id: "3e5a6924-b369-4eb3-8b06-3c0814701de4")
+    world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 
     publication = create(
       :publication,
-      organisations: [sfa_organisation]
+      publication_type: PublicationType::Guidance,
+      organisations: [world_tagging_organisation]
     )
 
-    login_as(create(:user, organisation: sfa_organisation))
+    login_as(create(:user, organisation: world_tagging_organisation))
 
     publication_has_world_expanded_links(publication.content_id)
 

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -35,27 +35,27 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     refute edition.must_be_tagged_to_taxonomy?
   end
 
-  test '#can_be_tagged_to_taxonomy? is true for Publication Guidance' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is true for Publication Guidance' do
     edition = create(:publication,
                      :draft,
                      access_limited: false,
                      publication_type_id: PublicationType::Guidance.id,
                      organisations: [@lead_org])
 
-    assert edition.can_be_tagged_to_taxonomy?
+    assert edition.can_be_tagged_to_worldwide_taxonomy?
   end
 
-  test '#can_be_tagged_to_taxonomy? is true for Publication Form' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is true for Publication Form' do
     edition = create(:publication,
                      :draft,
                      access_limited: false,
                      publication_type_id: PublicationType::Form.id,
                      organisations: [@lead_org])
 
-    assert edition.can_be_tagged_to_taxonomy?
+    assert edition.can_be_tagged_to_worldwide_taxonomy?
   end
 
-  test '#can_be_tagged_to_taxonomy? is false for other Publication types' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is false for other Publication types' do
     other_publication_types = PublicationType.all.reject do |publication_type|
       [PublicationType::Guidance, PublicationType::Form].include?(publication_type) ||
         publication_type.prevalence == :migration
@@ -69,26 +69,26 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
                        publication_type_id: publication_type.id,
                        organisations: [@lead_org])
 
-      refute edition.can_be_tagged_to_taxonomy?
+      refute edition.can_be_tagged_to_worldwide_taxonomy?
     end
   end
 
-  test '#can_be_tagged_to_taxonomy? is true for DetailedGuide' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is true for DetailedGuide' do
     edition = create(:detailed_guide, organisations: [@lead_org])
 
-    assert edition.can_be_tagged_to_taxonomy?
+    assert edition.can_be_tagged_to_worldwide_taxonomy?
   end
 
-  test '#can_be_tagged_to_taxonomy? is true for DocumentCollection' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is true for DocumentCollection' do
     edition = create(:document_collection, organisations: [@lead_org])
 
-    assert edition.can_be_tagged_to_taxonomy?
+    assert edition.can_be_tagged_to_worldwide_taxonomy?
   end
 
   # method will return `false` for all other edition types, we choose NewsArticle as example
-  test '#can_be_tagged_to_taxonomy? is false for NewsArticle' do
+  test '#can_be_tagged_to_worldwide_taxonomy? is false for NewsArticle' do
     edition = create(:news_article, organisations: [@lead_org])
 
-    refute edition.can_be_tagged_to_taxonomy?
+    refute edition.can_be_tagged_to_worldwide_taxonomy?
   end
 end

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -13,12 +13,6 @@ class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::
 
     assert edition.can_be_tagged_to_taxonomy?
   end
-
-  test '#must_be_tagged_to_taxonomy? is true for NewsArticle' do
-    edition = create(:news_article, organisations: [@lead_org])
-
-    assert edition.must_be_tagged_to_taxonomy?
-  end
 end
 
 class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::TestCase
@@ -26,13 +20,6 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     @lead_org = create(:organisation)
     worldwide_tagging_orgs = [@lead_org.content_id]
     Whitehall.stubs(:worldwide_tagging_organisations).returns(worldwide_tagging_orgs)
-  end
-
-  # Users are not required to tag World taggable editions in order to publish
-  test '#must_be_tagged_to_taxonomy? is false for DetailedGuide' do
-    edition = create(:detailed_guide, organisations: [@lead_org])
-
-    refute edition.must_be_tagged_to_taxonomy?
   end
 
   test '#can_be_tagged_to_worldwide_taxonomy? is true for Publication Guidance' do

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -4,8 +4,7 @@ class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::
   def setup
     @lead_org = create(:organisation)
     orgs_in_tagging_beta = {
-      "education_related" => [@lead_org.content_id],
-      "worldwide_related" => []
+      "education_related" => [@lead_org.content_id]
     }
     Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
   end

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -3,9 +3,7 @@ require "test_helper"
 class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::TestCase
   def setup
     @lead_org = create(:organisation)
-    orgs_in_tagging_beta = {
-      "education_related" => [@lead_org.content_id]
-    }
+    orgs_in_tagging_beta = [@lead_org.content_id]
     Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
   end
 

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -27,11 +27,8 @@ end
 class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::TestCase
   def setup
     @lead_org = create(:organisation)
-    orgs_in_tagging_beta = {
-      "education_related" => [],
-      "worldwide_related" => [@lead_org.content_id]
-    }
-    Whitehall.stubs(:organisations_in_tagging_beta).returns(orgs_in_tagging_beta)
+    worldwide_tagging_orgs = [@lead_org.content_id]
+    Whitehall.stubs(:worldwide_tagging_organisations).returns(worldwide_tagging_orgs)
   end
 
   # Users are not required to tag World taggable editions in order to publish

--- a/test/unit/validators/taxon_validator_test.rb
+++ b/test/unit/validators/taxon_validator_test.rb
@@ -7,7 +7,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
 
   test 'is invalid when edition has not been tagged to a taxon' do
     edition = create(:draft_edition)
-    edition.stubs(:must_be_tagged_to_taxonomy?).returns(true)
+    edition.stubs(:can_be_tagged_to_taxonomy?).returns(true)
 
     publishing_api_has_links(
       "content_id" => edition.content_id,
@@ -33,7 +33,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
 
   test 'is valid when edition has been tagged to a taxon' do
     edition = create(:draft_edition)
-    edition.stubs(:must_be_tagged_to_taxonomy?).returns(true)
+    edition.stubs(:can_be_tagged_to_taxonomy?).returns(true)
 
     publishing_api_has_links(
       "content_id" => edition.content_id,


### PR DESCRIPTION
Trello: https://trello.com/c/xcy8kV75

Related to PR #4057 

## What's changed

Add a new permission to determine whether an organisation can tag to the Worldwide taxonomy.

## Why

This allows us to allow more organisations to tag to the topic taxonomy, without also giving them permission to tag to the worldwide taxonomy.