### PR TITLE
Fix incorrect stub causing strange test output

### DIFF
--- a/features/step_definitions/new_tagging_workflow_steps.rb
+++ b/features/step_definitions/new_tagging_workflow_steps.rb
@@ -20,7 +20,7 @@ Then(/^I should be able to update the taxonomy$/) do
 end
 
 When(/^I start editing a draft document which cannot be tagged to the new taxonomy$/) do
-  stub_publishing_api_policies
+  stub_policies
   stub_topics
   stub_specialist_sectors
   create(:organisation, content_id: 'otherzzz-zzzz-zzzz-zzzz-zzzz0000zzzz', name: 'Non Taxon Org')

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -23,11 +23,28 @@ module AdminLegacyAssociationsHelper
     @pol_area_3 = create(:topic, name: policy_area_3['title'])
   end
 
+
+  def stub_policies
+    @policies = [
+      policy_1,
+      policy_2,
+      policy_3,
+    ]
+    publishing_api_has_linkables(@policies, document_type: "policy")
+
+    @policies.each do |policy|
+      publishing_api_has_links(
+        "content_id" => policy["content_id"],
+        "links" => policy["links"],
+      )
+    end
+  end
+
 private
 
   def assert_selected_policies_are_displayed
     assert has_css? ".policies li", text: policy_1['title']
-    assert has_css? ".policies li", text: policy_area_1['title'] # TODO this seems wrong
+    refute has_css? ".policies li", text: policy_area_1['title']
     refute has_css? ".policies li", text: policy_2['title']
   end
 
@@ -47,7 +64,7 @@ private
     topic_ids = [@pol_area_3.id]
     assert_equal topic_ids, Publication.last.topic_ids
   end
-  
+
   def tag_to_policy(policy)
     select policy["title"], from: 'Policies'
   end


### PR DESCRIPTION
There was an incorrect (and slightly confusing) assert in the new-tagging-workflow.feature

This was caused by basing the stubs for publishing api on another test.

This turned out to be wrong.
The test is now asserting the correct behaviour.

Trello: https://trello.com/c/VzX8yPsd/102-investigate-the-weird-assert-in-features-support-adminlegacyassociationshelperrb30