### PR TITLE
Add tracking to legacy tagging

### DIFF
--- a/app/assets/javascripts/admin/modules/track_select_click.js
+++ b/app/assets/javascripts/admin/modules/track_select_click.js
@@ -1,0 +1,48 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackSelectClick = function() {
+    function trackClick(event) {
+      var $el = $(event.target);
+      var action = $el.data('track-action');
+
+      if (!action) {
+        var selectBoxSelector = '#' + event.target.id;
+        action = getTextOptions(selectBoxSelector, $el.val());
+
+        if ($el.attr("multiple")) {
+          action = getMultipleSelectValues(selectBoxSelector);
+        }
+      }
+
+      var dataCategory = $el.data('track-category'),
+          dataAction = action,
+          dataLabel = $el.data('track-label');
+
+      if (GOVUKAdmin.trackEvent) {
+        GOVUKAdmin.trackEvent(dataCategory, dataAction, { label: dataLabel });
+      }
+    };
+
+    function getMultipleSelectValues(selectBoxSelector) {
+      var selectedOptionValues = $(selectBoxSelector).val();
+      var selectedOptionTextValues = [];
+
+      if (selectedOptionValues) {
+        selectedOptionTextValues = selectedOptionValues.map(function(item) {
+          return getTextOptions(selectBoxSelector, item);
+        });
+      }
+
+      return selectedOptionTextValues.toString();
+    };
+
+    function getTextOptions(selectBoxSelector, value) {
+      return $(selectBoxSelector + ' option[value="' + value + '"]').text();
+    };
+
+    this.start = function(element) {
+      element.on('change', trackClick);
+    };
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/views/admin/editions/_specialist_sector_fields.html.erb
+++ b/app/views/admin/editions/_specialist_sector_fields.html.erb
@@ -10,14 +10,24 @@
   <%= form.select :primary_specialist_sector_tag,
                   specialist_sector_options_for_select,
                   { include_blank: true },
-                  { class: 'chzn-select form-control',
-                    data: { placeholder: 'Choose a primary specialist sector…' } } %>
+                  class: 'chzn-select form-control',
+                  data: {
+                    "placeholder": 'Choose a primary specialist sector…',
+                    "module": "track-select-click",
+                    "track-category": "taxonSelectionPrimarySpecialist",
+                    "track-label": request.path
+                  } %>
 
   <%= form.label :secondary_specialist_sector_tags, 'Additional specialist sectors' %>
   <%= form.select :secondary_specialist_sector_tags,
                   specialist_sector_options_for_select,
                   {},
-                  { multiple: true,
-                    class: 'chzn-select form-control',
-                    data: { placeholder: 'Choose additional specialist sectors…' } } %>
+                  multiple: true,
+                  class: 'chzn-select form-control',
+                  data: {
+                    "placeholder": 'Choose additional specialist sectors…',
+                    "module": "track-select-click",
+                    "track-category": "taxonSelectionAdditionalSpecialist",
+                    "track-label": request.path
+                  } %>
 </fieldset>

--- a/app/views/admin/editions/_topic_fields.html.erb
+++ b/app/views/admin/editions/_topic_fields.html.erb
@@ -1,6 +1,16 @@
 <% cache_if edition.topic_ids.empty?, taggable_topics_cache_digest do %>
   <fieldset class="edition-topic-fields">
     <%= form.label :topic_ids, 'Policy Areas', required: true %>
-    <%= form.select :topic_ids, options_for_select(taggable_topics_container, edition.topic_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose policy areas…"} %>
+    <%= form.select :topic_ids,
+                    options_for_select(taggable_topics_container, edition.topic_ids),
+                    {},
+                    multiple: true,
+                    class: 'chzn-select form-control',
+                    data: {
+                      "placeholder": "Choose policy areas…",
+                      "module": "track-select-click",
+                      "track-category": "taxonSelectionPolicyAreas",
+                      "track-label": request.path
+                    } %>
   </fieldset>
 <% end %>

--- a/app/views/admin/shared/_policy_fields.html.erb
+++ b/app/views/admin/shared/_policy_fields.html.erb
@@ -5,5 +5,10 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose policies…"} %>
+                  data: {
+                    "placeholder": "Choose policies…",
+                    "module": "track-select-click",
+                    "track-category": "taxonSelectionPolicies",
+                    "track-label": request.path
+                  } %>
 </fieldset>

--- a/test/javascripts/unit/admin/modules/track_select_click_test.js
+++ b/test/javascripts/unit/admin/modules/track_select_click_test.js
@@ -1,0 +1,150 @@
+var form =
+  '<form id="non-english" class="js-supports-non-english"></form>'
+
+var policiesTrackedFieldset =
+'  <fieldset class="policies">' +
+'    <label for="edition_policy_content_ids">Policies</label>' +
+'    <input name="edition[policy_content_ids][]" type="hidden" value="" />' +
+'    <select multiple="multiple" class="chzn-select form-control" data-placeholder="Choose policies..." name="edition[policy_content_ids][]" id="edition_policy_content_ids" data-track-label="/government/admin/publication/new" data-track-category="taxonSelectionPolicies" data-module="track-select-click">' +
+'      <option value=""></option>' +
+'      <option value="17e4ab26-ee1f-4383-a345-d165c0b75fbf">School and college funding</option>' +
+'      <option value="26e3144d-b07f-4329-9401-54f503349cd1">Civil contingencies and resilience</option>' +
+'      <option value="2dcb5926-db6e-4347-b6d8-64fa9d5779a5">Brexit</option>' +
+'    </select>' +
+'  </fieldset>'
+
+var policyAreasTrackedFieldset =
+'  <fieldset class="edition-topic-fields">' +
+'    <label for="edition_topic_ids">Policy Areas</label>' +
+'    <input name="edition[topic_ids][]" type="hidden" value="" />' +
+'    <select multiple="multiple" class="chzn-select form-control" data-placeholder="Choose policy areas..." name="edition[topic_ids][]" id="edition_topic_ids" data-track-label="/government/admin/publication/new" data-track-category="taxonSelectionPolicyAreas" data-module="track-select-click">' +
+'      <option value=""></option>' +
+'      <option value="43">Arts and culture</option>' +
+'      <option value="44">Borders and immigration</option>' +
+'      <option value="46">Business and enterprise</option>' +
+'    </select>' +
+'  </fieldset>'
+
+var primarySpecialistSectorTrackedFieldset =
+'  <fieldset class="edition-specialist-sector-fields">' +
+'    <label for="edition_primary_specialist_sector_tag">Primary specialist sector tag</label>' +
+'    <select class="chzn-select form-control" data-placeholder="Choose a primary specialist sector..." name="edition[primary_specialist_sector_tag]" id="edition_primary_specialist_sector_tag" data-track-label="/government/admin/publication/new" data-track-category="taxonSelectionPrimarySpecialist" data-module="track-select-click">' +
+'      <option value=""></option>' +
+'      <optgroup label="Animal welfare">' +
+'       <option value="3e275a11-0fae-425b-a7a1-fe434594693f">Animal welfare: Pets</option>' +
+'      </optgroup>' +
+'      <optgroup label="Benefits">' +
+'       <option value="5285dff5-e786-4b88-b113-1d78b19ac8e1">Benefits: Universal Credit</option>' +
+'       <option value="cc9eb8ab-7701-43a7-a66d-bdc5046224c0">Benefits: Child Benefit</option>' +
+'      </optgroup>' +
+'      <optgroup label="Business and enterprise">' +
+'       <option value="05dd1330-d26e-4683-9717-b61019eae6e4">Business and enterprise: Licensing</option>' +
+'      </optgroup>' +
+'    </select>' +
+'  </fieldset>'
+
+var secondarySpecialistSectorTrackedFieldset =
+'  <fieldset class="edition-specialist-sector-fields">' +
+'    <label for="edition_secondary_specialist_sector_tags">Additional specialist sectors</label>' +
+'    <select class="chzn-select form-control" data-placeholder="Choose additional specialist sectors..." name="edition[secondary_specialist_sector_tags][]" id="edition_secondary_specialist_sector_tags" data-track-label="/government/admin/publication/new" data-track-category="taxonSelectionAdditionalSpecialist" data-module="track-select-click">' +
+'      <option value=""></option>' +
+'      <optgroup label="Animal welfare">' +
+'       <option value="3e275a11-0fae-425b-a7a1-fe434594693f">Animal welfare: Pets</option>' +
+'      </optgroup>' +
+'      <optgroup label="Benefits">' +
+'       <option value="5285dff5-e786-4b88-b113-1d78b19ac8e1">Benefits: Universal Credit</option>' +
+'       <option value="cc9eb8ab-7701-43a7-a66d-bdc5046224c0">Benefits: Child Benefit</option>' +
+'      </optgroup>' +
+'      <optgroup label="Business and enterprise">' +
+'       <option value="05dd1330-d26e-4683-9717-b61019eae6e4">Business and enterprise: Licensing</option>' +
+'      </optgroup>' +
+'    </select>' +
+'  </fieldset>'
+
+
+module("TrackSelectClick", {
+  setup: function() {
+    this.subject = new GOVUKAdmin.Modules.TrackSelectClick();
+
+    $('#qunit-fixture').append(form)
+    $('#qunit-fixture form').append(policiesTrackedFieldset)
+    $('#qunit-fixture form').append(policyAreasTrackedFieldset)
+    $('#qunit-fixture form').append(primarySpecialistSectorTrackedFieldset)
+    $('#qunit-fixture form').append(secondarySpecialistSectorTrackedFieldset)
+
+    GOVUK.adminEditionsForm.init({
+      selector: 'form#non-english',
+      right_to_left_locales:["ar"]
+    });
+    $('.js-hidden').hide();
+  }
+});
+
+test("the policies fieldset should send a tracking event on change", function () {
+  var policiesSelectBox = $('#edition_policy_content_ids');
+  var spy = sinon.spy(GOVUKAdmin, 'trackEvent');
+
+  this.subject.start(policiesSelectBox);
+
+  policiesSelectBox.val('17e4ab26-ee1f-4383-a345-d165c0b75fbf').change();
+
+  sinon.assert.calledOnce(spy);
+  deepEqual(
+    spy.args[0],
+    ["taxonSelectionPolicies", "School and college funding", {}]
+  );
+
+  spy.restore()
+});
+
+test("the policy areas fieldset should send a tracking event on change", function () {
+  var policyAreasSelectBox = $('#edition_topic_ids');
+  var spy = sinon.spy(GOVUKAdmin, 'trackEvent');
+
+  this.subject.start(policyAreasSelectBox);
+
+  policyAreasSelectBox.val('44').change();
+
+  sinon.assert.calledOnce(spy);
+  deepEqual(
+    spy.args[0],
+    ["taxonSelectionPolicyAreas", "Borders and immigration", {}]
+  );
+
+  spy.restore()
+});
+
+test("the primary specialist sector fieldset should send a tracking event on change", function () {
+  var primarySpecialistSectorSelectBox = $('#edition_primary_specialist_sector_tag');
+  var spy = sinon.spy(GOVUKAdmin, 'trackEvent');
+
+  this.subject.start(primarySpecialistSectorSelectBox);
+
+  primarySpecialistSectorSelectBox.val('5285dff5-e786-4b88-b113-1d78b19ac8e1').change();
+
+  sinon.assert.calledOnce(spy);
+  deepEqual(
+    spy.args[0],
+    ["taxonSelectionPrimarySpecialist", "Benefits: Universal Credit", {}]
+  );
+
+  spy.restore()
+});
+
+
+test("the additional specialist sector fieldset should send a tracking event on change", function () {
+  var additionalSpecialistSectorSelectBox = $('#edition_secondary_specialist_sector_tags');
+  var spy = sinon.spy(GOVUKAdmin, 'trackEvent');
+
+  this.subject.start(additionalSpecialistSectorSelectBox);
+
+  additionalSpecialistSectorSelectBox.val('3e275a11-0fae-425b-a7a1-fe434594693f').change();
+
+  sinon.assert.calledOnce(spy);
+  deepEqual(
+    spy.args[0],
+    ["taxonSelectionAdditionalSpecialist", "Animal welfare: Pets", {}]
+  );
+
+  spy.restore()
+});

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -757,6 +757,10 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
+          if document_type == "publication"
+            assert_select "select[name*='edition[policy_content_ids]'][data-track-category='taxonSelectionPolicies']"
+            assert_select "select[name*='edition[policy_content_ids]'][data-track-label='government/admin/#{document_type}/new']"
+          end
           assert_select "select[name*='edition[policy_content_ids]']" do
             assert_select "option[value='#{policy_1['content_id']}']"
             assert_select "option[value='#{policy_2['content_id']}']"
@@ -790,6 +794,10 @@ module AdminEditionControllerTestHelpers
 
         assert_select "form#edit_edition" do
           assert_select "select[name*='edition[policy_content_ids]']"
+          if document_type == "publication"
+            assert_select "select[name*='edition[policy_content_ids]'][data-track-category='taxonSelectionPolicies']"
+            assert_select "select[name*='edition[policy_content_ids]'][data-track-label='government/admin/#{document_type}/new']"
+          end
         end
       end
 


### PR DESCRIPTION
Trello: https://trello.com/c/WJc6DgVn/97-add-tracking-to-whitehall-publisher-legacy-tagging-fields

This adds tracking to select/listboxes for the following:
* Policies
* Policy Areas
* Specialist Sectors

The track attributes are defined in the following document: https://docs.google.com/document/d/1p19Im6XfWZG63RJRcLQmbuCCrpyESTY_2KnaqA82hyQ/edit?ts=5b03f594

# GA Debugger Output
## Policies
<img width="287" alt="screen shot 2018-05-30 at 15 02 23" src="https://user-images.githubusercontent.com/29889908/40725120-83bdbadc-641a-11e8-8924-069ceaa556e2.png">

## Policy Areas
<img width="308" alt="screen shot 2018-05-30 at 15 02 59" src="https://user-images.githubusercontent.com/29889908/40725139-90026202-641a-11e8-9a71-1796bd0e7a36.png">

## Primary Specialist Sectors
<img width="329" alt="screen shot 2018-05-30 at 15 03 31" src="https://user-images.githubusercontent.com/29889908/40725168-a370b9a6-641a-11e8-8638-a3c4f3589127.png">

## Additional Specialist Sectors
<img width="355" alt="screen shot 2018-05-30 at 15 03 57" src="https://user-images.githubusercontent.com/29889908/40725191-b3011154-641a-11e8-8e26-42e8606c35bb.png">

