### PR TITLE
Fix bug in localised articles

### DIFF
--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -58,7 +58,8 @@ private
   end
 
   def find_edition
-    @edition = Edition.find(params[:edition_id])
+    edition = Edition.find(params[:edition_id])
+    @edition = LocalisedModel.new(edition, edition.primary_locale)
   end
 
   def enforce_permissions!

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -106,10 +106,8 @@ When(/^I draft a French\-only "World news story" news article associated with "(
   select location_name, from: "Select the world locations this news article is about"
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
   select "", from: "edition_lead_organisation_ids_1"
-
-  click_button "Save"
-  # TODO  investigate why save legacy breaks this
-  click_link "cancel"
+  click_button "Next"
+  click_button "Save legacy associations"
   @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
 end
 


### PR DESCRIPTION
When building the legacy tagging page, I should have use the
LocalisedModel class used by the original editions controller.

This introduced a problem where the edition was not localised
correctly.

It also broke the "Create a News article of type 'world news story'
in a non-English language" scenario in news-article.feature

Trello: https://trello.com/c/6ReeGM43/101-investigate-the-comment-in-features-stepdefinitions-newsarticlestepsrb120