### PR TITLE
Return nil if the organisation link doesn't exist

### DIFF
--- a/lib/whitehall/admin_link_lookup.rb
+++ b/lib/whitehall/admin_link_lookup.rb
@@ -16,6 +16,7 @@ module Whitehall
     end
 
     def self.corporate_info_page(organisation:, corporate_info_slug:)
+      return nil unless organisation
       organisation.corporate_information_pages.find(corporate_info_slug)
     end
 


### PR DESCRIPTION
We expect it to return `nil` if the organisation doesn't exist, but this isn't the case because we try and call `corporate_info_page` with a `nil` organisation which fails.

https://sentry.io/govuk/app-whitehall/issues/537947492/?query=is:unresolved