### PR TITLE
Remove Slimmer::GovukComponents

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::GovukComponents
   include LocalisedUrlPathHelper
 
   protect_from_forgery

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -60,10 +60,6 @@ class TopicalEvent < Classification
     end
   end
 
-  def beta?
-    slug.in?(%w[farming])
-  end
-
   def base_path
     Whitehall.url_maker.topical_event_path(slug)
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -4,14 +4,6 @@
 
 <%= content_tag_for(:div, @classification, class: "classification #{@classification.class.name.underscore}") do %>
 
-  <% if @classification.beta? %>
-    <div class="inner-block">
-      <%= render 'govuk_component/beta_label',
-            message: "This page is in <a href='/help/beta'>beta</a>. " +
-            "We'll be updating it regularly and welcome <a href='/contact/govuk'>your feedback</a>." %>
-    </div>
-  <% end %>
-
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',

--- a/features/support/slimmer.rb
+++ b/features/support/slimmer.rb
@@ -1,7 +1,1 @@
 require Rails.root.join('test/support/skip_slimmer.rb')
-require Rails.root.join('test/support/static_stub_helpers.rb')
-
-Before do
-  stub_request(:get, %r{.*static.*/templates/locales\/.+}).
-    to_return(status: 400, headers: {})
-end

--- a/test/support/static_stub_helpers.rb
+++ b/test/support/static_stub_helpers.rb
@@ -1,9 +1,0 @@
-module StaticStubHelpers
-  def stub_static_locales
-    # Stub requests to static as per
-    # https://github.com/alphagov/slimmer/blob/c2a6b26d5884d7ee7c641dc072e9b28387f3603e/lib/slimmer/test_helpers/govuk_components.rb
-    # which can't be used here as we oddly still use alphagov.co.uk
-    stub_request(:get, %r{.*static.*/templates/locales\/.+}).
-      to_return(status: 400, headers: {})
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,6 @@ class ActiveSupport::TestCase
   include PublishingApiTestHelpers
   include PolicyTaggingHelpers
   include GovukContentSchemaTestHelpers::TestUnit
-  include StaticStubHelpers
   include UrlHelpers
   extend GovspeakValidationTestHelper
 
@@ -60,7 +59,6 @@ class ActiveSupport::TestCase
     stub_publishing_api_publish_intent
     stub_publishing_api_policies
     SyncCheckWorker.stubs(:enqueue)
-    stub_static_locales
     Services.stubs(:asset_manager).returns(stub_everything('asset-manager'))
   end
 
@@ -188,7 +186,6 @@ class ActionController::TestCase
   include AtomTestHelpers
   include CacheControlTestHelpers
   include ViewRendering
-  include StaticStubHelpers
 
   include PublicDocumentRoutesHelper
   include Admin::EditionRoutesHelper
@@ -206,7 +203,6 @@ class ActionController::TestCase
     stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
     publishing_api_has_linkables([], document_type: 'topic')
 
-    stub_static_locales
     stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/links/}).to_return(body: { links: {} }.to_json)
   end
 


### PR DESCRIPTION
This removes the last usage of a Static-based component, so we can get rid of `Slimmer::GovukComponents` and test helpers.

https://trello.com/c/qtXCDGQI