### PR TITLE
first_published_at can't be set in the future

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -13,7 +13,6 @@ class Admin::EditionsController < Admin::BaseController
   before_action :limit_edition_access!, only: %i[show edit update submit revise diff reject destroy]
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :deduplicate_specialist_sectors, only: %i[create update]
-  before_action :trigger_previously_published_validations, only: [:create], if: :document_can_be_previously_published
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update submit destory revise]
 
   def forbid_editing_of_historic_content!
@@ -390,13 +389,5 @@ private
     if edition_params[:secondary_specialist_sector_tags] && edition_params[:primary_specialist_sector_tag]
       edition_params[:secondary_specialist_sector_tags] -= [edition_params[:primary_specialist_sector_tag]]
     end
-  end
-
-  def trigger_previously_published_validations
-    @edition.trigger_previously_published_validations
-  end
-
-  def document_can_be_previously_published
-    true
   end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -166,6 +166,10 @@ class Consultation < Publicationesque
     true
   end
 
+  def previously_published
+    false
+  end
+
 private
 
   def validate_closes_after_opens

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -136,6 +136,10 @@ class CorporateInformationPage < Edition
     end
   end
 
+  def previously_published
+    false
+  end
+
 private
 
   def string_for_slug

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -52,6 +52,9 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65535 }
   validates :first_published_at, recent_date: true, allow_blank: true
   validates :first_published_at, previously_published: true
+  validates_each :first_published_at do |record, attr, value|
+    record.errors.add(attr, "can't be set to a future date") if value && Time.zone.now < value
+  end
 
   UNMODIFIABLE_STATES = %w(scheduled published superseded deleted).freeze
   FROZEN_STATES = %w(superseded deleted).freeze

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -643,7 +643,11 @@ class Edition < ApplicationRecord
       errors[:base] << 'You must specify whether the document has been published before'
       @has_first_published_error = true
     elsif previously_published == 'true' # not a real field, so isn't converted to bool
-      errors.add(:first_published_at, "can't be blank") if first_published_at.blank?
+      if first_published_at.blank?
+        errors.add(:first_published_at, "can't be blank")
+      elsif first_published_at > Time.zone.now
+        errors.add(:first_published_at, "can't be set to a future date")
+      end
       @has_first_published_error = true
     end
   end

--- a/app/validators/previously_published_validator.rb
+++ b/app/validators/previously_published_validator.rb
@@ -1,14 +1,16 @@
 class PreviouslyPublishedValidator < ActiveModel::Validator
   def validate(record)
+    record.has_previously_published_error = false
+
     if record.previously_published.nil?
       record.errors[:base] << "You must specify whether the document has been published before"
       record.has_previously_published_error = true
-    elsif record.previously_published
-      if record.first_published_at.blank?
-        record.errors.add(:first_published_at, "can't be blank")
-      elsif record.first_published_at > Time.zone.now
-        record.errors.add(:first_published_at, "can't be set to a future date")
-      end
+    elsif record.previously_published && record.first_published_at.blank?
+      record.errors.add(:first_published_at, "can't be blank")
+    end
+
+    if record.first_published_at && Time.zone.now < record.first_published_at
+      record.errors.add(:first_published_at, "can't be set to a future date")
     end
   end
 end

--- a/app/validators/previously_published_validator.rb
+++ b/app/validators/previously_published_validator.rb
@@ -1,0 +1,14 @@
+class PreviouslyPublishedValidator < ActiveModel::Validator
+  def validate(record)
+    if record.previously_published.nil?
+      record.errors[:base] << "You must specify whether the document has been published before"
+      record.has_previously_published_error = true
+    elsif record.previously_published
+      if record.first_published_at.blank?
+        record.errors.add(:first_published_at, "can't be blank")
+      elsif record.first_published_at > Time.zone.now
+        record.errors.add(:first_published_at, "can't be set to a future date")
+      end
+    end
+  end
+end

--- a/app/validators/previously_published_validator.rb
+++ b/app/validators/previously_published_validator.rb
@@ -8,9 +8,5 @@ class PreviouslyPublishedValidator < ActiveModel::Validator
     elsif record.previously_published && record.first_published_at.blank?
       record.errors.add(:first_published_at, "can't be blank")
     end
-
-    if record.first_published_at && Time.zone.now < record.first_published_at
-      record.errors.add(:first_published_at, "can't be set to a future date")
-    end
   end
 end

--- a/app/views/admin/editions/_first_published_at.html.erb
+++ b/app/views/admin/editions/_first_published_at.html.erb
@@ -1,5 +1,5 @@
 <% if edition.published_major_version.nil? %>
-  <fieldset class="first-published-date well <% if edition.has_first_published_error %>alert-danger form-errors field_with_errors<% end %>">
+  <fieldset class="first-published-date well <% if edition.has_previously_published_error %>alert-danger form-errors field_with_errors<% end %>">
   <p class="required">This document <span>*</span></p>
   <div class="radio">
     <%= form.label :previously_published_false, class: 'radio' do %>

--- a/features/previously_published.feature
+++ b/features/previously_published.feature
@@ -1,0 +1,33 @@
+Feature: Previously published options
+
+Scenario: Creating a new case study without selecting a 'previously published' option
+  Given I am a writer in the organisation "Department of Examples"
+  When I start a new case study
+  And I click save
+  Then I see a validation error for the 'previously published' option
+
+@javascript
+Scenario: Creating a new case study and selecting a previously published date in the future
+  Given the date is 2018-06-07
+  And I am a writer in the organisation "Department of Examples"
+  When I start a new case study
+  And I select a previously published date in the future
+  And I click save
+  Then I see a validation error for the future date
+
+Scenario: Creating a new case study and selecting previously published with no publication date
+  Given the date is 2018-06-07
+  And I am a writer in the organisation "Department of Examples"
+  When I start a new case study
+  And I select that this document has been previously published
+  And I click save
+  Then I see a validation error for the missing publication date
+
+@javascript
+Scenario: Creating a new case study with a valid previously published date
+  Given the date is 2018-06-07
+  And I am a writer in the organisation "Department of Examples"
+  When I start a new case study
+  And I select a previously published date in the past
+  And I click save
+  Then I should not see a validation error on the previously published date

--- a/features/step_definitions/previously_published_steps.rb
+++ b/features/step_definitions/previously_published_steps.rb
@@ -1,0 +1,54 @@
+Given(/^the date is 2018-06-07$/) do
+  Timecop.freeze "2018-06-07"
+end
+
+When(/^I start a new case study$/) do
+  visit "/government/admin/case-studies/new"
+end
+
+And(/^I click save$/) do
+  click_button "Save"
+end
+
+And(/^I select a previously published date in the future$/) do
+  choose "has previously been published on another website."
+  select "2018", from:"edition_first_published_at_1i"
+  select "July",  from: "edition_first_published_at_2i"
+  select "1",    from: "edition_first_published_at_3i"
+end
+
+And(/^I select that this document has been previously published$/) do
+  choose "has previously been published on another website."
+end
+
+And(/^I select a previously published date in the past$/) do
+  choose "has previously been published on another website."
+  select "2017",      from: "edition_first_published_at_1i"
+  select "February",  from: "edition_first_published_at_2i"
+  select "1",         from: "edition_first_published_at_3i"
+end
+
+Then(/^I see a validation error for the 'previously published' option$/) do
+  assert page.has_content?("You must specify whether the document has been published before"),
+    "Previously published option validation message not found"
+end
+
+Then(/^I see a validation error for the future date$/) do
+  assert page_has_first_published_at_in_future_error_message,
+    "Previously published (first_published_at) validation message not found"
+end
+
+Then(/^I see a validation error for the missing publication date$/) do
+  assert page.has_content?("First published at can't be blank"),
+    "First published can't be blank validation message found"
+end
+
+Then(/^I should not see a validation error on the previously published date$/) do
+  refute page_has_first_published_at_in_future_error_message,
+    "First published at in the future validation message found"
+end
+
+def page_has_first_published_at_in_future_error_message
+  page.has_content?("First published at can't be set to a future date")
+end
+

--- a/features/step_definitions/statistics_steps.rb
+++ b/features/step_definitions/statistics_steps.rb
@@ -2,17 +2,17 @@ Given(/^there are some statistics$/) do
   # 3 Custom ones are most recent, followed by the extras - largest number most recent
 
   create :published_statistics, title: "Womble to Wombat population ratios",
-                                first_published_at: Time.zone.parse("2055-02-15 12:45:00")
+                                first_published_at: Time.zone.parse("2011-02-15 12:45:00")
 
   create :published_national_statistics, title: "2055 beard lengths",
-                                         first_published_at: Time.zone.parse("2050-05-01 12:00:00")
+                                         first_published_at: Time.zone.parse("2010-05-01 12:00:00")
 
   create :published_statistics, title: "Wombat population in Wimbledon Common 2063",
-                                first_published_at: Time.zone.parse("2045-02-15 12:45:00")
+                                first_published_at: Time.zone.parse("2005-02-15 12:45:00")
 
   (1..40).each do |n|
     create :published_statistics, title: "No. #{n} - More stats",
-                                  first_published_at: Time.zone.parse("2040-01-01") + n.days
+                                  first_published_at: Time.zone.parse("2000-01-01") + n.days
   end
 end
 
@@ -51,8 +51,8 @@ end
 When(/^I filter the statistics by keyword, from date and to date$/) do
   within '.filter-form' do
     fill_in "Contains", with: "Wombat"
-    fill_in "Published after", with: "2048-01-01"
-    fill_in "Published before", with: "2060-01-01"
+    fill_in "Published after", with: "2008-01-01"
+    fill_in "Published before", with: "2016-01-01"
     click_on "Refresh results"
   end
 end

--- a/features/support/timecop.rb
+++ b/features/support/timecop.rb
@@ -1,0 +1,3 @@
+After do
+  Timecop.return
+end

--- a/test/functional/corporate_information_pages_controller_test.rb
+++ b/test/functional/corporate_information_pages_controller_test.rb
@@ -62,9 +62,9 @@ class CorporateInformationPagesControllerTest < ActionController::TestCase
   end
 
   test "should display published corporate publications on about-us page in order published" do
-    old_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2012-01-01'))
-    new_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2012-01-03'))
-    middle_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2012-01-02'))
+    old_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2011-01-01'))
+    new_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2011-01-03'))
+    middle_published_corporate_publication = create(:published_corporate_publication, first_published_at: Date.parse('2011-01-02'))
 
     organisation = create(:organisation, editions: [
       old_published_corporate_publication,

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -246,7 +246,7 @@ class PublicationsControllerTest < ActionController::TestCase
       org_2 = create(:organisation, name: "other-org")
       publication = create(:published_publication, title: "publication-title",
                            organisations: [org_1, org_2],
-                           first_published_at: Date.parse("2012-03-14"),
+                           first_published_at: Date.parse("2011-03-14"),
                            publication_type: PublicationType::CorporateReport)
 
       get :index, format: :json
@@ -259,7 +259,7 @@ class PublicationsControllerTest < ActionController::TestCase
       assert_equal publication.id, json["id"]
       assert_equal publication_path(publication.document), json["url"]
       assert_equal "org-name and other-org", json["organisations"]
-      assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
+      assert_equal %{<time class="public_timestamp" datetime="2011-03-14T00:00:00+00:00">14 March 2011</time>}, json["display_date_microformat"]
       assert_equal "Corporate report", json["display_type"]
     end
   end
@@ -272,7 +272,7 @@ class PublicationsControllerTest < ActionController::TestCase
                            organisations: [organisation_1, organisation_2],
                            opening_at: Time.zone.parse("2012-03-14"),
                            closing_at: Time.zone.parse("2012-03-15"),
-                           first_published_at: Time.zone.parse("2012-03-10"))
+                           first_published_at: Time.zone.parse("2011-03-10"))
 
       get :index, format: :json
 
@@ -284,7 +284,7 @@ class PublicationsControllerTest < ActionController::TestCase
       assert_equal consultation.id, json["id"]
       assert_equal consultation_path(consultation.document), json["url"]
       assert_equal "org-name and other-org", json["organisations"]
-      assert_equal %{<time class="public_timestamp" datetime="2012-03-10T00:00:00+00:00">10 March 2012</time>}, json["display_date_microformat"]
+      assert_equal %{<time class="public_timestamp" datetime="2011-03-10T00:00:00+00:00">10 March 2011</time>}, json["display_date_microformat"]
       assert_equal "Consultation", json["display_type"]
     end
   end

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -138,7 +138,7 @@ class StatisticsControllerTest < ActionController::TestCase
       organisation_2 = create(:organisation, name: "other-org")
       statistics_publication = create(:published_statistics, title: "statistics-title",
                                                              organisations: [organisation_1, organisation_2],
-                                                             first_published_at: Date.parse("2012-03-14"))
+                                                             first_published_at: Date.parse("2011-03-14"))
 
       get :index, format: :json
 
@@ -149,7 +149,7 @@ class StatisticsControllerTest < ActionController::TestCase
       assert_equal statistics_publication.id, json["id"]
       assert_equal statistic_path(statistics_publication.document), json["url"]
       assert_equal "org-name and other-org", json["organisations"]
-      assert_equal %{<time class="public_timestamp" datetime="2012-03-14T00:00:00+00:00">14 March 2012</time>}, json["display_date_microformat"]
+      assert_equal %{<time class="public_timestamp" datetime="2011-03-14T00:00:00+00:00">14 March 2011</time>}, json["display_date_microformat"]
       assert_equal "Official Statistics", json["display_type"]
     end
   end
@@ -199,7 +199,7 @@ class StatisticsControllerTest < ActionController::TestCase
       organisation_2 = create(:organisation, name: "other-org")
       statistics_publication = create(:published_statistics, title: "statistics-title",
                                                              organisations: [organisation_1, organisation_2],
-                                                             first_published_at: Date.parse("2012-03-14"))
+                                                             first_published_at: Date.parse("2011-03-14"))
 
       get :index, params: { departments: [organisation_1.to_param] }, format: :atom
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -293,7 +293,8 @@ module AdminEditionControllerTestHelpers
         put :update, params: {
           id: edition,
           edition: {
-            title: '   my title    '
+            title: '   my title    ',
+            previously_published: false,
           }
         }
 

--- a/test/unit/case_study_test.rb
+++ b/test/unit/case_study_test.rb
@@ -25,9 +25,9 @@ class CaseStudyTest < ActiveSupport::TestCase
     refute build(:case_study, primary_locale: :es).translatable?
   end
 
-  test 'imported case study is valid when the first_published_at is blank' do
+  test 'imported case study is not valid when the first_published_at is blank' do
     case_study = build(:case_study, state: 'imported', first_published_at: nil)
-    assert case_study.valid?
+    refute case_study.valid?
   end
 
   test 'imported case_study is not valid_as_draft? when the first_published_at is blank, but draft case_study is' do

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -460,4 +460,8 @@ class ConsultationTest < ActiveSupport::TestCase
     consultation = build(:consultation, outcome: outcome, public_feedback: public_feedback)
     assert_equal [consultation, outcome, public_feedback], consultation.attachables
   end
+
+  test "consultations cannot be previously published" do
+    refute build(:consultation).previously_published
+  end
 end

--- a/test/unit/edition/can_apply_to_local_government_through_related_policies_test.rb
+++ b/test/unit/edition/can_apply_to_local_government_through_related_policies_test.rb
@@ -13,7 +13,8 @@ class Edition::CanApplyToLocalGovernmentThroughRelatedPoliciesTest < ActiveSuppo
       title:   'edition-title',
       body:    'edition-body',
       summary: 'edition-summary',
-      creator: build(:user)
+      creator: build(:user),
+      previously_published: false,
     }
   end
 

--- a/test/unit/edition/images_test.rb
+++ b/test/unit/edition/images_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class Edition::ImagesTest < ActiveSupport::TestCase
   class EditionWithImages < Edition
     include ::Edition::Images
+
+    def previously_published
+      false
+    end
   end
 
   include ActionDispatch::TestProcess

--- a/test/unit/edition/statistical_data_sets_test.rb
+++ b/test/unit/edition/statistical_data_sets_test.rb
@@ -12,7 +12,8 @@ class Edition::StatisticalDataSetsTest < ActiveSupport::TestCase
       title:   'edition-title',
       body:    'edition-body',
       summary: 'edition-summary',
-      creator: create(:user)
+      creator: create(:user),
+      previously_published: false,
     }
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -793,6 +793,14 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
+  test 'first_published_at cannot be set to a future date when previously_published is true' do
+    edition = build(:edition, previously_published: 'true', first_published_at: 10.years.from_now)
+    edition.trigger_previously_published_validations
+
+    refute edition.valid?
+    assert_equal "First published at can't be set to a future date", edition.errors.full_messages.first
+  end
+
   test '#government returns the current government for a newly published edition' do
     government = create(:current_government)
     edition = create(:edition, first_published_at: Time.zone.now)

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -780,8 +780,8 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test 'first_published_at cannot be set to a future date when previously_published is true' do
-    edition = build(:edition, previously_published: "true", first_published_at: 10.years.from_now)
+  test 'first_published_at cannot be set to a future date' do
+    edition = build(:edition, first_published_at: 10.years.from_now)
 
     refute edition.valid?
     assert_equal "First published at can't be set to a future date", edition.errors.full_messages.first

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -21,4 +21,8 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
     corporate_information_page.destroy
   end
+
+  test "corporate information pages cannot be previously published" do
+    refute build(:corporate_information_page).previously_published
+  end
 end

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -177,7 +177,7 @@ end
 
 class PublishingApi::PublishedDocumentCollectionPresenterDetailsTest < ActiveSupport::TestCase
   setup do
-    @expected_first_published_at = Time.new(2015, 12, 25)
+    @expected_first_published_at = Time.new(2011, 2, 5)
     @document_collection = create(
       :document_collection,
       :published,

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -147,7 +147,7 @@ end
 
 class PublishingApi::PublishedFatalityNoticePresenterDetailsTest < ActiveSupport::TestCase
   setup do
-    @expected_time = Time.new(2015, 12, 25)
+    @expected_time = Time.new(2011, 2, 5)
     @fatality_notice = create(
       :fatality_notice,
       :published,

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -106,7 +106,7 @@ end
 
 class PublishingApi::PublishedStatisticalDataSetPresenterDetailsTest < ActiveSupport::TestCase
   setup do
-    @expected_first_published_at = Time.new(2015, 12, 25)
+    @expected_first_published_at = Time.new(2011, 2, 5)
     @statistical_data_set = create(
       :statistical_data_set,
       :published,

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -105,7 +105,7 @@ end
 
 class PublishingApi::WorldLocationNewsArticlePresenterDetailsTest < ActiveSupport::TestCase
   setup do
-    @expected_first_published_at = Time.new(2015, 12, 25)
+    @expected_first_published_at = Time.new(2011, 2, 5)
     @world_location_news_article = create(
       :world_location_news_article,
       :published,

--- a/test/unit/publication_test.rb
+++ b/test/unit/publication_test.rb
@@ -9,7 +9,9 @@ class PublicationTest < ActiveSupport::TestCase
   should_allow_external_attachments
 
   test 'imported publications are valid when the publication_type is imported-awaiting-type' do
-    publication = build(:publication, state: 'imported', publication_type: PublicationType.find_by_slug('imported-awaiting-type'))
+    publication = build(:publication, state: 'imported',
+                        publication_type: PublicationType.find_by_slug('imported-awaiting-type'),
+                        first_published_at: 1.year.ago)
     assert publication.valid?
   end
 

--- a/test/unit/services/edition_unpublisher_test.rb
+++ b/test/unit/services/edition_unpublisher_test.rb
@@ -46,7 +46,7 @@ class EditionUnpublisherTest < ActiveSupport::TestCase
 
   test 'other edition states cannot be unpublished' do
     (Edition.available_states - %i[published draft]).each do |state|
-      edition = create(:edition, state: state)
+      edition = create(:edition, state: state, first_published_at: 1.hour.ago)
       unpublisher = EditionUnpublisher.new(edition, unpublishing: unpublishing_params)
 
       refute unpublisher.perform!

--- a/test/unit/services/edition_withdrawer_test.rb
+++ b/test/unit/services/edition_withdrawer_test.rb
@@ -32,7 +32,7 @@ class EditionWithdrawerTest < ActiveSupport::TestCase
 
   test 'other states cannot be withdrawn' do
     (Edition.available_states - %i[published withdrawn]).each do |state|
-      edition = create(:edition, state: state)
+      edition = create(:edition, state: state, first_published_at: 1.year.ago)
       edition.build_unpublishing(unpublishing_params)
       unpublisher = EditionWithdrawer.new(edition)
 

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -50,7 +50,8 @@ class SpeechTest < ActiveSupport::TestCase
   end
 
   test "does not require an organisation or role appointment when being imported" do
-    speech = build(:speech, role_appointment: nil, create_default_organisation: false, state: 'imported')
+    speech = build(:speech, role_appointment: nil, create_default_organisation: false,
+                   state: 'imported', first_published_at: 1.year.ago)
     assert speech.valid?
   end
 

--- a/test/unit/validators/previously_published_validator_test.rb
+++ b/test/unit/validators/previously_published_validator_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class PreviouslyPublishedValidatorTest < ActiveSupport::TestCase
+  setup do
+    @validator = PreviouslyPublishedValidator.new
+  end
+
+  test "invalid if previously_published is nil" do
+    invalid_edition = Edition.new
+    @validator.validate(invalid_edition)
+    assert_equal "You must specify whether the document has been published before",
+      invalid_edition.errors[:base].first
+  end
+
+  test "no-op unless record can be previously published" do
+    edition = build(:consultation)
+    @validator.validate(edition)
+    assert edition.errors.empty?, "No errors were expected"
+  end
+
+  test "invalid if first_published_at is nil" do
+    invalid_edition = build(:edition, previously_published: true, first_published_at: nil)
+    @validator.validate(invalid_edition)
+    assert_equal "can't be blank",
+      invalid_edition.errors[:first_published_at].first
+  end
+
+  test "invalid if first_published_at is in the future" do
+    invalid_edition = build(:edition, previously_published: true, first_published_at: 1.hour.since)
+    @validator.validate(invalid_edition)
+    assert_equal "can't be set to a future date",
+      invalid_edition.errors[:first_published_at].first
+  end
+
+  test "valid if first_published_at is in the past" do
+    valid_edition = build(:edition, previously_published: true, first_published_at: 1.hour.ago)
+    @validator.validate(valid_edition)
+    assert valid_edition.valid?
+  end
+end

--- a/test/unit/validators/previously_published_validator_test.rb
+++ b/test/unit/validators/previously_published_validator_test.rb
@@ -25,13 +25,6 @@ class PreviouslyPublishedValidatorTest < ActiveSupport::TestCase
       invalid_edition.errors[:first_published_at].first
   end
 
-  test "invalid if first_published_at is in the future" do
-    invalid_edition = build(:edition, previously_published: true, first_published_at: 1.hour.since)
-    @validator.validate(invalid_edition)
-    assert_equal "can't be set to a future date",
-      invalid_edition.errors[:first_published_at].first
-  end
-
   test "valid if first_published_at is in the past" do
     valid_edition = build(:edition, previously_published: true, first_published_at: 1.hour.ago)
     @validator.validate(valid_edition)


### PR DESCRIPTION
There is an issue where if the `first_published_at` is set to any date after the current, it throws and error when trying to edit the edition again.

The `edition.goverment` relies on the `first_published_at` date to associate the edition with the right government and therefore should not be possible to set in the future.

Trello card: [Whitehall - documents can become uneditable if you change first published at date to future](https://trello.com/c/MzhjknzC/176-whitehall-documents-can-become-uneditable-if-you-change-first-published-at-date-to-future)