### PR TITLE
Copy all content tagged to Brexit Policy to Brexit Taxon

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,3 +15,7 @@ end
 every 10.minutes, roles: [:backend] do
   rake "taxonomy:rebuild_cache"
 end
+
+every 30.minutes, roles: [:backend] do
+  rake "taxonomy:copy_brexit_policies_to_brexit_taxon"
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -7,4 +7,9 @@ namespace :taxonomy do
       RebuildTaxonomyCacheWorker.perform_async
     end
   end
+
+  desc "Tags content to the new Brexit taxon if it's only tagged to the Brexit policy taxon"
+  task copy_brexit_policies_to_brexit_taxon: [:environment] do
+    Taxonomy::SyncBrexitPolicies.new.call
+  end
 end

--- a/lib/taxonomy/sync_brexit_policies.rb
+++ b/lib/taxonomy/sync_brexit_policies.rb
@@ -1,0 +1,51 @@
+module Taxonomy
+  class SyncBrexitPolicies
+    attr_reader :log
+
+    BREXIT_POLICY_ID = '2dcb5926-db6e-4347-b6d8-64fa9d5779a5'.freeze
+    BREXIT_TAXON_ID = 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'.freeze
+
+    def initialize
+      @log = []
+    end
+
+    def call
+      patch_editions
+    end
+
+  private
+
+    def brexit_policy_editions_query
+      Document.joins(:editions)
+        .joins('INNER JOIN edition_policies on editions.id = edition_policies.edition_id')
+        .where(editions: { state: 'published' }, edition_policies: { policy_content_id: BREXIT_POLICY_ID })
+        .pluck(:content_id)
+    end
+
+    def links_for_brexit_policy_editions
+      Services.publishing_api.get_links_for_content_ids(brexit_policy_editions_query)
+    end
+
+    def patch_editions
+      links_for_brexit_policy_editions.each do |content_id, edition_links|
+        edition_taxons = edition_links.dig("links", "taxons") || []
+
+        unless edition_taxons.include?(BREXIT_TAXON_ID)
+          Services.publishing_api.patch_links(
+            content_id,
+            links: {
+              taxons: edition_taxons << BREXIT_TAXON_ID
+            },
+            previous_version: edition_links.dig("version")
+          )
+        end
+      end
+    rescue GdsApi::HTTPConflict, GdsApi::HTTPGatewayTimeout, GdsApi::TimedOutException => ex
+      log << "ERROR: #{ex.message}"
+      retries ||= 0
+      retry if (retries += 1) < 3
+      puts log
+      raise
+    end
+  end
+end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -59,6 +59,15 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_policy_edition) do
+      transient do
+        policy_content_id ''
+      end
+      after :create do |edition, evaluator|
+        EditionPolicy.create(edition_id: edition.id, policy_content_id: evaluator.policy_content_id)
+      end
+    end
+
     trait(:imported) do
       state "imported"
       first_published_at { 1.year.ago }

--- a/test/unit/taxonomy/sync_brexit_policies_test.rb
+++ b/test/unit/taxonomy/sync_brexit_policies_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+class Taxonomy::SyncBrexitPoliciesTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  def class_instance
+    Taxonomy::SyncBrexitPolicies.new
+  end
+
+  def taxon_content_ids
+    @taxon_content_ids ||= [SecureRandom.uuid, SecureRandom.uuid]
+  end
+
+  def create_brexit_policy_edition
+    FactoryBot.create(:edition, :published, :with_policy_edition, policy_content_id: Taxonomy::SyncBrexitPolicies::BREXIT_POLICY_ID)
+  end
+
+  def has_links_for_content_ids(edition, taxons, version = 1)
+    publishing_api_has_links_for_content_ids(
+      edition.content_id =>
+      { "links" =>
+       { "taxons" => taxons },
+         "version" => version }
+    )
+  end
+
+  test 'if there is not content with brexit policies tagged' do
+    publishing_api_has_links_for_content_ids({})
+    Services.publishing_api.expects(:patch_links).never
+    class_instance.call
+  end
+
+  test 'if there is content with brexit policies tagged that is already linked to brexit taxon' do
+    edition = create_brexit_policy_edition
+
+    has_links_for_content_ids(edition, Taxonomy::SyncBrexitPolicies::BREXIT_TAXON_ID)
+
+    Services.publishing_api.expects(:patch_links).never
+    class_instance.call
+  end
+
+  test 'if there is content with brexit policies tagged that is not linked to brexit taxon' do
+    edition = create_brexit_policy_edition
+
+    has_links_for_content_ids(edition, taxon_content_ids)
+
+    stub_any_publishing_api_patch_links
+    class_instance.call
+
+    assert_publishing_api_patch_links(
+      edition.content_id,
+      'links' => {
+        'taxons' => taxon_content_ids + [Taxonomy::SyncBrexitPolicies::BREXIT_TAXON_ID],
+      },
+      'previous_version' => 1
+    )
+  end
+
+  test 'if the version id from get_content_ids does not match the previous version when calling patch links' do
+    edition = create_brexit_policy_edition
+
+    has_links_for_content_ids(edition, taxon_content_ids)
+
+    stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(2).then.to_return(body: '{}')
+    assert_nothing_raised do
+      class_instance.call
+    end
+
+    stub_any_publishing_api_patch_links.and_raise(GdsApi::HTTPConflict).times(3).then.to_return(body: '{}')
+    assert_raises GdsApi::HTTPConflict do
+      class_instance.call
+    end
+  end
+end


### PR DESCRIPTION
Every 30 minutes, a rake task will run which checks to see if there are
new content items tagged to the Brexit Policy taxon which are not tagged to
the Brexit Topic Taxonomy. If so, these content items will be tagged to
the new Brexit Topic Taxonomy, this will keep the new taxonomy up to
date with the latest information regarding Brexit.