### PR TITLE
Add FoI contacts and sub organisations to organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -29,10 +29,12 @@ module PublishingApi
         document_type: item.class.name.underscore,
         links: {
           ordered_contacts: contacts_links,
+          ordered_foi_contacts: foi_contacts_links,
           ordered_featured_policies: featured_policies_links,
           ordered_parent_organisations: parent_organisation_links,
           ordered_child_organisations: child_organisation_links,
           ordered_successor_organisations: successor_organisation_links,
+          ordered_high_profile_groups: high_profile_groups_links,
         },
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
@@ -325,6 +327,10 @@ module PublishingApi
       item.home_page_contacts.pluck(:content_id).uniq
     end
 
+    def foi_contacts_links
+      item.foi_contacts.pluck(:content_id).uniq
+    end
+
     def parent_organisation_links
       item.parent_organisations.distinct.pluck(:content_id)
     end
@@ -335,6 +341,10 @@ module PublishingApi
 
     def successor_organisation_links
       item.superseding_organisations.distinct.pluck(:content_id)
+    end
+
+    def high_profile_groups_links
+      item.sub_organisations.distinct.pluck(:content_id)
     end
 
     def featured_policies_links

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -25,10 +25,12 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       document_type: 'organisation',
       links: {
         ordered_contacts: [],
+        ordered_foi_contacts: [],
         ordered_featured_policies: [],
         ordered_parent_organisations: [],
         ordered_child_organisations: [],
         ordered_successor_organisations: [],
+        ordered_high_profile_groups: [],
       },
       locale: 'en',
       publishing_app: 'whitehall',


### PR DESCRIPTION
This commit adds FoI contacts and sub organisations (high profile groups) to the organisation content item for rendering.

Trello: https://trello.com/c/Fnixoocj/128-add-more-data-to-the-organisations-content-item