### PR TITLE
Alter legacy tagging page

### DIFF
--- a/app/controllers/admin/edition_legacy_associations_controller.rb
+++ b/app/controllers/admin/edition_legacy_associations_controller.rb
@@ -5,7 +5,7 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
 
 
   def edit
-    @cancel_path = get_cancel_path
+    @path = get_path
   end
 
   def update
@@ -13,12 +13,12 @@ class Admin::EditionLegacyAssociationsController < Admin::BaseController
     if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
     end
-    redirect_to admin_edition_path(@edition), saved_confirmation_notice
+    redirect_to get_path, saved_confirmation_notice
   end
 
 private
 
-  def get_cancel_path
+  def get_path
     paths = {
       'edit' => edit_admin_edition_path(@edition),
       'tags' => edit_admin_edition_tags_path(@edition)

--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -1,28 +1,20 @@
 <% page_title "Edit legacy associations: " + @edition.title %>
 <div class="row">
   <h1><%= @edition.title %></h1>
+  <p>
+    Policies, policy areas and specialist sectors will continue to be supported until the topic taxonomy replaces them.
+  </p>
 </div>
 
 <% if flash[:legacy_associations_changed] %>
   <div class="row">
     <div class="alert alert-success" role="alert">
-      <strong>
-        Suggestions
-        <span class="label label-default">New</span>
-      </strong>
-
       <p>
-        Some suggestions have been made below.
+        Some suggestions have been made based on the taxonomy topics you've selected.
       </p>
 
       <p>
-        This happens automatically when tagging new content to the
-        Topic Taxonomy, to reduce the amount of manual work required
-        to tag content.
-      </p>
-
-      <p>
-        You can still edit the selections below.
+        You can edit these suggestions.
       </p>
     </div>
   </div>
@@ -47,7 +39,7 @@
       </fieldset>
       <%= render 'specialist_sector_fields', form: form, edition: @edition %>
       <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save legacy associations' }, cancel: @cancel_path) %>
+        <%= form.form_actions(buttons: { save: 'Save' }, cancel: @path) %>
       </div>
     <% end %>
   </div>

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -7,7 +7,7 @@ When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/
     end
   end
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -2,7 +2,7 @@ When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/)
   begin_drafting_publication(title)
   select location_name, from: "Select the world locations this publication is about"
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -29,7 +29,7 @@ Then(/^I tag it to the policy "([^"]*)" and "([^"]*)"$/) do |policy_1, policy_2|
   click_button "Save and continue"
   select policy_1, from: "Policies"
   select policy_2, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 Then(/^I can see the consultation "([^"]*)" tagged to "([^"]*)" and "([^"]*)"$/) do |title, policy_1, policy_2|
@@ -73,7 +73,7 @@ When(/^I save and publish the amended consultation$/) do
   ensure_path edit_admin_consultation_path(Consultation.last)
   fill_in_change_note_if_required
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   publish force: true
 end
 

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -17,7 +17,7 @@ When(/^I create a new detailed guide "([^"]*)" associated with "([^"]*)"$/) do |
   begin_drafting_document type: 'detailed_guide', title: title, previously_published: false
   click_button "Save and continue"
   select policy, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 Then(/^I should see the detailed guide "([^"]*)" associated with "([^"]*)"$/) do |title, policy|
@@ -44,7 +44,7 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   publish(force: true)
 end
 

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -131,5 +131,5 @@ And(/^I tag that document collection to the policy "(.*?)"$/) do |policy|
   policies = publishing_api_has_policies([policy])
   click_button "Save and continue"
   select policy, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -165,7 +165,7 @@ When(/^I force publish (#{THE_DOCUMENT})$/) do |edition|
   click_link "Edit draft"
   fill_in_change_note_if_required
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   publish(force: true)
 end
 

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -107,7 +107,7 @@ When(/^I draft a French\-only "World news story" news article associated with "(
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
   select "", from: "edition_lead_organisation_ids_1"
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
 end
 
@@ -159,7 +159,7 @@ When(/^I tag the article to a policy "([^"]*)"$/) do |policy|
   click_button "Save and continue"
 
   select policy, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 Then(/^the news article "([^"]*)" should have been created$/) do |title|

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -20,13 +20,13 @@ end
 When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   add_external_attachment
 end
 
@@ -35,7 +35,7 @@ Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   as_user(user) do
     begin_drafting_publication(title)
     click_button "Save and continue"
-    click_button "Save legacy associations"
+    click_button "Save"
   end
 end
 
@@ -50,14 +50,14 @@ When(/^I draft a new publication "([^"]*)" relating it to the policies "([^"]*)"
   click_button "Save and continue"
   select first_policy, from: "Policies"
   select second_policy, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
   select data_set_name, from: "Related statistical data sets"
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -8,7 +8,7 @@ Given(/^"([^"]*)" submitted a speech "([^"]*)" with body "([^"]*)"$/) do |author
   visit new_admin_speech_path
   begin_drafting_speech title: title, body: body
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   click_button 'Submit'
 end
 
@@ -66,7 +66,7 @@ When(/^I draft a new speech "([^"]*)" relating it to the policies "([^"]*)" and 
   # @policies is populated by PolicyTaggingHelpers#stub_publishing_api_policies
   select first_policy, from: "Policies"
   select second_policy, from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 Then(/^I should see the speech was delivered on "([^"]*)" at "([^"]*)"$/) do |delivered_on, location|

--- a/features/step_definitions/statistical_data_set_steps.rb
+++ b/features/step_definitions/statistical_data_set_steps.rb
@@ -3,5 +3,5 @@ When(/^I draft a new statistical data set "([^"]*)" for organisation "([^"]*)"$/
   set_lead_organisation_on_document(Organisation.find_by(name: organisation_name))
   click_button "Save and continue"
   select "Policy 1", from: "Policies"
-  click_button "Save legacy associations"
+  click_button "Save"
 end

--- a/features/step_definitions/topic_assigment_steps.rb
+++ b/features/step_definitions/topic_assigment_steps.rb
@@ -7,7 +7,7 @@ When(/^I assign the publicationesque to a topic$/) do
   visit edit_admin_publication_path(@edition)
   click_button "Save and continue"
   select @topic.name, from: 'edition_topic_ids'
-  click_button "Save legacy associations"
+  click_button "Save"
 end
 
 Then(/^the edition will be assigned to the topic$/) do

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -50,7 +50,7 @@ When(/^I draft a new publication "([^"]*)" relating it to topical event "([^"]*)
   begin_drafting_publication publication_title
   select topical_event_name, from: "Topical events"
   click_button "Save and continue"
-  click_button "Save legacy associations"
+  click_button "Save"
   add_external_attachment
 end
 

--- a/features/support/admin_legacy_associations_helper.rb
+++ b/features/support/admin_legacy_associations_helper.rb
@@ -3,7 +3,7 @@ module AdminLegacyAssociationsHelper
     tag_to_policy(policy_1)
     tag_to_policy_area(policy_area_3)
     tag_specialist_sectors
-    click_button "Save legacy associations"
+    click_button "Save"
   end
 
   def check_associations_have_been_saved

--- a/features/support/corporate_information_page_helper.rb
+++ b/features/support/corporate_information_page_helper.rb
@@ -15,7 +15,7 @@ module CorporateInformationPageHelper
     markdown = find_markdown_snippet_to_insert_attachment(attachment)
     fill_in 'Body', with: page.body.to_s + "\n\n" + markdown
     click_button "Save and continue"
-    click_button "Save legacy associations"
+    click_button "Save"
   end
 
   def check_attachment_appears_on_corporate_information_page(attachment, page)

--- a/features/support/fatalities_helper.rb
+++ b/features/support/fatalities_helper.rb
@@ -8,7 +8,7 @@ module FatalitiesHelper
     select field, from: "Field of operation"
     click_button "Save and continue"
     select policy, from: "Policies"
-    click_button "Save legacy associations"
+    click_button "Save"
   end
 end
 


### PR DESCRIPTION
Add descriptive text on what legacy tagging is, and it's purpose. Change button text 'Save legacy associations' to 'Save' and redirect after clicking to the topic tagging page instead of the overview edit page.