### PR TITLE
Make changes to edit edition page

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -219,7 +219,7 @@ module Admin::EditionsHelper
                       locals: { form: form, edition: edition })
       end
 
-      concat form.save_or_next
+      concat form.save_or_continue_or_cancel
     end
   end
 

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -6,6 +6,7 @@
   <%= standard_edition_form(edition) do |form| %>
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render 'worldwide_organisation_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -44,6 +44,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <div class="js-external-url-set">
         <%= render 'appointment_fields', form: form, edition: edition %>
       </div>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -7,6 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
 
       <% cache_if edition.related_detailed_guide_ids.empty?, taggable_detailed_guides_cache_digest do %>

--- a/app/views/admin/document_collections/_form.html.erb
+++ b/app/views/admin/document_collections/_form.html.erb
@@ -7,6 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'topical_event_fields', locals: { form: form, edition: edition } %>
     </fieldset>

--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -7,6 +7,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'appointment_fields', locals: { form: form, edition: edition } %>
       <%= render partial: 'operational_field_fields', locals: { form: form, edition: edition } %>

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -10,6 +10,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render 'appointment_fields', form: form, edition: edition %>
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'worldwide_organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -11,6 +11,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render 'appointment_fields', form: form, edition: edition %>
       <%= render 'statistical_data_set_fields', form: form, edition: edition %>
       <%= render 'topical_event_fields', form: form, edition: edition %>

--- a/app/views/admin/speeches/_form.html.erb
+++ b/app/views/admin/speeches/_form.html.erb
@@ -9,6 +9,7 @@
   <%= standard_edition_form(edition) do |form| %>
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render 'topical_event_fields', form: form, edition: edition %>
       <%= render 'world_location_fields', form: form, edition: edition %>
       <%= render 'organisation_fields', form: form, edition: edition %>

--- a/app/views/admin/statistical_data_sets/_form.html.erb
+++ b/app/views/admin/statistical_data_sets/_form.html.erb
@@ -11,6 +11,7 @@
 
     <fieldset>
       <legend>Associations</legend>
+      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
       <%= render partial: 'organisation_fields', locals: { form: form, edition: edition } %>
     </fieldset>
   <% end %>

--- a/features/step_definitions/admin_excluded_nations_steps.rb
+++ b/features/step_definitions/admin_excluded_nations_steps.rb
@@ -6,7 +6,7 @@ When(/^I draft a new publication "([^"]*)" that does not apply to the nations:$/
       fill_in "Alternative url", with: "http://www.#{nation_name}.com/"
     end
   end
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   add_external_attachment
 end

--- a/features/step_definitions/admin_world_locations_steps.rb
+++ b/features/step_definitions/admin_world_locations_steps.rb
@@ -1,7 +1,7 @@
 When(/^I draft a new publication "([^"]*)" about the world location "([^"]*)"$/) do |title, location_name|
   begin_drafting_publication(title)
   select location_name, from: "Select the world locations this publication is about"
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   add_external_attachment
 end

--- a/features/step_definitions/audit_trail_steps.rb
+++ b/features/step_definitions/audit_trail_steps.rb
@@ -1,6 +1,6 @@
 Given(/^a document that has gone through many changes$/) do
   begin_drafting_publication('An frequently changed publication')
-  click_on "Next"
+  click_on "Save and continue"
   assert page.has_content?('An frequently changed publication')
   @the_publication = Publication.find_by(title: 'An frequently changed publication')
   # fake it

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -26,7 +26,7 @@ end
 Then(/^I tag it to the policy "([^"]*)" and "([^"]*)"$/) do |policy_1, policy_2|
   policies = publishing_api_has_policies([policy_1, policy_2])
 
-  click_button "Next"
+  click_button "Save and continue"
   select policy_1, from: "Policies"
   select policy_2, from: "Policies"
   click_button "Save legacy associations"
@@ -36,7 +36,7 @@ Then(/^I can see the consultation "([^"]*)" tagged to "([^"]*)" and "([^"]*)"$/)
   assert has_css?(".flash.notice", text: "The associations have been saved")
 
   click_on 'Edit draft'
-  click_on "Next"
+  click_on "Save and continue"
 
   assert has_css?(".policies option[selected]", text: policy_1)
   assert has_css?(".policies option[selected]", text: policy_2)
@@ -72,7 +72,7 @@ end
 When(/^I save and publish the amended consultation$/) do
   ensure_path edit_admin_consultation_path(Consultation.last)
   fill_in_change_note_if_required
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   publish force: true
 end

--- a/features/step_definitions/detailed_guide_steps.rb
+++ b/features/step_definitions/detailed_guide_steps.rb
@@ -15,7 +15,7 @@ When(/^I create a new detailed guide "([^"]*)" associated with "([^"]*)"$/) do |
   create(:government)
 
   begin_drafting_document type: 'detailed_guide', title: title, previously_published: false
-  click_button "Next"
+  click_button "Save and continue"
   select policy, from: "Policies"
   click_button "Save legacy associations"
 end
@@ -25,7 +25,7 @@ Then(/^I should see the detailed guide "([^"]*)" associated with "([^"]*)"$/) do
   assert has_css?(".page-header", text: title)
 
   click_on 'Edit draft'
-  click_on "Next"
+  click_on "Save and continue"
 
   assert has_css?(".policies option[selected]", text: policy)
 end
@@ -43,7 +43,7 @@ When(/^I publish a new edition of the detailed guide "([^"]*)" with a change not
   visit admin_edition_path(guide)
   click_button "Create new edition"
   fill_in "edition_change_note", with: change_note
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   publish(force: true)
 end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -129,7 +129,7 @@ end
 
 And(/^I tag that document collection to the policy "(.*?)"$/) do |policy|
   policies = publishing_api_has_policies([policy])
-  click_button "Next"
+  click_button "Save and continue"
   select policy, from: "Policies"
   click_button "Save legacy associations"
 end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -164,7 +164,7 @@ When(/^I force publish (#{THE_DOCUMENT})$/) do |edition|
   visit_edition_admin edition.title, :draft
   click_link "Edit draft"
   fill_in_change_note_if_required
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   publish(force: true)
 end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -106,7 +106,7 @@ When(/^I draft a French\-only "World news story" news article associated with "(
   select location_name, from: "Select the world locations this news article is about"
   select "French embassy", from: "Select the worldwide organisations associated with this news article"
   select "", from: "edition_lead_organisation_ids_1"
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   @news_article = find_news_article_in_locale!(:fr, 'French-only news article')
 end
@@ -156,7 +156,7 @@ end
 When(/^I tag the article to a policy "([^"]*)"$/) do |policy|
   policies = publishing_api_has_policies([policy])
 
-  click_button "Next"
+  click_button "Save and continue"
 
   select policy, from: "Policies"
   click_button "Save legacy associations"
@@ -170,6 +170,6 @@ And(/^the news article is tagged to policy "([^"]*)"$/) do |policy|
   assert has_css?(".flash.notice", text: "The associations have been saved")
 
   click_on 'Edit draft'
-  click_on "Next"
+  click_on "Save and continue"
   assert has_css?(".policies option[selected]", text: policy)
 end

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -19,13 +19,13 @@ end
 
 When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
 end
 
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   add_external_attachment
 end
@@ -34,7 +34,7 @@ Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   user = User.find_by(name: user_name)
   as_user(user) do
     begin_drafting_publication(title)
-    click_button "Next"
+    click_button "Save and continue"
     click_button "Save legacy associations"
   end
 end
@@ -47,7 +47,7 @@ end
 
 When(/^I draft a new publication "([^"]*)" relating it to the policies "([^"]*)" and "([^"]*)"$/) do |title, first_policy, second_policy|
   begin_drafting_publication(title)
-  click_button "Next"
+  click_button "Save and continue"
   select first_policy, from: "Policies"
   select second_policy, from: "Policies"
   click_button "Save legacy associations"
@@ -56,7 +56,7 @@ end
 When(/^I draft a new publication "([^"]*)" referencing the data set "([^"]*)"$/) do |title, data_set_name|
   begin_drafting_publication(title)
   select data_set_name, from: "Related statistical data sets"
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   add_external_attachment
 end

--- a/features/step_definitions/speech_steps.rb
+++ b/features/step_definitions/speech_steps.rb
@@ -7,7 +7,7 @@ Given(/^"([^"]*)" submitted a speech "([^"]*)" with body "([^"]*)"$/) do |author
   step %{I am a writer called "#{author}"}
   visit new_admin_speech_path
   begin_drafting_speech title: title, body: body
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   click_button 'Submit'
 end
@@ -62,7 +62,7 @@ end
 
 When(/^I draft a new speech "([^"]*)" relating it to the policies "([^"]*)" and "([^"]*)"$/) do |title, first_policy, second_policy|
   begin_drafting_speech title: title
-  click_button "Next"
+  click_button "Save and continue"
   # @policies is populated by PolicyTaggingHelpers#stub_publishing_api_policies
   select first_policy, from: "Policies"
   select second_policy, from: "Policies"

--- a/features/step_definitions/statistical_data_set_steps.rb
+++ b/features/step_definitions/statistical_data_set_steps.rb
@@ -1,7 +1,7 @@
 When(/^I draft a new statistical data set "([^"]*)" for organisation "([^"]*)"$/) do |title, organisation_name|
   begin_drafting_statistical_data_set(title: title)
   set_lead_organisation_on_document(Organisation.find_by(name: organisation_name))
-  click_button "Next"
+  click_button "Save and continue"
   select "Policy 1", from: "Policies"
   click_button "Save legacy associations"
 end

--- a/features/step_definitions/tagging_steps.rb
+++ b/features/step_definitions/tagging_steps.rb
@@ -1,3 +1,3 @@
 When(/^I continue to the tagging page$/) do
-  click_button 'Next'
+  click_button 'Save and continue'
 end

--- a/features/step_definitions/topic_assigment_steps.rb
+++ b/features/step_definitions/topic_assigment_steps.rb
@@ -5,7 +5,7 @@ end
 
 When(/^I assign the publicationesque to a topic$/) do
   visit edit_admin_publication_path(@edition)
-  click_button "Next"
+  click_button "Save and continue"
   select @topic.name, from: 'edition_topic_ids'
   click_button "Save legacy associations"
 end

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -49,7 +49,7 @@ end
 When(/^I draft a new publication "([^"]*)" relating it to topical event "([^"]*)"$/) do |publication_title, topical_event_name|
   begin_drafting_publication publication_title
   select topical_event_name, from: "Topical events"
-  click_button "Next"
+  click_button "Save and continue"
   click_button "Save legacy associations"
   add_external_attachment
 end

--- a/features/support/corporate_information_page_helper.rb
+++ b/features/support/corporate_information_page_helper.rb
@@ -14,7 +14,7 @@ module CorporateInformationPageHelper
     click_link 'Edit draft'
     markdown = find_markdown_snippet_to_insert_attachment(attachment)
     fill_in 'Body', with: page.body.to_s + "\n\n" + markdown
-    click_button "Next"
+    click_button "Save and continue"
     click_button "Save legacy associations"
   end
 

--- a/features/support/fatalities_helper.rb
+++ b/features/support/fatalities_helper.rb
@@ -6,7 +6,7 @@ module FatalitiesHelper
     begin_drafting_document type: "fatality_notice", title: title, summary: "fatality notice summary", previously_published: false
     fill_in "Introduction", with: "fatality notice roll call introduction"
     select field, from: "Field of operation"
-    click_button "Next"
+    click_button "Save and continue"
     select policy, from: "Policies"
     click_button "Save legacy associations"
   end

--- a/features/support/specialist_sector_helper.rb
+++ b/features/support/specialist_sector_helper.rb
@@ -54,7 +54,7 @@ module SpecialistSectorHelper
   def assert_specialist_sectors_were_saved
     assert has_css?('.flash.notice')
     click_on 'Edit draft'
-    click_on "Next"
+    click_on "Save and continue"
     assert_equal 'WELLS', find_field('Primary specialist sector').value
     assert_equal %w[OFFSHORE FIELDS DISTILL].to_set,
                  find_field('Additional specialist sectors').value.to_set

--- a/lib/whitehall/form_builder.rb
+++ b/lib/whitehall/form_builder.rb
@@ -74,11 +74,6 @@ module Whitehall
       form_actions(options.reverse_merge(buttons: buttons))
     end
 
-    def save_or_next(options = {})
-      buttons = { save: 'Save', next: 'Next' }
-      form_actions(options.reverse_merge(buttons: buttons))
-    end
-
     def text_field(method, options = {})
       add_class_to_options(options, 'form-control')
       label_options = { required: options.delete(:required) }


### PR DESCRIPTION
Trello: https://trello.com/c/N83zcjou

## Motivation

Following user research, we need to make some small changes to Whitehall before the next round of research on **Tuesday 5 June**.

1. Change buttons text to `Save` and `Save and continue`.

2. Add a line of text immediately under Associations heading:

`You'll be able to select policies, policy areas and specialist sectors later.`

## Button text
### Before
![screenshot-whitehall-admin dev gov uk-2018 06 04-15-29-00](https://user-images.githubusercontent.com/5793815/40923383-9c32ed30-680c-11e8-9395-4740a3eca7d6.png)

### After
![screenshot-whitehall-admin dev gov uk-2018 06 04-14-55-19](https://user-images.githubusercontent.com/5793815/40923367-903b0f76-680c-11e8-82d2-61620b3a3396.png)

## Associations help text
### Before
![screenshot-whitehall-admin dev gov uk-2018 06 04-15-28-45](https://user-images.githubusercontent.com/5793815/40923378-98b27d42-680c-11e8-8cf5-e70843e971e4.png)

### After
![screenshot-whitehall-admin dev gov uk-2018 06 04-15-23-59](https://user-images.githubusercontent.com/5793815/40923375-939c0846-680c-11e8-817c-a24c6b31f8a8.png)