### PR TITLE
Make changes to topic taxonomy page

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -48,7 +48,7 @@
       </p>
 
       <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes', legacy_tags: 'Legacy tags' }, cancel: admin_edition_path(@edition)) %>
+        <%= form.form_actions(buttons: { save: 'Save topic changes', legacy_tags: 'Save and review legacy tagging' }, cancel: admin_edition_path(@edition)) %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -48,7 +48,14 @@
       </p>
 
       <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes', legacy_tags: 'Save and review legacy tagging' }, cancel: admin_edition_path(@edition)) %>
+        <div class="form-actions" data-module="track-button-click" data-track-category="form-button" data-track-action="taxonomy-tag-form-button">
+          <%= form.submit('Save topic changes', name: "save", class: "btn btn-lg btn-success") %>
+          <%= form.submit('Save and review legacy tagging', name: "legacy_tags", class: "btn btn-lg btn-primary") %>
+          <span class="or_cancel">
+            or
+            <%= link_to('cancel', admin_edition_path(@edition)) %>
+          </span>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -7,6 +7,8 @@
   <div class="col-md-12">
     <h2>Topics (new taxonomy)</h2>
     <p>Topics categorise content on GOV.UK by subject area.</p>
+    <p>Choose the topic(s) that best describe what this content is about.</p>
+    <p>You can use the whole taxonomy. There's no limit to the number of topics you can choose.</p>
     <hr>
 
     <%= form_for @tag_form, url: admin_edition_tags_path(@edition), method: :put do |form| %>


### PR DESCRIPTION
Trello: https://trello.com/c/VmkKipKh

## Motivation

Following user research, we need to make some small changes to Whitehall before the next round of research on **Tuesday 5 June**.

1. Make button text changes from https://github.com/alphagov/whitehall/pull/4055 _and_ make 'Save topic changes' button green.
2. Add content just below the existing line of content (above tagging interface):
```
Choose the topic(s) that best describe what this content is about.
You can use the whole taxonomy. There's no limit to the number of topics you can choose.
```

## Button changes
### Before
![](https://user-images.githubusercontent.com/1130010/40496502-d2d6995c-5f71-11e8-8bfc-e15af4bdd920.png)

### After
![screenshot-whitehall-admin dev gov uk-2018 06 04-18-22-11](https://user-images.githubusercontent.com/5793815/40931788-3c4aead6-6824-11e8-9b4b-08dfef638b73.png)

## Description changes
### Before
![screenshot-whitehall-admin dev gov uk-2018 06 04-17-20-51](https://user-images.githubusercontent.com/5793815/40929215-00c131e4-681c-11e8-9670-1ebfa8165790.png)

### After
![screenshot-whitehall-admin dev gov uk-2018 06 04-17-17-23](https://user-images.githubusercontent.com/5793815/40929212-fd14ffee-681b-11e8-8364-4a27bcb63e73.png)
