### PR TITLE
Add DH to taggle organisations for user research

### DIFF
--- a/config/organisations_in_tagging_beta.yml
+++ b/config/organisations_in_tagging_beta.yml
@@ -1,6 +1,7 @@
 # This file has a list of organisation content_id's
 # that are allowed tag their documents to the topic taxonomy
 
+- "7cd6bf12-bbe9-4118-8523-f927b0442156" # TEST TEST TEST NEEDED FOR USER RESEARCH FOR DH
 - "71381a6e-aa5c-43ae-a982-be9bfd46ea5b" # Education & Skills Funding Agency
 - "b9fc8528-81d1-419b-8748-6c00be71044b" # Education Funding Agency (replaced by Education & Skills Funding Agency in April 2017)
 - "ebd15ade-73b2-4eaf-b1c3-43034a42eb37" # Department for Education


### PR DESCRIPTION
This needs to be removed after user research with the Department of Health.