### PR TITLE
Remove "required" asterisk for policy areas

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -439,6 +439,10 @@ class Edition < ApplicationRecord
     false
   end
 
+  def must_be_tagged_to_policy_area?
+    true
+  end
+
   def has_been_tagged?
     api_response = Services.publishing_api.get_links(content_id)
 

--- a/app/models/edition/taggable_organisations.rb
+++ b/app/models/edition/taggable_organisations.rb
@@ -16,6 +16,10 @@ module Edition::TaggableOrganisations
     world_taggable?
   end
 
+  def must_be_tagged_to_policy_area?
+    !topic_taxonomy_taggable?
+  end
+
 private
 
   def topic_taxonomy_taggable?

--- a/app/views/admin/base/_policy_area_fields.html.erb
+++ b/app/views/admin/base/_policy_area_fields.html.erb
@@ -1,6 +1,6 @@
 <% cache_if edition.topic_ids.empty?, taggable_topics_cache_digest do %>
   <fieldset class="edition-topic-fields">
-    <%= form.label :topic_ids, 'Policy Areas', required: true %>
+    <%= form.label :topic_ids, 'Policy Areas', required: edition.must_be_tagged_to_policy_area? %>
     <%= form.select :topic_ids,
                     options_for_select(taggable_topics_container, edition.topic_ids),
                     {},

--- a/test/unit/edition_taggable_organisations_test.rb
+++ b/test/unit/edition_taggable_organisations_test.rb
@@ -13,6 +13,12 @@ class EditionTaggableOrganisationTestForEducationOrganisations < ActiveSupport::
 
     assert edition.can_be_tagged_to_taxonomy?
   end
+
+  test '#must_be_tagged_to_policy_area? is false for NewsArticle' do
+    edition = create(:news_article, organisations: [@lead_org])
+
+    refute edition.must_be_tagged_to_policy_area?
+  end
 end
 
 class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::TestCase


### PR DESCRIPTION
Trello: https://trello.com/c/41oes1YT

## What's changed

If a piece of content can be tagged to the topic taxonomy it is no longer required for them to also be tagged to a policy area.

Seeing a red asterisk on the legacy tagging page could mislead a user into extra tagging.

Created a new function to determine whether it's mandatory to tag a policy area as the partial is also used for world location news content and speed tagging.

## Before
![screenshot-whitehall-admin staging publishing service gov uk-2018 06 05-16-43-34](https://user-images.githubusercontent.com/5793815/40987190-e3b573c0-68df-11e8-861d-a3aef16ce4d4.png)

## After
![screenshot-whitehall-admin dev gov uk-2018 06 05-16-42-00](https://user-images.githubusercontent.com/5793815/40987199-e89a3006-68df-11e8-8185-db8b1689f377.png)
