### PR TITLE
Fix the delay of topic taxons appearing on the editions overview page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     fugit (1.1.1)
       et-orbi (~> 1.1, >= 1.1.1)
       raabro (~> 1.1)
-    gds-api-adapters (52.5.1)
+    gds-api-adapters (52.6.0)
       addressable
       link_header
       lrucache (~> 0.1.1)
@@ -366,7 +366,7 @@ GEM
     public_suffix (3.0.2)
     raabro (1.1.5)
     rack (2.0.5)
-    rack-cache (1.7.1)
+    rack-cache (1.7.2)
       rack (>= 0.4)
     rack-protection (2.0.1)
       rack

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -43,7 +43,7 @@ private
   end
 
   def response
-    Services.publishing_api.get_expanded_links(content_id)
+    Services.publishing_api.get_expanded_links(content_id, generate: true)
   end
 
   def all_world_taxons

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -327,16 +327,17 @@ private
   end
 
   def publication_has_no_expanded_links(content_id)
-    publishing_api_has_expanded_links(
-      content_id: content_id,
-      expanded_links: {}
-    )
+    expanded_links = {
+      "content_id" =>  content_id,
+      "expanded_links" =>  {}
+    }
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 
   def publication_has_expanded_links(content_id)
-    publishing_api_has_expanded_links(
-      content_id: content_id,
-      expanded_links: {
+    expanded_links = {
+      "content_id" =>  content_id,
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Primary Education",
@@ -357,13 +358,15 @@ private
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 
   def publication_has_world_expanded_links(content_id)
-    publishing_api_has_expanded_links(
-      content_id:  content_id,
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  content_id,
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "World Grandchild Taxon",
@@ -384,7 +387,9 @@ private
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -195,16 +195,17 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 private
 
   def announcement_has_no_expanded_links(content_id)
-    publishing_api_has_expanded_links(
-      content_id:  content_id,
-      expanded_links:  {}
-    )
+    expanded_links = {
+      "content_id" =>  content_id,
+      "expanded_links" => {}
+    }
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 
   def announcement_has_expanded_links(content_id)
-    publishing_api_has_expanded_links(
-      content_id:  content_id,
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  content_id,
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Primary Education",
@@ -225,6 +226,7 @@ private
           }
         ]
       }
-    )
+    }
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -68,13 +68,14 @@ module TaxonomyHelper
   end
 
   def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
-    publishing_api_has_expanded_links(
+    expanded_links = {
       "content_id" => content_id,
       "expanded_links" => {
         "taxons" => taxons,
       },
       "version" => 1,
-      )
+    }
+    publishing_api_has_expanded_links(expanded_links, generate: true)
   end
 
 private

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -26,10 +26,12 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns '[]' if there are no taxons" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {}
-    )
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" => {}
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
 
     links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal [], links_fetcher.fetch
@@ -37,10 +39,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
 
   test "it returns a taxon without a parent" do
     title = "Education, training and skills"
-
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => title,
@@ -51,15 +52,17 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
   end
 
   test "it returns a taxon with a parent" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -80,16 +83,19 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
     assert_equal 'bbbb', taxons.first.parent_node.content_id
   end
 
   test "it returns a taxon with parent and grandparent" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links =
+      {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Student Finance",
@@ -118,7 +124,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
     assert_equal 'bbbb', taxons.first.parent_node.content_id
@@ -126,9 +134,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns paths for multiple taxons" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -166,7 +174,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 2, taxons.count
     assert_equal "aaaa", taxons.first.content_id
@@ -176,9 +186,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it sets the first parent taxon if there are multiple parents" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -206,16 +216,18 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal "aaaa", taxons.first.content_id
     assert_equal "bbbb", taxons.first.parent_node.content_id
   end
 
   test "it only returns published or visible draft taxons" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "I am the published taxon",
@@ -270,16 +282,17 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
 
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal %w[aaaa cccc], taxons.map(&:content_id)
   end
 
   test "it gets world taxons tagged to the edition" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "I am the published taxon",
@@ -317,7 +330,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
+
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
 
     redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
@@ -327,9 +342,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns legacy mappings" do
-    publishing_api_has_expanded_links(
-      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      expanded_links:  {
+    expanded_links = {
+      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      "expanded_links" =>  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -349,8 +364,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    )
+    }
 
+    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'policy', taxons.first.legacy_mapping["policy"][0]["document_type"]
   end


### PR DESCRIPTION
https://trello.com/c/Ch9ufVJ4/139-bug-when-i-save-a-topic-selection-for-the-first-time-the-topics-dont-appear-on-the-overview-page

Currently, when rendering the overview edit page, after selecting the
Topic Taxons you want to tag the edition too, the taxons sometimes don't
show in the topic taxon display box.

This is due to the request getting the Publishing API's stored
data which might be out of date, adding `generate: true` into the
request requires publishing-api to generate the expanded links instead
of relying on its already stored expanded links. This should ensure that
the most up to date links are returned. Meaning there now should be no
delay in the displaying of taxon information.

This relies on https://github.com/alphagov/gds-api-adapters/pull/837 to be updated first.