### PR TITLE
Add GA tracking to other Whitehall fields

### DIFF
--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -6,6 +6,11 @@
                     { include_blank: true },
                     multiple: true,
                     class: 'chzn-select form-control',
-                    data: { placeholder: "Choose ministers…"} %>
+                    data: {
+                        placeholder: "Choose ministers…",
+                        module: 'track-select-click',
+                        track_category: 'ministerSelection',
+                        track_label: request.path
+                    } %>
   </fieldset>
 <% end %>

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -19,7 +19,12 @@
                                   include_blank: true,
                                   multiple: false,
                                   class: 'chzn-select-non-ie form-control',
-                                  data: { placeholder: "Choose a lead organisation which produced this document…" },
+                                  data: {
+                                      placeholder: "Choose a lead organisation which produced this document…",
+                                      module: 'track-select-click',
+                                      track_category: 'leadOrgSelection',
+                                      track_label: request.path
+                                  },
                                   id: "edition_lead_organisation_ids_#{index + 1}" %>
                 <% end %>
               </div>
@@ -44,7 +49,12 @@
                                   include_blank: true,
                                   multiple: false,
                                   class: 'chzn-select-non-ie form-control',
-                                  data: { placeholder: "Choose a supporting organisation which produced this document…" },
+                                  data: {
+                                      placeholder: "Choose a supporting organisation which produced this document…",
+                                      module: 'track-select-click',
+                                      track_category: 'supportingOrgSelection',
+                                      track_label: request.path
+                                  },
                                   id: "edition_supporting_organisation_ids_#{index + 1}" %>
                 <% end %>
               </div>

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -5,5 +5,10 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose statistical data sets…"} %>
+                  data: {
+                      placeholder: "Choose statistical data sets…",
+                      module: 'track-select-click',
+                      track_category: 'statisticalDataSetSelection',
+                      track_label: request.path
+                  } %>
 <% end %>

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -5,5 +5,10 @@
                   {},
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "Choose topical events…"} %>
+                  data: {
+                      placeholder: "Choose topical events…",
+                      module: 'track-select-click',
+                      track_category: 'topicalEventSelection',
+                      track_label: request.path
+                  } %>
 <% end %>

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -8,5 +8,10 @@
                   { include_blank: true },
                   multiple: true,
                   class: 'chzn-select form-control',
-                  data: { placeholder: "World locations…"} %>
+                  data: {
+                      placeholder: "World locations…",
+                      module: 'track-select-click',
+                      track_category: 'worldLocationSelection',
+                      track_label: request.path
+                  } %>
 <% end %>

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -8,6 +8,11 @@
                     { include_blank: true },
                     multiple: true,
                     class: 'chzn-select form-control',
-                    data: { placeholder: "Worldwide organisations…"} %>
+                    data: {
+                        placeholder: "Worldwide organisations…",
+                        module: 'track-select-click',
+                        track_category: 'worldwideOrganisationSelection',
+                        track_label: request.path
+                    } %>
   <% end %>
 </fieldset>

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -853,7 +853,13 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[statistical_data_set_document_ids]']"
+          assert_select "#edition_statistical_data_set_document_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_statistical_data_sets(
+              element: elements.first,
+              track_label: new_edition_path(edition_type)
+            )
+          end
         end
       end
 
@@ -878,7 +884,13 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
-          assert_select "select[name*='edition[statistical_data_set_document_ids]']"
+          assert_select "#edition_statistical_data_set_document_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_statistical_data_sets(
+              element: elements.first,
+              track_label: edit_edition_path(edition_type)
+            )
+          end
         end
       end
 
@@ -1577,6 +1589,13 @@ private
     assert_equal 'Choose ministers…', element['data-placeholder']
     assert_equal 'track-select-click', element['data-module']
     assert_equal 'ministerSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  def assert_data_attributes_for_statistical_data_sets(element:, track_label:)
+    assert_equal 'Choose statistical data sets…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'statisticalDataSetSelection', element['data-track-category']
     assert_equal track_label, element['data-track-label']
   end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -903,12 +903,24 @@ module AdminEditionControllerTestHelpers
     def should_allow_organisations_for(edition_type)
       edition_class = class_for(edition_type)
 
-      view_test "new should display edition organisations field" do
+      view_test "new should display edition organisations fields" do
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[lead_organisation_ids][]']"
-          assert_select "select[name*='edition[supporting_organisation_ids][]']"
+          (1..4).each do |i|
+            assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
+              assert_equal 1, elements.length
+              assert_data_attributes_for_lead_org(element: elements.first, track_label: new_edition_path(edition_type))
+            end
+          end
+          refute_select '#edition_lead_organisation_ids_5'
+          (1..6).each do |i|
+            assert_select("#edition_supporting_organisation_ids_#{i}") do |elements|
+              assert_equal 1, elements.length
+              assert_data_attributes_for_supporting_org(element: elements.first, track_label: new_edition_path(edition_type))
+            end
+          end
+          refute_select '#edition_supporting_organisation_ids_7'
         end
       end
 
@@ -944,8 +956,20 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
-          assert_select "select[name*='edition[lead_organisation_ids][]']"
-          assert_select "select[name*='edition[supporting_organisation_ids][]']"
+          (1..4).each do |i|
+            assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
+              assert_equal 1, elements.length
+              assert_data_attributes_for_lead_org(element: elements.first, track_label: edit_edition_path(edition_type))
+            end
+          end
+          refute_select '#edition_lead_organisation_ids_5'
+          (1..6).each do |i|
+            assert_select("#edition_supporting_organisation_ids_#{i}") do |elements|
+              assert_equal 1, elements.length
+              assert_data_attributes_for_supporting_org(element: elements.first, track_label: edit_edition_path(edition))
+            end
+          end
+          refute_select '#edition_supporting_organisation_ids_7'
         end
       end
 
@@ -1527,5 +1551,30 @@ module AdminEditionControllerTestHelpers
         assert_equal [first_world_organisation, second_world_organisation], edition.worldwide_organisations
       end
     end
+  end
+
+private
+
+  def assert_data_attributes_for_lead_org(element:, track_label:)
+    assert_equal 'Choose a lead organisation which produced this document…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'leadOrgSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  def assert_data_attributes_for_supporting_org(element:, track_label:)
+    assert_equal 'Choose a supporting organisation which produced this document…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'supportingOrgSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  def new_edition_path(edition_type)
+    edition = build(edition_type)
+    new_polymorphic_path([:admin, edition])
+  end
+
+  def edit_edition_path(edition)
+    edit_polymorphic_path([:admin, edition])
   end
 end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -353,9 +353,9 @@ module AdminEditionControllerTestHelpers
 
       view_test "reports an error if the updater has an error on create" do
         draft_updater = stub("draft updater",
-                              can_perform?: false,
-                              perform!: false,
-                              failure_reason: "Unable to perform draft update")
+          can_perform?: false,
+          perform!: false,
+          failure_reason: "Unable to perform draft update")
 
         Whitehall.edition_services.stubs(:draft_updater).returns(draft_updater)
 
@@ -378,9 +378,9 @@ module AdminEditionControllerTestHelpers
         edition = create("draft_#{edition_type}", title: "Original title")
 
         draft_updater = stub("draft updater",
-                              can_perform?: false,
-                              perform!: false,
-                              failure_reason: "Unable to perform draft update")
+          can_perform?: false,
+          perform!: false,
+          failure_reason: "Unable to perform draft update")
 
         Whitehall.edition_services.stubs(:draft_updater).returns(draft_updater)
 
@@ -435,7 +435,7 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text", caption: "longer-caption-for-image",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         post :create, params: {
@@ -454,7 +454,7 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         ImageData.any_instance.expects(:file=).once
@@ -481,7 +481,7 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         post :create, params: {
@@ -498,7 +498,7 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         post :create, params: {
@@ -517,7 +517,7 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type, title: "")
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         post :create, params: {
@@ -532,9 +532,9 @@ module AdminEditionControllerTestHelpers
         attributes = controller_attributes_for(edition_type)
         attributes[:images_attributes] = {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) },
+            image_data_attributes: attributes_for(:image_data, file: image) },
           "1" => { alt_text: "more-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         }
 
         post :create, params: {
@@ -568,7 +568,7 @@ module AdminEditionControllerTestHelpers
         image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         edition = create(edition_type)
         create(:image, alt_text: "blah", edition: edition,
-               image_data_attributes: attributes_for(:image_data, file: image))
+          image_data_attributes: attributes_for(:image_data, file: image))
 
         get :edit, params: { id: edition }
 
@@ -627,7 +627,7 @@ module AdminEditionControllerTestHelpers
       test 'updating an edition with an existing image allows image attributes to be changed' do
         edition = create(edition_type)
         image = create(:image, edition: edition, alt_text: "old-alt-text", caption: 'old-caption',
-                       image_data_attributes: attributes_for(:image_data, file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')))
+          image_data_attributes: attributes_for(:image_data, file: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')))
         VirusScanHelpers.simulate_virus_scan
 
         put :update, params: {
@@ -654,9 +654,9 @@ module AdminEditionControllerTestHelpers
         image = fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
         attributes = { images_attributes: {
           "0" => { alt_text: "some-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) },
+            image_data_attributes: attributes_for(:image_data, file: image) },
           "1" => { alt_text: "more-alt-text",
-                  image_data_attributes: attributes_for(:image_data, file: image) }
+            image_data_attributes: attributes_for(:image_data, file: image) }
         } }
 
         put :update, params: { id: edition, edition: attributes }
@@ -1092,7 +1092,13 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[role_appointment_ids]']"
+          assert_select "#edition_role_appointment_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_ministers(
+              element: elements.first,
+              track_label: new_edition_path(edition_type)
+            )
+          end
         end
       end
 
@@ -1554,6 +1560,13 @@ module AdminEditionControllerTestHelpers
   end
 
 private
+
+  def assert_data_attributes_for_ministers(element:, track_label:)
+    assert_equal 'Choose ministers…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'ministerSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
 
   def assert_data_attributes_for_lead_org(element:, track_label:)
     assert_equal 'Choose a lead organisation which produced this document…', element['data-placeholder']

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1546,7 +1546,11 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[worldwide_organisation_ids]']"
+          assert_select "#edition_worldwide_organisation_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_worldwide_organisations(element: elements.first,
+              track_label: new_edition_path(edition_type))
+          end
         end
       end
 
@@ -1564,6 +1568,19 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_equal assigns(:edition).world_locations, [world_location]
+      end
+
+      view_test "edit should display worldwide organisations field" do
+        edition = create(edition_type)
+        get :edit, params: { id: edition }
+
+        assert_select "form#edit_edition" do
+          assert_select "#edition_worldwide_organisation_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_worldwide_organisations(element: elements.first,
+              track_label: edit_edition_path(edition_type))
+          end
+        end
       end
 
       test "create should associate worldwide organisations with the edition" do
@@ -1589,6 +1606,13 @@ private
     assert_equal 'Choose ministers…', element['data-placeholder']
     assert_equal 'track-select-click', element['data-module']
     assert_equal 'ministerSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  def assert_data_attributes_for_worldwide_organisations(element:, track_label:)
+    assert_equal 'Worldwide organisations…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'worldwideOrganisationSelection', element['data-track-category']
     assert_equal track_label, element['data-track-label']
   end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1468,7 +1468,13 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[topical_event_ids]']"
+          assert_select "#edition_topical_event_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_topical_events(
+              element: elements.first,
+              track_label: new_edition_path(edition_type)
+            )
+          end
         end
       end
 
@@ -1493,7 +1499,13 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
-          assert_select "select[name*='edition[topical_event_ids]']"
+          assert_select "#edition_topical_event_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_topical_events(
+              element: elements.first,
+              track_label: edit_edition_path(edition_type)
+            )
+          end
         end
       end
 
@@ -1565,6 +1577,13 @@ private
     assert_equal 'Choose ministers…', element['data-placeholder']
     assert_equal 'track-select-click', element['data-module']
     assert_equal 'ministerSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  def assert_data_attributes_for_topical_events(element:, track_label:)
+    assert_equal 'Choose topical events…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'topicalEventSelection', element['data-track-category']
     assert_equal track_label, element['data-track-label']
   end
 

--- a/test/support/admin_edition_world_locations_behaviour.rb
+++ b/test/support/admin_edition_world_locations_behaviour.rb
@@ -9,7 +9,13 @@ module AdminEditionWorldLocationsBehaviour
         get :new
 
         assert_select "form#new_edition" do
-          assert_select "select[name*='edition[world_location_ids]']"
+          assert_select "#edition_world_location_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_world_locations(
+              element: elements.first,
+              track_label: new_edition_path(document_type)
+            )
+          end
         end
       end
 
@@ -27,6 +33,22 @@ module AdminEditionWorldLocationsBehaviour
         assert document = edition_class.last
         assert_equal [world_location_1, world_location_2], document.world_locations
       end
+
+      view_test "edit displays document form with world locations field" do
+        edition = create(document_type)
+        get :edit, params: { id: edition }
+
+        assert_select "form#edit_edition" do
+          assert_select "#edition_world_location_ids" do |elements|
+            assert_equal 1, elements.length
+            assert_data_attributes_for_world_locations(
+              element: elements.first,
+              track_label: edit_edition_path(document_type)
+            )
+          end
+        end
+      end
+
 
       test "updating should save modified document attributes with world locations" do
         world_location_1 = create(:world_location)
@@ -53,5 +75,14 @@ module AdminEditionWorldLocationsBehaviour
         end
       end
     end
+  end
+
+private
+
+  def assert_data_attributes_for_world_locations(element:, track_label:)
+    assert_equal 'World locations…', element['data-placeholder']
+    assert_equal 'track-select-click', element['data-module']
+    assert_equal 'worldLocationSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
   end
 end


### PR DESCRIPTION
**what and why**
Following on from: https://trello.com/c/WJc6DgVn/97-add-tracking-to-whitehall-publisher-legacy-tagging-fields 

We also need to add tracking to all the other form fields that publishers encounter in Whitehall. These are:

- Organisation drop downs across all document types
- Ministers drop down: consultations; speech; publication; news article
- Topical Events: consultations; speech; publication; news article
- Related stats: publication
- World Location: speech; case study; publication; news article
- World Organisation: case study

Trello: [Add tracking to other Whitehall publisher fields](https://trello.com/c/jk6S82r0/98-add-tracking-to-other-whitehall-publisher-fields-2)
