### PR TITLE
Remove some inconsistency in the taxonomy tree data

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -20,7 +20,9 @@ module Taxonomy
     def expand_taxon_array(taxons)
       taxons.map do |taxon_hash|
         taxon_hash.tap do |hash|
-          hash['expanded_links_hash'] = expanded_links_hash(taxon_hash['content_id'])
+          hash['links'] = expanded_links_hash(
+            taxon_hash['content_id']
+          )['expanded_links']
         end
       end
     end

--- a/lib/taxonomy/tree.rb
+++ b/lib/taxonomy/tree.rb
@@ -7,12 +7,9 @@ module Taxonomy
   class Tree
     attr_reader :root_taxon
 
-    def initialize(expanded_root_taxon_hash)
-      @root_taxon = Taxon.from_taxon_hash(expanded_root_taxon_hash)
-      root_taxon.children = parse_taxons(
-        root_taxon,
-          expanded_root_taxon_hash['expanded_links_hash']
-      )
+    def initialize(root_taxon_hash)
+      @root_taxon = Taxon.from_taxon_hash(root_taxon_hash)
+      root_taxon.children = parse_taxons(root_taxon, root_taxon_hash)
     end
 
   private
@@ -27,8 +24,7 @@ module Taxonomy
     end
 
     def child_nodes(item_hash)
-      children = item_hash.dig('links', 'child_taxons') ||
-        item_hash.dig('expanded_links', 'child_taxons') || []
+      children = item_hash.dig('links', 'child_taxons') || []
       children.sort_by { |hsh| hsh.fetch('title') }
     end
   end

--- a/test/factories/taxon_hash.rb
+++ b/test/factories/taxon_hash.rb
@@ -10,17 +10,9 @@ FactoryBot.define do
     sequence("content_id") { |i| "taxon_uuid_#{i}" }
     phase 'live'
     after :build do |hash, evaluator|
-      if evaluator.is_level_one_taxon
-        hash["expanded_links_hash"] = {
-          "expanded_links" => {
-            "child_taxons" => evaluator.children
-          }
-        }
-      else
-        hash["links"] = {
-            "child_taxons" => evaluator.children
-        }
-      end
+      hash["links"] = {
+        "child_taxons" => evaluator.children
+      }
       hash["details"] = {
         "visible_to_departmental_editors" => evaluator.visibility
       }

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -16,7 +16,7 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
     test "expanded links" do
       setup_taxons
       assert_equal %w[child1 child2],
-                   (subject.taxon_data.first.dig('expanded_links_hash', 'expanded_links', 'child_taxons').map { |t| t['title'] })
+                   (subject.taxon_data.first.dig('links', 'child_taxons').map { |t| t['title'] })
     end
   end
 
@@ -29,7 +29,7 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
     test "#expanded links" do
       setup_world_taxons
       assert_equal %w(country-1 country-2),
-                   (subject.world_taxon_data.first.dig('expanded_links_hash', 'expanded_links', 'child_taxons').map { |t| t['title'] })
+                   (subject.world_taxon_data.first.dig('links', 'child_taxons').map { |t| t['title'] })
     end
   end
 

--- a/test/unit/taxonomy/tree_test.rb
+++ b/test/unit/taxonomy/tree_test.rb
@@ -2,14 +2,14 @@ require 'test_helper'
 
 class Taxonomy::TreeTest < ActiveSupport::TestCase
   test ".new sets the root_taxon property" do
-    subject = Taxonomy::Tree.new(expanded_root_taxon_hash)
+    subject = Taxonomy::Tree.new(root_taxon_hash)
     assert subject.root_taxon.class == Taxonomy::Taxon
   end
 
   # Example of expanded links hash:
   #
   # {
-  #   "expanded_links" => {
+  #   "links" => {
   #     "child_taxons" => [
   #       {
   #         "base_path" => "/root-path",
@@ -31,12 +31,12 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
   # }
 
   test "it parses an empty set of child_taxons" do
-    assert result("expanded_links" => {}).empty?
+    assert result("links" => {}).empty?
   end
 
   test "it parses a single child_taxon" do
     single_root_node = {
-      "expanded_links" => {
+      "links" => {
         "child_taxons" => [
           node
         ]
@@ -49,7 +49,7 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
 
   test "it parses two child_taxons" do
     two_root_nodes = {
-      "expanded_links" => {
+      "links" => {
         "child_taxons" => [
           node,
           node
@@ -63,7 +63,7 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
 
   test "it parses descendants of root node" do
     single_root_with_descendant = {
-      "expanded_links" => {
+      "links" => {
         "child_taxons" => [
           node([node])
         ]
@@ -77,7 +77,7 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
 
   test "it sorts the taxon list alphabetically" do
     taxons = {
-      "expanded_links" => {
+      "links" => {
         "child_taxons" => [
           node,
           node
@@ -85,24 +85,23 @@ class Taxonomy::TreeTest < ActiveSupport::TestCase
       }
     }
 
-    taxons["expanded_links"]["child_taxons"][0]["title"] = "zaphod"
-    taxons["expanded_links"]["child_taxons"][1]["title"] = "allen"
+    taxons["links"]["child_taxons"][0]["title"] = "zaphod"
+    taxons["links"]["child_taxons"][1]["title"] = "allen"
 
     assert result(taxons).first.name == "allen"
     assert result(taxons).second.name == "zaphod"
   end
 
-  def expanded_root_taxon_hash(expanded_links = {})
+  def root_taxon_hash(links = {})
     @_root_taxon_hash ||= {
       'title' => 'root',
       'base_path' => '/root',
       'content_id' => 'root_id',
-      'expanded_links_hash' => expanded_links
-    }
+    }.merge(links)
   end
 
-  def result(expanded_links = {})
-    taxon_hash = expanded_root_taxon_hash(expanded_links)
+  def result(links = {})
+    taxon_hash = root_taxon_hash(links)
     Taxonomy::Tree.new(taxon_hash).root_taxon.children
   end
 


### PR DESCRIPTION
Previously the root hash would have a `links` value, and also a
`expanded_links_hash` value. This is because of the way the expanded
links payload for the homepage is split up, and spliced together with
the expanded links payload for each level one taxon.

All JSON payloads include the "expanded" links from the Publishing
API, and the name "links" is used throughout the payloads for
this. This change inserts the expanded links for each level one taxon
in to this place in the hash for the level one taxon, allowing the
code to handle the data in a more uniform manor.

I was looking in to this due to the mapping code not handling the
legacy_taxons for level one taxons correctly, which was due to the
code previously not knowing to look for the data in two places due to
this edge case. This is now unnecesary, and the code works.