### PR TITLE
Remove empty fields from role appointments presenter

### DIFF
--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -13,22 +13,16 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(
-        item,
-        title: "",
-        update_type: update_type,
-      ).base_attributes
-
-      content.merge!(
-        base_path: nil,
-        description: nil,
+      {
+        title: title,
+        locale: locale,
         details: {},
+        publishing_app: "whitehall",
+        update_type: update_type,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
-        routes: [],
-        schema_name: 'role_appointment',
-      )
+        schema_name: "role_appointment",
+      }
     end
 
     def links
@@ -40,6 +34,16 @@ module PublishingApi
           item.role.content_id,
         ],
       }
+    end
+
+  private
+
+    def title
+      "#{item.person.name} - #{item.role.name}"
+    end
+
+    def locale
+      I18n.locale.to_s
     end
   end
 end

--- a/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -22,17 +22,12 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
     )
 
     expected_hash = {
-      base_path: nil,
-      title: "",
-      description: nil,
+      title: "#{person.name} - #{role.name}",
       schema_name: 'role_appointment',
       document_type: 'role_appointment',
       locale: 'en',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
       public_updated_at: role.updated_at,
-      routes: [],
-      redirects: [],
       update_type: 'major',
       details: {}
     }


### PR DESCRIPTION
This commit removes the empty fields from the role appointments presenter, and also provides a title field, which is required.