### PR TITLE
Disable organisation re-publishing

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,7 +48,8 @@ class Person < ApplicationRecord
 
   delegate :url, to: :image, prefix: :image
 
-  after_save :republish_organisation_to_publishing_api
+  # Disabled while all people are re-published
+  #after_save :republish_organisation_to_publishing_api
   before_destroy :prevent_destruction_if_appointed
   after_update :touch_role_appointments
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -48,7 +48,8 @@ class Role < ApplicationRecord
   validates :type, presence: true
   validates_with SafeHtmlValidator
 
-  after_save :republish_organisation_to_publishing_api
+  # Disabled while all roles are re-published
+  #after_save :republish_organisation_to_publishing_api
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -66,8 +66,9 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api
+  # Disabled while all role appointments are re-published
+  #after_save :republish_organisation_to_publishing_api
+  #after_destroy :republish_organisation_to_publishing_api
   after_save :update_indexes
   after_destroy :update_indexes
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -39,9 +39,9 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
       stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major'),
-      stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
-      stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
-      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: 'major')
+      #stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
+      #stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
+      #stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/models/person_role_test.rb
+++ b/test/unit/models/person_role_test.rb
@@ -1,37 +1,37 @@
 require 'test_helper'
 
-class PersonRoleTest < ActiveSupport::TestCase
-  test "creating a new role and person republishes the linked organisation" do
-    test_object = create(:organisation)
-    role = create(:role, organisations: [test_object])
-    person = create(:person)
-    role_appointment = build(:role_appointment, person: person, role: role)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-    Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
-    role_appointment.save!
-  end
-
-  test "updating an existing person republishes the linked organisation" do
-    test_object = create(:organisation)
-    role = create(:role, organisations: [test_object])
-    person = create(:person)
-    create(:role_appointment, person: person, role: role)
-    person.reload
-    person.forename = "Test"
-    Whitehall::PublishingApi.expects(:publish_async).with(person).once
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-    person.save!
-  end
-
-  test "updating an existing role republishes the linked organisation" do
-    test_object = create(:organisation)
-    role = create(:role, organisations: [test_object])
-    person = create(:person)
-    create(:role_appointment, person: person, role: role)
-    person.reload
-    role.cabinet_member = true
-    Whitehall::PublishingApi.expects(:publish_async).with(role).once
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-    role.save!
-  end
-end
+# class PersonRoleTest < ActiveSupport::TestCase
+#   test "creating a new role and person republishes the linked organisation" do
+#     test_object = create(:organisation)
+#     role = create(:role, organisations: [test_object])
+#     person = create(:person)
+#     role_appointment = build(:role_appointment, person: person, role: role)
+#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+#     Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
+#     role_appointment.save!
+#   end
+#
+#   test "updating an existing person republishes the linked organisation" do
+#     test_object = create(:organisation)
+#     role = create(:role, organisations: [test_object])
+#     person = create(:person)
+#     create(:role_appointment, person: person, role: role)
+#     person.reload
+#     person.forename = "Test"
+#     Whitehall::PublishingApi.expects(:publish_async).with(person).once
+#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+#     person.save!
+#   end
+#
+#   test "updating an existing role republishes the linked organisation" do
+#     test_object = create(:organisation)
+#     role = create(:role, organisations: [test_object])
+#     person = create(:person)
+#     create(:role_appointment, person: person, role: role)
+#     person.reload
+#     role.cabinet_member = true
+#     Whitehall::PublishingApi.expects(:publish_async).with(role).once
+#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+#     role.save!
+#   end
+# end


### PR DESCRIPTION
This commit temporarily disables organisation re-publishing each time a person, role or role appointment is published. This will allow us to publish all of these without causing too much unnecessary re-publishing.