### PR TITLE
Rename a regulatory judgement publication 

### DIFF
--- a/db/data_migration/20180607142603_rename_regulatory_judgement_publication.rb
+++ b/db/data_migration/20180607142603_rename_regulatory_judgement_publication.rb
@@ -1,0 +1,4 @@
+DataHygiene::DocumentReslugger.call(
+  from: "regulatory-judgement-symphony-housing-group-ltd",
+  to: "regulatory-judgement-onwards-homes-limited",
+)

--- a/lib/data_hygiene/document_reslugger.rb
+++ b/lib/data_hygiene/document_reslugger.rb
@@ -1,0 +1,19 @@
+module DataHygiene
+  class DocumentReslugger
+    def self.call(from:, to:)
+      old_slug = from
+      new_slug = to
+
+      document = Document.find_by(slug: old_slug)
+      return unless document
+
+      puts "Reslugging #{old_slug} document to #{new_slug}"
+
+      edition = document.editions.published.last
+      Whitehall::SearchIndex.delete(edition)
+
+      document.update_attributes!(slug: new_slug)
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+end


### PR DESCRIPTION
A company name change means we should update the URL to match.

[Trello Card](https://trello.com/c/hp0YNMBB/210-whitehall-url-change)