### PR TITLE
Fix removing all tags in the worldwide taxonomy tagging interface

### DIFF
--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -11,7 +11,8 @@
     <%= form_for(
       @tag_form,
       url: admin_edition_world_tags_path(@edition),
-      method: :put
+      method: :put,
+      as: :taxonomy_tag_form
     ) do |form| %>
       <%= form.hidden_field :previous_version %>
 

--- a/app/views/admin/edition_world_tags/edit.html.erb
+++ b/app/views/admin/edition_world_tags/edit.html.erb
@@ -8,7 +8,11 @@
     <h2>Worldwide</h2>
     <hr>
 
-    <%= form_for @tag_form, url: admin_edition_world_tags_path(@edition), method: :put do |form| %>
+    <%= form_for(
+      @tag_form,
+      url: admin_edition_world_tags_path(@edition),
+      method: :put
+    ) do |form| %>
       <%= form.hidden_field :previous_version %>
 
       <div class="form-group"
@@ -17,7 +21,13 @@
         data-content-format="<%= @edition.content_store_document_type %>"
         data-content-public-path="<%= public_document_path(@edition) %>">
 
-        <%= render partial: "/admin/shared/tagging/taxonomy", locals: { selected_taxons: @tag_form.selected_taxons, level_one_taxons: @world_taxonomy.all_world_taxons } %>
+        <%= render(
+          partial: "/admin/shared/tagging/taxonomy",
+          locals: {
+            selected_taxons: @tag_form.selected_taxons,
+            level_one_taxons: @world_taxonomy.all_world_taxons
+          }
+        ) %>
       </div>
 
       <h2>Selected topics</h2>
@@ -29,7 +39,10 @@
       </p>
 
       <div class="publishing-controls well">
-        <%= form.form_actions(buttons: { save: 'Save topic changes' }, cancel: admin_edition_path(@edition)) %>
+        <%= form.form_actions(
+          buttons: { save: 'Save topic changes' },
+          cancel: admin_edition_path(@edition)
+        ) %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Previously it would error in the controller as nothing was in the
params with the name `taxonomy_tag_form`. The functional part of the
form is in a partial as it's currently shared between the Worldwide
and Taxonomy tagging interfaces, and this works fine for the Taxonomy
Tagging form, just not the Worldwide one.

It works for the Taxonomy tagging interface, as in that case, there
are other things in the `taxonomy_tag_form` entry in params, so to
keep the code somewhat consistent, change the name of the value in
params.

In the future, these interfaces will hopefully diverge further, as the
Topic Taxonomy tagging interface doesn't suit the data in the
Worldwide tagging interface. At which point this change will hopefully
no longer be needed/relevant.