### PR TITLE
Always show the legacy associations box

### DIFF
--- a/app/views/admin/editions/_show_metadata.html.erb
+++ b/app/views/admin/editions/_show_metadata.html.erb
@@ -53,17 +53,17 @@
   } %>
 <% end %>
 
+<%= render partial: '/admin/shared/tagging/legacy_associations_box', locals: {
+  path_to_edit_associations: edit_admin_edition_legacy_associations_path(@edition.id),
+  edition: @edition,
+  no_associations_message: 'No associations'
+} %>
+
 <% if @edition.can_be_tagged_to_worldwide_taxonomy? %>
   <%= render partial: '/admin/shared/tagging/show_world_topics_box', locals: {
     path_to_edit_tags: edit_admin_edition_world_tags_path(@edition.id),
     selected_taxon_paths: @edition_world_taxons.map(&:full_path),
     no_topics_message: 'No worldwide related topics'
-  } %>
-<% else %>
-  <%= render partial: '/admin/shared/tagging/legacy_associations_box', locals: {
-      path_to_edit_associations: edit_admin_edition_legacy_associations_path(@edition.id),
-      edition: @edition,
-      no_associations_message: 'No associations'
   } %>
 <% end %>
 


### PR DESCRIPTION
Rather than making it show up only when you can't tag to the Worldwide
taxonomy, as this doesn't make sense.