### PR TITLE
Add links to expand and collapse all taxonomy trees

### DIFF
--- a/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
+++ b/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
@@ -2,7 +2,6 @@
   "use strict";
 
   Modules.TaxonomyTreeCheckboxes = function() {
-
     var ancestors = function(element) {
       var $parents = $(element).parents('.topics,.topic-tree');
       return $parents.prev('p').find('input[type="checkbox"]');
@@ -55,11 +54,24 @@
       });
     };
 
+    var bindExpandAndCollapseAll = function() {
+        $('#expand_all_id').click(function(event) {
+            $('.level-one-taxon').collapse('show');
+            event.preventDefault()
+        });
+        $('#collapse_all_id').click(function(event) {
+            $('.level-one-taxon').collapse('hide');
+            event.preventDefault()
+        });
+    };
+
     this.start = function(element) {
       var $element = $(element);
       var publicPath = $element.data("content-public-path");
       var contentFormat = $element.data("content-format");
       var contentId = $element.data("content-id");
+
+      bindExpandAndCollapseAll();
 
       $element.on('click', 'input:checkbox', function() {
         var $checkbox = $(this);

--- a/app/presenters/topic_tree_presenter.rb
+++ b/app/presenters/topic_tree_presenter.rb
@@ -13,7 +13,7 @@ class TopicTreePresenter < SimpleDelegator
   end
 
   def tree_classes
-    tree_classes = ["collapse"]
+    tree_classes = ["collapse", "level-one-taxon"]
     tree_classes << "in" unless collapsed
     tree_classes.join(" ")
   end

--- a/app/views/admin/shared/tagging/_taxonomy.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy.html.erb
@@ -1,3 +1,5 @@
+<p><a id="expand_all_id" href="#">expand all</a> | <a id="collapse_all_id" href="#">collapse all</a></p>
+
 <% level_one_taxons.each do |taxon| %>
   <% taxon = TopicTreePresenter.new(taxon, collapsed: level_one_taxons.size > 1) %>
 

--- a/test/unit/presenters/topic_tree_presenter_test.rb
+++ b/test/unit/presenters/topic_tree_presenter_test.rb
@@ -13,12 +13,12 @@ class TopicTreePresenterTest < ActiveSupport::TestCase
 
   test ".tree_classes when collapsed is false" do
     result = TopicTreePresenter.new(nil, collapsed: false).tree_classes
-    assert_equal "collapse in", result
+    assert_equal "collapse level-one-taxon in", result
   end
 
   test ".tree_classes when collapsed is true" do
     result = TopicTreePresenter.new(nil, collapsed: true).tree_classes
-    assert_equal "collapse", result
+    assert_equal "collapse level-one-taxon", result
   end
 
   test "other method calls are delegated to the taxon" do


### PR DESCRIPTION
Adds two links to the taxonomy tree - one to expand and one to collapse all nodes.

Trello: https://trello.com/c/mdLJHb6N/132-add-display-all-functionality-to-expand-full-taxonomy-tree

![image](https://user-images.githubusercontent.com/6050162/41156574-6d14eb96-6b1a-11e8-8247-111103325440.png)

