### PR TITLE
Add original primary publishing organisation

### DIFF
--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -3,6 +3,7 @@ module PublishingApi
     LINK_NAMES_TO_METHODS_MAP = {
       organisations: :organisation_ids,
       primary_publishing_organisation: :primary_publishing_organisation_id,
+      original_primary_publishing_organisation: :original_primary_publishing_organisation_id,
       policy_areas: :policy_area_ids,
       related_policies: :related_policy_ids,
       statistical_data_set_documents: :statistical_data_set_ids,
@@ -19,6 +20,7 @@ module PublishingApi
     def extract(filter_links)
       if filter_links.include?(:organisations)
         filter_links << :primary_publishing_organisation
+        filter_links << :original_primary_publishing_organisation
       end
 
       filter_links.reduce(Hash.new) do |links, link_name|
@@ -51,6 +53,11 @@ module PublishingApi
     def primary_publishing_organisation_id
       lead_organisations = item.try(:lead_organisations) || []
       [lead_organisations.map(&:content_id).first].compact
+    end
+
+    def original_primary_publishing_organisation_id
+      original_lead_organisations = item.try(:document).try(:editions).try(:first).try(:lead_organisations) || []
+      [original_lead_organisations.map(&:content_id).first].compact
     end
 
     def world_location_ids

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -71,6 +71,7 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
       people: [],
       policy_areas: [],
       primary_publishing_organisation: [],
+      original_primary_publishing_organisation: [],
       roles: [],
     }
     assert_equal expected_links, @presented_content[:links]

--- a/test/unit/presenters/publishing_api/links_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/links_presenter_test.rb
@@ -26,7 +26,8 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
         topics: %w(content_id_1),
         parent: [],
         organisations: [],
-        primary_publishing_organisation: []
+        primary_publishing_organisation: [],
+        original_primary_publishing_organisation: [],
       },
       links
     )
@@ -45,6 +46,7 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
         parent: %w(content_id_1),
         organisations: [],
         primary_publishing_organisation: [],
+        original_primary_publishing_organisation: [],
       },
       links
     )
@@ -60,6 +62,7 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
         parent: [],
         organisations: [],
         primary_publishing_organisation: [],
+        original_primary_publishing_organisation: [],
       },
       links
     )
@@ -75,6 +78,26 @@ class PublishingApi::LinksPresenterTest < ActionView::TestCase
       {
         organisations: [organisation.content_id],
         primary_publishing_organisation: [organisation.content_id],
+        original_primary_publishing_organisation: [organisation.content_id],
+      },
+      links
+    )
+  end
+
+  test "adds original publishing organisation with the first lead organisation assigned to the first edition" do
+    organisation = create(:organisation)
+    edition = create(:published_publication, lead_organisations: [organisation])
+
+    new_organisation = create(:organisation)
+    new_edition = create(:published_publication, document: edition.document, lead_organisations: [new_organisation])
+
+    links = links_for(new_edition, [:organisations])
+
+    assert_equal(
+      {
+        organisations: [new_organisation.content_id],
+        primary_publishing_organisation: [new_organisation.content_id],
+        original_primary_publishing_organisation: [organisation.content_id],
       },
       links
     )

--- a/test/unit/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/publication_presenter_test.rb
@@ -63,6 +63,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       topics: [],
       parent: [],
       primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
+      original_primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       organisations: publication.lead_organisations.map(&:content_id),
       ministers: [minister.person.content_id],
       related_statistical_data_sets: [statistical_data_set.content_id],


### PR DESCRIPTION
This commit adds a new `original_primary_publishing_organisation` field to the presented version of any document that is tagged to an organisation. This field contains the organisation that originally published the document, even if that has changed.

Trello: https://trello.com/c/u80rFvuW/152-retain-org-ownership-history-of-content