### PR TITLE
Add tracking to taxon selections

### DIFF
--- a/app/assets/javascripts/admin/modules/track_selected_taxons.js
+++ b/app/assets/javascripts/admin/modules/track_selected_taxons.js
@@ -1,0 +1,25 @@
+(function (Modules) {
+    "use strict";
+
+    Modules.TrackSelectedTaxons = function () {
+        var extractBreadcrumb = function (element) {
+            return element.find('li').map(function () {
+                return $(this).text();
+            }).get().join(' > ');
+        };
+        this.start = function (container) {
+            var trackSelectedTaxons = function () {
+                var category = container.data("track-category"),
+                    label = container.data("track-label");
+
+                $('.taxon-breadcrumb').each(function (idx, element) {
+                    var action = extractBreadcrumb($(element));
+                    GOVUKAdmin.trackEvent(category, action, {label: label});
+                });
+            };
+
+            container.on("click", trackSelectedTaxons);
+        };
+    };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -51,8 +51,18 @@
       </div>
       <div class="publishing-controls well">
         <div class="form-actions" data-module="track-button-click" data-track-category="form-button" data-track-action="taxonomy-tag-form-button">
-          <%= form.submit('Save topic changes', name: "save", class: "btn btn-lg btn-success") %>
-          <%= form.submit('Save and review legacy tagging', name: "legacy_tags", class: "btn btn-lg btn-primary") %>
+          <%= form.submit('Save topic changes', name: "save", class: "btn btn-lg btn-success",
+              data: {
+                  module: 'track-selected-taxons',
+                  track_category: 'taxonSelection',
+                  track_label: request.path
+              }) %>
+          <%= form.submit('Save and review legacy tagging', name: "legacy_tags", class: "btn btn-lg btn-primary",
+              data: {
+                  module: 'track-selected-taxons',
+                  track_category: 'taxonSelection',
+                  track_label: request.path
+              }) %>
           <span class="or_cancel">
             or
             <%= link_to('cancel', admin_edition_path(@edition)) %>

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -117,6 +117,41 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
     assert_select "input[name='taxonomy_tag_form[invisible_draft_taxons]'][value='invisible_draft_taxon_1_content_id,invisible_draft_taxon_2_content_id']"
   end
 
+  def assert_tracking_attributes(element:, track_label:)
+    assert_equal 'track-selected-taxons', element['data-module']
+    assert_equal 'taxonSelection', element['data-track-category']
+    assert_equal track_label, element['data-track-label']
+  end
+
+  view_test 'should render save button with tracking attributes' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select "input[name*='save']" do |elements|
+      assert_equal 1, elements.length
+      assert_tracking_attributes(
+        element: elements.first,
+        track_label: edit_admin_edition_tags_path(@edition)
+      )
+    end
+  end
+
+
+  view_test 'should render save and review legacy button with tracking attributes' do
+    stub_publishing_api_links_with_taxons(@edition.content_id, [parent_taxon_content_id])
+
+    get :edit, params: { edition_id: @edition }
+
+    assert_select "input[name*='legacy_tags']" do |elements|
+      assert_equal 1, elements.length
+      assert_tracking_attributes(
+        element: elements.first,
+        track_label: edit_admin_edition_tags_path(@edition)
+      )
+    end
+  end
+
   test 'should post invisible draft taxons to publishing-api' do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [])
 

--- a/test/javascripts/unit/admin/modules/track_selected_taxons_test.js
+++ b/test/javascripts/unit/admin/modules/track_selected_taxons_test.js
@@ -1,0 +1,59 @@
+var form =
+    '<form id="taxon-form" class="js-supports-non-english" onsubmit="function(){return false;}"></form>'
+
+var taxonBreadcrumbs =
+'<div class="content">' +
+'    <div class="taxon-breadcrumb">' +
+'       <ol>' +
+'           <li>Parent 1</li>' +
+'           <li>Child 1</li>' +
+'       </ol>' +
+'   </div>' +
+'    <div class="taxon-breadcrumb">' +
+'       <ol>' +
+'           <li>Parent 2</li>' +
+'           <li>Child 2</li>' +
+'       </ol>' +
+'   </div>' +
+'</div>';
+
+var saveButton =
+'<input type="button" id="save" name="save" value="Save topic changes" data-module="track-selected-taxons"' +
+'   data-track-category="taxonSelection" data-track-label="/government/admin/editions/798947/tags/edit">';
+
+module("TrackSelectedTaxons", {
+    setup: function() {
+        this.subject = new GOVUKAdmin.Modules.TrackSelectedTaxons();
+
+        $('#qunit-fixture').append(form);
+        $('#qunit-fixture form').append(taxonBreadcrumbs);
+        $('#qunit-fixture form').append(saveButton);
+
+
+        GOVUK.adminEditionsForm.init({
+            selector: 'form#taxon-form',
+            right_to_left_locales:["ar"]
+        });
+    }
+});
+
+test("the save button should send a GA event for each taxon breadcrumb", function () {
+    var saveButton = $('#save');
+    var spy = sinon.spy(GOVUKAdmin, 'trackEvent');
+
+    this.subject.start(saveButton);
+
+    saveButton.click();
+
+    sinon.assert.calledTwice(spy);
+    deepEqual(
+        spy.args[0],
+        ["taxonSelection", "Parent 1 > Child 1", {}]
+    );
+    deepEqual(
+        spy.args[1],
+        ["taxonSelection", "Parent 2 > Child 2", {}]
+    );
+
+    spy.restore()
+});


### PR DESCRIPTION
## Why
We want GA events for taxon selections. We want to know what users are tagging to, so we can analyse the amount of time a given publication takes against the type of topics a user selects.

## What
Send an event to GA with the selections the user has made, ideally once (on save) with the complete list of selected taxons.

We want to track the final selections our publishers make, but we do not want to track anything a user selects prior without saving as it gives us little insight. This would give us too much noise and not help gain insight into the decisions users are making prior to publishing. 

Trello: [Add GA tracking of the topic taxonomy selections in Whitehall](https://trello.com/c/Ex7vU71H/140-add-ga-tracking-of-the-topic-taxonomy-selections-in-whitehall)