### PR TITLE
Improve the code linting situation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Naming/VariableNumber:
 Style/FormatStringToken:
   Exclude:
     - 'config/routes.rb'
+    # Hopefully this file can be removed soon...
+    - 'lib/migrate_assets_to_asset_manager.rb'
+    - 'lib/tasks/scheduled_publishing.rake'
 
 Style/MethodMissing:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Metrics/BlockLength:
 Layout/EmptyLinesAroundArguments:
   Enabled: false
 
+Style/EvalWithLocation:
+  Exclude:
+    - 'app/helpers/admin/edition_routes_helper.rb'
+
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,11 @@ AllCops:
 Metrics/BlockLength:
   Enabled: false
 
+# This doesn't pass at the moment, as there are some empty lines
+# around comments
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-whitehall")
   govuk.buildProject(
     sassLint: false,
+    rubyLintDiff: false,
     publishingE2ETests: true,
     beforeTest: {
       stage("Generate directories for upload tests") {

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -68,7 +68,7 @@ class WorldLocation < ApplicationRecord
     remove_from_search_index if self.active_changed? && !self.active
   end
 
-  scope :ordered_by_name, ->() { with_translations(I18n.default_locale).order('world_location_translations.name') }
+  scope :ordered_by_name, -> { with_translations(I18n.default_locale).order('world_location_translations.name') }
 
   def self.active
     where(active: true)

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -21,7 +21,7 @@ class WorldwideOrganisation < ApplicationRecord
 
   accepts_nested_attributes_for :default_news_image, reject_if: :all_blank
 
-  scope :ordered_by_name, ->() { with_translations(I18n.default_locale).order(translation_class.arel_table[:name]) }
+  scope :ordered_by_name, -> { with_translations(I18n.default_locale).order(translation_class.arel_table[:name]) }
 
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = 'WO'

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -60,7 +60,7 @@ module Whitehall
   end
 
   def self.admin_host
-    @admin_host ||=  URI(admin_root).host
+    @admin_host ||= URI(admin_root).host
   end
 
   def self.internal_admin_host

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -393,7 +393,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   test "PUT :update_many changes attributes of multiple attachments" do
     files = Dir.glob(Rails.root.join('test', 'fixtures', '*.csv')).take(4)
     files.each_with_index do |f, i|
-      create(:file_attachment, title: "attachment_%s" % i, attachable: @edition, file: File.open(f))
+      create(:file_attachment, title: "attachment_#{i}", attachable: @edition, file: File.open(f))
     end
     attachments = @edition.reload.attachments
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -76,7 +76,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     test "DELETE :destroy handles file attachments for #{type} as attachable" do
       attachable = create(type)
       attachment = create(:file_attachment, attachable: attachable)
-      attachment_data = attachment.attachment_data
 
       delete :destroy, params: { param_name => attachable.id, id: attachment.id }
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -33,7 +33,7 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     content[:routes][0][:path] = new_base_path
     content_item.stubs(content: content)
 
-    organisation_content_item = PublishingApiPresenters.presenter_for(@organisation)
+    #organisation_content_item = PublishingApiPresenters.presenter_for(@organisation)
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),

--- a/test/unit/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/govspeak/admin_link_replacer_test.rb
@@ -15,7 +15,6 @@ module Govspeak
     test 'unpublished edition links are replaced with plain text' do
       draft_speech = create(:draft_speech)
       _admin_path  = Whitehall.url_maker.admin_speech_path(draft_speech)
-      public_url   = Whitehall.url_maker.public_document_url(draft_speech)
       fragment     = govspeak_to_nokogiri_fragment("this is an [unpublished thing](/government/admin/speeches/#{draft_speech.id})")
 
       AdminLinkReplacer.new(fragment).replace!

--- a/test/unit/models/taxonomy_tag_form_test.rb
+++ b/test/unit/models/taxonomy_tag_form_test.rb
@@ -46,10 +46,7 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
     publishing_api_has_links(
       "content_id" => content_id,
       "links" => {
-        "taxons" => [
-          "visible_id",
-          "invisible_id"
-        ]
+        "taxons" => %w[visible_id invisible_id]
       },
       "version" => 1
     )

--- a/test/unit/sync_checker/checks/topics_check_test.rb
+++ b/test/unit/sync_checker/checks/topics_check_test.rb
@@ -264,8 +264,7 @@ module SyncChecker
           response_code: 200,
           body: {
             links: {
-              topics: [
-              ]
+              topics: []
             }
           }.to_json
         )


### PR DESCRIPTION
Fix all the current issues, or disable the checks. Then set the `rubyLintDiff` option in the Jenkinsfile to `false` to ensure the code doesn't drift away from the linting rules in the future.