### PR TITLE
Make Worldwide taxons expand/collapse per country

### DIFF
--- a/lib/taxonomy/publishing_api_adapter.rb
+++ b/lib/taxonomy/publishing_api_adapter.rb
@@ -10,9 +10,9 @@ module Taxonomy
     end
 
     def world_taxon_data
-      @_world_taxon_data = expand_taxon_array(
-        [world_taxon]
-      )
+      publishing_api_with_huge_timeout
+        .get_expanded_links(WORLD_CONTENT_ID, with_drafts: false)
+        .dig('expanded_links', 'child_taxons')
     end
 
   private
@@ -29,10 +29,6 @@ module Taxonomy
 
     def level_one_taxons
       expanded_links_hash(HOMEPAGE_CONTENT_ID).dig('expanded_links', 'level_one_taxons') || []
-    end
-
-    def world_taxon
-      publishing_api_with_huge_timeout.get_content(WORLD_CONTENT_ID).to_h
     end
 
     def expanded_links_hash(content_id)

--- a/lib/taxonomy/world_taxonomy.rb
+++ b/lib/taxonomy/world_taxonomy.rb
@@ -6,10 +6,16 @@ module Taxonomy
     end
 
     def all_world_taxons
-      @_world_taxon_list ||= world_taxon_branches
+      @_all_world_taxons ||= sorted_world_taxons
     end
 
   private
+
+    def sorted_world_taxons
+      world_taxon_branches.sort_by do |world_taxon|
+        [world_taxon.children.count.zero? ? 0 : 1, world_taxon.name]
+      end
+    end
 
     def world_taxon_branches
       @_branches ||= @adapter.world_taxon_data.map do |world_taxon_hash|

--- a/test/integration/world_tagging_flow.rb
+++ b/test/integration/world_tagging_flow.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+require 'capybara/rails'
+
+class WorldTaggingFlow < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include TaxonomyHelper
+  include Rails.application.routes.url_helpers
+
+  setup do
+    login_as_admin
+  end
+
+  context 'given I want to tag to the WorldWide taxonomy' do
+    let(:world_organisation) do
+      create(:organisation, content_id: "9adfc4ed-9f6c-4976-a6d8-18d34356367c")
+    end
+    let(:world_edition) do
+      create(:publication, :guidance, organisations: [world_organisation])
+    end
+
+    before do
+      setup_world_tagging_page
+    end
+
+    it "asserts WorldWide tagging path" do
+      visit_world_tags_path
+      assert_equal(200, page.status_code)
+    end
+
+    it "asserts a selected checkbox' " do
+      visit_world_tags_path
+      expand_and_check_checkbox
+      assert page.has_checked_field?('World grandchild taxon')
+    end
+
+    it "asserts redirect by clicking 'Save topic changes'" do
+      visit_world_tags_path
+      stub_publishing_api_expanded_links_with_taxons(
+        world_edition.content_id,
+        [world_child_taxon]
+      )
+      click_save_topic_changes
+      assert_current_path "/government/admin/publications/#{world_edition.id}"
+      assert_equal(200, page.status_code)
+    end
+  end
+
+  def click_save_topic_changes
+    click_button "Save topic changes"
+  end
+
+  def expand_and_check_checkbox
+    click_link "World child taxon"
+    check "World grandchild taxon"
+  end
+
+  def visit_world_tags_path
+    visit "/government/admin/editions/#{world_edition.id}/world_tags/edit"
+  end
+
+  def setup_world_tagging_page
+    redis_cache_has_world_taxons([world_child_taxon])
+    stub_publishing_api_links_with_taxons(world_edition.content_id, [])
+  end
+end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -134,7 +134,7 @@ private
 
   def world_grandchild_taxon
     FactoryBot.build(:taxon_hash,
-                     title: "World Child Taxon",
+                     title: "World grandchild taxon",
                      base_path: "/world/grand-child",
                      content_id: world_grandchild_taxon_content_id,
                      is_level_one_taxon: false)
@@ -142,7 +142,7 @@ private
 
   def world_child_taxon
     FactoryBot.build(:taxon_hash,
-                     title: "World Child Taxon",
+                     title: "World child taxon",
                      base_path: "/world/child",
                      content_id: world_child_taxon_content_id,
                      is_level_one_taxon: false,

--- a/test/unit/taxonomy/publishing_api_adapter_test.rb
+++ b/test/unit/taxonomy/publishing_api_adapter_test.rb
@@ -21,15 +21,10 @@ class Taxonomy::PublishingApiAdapterTest < ActiveSupport::TestCase
   end
 
   describe "#world_taxon_data" do
-    test "base hash" do
-      setup_world_taxons
-      assert_equal %w[World], (subject.world_taxon_data.map { |t| t['title'] })
-    end
-
     test "#expanded links" do
       setup_world_taxons
       assert_equal %w(country-1 country-2),
-                   (subject.world_taxon_data.first.dig('links', 'child_taxons').map { |t| t['title'] })
+                   (subject.world_taxon_data.map { |t| t['title'] })
     end
   end
 
@@ -43,24 +38,24 @@ private
     {
       "content_id" => Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID,
       "expanded_links" => {
-          "level_one_taxons" => level_one_taxons
+        "level_one_taxons" => level_one_taxons
       }
     }
   end
 
   def taxon(id)
     {
-        "content_id" => id.to_s,
-        "title" => id.to_s
+      "content_id" => id.to_s,
+      "title" => id.to_s
     }
   end
 
   def expanded_link(content_id, taxons)
     {
-        "content_id" => content_id,
-        "expanded_links" => {
-          "child_taxons" => taxons
-        }
+      "content_id" => content_id,
+      "expanded_links" => {
+        "child_taxons" => taxons
+      }
     }
   end
 
@@ -74,15 +69,9 @@ private
   end
 
   def setup_world_taxons
-    publishing_api_has_item(
-      content_id: Taxonomy::PublishingApiAdapter::WORLD_CONTENT_ID,
-      title: "World",
-      base_path: "/world/all"
-    )
-
     world_content_id = Taxonomy::PublishingApiAdapter::WORLD_CONTENT_ID
 
-    expanded_link_hash = expanded_link(world_content_id, [taxon("country-1"), taxon("country-2")])
-    publishing_api_has_expanded_links(expanded_link_hash, with_drafts: false)
+    world_expanded_link_hash = expanded_link(world_content_id, [taxon("country-1"), taxon("country-2")])
+    publishing_api_has_expanded_links(world_expanded_link_hash, with_drafts: false)
   end
 end

--- a/test/unit/taxonomy/world_taxonomy_test.rb
+++ b/test/unit/taxonomy/world_taxonomy_test.rb
@@ -7,14 +7,16 @@ class Taxonomy::WorldTaxonomyTest < ActiveSupport::TestCase
     Taxonomy::WorldTaxonomy.new
   end
 
-  test "#world_taxons" do
+  test "#order of world taxons" do
     redis_cache_has_world_taxons(
       [
-        build(:taxon_hash, content_id: 'content_id_1'),
-        build(:taxon_hash, content_id: 'content_id_2'),
-        build(:taxon_hash, content_id: 'content_id_3')
+        build(:taxon_hash, title: 'France', children: [child_taxon]),
+        build(:taxon_hash, title: 'Australia', children: [child_taxon, child_taxon]),
+        build(:taxon_hash, title: 'News and events'),
+        build(:taxon_hash, title: 'Birth, death and marriage abroad')
       ]
     )
-    assert_equal %w[content_id_1 content_id_2 content_id_3], subject.all_world_taxons.map(&:content_id)
+    assert_equal ['Birth, death and marriage abroad', 'News and events', 'Australia', 'France'],
+                 subject.all_world_taxons.map(&:name)
   end
 end


### PR DESCRIPTION
https://trello.com/c/O7if1mGu/147-improve-the-worldwide-tagging-interface-3

Currently, only `world` expands which displays a huge list of all
the countries and their sub taxons. This is not good for the user as its
an overload of information.

This change provides a link to expand/collapse per country, this new list
also displays everything alphabetically starting with all the taxons
that have no children.

## Before 
![worldwide-tagging](https://user-images.githubusercontent.com/24479188/41348896-fe656d2a-6f05-11e8-9ff5-4ef60bcc5116.png)

## After
<img width="831" alt="screen shot 2018-06-13 at 12 33 19" src="https://user-images.githubusercontent.com/24479188/41348901-04e186e8-6f06-11e8-8568-5a2e0cc33c25.png">
