### PR TITLE
Add acronym to organisations presenter

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -58,6 +58,7 @@ module PublishingApi
 
     def details
       {
+        acronym: acronym,
         body: summary,
         brand: brand,
         logo: {
@@ -80,6 +81,10 @@ module PublishingApi
         organisation_type: organisation_type,
         social_media_links: social_media_links,
       }
+    end
+
+    def acronym
+      item.acronym
     end
 
     def summary

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -40,6 +40,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       redirects: [],
       update_type: "major",
       details: {
+        acronym: nil,
         body: "",
         brand: nil,
         logo: {


### PR DESCRIPTION
This commit adds a new acronym field to the organisations presenter to present this to the publishing-api.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/773

Trello: https://trello.com/c/lTOLkzUo/148-org-show-page-issues