### PR TITLE
Add more information about an organisation to the body

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -3,6 +3,10 @@ module PublishingApi
     include Rails.application.routes.url_helpers
     include ApplicationHelper
     include FilterRoutesHelper
+    # This is so we can get the extra text for the summary field
+    include OrganisationHelper
+    # This is a hack to get the OrganisationHelper to work in this context
+    include ActionView::Helpers::UrlHelper
 
     attr_accessor :item
     attr_accessor :update_type
@@ -88,7 +92,7 @@ module PublishingApi
     end
 
     def summary
-      item.summary || ""
+      "#{item.summary}#{organisation_display_name_including_parental_and_child_relationships(item)}"
     end
 
     def brand

--- a/features/support/organisation_test_helper.rb
+++ b/features/support/organisation_test_helper.rb
@@ -1,4 +1,4 @@
-module OrganisationHelper
+module OrganisationTestHelper
   def find_or_create_organisation(name)
     Organisation.find_by(name: name) || create(:organisation, name: name)
   end
@@ -61,4 +61,4 @@ module OrganisationHelper
   end
 end
 
-World(OrganisationHelper)
+World(OrganisationTestHelper)

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -13,7 +13,13 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
   end
 
   test 'presents an Organisation ready for adding to the publishing API' do
-    organisation = create(:organisation, name: 'Organisation of Things', analytics_identifier: 'O123')
+    parent_organisation = create(:organisation, name: 'Department for Stuff')
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      analytics_identifier: 'O123',
+      parent_organisations: [parent_organisation]
+    )
     role = create(:role, organisations: [organisation])
     public_path = Whitehall.url_maker.organisation_path(organisation)
 
@@ -27,7 +33,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         ordered_contacts: [],
         ordered_foi_contacts: [],
         ordered_featured_policies: [],
-        ordered_parent_organisations: [],
+        ordered_parent_organisations: [parent_organisation.content_id],
         ordered_child_organisations: [],
         ordered_successor_organisations: [],
         ordered_high_profile_groups: [],
@@ -41,7 +47,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       update_type: "major",
       details: {
         acronym: nil,
-        body: "",
+        body: "Organisation of Things works with the <a href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>.",
         brand: nil,
         logo: {
           formatted_title: "Organisation<br/>of<br/>Things",


### PR DESCRIPTION
This commit adds more information about an organisation, including its parent and child organisations, the the `body` field in the content item.

Trello: https://trello.com/c/lTOLkzUo/148-org-show-page-issues