### PR TITLE
Let collections render the org index page

### DIFF
--- a/lib/publish_organisations_index_page.rb
+++ b/lib/publish_organisations_index_page.rb
@@ -22,7 +22,7 @@ private
         locale: "en",
         base_path: BASE_PATH,
         publishing_app: "whitehall",
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         routes: [
           {
             path: BASE_PATH,

--- a/lib/whitehall/rendering_app.rb
+++ b/lib/whitehall/rendering_app.rb
@@ -2,5 +2,6 @@ module Whitehall
   module RenderingApp
     WHITEHALL_FRONTEND = 'whitehall-frontend'.freeze
     GOVERNMENT_FRONTEND = 'government-frontend'.freeze
+    COLLECTIONS_FRONTEND = 'collections'.freeze
   end
 end


### PR DESCRIPTION
This page has been now been migrated:

http://govuk-collections.herokuapp.com/government/organisations

This switches the rendering_app from Whitehall to Collections. This will tell the router to forward requests for this page to the new app.

https://trello.com/c/bAsH0CWM