### PR TITLE
Add public_updated_at for offsite links

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -234,7 +234,7 @@ module PublishingApi
           alt_text: feature.alt_text
         },
         summary: offsite_link.summary,
-        public_updated_at: nil, # We don't want a date for offsite links
+        public_updated_at: offsite_link.date,
         document_type: offsite_link.humanized_link_type
       }
     end


### PR DESCRIPTION
This commit adds a `public_updated_at` date for offsite links in the organisation content item so it can be displayed on the page.

Trello: https://trello.com/c/lTOLkzUo/148-org-show-page-issues