### PR TITLE
Clean up organisation presenter

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -31,15 +31,6 @@ module PublishingApi
         description: nil,
         details: details,
         document_type: item.class.name.underscore,
-        links: {
-          ordered_contacts: contacts_links,
-          ordered_foi_contacts: foi_contacts_links,
-          ordered_featured_policies: featured_policies_links,
-          ordered_parent_organisations: parent_organisation_links,
-          ordered_child_organisations: child_organisation_links,
-          ordered_successor_organisations: successor_organisation_links,
-          ordered_high_profile_groups: high_profile_groups_links,
-        },
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
         schema_name: schema_name,
@@ -50,7 +41,14 @@ module PublishingApi
 
     def links
       {
-        ordered_roles: item.roles.pluck(:content_id),
+        ordered_contacts: contacts_links,
+        ordered_foi_contacts: foi_contacts_links,
+        ordered_featured_policies: featured_policies_links,
+        ordered_parent_organisations: parent_organisation_links,
+        ordered_child_organisations: child_organisation_links,
+        ordered_successor_organisations: successor_organisation_links,
+        ordered_high_profile_groups: high_profile_groups_links,
+        ordered_roles: roles_links,
       }
     end
 
@@ -358,6 +356,10 @@ module PublishingApi
 
     def featured_policies_links
       item.featured_policies.order(:ordering).distinct.pluck(:policy_content_id)
+    end
+
+    def roles_links
+      item.roles.distinct.pluck(:content_id)
     end
   end
 end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -29,15 +29,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       description: nil,
       schema_name: 'organisation',
       document_type: 'organisation',
-      links: {
-        ordered_contacts: [],
-        ordered_foi_contacts: [],
-        ordered_featured_policies: [],
-        ordered_parent_organisations: [parent_organisation.content_id],
-        ordered_child_organisations: [],
-        ordered_successor_organisations: [],
-        ordered_high_profile_groups: [],
-      },
       locale: 'en',
       publishing_app: 'whitehall',
       rendering_app: 'whitehall-frontend',
@@ -87,6 +78,13 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       analytics_identifier: "O123",
     }
     expected_links = {
+      ordered_contacts: [],
+      ordered_foi_contacts: [],
+      ordered_featured_policies: [],
+      ordered_parent_organisations: [parent_organisation.content_id],
+      ordered_child_organisations: [],
+      ordered_successor_organisations: [],
+      ordered_high_profile_groups: [],
       ordered_roles: [role.content_id],
     }
 


### PR DESCRIPTION
This commit cleans-up the organisation presenter by moving all links to the same place.

Trello: https://trello.com/c/lTOLkzUo/148-org-show-page-issues