### PR TITLE
Separate DocumentListExportWorker to have own queue

### DIFF
--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -1,4 +1,6 @@
 class DocumentListExportWorker < WorkerBase
+  sidekiq_options queue: 'export_documents_list'
+
   def perform(filter_options, user_id)
     user = User.find(user_id)
     filter = create_filter(filter_options, user)


### PR DESCRIPTION
I would like to separate this worker, to have it's own queue, as I believe the emails are not being sent in production.

We currently have a few errors regarding the size of the attachment [being superior to 10MB ](https://sentry.io/govuk/app-whitehall/?query=is%3Aunresolved+Net%3A%3ASMTPFatalError).

I want to narrow down if the queue is too big in Production that the emails are not being triggered in a timely fashion way.