### PR TITLE
Hide ministers in reshuffle mode

### DIFF
--- a/app/views/ministerial_roles/index.html.erb
+++ b/app/views/ministerial_roles/index.html.erb
@@ -19,7 +19,7 @@
       </aside>
     </div>
   </div>
-<% end %>
+<% else %>
 
 <div class="block-2">
   <div class="inner-block floated-children">
@@ -121,3 +121,5 @@
     <% end %>
   </div>
 </div>
+
+<% end %>

--- a/features/sitewide_settings.feature
+++ b/features/sitewide_settings.feature
@@ -9,6 +9,7 @@ Feature: Sitewide settings
     Given we are during a reshuffle
     When I visit the ministers page
     Then I should see a reshuffle warning message
+    And I should not see the ministers and cabinet
 
   Scenario: Minister counts should be visible outside of a minister reshuffle
     Given we are not during a reshuffle

--- a/features/step_definitions/sitewide_settings_steps.rb
+++ b/features/step_definitions/sitewide_settings_steps.rb
@@ -31,3 +31,9 @@ Then(/^I should (not )?see a reshuffle warning message$/) do |negate|
     assert page.has_content?("Test minister reshuffle message")
   end
 end
+
+Then(/^I should not see the ministers and cabinet$/) do
+  refute page.has_css?("h2", text: "Cabinet ministers")
+  refute page.has_css?("h2", text: "Also attends Cabinet")
+  refute page.has_css?("h2", text: "Ministers by department")
+end


### PR DESCRIPTION
During reshuffles we don't want to show the ministers and cabinet, because people and roles are still being assigned.

## Before

<img width="1151" alt="screen shot 2018-06-14 at 16 52 30" src="https://user-images.githubusercontent.com/233676/41423668-d5002fda-6ff3-11e8-9162-dc35884a40fd.png">

## After

<img width="1151" alt="screen shot 2018-06-14 at 16 55 34" src="https://user-images.githubusercontent.com/233676/41423658-d06f36e6-6ff3-11e8-922d-a93b1a8631e9.png">

https://trello.com/c/R6NYgbQ8