### PR TITLE
Update the docs for incorrect javascript test url

### DIFF
--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -41,7 +41,7 @@ To run individual tests or when debugging:
 
     ./script/javascript-test-server
 
-And go to http://localhost:3100/test/qunit in the browser
+And go to http://localhost:3100/teaspoon/default in the browser
 
 ### Shared mustache templates
 

--- a/script/javascript-test-server
+++ b/script/javascript-test-server
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "Starting test server on http://localhost:3100/test/qunit"
+echo "Starting test server on http://localhost:3100/teaspoon/default"
 rails server -p 3100 --environment=test --pid=tmp/pids/javascript_tests.pid
 


### PR DESCRIPTION
The javascript test url is shown as  http://localhost:3100/test/qunit in the docs and command line.

It should be  http://localhost:3100/teaspoon/default.

Discovered when implementing https://trello.com/c/4C2HLbcp/134-add-a-remove-topic-button-to-the-topic-tagging-interface-in-whitehall-2