### PR TITLE
Tweak formatting for organisations relationship text

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -125,7 +125,7 @@ module OrganisationHelper
       child_relationships_link_text = child_organisations.size.to_s
       child_relationships_link_text += child_organisations.size == 1 ? " public body" : " agencies and public bodies"
 
-      organisation_name += link_to(child_relationships_link_text, organisations_path(anchor: organisation.slug))
+      organisation_name += link_to(child_relationships_link_text, organisations_path(anchor: organisation.slug), class: 'brand__color')
       organisation_name += "."
     end
 
@@ -134,7 +134,7 @@ module OrganisationHelper
 
   def organisation_relationship_html(organisation)
     prefix = needs_definite_article?(organisation.name) ? "the " : ""
-    (prefix + link_to(organisation.name, organisation_path(organisation)))
+    (prefix + link_to(organisation.name, organisation_path(organisation), class: 'brand__color'))
   end
 
   def needs_definite_article?(phrase)

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -90,7 +90,13 @@ module PublishingApi
     end
 
     def summary
-      "#{item.summary}#{organisation_display_name_including_parental_and_child_relationships(item)}"
+      "#{item.summary}#{parent_child_relationships_text}"
+    end
+
+    def parent_child_relationships_text
+      if item.parent_organisations.any? || item.supporting_bodies.any?
+        "\n\n#{organisation_display_name_including_parental_and_child_relationships(item)}"
+      end
     end
 
     def brand

--- a/test/unit/helpers/organisation_helper_test.rb
+++ b/test/unit/helpers/organisation_helper_test.rb
@@ -306,7 +306,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   test 'links to parent organisation' do
     parent = create(:organisation)
     child = create(:organisation, parent_organisations: [parent])
-    assert_match %r{the <a href="/government/organisations/#{parent.to_param}">#{parent.name}</a>}, organisation_display_name_and_parental_relationship(child)
+    assert_match %r{the <a class="brand__color" href="/government/organisations/#{parent.to_param}">#{parent.name}</a>}, organisation_display_name_and_parental_relationship(child)
   end
 
   test 'relationship types are described correctly' do

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -38,7 +38,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       update_type: "major",
       details: {
         acronym: nil,
-        body: "Organisation of Things works with the <a href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>.",
+        body: "\n\nOrganisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>.",
         brand: nil,
         logo: {
           formatted_title: "Organisation<br/>of<br/>Things",
@@ -140,5 +140,15 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_nil presented_item.content[:details][:logo][:crest]
+  end
+
+  test 'presents an organisation with no parents/children without the relationship text' do
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things'
+    )
+    presented_item = present(organisation)
+
+    assert_equal("", presented_item.content[:details][:body])
   end
 end


### PR DESCRIPTION
This commit:

* Adds spacing before the organisation relationship text
* Only displays the organisation relationship text if the organisation has parents/children
* Adds a class to links in the organisations relationship text to ensure they have the correct colour