### PR TITLE
Only present images for important board members

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -248,7 +248,7 @@ module PublishingApi
     end
 
     def board_members
-      people_in_role("management")
+      people_in_role("management", important_people: item.important_board_members)
     end
 
     def military_personnel
@@ -267,7 +267,7 @@ module PublishingApi
       people_in_role("special_representative")
     end
 
-    def people_in_role(role_type)
+    def people_in_role(role_type, important_people: 0)
       item.send("#{role_type}_roles")
         .order("organisation_roles.ordering")
         .reduce([]) do |ary, role|
@@ -286,7 +286,8 @@ module PublishingApi
               attends_cabinet_type: role.attends_cabinet_type&.name
             }
 
-            unless person.image.url.nil?
+            unless person.image.url.nil? ||
+                (important_people.positive? && ary.count >= important_people)
               person_object[:image] = {
                 url: person.image.url,
                 alt_text: full_name

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -151,4 +151,39 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
 
     assert_equal("", presented_item.content[:details][:body])
   end
+
+  test 'presents an organisation with the correct important board members' do
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      important_board_members: 2
+    )
+
+    role_1 = create(:board_member_role, organisations: [organisation])
+    board_member_1 = create(
+      :person,
+      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+    )
+    create(:role_appointment, person: board_member_1, role: role_1)
+
+    role_2 = create(:board_member_role, organisations: [organisation])
+    board_member_2 = create(
+      :person,
+      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+    )
+    create(:role_appointment, person: board_member_2, role: role_2)
+
+    role_3 = create(:board_member_role, organisations: [organisation])
+    board_member_3 = create(
+      :person,
+      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
+    )
+    create(:role_appointment, person: board_member_3, role: role_3)
+
+    presented_item = present(organisation)
+
+    refute_nil presented_item.content[:details][:ordered_board_members][0][:image]
+    refute_nil presented_item.content[:details][:ordered_board_members][1][:image]
+    assert_nil presented_item.content[:details][:ordered_board_members][2][:image]
+  end
 end


### PR DESCRIPTION
This commit changes the organisation presenter to only present images for board members that are classed as important.