### PR TITLE
Present promotional features to publishing-api

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -72,6 +72,7 @@ module PublishingApi
         ordered_corporate_information_pages: corporate_information_pages,
         ordered_featured_links: featured_links,
         ordered_featured_documents: featured_documents,
+        ordered_promotional_features: promotional_features,
         ordered_ministers: ministers,
         ordered_board_members: board_members,
         ordered_military_personnel: military_personnel,
@@ -241,6 +242,34 @@ module PublishingApi
         public_updated_at: offsite_link.date,
         document_type: offsite_link.humanized_link_type
       }
+    end
+
+    def promotional_features
+      return [] unless item.type.allowed_promotional?
+
+      item.promotional_features.map do |promotional_feature|
+        {
+          title: promotional_feature.title,
+          items: promotional_feature.items.map do |promotional_feature_item|
+            {
+              title: promotional_feature_item.title,
+              href: promotional_feature_item.title_url,
+              summary: promotional_feature_item.summary,
+              image: {
+                url: promotional_feature_item.image,
+                alt_text: promotional_feature_item.image_alt_text
+              },
+              double_width: promotional_feature_item.double_width,
+              links: promotional_feature_item.links.map do |link|
+                {
+                  title: link.text,
+                  href: link.url
+                }
+              end
+            }
+          end
+        }
+      end
     end
 
     def ministers

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -61,6 +61,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         ],
         ordered_featured_links: [],
         ordered_featured_documents: [],
+        ordered_promotional_features: [],
         ordered_ministers: [],
         ordered_board_members: [],
         ordered_military_personnel: [],
@@ -185,5 +186,39 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     refute_nil presented_item.content[:details][:ordered_board_members][0][:image]
     refute_nil presented_item.content[:details][:ordered_board_members][1][:image]
     assert_nil presented_item.content[:details][:ordered_board_members][2][:image]
+  end
+
+  test 'presents an eligible organisation with promotional features' do
+    promotional_feature = create(:promotional_feature)
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      organisation_type: OrganisationType.executive_office,
+      promotional_features: [promotional_feature]
+    )
+    presented_item = present(organisation)
+
+    assert_equal(
+      [
+        {
+          title: promotional_feature.title,
+          items: []
+        }
+      ],
+      presented_item.content[:details][:ordered_promotional_features]
+    )
+  end
+
+  test 'does not present an ineligible organisation with promotional features' do
+    promotional_feature = create(:promotional_feature)
+    organisation = create(
+      :organisation,
+      name: 'Organisation of Things',
+      organisation_type: OrganisationType.ministerial_department,
+      promotional_features: [promotional_feature]
+    )
+    presented_item = present(organisation)
+
+    assert_equal([], presented_item.content[:details][:ordered_promotional_features])
   end
 end


### PR DESCRIPTION
This commit adds support for presenting promotional features for organisations to the publishing-api. These features are currently used by the Prime Minister’s Office and the Civil Service.

Trello: https://trello.com/c/zzD0d2N5/196-add-promotional-features-to-organisation-content-items