### PR TITLE
Fix contact presenter

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -80,13 +80,16 @@ module PublishingApi
     end
 
     def post_address
-      {
+      post_address = {
         title: recipient || title,
         street_address: street_address,
-        locality: locality,
         postal_code: postal_code,
         world_location: country_name
       }
+
+      post_address[:locality] = locality unless locality.nil?
+
+      post_address
     end
 
     def phone_numbers
@@ -106,17 +109,12 @@ module PublishingApi
     end
 
     def country_name
-      country.try(:title) || ""
+      country.try(:name) || ""
     end
 
     def updated_at
       translation.updated_at
     end
-
     alias_method :public_updated_at, :updated_at
-
-    def rendering_app
-      Whitehall::RenderingApp::GOVERNMENT_FRONTEND
-    end
   end
 end

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -7,11 +7,11 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
 
     world_location = FactoryBot.build(:world_location,
                                        content_id: @world_location_content_id,
-                                       title: "United Kingdom")
+                                       name: "United Kingdom")
 
     @contact = FactoryBot.build(:contact,
                                  title: "Government Digital Service",
-                                 recipient: "GDS mail room",
+                                 recipient: "GDS Mail Room",
                                  street_address: "Aviation House, 125 Kingsway",
                                  postal_code: "WC2B 6NH",
                                  country: world_location,
@@ -42,16 +42,15 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
         contact_type: "General contact",
         post_addresses: [
           {
-            title: "GDS mail room",
+            title: "GDS Mail Room",
             street_address: "Aviation House, 125 Kingsway",
-            locality: nil,
             postal_code: "WC2B 6NH",
             world_location: "United Kingdom",
           }
         ],
         email_addresses: [
           {
-            title: "GDS mail room",
+            title: "GDS Mail Room",
             email: "gds-mailroom@digital.cabinet-office.gov.uk",
           }
         ],
@@ -65,6 +64,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
     }
 
     assert_equal expected_content, @presented.content
+    assert_valid_against_schema(@presented.content, 'contact')
   end
 
   test "links hash includes organisations" do


### PR DESCRIPTION
This commit fixes the contact presenter to follow the correct schema:

* `locality` is only added if it has a value
* `country` uses the country name rather than the title so that it appears as “Armenia” rather than “Armenia and the UK”
* `rendering_app` is removed since it is not used

The tests are also extended to validate the generated content item to stop this happening again.