### PR TITLE
Limit the number of featured documents for organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -185,7 +185,7 @@ module PublishingApi
     end
 
     def featured_documents
-      item.feature_list_for_locale(I18n.locale).current.map do |feature|
+      item.feature_list_for_locale(I18n.locale).current.limit(6).map do |feature|
         if feature.document
           featured_documents_editioned(feature)
         elsif feature.topical_event


### PR DESCRIPTION
This commit limits the number of presented featured documents for organisations to 6 to match the current logic.

Trello: https://trello.com/c/fatjaDI1/198-limit-the-number-of-featured-news-stories-for-an-organisation