### PR TITLE
Present contact form URL for contacts

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -5,7 +5,7 @@ module PublishingApi
     def_delegators :contact,
       :contact_numbers, :content_id, :comments, :country, :email,
       :locality, :postal_code, :recipient, :street_address,
-      :title, :translation
+      :title, :contact_form_url, :translation
 
     def initialize(model, _options)
       @contact = model
@@ -72,11 +72,20 @@ module PublishingApi
 
     def details
       details = { description: description, contact_type: contact_type, title: title }
+      details[:contact_form_links] = [contact_form_links] if contact_form_url
       details[:post_addresses] = [post_address] if postal_code
       details[:email_addresses] = [email_address] if email
       details[:phone_numbers] = phone_numbers if contact_numbers.any?
 
       details
+    end
+
+    def contact_form_links
+      {
+        title: title,
+        link: contact_form_url,
+        description: ""
+      }
     end
 
     def post_address

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -18,7 +18,8 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
                                  contact_numbers: [
                                    ContactNumber.new(label: "Mail Room", number: "+44 12345 67890")
                                  ],
-                                 email: "gds-mailroom@digital.cabinet-office.gov.uk")
+                                 email: "gds-mailroom@digital.cabinet-office.gov.uk",
+                                 contact_form_url: "https://www.gov.uk")
 
     @updated_at = Time.zone.parse("2016-06-23 10:32:00")
     @contact.translation.updated_at = @updated_at
@@ -40,6 +41,13 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
         description: nil,
         title: "Government Digital Service",
         contact_type: "General contact",
+        contact_form_links: [
+          {
+            title: "Government Digital Service",
+            link: "https://www.gov.uk",
+            description: "",
+          }
+        ],
         post_addresses: [
           {
             title: "GDS Mail Room",


### PR DESCRIPTION
This commit adds the contact form URL to the contacts presenter so it is sent to the publishing-api.