### PR TITLE
Reslug Highways Agency road proposals

### DIFF
--- a/db/data_migration/20180622093427_reslug_highways_agency_road_proposals.rb
+++ b/db/data_migration/20180622093427_reslug_highways_agency_road_proposals.rb
@@ -1,0 +1,12 @@
+old_slug = "your-property-and-highways-agency-road-proposals"
+new_slug = "your-property-and-highways-england-road-proposals"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"


### PR DESCRIPTION
To update the name to Highways England.

Zendesk: https://govuk.zendesk.com/agent/tickets/2829919