### PR TITLE
Reslug “Exporting to Belgium”

### DIFF
--- a/db/data_migration/20180622100250_reslug_exporting_to_belgium.rb
+++ b/db/data_migration/20180622100250_reslug_exporting_to_belgium.rb
@@ -1,0 +1,12 @@
+old_slug = "exporting-to-belgium--2"
+new_slug = "exporting-to-belgium"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"


### PR DESCRIPTION
To get rid of the `--2` suffix.

Zendesk: https://govuk.zendesk.com/agent/tickets/2854759