### PR TITLE
Redirect draft asset requests to the draft assets host

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -1,6 +1,10 @@
 class AssetManagerRedirectController < ApplicationController
   def show
-    asset_host = URI.parse(Plek.new.public_asset_host).host
-    redirect_to host: asset_host
+    asset_url = Plek.new.public_asset_host
+    if request.host.start_with?('draft-')
+      asset_url = Plek.new.external_url_for('draft-assets')
+    end
+
+    redirect_to host: URI.parse(asset_url).host
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -3,9 +3,15 @@ class AttachmentsController < BaseAttachmentsController
 
   def show
     unless user_signed_in?
-      asset_host = URI.parse(Plek.new.public_asset_host).host
+      asset_url = if request.host.start_with?('draft-')
+                    Plek.new.external_url_for('draft-assets')
+                  else
+                    Plek.new.public_asset_host
+                  end
+      asset_host = URI.parse(asset_url).host
+
       unless request.host == asset_host
-        redirect_to host: asset_host
+        redirect_to host: asset_url
         return
       end
     end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -11,7 +11,7 @@ class AttachmentsController < BaseAttachmentsController
       asset_host = URI.parse(asset_url).host
 
       unless request.host == asset_host
-        redirect_to host: asset_url
+        redirect_to host: asset_host
         return
       end
     end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -24,6 +24,7 @@ class AttachmentsControllerTest < ActionController::TestCase
 
     request.host = 'asset-host.com'
     Plek.any_instance.stubs(:public_asset_host).returns('http://asset-host.com')
+    Plek.any_instance.stubs(:external_url_for).returns('http://draft-asset-host.com')
   end
 
   teardown do
@@ -42,6 +43,24 @@ class AttachmentsControllerTest < ActionController::TestCase
     setup_stubs
     login_as :user
     request.host = 'not-asset-host.com'
+
+    get :show, params: params
+
+    assert_response 200
+  end
+
+  test "redirects draft asset requests that aren't made via the draft asset host when no user is signed in" do
+    request.host = 'draft-not-asset-host.com'
+
+    get :show, params: params
+
+    assert_redirected_to "http://draft-asset-host.com#{attachment_data.file.asset_manager_path}"
+  end
+
+  test 'serves draft asset requests when not made from draft asset host if there is a signed in user' do
+    setup_stubs
+    login_as :user
+    request.host = 'draft-not-asset-host.com'
 
     get :show, params: params
 


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/7701, we're merging draft-whitehall-frontend with whitehall-admin, to avoid the special-case behaviour of serving asset files directly from NFS.  This means that the asset host redirects in whitehall now need to redirect to the draft-assets host if the request came from draft-origin.

---

[Trello card](https://trello.com/c/sMwEMvsv/265-redirect-draft-origin-assets-to-assets-origin)