### PR TITLE
Limit the number of records which can be exported.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -59,8 +59,12 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def export
-    DocumentListExportWorker.perform_async(params_filters_with_default_state, current_user.id)
-    flash[:notice] = "The document list is being exported"
+    if filter && filter.exportable?
+      DocumentListExportWorker.perform_async(params_filters_with_default_state, current_user.id)
+      flash[:notice] = "The document list is being exported"
+    else
+      flash[:alert] = "The document list is too large for export"
+    end
     redirect_to params_filters.merge(action: :index)
   end
 

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -7,6 +7,8 @@ module Admin
       lookup
     end
 
+    MAX_EXPORT_SIZE = 8000
+
     attr_reader :options
 
     def initialize(source, current_user, options = {})
@@ -91,6 +93,10 @@ module Admin
       elsif to_date
         "before #{to_date.to_date.to_s(:uk_short)}"
       end
+    end
+
+    def exportable?
+      unpaginated_editions.count <= MAX_EXPORT_SIZE
     end
 
   private

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -274,6 +274,18 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  view_test "prevents oversized exports" do
+    login_as(create(:gds_editor))
+    Admin::EditionFilter.any_instance.stubs(exportable?: false)
+    post :export, params: {
+      include_last_author: true,
+      include_link_check_reports: true,
+      include_unpublishing: true,
+      state: 'active',
+    }
+    assert_equal "The document list is too large for export", flash[:alert]
+  end
+
 private
 
   def stub_edition_filter(attributes = {})

--- a/test/unit/admin/edition_filter_test.rb
+++ b/test/unit/admin/edition_filter_test.rb
@@ -325,4 +325,12 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     filter.each_edition_for_csv { |_unused| count += 1 }
     assert_equal 3, count
   end
+
+  test "exportable? if number of editions is below threshold" do
+    filter = Admin::EditionFilter.new(Edition, build(:user), per_page: 2)
+    filter.stubs(:unpaginated_editions).returns(stub(count: 8000))
+    assert filter.exportable?
+    filter.stubs(:unpaginated_editions).returns(stub(count: 8001))
+    refute filter.exportable?
+  end
 end


### PR DESCRIPTION
https://trello.com/c/l8OjBZ5W/256-look-into-whitehall-documentlistexportworker-for-limits-cpu-memory-usage-email-size

![screenshot from 2018-06-25 11-51-11](https://user-images.githubusercontent.com/93511/41846281-1da01e80-786e-11e8-83d1-236e96ac4ce2.png)


Large exports of unfiltered documents can total around 250,000
records which makes for a > 10MB email attachment, which then fails
to be sent because of notification limits.
It also loads the backend quite heavily so adding a restriction with
an appropriate message is the agreed protection against this.

The limit is 8000 documents which was determined with a few tests on staging. Anything above ~8000 documents failed to create attachments because of the 10MB threshold.

