### PR TITLE
Publish org routes

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -3,7 +3,7 @@ module PublishingApi
     include Rails.application.routes.url_helpers
     include ApplicationHelper
     include FilterRoutesHelper
-    # This is so we can get the extra text for the summary field
+    # This is so we can get the extra text for the summary field
     include OrganisationHelper
     # This is a hack to get the OrganisationHelper to work in this context
     include ActionView::Helpers::UrlHelper
@@ -32,7 +32,7 @@ module PublishingApi
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
+        rendering_app: rendering_app,
         schema_name: schema_name,
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
@@ -56,6 +56,14 @@ module PublishingApi
 
     def schema_name
       "organisation"
+    end
+
+    def rendering_app
+      if item.organisation_type.court?
+        Whitehall::RenderingApp::WHITEHALL_FRONTEND
+      else
+        Whitehall::RenderingApp::COLLECTIONS_FRONTEND
+      end
     end
 
     def details

--- a/lib/tasks/publish_organisation_routes.rake
+++ b/lib/tasks/publish_organisation_routes.rake
@@ -1,0 +1,39 @@
+namespace :router do
+  desc "Switch organisations to be rendered from collections. This should be
+  followed by a republish of organisations, but this takes several hours so is
+  a little unwieldy"
+  task render_orgs_from_collections: :environment do
+    set_routes(Whitehall::RenderingApp::COLLECTIONS_FRONTEND)
+  end
+
+  def set_routes(rendering_app)
+    router_api = GdsApi::Router.new(Plek.find('router-api'))
+
+    Organisation.all.order(:slug).each do |org|
+      set_route_for_org(router_api, org, rendering_app)
+    end
+
+    router_api.commit_routes
+  end
+
+  def set_route_for_org(router_api, organisation, rendering_app)
+    path = Whitehall.url_maker.polymorphic_path(organisation)
+
+    unless path.start_with? "/court"
+      puts "adding route for #{path} to #{rendering_app}"
+      router_api.add_route(path, "exact", rendering_app)
+
+      if organisation.translations.count > 1
+        puts "adding route for #{path}.cy to #{rendering_app}"
+        router_api.add_route("#{path}.cy", "exact", rendering_app)
+      end
+    end
+  end
+
+  desc "Switch organisations to be rendered from whitehall. The presenter would
+  need to be fixed as well if this is done on production, followed by a republish
+  of organisations, but this takes several hours so is a little unwieldy"
+  task render_orgs_from_whitehall: :environment do
+    set_routes(Whitehall::RenderingApp::WHITEHALL_FRONTEND)
+  end
+end

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -37,9 +37,11 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       document_type: 'organisation',
       locale: 'en',
       publishing_app: 'whitehall',
-      rendering_app: 'whitehall-frontend',
+      rendering_app: 'collections',
       public_updated_at: organisation.updated_at,
-      routes: [{ path: public_path, type: "exact" }],
+      routes: [
+        { path: public_path, type: "exact" }
+      ],
       redirects: [],
       update_type: "major",
       details: {
@@ -198,5 +200,17 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_equal("http://www.example.com/org-of-things", presented_item.content[:details][:organisation_govuk_status][:url])
+  end
+
+  test 'renders courts via Whitehall' do
+    organisation = create(
+      :organisation,
+      name: 'Court at mid-wicket',
+      organisation_type_key: "court",
+    )
+    presented_item = present(organisation)
+
+    assert_equal("whitehall-frontend", presented_item.content[:rendering_app])
+    assert_equal([{ path: "/courts-tribunals/court-at-mid-wicket", type: "exact" }], presented_item.content[:routes])
   end
 end


### PR DESCRIPTION
This makes publishing org pages set the routes for that page to go to collections.

This also contain rake tasks to switch org routes between collections and whitehall so that we can do visual regression testing more easily than republishing everything.

We'll remove those tasks once we're happy.

https://trello.com/c/K1IzeNgz/205-publish-routes-for-org-pages