### PR TITLE
Add brand color class to secondary CIPs

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -237,7 +237,8 @@ module PublishingApi
       page.extend(UseSlugAsParam)
       link_to(
         t_corporate_information_page_type_link_text(page),
-        Whitehall.url_maker.public_document_path(page)
+        Whitehall.url_maker.public_document_path(page),
+        class: "brand__color"
       )
     end
 


### PR DESCRIPTION
This commit adds the `brand__color` class to all links in the `secondary_corporate_information_pages` sentences to make their colour consistent with the brand colour of the organisation in question.

Trello: https://trello.com/c/x2P5X6Kt/209-need-branding-on-secondary-corporate-information-links