### PR TITLE
Update contact fields presented to publishing-api

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -4,7 +4,7 @@ module PublishingApi
 
     def_delegators :contact,
       :contact_numbers, :content_id, :comments, :country, :email,
-      :locality, :postal_code, :recipient, :street_address,
+      :locality, :region, :postal_code, :recipient, :street_address,
       :title, :contact_form_url, :translation
 
     def initialize(model, _options)
@@ -90,13 +90,13 @@ module PublishingApi
 
     def post_address
       post_address = {
-        title: recipient || title,
+        title: recipient || "",
         street_address: street_address,
+        locality: locality || "",
+        region: region || "",
         postal_code: postal_code,
         world_location: country_name
       }
-
-      post_address[:locality] = locality unless locality.nil?
 
       post_address
     end
@@ -112,7 +112,7 @@ module PublishingApi
 
     def email_address
       {
-        title: recipient || title,
+        title: recipient || "",
         email: email,
       }
     end

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -52,6 +52,8 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
           {
             title: "GDS Mail Room",
             street_address: "Aviation House, 125 Kingsway",
+            locality: "",
+            region: "",
             postal_code: "WC2B 6NH",
             world_location: "United Kingdom",
           }


### PR DESCRIPTION
This commit updates the contact presenter with the following changes:

* The recipient name is no longer changed to the contact title if there is no recipient, so that the title is not repeated on pages
* `locality` is changed to always be published
* `region` is added

Trello: https://trello.com/c/u2NZwnL7/61-cefas-first-line-of-address-contains-section-title