### PR TITLE
Add field for important board members

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -80,6 +80,7 @@ module PublishingApi
         ordered_traffic_commissioners: traffic_commissioners,
         ordered_chief_professional_officers: chief_professional_officers,
         ordered_special_representatives: special_representatives,
+        important_board_members: important_board_members,
         organisation_featuring_priority: organisation_featuring_priority,
         organisation_govuk_status: organisation_govuk_status,
         organisation_type: organisation_type,
@@ -346,7 +347,7 @@ module PublishingApi
     end
 
     def board_members
-      people_in_role("management", important_people: item.important_board_members)
+      people_in_role("management")
     end
 
     def military_personnel
@@ -365,7 +366,7 @@ module PublishingApi
       people_in_role("special_representative")
     end
 
-    def people_in_role(role_type, important_people: 0)
+    def people_in_role(role_type)
       item.send("#{role_type}_roles")
         .order("organisation_roles.ordering")
         .reduce([]) do |ary, role|
@@ -384,8 +385,7 @@ module PublishingApi
               attends_cabinet_type: role.attends_cabinet_type&.name
             }
 
-            unless person.image.url.nil? ||
-                (important_people.positive? && ary.count >= important_people)
+            unless person.image.url.nil?
               person_object[:image] = {
                 url: person.image.url,
                 alt_text: full_name
@@ -397,6 +397,10 @@ module PublishingApi
 
           ary
         end
+    end
+
+    def important_board_members
+      item.important_board_members
     end
 
     def organisation_featuring_priority

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -23,7 +23,8 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       name: 'Organisation of Things',
       analytics_identifier: 'O123',
       parent_organisations: [parent_organisation],
-      url: "https://www.gov.uk/oot"
+      url: "https://www.gov.uk/oot",
+      important_board_members: 5
     )
     role = create(:role, organisations: [organisation])
     public_path = Whitehall.url_maker.organisation_path(organisation)
@@ -66,6 +67,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         ordered_traffic_commissioners: [],
         ordered_chief_professional_officers: [],
         ordered_special_representatives: [],
+        important_board_members: 5,
         organisation_featuring_priority: "news",
         organisation_govuk_status: {
           status: "live",
@@ -150,41 +152,6 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     presented_item = present(organisation)
 
     assert_equal(govspeak_to_html(""), presented_item.content[:details][:body])
-  end
-
-  test 'presents an organisation with the correct important board members' do
-    organisation = create(
-      :organisation,
-      name: 'Organisation of Things',
-      important_board_members: 2
-    )
-
-    role_1 = create(:board_member_role, organisations: [organisation])
-    board_member_1 = create(
-      :person,
-      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
-    )
-    create(:role_appointment, person: board_member_1, role: role_1)
-
-    role_2 = create(:board_member_role, organisations: [organisation])
-    board_member_2 = create(
-      :person,
-      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
-    )
-    create(:role_appointment, person: board_member_2, role: role_2)
-
-    role_3 = create(:board_member_role, organisations: [organisation])
-    board_member_3 = create(
-      :person,
-      image: fixture_file_upload('minister-of-funk.960x640.jpg', 'image/jpg')
-    )
-    create(:role_appointment, person: board_member_3, role: role_3)
-
-    presented_item = present(organisation)
-
-    refute_nil presented_item.content[:details][:ordered_board_members][0][:image]
-    refute_nil presented_item.content[:details][:ordered_board_members][1][:image]
-    assert_nil presented_item.content[:details][:ordered_board_members][2][:image]
   end
 
   test 'presents an eligible organisation with promotional features' do


### PR DESCRIPTION
This commit adds a new field to the organisation presenter to denote the number of important board members, which are board members who have their photos displayed on the organisation home page. It also removes the former logic which only presented photos for such people since it didn’t work for people with multiple roles.

Trello: https://trello.com/c/bQTgWtGh/43-img-missing