### PR TITLE
Don’t present organisation relationship info for closed organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -99,7 +99,9 @@ module PublishingApi
     end
 
     def parent_child_relationships_text
-      unless item.organisation_type.executive_office? || item.organisation_type.civil_service?
+      unless item.organisation_type.executive_office? ||
+          item.organisation_type.civil_service? ||
+          item.closed?
         if item.parent_organisations.any? || item.supporting_bodies.any?
           "\n\n#{organisation_display_name_including_parental_and_child_relationships(item)}"
         end


### PR DESCRIPTION
This commit prevents the organisation presenter from presenting details of an organisation’s relationships with other organisations if it is closed.

https://trello.com/c/Ekh48rFg/99-part-of-still-on-closed-orgs-and-shouldnt-be