### PR TITLE
Disable asset workers & block publishing an edition until all assets have uploaded to the asset-manager

### DIFF
--- a/app/assets/stylesheets/admin/document.scss
+++ b/app/assets/stylesheets/admin/document.scss
@@ -120,6 +120,11 @@ ol.existing-attachments {
       display: block;
     }
 
+    p.asset-manager-uploading {
+      color: $notice-color;
+      background: $notice-background;
+    }
+
     p.virus-scanning {
       color: $notice-color;
       background: $notice-background;
@@ -160,6 +165,10 @@ input[name="next"] {
 }
 input[name="legacy_tags"] {
   margin-left: 0.4em;
+}
+
+.asset-manager-uploading-status {
+  width: 20%;
 }
 
 .virus-status {

--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -194,6 +194,6 @@ private
   end
 
   def attachment_updater
-    ServiceListeners::AttachmentUpdater.new(attachable.reload).update!
+    ServiceListeners::AttachmentUpdater.call(attachable: attachable.reload)
   end
 end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -244,6 +244,12 @@ module Admin::EditionsHelper
     end
   end
 
+  def attachment_uploading_status(attachment)
+    return unless attachment.attachment_data
+    content_tag(:p, "Uploading", class: "asset-manager-uploading") unless
+      attachment.attachment_data.uploaded_to_asset_manager_at
+  end
+
   def attachment_metadata_tag(attachment)
     labels = {
       isbn: 'ISBN',

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -247,7 +247,7 @@ module Admin::EditionsHelper
   def attachment_uploading_status(attachment)
     return unless attachment.attachment_data
     content_tag(:p, "Uploading", class: "asset-manager-uploading") unless
-      attachment.attachment_data.uploaded_to_asset_manager_at
+      attachment.attachment_data.uploaded_to_asset_manager?
   end
 
   def attachment_metadata_tag(attachment)

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -75,6 +75,14 @@ module Attachable
     true
   end
 
+  def uploaded_to_asset_manager?
+    attachments.each do |attachment|
+      next unless attachment.attachment_data
+      return false unless attachment.attachment_data.uploaded_to_asset_manager_at
+    end
+    true
+  end
+
   def allows_attachments?
     true
   end

--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -76,11 +76,10 @@ module Attachable
   end
 
   def uploaded_to_asset_manager?
-    attachments.each do |attachment|
-      next unless attachment.attachment_data
-      return false unless attachment.attachment_data.uploaded_to_asset_manager_at
-    end
-    true
+    attachments
+      .map(&:attachment_data)
+      .compact
+      .all?(&:uploaded_to_asset_manager?)
   end
 
   def allows_attachments?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -108,6 +108,10 @@ class AttachmentData < ApplicationRecord
     ServiceListeners::AttachmentUpdater.update_attachment_data! self
   end
 
+  def uploaded_to_asset_manager?
+    uploaded_to_asset_manager_at.present?
+  end
+
   def deleted?
     significant_attachment(include_deleted_attachables: true).deleted?
   end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -105,7 +105,7 @@ class AttachmentData < ApplicationRecord
 
   def uploaded_to_asset_manager!
     update!(uploaded_to_asset_manager_at: Time.zone.now)
-    ServiceListeners::AttachmentUpdater.update_attachment_data! self
+    ServiceListeners::AttachmentUpdater.call(attachment_data: self)
   end
 
   def uploaded_to_asset_manager?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -103,6 +103,11 @@ class AttachmentData < ApplicationRecord
     end
   end
 
+  def uploaded_to_asset_manager!
+    update!(uploaded_to_asset_manager_at: Time.now)
+    ServiceListeners::AttachmentUpdater.update_attachment_data! self
+  end
+
   def deleted?
     significant_attachment(include_deleted_attachables: true).deleted?
   end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -104,7 +104,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def uploaded_to_asset_manager!
-    update!(uploaded_to_asset_manager_at: Time.now)
+    update!(uploaded_to_asset_manager_at: Time.zone.now)
     ServiceListeners::AttachmentUpdater.update_attachment_data! self
   end
 

--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -7,6 +7,7 @@ module Edition::Publishing
     validates :major_change_published_at, presence: true, if: :published?
     validate :change_note_present!, if: :change_note_required?
     validate :attachment_passed_virus_scan!, if: :virus_check_required?
+    validate :attachment_uploaded_to_asset_manager!, if: :asset_manager_check_required?
 
     attr_accessor :skip_virus_status_check
 
@@ -58,8 +59,16 @@ module Edition::Publishing
     allows_attachments? && published? && !skip_virus_status_check
   end
 
+  def asset_manager_check_required?
+    allows_attachments? && published?
+  end
+
   def attachment_passed_virus_scan!
     errors.add(:attachments, "must have passed virus scanning.") unless valid_virus_state?
+  end
+
+  def attachment_uploaded_to_asset_manager!
+    errors.add(:attachments, "must have finished uploading.") unless uploaded_to_asset_manager?
   end
 
   def build_unpublishing(attributes = {})

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -5,56 +5,55 @@ module ServiceListeners
     end
 
     def update!
-      Attachment.where(attachable: attachable.attachables).find_each do |attachment|
+      Attachment.where(attachable: @attachable.attachables).find_each do |attachment|
         next unless attachment.attachment_data
-
-        draft_status_updater attachment.attachment_data
-        redirect_url_updater attachment.attachment_data
-        link_header_updater attachment.attachment_data
-        access_limited_updater attachment.attachment_data
-        deleter attachment.attachment_data
-
-        AttachmentData.where(replaced_by_id: attachment.attachment_data.id).find_each do |attachment_data|
-          replacement_id_updater attachment_data
-        end
+        self.class.update_attachment_data! attachment.attachment_data
       end
     end
 
-  private
+    def self.update_attachment_data!(attachment_data)
+      draft_status_updater attachment_data
+      redirect_url_updater attachment_data
+      link_header_updater attachment_data
+      access_limited_updater attachment_data
+      deleter attachment_data
 
-    attr_reader :attachable
+      AttachmentData.where(replaced_by_id: attachment_data.id).find_each do |data|
+        replacement_id_updater data
+      end
+    end
 
-    def draft_status_updater(attachment_data)
+    def self.draft_status_updater(attachment_data)
       ServiceListeners::AttachmentDraftStatusUpdater
         .new(attachment_data)
         .update!
     end
 
-    def redirect_url_updater(attachment_data)
+    def self.redirect_url_updater(attachment_data)
       ServiceListeners::AttachmentRedirectUrlUpdater
         .new(attachment_data)
         .update!
     end
 
-    def link_header_updater(attachment_data)
+    def self.link_header_updater(attachment_data)
       ServiceListeners::AttachmentLinkHeaderUpdater
         .new(attachment_data)
         .update!
     end
 
-    def access_limited_updater(attachment_data)
+    def self.access_limited_updater(attachment_data)
       ServiceListeners::AttachmentAccessLimitedUpdater
         .new(attachment_data)
         .update!
     end
 
-    def replacement_id_updater(attachment_data)
+    def self.replacement_id_updater(attachment_data)
       ServiceListeners::AttachmentReplacementIdUpdater
         .new(attachment_data)
         .update!
     end
 
-    def deleter(attachment_data)
+    def self.deleter(attachment_data)
       ServiceListeners::AttachmentDeleter
         .new(attachment_data)
         .delete!

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -12,6 +12,8 @@ module ServiceListeners
     end
 
     def self.update_attachment_data!(attachment_data)
+      return unless attachment_data.uploaded_to_asset_manager_at
+
       draft_status_updater attachment_data
       redirect_url_updater attachment_data
       link_header_updater attachment_data

--- a/app/services/service_listeners/attachment_updater.rb
+++ b/app/services/service_listeners/attachment_updater.rb
@@ -1,17 +1,18 @@
 module ServiceListeners
   class AttachmentUpdater
-    def initialize(attachable)
-      @attachable = attachable
+    def self.call(attachable: nil, attachment_data: nil)
+      update_attachable! attachable if attachable
+      update_attachment_data! attachment_data if attachment_data
     end
 
-    def update!
-      Attachment.where(attachable: @attachable.attachables).find_each do |attachment|
+    private_class_method def self.update_attachable!(attachable)
+      Attachment.where(attachable: attachable.attachables).find_each do |attachment|
         next unless attachment.attachment_data
-        self.class.update_attachment_data! attachment.attachment_data
+        update_attachment_data! attachment.attachment_data
       end
     end
 
-    def self.update_attachment_data!(attachment_data)
+    private_class_method def self.update_attachment_data!(attachment_data)
       return unless attachment_data.uploaded_to_asset_manager_at
 
       draft_status_updater attachment_data
@@ -25,37 +26,37 @@ module ServiceListeners
       end
     end
 
-    def self.draft_status_updater(attachment_data)
+    private_class_method def self.draft_status_updater(attachment_data)
       ServiceListeners::AttachmentDraftStatusUpdater
         .new(attachment_data)
         .update!
     end
 
-    def self.redirect_url_updater(attachment_data)
+    private_class_method def self.redirect_url_updater(attachment_data)
       ServiceListeners::AttachmentRedirectUrlUpdater
         .new(attachment_data)
         .update!
     end
 
-    def self.link_header_updater(attachment_data)
+    private_class_method def self.link_header_updater(attachment_data)
       ServiceListeners::AttachmentLinkHeaderUpdater
         .new(attachment_data)
         .update!
     end
 
-    def self.access_limited_updater(attachment_data)
+    private_class_method def self.access_limited_updater(attachment_data)
       ServiceListeners::AttachmentAccessLimitedUpdater
         .new(attachment_data)
         .update!
     end
 
-    def self.replacement_id_updater(attachment_data)
+    private_class_method def self.replacement_id_updater(attachment_data)
       ServiceListeners::AttachmentReplacementIdUpdater
         .new(attachment_data)
         .update!
     end
 
-    def self.deleter(attachment_data)
+    private_class_method def self.deleter(attachment_data)
       ServiceListeners::AttachmentDeleter
         .new(attachment_data)
         .delete!

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -16,6 +16,7 @@
           <%= attachment.is_a?(ExternalAttachment) ? 'Link' : 'File' %>: <%= link_to_attachment(attachment, preview: true, full_url: true) %>
         </span>
         <%= attachment_virus_status(attachment) %>
+        <%= attachment_uploading_status(attachment) %>
         <%= attachment_metadata_tag(attachment) %>
 
         <% if attachable.can_order_attachments? %>

--- a/app/views/admin/editions/_edit_attachments.html.erb
+++ b/app/views/admin/editions/_edit_attachments.html.erb
@@ -18,6 +18,7 @@
       </td>
       <td class="attachment-filename"><%= link_to_attachment(attachment, preview: !@edition.published?, truncate: @edition.imported?) %></td>
       <td class="virus-status"><%= attachment_virus_status(attachment) %></td>
+      <td class="asset-manager-uploading-status"><%= attachment_uploading_status(attachment) %></td>
     </tr>
   <% end %>
   </table>

--- a/app/views/admin/editions/_show_attachments.html.erb
+++ b/app/views/admin/editions/_show_attachments.html.erb
@@ -4,6 +4,7 @@
     <th>Title</th>
     <th>Filename</th>
     <th></th>
+    <th></th>
   </tr>
 </thead>
 <% @edition.attachments.each do |attachment| %>
@@ -13,6 +14,7 @@
     </td>
     <td class="attachment-filename"><%= link_to_attachment(attachment, preview: !@edition.published?, truncate: @edition.imported?, full_url: true) %></td>
     <td class="virus-status"><%= attachment_virus_status(attachment) %></td>
+    <td class="asset-manager-uploading-status"><%= attachment_uploading_status(attachment) %></td>
     <!--<td><%= attachment_metadata_tag(attachment) %></td>-->
   </tr>
 <% end %>

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -21,6 +21,14 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     end
 
     asset_manager.create_whitehall_asset(asset_options)
+
+    if model
+      Attachment.where(attachable: model.attachables).where.not(attachment_data: nil).find_each do |attachment|
+        attachment.attachment_data.uploaded_to_asset_manager_at = Time.now
+        attachment.attachment_data.save!
+      end
+    end
+
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
   end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -24,8 +24,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
 
     if model
       Attachment.where(attachable: model.attachables).where.not(attachment_data: nil).find_each do |attachment|
-        attachment.attachment_data.uploaded_to_asset_manager_at = Time.now
-        attachment.attachment_data.save!
+        attachment.attachment_data.uploaded_to_asset_manager!
       end
     end
 

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -7,9 +7,7 @@ Whitehall.edition_services.tap do |coordinator|
   end
 
   coordinator.subscribe do |_event, edition, _options|
-    ServiceListeners::AttachmentUpdater
-      .new(edition)
-      .update!
+    ServiceListeners::AttachmentUpdater.call(attachable: edition)
   end
 
   coordinator.subscribe('unpublish') do |_event, edition, _options|

--- a/db/migrate/20180626121716_add_uploaded_to_asset_manager_at_time_to_attachment_data.rb
+++ b/db/migrate/20180626121716_add_uploaded_to_asset_manager_at_time_to_attachment_data.rb
@@ -1,0 +1,11 @@
+class AddUploadedToAssetManagerAtTimeToAttachmentData < ActiveRecord::Migration[5.0]
+  def up
+    add_column :attachment_data, :uploaded_to_asset_manager_at, :datetime
+    AttachmentData.reset_column_information
+    AttachmentData.update_all(uploaded_to_asset_manager_at: Time.zone.now)
+  end
+
+  def down
+    remove_column :attachment_data, :uploaded_to_asset_manager_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180608101314) do
+ActiveRecord::Schema.define(version: 20180626121716) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "topical_event_id"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20180608101314) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "replaced_by_id"
+    t.datetime "uploaded_to_asset_manager_at"
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id", using: :btree
   end
 

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -57,6 +57,15 @@ Feature: Managing attachments on editions
     When I try and upload an attachment but there are validation errors
     Then I should be able to submit the attachment without re-uploading the file
 
+  Scenario: Attempting to publish attachment which is still being uploaded to the asset manager
+    Given I am an editor
+    And a published publication "Standard Beard Lengths" with a PDF attachment
+    And the attachment has been virus-checked
+    And the attachment has been uploaded to the asset-manager
+    When I replace the data file of the attachment in a new draft of the publication
+    And I try to publish the draft edition
+    Then I see a validation error for uploading attachments
+
   Scenario: Editing metadata on attachments
     Given I am an writer
     And I start drafting a new publication "Standard Beard Lengths"

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -35,8 +35,10 @@ Feature: Managing attachments on editions
     Given I am an editor
     And a published publication "Standard Beard Lengths" with a PDF attachment
     And the attachment has been virus-checked
+    And the attachment has been uploaded to the asset-manager
     When I replace the data file of the attachment in a new draft of the publication
     And the attachment has been virus-checked
+    And the attachment has been uploaded to the asset-manager
     Then the new data file should not have replaced the old data file
     When I published the draft edition
     And I log out

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -8,6 +8,10 @@ When(/^the (?:attachment|image)s? (?:has|have) been virus\-checked$/) do
   FileUtils.mkdir(Whitehall.incoming_uploads_root)
 end
 
+When(/^the attachment has been uploaded to the asset\-manager$/) do
+  Attachment.last.attachment_data.uploaded_to_asset_manager!
+end
+
 When(/^I start editing the attachments from the .*? page$/) do
   click_on 'Modify attachments'
 end

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -119,3 +119,8 @@ Then(/^the html attachment "(.*?)" includes the contact address "(.*?)" and the 
   assert_equal isbn, html_attachment.isbn
   assert_equal web_isbn, html_attachment.web_isbn
 end
+
+Then(/^I see a validation error for uploading attachments$/) do
+  assert page.has_content?("must have finished uploading"),
+    "Uploading attachment validation message not found"
+end

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -122,6 +122,7 @@ Then(/^I should be able to add attachments to the "(.*?)" corporate information 
   attachment = upload_pdf_to_corporate_information_page(page)
   VirusScanHelpers.simulate_virus_scan(attachment.attachment_data.file)
   insert_attachment_markdown_into_corporate_information_page_body(attachment, page)
+  Attachment.last.attachment_data.uploaded_to_asset_manager!
   publish(force: true)
   check_attachment_appears_on_corporate_information_page(attachment, page)
 end

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -128,6 +128,11 @@ When(/^I published the draft edition$/) do
   publish(force: true)
 end
 
+When(/^I try to publish the draft edition$/) do
+  visit admin_publication_path(@new_edition)
+  publish(force: true, ignore_errors: true)
+end
+
 Then(/^the old data file should redirect to the new data file$/) do
   new_attachment_data = @new_edition.attachments.first.attachment_data
   old_attachment_data = @old_edition.reload.attachments.first.attachment_data

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :attachment_data do
     file { File.open(File.join(Rails.root, 'test', 'fixtures', 'greenpaper.pdf')) }
-    uploaded_to_asset_manager_at { Time.now }
+    uploaded_to_asset_manager_at { Time.zone.now }
   end
 
   factory :image_attachment_data, parent: :attachment_data do

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :attachment_data do
     file { File.open(File.join(Rails.root, 'test', 'fixtures', 'greenpaper.pdf')) }
+    uploaded_to_asset_manager_at { Time.now }
   end
 
   factory :image_attachment_data, parent: :attachment_data do

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -23,6 +23,8 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
 
       add_file_attachment('logo.png', to: edition)
       VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      edition.attachments[0].attachment_data.uploaded_to_asset_manager!
+      edition.save!
 
       stub_whitehall_asset('logo.png', id: 'asset-id', draft: true)
     end
@@ -36,7 +38,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'marks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).with('asset-id', 'access_limited' => ['user-uid'])
+        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => ['user-uid'])
 
         AssetManagerAttachmentAccessLimitedWorker.drain
       end
@@ -152,6 +154,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
 
       add_file_attachment('logo.png', to: edition)
       VirusScanHelpers.simulate_virus_scan(include_versions: true)
+      edition.attachments[0].attachment_data.uploaded_to_asset_manager!
 
       stub_whitehall_asset('logo.png', id: 'asset-id', draft: true)
     end
@@ -165,7 +168,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'unmarks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).with('asset-id', 'access_limited' => [])
+        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => [])
 
         AssetManagerAttachmentAccessLimitedWorker.drain
       end

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -23,6 +23,8 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       setup_publishing_api_for(edition)
       stub_whitehall_asset(filename, id: asset_id)
       VirusScanHelpers.simulate_virus_scan
+      attachment.attachment_data.uploaded_to_asset_manager!
+      edition.save!
 
       visit admin_news_article_path(edition)
       click_link 'Modify attachments'
@@ -50,7 +52,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'deletes corresponding asset(s) in Asset Manager' do
-        Services.asset_manager.expects(:delete_asset).with(asset_id)
+        Services.asset_manager.expects(:delete_asset).at_least_once.with(asset_id)
         AssetManagerAttachmentDeleteWorker.drain
       end
     end
@@ -69,7 +71,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'deletes corresponding asset(s) in Asset Manager' do
-        Services.asset_manager.expects(:delete_asset).with(asset_id)
+        Services.asset_manager.expects(:delete_asset).at_least_once.with(asset_id)
         AssetManagerAttachmentDeleteWorker.drain
       end
     end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -24,6 +24,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
       setup_publishing_api_for(edition)
       attachable.attachments << attachment
       VirusScanHelpers.simulate_virus_scan
+      attachable.save!
     end
 
     context 'on a draft document' do
@@ -82,6 +83,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
     it 'marks attachment as published in Asset Manager when added to policy group' do
       visit admin_policy_group_attachments_path(policy_group)
       add_attachment(filename)
+      Attachment.last.attachment_data.uploaded_to_asset_manager!
       assert_sets_draft_status_in_asset_manager_to false
     end
   end

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -25,6 +25,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
       setup_publishing_api_for(edition)
       attachable.attachments << attachment
       VirusScanHelpers.simulate_virus_scan
+      attachable.save!
     end
 
     context 'on a draft document' do
@@ -38,6 +39,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
         parent_document_url = Whitehall.url_maker.public_document_url(edition)
 
         Services.asset_manager.expects(:update_asset)
+          .at_least_once
           .with(asset_id, 'parent_document_url' => parent_document_url)
 
         AssetManagerAttachmentLinkHeaderUpdateWorker.drain

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -21,6 +21,7 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
     attachable.attachments << attachment
     VirusScanHelpers.simulate_virus_scan
     stub_whitehall_asset(filename, id: asset_id)
+    attachable.save!
 
     asset_host = URI.parse(Plek.new.public_asset_host).host
     host! asset_host

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -45,6 +45,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
         assert_text "Attachment 'Attachment Title' updated"
 
         VirusScanHelpers.simulate_virus_scan
+        Attachment.last.attachment_data.uploaded_to_asset_manager!
         stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
       end
 
@@ -86,6 +87,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
         click_button 'Save'
         assert_text "Attachment 'attachment-title' updated"
         VirusScanHelpers.simulate_virus_scan
+        Attachment.last.attachment_data.uploaded_to_asset_manager!
         stub_whitehall_asset(replacement_filename, id: replacement_asset_id)
       end
 

--- a/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
+++ b/test/unit/workers/asset_manager_create_whitehall_asset_worker_test.rb
@@ -73,10 +73,11 @@ class AssetManagerCreateWhitehallAssetWorkerTest < ActiveSupport::TestCase
     FactoryBot.create(:user, organisation: organisation, uid: 'user-uid')
     policy_group = FactoryBot.create(:policy_group)
     attachment = FactoryBot.create(:file_attachment, attachable: policy_group)
+    attachment.attachment_data.attachable = policy_group
 
     Services.asset_manager.expects(:create_whitehall_asset).with(Not(has_key(:access_limited)))
 
-    @worker.perform(@file.path, @legacy_url_path, true, attachment.attachment_data.class.to_s, attachment.attachment_data.id)
+    @worker.perform(@file.path, @legacy_url_path, true, policy_group.class.to_s, policy_group.id)
   end
 
   test "doesn't run if the file is missing (e.g. job ran twice)" do


### PR DESCRIPTION
Doing attachment things to an edition (including publishing) triggers workers to run on all of its attachments, updating metadata.  However, if the asset has not yet made its way over to the asset-manager, then these workers will fail with an `AssetManagerWorkerHelper::AssetManagerAssetNotFound` exception.  This isn't a problem as such, because the workers will be retried, but it does lead to our logs and reporting filling up with these harmless errors.

This PR disables triggering those workers until assets have made it across.  To prevent this from being a problem, publishing is now blocked until this point.

**Review:** It would be good to deploy this to integration and do some asset stuff, to verify that the number of errors has been reduced.

**Downsides:** This is a new message in the UI, and it exposes an implementation detail to users.  We should be confident that this isn't going to confuse people - do we need to let the content community know?  On the other hand, uploading to the asset manager is really fast, it's just that the erroring workers are somewhat faster; so people usually won't even notice the delay.

---

[Trello card](https://trello.com/c/D5oLPmZR/266-add-a-pending-state-to-whitehall-attachmentdatas-while-state-is-copied-over-to-asset-manager)