### PR TITLE
Revert "Fix the delay of topic taxons appearing on the editions overview page"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     fugit (1.1.1)
       et-orbi (~> 1.1, >= 1.1.1)
       raabro (~> 1.1)
-    gds-api-adapters (52.6.0)
+    gds-api-adapters (52.5.1)
       addressable
       link_header
       lrucache (~> 0.1.1)
@@ -367,7 +367,7 @@ GEM
     public_suffix (3.0.2)
     raabro (1.1.5)
     rack (2.0.5)
-    rack-cache (1.7.2)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-protection (2.0.1)
       rack

--- a/app/services/edition_taxons_fetcher.rb
+++ b/app/services/edition_taxons_fetcher.rb
@@ -43,7 +43,7 @@ private
   end
 
   def response
-    Services.publishing_api.get_expanded_links(content_id, generate: true)
+    Services.publishing_api.get_expanded_links(content_id)
   end
 
   def all_world_taxons

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -327,17 +327,16 @@ private
   end
 
   def publication_has_no_expanded_links(content_id)
-    expanded_links = {
-      "content_id" =>  content_id,
-      "expanded_links" =>  {}
-    }
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    publishing_api_has_expanded_links(
+      content_id: content_id,
+      expanded_links: {}
+    )
   end
 
   def publication_has_expanded_links(content_id)
-    expanded_links = {
-      "content_id" =>  content_id,
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id: content_id,
+      expanded_links: {
         "taxons" => [
           {
             "title" => "Primary Education",
@@ -358,15 +357,13 @@ private
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
   end
 
   def publication_has_world_expanded_links(content_id)
-    expanded_links = {
-      "content_id" =>  content_id,
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  content_id,
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "World Grandchild Taxon",
@@ -387,9 +384,7 @@ private
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
   end
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -195,17 +195,16 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
 private
 
   def announcement_has_no_expanded_links(content_id)
-    expanded_links = {
-      "content_id" =>  content_id,
-      "expanded_links" => {}
-    }
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    publishing_api_has_expanded_links(
+      content_id:  content_id,
+      expanded_links:  {}
+    )
   end
 
   def announcement_has_expanded_links(content_id)
-    expanded_links = {
-      "content_id" =>  content_id,
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  content_id,
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Primary Education",
@@ -226,7 +225,6 @@ private
           }
         ]
       }
-    }
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
   end
 end

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -68,14 +68,13 @@ module TaxonomyHelper
   end
 
   def stub_publishing_api_expanded_links_with_taxons(content_id, taxons)
-    expanded_links = {
+    publishing_api_has_expanded_links(
       "content_id" => content_id,
       "expanded_links" => {
         "taxons" => taxons,
       },
       "version" => 1,
-    }
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+      )
   end
 
 private

--- a/test/unit/services/edition_taxons_fetcher_test.rb
+++ b/test/unit/services/edition_taxons_fetcher_test.rb
@@ -26,12 +26,10 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns '[]' if there are no taxons" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" => {}
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {}
+    )
 
     links_fetcher = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05")
     assert_equal [], links_fetcher.fetch
@@ -39,9 +37,10 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
 
   test "it returns a taxon without a parent" do
     title = "Education, training and skills"
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => title,
@@ -52,17 +51,15 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
   end
 
   test "it returns a taxon with a parent" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -83,19 +80,16 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
     assert_equal 'bbbb', taxons.first.parent_node.content_id
   end
 
   test "it returns a taxon with parent and grandparent" do
-    expanded_links =
-      {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Student Finance",
@@ -124,9 +118,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'aaaa', taxons.first.content_id
     assert_equal 'bbbb', taxons.first.parent_node.content_id
@@ -134,9 +126,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns paths for multiple taxons" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -174,9 +166,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 2, taxons.count
     assert_equal "aaaa", taxons.first.content_id
@@ -186,9 +176,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it sets the first parent taxon if there are multiple parents" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -216,18 +206,16 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal "aaaa", taxons.first.content_id
     assert_equal "bbbb", taxons.first.parent_node.content_id
   end
 
   test "it only returns published or visible draft taxons" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "I am the published taxon",
@@ -282,17 +270,16 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
+    )
 
-    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal %w[aaaa cccc], taxons.map(&:content_id)
   end
 
   test "it gets world taxons tagged to the edition" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "I am the published taxon",
@@ -330,9 +317,7 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
-
-    publishing_api_has_expanded_links(expanded_links, generate: true)
+    )
     redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
 
     redis_cache_has_world_taxons([build(:taxon_hash, content_id: 'world-taxon')])
@@ -342,9 +327,9 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
   end
 
   test "it returns legacy mappings" do
-    expanded_links = {
-      "content_id" =>  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
-      "expanded_links" =>  {
+    publishing_api_has_expanded_links(
+      content_id:  "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+      expanded_links:  {
         "taxons" => [
           {
             "title" => "Further Education",
@@ -364,9 +349,8 @@ class EditionTaxonsFetcherTest < ActiveSupport::TestCase
           }
         ]
       }
-    }
+    )
 
-    publishing_api_has_expanded_links(expanded_links, generate: true)
     taxons = EditionTaxonsFetcher.new("64aadc14-9bca-40d9-abb4-4f21f9792a05").fetch
     assert_equal 'policy', taxons.first.legacy_mapping["policy"][0]["document_type"]
   end


### PR DESCRIPTION
Reverts #4094

We need to revert to using the cached endpoint for expanded links. Constantly hitting the uncached endpoint is causing very high load on Postgres, and giving users 500s. We think this bug existing may be preferable to serving lots of errors and reducing platform stability.

This is a temporary revert while we investigate a longer term solution.