### PR TITLE
Change to default halt_callback_chains_on_return_false option

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
This will make it easier to migrate to Rails 5.2 since this option has no affect now and it gets fully removed then.

[Trello Card](https://trello.com/c/v8nU6sMK/239-remove-use-of-deprecated-haltcallbackchainsonreturnfalse)