### PR TITLE
Render courts and tribunals using whitehall

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -59,7 +59,7 @@ module PublishingApi
     end
 
     def rendering_app
-      if item.organisation_type.court?
+      if court_or_tribunal?
         Whitehall::RenderingApp::WHITEHALL_FRONTEND
       else
         Whitehall::RenderingApp::COLLECTIONS_FRONTEND
@@ -439,6 +439,10 @@ module PublishingApi
 
     def organisation_type
       item.organisation_type_key.to_s
+    end
+
+    def court_or_tribunal?
+      item.organisation_type.court? || item.organisation_type.tribunal_ndpb?
     end
 
     def social_media_links

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -202,7 +202,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal("http://www.example.com/org-of-things", presented_item.content[:details][:organisation_govuk_status][:url])
   end
 
-  test 'renders courts via Whitehall' do
+  test 'renders courts and tribunals using Whitehall' do
     organisation = create(
       :organisation,
       name: 'Court at mid-wicket',


### PR DESCRIPTION
This commit amends the organisations presenter to continue rendering court and tribunal pages using whitehall since they have not yet been migrated.