### PR TITLE
Thread-safe workers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,10 @@ Whitehall::Application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners.
+  # Enable threaded mode
+  # config.threadsafe!
+
+  # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 :verbose: true
-:concurrency: 2
+:concurrency: 8
 :logfile: ./log/sidekiq.json.log
 :queues:
   - scheduled_publishing

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,5 @@
 :verbose: true
-# We set concurrency to 1 because parts of the publishing pipeline
-# are not threadsafe. Once we've removed instances of `I18n.with_locale`
-# from the workers, we can increase this again.
-:concurrency: 1
+:concurrency: 2
 :logfile: ./log/sidekiq.json.log
 :queues:
   - scheduled_publishing


### PR DESCRIPTION
Mark workers as thread-safe and increase concurrency to 8. Once this is merged we can revert https://github.com/alphagov/govuk-puppet/pull/7729.

In #2725 we noticed there was a problem with `I18n.with_locale` being not thread safe. Since then https://github.com/svenfuchs/i18n/pull/320 has been merged which makes accessing the `locale` variable thread safe.

Setting the locale is done by https://github.com/svenfuchs/i18n/blob/697b42d8d1f7459610186bcd8346db95d807d014/lib/i18n.rb#L278-L287 which looks thread safe as it uses the `config` variable from https://github.com/svenfuchs/i18n/blob/697b42d8d1f7459610186bcd8346db95d807d014/lib/i18n.rb#L41-L43 which is a thread local variable. However, confusingly, this code hasn't changed in 8 years so it was thread safe when we initially marked the usage of `with_locale` as not safe.

I ran [this script](https://gist.github.com/thomasleese/036a57017e8dac4d78bfb73cd025b581) a few times with i18n versions 0.9.5 and 0.7.0 and I was never able to reproduce the thread safety problem implied when we marked the workers as unsafe. Obviously that's not conclusive (dealing with threads never is) but it's worth noting.

[Trello Card](https://trello.com/c/R0eXp4Di/281-think-about-asset-sidekiq-stuff)