### PR TITLE
Mark Publishing API client error a warning

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -33,7 +33,15 @@ private
   end
 
   def handle_client_error(error)
-    explanation = "The error code indicates that retrying this request will not help. This job is being aborted and will not be retried."
-    GovukError.notify(error, extra: { explanation: explanation })
+    GovukError.notify(
+      error,
+      level: "warning",
+      extra: {
+        explanation: %{
+          The error code indicates that retrying this request will not help.
+          This job is being aborted and will not be retried.
+        },
+      },
+    )
   end
 end


### PR DESCRIPTION
This goes against https://github.com/alphagov/govuk-rfcs/pull/87 but I think it's more useful for this to be in Sentry rather than Kibana as it includes far more information, and if there's a problem where devs need to investigate why things aren't going to the Publishing API Sentry is the first place they would look.