### PR TITLE
Whitehall renders only courts and HMCTS tribunals

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -442,7 +442,7 @@ module PublishingApi
     end
 
     def court_or_tribunal?
-      item.organisation_type.court? || item.organisation_type.tribunal_ndpb?
+      item.court_or_hmcts_tribunal?
     end
 
     def social_media_links


### PR DESCRIPTION
It turns out we went too far the other way.  There's special logic for HMCTS tribunals which we can use.  There are other tribunals which are also `tribual_ndpb`s for example https://www.gov.uk/government/organisations/insolvency-practitioners-tribunal.  (Of course there are)