### PR TITLE
Add Atom route for organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -35,7 +35,9 @@ module PublishingApi
         rendering_app: rendering_app,
         schema_name: schema_name,
       )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      content.merge!(
+        PayloadBuilder::PolymorphicPath.for(item, additional_routes: additional_routes)
+      )
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
 
@@ -64,6 +66,11 @@ module PublishingApi
       else
         Whitehall::RenderingApp::COLLECTIONS_FRONTEND
       end
+    end
+
+    def additional_routes
+      return [] if court_or_tribunal?
+      ["atom"]
     end
 
     def details

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -1,18 +1,21 @@
 module PublishingApi
   module PayloadBuilder
     class PolymorphicPath
-      attr_reader :item
+      attr_reader :item, :additional_routes
 
-      def self.for(item)
-        new(item).call
+      def self.for(item, additional_routes: [])
+        new(item, additional_routes: additional_routes).call
       end
 
-      def initialize(item)
+      def initialize(item, additional_routes: [])
         @item = item
+        @additional_routes = additional_routes
       end
 
       def call
-        { base_path: base_path }.merge(PayloadBuilder::Routes.for(base_path))
+        { base_path: base_path }.merge(
+          PayloadBuilder::Routes.for(base_path, additional_routes: additional_routes)
+        )
       end
 
     private

--- a/app/presenters/publishing_api/payload_builder/routes.rb
+++ b/app/presenters/publishing_api/payload_builder/routes.rb
@@ -1,18 +1,24 @@
 module PublishingApi
   module PayloadBuilder
     class Routes
-      attr_reader :base_path
+      attr_reader :base_path, :additional_routes
 
-      def self.for(base_path)
-        new(base_path).call
+      def self.for(base_path, additional_routes: [])
+        new(base_path, additional_routes: additional_routes).call
       end
 
-      def initialize(base_path)
+      def initialize(base_path, additional_routes: [])
         @base_path = base_path
+        @additional_routes = additional_routes
       end
 
       def call
-        { routes: [{ path: base_path, type: "exact" }] }
+        routes = []
+        routes << { path: base_path, type: "exact" }
+        additional_routes.each do |additional_route|
+          routes << { path: "#{base_path}.#{additional_route}", type: "exact" }
+        end
+        { routes: routes }
       end
     end
   end

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -31,11 +31,13 @@ module OrganisationResluggerTest
 
     test "publishes to Publishing API with the new slug" do
       new_base_path = "#{base_path}/corrected-slug"
+      new_atom_base_path = "#{base_path}/corrected-slug.atom"
 
       content_item = PublishingApiPresenters.presenter_for(@organisation)
       content = content_item.content
       content[:base_path] = new_base_path
       content[:routes][0][:path] = new_base_path
+      content[:routes][1][:path] = new_atom_base_path unless content[:routes][1].nil?
       content_item.stubs(content: content)
 
       expected_publish_requests = [

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -28,6 +28,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     )
     role = create(:role, organisations: [organisation])
     public_path = Whitehall.url_maker.organisation_path(organisation)
+    public_atom_path = "#{public_path}.atom"
 
     expected_hash = {
       base_path: public_path,
@@ -40,7 +41,8 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       rendering_app: 'collections',
       public_updated_at: organisation.updated_at,
       routes: [
-        { path: public_path, type: "exact" }
+        { path: public_path, type: "exact" },
+        { path: public_atom_path, type: "exact" }
       ],
       redirects: [],
       update_type: "major",


### PR DESCRIPTION
This commit adds a new route to all non-court/tribunal organisations to point to the organisation’s Atom feed.