### PR TITLE
[WIP] Fix sending nil attribute changes to the asset-manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,9 +63,7 @@ gem 'validates_email_format_of'
 gem 'whenever', '~> 0.10.0', require: false
 
 # rubocop:disable Bundler/DuplicatedGem
-if ENV['GDS_API_ADAPTERS_DEV']
-  gem 'gds-api-adapters', path: '../gds-api-adapters'
-else
+git 'https://github.com/alphagov/gds-api-adapters.git', :branch => 'msw-put-json' do
   gem 'gds-api-adapters'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/alphagov/gds-api-adapters.git
+  revision: 5ee908c940b881702ab4f2cd4ef461a9e277c450
+  branch: msw-put-json
+  specs:
+    gds-api-adapters (52.6.0)
+      addressable
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -154,14 +168,6 @@ GEM
     fugit (1.1.1)
       et-orbi (~> 1.1, >= 1.1.1)
       raabro (~> 1.1)
-    gds-api-adapters (52.5.1)
-      addressable
-      link_header
-      lrucache (~> 0.1.1)
-      null_logger
-      plek (>= 1.9.0)
-      rack-cache
-      rest-client (~> 2.0)
     gds-sso (13.6.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -367,7 +373,7 @@ GEM
     public_suffix (3.0.2)
     raabro (1.1.5)
     rack (2.0.5)
-    rack-cache (1.7.1)
+    rack-cache (1.8.0)
       rack (>= 0.4)
     rack-protection (2.0.1)
       rack
@@ -588,7 +594,7 @@ DEPENDENCIES
   factory_bot
   faraday
   friendly_id (~> 5.2.4)
-  gds-api-adapters
+  gds-api-adapters!
   gds-sso (~> 13.6)
   globalize (= 5.1.0)
   govspeak (~> 5.5.0)

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -24,7 +24,7 @@ class AssetManagerUpdateAssetWorker
 
     keys = new_attributes.keys
     unless attributes.slice(*keys) == new_attributes.slice(*keys)
-      asset_manager.update_asset(attributes['id'], new_attributes)
+      asset_manager.update_asset_attributes(attributes['id'], new_attributes)
     end
   end
 end


### PR DESCRIPTION
When we unpublish a thing, a redirect URL is set in the asset-manager.  This is all fine and dandy, but unpublished things can be re-published too.  In that case, we should *unset* the redirect URL, which we do by setting it to `nil`.

Unfortunately, the `asset_manager.update_asset` method uses multipart/form-data to send changes, and so it silently drops `nil` attributes.  So instead use the new `asset_manager.update_asset_attributes` which sends data as json instead.

---

[Trello card](https://trello.com/c/hoC9DL84/290-investigate-asset-manager-redirecturl-weirdness)