### PR TITLE
Do not do redundant Asset Manager jobs

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -112,6 +112,14 @@ class AttachmentData < ApplicationRecord
     uploaded_to_asset_manager_at.present?
   end
 
+  def synchronised_with_asset_manager?
+    if synchronised_with_asset_manager_at.present?
+      updated_at <= synchronised_with_asset_manager_at
+    else
+      false
+    end
+  end
+
   def deleted?
     significant_attachment(include_deleted_attachables: true).deleted?
   end

--- a/app/workers/asset_manager_attachment_data_worker.rb
+++ b/app/workers/asset_manager_attachment_data_worker.rb
@@ -4,6 +4,7 @@ class AssetManagerAttachmentDataWorker < WorkerBase
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find(attachment_data_id)
     return unless attachment_data.uploaded_to_asset_manager_at
+    return if attachment_data.synchronised_with_asset_manager?
 
     draft_status_updater attachment_data_id
     redirect_url_updater attachment_data_id

--- a/app/workers/asset_manager_attachment_data_worker.rb
+++ b/app/workers/asset_manager_attachment_data_worker.rb
@@ -14,6 +14,11 @@ class AssetManagerAttachmentDataWorker < WorkerBase
     AttachmentData.where(replaced_by: attachment_data).find_each do |data|
       replacement_id_updater data
     end
+
+    # ideally attachment data would have a version field, and we'd
+    # record which version we sent to the asset manager
+    attachment_data.synchronised_with_asset_manager_at = attachment_data.updated_at
+    attachment_data.save!
   end
 
 private

--- a/db/migrate/20180705130709_add_synchronised_with_asset_manager_at_time_to_attachment_data.rb
+++ b/db/migrate/20180705130709_add_synchronised_with_asset_manager_at_time_to_attachment_data.rb
@@ -1,0 +1,5 @@
+class AddSynchronisedWithAssetManagerAtTimeToAttachmentData < ActiveRecord::Migration[5.0]
+  def change
+    add_column :attachment_data, :synchronised_with_asset_manager_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626121716) do
+ActiveRecord::Schema.define(version: 20180705130709) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "topical_event_id"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20180626121716) do
     t.datetime "updated_at"
     t.integer  "replaced_by_id"
     t.datetime "uploaded_to_asset_manager_at"
+    t.datetime "synchronised_with_asset_manager_at"
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id", using: :btree
   end
 

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -38,7 +38,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'marks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => ['user-uid'])
+        Services.asset_manager.expects(:update_asset).with('asset-id', 'access_limited' => ['user-uid'])
 
         AssetManagerAttachmentDataWorker.drain
       end
@@ -168,7 +168,7 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'unmarks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => [])
+        Services.asset_manager.expects(:update_asset).with('asset-id', 'access_limited' => [])
 
         AssetManagerAttachmentDataWorker.drain
       end

--- a/test/integration/attachment_deletion_integration_test.rb
+++ b/test/integration/attachment_deletion_integration_test.rb
@@ -52,7 +52,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'deletes corresponding asset(s) in Asset Manager' do
-        Services.asset_manager.expects(:delete_asset).at_least_once.with(asset_id)
+        Services.asset_manager.expects(:delete_asset).with(asset_id)
         AssetManagerAttachmentDataWorker.drain
       end
     end
@@ -71,7 +71,7 @@ class AttachmentDeletionIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'deletes corresponding asset(s) in Asset Manager' do
-        Services.asset_manager.expects(:delete_asset).at_least_once.with(asset_id)
+        Services.asset_manager.expects(:delete_asset).with(asset_id)
         AssetManagerAttachmentDataWorker.drain
       end
     end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -115,7 +115,6 @@ private
   def assert_sets_draft_status_in_asset_manager_to(draft, never: false)
     expectation = Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'draft' => draft)
-      .at_least_once
     expectation.never if never
     AssetManagerAttachmentDataWorker.drain
   end

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -39,7 +39,6 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
         parent_document_url = Whitehall.url_maker.public_document_url(edition)
 
         Services.asset_manager.expects(:update_asset)
-          .at_least_once
           .with(asset_id, 'parent_document_url' => parent_document_url)
 
         AssetManagerAttachmentDataWorker.drain

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -189,7 +189,6 @@ private
   def assert_sets_redirect_url_in_asset_manager_to(redirect_url)
     Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'redirect_url' => redirect_url)
-      .at_least_once
     AssetManagerAttachmentDataWorker.drain
   end
 

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -64,7 +64,6 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
       # because the replacement is visible to the user.
       it 'updates replacement_id for attachment in Asset Manager' do
         Services.asset_manager.expects(:update_asset)
-          .at_least_once
           .with(asset_id, 'replacement_id' => replacement_asset_id)
         AssetManagerAttachmentDataWorker.drain
       end
@@ -104,7 +103,6 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
       # visible to the user.
       it 'updates replacement_id for attachment in Asset Manager' do
         Services.asset_manager.expects(:update_asset)
-          .at_least_once
           .with(asset_id, 'replacement_id' => replacement_asset_id)
         AssetManagerAttachmentDataWorker.drain
       end


### PR DESCRIPTION
This adds a field `synchronised_with_asset_manager_at` to `AttachmentData`, which is set to `updated_at` when `AssetManagerAttachmentDataWorker` finishes.  If the worker is called with an `AttachmentData` which hasn't been updated since the worker last ran, it short-circuits.  This column **doesn't** have a default, because I didn't want to iterate through all `AttachmentData`s to pull out their `updated_at`, and I didn't want to just set them all to `Time.zone.now`.

We tried using the unique jobs gem [and had to revert](https://github.com/alphagov/whitehall/pull/4189), so this is another attempt in the same spirit.

---

This seems to be strictly an improvement, as now the tests are not making redundant calls to the Asset Manager.

---

[Trello card](https://trello.com/c/1sd6Ve2a/292-look-into-sidekiq-unique-jobs-for-whitehall-asset-manager)