### PR TITLE
Reenable org publishing on people/roles update

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,8 +48,7 @@ class Person < ApplicationRecord
 
   delegate :url, to: :image, prefix: :image
 
-  # Disabled while all people are re-published
-  #after_save :republish_organisation_to_publishing_api
+  after_save :republish_organisation_to_publishing_api
   before_destroy :prevent_destruction_if_appointed
   after_update :touch_role_appointments
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -48,8 +48,7 @@ class Role < ApplicationRecord
   validates :type, presence: true
   validates_with SafeHtmlValidator
 
-  # Disabled while all roles are re-published
-  #after_save :republish_organisation_to_publishing_api
+  after_save :republish_organisation_to_publishing_api
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -66,9 +66,8 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  # Disabled while all role appointments are re-published
-  #after_save :republish_organisation_to_publishing_api
-  #after_destroy :republish_organisation_to_publishing_api
+  after_save :republish_organisation_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api
   after_save :update_indexes
   after_destroy :update_indexes
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -33,15 +33,15 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     content[:routes][0][:path] = new_base_path
     content_item.stubs(content: content)
 
-    #organisation_content_item = PublishingApiPresenters.presenter_for(@organisation)
+    organisation_content_item = PublishingApiPresenters.presenter_for(@organisation)
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
       stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major'),
-      #stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
-      #stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
-      #stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
+      stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
+      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: 'major')
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/models/person_role_test.rb
+++ b/test/unit/models/person_role_test.rb
@@ -1,37 +1,37 @@
 require 'test_helper'
 
-# class PersonRoleTest < ActiveSupport::TestCase
-#   test "creating a new role and person republishes the linked organisation" do
-#     test_object = create(:organisation)
-#     role = create(:role, organisations: [test_object])
-#     person = create(:person)
-#     role_appointment = build(:role_appointment, person: person, role: role)
-#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-#     Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
-#     role_appointment.save!
-#   end
-#
-#   test "updating an existing person republishes the linked organisation" do
-#     test_object = create(:organisation)
-#     role = create(:role, organisations: [test_object])
-#     person = create(:person)
-#     create(:role_appointment, person: person, role: role)
-#     person.reload
-#     person.forename = "Test"
-#     Whitehall::PublishingApi.expects(:publish_async).with(person).once
-#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-#     person.save!
-#   end
-#
-#   test "updating an existing role republishes the linked organisation" do
-#     test_object = create(:organisation)
-#     role = create(:role, organisations: [test_object])
-#     person = create(:person)
-#     create(:role_appointment, person: person, role: role)
-#     person.reload
-#     role.cabinet_member = true
-#     Whitehall::PublishingApi.expects(:publish_async).with(role).once
-#     Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
-#     role.save!
-#   end
-# end
+class PersonRoleTest < ActiveSupport::TestCase
+  test "creating a new role and person republishes the linked organisation" do
+    test_object = create(:organisation)
+    role = create(:role, organisations: [test_object])
+    person = create(:person)
+    role_appointment = build(:role_appointment, person: person, role: role)
+    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
+    role_appointment.save!
+  end
+
+  test "updating an existing person republishes the linked organisation" do
+    test_object = create(:organisation)
+    role = create(:role, organisations: [test_object])
+    person = create(:person)
+    create(:role_appointment, person: person, role: role)
+    person.reload
+    person.forename = "Test"
+    Whitehall::PublishingApi.expects(:publish_async).with(person).once
+    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    person.save!
+  end
+
+  test "updating an existing role republishes the linked organisation" do
+    test_object = create(:organisation)
+    role = create(:role, organisations: [test_object])
+    person = create(:person)
+    create(:role_appointment, person: person, role: role)
+    person.reload
+    role.cabinet_member = true
+    Whitehall::PublishingApi.expects(:publish_async).with(role).once
+    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    role.save!
+  end
+end


### PR DESCRIPTION
This reverts commit 077b9d4b4e2fa3b5b3bfb02b9e4d91d07fff5076 (in https://github.com/alphagov/whitehall/pull/4100).

We want to ensure that organisations get republished when people or roles are updated.

An organisation page contains lots of stuff in the details hash which is relevant to these things, and it's not feasible to wait for dependency resolution to unwind for the page to show the correct information.