### PR TITLE
Add Jeremy Hunt to past foreign secretaries.

### DIFF
--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -119,8 +119,14 @@
       <ol>
         <li>
           <div class="inner">
-            <h4 class="name"><a href="/government/people/boris-johnson">Boris Johnson</a></h4>
-            <p class="term">2016 to present</p>
+            <h4 class="name"><a href="/government/people/jeremy-hunt">Jeremy Hunt</a></h4>
+            <p class="term">2018 to present</p>
+          </div>
+        </li>
+        <li>
+          <div class="inner">
+            <h4 class="name">Boris Johnson</h4>
+            <p class="term">2016 to 2018</p>
           </div>
         </li>
         <li>


### PR DESCRIPTION
Jeremy Hunt has taken over from Boris Johnson as Foreign Secretary.
This has to be reflected in the past foreign secretaries page.

https://govuk.zendesk.com/agent/tickets/2909705