### PR TITLE
Add a database connection pool

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -28,6 +28,7 @@ production:
   encoding: utf8
   adapter: mysql2
   database: whitehall_production
+  pool: 10
 
 cucumber:
   <<: *test


### PR DESCRIPTION
We increased the Sidekiq concurrency in 658f107445adb347760157afaec624804e28d3d8, but didn't give the database a connection pool.  So workers are often failing with "could not obtain a connection from the pool within 5.000 seconds (waited 5.002 seconds); all pooled connections were in use".