### PR TITLE
Set uploaded_to_asset_manager_at timestamp for just the one asset which was just uploaded

### DIFF
--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -26,7 +26,12 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
       # sadly we can't just search for url, because it's a magic
       # carrierwave thing not in our model
       Attachment.where(attachable: model.attachables).where.not(attachment_data: nil).find_each do |attachment|
-        if attachment.attachment_data.url == legacy_url_path
+        # 'attachment.attachment_data' can still be nil even with the
+        # check above, because if the 'attachment_data_id' is non-nil
+        # but invalid, the 'attachment_data' will be nil - and the
+        # generated SQL only checks if the 'attachment_data_id' is
+        # nil.
+        if attachment.attachment_data && attachment.attachment_data.url == legacy_url_path
           attachment.attachment_data.uploaded_to_asset_manager!
         end
       end

--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -23,8 +23,12 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
     asset_manager.create_whitehall_asset(asset_options)
 
     if model
+      # sadly we can't just search for url, because it's a magic
+      # carrierwave thing not in our model
       Attachment.where(attachable: model.attachables).where.not(attachment_data: nil).find_each do |attachment|
-        attachment.attachment_data.uploaded_to_asset_manager!
+        if attachment.attachment_data.url == legacy_url_path
+          attachment.attachment_data.uploaded_to_asset_manager!
+        end
       end
     end
 


### PR DESCRIPTION
Because we don't get given the ID of the `AttachmentData` in the `AssetManagerCreateWhitehallAssetWorker`, we currently use a hacky work-around where we just look up all attachments for the given model.  We should only set the timestamp of the attachment we've just uploaded.

Furthermore, some `Attachment`s have a weird state where they refer to a non-existent `AttachmentData`.  These are *not* filtered out by the `where.not(attachment_data: nil)` clause, because that generates the sql `where attachment_data_id IS NOT NULL`.  If the `attachment_data_id` is not-NULL but invalid, the `AttachmentData` will be nil.  Leaky abstractions!

---

This is causing an issue with `PolicyGroup`s 543, 547, 563, and 725, all of which have one of these weird attachments.

It would also be nice to clean up the state in the database, but that can be a separate, much lower-priority, task.