### PR TITLE
Use more progressive disclosure for Taxonomy tagging

### DIFF
--- a/app/assets/javascripts/admin/modules/breadcrumb_preview.js
+++ b/app/assets/javascripts/admin/modules/breadcrumb_preview.js
@@ -88,7 +88,7 @@
       };
 
       renderUpdatedBreadcrumbsForElement();
-      $topicTree.on('click', renderUpdatedBreadcrumbsForElement);
+      $topicTree.on('change', renderUpdatedBreadcrumbsForElement);
     };
   };
 })(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
+++ b/app/assets/javascripts/admin/modules/taxonomy_tree_checkboxes.js
@@ -2,44 +2,47 @@
   "use strict";
 
   Modules.TaxonomyTreeCheckboxes = function() {
-    var ancestors = function(element) {
-      var $parents = $(element).parents('.topics,.topic-tree');
-      return $parents.prev('p').find('input[type="checkbox"]');
+    var ancestors = function($element) {
+      var parentContentID = $element.data("parent-content-id");
+      if (parentContentID) {
+        var $parent = $("#" + parentContentID);
+        return $parent.add(ancestors($parent));
+      } else {
+        return $();
+      }
     };
 
-    var descendants = function(element) {
-      return $(element).closest('p').next('.topics').find('input[type="checkbox"]');
+    var descendants = function($element) {
+      return $("#topic-tree-" + $element.attr("id")).find('input[type="checkbox"]');
     };
 
     /**
      Check all ancestor topics.
      */
-    var checkAncestors = function(element) {
-      ancestors(element).prop('checked', true);
+    var checkAncestors = function($element) {
+      ancestors($element).prop('checked', true);
     };
 
     /**
      Uncheck all ancestor topics.
      */
-    var uncheckAncestors = function(element) {
-      ancestors(element).prop('checked', false);
+    var uncheckAncestors = function($element) {
+      ancestors($element).prop('checked', false);
     };
 
     /**
      Uncheck all descendant topics.
      */
-    var uncheckDescendants = function(element) {
-      descendants(element).prop('checked', false);
+    var uncheckDescendants = function($element) {
+      descendants($element).prop('checked', false);
     };
 
     /**
      Check if a sibling topic (or its children) are checked.
      If any of the siblings, children are checked we expect the sibling to be checked too.
      */
-    var hasCheckedSiblings = function(element) {
-      var $p = $(element).closest('.topics').children('p');
-      var $checkedSiblings = $p.find('input:checked');
-      return $checkedSiblings.length > 0;
+    var hasCheckedSiblings = function($element) {
+      return $element.closest('.topics').find('input:checked').length > 0;
     };
 
     var checkboxTrackClick = function(action, options) {
@@ -56,11 +59,11 @@
 
     var bindExpandAndCollapseAll = function() {
       $('#expand_all_id').click(function(event) {
-        $('.level-one-taxon').collapse('show');
+        $('.topics').collapse('show');
         event.preventDefault();
       });
       $('#collapse_all_id').click(function(event) {
-        $('.level-one-taxon').collapse('hide');
+        $('.topics').collapse('hide');
         event.preventDefault();
       });
     };
@@ -93,13 +96,15 @@
         */
         if (checked) {
           checkboxTrackClick("checkboxClickedOn", options);
-          checkAncestors(this);
+          checkAncestors($checkbox);
+
+          $("#topic-tree-" + $checkbox.attr("id")).collapse('show');
         } else {
           checkboxTrackClick("checkboxClickedOff", options);
-          uncheckDescendants(this);
+          uncheckDescendants($checkbox);
 
-          if (!hasCheckedSiblings(this)) {
-            uncheckAncestors(this);
+          if (!hasCheckedSiblings($checkbox)) {
+            uncheckAncestors($checkbox);
           }
         }
       });

--- a/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
+++ b/app/assets/stylesheets/admin/views/_edition_tags_edit.scss
@@ -1,8 +1,6 @@
 .topic-tree {
   .taxon-name {
     font-size: 16px;
-    font-weight: bold;
-    margin-bottom: 10px;
     display: inline-block;
 
     &:hover, &:focus {
@@ -11,12 +9,20 @@
 
     .icon {
       display: inline-block;
-      width: 15px;
+      font-size: 25px;
+      text-align: center;
+      width: 28px;
+      height: 28px;
 
       &:before {
         content: '\25BE';
       }
     }
+  }
+  .no-children-icon {
+    display: inline-block;
+    width: 28px;
+    height: 28px;
   }
   .taxon-name.collapsed .icon {
     &:before {
@@ -24,22 +30,21 @@
     }
   }
 
+  label {
+    font-size: 16px;
+    font-weight: normal;
+    input[type="checkbox"] {
+      margin-right: 10px;
+    }
+    input[type="checkbox"]:checked + span {
+      font-weight: bold;
+    }
+  }
+
   .topics {
     padding-left: 36px;
     border-left: 1px solid #aaa;
     margin-left: 6px;
-
-    label {
-      font-size: 16px;
-      font-weight: normal;
-      input[type="checkbox"] {
-        margin-right: 10px;
-      }
-
-      input[type="checkbox"]:checked + span {
-        font-weight: bold;
-      }
-    }
   }
 }
 

--- a/app/helpers/admin/edition_tags_helper.rb
+++ b/app/helpers/admin/edition_tags_helper.rb
@@ -10,6 +10,7 @@ module Admin::EditionTagsHelper
       checked,
       id: taxon.content_id,
       "data-taxon-name" => taxon.name,
+      "data-parent-content-id" => taxon.parent_node.try(:content_id),
       "data-ancestors": taxon.breadcrumb_trail.map(&:name).join('|')
     )
   end

--- a/app/views/admin/shared/tagging/_sub_taxons.html.erb
+++ b/app/views/admin/shared/tagging/_sub_taxons.html.erb
@@ -1,15 +1,24 @@
-<div class="topics topic-tree">
 <% taxons.each do |taxon| %>
-  <p>
+  <div>
+    <% if taxon.children.present? %>
+      <a class="taxon-name collapsed"
+         data-toggle="collapse"
+         href="#topic-tree-<%= taxon.content_id %>">
+        <span class='icon'></span>
+      </a>
+    <% else %>
+      <span class='no-children-icon'></span>
+    <% end %>
     <label>
       <%= checkbox_for_taxonomy(selected_taxons, taxon) %>
       <span><%= taxon.name %></span>
     </label>
-  </p>
+  </div>
 
   <% if taxon.children.present? %>
+    <div id="topic-tree-<%= taxon.content_id %>" class="topics collapse">
     <%= render partial: "/admin/shared/tagging/sub_taxons",
           locals: { selected_taxons: selected_taxons, taxons: taxon.children } %>
+    </div>
   <% end %>
 <% end %>
-</div>

--- a/app/views/admin/shared/tagging/_taxonomy.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy.html.erb
@@ -1,17 +1,9 @@
 <p><a id="expand_all_id" href="#">expand all</a> | <a id="collapse_all_id" href="#">collapse all</a></p>
 
+<div class="topic-tree">
 <% level_one_taxons.each do |taxon| %>
   <% taxon = TopicTreePresenter.new(taxon, collapsed: level_one_taxons.size > 1) %>
 
-  <% if taxon.children.empty? %>
-    <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: [taxon] } %>
-  <% else %>
-    <div class="topic-tree">
-      <a class="<%= taxon.toggle_classes %>" data-toggle="collapse" href="#<%= taxon.content_id %>"><span class='icon'></span><%= taxon.name %></a>
-
-      <div class="<%= taxon.tree_classes %>" id="<%= taxon.content_id %>">
-        <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: taxon.children } %>
-      </div>
-    </div>
-  <% end %>
+  <%= render partial: "/admin/shared/tagging/sub_taxons", locals: { selected_taxons: selected_taxons, taxons: [taxon] } %>
 <% end %>
+</div>


### PR DESCRIPTION
Allow each level of the Topic Taxonomy to be expanded.

This change also allows the level one taxons to be selected and
unselected, which wasn't possible in the previous design.

![taxonomy-progressive-disclosure](https://user-images.githubusercontent.com/1130010/42633170-8163a146-85d7-11e8-85ef-680038d87611.png)
