### PR TITLE
Set uploaded_to_asset_manager timestamp in a worker

### DIFF
--- a/app/workers/set_uploaded_to_asset_manager_worker.rb
+++ b/app/workers/set_uploaded_to_asset_manager_worker.rb
@@ -1,0 +1,33 @@
+class SetUploadedToAssetManagerWorker < WorkerBase
+  sidekiq_options queue: 'asset_manager'
+
+  class AttachmentDataNotFound < StandardError
+    def initialize(legacy_url_path)
+      message = "AttachmentData corresponding to legacy URL path #{legacy_url_path} does not exist."
+      super(message)
+    end
+  end
+
+  def perform(model_class, model_id, legacy_url_path)
+    model = model_class.constantize.find(model_id)
+
+    found = false
+    # sadly we can't just search for url, because it's a magic
+    # carrierwave thing not in our model
+    Attachment.where(attachable: model.attachables).where.not(attachment_data: nil).find_each do |attachment|
+      # 'attachment.attachment_data' can still be nil even with the
+      # check above, because if the 'attachment_data_id' is non-nil
+      # but invalid, the 'attachment_data' will be nil - and the
+      # generated SQL only checks if the 'attachment_data_id' is
+      # nil.
+      if attachment.attachment_data && attachment.attachment_data.url == legacy_url_path
+        found = true
+        attachment.attachment_data.uploaded_to_asset_manager!
+      end
+    end
+
+    # the AttachmentData should exist, so if we didn't find it try
+    # again.
+    raise AttachmentDataNotFound.new(legacy_url_path) unless found
+  end
+end

--- a/features/bulk-upload.feature
+++ b/features/bulk-upload.feature
@@ -1,3 +1,4 @@
+@disable-sidekiq-test-mode
 Feature: Bulk uploading attachments to editions
 
   Background:

--- a/features/consultations.feature
+++ b/features/consultations.feature
@@ -25,6 +25,7 @@ Scenario: Publishing a submitted consultation
   And I publish the consultation "Beard Length Review"
   Then I should see the consultation "Beard Length Review" in the list of published documents
 
+@disable-sidekiq-test-mode
 Scenario: Adding an outcome to a closed consultation
   Given I am an editor
   And a closed consultation exists
@@ -32,6 +33,7 @@ Scenario: Adding an outcome to a closed consultation
   And I save and publish the amended consultation
   Then I can see that the consultation has been published
 
+@disable-sidekiq-test-mode
 Scenario: Adding public feedback to a closed consultation
   Given I am an editor
   And a closed consultation exists

--- a/features/corporate-information-pages.feature
+++ b/features/corporate-information-pages.feature
@@ -17,6 +17,7 @@ Scenario: Translating a corporate information page for a worldwide organisation
   And I force-publish the "Terms of reference" corporate information page for the organisation "Ministry of Pop"
   Then I should be able to read the translated "Terms of reference" corporate information page for the organisation "Ministry of Pop" on the site
 
+@disable-sidekiq-test-mode
 Scenario:
   Given I am a GDS editor
   And my organisation has a "Terms of reference" corporate information page

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -1,3 +1,4 @@
+@disable-sidekiq-test-mode
 Feature: Managing attachments on editions
   As a writer or editor
   I want to attach files and additional HTML content to publications and consultations

--- a/features/policy-groups.feature
+++ b/features/policy-groups.feature
@@ -20,6 +20,7 @@ Feature: Policy groups
   Background:
     Given I am an editor
 
+  @disable-sidekiq-test-mode
   Scenario:
     Given a policy group "Panel" exists
     Then I should be able to add attachments to the policy group "Panel"


### PR DESCRIPTION
There exist a few `AttachmentData`s which do not have an `uploaded_to_asset_manager_at` timestamp, and which don't correspond to any `AssetManagerCreateWhitehallAssetWorker` exceptions in the logs.  The worker succeeded, but failed to set the timestamp.  This means that the `AttachmentData` for the given `legacy_url_path` was not found.

Having looked at a few of these assets, the `AttachmentData` in Whitehall and the `WhitehallAsset` in Asset Manager were created in the very same second.

Given that there doesn't appear to be any direct causal link between creating the `AttachmentData` and running the worker, I suspect there is a race condition between the two: if the worker runs to completion before the `AttachmentData` is created (which it could feasibly do for small files when the Sidekiq queue is otherwise empty), then the `AttachmentData` will not exist when the worker tries to set its `uploaded_to_asset_manager_at`.

This commit splits out the setting of the timestamp to a separate worker, which throws an exception (and so gets retried) if it fails to find the `AttachmentData`.  This is a bit of noise, which is sad, but
it does only appear to affect a very small proportion of uploads.