### PR TITLE
Update asset redirect url on unpublish

### DIFF
--- a/app/services/service_listeners/attachment_redirect_url_updater.rb
+++ b/app/services/service_listeners/attachment_redirect_url_updater.rb
@@ -1,0 +1,10 @@
+module ServiceListeners
+  class AttachmentRedirectUrlUpdater
+    def self.call(attachable: nil)
+      Attachment.where(attachable: attachable.attachables).find_each do |attachment|
+        next unless attachment.attachment_data
+        AssetManagerAttachmentRedirectUrlUpdateWorker.perform_async attachment.attachment_data.id
+      end
+    end
+  end
+end

--- a/app/workers/asset_manager_attachment_data_worker.rb
+++ b/app/workers/asset_manager_attachment_data_worker.rb
@@ -6,7 +6,6 @@ class AssetManagerAttachmentDataWorker < WorkerBase
     return unless attachment_data.uploaded_to_asset_manager_at
 
     draft_status_updater attachment_data_id
-    redirect_url_updater attachment_data_id
     link_header_updater attachment_data_id
     access_limited_updater attachment_data_id
     deleter attachment_data_id
@@ -20,10 +19,6 @@ private
 
   def draft_status_updater(attachment_data_id)
     AssetManagerAttachmentDraftStatusUpdateWorker.new.perform attachment_data_id
-  end
-
-  def redirect_url_updater(attachment_data_id)
-    AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform attachment_data_id
   end
 
   def link_header_updater(attachment_data_id)

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -18,6 +18,9 @@ Whitehall.edition_services.tap do |coordinator|
     ServiceListeners::SearchIndexer
       .new(edition)
       .remove!
+
+    # Update attachment redirect urls
+    ServiceListeners::AttachmentRedirectUrlUpdater.call(attachable: edition)
   end
 
   coordinator.subscribe(/^(force_publish|publish|unwithdraw)$/) do |_event, edition, options|
@@ -38,6 +41,9 @@ Whitehall.edition_services.tap do |coordinator|
     ServiceListeners::AuthorNotifier
       .new(edition, options[:user])
       .notify!
+
+    # Update attachment redirect urls
+    ServiceListeners::AttachmentRedirectUrlUpdater.call(attachable: edition)
   end
 
   coordinator.subscribe(/^(force_publish|publish|withdraw|unwithdraw)$/) do |_event, edition, _options|

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -48,13 +48,13 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
+    it 'does not set a redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_news_article_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
-      assert_sets_redirect_url_in_asset_manager_to nil
+      refute_sets_redirect_url_in_asset_manager
     end
   end
 
@@ -72,13 +72,13 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
+    it 'does not set redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_consultation_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
-      assert_sets_redirect_url_in_asset_manager_to nil
+      refute_sets_redirect_url_in_asset_manager
     end
   end
 
@@ -96,13 +96,13 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       assert_sets_redirect_url_in_asset_manager_to redirect_url
     end
 
-    it 'resets redirect URI for attachment in Asset Manager when document is withdrawn' do
+    it 'does not set redirect URI for attachment in Asset Manager when document is withdrawn' do
       visit admin_consultation_path(edition)
       withdraw_document
       logout
       get attachment.url
       assert_response :success
-      assert_sets_redirect_url_in_asset_manager_to nil
+      refute_sets_redirect_url_in_asset_manager
     end
   end
 
@@ -190,7 +190,14 @@ private
     Services.asset_manager.expects(:update_asset)
       .with(asset_id, 'redirect_url' => redirect_url)
       .at_least_once
-    AssetManagerAttachmentDataWorker.drain
+    AssetManagerAttachmentRedirectUrlUpdateWorker.drain
+  end
+
+  def refute_sets_redirect_url_in_asset_manager
+    Services.asset_manager.expects(:update_asset)
+      .with(asset_id, 'redirect_url' => anything)
+      .never
+    AssetManagerAttachmentRedirectUrlUpdateWorker.drain
   end
 
   def unpublish_document_published_in_error


### PR DESCRIPTION
https://trello.com/c/4CyAB1r9/295-fix-issue-with-previewing-assets-on-unpublished-documents

`AttachmentUpdater` will update all asset fields for most
Edition workflow operations. This makes it difficult
to clear the `redirect_url` for attachments which have been
added to a draft which has been previously unpublished.

This commits changes this behaviour so that the `redirect_url`
is only written when editions are unpublished or published. 
This allows an attachment on a (re)drafted edition to be previewable.