### PR TITLE
Featurable organisation republisher

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -1,4 +1,5 @@
 class TopicalEvent < Classification
+  extend Forwardable
   include PublishesToPublishingApi
 
   searchable title: :name,
@@ -9,6 +10,8 @@ class TopicalEvent < Classification
              slug: :slug,
              start_date: :start_date,
              end_date: :end_date
+
+  after_commit :republish_feature_organisations_to_publishing_api, if: :features?
 
   has_one :about_page
 
@@ -69,6 +72,12 @@ class TopicalEvent < Classification
   end
 
 private
+
+  def_delegator :features, :any?, :features?
+
+  def republish_feature_organisations_to_publishing_api
+    features.map(&:republish_organisation_to_publishing_api)
+  end
 
   def start_and_end_dates
     if start_date && end_date

--- a/app/services/service_listeners/featurable_organisation_republisher.rb
+++ b/app/services/service_listeners/featurable_organisation_republisher.rb
@@ -1,0 +1,9 @@
+class ServiceListeners::FeaturableOrganisationRepublisher
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def call
+    @edition.document.features.map(&:republish_organisation_to_publishing_api)
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -50,5 +50,9 @@ Whitehall.edition_services.tap do |coordinator|
     ServiceListeners::EditorialRemarker
       .new(edition, options[:user], options[:remark])
       .save_remark!
+
+    ServiceListeners::FeaturableOrganisationRepublisher
+      .new(edition)
+      .call
   end
 end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -21,6 +21,16 @@ FactoryBot.define do
       sequence(:alternative_format_contact_email) { |n| "organisation-#{n}@example.com" }
     }
 
+    trait(:with_feature_list) do
+      transient do
+        feature_list_count 1
+      end
+
+      after(:create) do |organisation, evaluator|
+        create_list(:feature_list, evaluator.feature_list_count, featurable: organisation)
+      end
+    end
+
     trait(:political) do
       political true
     end
@@ -43,6 +53,8 @@ FactoryBot.define do
   factory :organisation_with_alternative_format_contact_email, parent: :organisation, aliases: [:alternative_format_provider] do
     alternative_format_contact_email "alternative@example.com"
   end
+
+  factory :organisation_with_feature_list, parent: :organisation, traits: [:with_feature_list]
 
   factory :sub_organisation, parent: :organisation do
     parent_organisations { [build(:organisation)] }

--- a/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
+++ b/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ServiceListeners::FeaturableOrganisationRepublisherTest < ActiveSupport::TestCase
+  setup do
+    stub_any_publishing_api_call
+  end
+
+  test 'republish organisation to Publishing API' do
+    organisation = create(:organisation, :with_feature_list, :with_published_edition)
+
+    feature_list = organisation.feature_lists.sample
+    published_edition = organisation.published_editions.sample
+
+    create(:feature, document: published_edition.document, feature_list: feature_list)
+
+    Sidekiq::Testing.inline! do
+      expect_publishing(organisation)
+
+      assert ServiceListeners::FeaturableOrganisationRepublisher.new(published_edition).call
+    end
+  end
+end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -73,4 +73,16 @@ class TopicalEventTest < ActiveSupport::TestCase
     feature_list.reload
     assert_equal 0, feature_list.features.size
   end
+
+  test '#save republishes any organisations that feature the topical event' do
+    topical_event = create(:topical_event)
+    organisation = create(:organisation, :with_feature_list)
+
+    create(:feature, feature_list: organisation.feature_lists.sample, topical_event: topical_event)
+
+    Whitehall::PublishingApi.expects(:publish_async).with(topical_event).once
+    Whitehall::PublishingApi.expects(:publish_async).with(organisation).once
+
+    topical_event.save
+  end
 end


### PR DESCRIPTION
When content is featured on an organisation page and then updated the updates should be reflected
on the organisation page.

See https://trello.com/c/CC2q50Ci