### PR TITLE
Add a special route for /government/feed

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -16,6 +16,13 @@ namespace :publishing_api do
         description: "The prefix route under which almost all government content is published.",
       },
       {
+        base_path: "/government/feed",
+        content_id: "725a346f-9e5b-486d-873d-2b050c126e09",
+        title: "Government feed",
+        description: "This route serves the feed of published content",
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+      },
+      {
         base_path: "/courts-tribunals",
         content_id: "f990c58c-687a-4baf-b1a0-ec2d02c4d654",
         title: "Courts and tribunals",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -23,14 +23,14 @@ namespace :publishing_api do
       },
     ].each do |route|
       publisher.publish(
-        route.merge(
+        {
           format: "special_route",
           publishing_app: "whitehall",
           rendering_app: Whitehall::RenderingApp::WHITEHALL_FRONTEND,
           update_type: "major",
           type: "prefix",
           public_updated_at: Time.zone.now.iso8601,
-          )
+        }.merge(route)
       )
     end
   end


### PR DESCRIPTION
We're going to migrate this feed to be rendered from collections (https://github.com/alphagov/collections/pull/792). This creates an explicit route for it. The content_id was randomly generated, because there's currently no content item for it yet (it's served by the prefix route).

https://trello.com/c/wGkUiiGq