### PR TITLE
Remove /government/feed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
   include LocalisedUrlPathHelper
+  include LegacyUrlHelper
 
   protect_from_forgery
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,12 +1,6 @@
 class HomeController < PublicFacingController
   layout 'frontend'
 
-  enable_request_formats feed: [:atom]
-
-  def feed
-    @recently_updated = Edition.published.in_reverse_chronological_order.includes(:document).limit(10)
-  end
-
   def how_government_works
     sitewide_setting = load_reshuffle_setting
     @is_during_reshuffle = sitewide_setting.on if sitewide_setting

--- a/app/helpers/legacy_url_helper.rb
+++ b/app/helpers/legacy_url_helper.rb
@@ -1,0 +1,9 @@
+module LegacyUrlHelper
+  def atom_feed_path
+    "/government/feed"
+  end
+
+  def atom_feed_url(_)
+    "#{Plek.new.website_root}/government/feed"
+  end
+end

--- a/app/views/home/feed.atom.builder
+++ b/app/views/home/feed.atom.builder
@@ -1,8 +1,0 @@
-atom_feed language: 'en-GB', url: atom_feed_url(format: :atom), root_url: root_url do |feed|
-  feed.title 'GOV.UK departments and policy - all updates'
-  feed.author do |author|
-    author.name 'HM Government'
-  end
-
-  documents_as_feed_entries(@recently_updated, feed)
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,6 @@ Whitehall::Application.routes.draw do
     resource :email_signups, path: 'email-signup', only: %i[create new]
     get "/email-signup", to: redirect('/')
 
-    get '/feed' => 'home#feed', defaults: { format: :atom }, constraints: { format: :atom }, as: :atom_feed
     get '/tour' => redirect("/tour", prefix: "")
 
     get '/announcements(.:locale)', as: 'announcements', to: 'announcements#index', constraints: { locale: VALID_LOCALES_REGEX }

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -9,39 +9,6 @@ class HomeControllerTest < ActionController::TestCase
     create(:ministerial_role_appointment, role: pm_role, person: pm_person)
   end
 
-  view_test 'Atom feed has the right elements' do
-    document = create(:published_news_article)
-
-    get :feed, format: :atom
-
-    assert_select_atom_feed do
-      assert_select 'feed > id', 1
-      assert_select 'feed > title', 1
-      assert_select 'feed > author, feed > entry > author'
-      assert_select 'feed > updated', 1
-      assert_select 'feed > link[rel=?][type=?][href=?]', 'self', 'application/atom+xml', atom_feed_url(format: :atom), 1
-      assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', root_url, 1
-
-      assert_select_atom_entries([document])
-    end
-  end
-
-  view_test 'Atom feed shows a list of recently published documents' do
-    create_published_documents
-    create_draft_documents
-
-    get :feed, format: :atom
-
-    documents = Edition.published.in_reverse_chronological_order
-    recent_documents = documents[0...10]
-
-    assert_select_atom_feed do
-      assert_select 'feed > updated', text: recent_documents.first.public_timestamp.iso8601
-
-      assert_select_atom_entries(recent_documents)
-    end
-  end
-
   view_test "frontend layout includes header-context element to stop breadcrumbs being inserted" do
     get :how_government_works
 

--- a/test/functional/latest_controller_test.rb
+++ b/test/functional/latest_controller_test.rb
@@ -39,7 +39,7 @@ class LatestControllerTest < ActionController::TestCase
     get :index
 
     assert_response :redirect
-    assert_redirected_to atom_feed_path
+    assert_redirected_to "/government/feed"
   end
 
   test 'GET :index should expose documents for the subject' do

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -90,22 +90,6 @@ class RoutingTest < ActionDispatch::IntegrationTest
     assert_redirected_to publications_path
   end
 
-  test "atom feed responds with atom to both /government/feed and /government/feed.atom requests" do
-    get "/government/feed"
-    assert_equal 200, response.status
-    assert_equal Mime[:atom], response.content_type
-
-    get "/government/feed.atom"
-    assert_equal 200, response.status
-    assert_equal Mime[:atom], response.content_type
-  end
-
-  test "atom feed returns 404s for other content types" do
-    assert_raise ActionController::RoutingError do
-      get "/government/feed.json"
-    end
-  end
-
   test "routing to editions#show will redirect to correct edition type" do
     login_as_admin
     publication = create(:publication)


### PR DESCRIPTION
This feed is [now rendered by collections](https://github.com/alphagov/collections/pull/792). 

In a few places this app uses the atom feed URL helpers to redirect to. By removing the routes these
are also removed. This is fixed by adding `atom_feed_path helper` and `atom_feed_url` to a helper.

https://trello.com/c/wGkUiiGq