### PR TITLE
Fix link to view organisations translations

### DIFF
--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -81,6 +81,10 @@ module PublicDocumentRoutesHelper
     organisation_url(organisation_or_court_or_slug, options.merge(only_path: true))
   end
 
+  def organisation_preview_url(organisation, options = {})
+    polymorphic_url(organisation, options.merge(host: URI(Plek.new.external_url_for("draft-origin")).host))
+  end
+
 private
 
   def build_url_for_corporate_information_page(edition, options)

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -19,7 +19,8 @@
         <% @organisation.non_english_translated_locales.each do |locale| %>
           <tr>
             <td class="locale">
-              <%= link_to locale.native_language_name, edit_admin_organisation_translation_path(@organisation, locale.code) %> (<%= link_to "view", organisation_path(@organisation, locale: locale) %>)
+              <%= link_to locale.native_language_name, edit_admin_organisation_translation_path(@organisation, locale.code) %>
+              (<%= link_to "view", organisation_preview_url(@organisation, locale: locale) %>)
             </td>
             <td class="actions">
               <%= button_to 'Delete',

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -45,9 +45,9 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     organisation = create(:organisation, translated_into: [:fr])
     get :index, params: { organisation_id: organisation }
     edit_translation_path = edit_admin_organisation_translation_path(organisation, 'fr')
-    view_organisation_path = organisation_path(organisation, locale: 'fr')
+    view_organisation_url = organisation_preview_url(organisation, locale: 'fr')
     assert_select "a[href=?]", edit_translation_path, text: 'Français'
-    assert_select "a[href=?]", view_organisation_path, text: 'view'
+    assert_select "a[href=?]", view_organisation_url, text: 'view'
   end
 
   view_test 'index does not list the english translation' do


### PR DESCRIPTION
- currently the 'view' link on the organisations list of translations page points to a relative URL, which is therefore going to `whitehall-admin.publishing.service.gov.uk`, when it should be pointing to `draft-origin.publishing.service.gov.uk`

<img width="601" alt="screen shot 2018-07-18 at 14 19 16" src="https://user-images.githubusercontent.com/861310/42884175-94ecf1aa-8a95-11e8-815a-62ab220aea6e.png">
