### PR TITLE
Group attachment updates together

### DIFF
--- a/app/services/asset_manager/attachment_access_limited_updater.rb
+++ b/app/services/asset_manager/attachment_access_limited_updater.rb
@@ -1,5 +1,0 @@
-class AssetManager::AttachmentAccessLimitedUpdater
-  def self.call(attachment_data)
-    AssetManager::AttachmentUpdater.call(attachment_data, access_limited: true)
-  end
-end

--- a/app/services/asset_manager/attachment_access_limited_updater.rb
+++ b/app/services/asset_manager/attachment_access_limited_updater.rb
@@ -1,35 +1,5 @@
 class AssetManager::AttachmentAccessLimitedUpdater
-  def initialize(attachment_data)
-    @attachment_data = attachment_data
-  end
-
-  def self.call(*args)
-    new(*args).call
-  end
-
-  def call
-    access_limited_to_these_users = []
-    if attachment_data.access_limited?
-      access_limited_to_these_users = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
-    end
-
-    update_asset(attachment_data, attachment_data.file, access_limited_to_these_users)
-    if attachment_data.pdf?
-      update_asset(attachment_data, attachment_data.file.thumbnail, access_limited_to_these_users)
-    end
-  end
-
-  private_class_method :new
-
-private
-
-  attr_reader :attachment_data
-
-  def update_asset(attachment_data, uploader, access_limited_to_these_users)
-    AssetManager::AssetUpdater.call(
-      attachment_data,
-      uploader.asset_manager_path,
-      "access_limited" => access_limited_to_these_users,
-    )
+  def self.call(attachment_data)
+    AssetManager::AttachmentUpdater.call(attachment_data, access_limited: true)
   end
 end

--- a/app/services/asset_manager/attachment_draft_status_updater.rb
+++ b/app/services/asset_manager/attachment_draft_status_updater.rb
@@ -1,5 +1,0 @@
-class AssetManager::AttachmentDraftStatusUpdater
-  def self.call(attachment_data)
-    AssetManager::AttachmentUpdater.call(attachment_data, draft_status: true)
-  end
-end

--- a/app/services/asset_manager/attachment_draft_status_updater.rb
+++ b/app/services/asset_manager/attachment_draft_status_updater.rb
@@ -1,14 +1,5 @@
 class AssetManager::AttachmentDraftStatusUpdater
   def self.call(attachment_data)
-    draft = attachment_data.draft? && !attachment_data.unpublished? && !attachment_data.replaced?
-
-    self.update_asset(attachment_data, attachment_data.file, draft)
-    self.update_asset(attachment_data, attachment_data.file.thumbnail, draft) if attachment_data.pdf?
-  end
-
-  def self.update_asset(attachment_data, uploader, draft)
-    AssetManager::AssetUpdater.call(
-      attachment_data, uploader.asset_manager_path, "draft" => draft
-    )
+    AssetManager::AttachmentUpdater.call(attachment_data, draft_status: true)
   end
 end

--- a/app/services/asset_manager/attachment_link_header_updater.rb
+++ b/app/services/asset_manager/attachment_link_header_updater.rb
@@ -1,19 +1,5 @@
 class AssetManager::AttachmentLinkHeaderUpdater < WorkerBase
   def self.call(attachment_data)
-    visible_edition = attachment_data.visible_edition_for(nil)
-    return unless visible_edition.present?
-
-    parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
-
-    self.update_asset(attachment_data, attachment_data.file, parent_document_url)
-    self.update_asset(attachment_data, attachment_data.file.thumbnail, parent_document_url) if attachment_data.pdf?
-  end
-
-  def self.update_asset(attachment_data, uploader, parent_document_url)
-    AssetManager::AssetUpdater.call(
-      attachment_data,
-      uploader.asset_manager_path,
-      "parent_document_url" => parent_document_url,
-    )
+    AssetManager::AttachmentUpdater.call(attachment_data, link_header: true)
   end
 end

--- a/app/services/asset_manager/attachment_link_header_updater.rb
+++ b/app/services/asset_manager/attachment_link_header_updater.rb
@@ -1,5 +1,0 @@
-class AssetManager::AttachmentLinkHeaderUpdater < WorkerBase
-  def self.call(attachment_data)
-    AssetManager::AttachmentUpdater.call(attachment_data, link_header: true)
-  end
-end

--- a/app/services/asset_manager/attachment_redirect_url_updater.rb
+++ b/app/services/asset_manager/attachment_redirect_url_updater.rb
@@ -1,5 +1,0 @@
-class AssetManager::AttachmentRedirectUrlUpdater
-  def self.call(attachment_data)
-    AssetManager::AttachmentUpdater.call(attachment_data, redirect_url: true)
-  end
-end

--- a/app/services/asset_manager/attachment_redirect_url_updater.rb
+++ b/app/services/asset_manager/attachment_redirect_url_updater.rb
@@ -1,17 +1,5 @@
 class AssetManager::AttachmentRedirectUrlUpdater
   def self.call(attachment_data)
-    redirect_url = nil
-    if attachment_data.unpublished?
-      redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
-    end
-
-    self.update_asset(attachment_data, attachment_data.file, redirect_url)
-    self.update_asset(attachment_data, attachment_data.file.thumbnail, redirect_url) if attachment_data.pdf?
-  end
-
-  def self.update_asset(attachment_data, uploader, redirect_url)
-    AssetManager::AssetUpdater.call(
-      attachment_data, uploader.asset_manager_path, "redirect_url" => redirect_url
-    )
+    AssetManager::AttachmentUpdater.call(attachment_data, redirect_url: true)
   end
 end

--- a/app/services/asset_manager/attachment_replacement_id_updater.rb
+++ b/app/services/asset_manager/attachment_replacement_id_updater.rb
@@ -1,28 +1,5 @@
 class AssetManager::AttachmentReplacementIdUpdater
   def self.call(attachment_data)
-    return unless attachment_data.replaced?
-
-    replacement = attachment_data.replaced_by
-
-    self.replace_path(attachment_data, attachment_data.file, replacement.file)
-    if attachment_data.pdf?
-      if replacement.pdf?
-        self.replace_path(attachment_data, attachment_data.file.thumbnail, replacement.file.thumbnail)
-      else
-        self.replace_path(attachment_data, attachment_data.file.thumbnail, replacement.file)
-      end
-    end
+    AssetManager::AttachmentUpdater.call(attachment_data, replacement_id: true)
   end
-
-  def self.replace_path(attachment_data, original_file, replacement_file)
-    AssetManager::AssetUpdater.call(
-      attachment_data,
-      original_file.asset_manager_path,
-      "replacement_legacy_url_path" => replacement_file.asset_manager_path,
-    )
-  rescue AssetManager::ServiceHelper::AssetNotFound
-    raise AssetNotFound.new('Asset unavailable, it may not have synced yet')
-  end
-
-  class AssetNotFound < StandardError; end
 end

--- a/app/services/asset_manager/attachment_replacement_id_updater.rb
+++ b/app/services/asset_manager/attachment_replacement_id_updater.rb
@@ -1,5 +1,0 @@
-class AssetManager::AttachmentReplacementIdUpdater
-  def self.call(attachment_data)
-    AssetManager::AttachmentUpdater.call(attachment_data, replacement_id: true)
-  end
-end

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -1,0 +1,34 @@
+class AssetManager::AttachmentUpdater
+  def self.call(
+    attachment_data,
+    access_limited: false,
+    draft_status: false,
+    link_header: false,
+    redirect_url: false,
+    replacement_id: false
+  )
+    updates = []
+
+    updates += AccessLimitedUpdates.call(attachment_data).to_a if access_limited
+    updates += DraftStatusUpdates.call(attachment_data).to_a if draft_status
+    updates += LinkHeaderUpdates.call(attachment_data).to_a if link_header
+    updates += RedirectUrlUpdates.call(attachment_data).to_a if redirect_url
+    updates += ReplacementIdUpdates.call(attachment_data).to_a if replacement_id
+
+    self.combined_updates(updates).each(&:call)
+  end
+
+  def self.combined_updates(updates)
+    grouped_updates = updates.group_by do |update|
+      [update.attachment_data, update.legacy_url_path]
+    end
+
+    grouped_updates.map do |(attachment_data, legacy_url_path), updates_to_combine|
+      new_attributes = updates_to_combine.each_with_object({}) do |update, hash|
+        hash.merge!(update.new_attributes)
+      end
+
+      Update.new(attachment_data, legacy_url_path, new_attributes)
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/access_limited_updates.rb
+++ b/app/services/asset_manager/attachment_updater/access_limited_updates.rb
@@ -1,0 +1,20 @@
+class AssetManager::AttachmentUpdater::AccessLimitedUpdates
+  def self.call(attachment_data)
+    access_limited = []
+    if attachment_data.access_limited?
+      access_limited = AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
+    end
+
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        attachment_data, attachment_data.file, access_limited: access_limited
+      )
+
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          attachment_data, attachment_data.file.thumbnail, access_limited: access_limited
+        )
+      end
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/draft_status_updates.rb
+++ b/app/services/asset_manager/attachment_updater/draft_status_updates.rb
@@ -1,0 +1,17 @@
+class AssetManager::AttachmentUpdater::DraftStatusUpdates
+  def self.call(attachment_data)
+    draft = attachment_data.draft? && !attachment_data.unpublished? && !attachment_data.replaced?
+
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        attachment_data, attachment_data.file, draft: draft
+      )
+
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          attachment_data, attachment_data.file.thumbnail, draft: draft
+        )
+      end
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/link_header_updates.rb
+++ b/app/services/asset_manager/attachment_updater/link_header_updates.rb
@@ -1,0 +1,20 @@
+class AssetManager::AttachmentUpdater::LinkHeaderUpdates
+  def self.call(attachment_data)
+    visible_edition = attachment_data.visible_edition_for(nil)
+    return [] unless visible_edition.present?
+
+    parent_document_url = Whitehall.url_maker.public_document_url(visible_edition)
+
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        attachment_data, attachment_data.file, parent_document_url: parent_document_url
+      )
+
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          attachment_data, attachment_data.file.thumbnail, parent_document_url: parent_document_url
+        )
+      end
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
+++ b/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
@@ -1,0 +1,20 @@
+class AssetManager::AttachmentUpdater::RedirectUrlUpdates
+  def self.call(attachment_data)
+    redirect_url = nil
+    if attachment_data.unpublished?
+      redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
+    end
+
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        attachment_data, attachment_data.file, redirect_url: redirect_url
+      )
+
+      if attachment_data.pdf?
+        enum.yield AssetManager::AttachmentUpdater::Update.new(
+          attachment_data, attachment_data.file.thumbnail, redirect_url: redirect_url
+        )
+      end
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/replacement_id_updates.rb
+++ b/app/services/asset_manager/attachment_updater/replacement_id_updates.rb
@@ -1,0 +1,25 @@
+class AssetManager::AttachmentUpdater::ReplacementIdUpdates
+  def self.call(attachment_data)
+    return [] unless attachment_data.replaced?
+
+    replacement = attachment_data.replaced_by
+
+    Enumerator.new do |enum|
+      enum.yield AssetManager::AttachmentUpdater::Update.new(
+        attachment_data, attachment_data.file, replacement_legacy_url_path: replacement.file.asset_manager_path
+      )
+
+      if attachment_data.pdf?
+        if replacement.pdf?
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            attachment_data, attachment_data.file.thumbnail, replacement_legacy_url_path: replacement.file.thumbnail.asset_manager_path
+          )
+        else
+          enum.yield AssetManager::AttachmentUpdater::Update.new(
+            attachment_data, attachment_data.file.thumbnail, replacement_legacy_url_path: replacement.file.asset_manager_path
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/asset_manager/attachment_updater/update.rb
+++ b/app/services/asset_manager/attachment_updater/update.rb
@@ -1,0 +1,23 @@
+class AssetManager::AttachmentUpdater::Update
+  def initialize(attachment_data, uploader_or_legacy_url_path, new_attributes)
+    @attachment_data = attachment_data
+
+    @legacy_url_path = if uploader_or_legacy_url_path.respond_to?(:asset_manager_path)
+                         uploader_or_legacy_url_path.asset_manager_path
+                       else
+                         uploader_or_legacy_url_path
+                       end
+
+    @new_attributes = new_attributes
+  end
+
+  def call
+    AssetManager::AssetUpdater.call(
+      attachment_data,
+      legacy_url_path,
+      new_attributes.deep_stringify_keys,
+    )
+  end
+
+  attr_reader :attachment_data, :legacy_url_path, :new_attributes
+end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -5,6 +5,6 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return unless attachment_data.present?
 
-    AssetManager::AttachmentRedirectUrlUpdater.call(attachment_data)
+    AssetManager::AttachmentUpdater.call(attachment_data, redirect_url: true)
   end
 end

--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,3 +1,0 @@
-GovukError.configure do |config|
-  config.excluded_exceptions << 'AssetManager::AttachmentReplacementIdUpdater::AssetNotFound'
-end

--- a/test/integration/attachment_access_limited_integration_test.rb
+++ b/test/integration/attachment_access_limited_integration_test.rb
@@ -38,7 +38,9 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'marks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => ['user-uid'])
+        Services.asset_manager
+          .expects(:update_asset)
+          .at_least_once.with('asset-id', has_entry('access_limited', ['user-uid']))
 
         AssetManagerAttachmentMetadataWorker.drain
       end
@@ -168,7 +170,9 @@ class AttachmentAccessLimitedIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       it 'unmarks attachment as access limited in Asset Manager' do
-        Services.asset_manager.expects(:update_asset).at_least_once.with('asset-id', 'access_limited' => [])
+        Services.asset_manager
+          .expects(:update_asset)
+          .at_least_once.with('asset-id', has_entry('access_limited', []))
 
         AssetManagerAttachmentMetadataWorker.drain
       end

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -114,7 +114,7 @@ private
 
   def assert_sets_draft_status_in_asset_manager_to(draft, never: false)
     expectation = Services.asset_manager.expects(:update_asset)
-      .with(asset_id, 'draft' => draft)
+      .with(asset_id, has_entry('draft', draft))
       .at_least_once
     expectation.never if never
     AssetManagerAttachmentMetadataWorker.drain

--- a/test/integration/attachment_link_header_test.rb
+++ b/test/integration/attachment_link_header_test.rb
@@ -40,7 +40,7 @@ class AttachmentLinkHeaderIntegrationTest < ActionDispatch::IntegrationTest
 
         Services.asset_manager.expects(:update_asset)
           .at_least_once
-          .with(asset_id, 'parent_document_url' => parent_document_url)
+          .with(asset_id, has_entry('parent_document_url', parent_document_url))
 
         AssetManagerAttachmentMetadataWorker.drain
       end

--- a/test/unit/services/asset_manager/attachment_replacement_id_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_replacement_id_updater_test.rb
@@ -87,7 +87,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
     end
 
     it 'raises a AssetNotFound error' do
-      assert_raises(AssetManager::AttachmentReplacementIdUpdater::AssetNotFound) do
+      assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
         worker.call(attachment_data)
       end
     end

--- a/test/unit/services/asset_manager/attachment_updater/attachment_access_limited_worker_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_access_limited_worker_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AssetManager::AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  let(:worker) { AssetManager::AttachmentAccessLimitedUpdater }
+  let(:updater) { AssetManager::AttachmentUpdater }
   let(:attachment_data) { attachment.attachment_data }
   let(:update_worker) { mock('asset-manager-update-asset-worker') }
 
@@ -31,7 +31,7 @@ class AssetManager::AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => ['user-uid'])
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, access_limited: true)
     end
   end
 
@@ -55,7 +55,7 @@ class AssetManager::AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'access_limited' => ['user-uid'])
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, access_limited: true)
     end
   end
 
@@ -71,7 +71,7 @@ class AssetManager::AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.asset_manager_path, 'access_limited' => [])
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, access_limited: true)
     end
   end
 
@@ -89,7 +89,7 @@ class AssetManager::AttachmentAccessLimitedUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'access_limited' => [])
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, access_limited: true)
     end
   end
 end

--- a/test/unit/services/asset_manager/attachment_updater/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_draft_status_updater_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  let(:worker) { AssetManager::AttachmentDraftStatusUpdater }
+  let(:updater) { AssetManager::AttachmentUpdater }
   let(:attachment_data) { attachment.attachment_data }
   let(:update_worker) { mock('asset-manager-update-asset-worker') }
 
@@ -27,7 +27,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.asset_manager_path, 'draft' => true)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, draft_status: true)
     end
   end
 
@@ -51,7 +51,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => true)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, draft_status: true)
     end
 
     context 'and attachment is not draft' do
@@ -63,7 +63,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
         update_worker.expects(:call)
           .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => false)
 
-        worker.call(attachment_data)
+        updater.call(attachment_data, draft_status: true)
       end
     end
 
@@ -76,7 +76,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
         update_worker.expects(:call)
           .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => false)
 
-        worker.call(attachment_data)
+        updater.call(attachment_data, draft_status: true)
       end
     end
 
@@ -89,7 +89,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
         update_worker.expects(:call)
           .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'draft' => false)
 
-        worker.call(attachment_data)
+        updater.call(attachment_data, draft_status: true)
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/attachment_link_header_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_link_header_updater_test.rb
@@ -5,7 +5,7 @@ class AssetManager::AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
   include PublicDocumentRoutesHelper
 
-  let(:worker) { AssetManager::AttachmentLinkHeaderUpdater }
+  let(:updater) { AssetManager::AttachmentUpdater }
   let(:attachment_data) { attachment.attachment_data }
   let(:edition) { FactoryBot.create(:published_edition) }
   let(:parent_document_url) { Whitehall.url_maker.public_document_url(edition) }
@@ -23,7 +23,7 @@ class AssetManager::AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
     it 'does not update draft status of any assets' do
       update_worker.expects(:call).never
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, link_header: true)
     end
   end
 
@@ -35,7 +35,7 @@ class AssetManager::AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.asset_manager_path, 'parent_document_url' => parent_document_url)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, link_header: true)
     end
   end
 
@@ -49,7 +49,7 @@ class AssetManager::AttachmentLinkHeaderUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'parent_document_url' => parent_document_url)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, link_header: true)
     end
   end
 end

--- a/test/unit/services/asset_manager/attachment_updater/attachment_redirect_url_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_redirect_url_updater_test.rb
@@ -5,7 +5,7 @@ class AssetManager::AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
   include PublicDocumentRoutesHelper
 
-  let(:worker) { AssetManager::AttachmentRedirectUrlUpdater }
+  let(:updater) { AssetManager::AttachmentUpdater }
   let(:attachment_data) { attachment.attachment_data }
   let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
   let(:redirect_url) { Whitehall.url_maker.public_document_url(unpublished_edition) }
@@ -32,7 +32,7 @@ class AssetManager::AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.asset_manager_path, 'redirect_url' => redirect_url)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, redirect_url: true)
     end
   end
 
@@ -52,7 +52,7 @@ class AssetManager::AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'redirect_url' => redirect_url)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, redirect_url: true)
     end
 
     context 'and attachment is not unpublished' do
@@ -65,7 +65,7 @@ class AssetManager::AttachmentRedirectUrlUpdaterTest < ActiveSupport::TestCase
         update_worker.expects(:call)
           .with(attachment_data, attachment.file.thumbnail.asset_manager_path, 'redirect_url' => nil)
 
-        worker.call(attachment_data)
+        updater.call(attachment_data, redirect_url: true)
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater/attachment_replacement_id_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_replacement_id_updater_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  let(:worker) { AssetManager::AttachmentReplacementIdUpdater }
+  let(:updater) { AssetManager::AttachmentUpdater }
   let(:update_worker) { mock('asset-manager-update-asset-worker') }
 
   around do |test|
@@ -24,7 +24,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment_data.file.asset_manager_path, attributes)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, replacement_id: true)
     end
   end
 
@@ -35,7 +35,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
     it 'does not update asset manager' do
       update_worker.expects(:call).never
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, replacement_id: true)
     end
   end
 
@@ -56,7 +56,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
       update_worker.expects(:call)
         .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
-      worker.call(attachment_data)
+      updater.call(attachment_data, replacement_id: true)
     end
 
     context 'but replacement is not a PDF' do
@@ -70,7 +70,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
         update_worker.expects(:call)
           .with(attachment_data, attachment_data.file.thumbnail.asset_manager_path, thumbnail_attributes)
 
-        worker.call(attachment_data)
+        updater.call(attachment_data, replacement_id: true)
       end
     end
   end
@@ -88,7 +88,7 @@ class AssetManager::AttachmentReplacementIdUpdaterTest < ActiveSupport::TestCase
 
     it 'raises a AssetNotFound error' do
       assert_raises(AssetManager::ServiceHelper::AssetNotFound) do
-        worker.call(attachment_data)
+        updater.call(attachment_data, replacement_id: true)
       end
     end
   end

--- a/test/unit/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:subject) { AssetManager::AttachmentUpdater }
+  let(:file) { File.open(fixture_path.join("sample.rtf")) }
+  let(:attachment) { FactoryBot.create(:file_attachment, file: file) }
+  let(:attachment_data) { attachment.attachment_data }
+
+  it "groups updates together" do
+    AssetManager::AssetUpdater.expects(:call).once
+
+    subject.call(attachment_data, redirect_url: true, draft_status: true)
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_metadata_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_metadata_worker_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class AssetManagerAttachmentMetadataWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:file) { File.open(fixture_path.join("sample.rtf")) }
+  let(:attachment) { FactoryBot.create(:file_attachment, file: file) }
+  let(:attachment_data) { attachment.attachment_data }
+  let(:worker) { AssetManagerAttachmentMetadataWorker.new }
+
+  it "calls AssetManager::AttachmentRedirectUrlUpdater" do
+    AssetManager::AttachmentUpdater.expects(:call).with(
+      attachment_data,
+      access_limited: true,
+      draft_status: true,
+      link_header: true,
+    )
+
+    AssetManager::AttachmentDeleter.expects(:call).with(
+      attachment_data
+    )
+
+    worker.perform(attachment_data.id)
+  end
+end

--- a/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -9,7 +9,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
   let(:worker) { AssetManagerAttachmentRedirectUrlUpdateWorker.new }
 
   it "calls AssetManager::AttachmentRedirectUrlUpdater" do
-    AssetManager::AttachmentRedirectUrlUpdater.expects(:call).with(attachment_data)
+    AssetManager::AttachmentUpdater.expects(:call).with(attachment_data, redirect_url: true)
     worker.perform(attachment_data.id)
   end
 end


### PR DESCRIPTION
This is the final part after #4222. It refactors how the Attachment Update workers are designed to reduce the number of calls to Asset Manager.

Previously each subupdate of a larger asset update would required a database search and at least one request to the Asset Manager, for each part of the asset (access limiting, draft status, link header, replacement ID, redirect URL). Now there will only be at most two requests to Asset Manager for each asset in full.

[Trello Card](https://trello.com/c/1sd6Ve2a/292-investigate-and-reduce-daily-asset-job-spike)