### PR TITLE
Only report AttachmentDataNotFound to Sentry if the final retry fails

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.excluded_exceptions << 'AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFound'
+end

--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,3 +1,3 @@
 GovukError.configure do |config|
-  config.excluded_exceptions << 'AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFound'
+  config.excluded_exceptions << 'AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient'
 end


### PR DESCRIPTION
The worker needs to run after the `AttachmentData` has been created in the database, but that doesn't always happen.  The exception is benign - it just has the effect of trying again later.

However, if *all* retries fail, then something is up because the `AttachmentData` shouldn't take that long to make it to the database.

---

[Trello card](https://trello.com/c/P7ZF9V3z/285-investigate-assetmanagerassetnotfound-sentry-issue)