### PR TITLE
Mark attachments as draft in Asset Manager when a document is unpublished

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -21,6 +21,8 @@ class AttachmentData < ApplicationRecord
 
   attr_accessor :attachable
 
+  attribute :present_at_unpublish, :boolean, default: false
+
   def filename
     url && File.basename(url)
   end
@@ -138,6 +140,10 @@ class AttachmentData < ApplicationRecord
 
   def unpublished_edition
     last_attachable.unpublished_edition
+  end
+
+  def present_at_unpublish?
+    self[:present_at_unpublish]
   end
 
   def replaced?

--- a/app/services/asset_manager/attachment_updater/draft_status_updates.rb
+++ b/app/services/asset_manager/attachment_updater/draft_status_updates.rb
@@ -1,6 +1,6 @@
 class AssetManager::AttachmentUpdater::DraftStatusUpdates
   def self.call(attachment_data)
-    draft = attachment_data.draft? && !attachment_data.unpublished? && !attachment_data.replaced?
+    draft = (attachment_data.draft? && !attachment_data.unpublished? && !attachment_data.replaced?) || (attachment_data.unpublished? && !attachment_data.present_at_unpublish? && !attachment_data.replaced?)
 
     Enumerator.new do |enum|
       enum.yield AssetManager::AttachmentUpdater::Update.new(

--- a/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
+++ b/app/services/asset_manager/attachment_updater/redirect_url_updates.rb
@@ -1,7 +1,7 @@
 class AssetManager::AttachmentUpdater::RedirectUrlUpdates
   def self.call(attachment_data)
     redirect_url = nil
-    if attachment_data.unpublished?
+    if attachment_data.unpublished? && attachment_data.present_at_unpublish?
       redirect_url = attachment_data.unpublished_edition.unpublishing.document_url
     end
 

--- a/app/services/service_listeners/attachment_present_at_unpublish_updater.rb
+++ b/app/services/service_listeners/attachment_present_at_unpublish_updater.rb
@@ -1,0 +1,10 @@
+module ServiceListeners
+  class AttachmentPresentAtUnpublishUpdater
+    def self.call(attachable: nil, value: false)
+      Attachment.where(attachable: attachable.attachables).find_each do |attachment|
+        next unless attachment.attachment_data
+        attachment.attachment_data.update_attribute(:present_at_unpublish, value)
+      end
+    end
+  end
+end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -19,6 +19,9 @@ Whitehall.edition_services.tap do |coordinator|
       .new(edition)
       .remove!
 
+    # Update unpublish status
+    ServiceListeners::AttachmentPresentAtUnpublishUpdater.call(attachable: edition, value: true)
+
     # Update attachment redirect urls
     ServiceListeners::AttachmentRedirectUrlUpdater.call(attachable: edition)
   end

--- a/db/migrate/20180726082757_add_present_on_unpublish_to_attachment_data.rb
+++ b/db/migrate/20180726082757_add_present_on_unpublish_to_attachment_data.rb
@@ -1,0 +1,6 @@
+class AddPresentOnUnpublishToAttachmentData < ActiveRecord::Migration[5.0]
+  def change
+    add_column :attachment_data, :present_at_unpublish, :boolean
+    AttachmentData.reset_column_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626121716) do
+ActiveRecord::Schema.define(version: 20180726082757) do
 
   create_table "about_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "topical_event_id"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20180626121716) do
     t.datetime "updated_at"
     t.integer  "replaced_by_id"
     t.datetime "uploaded_to_asset_manager_at"
+    t.boolean  "present_at_unpublish"
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id", using: :btree
   end
 

--- a/test/unit/services/asset_manager/attachment_updater/attachment_draft_status_updater_test.rb
+++ b/test/unit/services/asset_manager/attachment_updater/attachment_draft_status_updater_test.rb
@@ -71,6 +71,7 @@ class AssetManager::AttachmentDraftStatusUpdaterTest < ActiveSupport::TestCase
       let(:unpublished) { true }
 
       it 'marks corresponding assets as not draft even though attachment is draft' do
+        attachment_data.update_attribute(:present_at_unpublish, true)
         update_worker.expects(:call)
           .with(attachment_data, attachment.file.asset_manager_path, 'draft' => false)
         update_worker.expects(:call)


### PR DESCRIPTION
Currently, after a document is unpublished, any attachments are marked as 'not draft' in Asset Manager.  This means it could be possible for the attachments to be accessed by anyone by guessing the URL.

This changes the logic is mark attachments as draft in Asset Manager once a document has been unpublished.

https://trello.com/c/PlPb1iNY/337-fix-attachments-on-unpublished