### PR TITLE
Export news documents as JSON

### DIFF
--- a/lib/export_news_document.rb
+++ b/lib/export_news_document.rb
@@ -1,0 +1,133 @@
+class ExportNewsDocument
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def as_json
+    document.as_json.merge("editions" => editions.as_json)
+  end
+
+private
+
+  def editions
+    document.editions.map do |edition|
+      edition
+        .as_json(only: edition_fields)
+        .merge(edition_associations(edition))
+    end
+  end
+
+  def edition_fields
+    %i[
+      id
+      created_at
+      updated_at
+      lock_version
+      state
+      type
+      major_change_published_at
+      first_published_at
+      change_note
+      force_published
+      minor_change
+      public_timestamp
+      scheduled_publication
+      access_limited
+      published_major_version
+      published_minor_version
+      primary_locale
+      political
+    ]
+  end
+
+  def edition_associations(edition)
+    {
+      alternative_format_provider: organisation(edition.alternative_format_provider),
+      news_article_type: edition.news_article_type&.as_json,
+      translations: translations(edition),
+      unpublishing: unpublishing(edition),
+      last_author: edition.last_author&.uid,
+      authors: edition.authors.map(&:uid),
+      # These specialist sectors map to document types of topic
+      primary_specialist_sectors: edition.primary_specialist_sectors.map(&:topic_content_id),
+      secondary_specialist_sectors: edition.secondary_specialist_sectors.map(&:topic_content_id),
+      lead_organisations: edition.lead_organisations.map { |o| organisation(o) },
+      supporting_organisations: edition.supporting_organisations.map { |o| organisation(o) },
+      topics: edition.topics.map { |t| t.as_json(only: %i[id content_id name type]) },
+      policy_content_ids: edition.policy_content_ids,
+      world_locations: edition.world_locations.map(&:content_id),
+      worldwide_organisations: edition.worldwide_organisations.map(&:content_id),
+      ministers: ministers(edition),
+      topical_events: TopicalEvent.for_edition(edition.id).map(&:content_id),
+      images: images(edition),
+      attachments: attachments(edition),
+    }
+  end
+
+  def organisation(organisation)
+    return unless organisation
+    organisation
+      .as_json(only: %i[id content_id name])
+      .merge(type: "Organisation")
+  end
+
+  def translations(edition)
+    fields = %i[locale title summary body]
+    edition.translations.map { |translation| translation.as_json(only: fields) }
+  end
+
+  def unpublishing(edition)
+    return unless edition.unpublishing
+    edition.unpublishing
+      .as_json(only: %i[explanation alternative_url redirect])
+      .merge(reason: edition.unpublishing.unpublishing_reason.name)
+  end
+
+  def ministers(edition)
+    edition.role_appointments.map do |appointment|
+      {
+        id: appointment.id,
+        content_id: appointment.content_id,
+        role: {
+          id: appointment.role.id,
+          content_id: appointment.role.content_id,
+        },
+        person: {
+          id: appointment.person.id,
+          content_id: appointment.person.content_id,
+        },
+      }
+    end
+  end
+
+  def images(edition)
+    edition.images.map do |image|
+      {
+        id: image.id,
+        alt_text: image.alt_text,
+        caption: image.caption,
+        carrierwave_image: image.image_data.carrierwave_image,
+      }
+    end
+  end
+
+  def attachments(edition)
+    edition.attachments.map do |attachment|
+      data = attachment.as_json(except: %i[attachable_id attachable_type attachment_data_id])
+
+      if attachment.respond_to?(:attachment_data)
+        data[:attachment_data] =  attachment.attachment_data.as_json
+      end
+
+      if attachment.respond_to?(:govspeak_content)
+        data[:govspeak_content] = attachment.govspeak_content.as_json(
+          expect: :html_attachment_id
+        )
+      end
+
+      data
+    end
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -141,7 +141,7 @@ namespace :export do
       {
         title: a.title,
         body: a.govspeak_content_body,
-        issued_date: a.created_at.strftime("%Y-%m-%d"),
+        issued_date: a.created_at.strftime("%Y-%m-%d"), # rubocop:disable Style/FormatStringToken
         summary: edition.summary,
         slug: a.slug
       }

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -148,4 +148,29 @@ namespace :export do
     end
     puts result.to_json
   end
+
+  desc "Export news documents to JSON format export:news_documents ORGS=org-slug FROM=2018-07-01 OUTPUT=/path/to/file"
+  task news_documents: :environment do
+    org_slugs = ENV.fetch("ORGS", "").split(',')
+    path = ENV.fetch("OUTPUT", "tmp/news-documents-export-#{Time.now.to_i}.json")
+
+    scope = Document
+      .eager_load(:editions)
+      .joins(:latest_edition)
+      .joins("INNER JOIN edition_organisations ON editions.id = edition_organisations.edition_id")
+      .joins("INNER JOIN organisations ON edition_organisations.organisation_id = organisations.id")
+      .where("document_type": "NewsArticle")
+
+    scope = scope.where("organisations.slug": org_slugs) if org_slugs.any?
+    scope = scope.where("editions.updated_at >= ?", ENV["FROM"]) if ENV["FROM"]
+    total = scope.count
+
+    document_data = scope.find_each.with_index.map do |document, index|
+      puts "#{index + 1}/#{total} exported" if ((index + 1) % 100).zero?
+      ExportNewsDocument.new(document).as_json
+    end
+
+    File.open(path, "w") { |f| f.write(document_data.to_json + "\n") }
+    puts "JSON wrote to #{path}"
+  end
 end

--- a/test/unit/export_news_document_test.rb
+++ b/test/unit/export_news_document_test.rb
@@ -1,0 +1,10 @@
+
+require "test_helper"
+
+class ExportNewsDocumentTest < ActiveSupport::TestCase
+  test "returns a hash representation of a document" do
+    document = FactoryBot.build(:edition, :with_document).document
+    export = ExportNewsDocument.new(document).as_json
+    assert_instance_of Hash, export
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Zx8mNyZi/35-investigate-how-could-data-be-exported-from-whitehall-m-1-day

This is to provide the functionality to export the data for news
documents so that they can be imported into a different publishing
application. They are exported in a JSON format with most of the known
data associated within a news document/edition with the exception of
Versions.

The usage is:

```
rake export:news_documents ORGS=org-slug FROM=2018-01-01 OUTPUT=/path/to/file"
```

where:
ORGS is a comma-separated list of organisation slugs (e.g.
hm-revenue-customs,ministry-of-defence) and is a required option
FROM is a parsable date string that MySQL can understand
OUTPUT is a path to the file to write the output too

This task is focussed on news as that is the first format we are
considering for moving to a new publishing application. This could be
developed further to cover all document types, however we would need to
learn further about their individual fields and associations.