### PR TITLE
Render announcements on people page using rummager 

### DIFF
--- a/app/assets/stylesheets/frontend/views/_biographical-page.scss
+++ b/app/assets/stylesheets/frontend/views/_biographical-page.scss
@@ -41,6 +41,12 @@
 
     section {
       margin: $gutter 0 $gutter*2;
+
+      // The components also use `section`, so fix the margin on that.
+      &.gem-c-subscription-links {
+        margin: 20px 0;
+      }
+
       h1 {
         @include ig-core-27;
         font-weight: bold;

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -101,7 +101,27 @@
         </section>
       <% end %>
 
-      <%= render 'shared/announcement_list', announcer: @person %>
+      <% atom_discovery_link_tag atom_feed_url_for(@person), t('announcements.heading') %>
+
+      <% if @person.announcements.any? %>
+        <section class="announcements" id="announcements">
+          <h2><%=  %></h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t("announcements.heading")
+          } %>
+
+          <%= render "govuk_publishing_components/components/subscription-links", {
+            email_signup_link: email_signup_path(atom_feed_url_for(@person)),
+            feed_link: atom_feed_url_for(@person)
+          } %>
+
+          <%= render "govuk_publishing_components/components/document_list", items: @person.announcements %>
+
+          <div class="read-more">
+            <%= link_to t('announcements.view_all'), announcements_path(people: [@person.slug]) %>
+          </div>
+        </section>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/features/people.feature
+++ b/features/people.feature
@@ -11,13 +11,10 @@ Scenario: Viewing the person page for a person
   When I visit the person page for "Benjamin Disraeli"
   Then I should see information about the person "Benjamin Disraeli"
 
-Scenario: Announcements by that person over their career are shown
+Scenario: Announcements by that person are shown
   Given I am an editor
-  And "Don Deputy" is the "Deputy Prime Minister" for the "Cabinet Office"
   And "Harriet Home" is the "Home Secretary" for the "Cabinet Office"
-  And a published news article "News from Harriet, Home Sec" associated with "Harriet Home"
-  And there is a reshuffle and "Harriet Home" is now "Deputy Prime Minister"
-  And a published news article "News from Harriet, Deputy PM" associated with "Harriet Home"
+  And "Harriet Home" has news associated with her
   When I visit the person page for "Harriet Home"
   Then I should see both the news articles for Harriet Home
 

--- a/features/step_definitions/email_signup_steps.rb
+++ b/features/step_definitions/email_signup_steps.rb
@@ -3,14 +3,11 @@ Given(/^email alert api exists$/) do
 end
 
 When(/^I sign up for emails$/) do
-  within '.feeds' do
-    click_on 'email'
-  end
-
   # There is a bug which is causes external urls to get requested from the
   # server. So catch the routing error and handle it so we can continue to
   # assert that the right things have happened to generate the redirect.
   begin
+    click_on 'email'
     click_on 'Create subscription'
   rescue ActionController::RoutingError # rubocop:disable Lint/HandleExceptions
   end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -70,9 +70,19 @@ Then(/^I should see both the news articles for the Deputy Prime Minister role$/)
   assert has_css?(".news_article", text: "News from Harriet, Deputy PM")
 end
 
+Given(/^"([^"]*)" has news associated with her$/) do |arg1|
+  stub_any_rummager_search.to_return(
+    body: {
+      results: [
+        { link: "/foo", title: "First article" },
+        { link: "/foo", title: "Second article" }
+      ]
+    }.to_json)
+end
+
 Then(/^I should see both the news articles for Harriet Home$/) do
-  assert has_css?(".news_article", text: "News from Harriet, Deputy PM")
-  assert has_css?(".news_article", text: "News from Harriet, Home Sec")
+  assert has_content?("First article")
+  assert has_content?("Second article")
 end
 
 Then(/^I should be informed I shouldn't use this image in the markdown$/) do

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -78,18 +78,4 @@ class PeopleControllerTest < ActionController::TestCase
       assert_select "a[href='/government/policies/welfare-reform']", text: "Welfare reform"
     end
   end
-
-  view_test "should display a link to view all announcements for a person" do
-    organisation = create(:organisation)
-    ministerial_role = create(:ministerial_role, organisations: [organisation])
-    person = create(:person)
-    role_appointment = create(:role_appointment, role: ministerial_role, person: person)
-    create(:published_speech, role_appointment: role_appointment)
-
-    get :show, params: { id: person }
-
-    assert_select "#announcements" do
-      assert_select "a[href='/government/announcements?people%5B%5D=#{person.slug}']", text: "View all announcements"
-    end
-  end
 end

--- a/test/unit/presenters/person_presenter_test.rb
+++ b/test/unit/presenters/person_presenter_test.rb
@@ -37,21 +37,6 @@ class PersonPresenterTest < ActionView::TestCase
     assert_no_match %r[This is the second paragraph.], @presenter.biography
   end
 
-  test "#announcements returns decorated published speeches and news articles available in the current locale in descending date" do
-    speech_1 = build(:published_speech, first_published_at: 1.day.ago)
-    speech_2 = build(:published_speech, first_published_at: 30.days.ago, translated_into: :cy)
-    _speech_3 = build(:draft_speech)
-    news_1 = build(:published_news_article, first_published_at: 4.days.ago, translated_into: :cy)
-    role_appointment = create(:ministerial_role_appointment, news_articles: [news_1], speeches: [speech_1, speech_2])
-    presenter = PersonPresenter.new(role_appointment.person)
-
-    assert_equal [speech_1, news_1, speech_2], presenter.announcements.map(&:model)
-
-    I18n.with_locale(:cy) do
-      assert_equal [news_1, speech_2], presenter.announcements.map(&:model)
-    end
-  end
-
   test "is not available in multiple languages if person is not available in multiple languages" do
     role = stub_translatable_record(:role_without_organisations)
     role.stubs(:translated_locales).returns(%i[en fr])


### PR DESCRIPTION
This converts the "Announcements" section on people pages to use the search API. This means that content published by other applications (like upcoming content-publisher) will be surfaced on this page too.

The short/medium term plan for these pages is that they're moved to the collections app. To make this easier, I've chosen to use some components to rebuild the interface. This way I can avoid refactoring whitehall code to make use of the search data structure instead of the data from the database (the `feeds` partial is tightly coupled to the active record models). It hopefully makes the interface better as well.

## Before

![screen shot 2018-08-01 at 12 43 34](https://user-images.githubusercontent.com/233676/43522834-6d72afe0-9592-11e8-910f-697dc820a23c.png)

## After 

![screen shot 2018-08-01 at 12 42 22](https://user-images.githubusercontent.com/233676/43522839-6fdd28dc-9592-11e8-9244-e04f5bcc8123.png)

(The data is different because this uses production data, not my local data).


https://trello.com/c/vYdbh3TQ