### PR TITLE
Redirect people atom feed to rummager-backed equivalent

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -2,15 +2,17 @@ class PeopleController < PublicFacingController
   enable_request_formats show: [:atom]
 
   def show
-    @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
-
     respond_to do |format|
       format.html do
+        @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
         set_meta_description("Biography of #{@person.name}.")
         set_slimmer_organisations_header(@person.organisations)
         set_slimmer_page_owner_header(@person.organisations.first)
       end
-      format.atom
+
+      format.atom do
+        redirect_to "/government/announcements.atom?people[]=#{params[:id]}"
+      end
     end
   end
 end

--- a/app/views/people/show.atom.builder
+++ b/app/views/people/show.atom.builder
@@ -1,9 +1,0 @@
-atom_feed language: 'en-GB', root_url: root_url do |feed|
-  feed.title [@person.name, 'Activity on GOV.UK'].join(' - ')
-  feed.author do |author|
-    author.name 'HM Government'
-  end
-  announcements = @person.announcements
-
-  documents_as_feed_entries(announcements, feed)
-end

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -61,18 +61,11 @@ class PeopleControllerTest < ActionController::TestCase
   end
 
   view_test "#show generates an atom feed of news and speeches associated with the person" do
-    person = create(:person)
-    role_appointment = create(:role_appointment, person: person)
-    expected_entries = [
-      create(:published_news_article, role_appointments: [role_appointment], first_published_at: 1.day.ago),
-      create(:published_speech, role_appointment: role_appointment, delivered_on: 2.day.ago.to_date)
-    ]
+    person = create(:person, slug: 'a-person')
 
     get :show, params: { id: person }, format: :atom
 
-    assert_select_atom_feed do
-      assert_select_atom_entries(expected_entries)
-    end
+    assert_redirected_to '/government/announcements.atom?people[]=a-person'
   end
 
   view_test "should display the person's policies with content" do


### PR DESCRIPTION
This redirects the atom for people to an equivalent feed that is backed by rummager. This means pages by publishing apps other than whitehall (like content publisher).

https://trello.com/c/vYdbh3TQ