### PR TITLE
Add machine readable metadata to people pages

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -5,6 +5,7 @@ class PeopleController < PublicFacingController
     respond_to do |format|
       format.html do
         @person = PersonPresenter.new(Person.friendly.find(params[:id]), view_context)
+        @content_item = Whitehall.content_store.content_item(@person.path)
         set_meta_description("Biography of #{@person.name}.")
         set_slimmer_organisations_header(@person.organisations)
         set_slimmer_page_owner_header(@person.organisations.first)

--- a/app/views/layouts/_frontend_base.html.erb
+++ b/app/views/layouts/_frontend_base.html.erb
@@ -25,6 +25,7 @@
     <%= stylesheet_link_tag "frontend/print.css", media: "print", integrity: true, crossorigin: 'anonymous' %>
     <%= csrf_meta_tags %>
     <%= atom_discovery_link_tag %>
+    <%= yield :extra_head %>
   </head>
   <body class="website government<%= " #{local_assigns[:extra_body_class]}" if local_assigns[:extra_body_class] %>">
     <% unless local_assigns[:show_breadcrumbs] %><div class="header-context group"><!-- deliberately empty --></div><% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,6 +1,12 @@
 <% page_title @person.name %>
 <% page_class "people-show biographical-page" %>
 
+<% content_for :extra_head do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+    schema: :person,
+    content_item: @content_item %>
+<% end %>
+
 <%= content_tag_for :div, @person, class: "two-column-page" do %>
   <header class="block headings-block">
     <div class="inner-block floated-children">

--- a/features/support/person_helper.rb
+++ b/features/support/person_helper.rb
@@ -1,6 +1,12 @@
+require "gds_api/test_helpers/content_store"
+
 module PersonHelper
+  include GdsApi::TestHelpers::ContentStore
+
   def create_person(name, attributes = {})
-    create(:person, split_person_name(name).merge(attributes))
+    person = create(:person, split_person_name(name).merge(attributes))
+    content_store_has_item(person.search_link)
+    person
   end
 
   def find_person(name)

--- a/features/support/role_appointments_helper.rb
+++ b/features/support/role_appointments_helper.rb
@@ -1,4 +1,8 @@
+require "gds_api/test_helpers/content_store"
+
 module RoleAppointmentsHelper
+  include GdsApi::TestHelpers::ContentStore
+
   def create_role_appointment(person_name, role_name, organisation_name, timespan, options = {})
     person = find_or_create_person(person_name)
     organisation = Organisation.find_by(name: organisation_name) || create(:ministerial_department, name: organisation_name)
@@ -14,6 +18,7 @@ module RoleAppointmentsHelper
     end
 
     create(:role_appointment, role: role, person: person, started_at: started_at, ended_at: ended_at)
+    content_store_has_item(person.search_link)
   end
 
   def find_or_create_ministerial_role(name)

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -4,6 +4,7 @@ require "gds_api/test_helpers/rummager"
 class PeopleControllerTest < ActionController::TestCase
   include FeedHelper
   include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::ContentStore
 
   should_be_a_public_facing_controller
 
@@ -21,6 +22,7 @@ class PeopleControllerTest < ActionController::TestCase
   setup do
     @person = create(:person)
     rummager_has_no_policies_for_any_type
+    content_store_has_item(@person.search_link)
   end
 
   view_test "#show displays the details of the person and their roles" do


### PR DESCRIPTION
This adds a canonical tag, schema.org metadata and Facebook sharing tags to the people pages.

https://govuk-publishing-components.herokuapp.com/componentguide/machine_readable_metadata

https://trello.com/c/hDzVLMrm