### PR TITLE
Republish all DfT documents

### DIFF
--- a/db/data_migration/20180801114127_republish_dft_documents.rb
+++ b/db/data_migration/20180801114127_republish_dft_documents.rb
@@ -1,0 +1,9 @@
+dft = Organisation.find_by!(slug: "department-for-transport")
+
+editions = Edition.published.where(alternative_format_provider_id: dft)
+document_ids = editions.pluck(:document_id).uniq
+
+document_ids.each do |id|
+  PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id)
+  print "."
+end


### PR DESCRIPTION
The email address to request an accessible format has been changed therefore we need to republish all the documents to show this change.

[Trello Card](https://trello.com/c/m3GRNRRZ/360-republish-dft-whitehall-editions-with-attachments)