### PR TITLE
Apply `-dUseCropBox` when generating PDF thumbnails

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -80,7 +80,7 @@ class AttachmentUploader < WhitehallUploader
   end
 
   def pdf_thumbnail_command(width, height)
-    %{gs -o #{path} -sDEVICE=pngalpha -dLastPage=1 -r72 -dDEVICEWIDTHPOINTS=#{width} -dDEVICEHEIGHTPOINTS=#{height} -dPDFFitPage #{path} 2>&1}
+    %{gs -o #{path} -sDEVICE=pngalpha -dLastPage=1 -r72 -dDEVICEWIDTHPOINTS=#{width} -dDEVICEHEIGHTPOINTS=#{height} -dPDFFitPage -dUseCropBox #{path} 2>&1}
   end
 
   def extension_whitelist


### PR DESCRIPTION
The issue:
Certain PDF thumbnails contain extra blank space.

The cause:
The MediaBox and CropBox settings of the first page of those PDFs do not match, and the PDFFitPage option is not cropping.

The solution:
Use the CropBox setting to properly crop the page.

References:
https://stackoverflow.com/questions/27779246/when-converting-first-page-of-a-pdf-into-an-image-using-ghostscript-sometimes-i

I've tested this command against the PDF from the zendesk ticket and a handful of random PDFs from the most recent whitehall publications and they all behave correctly.

https://govuk.zendesk.com/agent/tickets/3045098
https://trello.com/c/T5vRXSrW/193-fix-issue-with-pdf-thumbnailing