### PR TITLE
Support running the sanitise db test with a custom host and port

### DIFF
--- a/test/integration/sanitise_db_test.rb
+++ b/test/integration/sanitise_db_test.rb
@@ -83,10 +83,15 @@ class SanitiseDBTest < ActiveSupport::TestCase
 private
 
   def run_script
-    database, username, password = %w(database username password).map do |key|
+    database, host, port, username, password = %w(database host port username password).map do |key|
       ActiveRecord::Base.configurations[Rails.env][key]
     end
 
-    `./script/scrub-database --no-copy -D #{database} -U #{username} -P #{password}`
+    # Use the right port, if one is specified in the Rails
+    # configuration
+    ENV['MYSQL_TCP_PORT'] = port.to_s if port
+    host_arg = "-H #{host}" if host
+
+    `./script/scrub-database --no-copy #{host_arg} -D #{database} -U #{username} -P #{password}`
   end
 end


### PR DESCRIPTION
Without this change, the default host and port are used. Adding the -H
option, and setting the MYSQL_TCP_PORT environment variable means that
the ActiveRecord host and port settings are respected.

This makes it possible to run this test when not using the standard
host and port for MySQL.