### PR TITLE
Republish editions containing ODF attachments

### DIFF
--- a/db/data_migration/20180803160419_republish_editions_with_opendocument_attachments.rb
+++ b/db/data_migration/20180803160419_republish_editions_with_opendocument_attachments.rb
@@ -1,0 +1,13 @@
+document_ids = Document.joins(:editions)
+  .joins("INNER JOIN attachments ON editions.id = attachments.attachable_id
+          AND attachments.attachable_type = 'Edition'")
+  .joins("INNER JOIN attachment_data ON attachments.attachment_data_id = attachment_data.id")
+  .where("editions.state = 'published'")
+  .where("attachment_data.carrierwave_file like '%.odt'
+          OR attachment_data.carrierwave_file like '%.odp'
+          OR attachment_data.carrierwave_file like '%.ods'")
+  .pluck(:id).uniq
+
+document_ids.each do | document_id |
+  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+end


### PR DESCRIPTION
There was a recent change to update the link to our own gov.uk guidance (https://github.com/alphagov/whitehall/pull/3989). This change only affects published editions after the change was merged.

This data migration finds all published editions that contain ODF attachments and republishes them.

Trello card: [Republish whitehall editions that contain OpenDocument links](https://trello.com/c/Dgt3ta3y/369-republish-whitehall-editions-that-contain-opendocument-links)

Paired with @steventux 

Example of an affected link:
<img width="1192" alt="example_of_otd_link" src="https://user-images.githubusercontent.com/19667619/43721323-60e5f420-998a-11e8-8084-6e4500dba6b1.png">