### PR TITLE
Send image url to government search index

### DIFF
--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -42,7 +42,10 @@ class NewsArticle < Newsesque
   end
 
   def search_index
-    super.merge("news_article_type" => news_article_type.slug)
+    super.merge(
+      "news_article_type" => news_article_type.slug,
+      "image_url" => image_url
+    )
   end
 
   def search_format_types
@@ -88,6 +91,10 @@ class NewsArticle < Newsesque
   end
 
 private
+
+  def image_url
+    PublishingApi::NewsArticlePresenter::Image.for(self).dig(:image, :url)
+  end
 
   def organisations_are_not_associated
     if edition_organisations.present? && !all_edition_organisations_marked_for_destruction?

--- a/test/unit/news_article_test.rb
+++ b/test/unit/news_article_test.rb
@@ -48,6 +48,11 @@ class NewsArticleTest < ActiveSupport::TestCase
     assert_equal news_article.role_appointments.map(&:slug), news_article.search_index["people"]
   end
 
+  test "search_index includes image_url" do
+    news_article = create(:news_article)
+    assert_equal "https://static.test.gov.uk/government/assets/placeholder.jpg", news_article.search_index["image_url"]
+  end
+
   test "search_format_types tags the news article as a news-article and announcement" do
     news_article = build(:news_article)
     assert news_article.search_format_types.include?('news-article')


### PR DESCRIPTION
Indexing the image_url allows us to power navigation in news and communications section (like on https://www.gov.uk/education) without making additional content_store calls

Ideally we'd like to migrate these formats so that the search index is populated from the publishing pipeline.  We've [added the necessary plumbing](https://github.com/alphagov/rummager/pull/1269) to Rummager so that any migrated formats will automatically have their image_url indexed, but there's a bit more than that to do for Whitehall formats, so I'd like to do this in the short term.

This sends the `image_url` for `news_story`, `government_response`, `press_release` and `world_news_story` formats.

I'm slightly unhappy with using logic from the publishing_api presenter to populate this, but it does exactly what we need, and the search indexing logic seems pretty entrenched at the moment, so it's difficult to pull out into a presenter itself.  I've added [this card](https://trello.com/c/cqx7DvHM/135-migrate-newsarticle-whitehall-types-to-index-via-publishingapi-rather-than-directly-to-rummager) to undo this, and [change the indexing process](https://github.com/alphagov/rummager/blob/master/doc/new-indexing-process.md).  When we migrate formats, we'll need to exclude them from https://github.com/alphagov/whitehall/blob/58f0440fbdf3a38d0f2c716197f9d55670dc14b8/app/presenters/rummager_presenters.rb#L22-L36

https://trello.com/c/6M8ciQgi/111-get-news-images-from-rummager