### PR TITLE
Avoid having two elements with the same id on the page

### DIFF
--- a/app/views/ministerial_roles/show.html.erb
+++ b/app/views/ministerial_roles/show.html.erb
@@ -60,7 +60,7 @@
 
   <div class="block-3">
     <div class="inner-block" id="responsibilities">
-      <%= content_tag_for :section, @ministerial_role, class: "responsibilities" do %>
+      <%= content_tag_for :section, @ministerial_role, 'responsibilities_for', class: "responsibilities" do %>
         <h1><%= t('roles.headings.responsibilities') %></h1>
         <%= @ministerial_role.responsibilities %>
       <% end %>


### PR DESCRIPTION
Previously this template would result in HTML where two elements
shared the same id. The content_tag_for function is used twice, with
the same model instance, so add a prefix to the second invocation so
that the ids differ.