### PR TITLE
Change how organisations are republished

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -19,7 +19,7 @@ class Feature < ApplicationRecord
   def republish_organisation_to_publishing_api
     featurable = feature_list.featurable if feature_list
     if featurable.is_a?(Organisation) && featurable.persisted?
-      featurable.publish_to_publishing_api
+      Whitehall::PublishingApi.republish_async(featurable)
     end
   end
 

--- a/app/models/featured_link.rb
+++ b/app/models/featured_link.rb
@@ -12,7 +12,7 @@ class FeaturedLink < ApplicationRecord
 
   def republish_organisation_to_publishing_api
     if linkable_type == "Organisation" && linkable.persisted?
-      linkable.publish_to_publishing_api
+      Whitehall::PublishingApi.republish_async(linkable)
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -53,7 +53,9 @@ class Person < ApplicationRecord
   after_update :touch_role_appointments
 
   def republish_organisation_to_publishing_api
-    organisations.each(&:publish_to_publishing_api)
+    organisations.each do |organisation|
+      Whitehall::PublishingApi.republish_async(organisation)
+    end
   end
 
   def published_policies

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -59,7 +59,9 @@ class Role < ApplicationRecord
   translates :name, :responsibilities
 
   def republish_organisation_to_publishing_api
-    organisations.each(&:publish_to_publishing_api)
+    organisations.each do |organisation|
+      Whitehall::PublishingApi.republish_async(organisation)
+    end
   end
 
   def self.whip

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -72,7 +72,9 @@ class RoleAppointment < ApplicationRecord
   after_destroy :update_indexes
 
   def republish_organisation_to_publishing_api
-    organisations.each(&:publish_to_publishing_api)
+    organisations.each do |organisation|
+      Whitehall::PublishingApi.republish_async(organisation)
+    end
   end
 
   def self.between(start_time, end_time)

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -11,7 +11,7 @@ class SocialMediaAccount < ApplicationRecord
 
   def republish_organisation_to_publishing_api
     if socialable_type == "Organisation" && socialable.persisted?
-      socialable.publish_to_publishing_api
+      Whitehall::PublishingApi.republish_async(socialable)
     end
   end
 

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -26,7 +26,10 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     content[:routes][0][:path] = new_base_path
     content_item.stubs(content: content)
 
-    organisation_content_item = PublishingApiPresenters.presenter_for(@organisation)
+    organisation_content_item = PublishingApiPresenters.presenter_for(
+      @organisation,
+      update_type: 'republish'
+    )
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
@@ -34,7 +37,7 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major'),
       stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
       stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
-      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: organisation_content_item.update_type)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/models/feature_test.rb
+++ b/test/unit/models/feature_test.rb
@@ -6,7 +6,7 @@ class FeatureTest < ActiveSupport::TestCase
   test "creating a new feature republishes the linked featurable if it's an Organisation" do
     test_object = create(:organisation)
     feature_list = create(:feature_list, featurable: test_object)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     create(:feature, feature_list: feature_list)
   end
 
@@ -15,7 +15,7 @@ class FeatureTest < ActiveSupport::TestCase
     feature_list = create(:feature_list, featurable: test_object)
     feature = create(:feature, feature_list: feature_list)
     feature.alt_text = "Test"
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     feature.save!
   end
 
@@ -23,14 +23,14 @@ class FeatureTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     feature_list = create(:feature_list, featurable: test_object)
     feature = create(:feature, feature_list: feature_list)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     feature.destroy
   end
 
   test "creating a new feature does not republish the linked featurable if it's not an Organisation" do
     test_object = create(:world_location)
     feature_list = create(:feature_list, featurable: test_object)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).never
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).never
     create(:feature, feature_list: feature_list)
   end
 end

--- a/test/unit/models/featured_link_test.rb
+++ b/test/unit/models/featured_link_test.rb
@@ -5,7 +5,7 @@ class FeaturedLinkTest < ActiveSupport::TestCase
   # can be used here. Ideally a seperate stub ActiveRecord object would be used.
   test "creating a new featured link republishes the linked linkable if it's an Organisation" do
     test_object = create(:organisation)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     create(:featured_link, linkable: test_object)
   end
 
@@ -13,20 +13,20 @@ class FeaturedLinkTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     featured_link = create(:featured_link, linkable: test_object)
     featured_link.title = "Test"
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     featured_link.save!
   end
 
   test "deleting a featured link republishes the linked linkable if it's an Organisation" do
     test_object = create(:organisation)
     featured_link = create(:featured_link, linkable: test_object)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     featured_link.destroy
   end
 
   test "creating a new featured link does not republish the linked linkable if it's not an Organisation" do
     test_object = create(:world_location)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).never
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).never
     create(:featured_link, linkable: test_object)
   end
 end

--- a/test/unit/models/person_role_test.rb
+++ b/test/unit/models/person_role_test.rb
@@ -6,7 +6,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     role = create(:role, organisations: [test_object])
     person = create(:person)
     role_appointment = build(:role_appointment, person: person, role: role)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
     role_appointment.save!
   end
@@ -19,7 +19,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     person.reload
     person.forename = "Test"
     Whitehall::PublishingApi.expects(:publish_async).with(person).once
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     person.save!
   end
 
@@ -31,7 +31,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     person.reload
     role.cabinet_member = true
     Whitehall::PublishingApi.expects(:publish_async).with(role).once
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     role.save!
   end
 end

--- a/test/unit/models/social_media_account_test.rb
+++ b/test/unit/models/social_media_account_test.rb
@@ -12,7 +12,7 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
 
   test "creating a new social media account republishes the linked socialable if it's an Organisation" do
     test_object = create(:organisation)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     create(:social_media_account, socialable: test_object)
   end
 
@@ -20,20 +20,20 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     social_media_account = create(:social_media_account, socialable: test_object)
     social_media_account.title = "Test"
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     social_media_account.save!
   end
 
   test "deleting a social media account republishes the linked socialable if it's an Organisation" do
     test_object = create(:organisation)
     social_media_account = create(:social_media_account, socialable: test_object)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     social_media_account.destroy
   end
 
   test "creating a new social media account does not republish the linked socialable if it's not an Organisation" do
     test_object = create(:world_location)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).never
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).never
     create(:social_media_account, socialable: test_object)
   end
 end

--- a/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
+++ b/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
@@ -14,7 +14,7 @@ class ServiceListeners::FeaturableOrganisationRepublisherTest < ActiveSupport::T
     create(:feature, document: published_edition.document, feature_list: feature_list)
 
     Sidekiq::Testing.inline! do
-      expect_publishing(organisation)
+      expect_republishing(organisation)
 
       assert ServiceListeners::FeaturableOrganisationRepublisher.new(published_edition).call
     end

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -78,10 +78,10 @@ class TopicalEventTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     organisation = create(:organisation, :with_feature_list)
 
-    create(:feature, feature_list: organisation.feature_lists.sample, topical_event: topical_event)
+    create(:feature, feature_list: organisation.feature_lists.first, topical_event: topical_event)
 
     Whitehall::PublishingApi.expects(:publish_async).with(topical_event).once
-    Whitehall::PublishingApi.expects(:publish_async).with(organisation).once
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
 
     topical_event.save
   end


### PR DESCRIPTION
Currently the organisation pages have a number of dependencies that
are not handled by the Publishing API. Change how these are handled,
to make it clearer at least in the code that the organisation is being
"republished".