### PR TITLE
Enable uploading of vCard files

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -104,6 +104,7 @@ module DocumentHelper
       "rtf"  => file_abbr_tag('RTF', 'Rich Text Format'),
       "sch"  => file_abbr_tag('SCH', 'XML based Schematic'),
       "txt"  => "Plain text",
+      "vcf"  => "vCard file",
       "wsdl" => file_abbr_tag('WSDL', 'Web Services Description Language'),
       "xls"  => MS_EXCEL_SPREADSHEET_HUMANIZED_CONTENT_TYPE,
       "xlsm" => file_abbr_tag('XLSM', 'MS Excel Macro-Enabled Workbook'),

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -6,7 +6,7 @@ class AttachmentUploader < WhitehallUploader
 
   THUMBNAIL_GENERATION_TIMEOUT = 10.seconds
   FALLBACK_PDF_THUMBNAIL = File.expand_path("../../assets/images/pub-cover.png", __FILE__)
-  EXTENSION_WHITELIST = %w(chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt wsdl xls xlsm xlsx xlt xml xsd xslt zip).freeze
+  EXTENSION_WHITELIST = %w(chm csv diff doc docx dot dxf eps gif gml ics jpg kml odp ods odt pdf png ppt pptx ps rdf ris rtf sch txt vcf wsdl xls xlsm xlsx xlt xml xsd xslt zip).freeze
 
   before :cache, :validate_zipfile_contents!
 

--- a/test/unit/attachment_uploader_test.rb
+++ b/test/unit/attachment_uploader_test.rb
@@ -13,7 +13,7 @@ class AttachmentUploaderTest < ActiveSupport::TestCase
 
   test 'should allow whitelisted file extensions' do
     graphics = %w(dxf eps gif jpg png ps)
-    documents = %w(chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt)
+    documents = %w(chm diff doc docx ics odp odt pdf ppt pptx rdf rtf txt vcf)
     document_support = %w(ris)
     spreadsheets = %w(csv ods xls xlsm xlsx)
     markup = %w(gml kml sch wsdl xml xsd)


### PR DESCRIPTION
This commit adds support for uploading vCard files with the `.vcf` extension, as per the guidance at https://www.gov.uk/government/publications/open-standards-for-government/exchange-of-contact-information.

This has been requested by the MoD so they can easily publish contact details in an open and shareable format.