### PR TITLE
Use 301s rather than 302s for attachments

### DIFF
--- a/app/controllers/asset_manager_redirect_controller.rb
+++ b/app/controllers/asset_manager_redirect_controller.rb
@@ -5,6 +5,6 @@ class AssetManagerRedirectController < ApplicationController
       asset_url = Plek.new.external_url_for('draft-assets')
     end
 
-    redirect_to host: URI.parse(asset_url).host
+    redirect_to host: URI.parse(asset_url).host, status: 301
   end
 end


### PR DESCRIPTION
All the Whitehall attachments have been migrated to Asset Manager,
permanently.  We're not going to switch back, so we should reflect
this in the status code.