### PR TITLE
Fix XML attachment metadata

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -110,6 +110,7 @@ module DocumentHelper
       "xlsm" => file_abbr_tag('XLSM', 'MS Excel Macro-Enabled Workbook'),
       "xlsx" => MS_EXCEL_SPREADSHEET_HUMANIZED_CONTENT_TYPE,
       "xlt"  => file_abbr_tag('XLT', 'MS Excel Spreadsheet Template'),
+      "xml"  => file_abbr_tag('XML', 'XML document'),
       "xsd"  => file_abbr_tag('XSD', 'XML Schema'),
       "xslt" => file_abbr_tag('XSLT', 'Extensible Stylesheet Language Transformation'),
       "zip"  => file_abbr_tag('ZIP', 'Zip archive'),

--- a/db/data_migration/20180824141307_republish_documents_with_xml_attachments.rb
+++ b/db/data_migration/20180824141307_republish_documents_with_xml_attachments.rb
@@ -1,0 +1,11 @@
+document_ids = Document.joins(:editions)
+  .joins("INNER JOIN attachments ON editions.id = attachments.attachable_id
+          AND attachments.attachable_type = 'Edition'")
+  .joins("INNER JOIN attachment_data ON attachments.attachment_data_id = attachment_data.id")
+  .where("editions.state = 'published'")
+  .where("attachment_data.carrierwave_file like '%.xml'")
+  .pluck(:id).uniq
+
+  document_ids.each do | document_id |
+    PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+  end

--- a/test/unit/helpers/document_helper_test.rb
+++ b/test/unit/helpers/document_helper_test.rb
@@ -123,6 +123,10 @@ class DocumentHelperTest < ActionView::TestCase
     assert_equal '<abbr title="Zip archive">ZIP</abbr>', humanized_content_type("zip")
   end
 
+  test "should return XML for humanized content type" do
+    assert_equal '<abbr title="XML document">XML</abbr>', humanized_content_type("xml")
+  end
+
   test "should return native language name for locale" do
     assert_equal "English", native_language_name_for(:en)
     assert_equal "Español", native_language_name_for(:es)


### PR DESCRIPTION
Initially reported in this issue: [XML files display odd behaviour](https://github.com/alphagov/whitehall/issues/4266)

There is currently a bug on documents that contain XML attachments. The attachment type is not displayed if it has the XML file extension, which makes it look slightly broken on the page.

This file type has now been included in `humanized_content_type` hash.

Before:
<img width="1056" alt="xml_metadata_before" src="https://user-images.githubusercontent.com/19667619/44590455-1ea64d80-a7b3-11e8-85b0-25878ad2dc06.png">

After:
<img width="1056" alt="xml_metadata_after" src="https://user-images.githubusercontent.com/19667619/44590460-249c2e80-a7b3-11e8-86bb-76cd71a95170.png">

Trello card: [Fix XML attachment metadata bug](https://trello.com/c/cYXs5gvC/412-fix-xml-attachment-metadata-bug)