### PR TITLE
Fix world location renaming data migration

### DIFF
--- a/db/data_migration/20180823093420_reslug_south_georgia_and_the_south_sandwich_islands.rb
+++ b/db/data_migration/20180823093420_reslug_south_georgia_and_the_south_sandwich_islands.rb
@@ -1,7 +1,7 @@
 old_slug = "south-georgia-and-south-sandwich-islands"
 new_slug = "south-georgia-and-the-south-sandwich-islands"
 
-world_location = WorldLocation.where(slug: old_slug)
+world_location = WorldLocation.find_by(slug: old_slug)
 
 Whitehall::SearchIndex.delete(world_location)
 


### PR DESCRIPTION
This commit fixes the data migration for re-slugging South Georgia and the South Sandwich Islands to make sure `SearchIndex.delete` works.