### PR TITLE
Add task to remove policy area

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -114,10 +114,6 @@ class Classification < ApplicationRecord
     organisations.reorder("organisation_classifications.lead DESC, organisation_classifications.lead_ordering")
   end
 
-  def destroyable?
-    policies.empty?
-  end
-
   def base_path
     Whitehall.url_maker.topic_path(slug)
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,4 +16,14 @@ class Topic < Classification
     joins(:statistics_announcement_topics)
       .group('statistics_announcement_topics.topic_id')
   end
+
+  def unpublish_and_redirect(redirect_path)
+    Services.publishing_api.unpublish(
+      self.content_id,
+      alternative_path: redirect_path,
+      type: "redirect",
+      discard_drafts: true
+    )
+    self.delete
+  end
 end

--- a/lib/tasks/delete_policy_area.rake
+++ b/lib/tasks/delete_policy_area.rake
@@ -1,0 +1,7 @@
+namespace :policy_area do
+  desc 'Remove and redirect policy area'
+  task :remove_and_redirect, %i(content_id redirect_path) => :environment do |_t, args|
+    policy_area = Topic.find_by(content_id: args[:content_id])
+    policy_area.unpublish_and_redirect(args[:redirect_path])
+  end
+end

--- a/test/functional/admin/topics_controller_test.rb
+++ b/test/functional/admin/topics_controller_test.rb
@@ -127,12 +127,4 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert topic.reload.deleted?
   end
-
-  test "DELETE :destroy does not delete topics with associated content" do
-    topic = create(:topic, policy_content_ids: [policy_1["content_id"]])
-
-    delete :destroy, params: { id: topic }
-    assert_equal "Cannot destroy Policy area with associated content", flash[:alert]
-    refute topic.reload.deleted?
-  end
 end

--- a/test/unit/topic_test.rb
+++ b/test/unit/topic_test.rb
@@ -22,17 +22,6 @@ class TopicTest < ActiveSupport::TestCase
     assert_equal 'bobs-bike', topic.slug
   end
 
-  test "should not be deletable if there are associated policies" do
-    topic = create(:topic, policy_content_ids: [])
-    assert topic.destroyable?
-
-    topic.update(policy_content_ids: [policy_1["content_id"]])
-
-    refute topic.destroyable?
-    topic.delete!
-    refute topic.deleted?
-  end
-
   test 'includes linked policies with multiple parents' do
     topic = create(:topic)
     assert_equal [], topic.policy_content_ids


### PR DESCRIPTION
This rake task unpublishes a policy area and sets up a redirect
for the given `base_path`.

Index is removed from rummager and the state of the
policy area in whitehall is set to `deleted`.

A few tests have been removed that stop policy areas being removed if
they have accosiated policies. This functionality isn't that relevent
anymore as policies are soon to be retired.

Trello;
https://trello.com/c/HbFEVJX3/135-l-add-rake-task-to-whitehall-to-unpublish-policy-areas