### PR TITLE
Update DIT logo on worldwide org pages

### DIFF
--- a/app/views/worldwide_organisations/_header.html.erb
+++ b/app/views/worldwide_organisations/_header.html.erb
@@ -1,18 +1,20 @@
 <%
   world_locations ||= organisation.world_locations
-  link_to_organisation ||= false
   object_for_translation ||= organisation
 %>
 <header class="block worldwide-organisation-header">
   <div class="inner-block floated-children">
     <div class="logo">
       <h1>
-        <% if link_to_organisation %>
-          <%= link_to content_tag(:span, organisation_logo_name(organisation)), organisation, class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
-        <% else %>
-          <%= content_tag :span, content_tag(:span, organisation_logo_name(organisation)), class: logo_classes(class_name: 'single-identity', size: 'large', stacked: true) %>
-        <% end %>
+        <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+                name: organisation_logo_name(organisation),
+                brand: "department-for-international-trade",
+                crest: "dit"
+            }
+        } %>
       </h1>
+
     </div>
     <div class="headings-block">
       <%= render partial: 'shared/available_languages', locals: {object: object_for_translation } %>


### PR DESCRIPTION
Use govuk-publishing-components to render
the DIT logo on wordwide organisation pages.

In response to [this ZenDesk ticket](https://govuk.zendesk.com/agent/tickets/3113611)