### PR TITLE
Fix the export_abbreviation_entities script

### DIFF
--- a/script/export_abbreviation_entities
+++ b/script/export_abbreviation_entities
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.dirname(__FILE__) + "/../lib"
-require File.dirname(__FILE__) + '/../config/environment'
+require_relative '../config/environment'
 require 'whitehall/abbreviation_extractor'
 
 Edition.published.find_each do |edition|


### PR DESCRIPTION
Use a require_relative, rather than require. I'm not sure what this
code does, but it seems to work with this change.