### PR TITLE
Handle publishing syncronously

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -70,12 +70,12 @@ module Organisation::OrganisationTypeConcern
   alias_method :type=, :organisation_type=
 
   def supporting_bodies
-    @supporting_bodies ||=
-      child_organisations.
+    child_organisations.
       excluding_govuk_status_closed.
       excluding_courts_and_tribunals.
       excluding_sub_organisations.
-      with_translations(I18n.locale).ordered_by_name_ignoring_prefix
+      with_translations(I18n.locale).
+      ordered_by_name_ignoring_prefix
   end
 
   def supporting_bodies_grouped_by_type

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -14,7 +14,7 @@ module ServiceListeners
 
       case event
       when "force_publish", "publish", "unwithdraw"
-        api.publish_async(edition)
+        api.publish(edition)
       when "update_draft"
         api.save_draft(edition)
       when "update_draft_translation"

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -25,7 +25,7 @@ private
   def send_item(payload, locale)
     save_draft(payload)
     Services.publishing_api.patch_links(payload.content_id, links: payload.links)
-    Services.publishing_api.publish(payload.content_id, payload.update_type, locale: locale)
+    Services.publishing_api.publish(payload.content_id, nil, locale: locale)
   end
 
   def save_draft(payload)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ end
 if Organisation.where(name: "HM Revenue & Customs").present?
   puts "Skipping because HMRC organisation already exists"
 else
+  Organisation.skip_callback(:commit, :after, :publish_to_publishing_api)
   Organisation.create!(
     name: "HM Revenue & Customs",
     slug: "hm-revenue-customs",
@@ -47,6 +48,7 @@ end
 if Topic.where(name: "Test Policy Area").present?
   puts "Skipping because Test Policy Area already exists"
 else
+  Topic.skip_callback(:commit, :after, :publish_to_publishing_api)
   Topic.create(
     name: "Test Policy Area",
     description: "Test Policy Area Description"

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -66,7 +66,7 @@ When(/^I delete the promotional item$/) do
 end
 
 Then(/^I should see the promotional feature on the organisation's page$/) do
-  assert promotional_feature = @executive_office.promotional_features.first
+  assert promotional_feature = @executive_office.reload.promotional_features.first
   assert_current_url admin_organisation_promotional_feature_url(@executive_office, promotional_feature)
 
   within record_css_selector(promotional_feature) do

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -14,7 +14,7 @@ module PublishesToPublishingApi
 
   def publish_to_publishing_api
     run_callbacks :published do
-      Whitehall::PublishingApi.publish_async(self)
+      Whitehall::PublishingApi.publish(self)
     end
   end
 

--- a/lib/tasks/update_people_in_publishing_api.rake
+++ b/lib/tasks/update_people_in_publishing_api.rake
@@ -2,7 +2,7 @@ namespace :publishing_api do
   desc "Updates all people to Publishing API, async"
   task update_all_people_in_publishing_api: :environment do
     Person.find_each do |person|
-      Whitehall::PublishingApi.publish_async(person)
+      Whitehall::PublishingApi.publish(person)
     end
   end
 end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -10,8 +10,38 @@ module Whitehall
   class UnpublishableInstanceError < StandardError; end
 
   class PublishingApi
-    def self.publish_async(model_instance, update_type_override = nil, queue_override = nil)
-      push_live(model_instance, update_type_override, queue_override)
+    def self.publish(model_instance, update_type_override = nil)
+      assert_public_edition!(model_instance)
+
+      # TODO: This should be unnecessary eventually, as the Publishing
+      # API should be kept up to date. Once no content is rendered
+      # through Whitehall Frontend, this can definately be removed, as
+      # the previews will always be representative of what will be
+      # published.
+      save_draft(model_instance, update_type_override)
+
+      presenter = PublishingApiPresenters.presenter_for(
+        model_instance,
+        update_type: update_type_override
+      )
+
+      locales_for(model_instance).each do |locale|
+        I18n.with_locale(locale) do
+          # TODO: This is probably redundant
+          Services.publishing_api.patch_links(
+            presenter.content_id,
+            links: presenter.links
+          )
+
+          Services.publishing_api.publish(
+            presenter.content_id,
+            # TODO: Replace this with nil, which means the Publishing
+            # API will use the update type from the edition
+            presenter.update_type,
+            locale: locale.to_s
+          )
+        end
+      end
     end
 
     def self.save_draft(model_instance, update_type_override = nil)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -35,9 +35,7 @@ module Whitehall
 
           Services.publishing_api.publish(
             presenter.content_id,
-            # TODO: Replace this with nil, which means the Publishing
-            # API will use the update type from the edition
-            presenter.update_type,
+            nil,
             locale: locale.to_s
           )
         end

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal @organisation, assigns(:organisation)
-    assert_equal @organisation.promotional_features, assigns(:promotional_features)
+    assert_equal @organisation.reload.promotional_features, assigns(:promotional_features)
     assert_template :index
   end
 

--- a/test/integration/operational_field_publishing_test.rb
+++ b/test/integration/operational_field_publishing_test.rb
@@ -18,7 +18,7 @@ class OperationalFieldPublishingTest < ActiveSupport::TestCase
 
       assert_publishing_api_publish(
         operational_field.content_id,
-        { update_type: 'major', locale: 'en' },
+        { update_type: nil, locale: 'en' },
         1
       )
     end

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -13,7 +13,7 @@ class PublishingTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
       stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links),
-      stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     perform_force_publishing_for(@draft_edition)
@@ -28,13 +28,13 @@ class PublishingTest < ActiveSupport::TestCase
 
       [
         stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
-        stub_publishing_api_publish(@presenter.content_id, locale: 'fr', update_type: 'major')
+        stub_publishing_api_publish(@presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
       stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
-      stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     links_request = stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links)

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -16,9 +16,7 @@ class PublishingTest < ActiveSupport::TestCase
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: 'major')
     ]
 
-    Sidekiq::Testing.inline! do
-      perform_force_publishing_for(@draft_edition)
-    end
+    perform_force_publishing_for(@draft_edition)
 
     assert_all_requested(requests)
   end
@@ -41,9 +39,7 @@ class PublishingTest < ActiveSupport::TestCase
 
     links_request = stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links)
 
-    Sidekiq::Testing.inline! do
-      perform_force_publishing_for(@draft_edition)
-    end
+    perform_force_publishing_for(@draft_edition)
 
     assert_all_requested(english_requests)
     assert_all_requested(french_requests)

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -150,6 +150,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
 
       date_change_attrs = attributes_for(:statistics_announcement_date_change)
       date_change = statistics_announcement.build_statistics_announcement_date_change(date_change_attrs)
+      statistics_announcement.reload
       date_change.save!
 
       expected = {

--- a/test/integration/statistics_announcement_test.rb
+++ b/test/integration/statistics_announcement_test.rb
@@ -41,7 +41,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       assert_publishing_api_put_content(statistics_announcement.content_id,
                                         expected)
       assert_publishing_api_publish(statistics_announcement.content_id,
-                                    { update_type: "minor", locale: "en" }, 1)
+                                    { update_type: nil, locale: "en" }, 1)
       assert_publishing_api_put_intent(
         statistics_announcement.base_path,
         expected_intent.as_json
@@ -85,7 +85,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       assert_publishing_api_put_content(statistics_announcement.content_id,
                                         expected)
       assert_publishing_api_publish(statistics_announcement.content_id,
-                                    { update_type: "minor", locale: "en" }, 2)
+                                    { update_type: nil, locale: "en" }, 2)
       assert_publishing_api_put_intent(
         statistics_announcement.base_path,
         expected_intent.as_json,
@@ -169,7 +169,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       assert_publishing_api_put_content(statistics_announcement.content_id,
                                         request_json_includes(expected))
       assert_publishing_api_publish(statistics_announcement.content_id,
-                                    { update_type: "minor", locale: "en" }, 2)
+                                    { update_type: nil, locale: "en" }, 2)
       assert_publishing_api_put_intent(
         statistics_announcement.base_path,
         expected_intent.as_json,

--- a/test/integration/take_part_page_test.rb
+++ b/test/integration/take_part_page_test.rb
@@ -19,7 +19,7 @@ class TakePartPageTest < ActiveSupport::TestCase
       )
 
       assert_publishing_api_put_content(@take_part_page.content_id, expected_json)
-      assert_publishing_api_publish(@take_part_page.content_id, { update_type: 'major',
+      assert_publishing_api_publish(@take_part_page.content_id, { update_type: nil,
                                                                   locale: 'en' }, 1)
     end
   end
@@ -58,7 +58,7 @@ class TakePartPageTest < ActiveSupport::TestCase
       )
 
       assert_publishing_api_put_content(@take_part_page.content_id, expected_json)
-      assert_publishing_api_publish(@take_part_page.content_id, { update_type: 'major',
+      assert_publishing_api_publish(@take_part_page.content_id, { update_type: nil,
                                                                  locale: 'en' }, 2)
     end
   end

--- a/test/integration/topical_event_about_page_test.rb
+++ b/test/integration/topical_event_about_page_test.rb
@@ -23,7 +23,7 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
       assert_publishing_api_publish(
         @topical_event_about_page.content_id,
         {
-          update_type: 'major',
+          update_type: nil,
           locale: 'en'
         },
         1
@@ -66,7 +66,7 @@ class TopicalEventAboutPageTest < ActiveSupport::TestCase
       assert_publishing_api_publish(
         @topical_event_about_page.content_id,
         {
-          update_type: 'major',
+          update_type: nil,
           locale: 'en'
         },
         2

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -13,7 +13,7 @@ module PublishingApiTestHelpers
       presenter = PublishingApiPresenters.presenter_for(edition)
       stub_publishing_api_put_content(presenter.content_id, presenter.content)
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'major')
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     end
   end
 
@@ -25,7 +25,7 @@ module PublishingApiTestHelpers
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)
-        .with(edition.content_id, 'major', locale: "en")
+        .with(edition.content_id, nil, locale: "en")
     end
   end
 
@@ -37,7 +37,7 @@ module PublishingApiTestHelpers
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)
-        .with(edition.content_id, 'republish', locale: "en")
+        .with(edition.content_id, nil, locale: "en")
     end
   end
 

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -37,7 +37,7 @@ module OrganisationResluggerTest
       expected_publish_requests = [
         stub_publishing_api_put_content(content_item.content_id, content_item.content),
         stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
-        stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
+        stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: nil)
       ]
 
       Sidekiq::Testing.inline! do

--- a/test/unit/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/data_hygiene/person_reslugger_test.rb
@@ -31,7 +31,7 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
       stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
-      stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_document_republisher_test.rb
@@ -9,7 +9,7 @@ class DataHygiene::PublishingApiDocumentRepublisherTest < ActiveSupport::TestCas
     expected_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/data_hygiene/publishing_api_republisher_test.rb
+++ b/test/unit/data_hygiene/publishing_api_republisher_test.rb
@@ -13,7 +13,7 @@ class DataHygiene::PublishingApiRepublisherTest < ActiveSupport::TestCase
     expected_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/data_hygiene/role_reslugger_test.rb
@@ -34,10 +34,10 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
       stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
-      stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: 'major'),
+      stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: nil),
       stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
       stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
-      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: organisation_content_item.update_type)
+      stub_publishing_api_publish(organisation_content_item.content_id, locale: 'en', update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CorporateInformationPageTest < ActiveSupport::TestCase
   test "creating a new corporate information page republishes the owning organisation" do
     test_object = create(:organisation)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:publish).with(test_object).once
     create(:corporate_information_page, organisation: test_object)
   end
 
@@ -11,14 +11,14 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
     corporate_information_page.external = true
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:publish).with(test_object).once
     corporate_information_page.save!
   end
 
   test "deleting a corporate information page republishes the owning organisation" do
     test_object = create(:organisation)
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object).once
+    Whitehall::PublishingApi.expects(:publish).with(test_object).once
     corporate_information_page.destroy
   end
 

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -778,6 +778,8 @@ class OrganisationTest < ActiveSupport::TestCase
   test 'destroy deletes related social media accounts' do
     organisation = create(:organisation)
     social_media_account = create(:social_media_account, socialable: organisation)
+    organisation.social_media_accounts.reload
+
     organisation.destroy
     assert_nil SocialMediaAccount.find_by(id: social_media_account.id)
   end

--- a/test/unit/models/person_role_test.rb
+++ b/test/unit/models/person_role_test.rb
@@ -7,7 +7,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     person = create(:person)
     role_appointment = build(:role_appointment, person: person, role: role)
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
-    Whitehall::PublishingApi.expects(:publish_async).with(role_appointment).once
+    Whitehall::PublishingApi.expects(:publish).with(role_appointment).once
     role_appointment.save!
   end
 
@@ -18,7 +18,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     create(:role_appointment, person: person, role: role)
     person.reload
     person.forename = "Test"
-    Whitehall::PublishingApi.expects(:publish_async).with(person).once
+    Whitehall::PublishingApi.expects(:publish).with(person).once
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     person.save!
   end
@@ -30,7 +30,7 @@ class PersonRoleTest < ActiveSupport::TestCase
     create(:role_appointment, person: person, role: role)
     person.reload
     role.cabinet_member = true
-    Whitehall::PublishingApi.expects(:publish_async).with(role).once
+    Whitehall::PublishingApi.expects(:publish).with(role).once
     Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     role.save!
   end

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -63,7 +63,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "publish to publishing api publishes async" do
     test_object = include_module(TestObject.new)
-    Whitehall::PublishingApi.expects(:publish_async).with(test_object)
+    Whitehall::PublishingApi.expects(:publish).with(test_object)
     test_object.publish_to_publishing_api
   end
 
@@ -75,7 +75,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
   end
 
   test "defines and executes published callback when published" do
-    Whitehall::PublishingApi.stubs(:publish_async)
+    Whitehall::PublishingApi.stubs(:publish)
     test_object = TestObject.new
     class << test_object
       include PublishesToPublishingApi

--- a/test/unit/models/social_media_account_test.rb
+++ b/test/unit/models/social_media_account_test.rb
@@ -6,6 +6,7 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
   test "destroy deletes related social media accounts" do
     test_object = create(:organisation)
     social_media_account = create(:social_media_account, socialable: test_object)
+    test_object.reload
     test_object.destroy
     assert_nil SocialMediaAccount.find_by(id: social_media_account.id)
   end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -68,7 +68,7 @@ class PersonTest < ActiveSupport::TestCase
   test '#previous_role_appointments include appointments that have ended' do
     person = create(:person)
     role_appointment = create(:ministerial_role_appointment, person: person, started_at: 1.year.ago, ended_at: 1.day.ago)
-    assert_equal [role_appointment], person.previous_role_appointments
+    assert_equal [role_appointment], person.reload.previous_role_appointments
   end
 
   test '#previous_role_appointments excludes current appointments' do
@@ -81,7 +81,7 @@ class PersonTest < ActiveSupport::TestCase
     person = create(:person)
     older_appointment = create(:ministerial_role_appointment, person: person, started_at: 2.year.ago, ended_at: 1.year.ago)
     newer_appointment = create(:ministerial_role_appointment, person: person, started_at: 1.year.ago, ended_at: 1.day.ago)
-    assert_equal [newer_appointment, older_appointment], person.previous_role_appointments
+    assert_equal [newer_appointment, older_appointment], person.reload.previous_role_appointments
   end
 
   test '#organisations includes organisations linked through current ministerial roles' do

--- a/test/unit/policy_group_test.rb
+++ b/test/unit/policy_group_test.rb
@@ -31,7 +31,7 @@ class PolicyGroupTest < ActiveSupport::TestCase
 
   test "publishes to the publishing API" do
     policy_group = create(:policy_group)
-    Whitehall::PublishingApi.expects(:publish_async).with(policy_group).once
+    Whitehall::PublishingApi.expects(:publish).with(policy_group).once
     policy_group.publish_to_publishing_api
   end
 

--- a/test/unit/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/person_presenter_test.rb
@@ -69,7 +69,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       ordered_previous_appointments: [previous_role_appointment.content_id],
     }
 
-    presented_item = present(person)
+    presented_item = present(person.reload)
 
     assert_equal expected_hash, presented_item.content
     assert_hash_includes presented_item.links, expected_links

--- a/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
+++ b/test/unit/services/service_listeners/featurable_organisation_republisher_test.rb
@@ -8,7 +8,7 @@ class ServiceListeners::FeaturableOrganisationRepublisherTest < ActiveSupport::T
   test 'republish organisation to Publishing API' do
     organisation = create(:organisation, :with_feature_list, :with_published_edition)
 
-    feature_list = organisation.feature_lists.sample
+    feature_list = organisation.feature_lists.first
     published_edition = organisation.published_editions.sample
 
     create(:feature, document: published_edition.document, feature_list: feature_list)

--- a/test/unit/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/services/service_listeners/publishing_api_pusher_test.rb
@@ -49,7 +49,7 @@ module ServiceListeners
 
     test "publish publishes" do
       edition = build(:publication, document: build(:document))
-      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      Whitehall::PublishingApi.expects(:publish).with(edition)
       stub_html_attachment_pusher(edition, "publish")
       stub_publications_pusher(edition, "publish")
       Sidekiq::Testing.inline! do
@@ -59,7 +59,7 @@ module ServiceListeners
 
     test "force_publish publishes" do
       edition = build(:publication, document: build(:document))
-      Whitehall::PublishingApi.expects(:publish_async).with(edition)
+      Whitehall::PublishingApi.expects(:publish).with(edition)
       stub_html_attachment_pusher(edition, "force_publish")
       stub_publications_pusher(edition, "force_publish")
       Sidekiq::Testing.inline! do
@@ -167,7 +167,7 @@ module ServiceListeners
       new_edition = res[:draft_edition]
       fr = res[:deleted_translation]
 
-      Whitehall::PublishingApi.expects(:publish_async).with(new_edition)
+      Whitehall::PublishingApi.expects(:publish).with(new_edition)
       stub_html_attachment_pusher(new_edition, "publish")
 
       pusher = mock

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -279,7 +279,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
       requests = [
         stub_publishing_api_put_content(presenter.content_id, presenter.content),
         stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-        stub_publishing_api_publish(presenter.content_id, update_type: "minor", locale: "en")
+        stub_publishing_api_publish(presenter.content_id, locale: "en", update_type: nil)
       ]
 
       requests.each { |request| assert_requested request }

--- a/test/unit/topical_event_test.rb
+++ b/test/unit/topical_event_test.rb
@@ -80,7 +80,7 @@ class TopicalEventTest < ActiveSupport::TestCase
 
     create(:feature, feature_list: organisation.feature_lists.first, topical_event: topical_event)
 
-    Whitehall::PublishingApi.expects(:publish_async).with(topical_event).once
+    Whitehall::PublishingApi.expects(:publish).with(topical_event).once
     Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
 
     topical_event.save

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -23,7 +23,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Whitehall::PublishingApi.publish(edition)
@@ -38,7 +38,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Whitehall::PublishingApi.publish(organisation)
@@ -53,7 +53,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Whitehall::PublishingApi.publish(edition)
@@ -72,13 +72,13 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
       [
         stub_publishing_api_put_content(presenter.content_id, presenter.content),
-        stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: 'major')
+        stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'major')
+      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
@@ -98,7 +98,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do
@@ -119,13 +119,13 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
       [
         stub_publishing_api_put_content(presenter.content_id, presenter.content),
-        stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: 'republish')
+        stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
-      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 
     links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
@@ -154,7 +154,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do
@@ -185,8 +185,8 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: 'republish'),
-      stub_publishing_api_publish(html_attachment_content_id, locale: presenter.content[:locale], update_type: 'republish')
+      stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil),
+      stub_publishing_api_publish(html_attachment_content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -17,7 +17,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     stub_any_publishing_api_publish
   end
 
-  test ".publish_async publishes an Edition with the Publishing API" do
+  test ".publish publishes an Edition with the Publishing API" do
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
@@ -26,14 +26,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_async(edition)
-    end
+    Whitehall::PublishingApi.publish(edition)
 
     assert_all_requested(requests)
   end
 
-  test ".publish_async publishes non-Edition instances with the Publishing API" do
+  test ".publish publishes non-Edition instances with the Publishing API" do
     organisation = create(:organisation)
     WebMock.reset! # because creating an organisation also pushes to Publishing API
     presenter = PublishingApiPresenters.presenter_for(organisation)
@@ -43,14 +41,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_async(organisation)
-    end
+    Whitehall::PublishingApi.publish(organisation)
 
     assert_all_requested(requests)
   end
 
-  test ".publish_async sends case studies to the content store" do
+  test ".publish sends case studies to the content store" do
     edition = create(:published_case_study)
 
     presenter = PublishingApiPresenters.presenter_for(edition)
@@ -60,14 +56,12 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: presenter.update_type)
     ]
 
-    Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_async(edition)
-    end
+    Whitehall::PublishingApi.publish(edition)
 
     assert_all_requested(requests)
   end
 
-  test ".publish_async publishes all available translations of a translatable model" do
+  test ".publish publishes all available translations of a translatable model" do
     organisation = create(:organisation)
     presenter = PublishingApiPresenters.presenter_for(organisation)
 
@@ -89,26 +83,11 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
 
-    Sidekiq::Testing.inline! do
-      Whitehall::PublishingApi.publish_async(organisation)
-    end
+    Whitehall::PublishingApi.publish(organisation)
 
     assert_all_requested(french_requests)
     assert_all_requested(english_requests)
     assert_requested(links_request, times: 2)
-  end
-
-  test ".publish_async propagates update_type and queue overrides to worker" do
-    queue_name = "bang"
-    update_type = "whizzo"
-
-    edition = create(:published_case_study)
-
-    PublishingApiWorker.expects(:perform_async_in_queue)
-      .with(queue_name, edition.class.name, edition.id,
-            update_type, edition.primary_locale.to_sym)
-
-    Whitehall::PublishingApi.publish_async(edition, update_type, queue_name)
   end
 
   test ".republish_async publishes to the Publishing API as a 'republish' update_type" do

--- a/test/unit/workers/publishing_api_coming_soon_worker_test.rb
+++ b/test/unit/workers/publishing_api_coming_soon_worker_test.rb
@@ -37,7 +37,7 @@ class PublishingApiComingSoonWorkerTest < ActiveSupport::TestCase
 
     requests = [
       stub_publishing_api_put_content(uuid, expected_payload),
-      stub_publishing_api_publish(uuid, locale: "fr", update_type: "major"),
+      stub_publishing_api_publish(uuid, locale: "fr", update_type: nil),
       stub_publishing_api_patch_links(uuid, links: expected_links),
     ]
 

--- a/test/unit/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/workers/publishing_api_document_republishing_worker_test.rb
@@ -64,9 +64,9 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     presenter = PublishingApiPresenters.presenter_for(edition, update_type: 'republish')
     requests = [
       stub_publishing_api_put_content(document.content_id, with_locale(:en) { presenter.content }),
-      stub_publishing_api_publish(document.content_id, locale: 'en', update_type: 'republish'),
+      stub_publishing_api_publish(document.content_id, locale: 'en', update_type: nil),
       stub_publishing_api_put_content(document.content_id, with_locale(:es) { presenter.content }),
-      stub_publishing_api_publish(document.content_id, locale: 'es', update_type: 'republish')
+      stub_publishing_api_publish(document.content_id, locale: 'es', update_type: nil)
     ]
     # Have to separate this as we need to manually assert it was done twice. If
     # we split the pushing of links into a separate job, then we would only push

--- a/test/unit/workers/publishing_api_services_and_information_worker_test.rb
+++ b/test/unit/workers/publishing_api_services_and_information_worker_test.rb
@@ -17,8 +17,8 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id",
-                                                  update_type: "minor",
-                                                  locale: "en")
+                                                  locale: "en",
+                                                  update_type: nil)
     patch_links_request = stub_publishing_api_patch_links("a-content-id", links: @payload.links)
 
     PublishingApiServicesAndInformationWorker.new.perform(@organisation.id)
@@ -33,7 +33,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
 
     put_content_request = stub_publishing_api_put_content("a-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("a-content-id",
-                                                  update_type: "minor",
+                                                  update_type: nil,
                                                   locale: "en")
     patch_links_request = stub_publishing_api_patch_links("a-content-id", links: @payload.links)
 
@@ -53,7 +53,7 @@ class PublishingApiServicesAndInformationWorkerTest < ActiveSupport::TestCase
 
     put_content_request = stub_publishing_api_put_content("another-content-id", @payload.content)
     publish_request = stub_publishing_api_publish("another-content-id",
-                                                  update_type: "minor",
+                                                  update_type: nil,
                                                   locale: "en")
     patch_links_request = stub_publishing_api_patch_links("another-content-id", links: @payload.links)
 

--- a/test/unit/workers/publishing_api_worker_test.rb
+++ b/test/unit/workers/publishing_api_worker_test.rb
@@ -11,7 +11,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
+      stub_publishing_api_publish(presenter.content_id, update_type: nil, locale: "en")
     ]
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
@@ -25,7 +25,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
+      stub_publishing_api_publish(presenter.content_id, update_type: nil, locale: "en")
     ]
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id)
@@ -41,7 +41,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
       requests = [
         stub_publishing_api_put_content(presenter.content_id, presenter.content),
         stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-        stub_publishing_api_publish(presenter.content_id, update_type: "major", locale: "en")
+        stub_publishing_api_publish(presenter.content_id, update_type: nil, locale: "en")
       ]
 
       PublishingApiWorker.new.perform(organisation.class.name, organisation.id)
@@ -64,7 +64,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
     requests = [
       stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-      stub_publishing_api_publish(presenter.content_id, update_type: update_type, locale: "en")
+      stub_publishing_api_publish(presenter.content_id, update_type: nil, locale: "en")
     ]
 
     PublishingApiWorker.new.perform(edition.class.name, edition.id, update_type)
@@ -84,7 +84,7 @@ class PublishingApiWorkerTest < ActiveSupport::TestCase
         [
           stub_publishing_api_put_content(presenter.content_id, presenter.content),
           stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
-          stub_publishing_api_publish(presenter.content_id, locale: "es", update_type: "major")
+          stub_publishing_api_publish(presenter.content_id, locale: "es", update_type: nil)
         ]
       end
 


### PR DESCRIPTION
While using the Publishing API used to be a side concern, it's now the
primary way in which Whitehall makes content available.

Therefore, to allow for simplifying the code, as well as adding better
error reporting, don't offload the communication with the Publishing
API to a Sidekiq worker.