### PR TITLE
Add a test for adding an attachment to an unpublished document

### DIFF
--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -54,6 +54,20 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       withdraw_document
       refute_sets_redirect_url_in_asset_manager
     end
+
+    it 'does not redirect new attachments added after a document is unpublished' do
+      stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+      visit admin_news_article_path(edition)
+      unpublish_document_published_in_error
+
+      file = File.open(path_to_attachment('sample.csv'))
+      new_attachment = build(:file_attachment, attachable: attachable, file: file)
+      attachable.attachments << new_attachment
+      new_attachment.save!
+
+      refute_sets_redirect_url_in_asset_manager
+    end
   end
 
   context 'given a published consultation with outcome with file attachment' do


### PR DESCRIPTION
This is the only automated test that was missing from our manual tests we did while migrating whitehall to use asset-manager.

[Trello Card](https://trello.com/c/FQFoZFLR/428-improve-whitehall-asset-end-to-end-tests-suggested-%F0%9F%8D%90)