### PR TITLE
Fix FactoryBot deprecation warnings

### DIFF
--- a/test/factories/about_page.rb
+++ b/test/factories/about_page.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :about_page do
     sequence(:name) { |index| "about-page-#{index}" }
-    read_more_link_text 'Read more'
-    summary 'Summary'
-    body 'Body'
+    read_more_link_text { 'Read more' }
+    summary { 'Summary' }
+    body { 'Body' }
   end
 
   factory :topical_event_about_page, parent: :about_page do

--- a/test/factories/access_and_opening_times.rb
+++ b/test/factories/access_and_opening_times.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :access_and_opening_times do
-    body "Access body"
+    body { "Access body" }
   end
 end

--- a/test/factories/ambassador_roles.rb
+++ b/test/factories/ambassador_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :ambassador_role do
-    name "Her Majesty's Ambassador to Spain"
+    name { "Her Majesty's Ambassador to Spain" }
   end
 end

--- a/test/factories/attachments.rb
+++ b/test/factories/attachments.rb
@@ -25,8 +25,8 @@ FactoryBot.define do
     sequence(:title) { |index| "html-attachment-title-#{index}" }
 
     transient do
-      body "Attachment body"
-      manually_numbered_headings false
+      body { "Attachment body" }
+      manually_numbered_headings { false }
     end
 
     attachable { build :edition }
@@ -44,6 +44,6 @@ FactoryBot.define do
 
   factory :external_attachment, traits: [:abstract_attachment] do
     sequence(:title) { |index| "external-attachment-title-#{index}" }
-    external_url "http://www.google.com"
+    external_url { "http://www.google.com" }
   end
 end

--- a/test/factories/board_member_roles.rb
+++ b/test/factories/board_member_roles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :board_member_role do
-    name "Permanent Secretary"
+    name { "Permanent Secretary" }
 
     after :build do |role, evaluator|
       role.organisations = [FactoryBot.build(:ministerial_department)] unless evaluator.organisations.any?

--- a/test/factories/case_studies.rb
+++ b/test/factories/case_studies.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :case_study, class: CaseStudy, parent: :edition_with_organisations do
-    title "case-study-title"
-    summary "case-study-summary"
-    body "case-study-body"
+    title { "case-study-title" }
+    summary { "case-study-summary" }
+    body { "case-study-body" }
   end
 
   factory :imported_case_study, parent: :case_study, traits: [:imported]

--- a/test/factories/chief_professional_officers.rb
+++ b/test/factories/chief_professional_officers.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :chief_professional_officer_role do
-    name "Chief Medical Officer"
+    name { "Chief Medical Officer" }
     after :build do |role, evaluator|
       role.organisations = [FactoryBot.build(:organisation)] unless evaluator.organisations.any?
     end

--- a/test/factories/chief_scientific_advisor_roles.rb
+++ b/test/factories/chief_scientific_advisor_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :chief_scientific_advisor_role do
-    name "Chief Scientific Advisor"
+    name { "Chief Scientific Advisor" }
   end
 end

--- a/test/factories/classification_featurings.rb
+++ b/test/factories/classification_featurings.rb
@@ -4,14 +4,14 @@ FactoryBot.define do
     classification
     sequence(:ordering) { |index| index }
     association :image, factory: :classification_featuring_image_data
-    alt_text "An accessible description of the image"
+    alt_text { "An accessible description of the image" }
   end
 
   factory :offsite_classification_featuring, class: ClassificationFeaturing do
     classification
     sequence(:ordering) { |index| index }
     association :image, factory: :classification_featuring_image_data
-    edition nil
-    alt_text "An accessible description of the image"
+    edition { nil }
+    alt_text { "An accessible description of the image" }
   end
 end

--- a/test/factories/classifications.rb
+++ b/test/factories/classifications.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :classification do
     sequence(:name) { |index| "classification-#{index}" }
-    description 'Classification description'
+    description { 'Classification description' }
   end
 end

--- a/test/factories/consultation_response_forms.rb
+++ b/test/factories/consultation_response_forms.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       file { File.open(File.join(Rails.root, 'test', 'fixtures', 'two-pages.pdf')) }
     end
     association :consultation_participation
-    title "consultation-response-form-title"
+    title { "consultation-response-form-title" }
     consultation_response_form_data { build(:consultation_response_form_data, file: file) }
   end
 end

--- a/test/factories/consultations.rb
+++ b/test/factories/consultations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :consultation, class: Consultation, parent: :edition, traits: %i[with_organisations with_topics] do
-    title "consultation-title"
-    body  "consultation-body"
+    title { "consultation-title" }
+    body { "consultation-body" }
     opening_at { 1.day.ago }
     closing_at { 6.weeks.from_now }
     read_consultation_principles { true }

--- a/test/factories/contact_numbers.rb
+++ b/test/factories/contact_numbers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :contact_number do
     contact
-    label "fax"
-    number "123"
+    label { "fax" }
+    number { "123" }
   end
 end

--- a/test/factories/contacts.rb
+++ b/test/factories/contacts.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :contact, traits: [:translated] do
-    title "Contact description"
+    title { "Contact description" }
     contact_type { ContactType::General }
   end
 
   factory :contact_with_country, parent: :contact do
-    street_address '29 Acacier Road'
+    street_address { '29 Acacier Road' }
     association :country, factory: :world_location
   end
 end

--- a/test/factories/corporate_information_pages.rb
+++ b/test/factories/corporate_information_pages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :corporate_information_page, class: CorporateInformationPage, parent: :edition, traits: [:translated] do
-    corporate_information_page_type_id CorporateInformationPageType::PublicationScheme.id
-    body "Some stuff"
+    corporate_information_page_type_id { CorporateInformationPageType::PublicationScheme.id }
+    body { "Some stuff" }
     association :organisation, factory: :organisation
 
     after(:create) do |corporate_information_page, _evaluator|
@@ -19,78 +19,78 @@ FactoryBot.define do
   factory :draft_corporate_information_page, parent: :corporate_information_page, traits: [:draft]
 
   factory :about_corporate_information_page, parent: :published_corporate_information_page do
-    corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
+    corporate_information_page_type_id { CorporateInformationPageType::AboutUs.id }
   end
 
   factory :draft_about_corporate_information_page, parent: :draft_corporate_information_page do
-    corporate_information_page_type_id CorporateInformationPageType::AboutUs.id
+    corporate_information_page_type_id { CorporateInformationPageType::AboutUs.id }
   end
 
   factory :about_our_services_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::AboutOurServices.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::AboutOurServices.id
+    }
   end
 
   factory :complaints_procedure_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::ComplaintsProcedure.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::ComplaintsProcedure.id
+    }
   end
 
   factory :our_energy_use_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::OurEnergyUse.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::OurEnergyUse.id
+    }
   end
 
   factory :personal_information_charter_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::PersonalInformationCharter.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::PersonalInformationCharter.id
+    }
   end
 
   factory :procurement_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::Procurement.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::Procurement.id
+    }
   end
 
   factory :publication_scheme_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::PublicationScheme.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::PublicationScheme.id
+    }
   end
 
   factory :recruitment_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::Recruitment.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::Recruitment.id
+    }
   end
 
   factory :social_media_use_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::SocialMediaUse.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::SocialMediaUse.id
+    }
   end
 
   factory :welsh_language_scheme_corporate_information_page,
           parent: :published_corporate_information_page do
-    corporate_information_page_type_id(
-      CorporateInformationPageType::WelshLanguageScheme.id,
-    )
+    corporate_information_page_type_id {
+      CorporateInformationPageType::WelshLanguageScheme.id
+    }
   end
 
   factory :published_worldwide_organisation_corporate_information_page, parent: :corporate_information_page, traits: [:published] do
-    organisation nil
+    organisation { nil }
     association :worldwide_organisation, factory: :worldwide_organisation
   end
 end

--- a/test/factories/deputy_head_of_mission_roles.rb
+++ b/test/factories/deputy_head_of_mission_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :deputy_head_of_mission_role do
-    name "Deputy head of mission in the British Virgin Islands"
+    name { "Deputy head of mission in the British Virgin Islands" }
   end
 end

--- a/test/factories/detailed_guides.rb
+++ b/test/factories/detailed_guides.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :detailed_guide, class: DetailedGuide, parent: :edition, traits: %i[with_organisations with_topics] do
     sequence(:title) { |index| "detailed-guide-title-#{index}" }
-    body "detailed-guide-body"
+    body { "detailed-guide-body" }
   end
 
   factory :draft_detailed_guide, parent: :detailed_guide, traits: [:draft]

--- a/test/factories/document_collection_group.rb
+++ b/test/factories/document_collection_group.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :document_collection_group do
     sequence(:heading) { |i| "Group #{i}" }
-    body 'Group body text'
+    body { 'Group body text' }
   end
 end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
   factory :edition, class: GenericEdition, traits: [:translated] do
     creator
     sequence(:title) { |index| "edition-title-#{index}" }
-    body "edition-body"
-    change_note "change-note"
-    summary 'edition-summary'
-    previously_published false
+    body { "edition-body" }
+    change_note { "change-note" }
+    summary { 'edition-summary' }
+    previously_published { false }
 
     trait(:with_organisations) do
       transient do
@@ -57,7 +57,7 @@ FactoryBot.define do
 
     trait(:with_policy_edition) do
       transient do
-        policy_content_id ''
+        policy_content_id { '' }
       end
       after :create do |edition, evaluator|
         EditionPolicy.create(edition_id: edition.id, policy_content_id: evaluator.policy_content_id)
@@ -65,17 +65,17 @@ FactoryBot.define do
     end
 
     trait(:imported) do
-      state "imported"
+      state { "imported" }
       first_published_at { 1.year.ago }
     end
 
-    trait(:draft) { state "draft" }
+    trait(:draft) { state { "draft" } }
 
     trait(:submitted) do
       transient do
-        submitter nil
+        submitter { nil }
       end
-      state "submitted"
+      state { "submitted" }
       after :create do |edition, evaluator|
         edition.versions.first.update_attributes(event: 'create', state: 'draft')
         submitter = evaluator.submitter.present? ? evaluator.submitter : edition.creator
@@ -83,30 +83,30 @@ FactoryBot.define do
       end
     end
 
-    trait(:rejected) { state "rejected" }
+    trait(:rejected) { state { "rejected" } }
 
     trait(:published) do
-      state "published"
+      state { "published" }
       first_published_at { 2.days.ago }
       major_change_published_at { 1.day.ago }
       force_published { false }
-      published_major_version 1
-      published_minor_version 0
+      published_major_version { 1 }
+      published_minor_version { 0 }
       after :create, &:refresh_index_if_required
     end
 
-    trait(:deleted) { state "deleted" }
+    trait(:deleted) { state { "deleted" } }
 
-    trait(:superseded) { state "superseded" }
+    trait(:superseded) { state { "superseded" } }
 
-    trait(:featured) { featured true }
+    trait(:featured) { featured { true } }
 
     trait(:scheduled) do
-      state "scheduled"
-      scheduled_publication 7.days.from_now
+      state { "scheduled" }
+      scheduled_publication { 7.days.from_now }
     end
 
-    trait(:access_limited) { access_limited true }
+    trait(:access_limited) { access_limited { true } }
 
     trait(:with_alternative_format_provider) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email
@@ -156,7 +156,7 @@ FactoryBot.define do
     end
 
     trait(:withdrawn) do
-      state "withdrawn"
+      state { "withdrawn" }
       after(:create) do |edition|
         edition.unpublishing = build(:withdrawn_unpublishing, edition: edition)
       end

--- a/test/factories/editorial_remarks.rb
+++ b/test/factories/editorial_remarks.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :editorial_remark do
     edition
     author
-    body "editorial-remark-body"
+    body { "editorial-remark-body" }
   end
 end

--- a/test/factories/fact_check_requests.rb
+++ b/test/factories/fact_check_requests.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :fact_check_request do
     association :edition, factory: :publication
     association :requestor, factory: :fact_check_requestor
-    email_address "fact-checker@example.com"
+    email_address { "fact-checker@example.com" }
   end
 end

--- a/test/factories/fatality_notice_casualties.rb
+++ b/test/factories/fatality_notice_casualties.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :fatality_notice_casualty, class: FatalityNoticeCasualty do
-    personal_details "personal-details"
+    personal_details { "personal-details" }
   end
 end

--- a/test/factories/fatality_notices.rb
+++ b/test/factories/fatality_notices.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :fatality_notice, class: FatalityNotice, parent: :edition, traits: %i[with_organisations with_topics] do
-    title "fatality-title"
-    summary "fatality-summary"
-    body "fatality-body"
-    roll_call_introduction "fatality-roll-call-introduction"
+    title { "fatality-title" }
+    summary { "fatality-summary" }
+    body { "fatality-body" }
+    roll_call_introduction { "fatality-roll-call-introduction" }
     operational_field
   end
 

--- a/test/factories/feature_list.rb
+++ b/test/factories/feature_list.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :feature_list do
-    locale :en
+    locale { :en }
   end
 end

--- a/test/factories/featured_link.rb
+++ b/test/factories/featured_link.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :featured_link do |link|
-    link.url "https://www.gov.uk/example/service"
-    link.title "An example service"
+    link.url { "https://www.gov.uk/example/service" }
+    link.title { "An example service" }
   end
 end

--- a/test/factories/features.rb
+++ b/test/factories/features.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :feature do
     document
     image { image_fixture_file }
-    alt_text "An accessible description of the image"
+    alt_text { "An accessible description of the image" }
   end
 end

--- a/test/factories/governments.rb
+++ b/test/factories/governments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :government do
     sequence(:name) { |index| "Government #{index}" }
-    start_date "2010-05-06"
+    start_date { "2010-05-06" }
   end
 
   factory :current_government, parent: :government do

--- a/test/factories/governor_roles.rb
+++ b/test/factories/governor_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :governor_role do
-    name "HM Governor in the British Virgin Islands"
+    name { "HM Governor in the British Virgin Islands" }
   end
 end

--- a/test/factories/high_commissioner_roles.rb
+++ b/test/factories/high_commissioner_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :high_commissioner_role do
-    name "High Commissioner of India"
+    name { "High Commissioner of India" }
   end
 end

--- a/test/factories/historical_accounts.rb
+++ b/test/factories/historical_accounts.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :historical_account do
     association :person
-    summary "Some summary text"
-    body "Some body text"
-    political_parties [PoliticalParty::Labour]
+    summary { "Some summary text" }
+    body { "Some body text" }
+    political_parties { [PoliticalParty::Labour] }
 
     after(:build) do |account|
       unless account.roles.present?

--- a/test/factories/images.rb
+++ b/test/factories/images.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :image do
-    alt_text "An accessible description of the image"
+    alt_text { "An accessible description of the image" }
     image_data
   end
 end

--- a/test/factories/link_checker_api_report.rb
+++ b/test/factories/link_checker_api_report.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :link_checker_api_report do
-    batch_id 1
-    status "in_progress"
+    batch_id { 1 }
+    status { "in_progress" }
     link_reportable do
       create(:draft_edition, body: "Includes a [link](http://www.example.com)")
     end
@@ -14,8 +14,8 @@ FactoryBot.define do
   end
 
   factory :link_checker_api_report_completed, class: LinkCheckerApiReport do
-    batch_id 1
-    status "completed"
+    batch_id { 1 }
+    status { "completed" }
     link_reportable do
       create(:draft_edition, body: "Includes a [link](http://www.example.com)")
     end

--- a/test/factories/link_checker_api_report_link.rb
+++ b/test/factories/link_checker_api_report_link.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :link_checker_api_report_link, class: LinkCheckerApiReport::Link do
-    uri "http://www.example.com"
-    status "ok"
-    ordering 0
+    uri { "http://www.example.com" }
+    status { "ok" }
+    ordering { 0 }
   end
 end

--- a/test/factories/links_reports.rb
+++ b/test/factories/links_reports.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :links_report do
-    links %w(http://link1.com http://link1.com)
+    links { %w(http://link1.com http://link1.com) }
     link_reportable { create(:draft_edition) }
   end
 end

--- a/test/factories/military_roles.rb
+++ b/test/factories/military_roles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :military_role do
-    name "Chief of the Air Staff"
+    name { "Chief of the Air Staff" }
     after :build do |role, evaluator|
       role.organisations = [FactoryBot.build(:organisation)] unless evaluator.organisations.any?
     end

--- a/test/factories/ministerial_roles.rb
+++ b/test/factories/ministerial_roles.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
   end
 
   factory :ministerial_role_without_organisation, class: MinisterialRole do
-    name "Parliamentary Under-Secretary of State"
+    name { "Parliamentary Under-Secretary of State" }
   end
 end

--- a/test/factories/nation_inapplicabilities.rb
+++ b/test/factories/nation_inapplicabilities.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :nation_inapplicability do
-    nation_id Nation::Scotland.id
+    nation_id { Nation::Scotland.id }
   end
 end

--- a/test/factories/news_articles.rb
+++ b/test/factories/news_articles.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :news_article, class: NewsArticle, parent: :edition, traits: %i[with_organisations with_topics] do
-    title "news-title"
-    summary "news-summary"
-    body "news-body"
+    title { "news-title" }
+    summary { "news-summary" }
+    body { "news-body" }
     news_article_type_id { NewsArticleType::PressRelease.id }
     transient do
       relevant_to_local_government { false }

--- a/test/factories/offsite_links.rb
+++ b/test/factories/offsite_links.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :offsite_link do
-    title 'Summary text'
-    link_type 'alert'
-    summary 'Summary text'
-    url 'http://gov.uk/test'
+    title { 'Summary text' }
+    link_type { 'alert' }
+    summary { 'Summary text' }
+    url { 'http://gov.uk/test' }
   end
 end

--- a/test/factories/operational_fields.rb
+++ b/test/factories/operational_fields.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :operational_field do
     sequence(:name) { |index| "field-#{index}" }
-    description "description of field"
+    description { "description of field" }
   end
 end

--- a/test/factories/organisation_classification.rb
+++ b/test/factories/organisation_classification.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :organisation_classification do
     organisation { FactoryBot.build(:organisation) }
     classification { FactoryBot.build(:topic) }
-    lead false
+    lead { false }
   end
 end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :organisation, traits: [:translated] do
     sequence(:name) { |index| "organisation-#{index}" }
     logo_formatted_name { name.to_s.split.join("\n") }
-    organisation_type_key :other
+    organisation_type_key { :other }
     sequence(:analytics_identifier) { |index| "T#{index}" }
     organisation_logo_type_id { OrganisationLogoType::SingleIdentity.id }
 
     trait(:closed) do
-      govuk_status 'closed'
-      govuk_closed_status 'no_longer_exists'
+      govuk_status { 'closed' }
+      govuk_closed_status { 'no_longer_exists' }
     end
 
     trait(:with_published_edition) {
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     trait(:with_feature_list) do
       transient do
-        feature_list_count 1
+        feature_list_count { 1 }
       end
 
       after(:create) do |organisation, evaluator|
@@ -32,46 +32,46 @@ FactoryBot.define do
     end
 
     trait(:political) do
-      political true
+      political { true }
     end
 
     trait(:non_political) do
-      political false
+      political { false }
     end
   end
 
   factory :closed_organisation, parent: :organisation, traits: [:closed]
 
   factory :ministerial_department, parent: :organisation do
-    organisation_type_key :ministerial_department
+    organisation_type_key { :ministerial_department }
   end
 
   factory :non_ministerial_department, parent: :organisation do
-    organisation_type_key :non_ministerial_department
+    organisation_type_key { :non_ministerial_department }
   end
 
   factory :organisation_with_alternative_format_contact_email, parent: :organisation, aliases: [:alternative_format_provider] do
-    alternative_format_contact_email "alternative@example.com"
+    alternative_format_contact_email { "alternative@example.com" }
   end
 
   factory :organisation_with_feature_list, parent: :organisation, traits: [:with_feature_list]
 
   factory :sub_organisation, parent: :organisation do
     parent_organisations { [build(:organisation)] }
-    organisation_type_key :sub_organisation
+    organisation_type_key { :sub_organisation }
   end
 
   factory :executive_office, parent: :organisation do
-    organisation_type_key :executive_office
+    organisation_type_key { :executive_office }
   end
 
   factory :devolved_administration, parent: :organisation do
-    organisation_type_key :devolved_administration
-    govuk_status 'exempt'
+    organisation_type_key { :devolved_administration }
+    govuk_status { 'exempt' }
   end
 
   factory :court, parent: :organisation do
-    organisation_type_key :court
+    organisation_type_key { :court }
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
     parent_organisations {
@@ -81,7 +81,7 @@ FactoryBot.define do
   end
 
   factory :hmcts_tribunal, parent: :organisation do
-    organisation_type_key :tribunal_ndpb
+    organisation_type_key { :tribunal_ndpb }
     organisation_logo_type_id { OrganisationLogoType::NoIdentity.id }
     logo_formatted_name { name }
     parent_organisations {

--- a/test/factories/policy_groups.rb
+++ b/test/factories/policy_groups.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :policy_group do
     sequence(:email) { |n| "policy-group-#{n}@example.com" }
-    name 'policy-group-name'
-    description ''
+    name { 'policy-group-name' }
+    description { '' }
 
     trait(:with_file_attachment) do
       attachments { FactoryBot.build_list :file_attachment, 1 }

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :promotional_feature_item do
     association :promotional_feature
-    summary 'Summary text'
+    summary { 'Summary text' }
     image { image_fixture_file }
-    image_alt_text "Image alt text"
+    image_alt_text { "Image alt text" }
   end
 end

--- a/test/factories/promotional_feature_links.rb
+++ b/test/factories/promotional_feature_links.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :promotional_feature_link do
     association :promotional_feature_item
-    url         'http://example.com'
-    text        'Link text'
+    url         { 'http://example.com' }
+    text        { 'Link text' }
   end
 end

--- a/test/factories/promotional_features.rb
+++ b/test/factories/promotional_features.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :promotional_feature do
     association :organisation, factory: :executive_office
-    title 'Feature title'
+    title { 'Feature title' }
   end
 end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :publication, class: Publication, parent: :edition, traits: %i[with_organisations with_topics] do
     sequence(:title) { |index| "publication-title-#{index}" }
-    body "publication-body"
-    summary "publication-summary"
+    body { "publication-body" }
+    summary { "publication-summary" }
     publication_type_id { PublicationType::PolicyPaper.id }
     attachments { FactoryBot.build_list :html_attachment, 1 }
 
@@ -61,8 +61,8 @@ FactoryBot.define do
 
   factory :publication_without_policy_areas, parent: :edition, class: Publication, traits: %i[with_organisations] do
     sequence(:title) { |index| "publication-title-#{index}" }
-    body "publication-body"
-    summary "publication-summary"
+    body { "publication-body" }
+    summary { "publication-summary" }
     publication_type_id { PublicationType::PolicyPaper.id }
   end
   factory :imported_publication, parent: :publication, traits: [:imported]

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -7,11 +7,11 @@ FactoryBot.define do
 
   factory :role_without_organisations, class: MinisterialRole, traits: [:translated] do
     sequence(:name) { |index| "role-name-#{index}" }
-    role_type "minister"
+    role_type { "minister" }
   end
 
   factory :historic_role, parent: :ministerial_role do
-    supports_historical_accounts true
+    supports_historical_accounts { true }
   end
 
   trait :occupied do

--- a/test/factories/sitewide_settings.rb
+++ b/test/factories/sitewide_settings.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :sitewide_setting do
     sequence(:key) { |index| "sitewide_setting_key-#{index}" }
-    description "Sitewide setting description"
-    on false
-    govspeak "example text"
+    description { "Sitewide setting description" }
+    on { false }
+    govspeak { "example text" }
   end
 end

--- a/test/factories/social_media_accounts.rb
+++ b/test/factories/social_media_accounts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :social_media_account do
     social_media_service
-    url "http://example.com"
+    url { "http://example.com" }
   end
 end

--- a/test/factories/special_representative_roles.rb
+++ b/test/factories/special_representative_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :special_representative_role do
-    name "United Kingdom Envoy to the Isles of Wonder"
+    name { "United Kingdom Envoy to the Isles of Wonder" }
   end
 end

--- a/test/factories/speeches.rb
+++ b/test/factories/speeches.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :speech, class: Speech, parent: :edition, traits: %i[with_organisations with_topics] do
-    title "speech-title"
-    body  "speech-body"
+    title { "speech-title" }
+    body  { "speech-body" }
     association :role_appointment, factory: :ministerial_role_appointment
     delivered_on { Time.zone.now }
-    location "speech-location"
-    speech_type SpeechType::Transcript
+    location { "speech-location" }
+    speech_type { SpeechType::Transcript }
     transient do
       relevant_to_local_government { false }
     end

--- a/test/factories/statistical_data_sets.rb
+++ b/test/factories/statistical_data_sets.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :statistical_data_set, class: StatisticalDataSet, parent: :edition, traits: %i[with_organisations with_topics] do
-    title   "statistical-data-set-title"
-    body    "statistical-data-set-body"
-    summary "statistical-data-set-summary"
+    title   { "statistical-data-set-title" }
+    body    { "statistical-data-set-body" }
+    summary { "statistical-data-set-summary" }
   end
 
   factory :imported_statistical_data_set, parent: :statistical_data_set, traits: [:imported] do
-    access_limited false
+    access_limited { false }
   end
   factory :draft_statistical_data_set, parent: :statistical_data_set, traits: [:draft]
   factory :submitted_statistical_data_set, parent: :statistical_data_set, traits: [:submitted]

--- a/test/factories/statistics_announcement_dates.rb
+++ b/test/factories/statistics_announcement_dates.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :statistics_announcement_date do
     release_date { Time.zone.today + 1.month + 9.hours + 30.minutes }
-    precision    StatisticsAnnouncementDate::PRECISION[:one_month]
-    confirmed    false
+    precision    { StatisticsAnnouncementDate::PRECISION[:one_month] }
+    confirmed    { false }
   end
 
   factory :statistics_announcement_date_change do
     release_date { Time.zone.today + 1.month + 9.hours + 30.minutes }
     current_release_date { create(:statistics_announcement_date) }
-    precision    StatisticsAnnouncementDate::PRECISION[:exact]
-    confirmed    true
+    precision    { StatisticsAnnouncementDate::PRECISION[:exact] }
+    confirmed    { true }
   end
 end

--- a/test/factories/statistics_announcements.rb
+++ b/test/factories/statistics_announcements.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :statistics_announcement do
     transient do
-      release_date nil
-      previous_display_date nil
-      change_note nil
+      release_date { nil }
+      previous_display_date { nil }
+      change_note { nil }
     end
 
     sequence(:title) { |index| "Stats announcement #{index}" }
-    summary "Summary of announcement"
-    publication_type_id PublicationType::OfficialStatistics.id
+    summary { "Summary of announcement" }
+    publication_type_id { PublicationType::OfficialStatistics.id }
     organisations { FactoryBot.build_list :organisation, 1 }
 
     topics { FactoryBot.build_list :topic, 1 }
@@ -34,13 +34,13 @@ FactoryBot.define do
   end
 
   factory :cancelled_statistics_announcement, parent: :statistics_announcement do
-    cancellation_reason "Cancelled for a reason"
-    cancelled_at Time.zone.now
+    cancellation_reason { "Cancelled for a reason" }
+    cancelled_at { Time.zone.now }
   end
 
   factory :unpublished_statistics_announcement, parent: :statistics_announcement do
-    publishing_state "unpublished"
-    redirect_url "https://www.test.gov.uk/government/sparkle"
+    publishing_state { "unpublished" }
+    redirect_url { "https://www.test.gov.uk/government/sparkle" }
   end
 
   factory :statistics_announcement_requiring_redirect,

--- a/test/factories/take_part_pages.rb
+++ b/test/factories/take_part_pages.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :take_part_page do
-    title 'A take part page title'
-    summary 'Summary text'
-    body 'Some govspeak body text'
+    title { 'A take part page title' }
+    summary { 'Summary text' }
+    body { 'Some govspeak body text' }
     image { image_fixture_file }
-    image_alt_text "Image alt text"
+    image_alt_text { "Image alt text" }
   end
 end

--- a/test/factories/taxon_hash.rb
+++ b/test/factories/taxon_hash.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :taxon_hash, class: Hash do
     transient do
-      is_level_one_taxon true
-      children []
-      visibility true
+      is_level_one_taxon { true }
+      children { [] }
+      visibility { true }
     end
     sequence("title") { |i| "Taxon Name #{i}" }
     sequence("base_path") { |i| "/path/to_taxon_#{i}" }
     sequence("content_id") { |i| "taxon_uuid_#{i}" }
-    phase 'live'
+    phase { 'live' }
     after :build do |hash, evaluator|
       hash["links"] = {
         "child_taxons" => evaluator.children

--- a/test/factories/topical_events.rb
+++ b/test/factories/topical_events.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :topical_event do
     sequence(:name) { |index| "topical-event-#{index}" }
-    description 'Topical event description'
+    description { 'Topical event description' }
     trait :active do
-      start_date Date.today - 1.month
-      end_date Date.today + 1.month
+      start_date { Date.today - 1.month }
+      end_date { Date.today + 1.month }
     end
   end
 end

--- a/test/factories/topics.rb
+++ b/test/factories/topics.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :topic do
     sequence(:name) { |index| "topic-#{index}" }
-    description 'Topic description'
+    description { 'Topic description' }
 
     trait :with_classification_policies do
       classification_policies { create_list(:classification_policy, 1) }

--- a/test/factories/traffic_commissioner_roles.rb
+++ b/test/factories/traffic_commissioner_roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :traffic_commissioner_role do
-    name "Traffic Commissioner for Scotland"
+    name { "Traffic Commissioner for Scotland" }
   end
 end

--- a/test/factories/translated_trait.rb
+++ b/test/factories/translated_trait.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   trait :translated do
     transient do
-      translated_into nil
+      translated_into { nil }
     end
 
     after(:build) do |object, evaluator|

--- a/test/factories/unpublishings.rb
+++ b/test/factories/unpublishings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :unpublishing do
-    unpublishing_reason_id UnpublishingReason::PUBLISHED_IN_ERROR_ID
+    unpublishing_reason_id { UnpublishingReason::PUBLISHED_IN_ERROR_ID }
     edition { create(:published_case_study, state: 'draft', first_published_at: 2.days.ago) }
 
     after(:build) do |unpublishing|
@@ -10,24 +10,24 @@ FactoryBot.define do
   end
 
   factory :published_in_error_redirect_unpublishing, parent: :unpublishing do
-    redirect true
-    alternative_url Whitehall.public_root + '/government/another/page'
+    redirect { true }
+    alternative_url { Whitehall.public_root + '/government/another/page' }
   end
 
   factory :published_in_error_no_redirect_unpublishing, parent: :unpublishing do
-    redirect false
-    explanation "published in error"
-    alternative_url Whitehall.public_root + '/government/another/page'
+    redirect { false }
+    explanation { "published in error" }
+    alternative_url { Whitehall.public_root + '/government/another/page' }
   end
 
   factory :consolidated_unpublishing, parent: :unpublishing do
-    unpublishing_reason_id UnpublishingReason::CONSOLIDATED_ID
-    alternative_url Whitehall.public_root + '/government/another/page'
+    unpublishing_reason_id { UnpublishingReason::CONSOLIDATED_ID }
+    alternative_url { Whitehall.public_root + '/government/another/page' }
   end
 
   factory :withdrawn_unpublishing, parent: :unpublishing do
-    unpublishing_reason_id UnpublishingReason::WITHDRAWN_ID
-    redirect false
-    explanation "content was withdrawn"
+    unpublishing_reason_id { UnpublishingReason::WITHDRAWN_ID }
+    redirect { false }
+    explanation { "content was withdrawn" }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
   end
 
   factory :disabled_user, parent: :user do
-    disabled true
+    disabled { true }
   end
 
   factory :writer, parent: :user, aliases: %i[author creator fact_check_requestor] do
@@ -34,8 +34,8 @@ FactoryBot.define do
   end
 
   factory :scheduled_publishing_robot, parent: :user do
-    uid nil
-    name "Scheduled Publishing Robot"
+    uid { nil }
+    name { "Scheduled Publishing Robot" }
     permissions { [User::Permissions::SIGNIN, User::Permissions::PUBLISH_SCHEDULED_EDITIONS] }
   end
 
@@ -63,8 +63,8 @@ FactoryBot.define do
   end
 
   factory :gds_team_user, parent: :user do
-    name "GDS Inside Government Team"
-    email 'govuk-whitehall@digital.cabinet-office.gov.uk'
+    name { "GDS Inside Government Team" }
+    email { 'govuk-whitehall@digital.cabinet-office.gov.uk' }
     permissions {
       [
         User::Permissions::SIGNIN,

--- a/test/factories/world_location_news_articles.rb
+++ b/test/factories/world_location_news_articles.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :world_location_news_article, class: WorldLocationNewsArticle, parent: :edition, traits: [:with_topics] do
-    title "world-location-news-title"
-    summary "world-location-news-summary"
-    body  "world-location-news-body"
+    title { "world-location-news-title" }
+    summary { "world-location-news-summary" }
+    body  { "world-location-news-body" }
 
     after :build do |news, evaluator|
       news.world_locations = [FactoryBot.build(:world_location)] unless evaluator.world_locations.any?

--- a/test/factories/world_locations.rb
+++ b/test/factories/world_locations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :world_location, traits: [:translated] do
-    name 'British Antarctic Territory'
-    world_location_type WorldLocationType::WorldLocation
+    name { 'British Antarctic Territory' }
+    world_location_type { WorldLocationType::WorldLocation }
 
     trait(:with_worldwide_organisations) {
       after :create do |world_location, _evaluator|
@@ -11,7 +11,7 @@ FactoryBot.define do
   end
 
   factory :international_delegation, parent: :world_location do
-    name "United Nations"
-    world_location_type WorldLocationType::InternationalDelegation
+    name { "United Nations" }
+    world_location_type { WorldLocationType::InternationalDelegation }
   end
 end

--- a/test/factories/worldwide_office_staff_roles.rb
+++ b/test/factories/worldwide_office_staff_roles.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :worldwide_office_staff_role do
-    name "Defence Attaché"
+    name { "Defence Attaché" }
   end
 end


### PR DESCRIPTION
Static attributes will be removed in FactoryBot 5.0 so update factories to use dynamic attributes.

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

external_url { "http://www.google.com" }
```