### PR TITLE
Update Export News Document to return content_ids for orgs

### DIFF
--- a/lib/export_news_document.rb
+++ b/lib/export_news_document.rb
@@ -53,8 +53,8 @@ private
       # These specialist sectors map to document types of topic
       primary_specialist_sectors: edition.primary_specialist_sectors.map(&:topic_content_id),
       secondary_specialist_sectors: edition.secondary_specialist_sectors.map(&:topic_content_id),
-      lead_organisations: edition.lead_organisations.map { |o| organisation(o) },
-      supporting_organisations: edition.supporting_organisations.map { |o| organisation(o) },
+      lead_organisations: edition.lead_organisations.map(&:content_id),
+      supporting_organisations: edition.supporting_organisations.map(&:content_id),
       topics: edition.topics.map { |t| t.as_json(only: %i[id content_id name type]) },
       policy_content_ids: edition.policy_content_ids,
       world_locations: edition.world_locations.map(&:content_id),


### PR DESCRIPTION
Related to: https://github.com/alphagov/content-publisher/pull/203

When importing documents into Content Publisher, we only need to know about
content_ids for organisations, so we update the scripts to export only
content_ids for lead organisations and supporting organisations.