### PR TITLE
Fix test errors by closing file before deleting it

### DIFF
--- a/app/workers/asset_manager_create_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_create_whitehall_asset_worker.rb
@@ -31,6 +31,7 @@ class AssetManagerCreateWhitehallAssetWorker < WorkerBase
       )
     end
 
+    file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
   end


### PR DESCRIPTION
In `AssetManagerCreateWhitehallAssetWorker`, an opened file is used when
running `asset_manager.create_whitehall_asset(asset_options)`:
```
file = File.open(file_path)
asset_options = { file: file, legacy_url_path: legacy_url_path }
```
We then try to delete that same file (`FileUtils.rm(file)`) without
closing it first. The deletion fails, causing the command
`FileUtils.rmdir(File.dirname(file))` to error because the directory
is not empty.
This fixes the issue by closing the file before trying to delete it.