### PR TITLE
Reslug cotswold_bakery_proves_an_export_success

### DIFF
--- a/db/data_migration/20180907160557_reslug_cotswold_bakery_proves_an_export_success.rb
+++ b/db/data_migration/20180907160557_reslug_cotswold_bakery_proves_an_export_success.rb
@@ -1,0 +1,12 @@
+old_slug = "cotswald-bakery-proves-an-export-success"
+new_slug = "cotswold-bakery-proves-an-export-success"
+
+document = Document.find_by!(slug: old_slug)
+edition = document.editions.published.last
+
+Whitehall::SearchIndex.delete(edition)
+
+document.update_attributes!(slug: new_slug)
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+puts "#{old_slug} -> #{new_slug}"


### PR DESCRIPTION
Fix a typo in the title of a published press release.

Change https://www.gov.uk/government/news/cotswald-bakery-proves-an-export-success

to https://www.gov.uk/government/news/cotswold-bakery-proves-an-export-success

https://govuk.zendesk.com/agent/tickets/3133783