### PR TITLE
Remove references to Policies and Policy Areas

### DIFF
--- a/app/views/admin/edition_legacy_associations/edit.html.erb
+++ b/app/views/admin/edition_legacy_associations/edit.html.erb
@@ -29,11 +29,15 @@
         <legend>Associations</legend>
 
         <div class="important-associations">
-          <% if @edition.can_be_related_to_policies? %>
+          <% if @edition.can_be_related_to_policies? && Policy.all.any? %>
             <%= render 'admin/shared/policy_fields', form: form %>
+          <% else %>
+            <p>There are no Policies to tag to.</p>
           <% end %>
-          <% if @edition.can_be_associated_with_topics? %>
+          <% if @edition.can_be_associated_with_topics? && Topic.exists? %>
             <%= render 'policy_area_fields', form: form, edition: @edition %>
+          <% else %>
+            <p>There are no Policy Areas to tag to.</p>
           <% end %>
         </div>
       </fieldset>

--- a/app/views/admin/publications/_form.html.erb
+++ b/app/views/admin/publications/_form.html.erb
@@ -11,7 +11,15 @@
 
     <fieldset>
       <legend>Associations</legend>
-      <p>You'll be able to select policies, policy areas and specialist sectors later.</p>
+      <% if Topic.exists? && Policy.all.any? %>
+        <p>You'll be able to select Topics, Policies, Policy Areas and Specialist Sectors later.</p>
+      <% elsif Topic.exists? %>
+        <p>You'll be able to select Topics, Policy Areas, and Specialist Sectors later.</p>
+      <% elsif Policy.all.any? %>
+        <p>You'll be able to select Topics, Policies, and Specialist Sectors later.</p>
+      <% else %>
+        <p>You'll be able to select Topics and Specialist Sectors later.</p>
+      <% end %>
       <%= render 'appointment_fields', form: form, edition: edition %>
       <%= render 'statistical_data_set_fields', form: form, edition: edition %>
       <%= render 'topical_event_fields', form: form, edition: edition %>


### PR DESCRIPTION
When a Whitehall user creates a new document, we allow them to associate
it with the legacy associations. As we are in the process of
unpublishing/retiring all Policies and Policy Areas, we should remove
this possibility, once they are not present.

With this, we now show only the legacy associations that are still
present.

Once all the Policies and Policy Areas are unpublished, we can modify
this and remove the conditionals introduced.