### PR TITLE
Don't generate invalid change_history entries

### DIFF
--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -85,7 +85,16 @@ module PublishingApi
     def change_history
       return {} unless corporate_information_page.change_history.present?
 
-      { change_history: corporate_information_page.change_history.as_json }
+      # Some speeches and corporate information pages don't seem to
+      # have first_published_at data, so ignore those change notes to
+      # avoid violating the relevant content schema.
+      changes_with_public_timestamps =
+        corporate_information_page
+          .change_history
+          .as_json
+          .select { |change| change[:public_timestamp].present? }
+
+      { change_history: changes_with_public_timestamps.as_json }
     end
 
     class CorporateInformationGroups

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -30,11 +30,20 @@ module PublishingApi
     end
 
     def details
+      # Some speeches and corporate information pages don't seem to
+      # have first_published_at data, so ignore those change notes to
+      # avoid violating the relevant content schema.
+      changes_with_public_timestamps =
+        item
+          .change_history
+          .as_json
+          .select { |change| change[:public_timestamp].present? }
+
       details = {
         body: body,
         political: item.political,
         delivered_on: item.delivered_on.iso8601,
-        change_history: item.change_history.as_json,
+        change_history: changes_with_public_timestamps.as_json,
       }
       details.merge!(speech_type_explanation)
       details.merge!(image_payload) if has_image?


### PR DESCRIPTION
For Speeches and Corporate Information Pages. Some editions for these
document types seem to be missing the first_published_at information.

I'm not sure how to fix the data issue, so for now, just don't include
invalid change history entries.