### PR TITLE
Avoid failures related to scheduled publishing

### DIFF
--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -42,7 +42,7 @@ class ScheduledPublishingWorker < WorkerBase
 
   def perform(edition_id)
     edition = Edition.find(edition_id)
-    return if edition.published?
+    return if edition.published? || !edition.scheduled?
 
     # Call `ScheduledEditionPublisher` via the `EditionServiceCoordinator`.
     publisher = Whitehall.edition_services.scheduled_publisher(edition)

--- a/test/unit/workers/scheduled_publishing_worker_test.rb
+++ b/test/unit/workers/scheduled_publishing_worker_test.rb
@@ -20,11 +20,10 @@ class ScheduledPublishingWorkerTest < ActiveSupport::TestCase
   test '#perform raises an error if the edition cannot be published' do
     edition = create(:superseded_edition)
 
-    exception = assert_raise(ScheduledPublishingWorker::ScheduledPublishingFailure) do
-      ScheduledPublishingWorker.new.perform(edition.id)
-    end
+    Whitehall.edition_services.expects(:scheduled_publisher).never
 
-    assert_equal 'Only scheduled editions can be published with ScheduledEditionPublisher', exception.message
+    ScheduledPublishingWorker.new.perform(edition.id)
+
     assert edition.reload.superseded?
   end
 


### PR DESCRIPTION
An error "Only scheduled editions can be published with
ScheduledEditionPublisher" seems to crop up often on Staging and
Integration. When the worker fails with this error, it retires the
job, which isn't helpful.

Therefore, make the worker more idempotent, and stop earlier if the
edition isn't scheduled.