### PR TITLE
Add taxon filter

### DIFF
--- a/app/assets/javascripts/application/document_filter.js
+++ b/app/assets/javascripts/application/document_filter.js
@@ -203,7 +203,7 @@ if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
       $filterSummary.mustache('documents/_filter_selections', context);
     },
     removeFilters: function(field, removed){
-      var selects = ['topics', 'departments', 'world_locations', 'official_document_status', 'people'],
+      var selects = ['taxons', 'topics', 'departments', 'world_locations', 'official_document_status', 'people'],
           inputs = ['keywords', 'from_date', 'to_date'];
 
       if($.inArray(field, selects) > -1){

--- a/app/helpers/document_filter_helper.rb
+++ b/app/helpers/document_filter_helper.rb
@@ -1,4 +1,9 @@
 module DocumentFilterHelper
+  def taxon_filter_options(selected_taxons = [])
+    selected_value = selected_taxons.any? ? selected_taxons : %w[all]
+    filter_option_html(filter_options.for(:taxons), selected_value)
+  end
+
   def topic_filter_options(selected_topics = [])
     selected_values = selected_topics.any? ? selected_topics.map(&:slug) : %w[all]
     options_for_select([filter_options.for(:topics).all], selected_values) +

--- a/app/helpers/document_filter_helper.rb
+++ b/app/helpers/document_filter_helper.rb
@@ -48,6 +48,20 @@ module DocumentFilterHelper
     end
   end
 
+  def filter_taxon_selections(content_ids)
+    taxons = ::Taxonomy::LevelOneTaxonsFetcher.fetch.select do |first_level_taxon|
+      content_ids.include?(first_level_taxon.content_id)
+    end
+    results = taxons.map do |obj|
+      {
+        name: obj.name,
+        url: url_for(remove_filter_from_params('taxons', obj.content_id)),
+        value: obj.content_id
+      }
+    end
+    merge_joining_option(results)
+  end
+
   def filter_results_selections(objects, type)
     results = objects.map do |obj|
       {
@@ -56,7 +70,7 @@ module DocumentFilterHelper
         value: obj.slug
       }
     end
-    results.map.with_index { |obj, i| obj.merge(joining: (results.length - 1 == i ? '' : 'and')) }
+    merge_joining_option(results)
   end
 
   def filter_results_keywords(keywords)
@@ -69,6 +83,10 @@ module DocumentFilterHelper
   end
 
 protected
+
+  def merge_joining_option(results)
+    results.map.with_index { |obj, i| obj.merge(joining: (results.length - 1 == i ? '' : 'and')) }
+  end
 
   def filter_options
     @filter_options ||= Whitehall::DocumentFilter::Options.new

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -22,7 +22,7 @@
                           [
                             :keyword, :date, :announcement_type,
                             :locations, :department, :topic,
-                            :include_world_location_news, :people
+                            :include_world_location_news, :people, :taxon
                           ]
                         else
                           [ :locations ]

--- a/app/views/documents/_filter_form.html.erb
+++ b/app/views/documents/_filter_form.html.erb
@@ -14,6 +14,13 @@
           </div>
         <% end %>
 
+        <% if filters.include? :taxon %>
+          <div class="filter">
+            <%= label_tag "taxons", "Topic" %>
+            <%= select_tag "taxons[]", taxon_filter_options(@filter.selected_taxons), class: "single-row-select", id: "taxons" %>
+          </div>
+        <% end %>
+
         <% if filters.include? :publication_type %>
           <div class="filter">
             <%= label_tag "publication_filter_option", "Publication type", class: "title" %>

--- a/app/views/documents/_filter_results.html.erb
+++ b/app/views/documents/_filter_results.html.erb
@@ -4,6 +4,7 @@
     pluralized_result_type: result_type.pluralize(filter.documents.total_count),
     departments: filter_results_selections(filter.selected_organisations, 'departments'),
     topics: filter_results_selections(filter.selected_topics, 'topics'),
+    taxons: filter_taxon_selections(filter.selected_taxons),
     people: filter_results_selections(filter.selected_people_option, 'people'),
     world_locations_any?: filter.selected_locations.any?,
     world_locations: filter_results_selections(filter.selected_locations, 'world_locations'),

--- a/app/views/documents/_filter_selections.mustache
+++ b/app/views/documents/_filter_selections.mustache
@@ -1,4 +1,9 @@
 <span class="count">{{result_count}}</span> <strong>{{pluralized_result_type}}</strong>
+<span class="taxons-selections">
+  {{#taxons}}
+    about <strong>{{name}}</strong> <a href="{{url}}" data-field="taxons" data-val="{{value}}" title="Remove {{name}} filter">&times;</a> {{joining}}
+  {{/taxons}}
+</span>
 <span class="topics-selections">
   {{#topics}}
     about <strong>{{name}}</strong> <a href="{{url}}" data-field="topics" data-val="{{value}}" title="Remove {{name}} filter">&times;</a> {{joining}}

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -22,7 +22,7 @@
                filters: if Locale.current.english?
                           [
                             :keyword, :date, :publication_type, :locations,
-                            :department, :topic, :official_document_status
+                            :department, :topic, :official_document_status, :taxon
                           ]
                         else
                           [ :locations ]

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -20,7 +20,7 @@
                document_type: :statistic,
                filters: if Locale.current.english?
                           [
-                            :keyword, :date, :department, :topic
+                            :keyword, :date, :department, :topic, :taxon
                           ]
                         else
                           [ ]

--- a/lib/taxonomy/level_one_taxons_fetcher.rb
+++ b/lib/taxonomy/level_one_taxons_fetcher.rb
@@ -1,0 +1,15 @@
+class Taxonomy::LevelOneTaxonsFetcher
+  def self.fetch
+    root_taxon = Rails.cache.fetch('taxonomy.root_taxon', expires_in: 15.minutes) do
+      Whitehall.content_store.content_item('/')
+    end
+    level_one_taxon_hashes = root_taxon.dig('links', 'level_one_taxons') || []
+    taxons = level_one_taxon_hashes.map do |level_one_taxon_hash|
+      Taxonomy::Taxon.from_taxon_hash(level_one_taxon_hash)
+    end
+    live_taxons = taxons.select { |t| t.phase == 'live' }
+    live_taxons.sort_by(&:name)
+  rescue GdsApi::ContentStore::ItemNotFound
+    {}
+  end
+end

--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -69,23 +69,15 @@ class UrlToSubscriberListCriteria
   end
 
   def from_params
-    return {} if @url.query.blank?
-
-    result = Rack::Utils.parse_nested_query(@url.query)
-    {
-      'departments' => 'organisations',
-      'topics' => method(:topic_map),
-    }.each do |from_key, to_key|
-      next unless result.key?(from_key)
-
-      if to_key.is_a?(String)
-        result[to_key] = result.delete(from_key)
-      else
-        values = result.delete(from_key)
-        result[to_key.call(values)] = values
+    Rack::Utils.parse_nested_query(@url.query).tap do |result|
+      if result.key?('departments')
+        result['organisations'] = result.delete('departments')
+      end
+      if result.key?('topics')
+        values = result.delete('topics')
+        result[topic_map(values)] = values
       end
     end
-    result
   end
 
   def topic_map(values)

--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -55,7 +55,8 @@ class UrlToSubscriberListCriteria
       if result.fetch("links", {})["announcement_filter_option"]
         result[GOVERNMENT_SUPERTYPE] = result["links"].delete("announcement_filter_option")
       end
-
+      #Official document status has not been implemented in the email-alert-api so remove this option
+      result.fetch("links", {}).delete('official_document_status')
       result
     end
   end

--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -15,7 +15,11 @@ class UrlToSubscriberListCriteria
       hash = map_url_to_hash.dup
       if hash["links"]
         links = hash["links"].each_with_object({}) do |(key, values), result|
-          result[key] = values.map { |value| lookup_content_id(key, value) }
+          result[key] = if key == 'taxons'
+                          values
+                        else
+                          Array.wrap(values).map { |value| lookup_content_id(key, value) }
+                        end
         end
         hash["links"] = links
       end

--- a/lib/whitehall/document_filter/cleaned_params.rb
+++ b/lib/whitehall/document_filter/cleaned_params.rb
@@ -1,7 +1,7 @@
 module Whitehall::DocumentFilter
   class CleanedParams < ActiveSupport::HashWithIndifferentAccess
     # These filter parameters are expected to be an array of values
-    PERMITTED_ARRAY_PARAMETER_KEYS  = %w(topics departments people world_locations).freeze
+    PERMITTED_ARRAY_PARAMETER_KEYS  = %w(taxons topics departments people world_locations).freeze
     # These filter params are expected to be scalar values, as defined by the strong_parameters code
     PERMITTED_SCALAR_PARAMETER_KEYS = %w(page
                                          per_page

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -17,6 +17,7 @@ module Whitehall::DocumentFilter
 
       @include_world_location_news = @params[:include_world_location_news]
 
+      @taxons          = Array(@params[:taxons])
       @topics          = Array(@params[:topics])
       @departments     = Array(@params[:departments])
       @people          = Array(@params[:people])
@@ -39,6 +40,10 @@ module Whitehall::DocumentFilter
 
     def documents
       raise NotImplementedError, 'you must provide #documents implementation in your filterer subclass'
+    end
+
+    def selected_taxons
+      @taxons.reject { |taxon| taxon == "all" }
     end
 
     def selected_topics

--- a/lib/whitehall/document_filter/options.rb
+++ b/lib/whitehall/document_filter/options.rb
@@ -30,6 +30,7 @@ module Whitehall
         official_documents: 'official_document_status',
         locations: 'world_locations',
         people: 'people',
+        taxons: 'taxons',
       }.freeze
 
       def valid_option_name?(option_name)
@@ -75,6 +76,15 @@ module Whitehall
 
       def options_for_topics
         @options_for_topics ||= StructuredOptions.new(all_label: "All policy areas", grouped: Classification.grouped_by_type)
+      end
+
+      def options_for_taxons
+        taxons = Taxonomy::LevelOneTaxonsFetcher.fetch
+
+        options = taxons.map do |taxon|
+          [taxon.name, taxon.content_id]
+        end
+        @options_for_taxons ||= StructuredOptions.new(all_label: "All topics", grouped: {}, ungrouped: options)
       end
 
       def options_for_people

--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -28,6 +28,7 @@ module Whitehall::DocumentFilter
         .merge(filter_by_organisations)
         .merge(filter_by_locations)
         .merge(filter_by_date)
+        .merge(filter_by_taxon)
         .merge(sort)
     end
 
@@ -52,6 +53,14 @@ module Whitehall::DocumentFilter
     def filter_by_topics
       if selected_topics.any?
         { policy_areas: selected_topics.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_taxon
+      if selected_taxons.any?
+        { part_of_taxonomy_tree: selected_taxons }
       else
         {}
       end

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -55,6 +55,7 @@ module Whitehall
             organisations
             people
             policy_areas
+            part_of_taxonomy_tree
             topical_events
             search_format_types
             world_locations

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -5,6 +5,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
   include ActionView::Helpers::DateHelper
   include DocumentFilterHelpers
   include GdsApi::TestHelpers::ContentStore
+  include TaxonomyHelper
 
   with_not_quite_as_fake_search
   should_be_a_public_facing_controller
@@ -17,6 +18,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
     )
 
     content_store_has_item(@content_item['base_path'], @content_item)
+    has_level_one_taxons([taxon('id1', 'taxon1'), taxon('id2', 'taxon2')])
   end
 
   view_test "index shows a mix of news and speeches" do
@@ -192,6 +194,23 @@ class AnnouncementsControllerTest < ActionController::TestCase
       (news + speeches[0..0]).each do |speech|
         refute_select_object(speech)
       end
+    end
+  end
+
+  view_test "#index highlights selected taxon filter options" do
+    get :index, params: { taxons: %w[id1 id2] }
+
+    assert_select "select#taxons[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: 'taxon1'
+      assert_select "option[selected='selected']", text: 'taxon2'
+    end
+  end
+
+  view_test "#index highlights all taxons filter options by default" do
+    get :index
+
+    assert_select "select[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: "All topics"
     end
   end
 

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -5,6 +5,7 @@ require "gds_api/test_helpers/content_store"
 
 class PublicationsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
+  include TaxonomyHelper
 
   with_not_quite_as_fake_search
   should_be_a_public_facing_controller
@@ -21,6 +22,7 @@ class PublicationsControllerTest < ActionController::TestCase
   setup do
     @content_item = content_item_for_base_path('/government/publications')
     content_store_has_item(@content_item['base_path'], @content_item)
+    has_level_one_taxons([taxon('id1', 'taxon1'), taxon('id2', 'taxon2')])
   end
 
   view_test "#index only displays *published* publications" do
@@ -70,6 +72,15 @@ class PublicationsControllerTest < ActionController::TestCase
     assert_select "select#world_locations[name='world_locations[]']" do
       assert_select "option[selected='selected']", text: @world_location_1.name
       assert_select "option[selected='selected']", text: @world_location_2.name
+    end
+  end
+
+  view_test "#index highlights selected taxon filter options" do
+    get :index, params: { taxons: %w[id1 id2] }
+
+    assert_select "select#taxons[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: 'taxon1'
+      assert_select "option[selected='selected']", text: 'taxon2'
     end
   end
 
@@ -179,6 +190,14 @@ class PublicationsControllerTest < ActionController::TestCase
 
     assert_select "select[name='departments[]']" do
       assert_select "option[selected='selected']", text: "All departments"
+    end
+  end
+
+  view_test "#index highlights all taxons filter options by default" do
+    get :index
+
+    assert_select "select[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: "All topics"
     end
   end
 

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/content_store"
 
 class StatisticsControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::ContentStore
+  include TaxonomyHelper
 
   with_not_quite_as_fake_search
   should_be_a_public_facing_controller
@@ -20,6 +21,8 @@ class StatisticsControllerTest < ActionController::TestCase
     )
 
     content_store_has_item(@content_item['base_path'], @content_item)
+
+    has_level_one_taxons([taxon('id1', 'taxon1'), taxon('id2', 'taxon2')])
   end
 
   view_test "#index only displays *published* statistics" do
@@ -65,6 +68,23 @@ class StatisticsControllerTest < ActionController::TestCase
     assert_select "select#departments[name='departments[]']" do
       assert_select "option[selected]", text: @organisation_1.name
       assert_select "option[selected]", text: @organisation_2.name
+    end
+  end
+
+  view_test "#index highlights selected taxon filter options" do
+    get :index, params: { taxons: %w[id1 id2] }
+
+    assert_select "select#taxons[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: 'taxon1'
+      assert_select "option[selected='selected']", text: 'taxon2'
+    end
+  end
+
+  view_test "#index highlights all taxons filter options by default" do
+    get :index
+
+    assert_select "select[name='taxons[]']" do
+      assert_select "option[selected='selected']", text: "All topics"
     end
   end
 

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/content_store"
 
 class RoutingTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::ContentStore
+  include TaxonomyHelper
 
   test "visiting #{Whitehall.router_prefix}/policy-topics redirects to #{Whitehall.router_prefix}/topics" do
     get "#{Whitehall.router_prefix}/policy-topics"
@@ -11,6 +12,7 @@ class RoutingTest < ActionDispatch::IntegrationTest
 
   test "assets are served under the #{Whitehall.router_prefix} prefix" do
     content_store_has_item('/government/publications', {})
+    has_a_level_one_taxon
 
     get publications_path
     assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -1,4 +1,18 @@
 module TaxonomyHelper
+  def has_a_level_one_taxon
+    has_level_one_taxons([taxon('id1', 'taxon1')])
+  end
+
+  def has_level_one_taxons(taxons)
+    Taxonomy::LevelOneTaxonsFetcher.stubs(:fetch).returns(taxons)
+  end
+
+  def taxon(content_id, title)
+    ::Taxonomy::Taxon.from_taxon_hash(
+      build(:taxon_hash, content_id: content_id, title: title)
+    )
+  end
+
   def homepage_content_id
     Taxonomy::PublishingApiAdapter::HOMEPAGE_CONTENT_ID
   end

--- a/test/unit/helpers/document_filter_helper_test.rb
+++ b/test/unit/helpers/document_filter_helper_test.rb
@@ -36,6 +36,20 @@ class DocumentFilterHelperTest < ActionView::TestCase
     assert_equal ({ first: 'one', second: %w[three] }), remove_filter_from_params(:second, 'two')
   end
 
+  test "#filter_taxon_selections gets objects ready for mustache" do
+    has_level_one_taxons([taxon('id1', 'taxon1'),
+                          taxon('id2', 'taxon2'),
+                          taxon('id3', 'taxon3')])
+
+    stubs(:params).returns(controller: 'publications', action: 'index', "taxons" => %w[id1 id2])
+
+    expected = [{ name: 'taxon1', value: 'id1', url: publications_path(taxons: %w[id2]), joining: 'and' },
+                { name: 'taxon2', value: 'id2', url: publications_path(taxons: %w[id1]), joining: '' }]
+    actual = filter_taxon_selections(%w[id1 id2])
+
+    assert_same_elements expected, actual
+  end
+
   test "filter_results_selections gets objects ready for mustache" do
     topic = build(:topic, slug: 'my-slug')
     stubs(:params).returns(controller: 'announcements', action: 'index', "topics" => ['my-slug', 'three'])

--- a/test/unit/helpers/document_filter_helper_test.rb
+++ b/test/unit/helpers/document_filter_helper_test.rb
@@ -2,6 +2,16 @@ require 'test_helper'
 
 class DocumentFilterHelperTest < ActionView::TestCase
   include ApplicationHelper
+  include TaxonomyHelper
+
+  test "#taxon_filter_options makes option tags for taxons" do
+    has_level_one_taxons([taxon('id1', 'taxon1'),
+                          taxon('id2', 'taxon2')])
+    result = taxon_filter_options
+    assert_includes result, '<option selected="selected" value="all">All topics</option>'
+    assert_includes result, '<option value="id1">taxon1</option>'
+    assert_includes result, '<option value="id2">taxon2</option>'
+  end
 
   test "#announcement_type_filter_options makes option tags with subtype name as text and slug as value" do
     expected = Whitehall::AnnouncementFilterOption.all.map { |o| [o.label, o.slug] }.unshift(["All announcement types", "all"])

--- a/test/unit/taxonomy/level_one_taxon_fetcher_test.rb
+++ b/test/unit/taxonomy/level_one_taxon_fetcher_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+require "gds_api/test_helpers/content_store"
+
+class Taxonomy::LevelOneTaxonFetcherTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  test "Fetches level one taxons" do
+    content_item_hash = {
+      "links" => {
+        "level_one_taxons" => [
+          {
+            "base_path" => "/entering-staying-uk",
+            "content_id" => "ba3a9702-da22-487f-86c1-8334a730e559",
+            "title" => "Entering and staying in the UK",
+            "details" =>
+              { "visible_to_departmental_editors" => true },
+            "phase" => "live",
+            "links" => {},
+          }
+        ]
+      }
+    }
+    content_store_has_item('/', content_item_hash)
+    level_one_taxons = ::Taxonomy::LevelOneTaxonsFetcher.fetch
+    assert_equal level_one_taxons.map(&:base_path), ["/entering-staying-uk"]
+    assert_equal level_one_taxons.map(&:content_id), ["ba3a9702-da22-487f-86c1-8334a730e559"]
+    assert_equal level_one_taxons.map(&:name), ["Entering and staying in the UK"]
+    assert_equal level_one_taxons.map(&:visible_to_departmental_editors), [true]
+    assert_equal level_one_taxons.map(&:phase), %w[live]
+  end
+
+  test 'omits non live' do
+    content_item_hash = {
+      "links" => {
+        "level_one_taxons" => [
+          {
+            "title" => "live",
+            "phase" => "live",
+          },
+          {
+            "title" => "alpha",
+            "phase" => "alpha",
+          }
+        ]
+      }
+    }
+    content_store_has_item('/', content_item_hash)
+    level_one_taxons = ::Taxonomy::LevelOneTaxonsFetcher.fetch
+    assert_equal level_one_taxons.map(&:name), %w[live]
+  end
+
+  test "Fetches level one taxons in order of title" do
+    content_item_hash = {
+      "links" => {
+        "level_one_taxons" => [
+          {
+            "title" => "a",
+            "phase" => "live",
+          },
+          {
+            "title" => "c",
+            "phase" => "live",
+          },
+          {
+            "title" => "b",
+            "phase" => "live",
+          },
+        ]
+      }
+    }
+    content_store_has_item('/', content_item_hash)
+    level_one_taxons = ::Taxonomy::LevelOneTaxonsFetcher.fetch
+    assert_equal level_one_taxons.map(&:name), %w[a b c]
+  end
+
+  test "There are no level one taxons so it returns an empty hash" do
+    content_store_has_item('/', {})
+    assert_empty ::Taxonomy::LevelOneTaxonsFetcher.fetch
+  end
+
+  test "There is no root taxon so it returns an empty hash" do
+    content_store_does_not_have_item('/')
+    assert_empty ::Taxonomy::LevelOneTaxonsFetcher.fetch
+  end
+end

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -112,13 +112,13 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
                  "government_document_supertype" => "statistics"
   end
 
-  test "can convert taxons" do
+  test "for now official document status gets ignored" do
     converter = UrlToSubscriberListCriteria.new(
-      'http://www.dev.gov.uk/government/publications.atom?taxons%5B%5D=a544d48b-1e9e-47fb-b427-7a987c658c14',
+      'http://www.dev.gov.uk/government/publications.atom?official_document_status=command_papers_only&taxons%5B%5D=a544d48b-1e9e-47fb-b427-7a987c658c14',
         stub("StaticData"),
         )
 
-    assert_equal converter.convert, "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
-                                      "email_document_supertype" => "publications"
+    assert_equal converter.convert,  "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
+                                     "email_document_supertype" => "publications"
   end
 end

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -112,6 +112,16 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
                  "government_document_supertype" => "statistics"
   end
 
+  test "It converts URLs containing taxons" do
+    converter = UrlToSubscriberListCriteria.new(
+      'http://www.dev.gov.uk/government/publications.atom?taxons%5B%5D=a544d48b-1e9e-47fb-b427-7a987c658c14',
+        stub("StaticData"),
+        )
+
+    assert_equal converter.convert, "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
+                                      "email_document_supertype" => "publications"
+  end
+
   test "for now official document status gets ignored" do
     converter = UrlToSubscriberListCriteria.new(
       'http://www.dev.gov.uk/government/publications.atom?official_document_status=command_papers_only&taxons%5B%5D=a544d48b-1e9e-47fb-b427-7a987c658c14',

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -112,36 +112,13 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
                  "government_document_supertype" => "statistics"
   end
 
-  test "can detect missing mappings from slug to content_id" do
+  test "can convert taxons" do
     converter = UrlToSubscriberListCriteria.new(
-      'https://www.gov.uk/government/feed?departments%5B%5D=other',
-      stub("StaticData", topical_event?: false, content_id: UrlToSubscriberListCriteria::MISSING_LOOKUP),
-    )
+      'http://www.dev.gov.uk/government/publications.atom?taxons%5B%5D=a544d48b-1e9e-47fb-b427-7a987c658c14',
+        stub("StaticData"),
+        )
 
-    assert_equal converter.convert, "links" => { "organisations" => ["*** MISSING KEY ***"] }
-    assert_equal converter.missing_lookup, "organisations: other"
-  end
-
-  test "can detect multiple missing mappings from slug to content_id" do
-    converter = UrlToSubscriberListCriteria.new(
-      'https://www.gov.uk/government/feed?departments%5B%5D=other&topics%5B%5D=unknown',
-      stub("StaticData", topical_event?: false, content_id: UrlToSubscriberListCriteria::MISSING_LOOKUP),
-    )
-
-    assert_equal converter.convert,
-                 "links" => {
-                   "organisations" => ["*** MISSING KEY ***"],
-                   "policy_areas" => ["*** MISSING KEY ***"],
-                 }
-    assert_equal converter.missing_lookup, "organisations: other and policy_areas: unknown"
-  end
-
-  test "does not incorrectly detect missing mapping from slug to content id" do
-    converter = UrlToSubscriberListCriteria.new(
-      'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
-      stub("StaticData", topical_event?: false, content_id: 'aaaaa-111111'),
-    )
-
-    assert !converter.missing_lookup
+    assert_equal converter.convert, "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
+                                      "email_document_supertype" => "publications"
   end
 end

--- a/test/unit/whitehall/document_filter/options_test.rb
+++ b/test/unit/whitehall/document_filter/options_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 module Whitehall
   module DocumentFilter
     class OptionsTest < ActiveSupport::TestCase
+      include TaxonomyHelper
+
       def filter_options
         @filter_options ||= Options.new
       end
@@ -108,6 +110,18 @@ module Whitehall
 
       test "valid_resource_filter_options? doesn't choke on string values" do
         refute filter_options.valid_resource_filter_options?(topics: 'string-option')
+      end
+
+      test "can get the list of options for taxons" do
+        has_level_one_taxons([
+           taxon('id1', 'taxon1'),
+           taxon('id2', 'taxon2')
+        ])
+        options = filter_options.for(:taxons)
+
+        assert_equal ["All topics", "all"], options.all
+        assert_equal [%w[taxon1 id1], %w[taxon2 id2]], options.ungrouped
+        assert_empty options.grouped
       end
 
       test "can get the list of options for publication_type" do

--- a/test/unit/whitehall/document_filter/rummager_test.rb
+++ b/test/unit/whitehall/document_filter/rummager_test.rb
@@ -21,6 +21,17 @@ module Whitehall::DocumentFilter
         )
     end
 
+    def expect_search_by_taxonomy_tree(taxons)
+      Whitehall
+          .government_search_client
+          .expects(:advanced_search)
+          .with(
+            has_entry(
+              part_of_taxonomy_tree: taxons
+            )
+          )
+    end
+
     def expect_search_by_people(people)
       Whitehall
         .government_search_client
@@ -64,6 +75,12 @@ module Whitehall::DocumentFilter
       rummager.announcements_search
     end
 
+    test 'announcements_search search the taxonomy tree if we use the taxons option' do
+      rummager = Rummager.new(taxons: 'content-id')
+      expect_search_by_taxonomy_tree(%w[content-id])
+      rummager.announcements_search
+    end
+
     test 'publications_search looks for Publications, Consultations, and StatisticalDataSets by default' do
       rummager = Rummager.new({})
       expect_search_by_format_types(format_types(Consultation, Publication, StatisticalDataSet))
@@ -73,6 +90,12 @@ module Whitehall::DocumentFilter
     test 'publications_search looks for a specific announcement sub type if we use the publication_type option' do
       rummager = Rummager.new(publication_type: 'policy-papers')
       expect_search_by_format_types(PublicationType::PolicyPaper.search_format_types)
+      rummager.publications_search
+    end
+
+    test 'publications_search search the taxonomy tree if we use the taxons option' do
+      rummager = Rummager.new(taxons: 'content-id')
+      expect_search_by_taxonomy_tree(%w[content-id])
       rummager.publications_search
     end
 


### PR DESCRIPTION
Adds filtering of publications, statistics and announcements by first level taxons.

The following pages now have an added 'Topic Taxon' selection box that allows filtering on a first level taxon:
- https://www.gov.uk/government/publications
- https://www.gov.uk/government/statistics
- https://www.gov.uk/government/announcements

Trello: https://trello.com/c/drJGmEYF/176-xl-replace-the-policy-area-filtering-with-topic-based-filtering-with-the-level-1-topics 

![image](https://user-images.githubusercontent.com/6050162/45817349-634fd680-bcd6-11e8-8072-a6b9588cd383.png)
