### PR TITLE
Fix AttachmentDataReporter#report

### DIFF
--- a/lib/attachment_data_reporter.rb
+++ b/lib/attachment_data_reporter.rb
@@ -35,7 +35,7 @@ class AttachmentDataReporter
       csv << ["Slug", "Organisations", "Total attachments", "Accessible attachments", "Content types", "Combined size"]
       published_editions_with_attachments.each do |edition|
         csv << [edition.document.slug, edition.organisations.map(&:name).join(","), edition.attachments.size,
-                accessible_details(edition.attachments), content_type_details(edition.attachments),
+                accessible_details(edition.attachments), content_type_details(edition.attachments.to_a),
                 combined_attachments_file_size(edition.attachments)]
       end
     end


### PR DESCRIPTION
https://trello.com/c/vAmYkM3F/466-create-reporting-on-which-documents-have-been-uploaded-by-which-department

One of the formatting methods was attempting to call `Enumerable#delete_if`
on `Attachment::ActiveRecord_Associations_CollectionProxy` so the collection
needs to be treated as an array.

https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/49/console