### PR TITLE
Avoid reporting EPIPE errors from export rake task

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -167,6 +167,8 @@ namespace :export do
     scope.find_each.with_index do |document, index|
       puts "#{index + 1}/#{total} exported", STDERR if ((index + 1) % 100).zero?
       puts ExportNewsDocument.new(document).call.to_json
+    rescue Errno::EPIPE
+      break # Can't do much about this, so just break
     end
   end
 end


### PR DESCRIPTION
This rake task sometimes errors because the receiving end of the
pipeline has crashed. Rescue the exception to avoid it propagating up
to Sentry.