### PR TITLE
Remove policies header if none is available

### DIFF
--- a/app/models/edition/related_policies.rb
+++ b/app/models/edition/related_policies.rb
@@ -70,6 +70,6 @@ module Edition::RelatedPolicies
   end
 
   def has_policies?
-    policy_content_ids.any?
+    policies.any?
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/RaETQPdI/177-mremove-policies-and-policy-area-headings-if-none-are-available-to-tag-to-in-whitehall-publisher

In the `Associations` section of Whitehall Document pages, for example
https://whitehall-admin.publishing.service.gov.uk/government/admin/consultations/877485,
the `Policies` header is still displayed even after unpublishing all
the Policies tagged to that particular Document.

This is because, even after being unpublished, Policies remain in the
ones a Document is tagged to, and so `policy_content_ids.any?` returns
true even if all the Policies are unpublished.

Using `policies.any?` instead of `policy_content_ids.any?` fixes this.

Before:
```
def has_policies?
  policy_content_ids.any?
end
```

After:
```
def has_policies?
  policies.any?
end
```