### PR TITLE
Fix bio truncation in search results

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -129,7 +129,7 @@ class Role < ApplicationRecord
   end
 
   def current_person_biography
-    current_person && current_person.biography_without_markup
+    current_person&.biography_appropriate_for_role_without_markup
   end
 
   def organisation_names

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -64,11 +64,7 @@ class PersonPresenter < Whitehall::Decorators::Decorator
   end
 
   def biography
-    if in_current_role?
-      context.govspeak_to_html model.biography
-    elsif model.biography
-      context.govspeak_to_html truncated_biography
-    end
+    context.govspeak_to_html(model.biography_appropriate_for_role)
   end
 
   def link(options = {})
@@ -86,15 +82,5 @@ class PersonPresenter < Whitehall::Decorators::Decorator
     if (img = image_url(:s216))
       context.image_tag img, alt: name
     end
-  end
-
-  def in_current_role?
-    current_role_appointments.any?
-  end
-
-private
-
-  def truncated_biography
-    model.biography.split(/\n/).first
   end
 end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -19,7 +19,7 @@
   <div class="block-2 ">
     <div class="inner-block">
       <section class="contextual-info in-page-navigation ">
-        <% if @person.in_current_role? %>
+        <% if @person.currently_in_a_role? %>
           <div class="image">
             <figure class="img">
               <%= @person.image %>
@@ -30,7 +30,7 @@
         <nav role="navigation">
           <ul>
             <li><%= link_to t('people.biography'), '#biography' %></li>
-            <% if @person.in_current_role? %>
+            <% if @person.currently_in_a_role? %>
               <li><%= link_to t('roles.heading', count: @person.current_role_appointments.count), "#current-roles" %></li>
             <% end %>
             <% if @person.previous_role_appointments.any? %>

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -17,6 +17,25 @@ class PersonTest < ActiveSupport::TestCase
                   }, person.search_index)
   end
 
+  test "truncates the biography sent to rummager unless they currently hold a role" do
+    full_bio = <<~BIO
+      Dapibus Mattis Euismod
+
+      Sit Aenean Venenatis
+
+      Vulputate Euismod Vehicula
+    BIO
+
+    person_in_role = FactoryBot.create(:person, biography: full_bio)
+    FactoryBot.create(:role_appointment, person: person_in_role)
+    person_in_role.reload
+
+    person_not_in_role = FactoryBot.create(:person, biography: full_bio)
+
+    assert_equal "Dapibus Mattis Euismod", person_not_in_role.search_index["indexable_content"]
+    assert_equal full_bio.gsub(/[\n]+/, " ").strip, person_in_role.search_index["indexable_content"]
+  end
+
   test "should be invalid without a name" do
     person = build(:person, title: nil, forename: nil, surname: nil, letters: nil)
     refute person.valid?

--- a/test/unit/presenters/person_presenter_test.rb
+++ b/test/unit/presenters/person_presenter_test.rb
@@ -32,8 +32,8 @@ class PersonPresenterTest < ActionView::TestCase
   end
 
   test 'biography is truncated for people without a current role' do
+    @person.role_appointments.destroy_all
     @person.stubs(:biography).returns("This is the first paragraph.\r\n\r\nThis is the second paragraph")
-    @presenter.stubs(:in_current_role?).returns(false)
     assert_no_match %r[This is the second paragraph.], @presenter.biography
   end
 


### PR DESCRIPTION
The biography of a person is currently truncated
to the first paragraph if that person is not in
an active role, however this was not being done
for bio text being sent to rummager.

https://trello.com/c/U3bfa2tZ/492-rummager-displaying-full-biography-in-search-results-instead-of-first-paragraph