### PR TITLE
Remove `Policies` from the shared nav bar

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -5,8 +5,7 @@
       <li><%= main_navigation_link_to "Worldwide", world_locations_path(locale: :en) %></li>
       <li><%= main_navigation_link_to 'How government works', how_government_works_path %></li>
       <li><%= main_navigation_link_to "Get involved", get_involved_path %></li>
-      <li class="clear-child"><%= main_navigation_link_to "Policies", policies_path %></li>
-      <li><%= main_navigation_link_to "Publications", publications_path %></li>
+      <li class="clear-child"><%= main_navigation_link_to "Publications", publications_path %></li>
       <li><%= main_navigation_link_to "Consultations", publications_filter_path(publication_filter_option: 'consultations') %></li>
       <li><%= main_navigation_link_to "Statistics", statistics_path %></li>
       <li><%= main_navigation_link_to "Announcements", announcements_path %></li>


### PR DESCRIPTION
Due to the retiring of `Policies`, the link to the policy finder has
been removed from the shared nav-bar accross whitehall-frontend as the
page will soon be deprecated.

Trello:
https://trello.com/c/e27ECoMb/209-remove-the-policies-link-from-the-content-page-header-applies-to-some-pages

## Before:
<img width="1028" alt="screen shot 2018-09-21 at 10 21 54" src="https://user-images.githubusercontent.com/24479188/45873483-8045e180-bd8a-11e8-9c80-b77a0b61e1a2.png">

## After:
<img width="1021" alt="screen shot 2018-09-21 at 10 21 14" src="https://user-images.githubusercontent.com/24479188/45873489-85a32c00-bd8a-11e8-923b-16994dab1f38.png">
