### PR TITLE
Remove link to the policy finder as this is soon to be deprecated

### DIFF
--- a/app/views/home/how_government_works.html.erb
+++ b/app/views/home/how_government_works.html.erb
@@ -79,7 +79,7 @@
         </div>
         <div class="two-thirds">
           <div class="inner-block">
-            <p>Departments and their agencies are responsible for putting government <%= link_to "policy", policies_path %> into practice.</p>
+            <p>Departments and their agencies are responsible for putting government policy into practice.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Trello:
https://trello.com/c/7gVMseqC/214-remove-policy-link-from-how-government-works-page