### PR TITLE
Use republish_async in republish_organisation_to_publishing_api

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -29,7 +29,7 @@ class CorporateInformationPage < Edition
   validate :only_one_organisation_or_worldwide_organisation
 
   def republish_organisation_to_publishing_api
-    owning_organisation.publish_to_publishing_api if owning_organisation.is_a?(Organisation)
+    Whitehall::PublishingApi.republish_async(owning_organisation) if owning_organisation.is_a?(Organisation)
   end
 
   def reindex_organisation_in_search_index

--- a/test/unit/models/corporate_information_page_test.rb
+++ b/test/unit/models/corporate_information_page_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CorporateInformationPageTest < ActiveSupport::TestCase
   test "creating a new corporate information page republishes the owning organisation" do
     test_object = create(:organisation)
-    Whitehall::PublishingApi.expects(:publish).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     create(:corporate_information_page, organisation: test_object)
   end
 
@@ -11,14 +11,14 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     test_object = create(:organisation)
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
     corporate_information_page.external = true
-    Whitehall::PublishingApi.expects(:publish).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     corporate_information_page.save!
   end
 
   test "deleting a corporate information page republishes the owning organisation" do
     test_object = create(:organisation)
     corporate_information_page = create(:corporate_information_page, organisation: test_object)
-    Whitehall::PublishingApi.expects(:publish).with(test_object).once
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
     corporate_information_page.destroy
   end
 


### PR DESCRIPTION
For the CorporateInformationPage model. Other models were changed in
2c424294878311a3031b550cad5cee6d63c05a36, but this one seems to have
been missed.