### PR TITLE
Unpublish policy and policy area finders and redirect to the homepage.

### DIFF
--- a/db/data_migration/20180924093448_redirect_policy_finder.rb
+++ b/db/data_migration/20180924093448_redirect_policy_finder.rb
@@ -1,0 +1,6 @@
+puts "Unpublishing /government/policies and redirecting to /"
+Services.publishing_api.unpublish(
+  "d6582d48-df19-46b3-bf84-9157192801a6",
+  type: "redirect",
+  alternative_path: "/",
+)

--- a/db/data_migration/20180924093521_redirect_policy_area_finder.rb
+++ b/db/data_migration/20180924093521_redirect_policy_area_finder.rb
@@ -1,0 +1,6 @@
+puts "Unpublishing /government/topics and redirecting to /"
+Services.publishing_api.unpublish(
+  "cdf678f7-d56d-4ea0-bdcc-054bdad4d2d2",
+  type: "redirect",
+  alternative_path: "/",
+)


### PR DESCRIPTION
Policies and Policy Areas will in future be superseded by the Topic
Taxonomy. As part of this work, we need to remove finders
at /government/topics and /government/policies.

These data migrations redirect those pages to the Gov.uk homepage.

Trello: https://trello.com/c/I3WFXlpg/219-remove-and-redirect-policy-finder and https://trello.com/c/VERGP1FP/215-remove-and-redirect-policy-area-finder