### PR TITLE
Remove Policy Areas from Organisations pages

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -80,6 +80,7 @@ class Organisation < ApplicationRecord
   has_many :organisation_classifications,
            -> { order('organisation_classifications.ordering') },
            dependent: :destroy
+  has_many :classifications, through: :organisation_classifications
 
   # DID YOU MEAN: Policy Area?
   # "Policy area" is the newer name for "topic"
@@ -91,7 +92,9 @@ class Organisation < ApplicationRecord
   has_many :topics,
            -> { order('organisation_classifications.ordering') },
            through: :organisation_classifications
-  has_many :classifications, through: :organisation_classifications
+  has_many :topical_events,
+           -> { order('organisation_classifications.ordering') },
+           through: :organisation_classifications
 
   has_many :users, foreign_key: :organisation_slug, primary_key: :slug, dependent: :nullify
 

--- a/app/models/organisation_classification.rb
+++ b/app/models/organisation_classification.rb
@@ -1,5 +1,6 @@
 class OrganisationClassification < ApplicationRecord
   belongs_to :organisation
+  belongs_to :classification
 
   # DID YOU MEAN: Policy Area?
   # "Policy area" is the newer name for "topic"
@@ -9,5 +10,5 @@ class OrganisationClassification < ApplicationRecord
   # You can help improve this code by renaming all usages of this field to use
   # the new terminology.
   belongs_to :topic, foreign_key: :classification_id
-  belongs_to :classification
+  belongs_to :topical_event, foreign_key: :classification_id
 end

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -77,14 +77,14 @@
       <%= organisation_form.select :parent_organisation_ids, options_from_collection_for_select(Organisation.with_translations(:en) - [organisation_form.object], 'id', 'select_name', organisation.parent_organisation_ids), {}, multiple: true, class: 'chzn-select form-control', data: { placeholder: "Choose parent organisations…" } %>
     </p>
 
-    <h3>Policy Areas</h3>
-    <% organisation_form.object.organisation_classifications.each do |ot| %>
+    <h3>Topical events</h3>
+    <% organisation_form.object.organisation_classifications.each do |oc| %>
       <p>
-        <%= label_tag "organisation_topic_ids_#{ot.ordering}" do %>
-          Policy Area <%= ot.ordering + 1 %>
-          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(Classification.all, 'id', 'name', ot.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose policy areas…"}, id: "organisation_topic_ids_#{ot.ordering}" %>
-          <%= hidden_field_tag "organisation[organisation_classifications_attributes][][ordering]", ot.ordering %>
-          <%= hidden_field_tag "organisation[organisation_classifications_attributes][][id]", ot.id %>
+        <%= label_tag "organisation_topical_event_ids_#{oc.ordering}" do %>
+          Topical Event <%= oc.ordering + 1 %>
+          <%= select_tag "organisation[organisation_classifications_attributes][][classification_id]", options_from_collection_for_select(TopicalEvent.all, 'id', 'name', oc.classification_id), include_blank: true, multiple: false, class: 'chzn-select form-control', data: { placeholder: "Choose topical events…"}, id: "organisation_topical_event_ids_#{oc.ordering}" %>
+          <%= hidden_field_tag "organisation[organisation_classifications_attributes][][ordering]", oc.ordering %>
+          <%= hidden_field_tag "organisation[organisation_classifications_attributes][][id]", oc.id %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -30,9 +30,9 @@
           None
         <% end %>
       </td></tr>
-      <tr><th>Policy areas and topical events</th><td>
-        <% if @organisation.classifications.any? %>
-          <%= @organisation.classifications.map {|t| link_to(t.name, [:edit, :admin, t]) }.to_sentence.html_safe %>
+      <tr><th>Topical events</th><td>
+        <% if @organisation.topical_events.any? %>
+          <%= @organisation.topical_events.map {|t| link_to(t.name, [:edit, :admin, t]) }.to_sentence.html_safe %>
         <% else %>
           None
         <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,6 +117,25 @@
       "note": "This comes from a new model so we trust the data."
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "4ab694e969b0cd5569812723ed4985088c9a4e2a8e241316bb97c26325cab992",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/organisations/show.html.erb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Organisation.friendly.find(params[:id]).topical_events.map do\n link_to(t.name, [:edit, :admin, t])\n end.to_sentence",
+      "render_path": [{"type":"controller","class":"Admin::OrganisationsController","method":"show","line":26,"file":"app/controllers/admin/organisations_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "admin/organisations/show"
+      },
+      "user_input": "Organisation.friendly.find(params[:id])",
+      "confidence": "Weak",
+      "note": "We don't link directly to any unescaped model attribute."
+    },
+    {
       "warning_type": "Cross-Site Request Forgery",
       "warning_code": 86,
       "fingerprint": "4d109bd02e4ccb3ea4c51485c947be435ee006a61af7d2cd37d1b358c7469189",
@@ -183,7 +202,7 @@
       "line": 31,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Organisation.with_translations(I18n.locale).find(params[:id]).url, Organisation.with_translations(I18n.locale).find(params[:id]).url, :class => \"url-link\")",
-      "render_path": [{"type":"controller","class":"OrganisationsController","method":"show","line":63,"file":"app/controllers/organisations_controller.rb"}],
+      "render_path": [{"type":"controller","class":"OrganisationsController","method":"show","line":62,"file":"app/controllers/organisations_controller.rb"}],
       "location": {
         "type": "template",
         "template": "organisations/not_live"
@@ -292,25 +311,6 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c028d9a68abae01d97f7ef17f1809ca27778be2eeac978d6b6c04d76cab890ec",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/admin/organisations/show.html.erb",
-      "line": 35,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Organisation.friendly.find(params[:id]).classifications.map do\n link_to(t.name, [:edit, :admin, t])\n end.to_sentence",
-      "render_path": [{"type":"controller","class":"Admin::OrganisationsController","method":"show","line":26,"file":"app/controllers/admin/organisations_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/organisations/show"
-      },
-      "user_input": "Organisation.friendly.find(params[:id])",
-      "confidence": "Weak",
-      "note": "We don't link directly to any unescaped model attribute"
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "c08711cc21cb1dbf0709db0011a9a4a782bf6c1a6f7a0a1e1d4b000d20462ae2",
       "check_name": "LinkToHref",
@@ -319,7 +319,7 @@
       "line": 31,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Unresolved Model).new.contact_form_url.truncate(25), (Unresolved Model).new.contact_form_url)",
-      "render_path": [{"type":"template","name":"organisations/show","line":240,"file":"app/views/organisations/show.html.erb"}],
+      "render_path": [{"type":"template","name":"organisations/show","line":222,"file":"app/views/organisations/show.html.erb"}],
       "location": {
         "type": "template",
         "template": "contacts/_contact"
@@ -444,6 +444,6 @@
       "note": "This comes from the Content Store and we trust data from there."
     }
   ],
-  "updated": "2018-08-03 13:39:30 +0100",
+  "updated": "2018-10-08 12:33:24 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -126,7 +126,7 @@ Given(/^I have an offsite link "(.*?)" for the organisation "(.*?)"$/) do |title
 end
 
 When(/^I add a new organisation called "([^"]*)"$/) do |organisation_name|
-  create(:topic, name: 'Jazz Bizniz')
+  create(:topical_event, name: 'Jazz Bizniz')
 
   visit new_admin_organisation_path
 
@@ -134,7 +134,7 @@ When(/^I add a new organisation called "([^"]*)"$/) do |organisation_name|
   fill_in 'Acronym', with: organisation_name.split(' ').collect { |word| word.chars.first }.join
   fill_in 'Logo formatted name', with: organisation_name
   select 'Ministerial department', from: 'Organisation type'
-  select 'Jazz Bizniz', from: 'organisation_topic_ids_0'
+  select 'Jazz Bizniz', from: 'organisation_topical_event_ids_0'
   within '.featured-links' do
     fill_in 'Title', with: 'Top task 1'
     fill_in 'URL', with: 'http://mainstream.co.uk'

--- a/test/unit/models/organisation_test.rb
+++ b/test/unit/models/organisation_test.rb
@@ -653,6 +653,14 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal 0, OrganisationClassification.count
   end
 
+  test 'destroy removes topical_event relationships' do
+    organisation = create(:organisation)
+    topical_event = create(:topical_event)
+    topical_event.organisations << organisation
+    organisation.destroy
+    assert_equal 0, OrganisationClassification.count
+  end
+
   test 'destroy unsets user organisation' do
     organisation = create(:organisation)
     user = create(:writer, organisation: organisation)
@@ -755,6 +763,15 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.organisation_classifications.create(classification_id: topics[1].id, ordering: 1)
     assert_match %r[order by]i, organisation.topics.to_sql
     assert_equal [topics[1], topics[0]], organisation.topics
+  end
+
+  test "topical_events are explicitly ordered" do
+    topical_events = [create(:topical_event), create(:topical_event)]
+    organisation = create(:organisation)
+    organisation.organisation_classifications.create(classification_id: topical_events[0].id, ordering: 2)
+    organisation.organisation_classifications.create(classification_id: topical_events[1].id, ordering: 1)
+    assert_match %r[order by]i, organisation.topical_events.to_sql
+    assert_equal [topical_events[1], topical_events[0]], organisation.topical_events
   end
 
   test "can have associated contacts" do


### PR DESCRIPTION
Remove Policy Areas from Organisations pages

Trello cards:
trello.com/c/VzhuAWdA/229-remove-policy-areas-from-orgs-in-whp
trello.com/c/OKJzONoO/233-after-policy-areas-are-retired-rename-the-tagging-lists-for-orgs-in-whp

As part of the work for the new Single Taxonomy, we are in the process
of unpublishing all Policy Areas. Because of this, all references to
Policy Areas need to be removed.

This removes Policy Areas from the Organisations admin pages and only
leaves Topical Events.