### PR TITLE
Change to the transaction Cucumber javascript_strategy

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -54,4 +54,4 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-Cucumber::Rails::Database.javascript_strategy = :truncation
+Cucumber::Rails::Database.javascript_strategy = :transaction


### PR DESCRIPTION
This will hopefully be faster than truncation, and hopefully won't
cause any issues. The Rails tests use transactions for isolation, as
well as separate databases.