### PR TITLE
Add speech image_url to rummager index

### DIFF
--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -2,6 +2,7 @@ class Speech < Announcement
   include Edition::Appointment
   include Edition::HasDocumentCollections
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
+  include LeadImagePresenterHelper
 
   validates :speech_type_id, presence: true
   validates :delivered_on, presence: true, unless: ->(speech) { speech.can_have_some_invalid_data? }
@@ -22,6 +23,12 @@ class Speech < Announcement
 
   def search_format_types
     super + [Speech.search_format_type] + speech_type.search_format_types
+  end
+
+  def search_index
+    super.merge(
+      "image_url" => lead_image_url
+    )
   end
 
   def speech_type
@@ -64,5 +71,11 @@ private
 
   def skip_organisation_validation?
     can_have_some_invalid_data? || person_override.present?
+  end
+
+  def lead_image_url
+    ActionController::Base.helpers.image_url(
+      lead_image_path, host: Whitehall.public_asset_host
+    )
   end
 end

--- a/test/unit/speech_test.rb
+++ b/test/unit/speech_test.rb
@@ -137,6 +137,17 @@ class SpeechTest < ActiveSupport::TestCase
     refute speech.search_index.has_key?('people')
   end
 
+  test "search_index includes default image_url if it has no image" do
+    speech = create(:published_speech)
+    assert_equal "https://static.test.gov.uk/government/assets/placeholder.jpg", speech.search_index["image_url"]
+  end
+
+  test "search_index includes default image_url if it has one" do
+    image = create(:image)
+    speech = create(:published_speech, images: [image])
+    assert_equal image.url(:s300), speech.search_index["image_url"]
+  end
+
   test 'search_format_types tags the speech as a speech and announcement' do
     speech = build(:speech)
     assert speech.search_format_types.include?('speech')


### PR DESCRIPTION
After [changing collections to use the `image_url` to from Rummager ](https://github.com/alphagov/collections/pull/875) when showing latest news, speeches weren't able to show their image as Rummager wasn't indexing the image_url for speeches so the default whitehall image was being shown. This fixes that

Trello card:
https://trello.com/c/vKMHCUiU/185-make-rummager-index-speech-image-urls

### Before
![before reindex](https://user-images.githubusercontent.com/41049800/46141431-c9df7200-c24b-11e8-9a18-0027f3900c10.png)

### After
![screenshot-www-origin integration publishing service gov uk-2018 09 27-11-48-08](https://user-images.githubusercontent.com/41049800/46141472-e5e31380-c24b-11e8-8cd6-daf1ce734d10.png)

