### PR TITLE
Add missing subtaxons filter to the Publications page

### DIFF
--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -22,7 +22,7 @@
                filters: if Locale.current.english?
                           [
                             :keyword, :date, :publication_type, :locations,
-                            :department, :official_document_status, :taxon
+                            :department, :official_document_status, :taxon, :subtaxon
                           ]
                         else
                           [ :locations ]


### PR DESCRIPTION
This was missed when adding the same thing to the Announcements page.