### PR TITLE
Whitehall publishing improvements

### DIFF
--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -14,6 +14,7 @@ module PublishesToPublishingApi
 
   def publish_to_publishing_api
     run_callbacks :published do
+      Whitehall::PublishingApi.save_draft(self)
       Whitehall::PublishingApi.publish(self)
     end
   end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -15,6 +15,7 @@ module PublishesToPublishingApi
   def publish_to_publishing_api
     run_callbacks :published do
       Whitehall::PublishingApi.save_draft(self)
+      Whitehall::PublishingApi.patch_links(self)
       Whitehall::PublishingApi.publish(self)
     end
   end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -17,12 +17,6 @@ module Whitehall
 
       locales_for(model_instance).each do |locale|
         I18n.with_locale(locale) do
-          # TODO: This is probably redundant
-          Services.publishing_api.patch_links(
-            presenter.content_id,
-            links: presenter.links
-          )
-
           Services.publishing_api.publish(
             presenter.content_id,
             nil,
@@ -54,6 +48,15 @@ module Whitehall
           presenter.content
         )
       end
+    end
+
+    def self.patch_links(model_instance)
+      presenter = PublishingApiPresenters.presenter_for(model_instance)
+
+      Services.publishing_api.patch_links(
+        presenter.content_id,
+        links: presenter.links
+      )
     end
 
     def self.republish_async(model_instance)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -10,7 +10,7 @@ module Whitehall
   class UnpublishableInstanceError < StandardError; end
 
   class PublishingApi
-    def self.publish(model_instance, update_type_override = nil)
+    def self.publish(model_instance)
       assert_public_edition!(model_instance)
 
       # TODO: This should be unnecessary eventually, as the Publishing
@@ -18,12 +18,9 @@ module Whitehall
       # through Whitehall Frontend, this can definately be removed, as
       # the previews will always be representative of what will be
       # published.
-      save_draft(model_instance, update_type_override)
+      save_draft(model_instance)
 
-      presenter = PublishingApiPresenters.presenter_for(
-        model_instance,
-        update_type: update_type_override
-      )
+      presenter = PublishingApiPresenters.presenter_for(model_instance)
 
       locales_for(model_instance).each do |locale|
         I18n.with_locale(locale) do

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -13,13 +13,6 @@ module Whitehall
     def self.publish(model_instance)
       assert_public_edition!(model_instance)
 
-      # TODO: This should be unnecessary eventually, as the Publishing
-      # API should be kept up to date. Once no content is rendered
-      # through Whitehall Frontend, this can definately be removed, as
-      # the previews will always be representative of what will be
-      # published.
-      save_draft(model_instance)
-
       presenter = PublishingApiPresenters.presenter_for(model_instance)
 
       locales_for(model_instance).each do |locale|

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -11,7 +11,6 @@ class PublishingTest < ActiveSupport::TestCase
 
   test "When an edition is published, it gets published with the Publishing API" do
     requests = [
-      stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
       stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
@@ -27,13 +26,11 @@ class PublishingTest < ActiveSupport::TestCase
       @draft_edition.save!
 
       [
-        stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
         stub_publishing_api_publish(@presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
-      stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -11,7 +11,6 @@ class PublishingTest < ActiveSupport::TestCase
 
   test "When an edition is published, it gets published with the Publishing API" do
     requests = [
-      stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 
@@ -34,13 +33,10 @@ class PublishingTest < ActiveSupport::TestCase
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 
-    links_request = stub_publishing_api_patch_links(@presenter.content_id, links: @presenter.links)
-
     perform_force_publishing_for(@draft_edition)
 
     assert_all_requested(english_requests)
     assert_all_requested(french_requests)
-    assert_requested(links_request, times: 2)
   end
 
 private

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -53,14 +53,12 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
 
     # Main document
     content_id = @draft_edition.content_id
-    assert_requested(:put, %r|publishing-api.*content/#{content_id}|, headers: onward_headers)
     assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
     assert_requested(:patch, %r|publishing-api.*links/#{content_id}|, headers: onward_headers)
 
     # HTML attachments
     @draft_edition.html_attachments.each do |html_attachment|
       attachment_content_id = html_attachment.content_id
-      assert_requested(:put, %r|publishing-api.*content/#{attachment_content_id}|, headers: onward_headers)
       assert_requested(:post, %r|publishing-api.*content/#{attachment_content_id}/publish|, headers: onward_headers)
       assert_requested(:patch, %r|publishing-api.*links/#{attachment_content_id}|, headers: onward_headers)
     end

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -54,13 +54,11 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
     # Main document
     content_id = @draft_edition.content_id
     assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
-    assert_requested(:patch, %r|publishing-api.*links/#{content_id}|, headers: onward_headers)
 
     # HTML attachments
     @draft_edition.html_attachments.each do |html_attachment|
       attachment_content_id = html_attachment.content_id
       assert_requested(:post, %r|publishing-api.*content/#{attachment_content_id}/publish|, headers: onward_headers)
-      assert_requested(:patch, %r|publishing-api.*links/#{attachment_content_id}|, headers: onward_headers)
     end
   end
 

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -17,11 +17,17 @@ module PublishingApiTestHelpers
     end
   end
 
-  def expect_publishing(*editions, content_entries: {})
+  def expect_put_content(*editions, content_entries: {})
     editions.each do |edition|
-      Services.publishing_api.expects(:put_content)
-        .with(edition.content_id,
-          has_entries({ publishing_app: 'whitehall' }.merge(content_entries)))
+      Services.publishing_api.expects(:put_content).with(
+        edition.content_id,
+        has_entries({ publishing_app: 'whitehall' }.merge(content_entries))
+      )
+    end
+  end
+
+  def expect_publishing(*editions)
+    editions.each do |edition|
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -118,6 +118,7 @@ class ContactTest < ActiveSupport::TestCase
       ServiceListeners::EditionDependenciesPopulator.new(news_article).populate!
       ServiceListeners::EditionDependenciesPopulator.new(corp_info_page).populate!
 
+      expect_put_content(contact)
       expect_publishing(contact)
       expect_republishing(news_article, corp_info_page)
 

--- a/test/unit/data_hygiene/organisation_reslugger_test.rb
+++ b/test/unit/data_hygiene/organisation_reslugger_test.rb
@@ -36,7 +36,6 @@ module OrganisationResluggerTest
 
       expected_publish_requests = [
         stub_publishing_api_put_content(content_item.content_id, content_item.content),
-        stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
         stub_publishing_api_publish(content_item.content_id, locale: 'en', update_type: nil)
       ]
 

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -61,12 +61,6 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     refute test_object.can_publish_to_publishing_api?
   end
 
-  test "publish to publishing api publishes async" do
-    test_object = include_module(TestObject.new)
-    Whitehall::PublishingApi.expects(:publish).with(test_object)
-    test_object.publish_to_publishing_api
-  end
-
   test "publish gone to publishing api publishes gone async" do
     test_object = include_module(TestObject.new)
     Whitehall::PublishingApi.expects(:publish_gone_async)
@@ -76,6 +70,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "defines and executes published callback when published" do
     Whitehall::PublishingApi.stubs(:publish)
+    Whitehall::PublishingApi.stubs(:save_draft)
     test_object = TestObject.new
     class << test_object
       include PublishesToPublishingApi

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -70,6 +70,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "defines and executes published callback when published" do
     Whitehall::PublishingApi.stubs(:publish)
+    Whitehall::PublishingApi.stubs(:patch_links)
     Whitehall::PublishingApi.stubs(:save_draft)
     test_object = TestObject.new
     class << test_object

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -21,7 +21,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -35,7 +34,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     WebMock.reset! # because creating an organisation also pushes to Publishing API
     presenter = PublishingApiPresenters.presenter_for(organisation)
     requests = [
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -49,7 +47,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
-      stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -76,13 +73,10 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 
-    links_request = stub_publishing_api_patch_links(presenter.content_id, links: presenter.links)
-
     Whitehall::PublishingApi.publish(organisation)
 
     assert_all_requested(french_requests)
     assert_all_requested(english_requests)
-    assert_requested(links_request, times: 2)
   end
 
   test ".republish_async publishes to the Publishing API as a 'republish' update_type" do

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -21,7 +21,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
@@ -36,7 +35,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     WebMock.reset! # because creating an organisation also pushes to Publishing API
     presenter = PublishingApiPresenters.presenter_for(organisation)
     requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
@@ -51,7 +49,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_patch_links(presenter.content_id, links: presenter.links),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
@@ -71,13 +68,11 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       WebMock.reset!
 
       [
-        stub_publishing_api_put_content(presenter.content_id, presenter.content),
         stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
-      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 


### PR DESCRIPTION
Further cleanup of the Publishing API interaction in Whitehall. See the individual commits for the details.