### PR TITLE
Add a 2-second delay to republishing HCS/RSA retagged documents

### DIFF
--- a/db/data_migration/20181001113221_retag_hca_to_rsa.rb
+++ b/db/data_migration/20181001113221_retag_hca_to_rsa.rb
@@ -351,7 +351,10 @@ regulator_social_housing = Organisation.find_by(slug: 'regulator-of-social-housi
     edition.lead_organisations = lead_organisations
     edition.save!
 
-    Whitehall::PublishingApi.republish_document_async(document, bulk: true)
+    PublishingApiDocumentRepublishingWorker.perform_in(
+      2.seconds,
+      document.id,
+    )
   rescue Exception => ex
     puts "#{slug}: #{ex.class}, #{ex.message}"
   end


### PR DESCRIPTION
The worker is enqueued before the transaction commits, and so can see
the old state if it runs quickly.