### PR TITLE
[WIP] Restore some news article related tests

### DIFF
--- a/features/news-articles.feature
+++ b/features/news-articles.feature
@@ -1,0 +1,63 @@
+Feature: News articles
+
+Scenario: Creating a new draft news article
+  Given I am a writer
+  When I draft a new news article "Stubble to be Outlawed"
+  Then I should see the news article "Stubble to be Outlawed" in the list of draft documents
+
+Scenario: Submitting a draft publication to a second pair of eyes
+  Given I am a writer
+  And a draft news article "Stubble to be Outlawed" exists
+  When I submit the news article "Stubble to be Outlawed"
+  Then I should see the news article "Stubble to be Outlawed" in the list of submitted documents
+
+Scenario: Viewing associated people on news articles not roles
+  Given I am an editor
+  And "Don Deputy" is the "Deputy Prime Minister" for the "Cabinet Office"
+  And "Harriet Home" is the "Home Secretary" for the "Cabinet Office"
+  When I publish a news article "News 1" associated with "Don Deputy"
+  When there is a reshuffle and "Harriet Home" is now "Deputy Prime Minister"
+  And I visit the news article "News 1"
+  Then the article mentions "Don Deputy" and links to their bio page
+  And the news article tag is the same as the person in the text
+
+Scenario: Lead image automatically selected as first uploaded image
+  Given I am an editor
+  When I draft a new news article "Stubble to be Outlawed"
+  Then I should see the first uploaded image used as the lead image
+  And if no image is uploaded a default image is shown
+
+Scenario: First image not allowed in markdown
+  Given I am a writer
+  When I draft a new news article "Stubble to be Outlawed"
+  Then I should be informed I shouldn't use this image in the markdown
+  When I attempt to add the article image into the markdown
+  Then my attempt to save it should fail with error "first image"
+
+@not-quite-as-fake-search
+Scenario: Publishing a submitted news article
+  Given I am an editor
+  And a submitted news article "Stubble to be Outlawed" exists
+  When I publish the news article "Stubble to be Outlawed"
+  Then I should see the news article "Stubble to be Outlawed" in the list of published documents
+  And the news article "Stubble to be Outlawed" should be visible to the public
+
+Scenario: Creating a news article related to multiple policies
+  Given I am a writer
+  When I draft a new news article "Healthy Eating" relating it to the policies "Policy 1" and "Policy 3"
+  Then I should see in the preview that "Healthy Eating" should related to "Policy 1" and "Policy 3" policies
+
+Scenario: Viewing a published news article with related policies
+  Given a published news article "News 1" with related published policies "Policy 1" and "Policy 2"
+  When I visit the news article "News 1"
+  Then I can see links to the related published policies "Policy 1" and "Policy 2"
+
+@javascript
+Scenario: Changes on an edition are not lost when adding attachments
+  Given I am a writer
+  And a draft news article "Stubble to be Outlawed" exists
+  When I make unsaved changes to the news article
+  And I attempt to visit the attachments page
+  Then I should stay on the edit screen for the news article
+  When I save my changes
+  Then I can visit the attachments page

--- a/features/scheduled-publishing.feature
+++ b/features/scheduled-publishing.feature
@@ -1,0 +1,15 @@
+Feature: Scheduled publishing
+
+  @disable-sidekiq-test-mode
+  Scenario: An editor schedules a submitted edition for scheduled publication
+    Given I am an editor
+    And a submitted scheduled news article exists
+    When I schedule the news article for publication
+    Then the news article is published when the scheduled publication time arrives
+
+  @disable-sidekiq-test-mode
+  Scenario: A writer force-schedules an edition for publication
+    Given I am an editor
+    And a draft scheduled news article exists
+    When I force schedule the news article for publication
+    Then the news article is published when the scheduled publication time arrives

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -119,7 +119,7 @@ When(/^I filter by organisation "(.*?)" with javascript enabled$/) do |organisat
   select_from_chosen(organisation_name, from: "organisation")
 end
 
-When(/^I visit the (publication|consultation) "([^"]*)"$/) do |document_type, title|
+When /^I visit the (publication|news article|consultation) "([^"]*)"$/ do |document_type, title|
   edition = document_class(document_type).find_by!(title: title)
   visit public_document_path(edition)
 end

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -58,7 +58,12 @@ When(/^I attempt to add the article image into the markdown$/) do
   fill_in "Body", with: "body copy\n!!1\nmore body"
 end
 
-Then(/^the news article tag is the same as the person in the text$/) do
+Then /^the article mentions "([^"]*)" and links to their bio page$/ do |person_name|
+  visit document_path(NewsArticle.last)
+  assert has_css?(".meta a[href*='#{person_path(find_person(person_name))}']", text: person_name)
+end
+
+Then /^the news article tag is the same as the person in the text$/ do
   visit admin_edition_path(NewsArticle.last)
   click_button "Create new edition"
   appointment = NewsArticle.last.role_appointments.first
@@ -90,8 +95,21 @@ Then(/^I should be informed I shouldn't use this image in the markdown$/) do
   assert has_no_css?("fieldset#image_fields .image input[value='!!1']")
 end
 
-When(/^I browse to the announcements index$/) do
-  stub_content_item_from_content_store_for(announcements_path)
+Then /^I should see the first uploaded image used as the lead image$/ do
+  article = NewsArticle.last
+  publish force: true
+  visit document_path(article)
+  assert page.has_css?("aside.sidebar img[src*='#{article.images.first.url(:s300)}']")
+end
+
+Then /^if no image is uploaded a default image is shown$/ do
+  article = NewsArticle.last
+  article.images.first.destroy
+  visit document_path(article)
+  assert page.has_css?("aside.sidebar img[src*='placeholder']")
+end
+
+When /^I browse to the announcements index$/ do
   visit announcements_path
 end
 

--- a/features/step_definitions/scheduled_publishing_steps.rb
+++ b/features/step_definitions/scheduled_publishing_steps.rb
@@ -11,3 +11,13 @@ When(/^I force schedule the news article for publication$/) do
   visit admin_news_article_path(@news_article)
   click_on "Force schedule"
 end
+
+Then(/^the news article is published when the scheduled publication time arrives$/) do
+  assert scheduled_publishing_job_for(@news_article)
+
+  Timecop.travel(1.day.from_now + 1.second) do
+    execute_scheduled_publication_job_for(@news_article)
+
+    assert_publishing_api_publish(@news_article.content_id)
+  end
+end

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -22,6 +22,12 @@ Scenario: Associating a speech with a topical event
   And I force publish the speech "A speech"
   Then I should see the speech "A speech" in the announcements section of the topical event "An Event"
 
+Scenario: Associating a news article with a topical event
+  Given a topical event called "An Event" with description "A topical event"
+  When I draft a new news article "A speech" relating it to topical event "An Event"
+  And I force publish the news article "A speech"
+  Then I should see the news article "A speech" in the announcements section of the topical event "An Event"
+
 Scenario: Associating a publication with a topical event
   Given a topical event called "An Event" with description "A topical event"
   When I draft a new publication "A speech" relating it to topical event "An Event"
@@ -34,6 +40,14 @@ Scenario: Associating a consultation with a topical event
   And I check "A Consultation" adheres to the consultation principles
   And I force publish the consultation "A Consultation"
   Then I should see the consultation "A Consultation" in the consultations section of the topical event "An Event"
+
+Scenario: Featuring news on an topical event page
+  Given a topical event called "An Event" with description "A topical event"
+  When I draft a new news article "A speech" relating it to topical event "An Event"
+  And I force publish the news article "A speech"
+  When I feature the document "A speech" for topical event "An Event" with image "minister-of-funk.960x640.jpg"
+  Then I should see the featured documents in the "An Event" topical event are:
+    | A speech | s465_minister-of-funk.960x640.jpg |
 
 Scenario: Creating offsite content on a topical event page
   Given a topical event called "An Event" with description "A topical event"


### PR DESCRIPTION
These were removed in 3ce2e64371e176ea2b137519ccb13103e9442af5, but I
think they should still be kept, as the tested functionality still
exists and is used.