### PR TITLE
Create Publishing API drafts for scheduled content

### DIFF
--- a/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
+++ b/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
@@ -1,0 +1,6 @@
+Document.where(
+  id: Edition.where(state: :scheduled).select(:document_id)
+).pluck(:id).each do |document_id|
+  puts "Enqueuing document #{document_id}"
+  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+end


### PR DESCRIPTION
This avoids issues with this content being publishing on schedule,
resulting from changing what Whitehall sends to the Publishing API
when publishing content. Previously, Whitehall created or updated the
draft edition, and then published that, now Whitehall just publishes
the existing draft edition (this changed in
6ea0aca7e55bfd5a2451ca96928252de41007c6c).

Unfortunately, this caused issues with scheduling new content to be
published, due to the use of 'Coming soon' placeholder content. This
approach for mitigating caching issues meant that there wasn't
actually a draft edition in the Publishing API to publish when the
scheduled time arrived.

This 'Coming soon' behaviour has now been removed, as this bit of
forgotten about technical debt has now been payed down, and there's
now a proper approach for dealing with cache invalidation. However, to
ensure publishing the already scheduled content happens without
incident, drafts need to exist in the Publishing API to publish. This
data migration creates those drafts for scheduled content.