### PR TITLE
Fix up Natural England migration for invalid editions

### DIFF
--- a/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
+++ b/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
@@ -15,7 +15,7 @@ docs_with_lead.each do |document|
     orgs.delete natural_england
 
     edition.lead_organisations = orgs
-    edition.save!
+    edition.save(validate: false)
 
     PublishingApiDocumentRepublishingWorker.perform_in(
       2.seconds,
@@ -38,7 +38,7 @@ docs_with_support.each do |document|
     orgs.delete natural_england
 
     edition.supporting_organisations = orgs
-    edition.save!
+    edition.save(validate: false)
 
     PublishingApiDocumentRepublishingWorker.perform_in(
       2.seconds,

--- a/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
+++ b/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
@@ -8,6 +8,7 @@ docs_with_lead.each do |document|
   begin
     next if document.document_type == 'CorporateInformationPage'
     edition = document.latest_edition
+    edition.read_consultation_principles = true if document.document_type == 'Consultation'
     orgs = edition.lead_organisations.to_a
 
     orgs << rpa unless orgs.include? rpa
@@ -29,6 +30,7 @@ docs_with_support.each do |document|
   begin
     next if document.document_type == 'CorporateInformationPage'
     edition = document.latest_edition
+    edition.read_consultation_principles = true if document.document_type == 'Consultation'
     orgs = edition.supporting_organisations.to_a
 
     # handle the case where NE is the lead and RPA the support (or vice versa)


### PR DESCRIPTION
A while ago we introduced a checkbox to the consultations page, where publishers have to say that they read some consultation principles.  Consultations published before this point won't have that field set on their model instance, which prevents saving any changes.

Additionally, we need to disable validations when saving, as the field cannot normally be changed on a published edition.  Lead and supporting organisations *can* be changed because that is only an association, despite appearances nothing to do with the *edition* is changing.