### PR TITLE
Change data migration to not use republish worker

### DIFF
--- a/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
+++ b/db/data_migration/20181002120423_create_publishing_api_drafts_for_scheduled_content.rb
@@ -1,6 +1,8 @@
 Document.where(
   id: Edition.where(state: :scheduled).select(:document_id)
-).pluck(:id).each do |document_id|
-  puts "Enqueuing document #{document_id}"
-  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+).all.each do |document|
+  next unless document.published_edition.nil?
+
+  puts "Saving draft for #{document.id} (content_id: #{document.content_id})"
+  Whitehall::PublishingApi.save_draft(document.pre_publication_edition)
 end


### PR DESCRIPTION
The previous iteration of this Rake task seemed to do the correct
thing on Integration, but not on Staging. I've got no idea what went
wrong, but the content seemed to be published. This makes me very
uneasy, so lets just directly save the draft.