### PR TITLE
Do not republish Natural England content

### DIFF
--- a/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
+++ b/db/data_migration/20181002101503_retag_natural_england_to_rpa.rb
@@ -16,11 +16,6 @@ docs_with_lead.each do |document|
 
     edition.lead_organisations = orgs
     edition.save(validate: false)
-
-    PublishingApiDocumentRepublishingWorker.perform_in(
-      2.seconds,
-      document.id,
-    )
   rescue StandardError => ex
     puts "#{document.slug}: #{ex.class}, #{ex.message}"
   end
@@ -39,11 +34,6 @@ docs_with_support.each do |document|
 
     edition.supporting_organisations = orgs
     edition.save(validate: false)
-
-    PublishingApiDocumentRepublishingWorker.perform_in(
-      2.seconds,
-      document.id,
-    )
   rescue StandardError => ex
     puts "#{document.slug}: #{ex.class}, #{ex.message}"
   end


### PR DESCRIPTION
This migration worked on integration, but left most of the content in
a weird half-migrated state on staging.  So we'll manually republish
the production content after the migration has been confirmed to work.