### PR TITLE
Swap policy areas for taxon filter

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -5,8 +5,13 @@ module FilterHelper
     options_for_select(Organisation.with_statistics_announcements.alphabetical.map { |org| [org.name, org.slug] }.unshift(['All departments', nil]), Array(selected_slug))
   end
 
-  def topic_options_for_statistics_announcement_filter(selected_slug = nil)
-    options_for_select(Topic.with_statistics_announcements.alphabetical.map { |topic| [topic.name, topic.slug] }.unshift(['All policy areas', nil]), Array(selected_slug))
+  def topic_options_for_statistics_announcement_filter(content_id = nil)
+    options_for_select(
+      Taxonomy::TopicTaxonomy
+        .new
+        .ordered_taxons
+        .map { |taxon| [taxon.name, taxon.content_id] }.unshift(['All topics', nil]), Array(content_id)
+    )
   end
 
   def describe_filter(filter, base_url, opts = {})
@@ -53,7 +58,7 @@ module FilterHelper
     def topics_fragment
       if filter.respond_to?(:topics) && filter.topics.any?
         "about " + filter.topics.map { |topic|
-          "<strong>#{CGI::escapeHTML(topic.name)}</strong> #{remove_field_link(:topics, topic.slug, topic.name)}"
+          "<strong>#{CGI::escapeHTML(topic.name)}</strong> #{remove_field_link(:topics, topic.base_path, topic.name)}"
         }.to_sentence
       end
     end

--- a/app/models/frontend/statistics_announcement.rb
+++ b/app/models/frontend/statistics_announcement.rb
@@ -9,15 +9,6 @@ class Frontend::StatisticsAnnouncement
 
   attr_reader :release_date, :cancellation_date
 
-  # DID YOU MEAN: Policy Area?
-  # "Policy area" is the newer name for "topic"
-  # (https://www.gov.uk/government/topics)
-  # "Topic" is the newer name for "specialist sector"
-  # (https://www.gov.uk/topic)
-  # You can help improve this code by renaming all usages of this field to use
-  # the new terminology.
-  attr_accessor :topics
-
   def initialize(attrs = {})
     attrs = Hash(attrs)
     attrs.each do |key, value|

--- a/app/models/frontend/statistics_announcements_filter.rb
+++ b/app/models/frontend/statistics_announcements_filter.rb
@@ -3,14 +3,6 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
   attr_accessor :keywords
   attr_reader :from_date, :to_date
 
-  # DID YOU MEAN: Policy Area?
-  # "Policy area" is the newer name for "topic"
-  # (https://www.gov.uk/government/topics)
-  # "Topic" is the newer name for "specialist sector"
-  # (https://www.gov.uk/topic)
-  # You can help improve this code by renaming all usages of this field to use
-  # the new terminology.
-
   RESULTS_PER_PAGE = 40
 
   def filter_type
@@ -53,22 +45,18 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
     organisations.map(&:slug)
   end
 
-  def topics=(topics)
-    @topics = Topic.where(slug: Array(topics))
+  def topic_ids
+    topics.map(&:content_id)
+  end
+
+  def topics=(ids)
+    @topics = Taxonomy::TopicTaxonomy.new.ordered_taxons.select do |taxon|
+      ids.include?(taxon.content_id)
+    end
   end
 
   def topics
     Array(@topics)
-  end
-
-  # Policy areas used to be named topics.
-  # Elsewhere we use "topic" to refer to specialist sectors.
-  def policy_areas
-    topics
-  end
-
-  def policy_area_slugs
-    policy_areas.map(&:slug)
   end
 
   def valid_filter_params
@@ -77,7 +65,7 @@ class Frontend::StatisticsAnnouncementsFilter < FormObject
     params[:to_date]       = to_date            if to_date.present?
     params[:from_date]     = from_date          if from_date.present?
     params[:organisations] = organisation_slugs if organisations.present?
-    params[:policy_areas]  = policy_area_slugs  if policy_areas.present?
+    params[:part_of_taxonomy_tree] = topic_ids if topics.present?
     params
   end
 

--- a/app/providers/frontend/statistics_announcement_provider.rb
+++ b/app/providers/frontend/statistics_announcement_provider.rb
@@ -24,7 +24,6 @@ module Frontend
           release_date_change_note: rummager_hash['metadata']['change_note'],
           previous_display_date: rummager_hash['metadata']['previous_display_date'],
           organisations: build_organisations(rummager_hash['organisations']),
-          topics: build_topics(rummager_hash['policy_areas']),
           state: rummager_hash['statistics_announcement_state'],
           cancellation_reason: rummager_hash['metadata']['cancellation_reason'],
           cancellation_date: rummager_hash['metadata']['cancelled_at']
@@ -33,10 +32,6 @@ module Frontend
 
       def build_organisations(org_slugs)
         Organisation.where(slug: org_slugs)
-      end
-
-      def build_topics(topic_slugs)
-        Topic.where(slug: topic_slugs)
       end
 
       def prepare_search_params(params)

--- a/app/views/statistics_announcements/_statistics_announcement.html.erb
+++ b/app/views/statistics_announcements/_statistics_announcement.html.erb
@@ -6,8 +6,5 @@
     <%- statistics_announcement.organisations.each do |org| -%>
       <li><%= link_to org.name, organisation_path(org) %></li>
     <%- end -%>
-    <%- statistics_announcement.topics.each do |topic| -%>
-      <li><%= link_to topic.name, topic_path(topic) %></li>
-    <%- end -%>
   </ul>
 </li>

--- a/app/views/statistics_announcements/index.html.erb
+++ b/app/views/statistics_announcements/index.html.erb
@@ -28,8 +28,8 @@
             <%= text_field_tag :keywords, @filter.keywords, placeholder: "keywords" %>
           </div>
           <div class="filter">
-            <%= label_tag "topics", "Policy Area" %>
-            <%= select_tag "topics[]", topic_options_for_statistics_announcement_filter(@filter.policy_area_slugs), id: "topics", class: "single-row-select" %>
+           <%= label_tag "topics", "Topic" %>
+            <%= select_tag "topics[]", topic_options_for_statistics_announcement_filter(@filter.topic_ids), id: "topics", class: "single-row-select" %>
           </div>
           <div class="filter">
             <%= label_tag "organisations", "Department" %>

--- a/features/viewing-statistics-announcements.feature
+++ b/features/viewing-statistics-announcements.feature
@@ -1,3 +1,4 @@
+@not-quite-as-fake-search
 Feature: Viewing upcoming statistics announcements
 
   Scenario: Citizen filters the list of statistics announcements and uses the pagination

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -91,7 +91,7 @@ module TaxonomyHelper
       raise "Not a NotQuiteAsFakeSearch Datastore"
     end
     document = store.delete(search_link, index_name)
-    store.add([document.merge(part_of_taxonomy_tree: taxon_ids)], index_name)
+    store.add([document.merge('part_of_taxonomy_tree' => taxon_ids)], index_name)
   end
 
 

--- a/test/unit/helpers/filter_helper_test.rb
+++ b/test/unit/helpers/filter_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class FilterHelperTest < ActionView::TestCase
+  include TaxonomyHelper
+
   test "#organisation_options_for_statistics_announcement_filter renders select options for all organisations with an associated release announcement in alphabetical order selecting passed in organisation" do
     _org_1 = create(:organisation, name: "B org")
     org_2 = create(:organisation, name: "C org")
@@ -19,25 +21,28 @@ class FilterHelperTest < ActionView::TestCase
   end
 
   test "#topic_options_for_statistics_announcement_filter renders select options for all topics with an associated release announcement in alphabetical order selecting passed in topic" do
-    _topic_1 = create(:topic, name: "B topic")
-    topic_2 = create(:topic, name: "C topic")
-    topic_3 = create(:topic, name: "A topic")
+    topic_b = build(:taxon_hash, content_id: 'b-content-id', title: 'B')
+    topic_c = build(:taxon_hash, content_id: 'c-content-id', title: 'C')
+    topic_z = build(:taxon_hash, content_id: 'z-content-id', title: 'Z')
 
-    create :statistics_announcement, topics: [topic_2]
-    create :statistics_announcement, topics: [topic_3]
+    redis_cache_has_taxons([topic_b, topic_c, topic_z])
 
-    rendered = Nokogiri::HTML::DocumentFragment.parse(topic_options_for_statistics_announcement_filter(topic_3.slug))
+    create :statistics_announcement
+    create :statistics_announcement
+
+    rendered = Nokogiri::HTML::DocumentFragment.parse(topic_options_for_statistics_announcement_filter(topic_b['content_id']))
     options = rendered.css("option")
     option_values = options.map { |option| option[:value] }
 
-    assert_equal ["All policy areas", topic_3.name, topic_2.name], options.map(&:text)
-    assert_equal ["", topic_3.slug, topic_2.slug], option_values
+    assert_equal ["All topics", topic_b['title'], topic_c['title'], topic_z['title']], options.map(&:text)
+    assert_equal ["", topic_b['content_id'], topic_c['content_id'], topic_z['content_id']], option_values
     assert options[1][:selected]
   end
 end
 
 class FilterHelperTest::FilterDescriptionTest < ActionView::TestCase
   include TextAssertions
+  include TaxonomyHelper
 
   def build_filter(params = {})
     OpenStruct.new(params.reverse_merge(filter_type: "publication",
@@ -63,8 +68,10 @@ class FilterHelperTest::FilterDescriptionTest < ActionView::TestCase
   end
 
   test "It describes topics" do
-    topic = build(:topic, name: "Community and society")
-    assert_string_includes "about Community and society", rendered_description(build_filter(topics: [topic])).text
+    topic = build(:taxon_hash, content_id: "contenty-content-id", title: "Community and society")
+    topic_object = Taxonomy::Taxon.from_taxon_hash(topic)
+
+    assert_string_includes "about Community and society", rendered_description(build_filter(topics: [topic_object])).text
   end
 
   test "It describes organisations" do
@@ -90,19 +97,21 @@ class FilterHelperTest::FilterDescriptionTest < ActionView::TestCase
   end
 
   test "It renders links to remove search parameters" do
-    topic = build(:topic, name: "Community and society", slug: "community-and-society")
+    topic = build(:taxon_hash, title: "Community and society", base_path: "community-and-society")
+    topic_object = Taxonomy::Taxon.from_taxon_hash(topic)
+
     organisation = build(:organisation, name: "Department of Magic", slug: "department-of-magic")
 
     filter = build_filter keywords: "fishslice",
                           organisations: [organisation],
-                          topics: [topic],
+                          topics: [topic_object],
                           from_date: Date.new(2040, 1, 1),
                           to_date: Date.new(2050, 1, 1)
 
     expected_filter_params = {
       keywords: "fishslice",
       organisations: [organisation.slug],
-      topics: [topic.slug],
+      topics: [topic_object.content_id],
       from_date: "2040-01-01",
       to_date: "2050-01-01"
     }
@@ -110,10 +119,10 @@ class FilterHelperTest::FilterDescriptionTest < ActionView::TestCase
     filter.stubs(:valid_filter_params).returns(expected_filter_params)
 
     rendered = rendered_description(filter)
-    assert_remove_filter_link_present(rendered, :keywords,      "fishslice",             "fishslice",       expected_filter_params.except(:keywords))
-    assert_remove_filter_link_present(rendered, :organisations, organisation.name,       organisation.slug, expected_filter_params.except(:organisations))
-    assert_remove_filter_link_present(rendered, :topics,        topic.name,              topic.slug,        expected_filter_params.except(:topics))
-    assert_remove_filter_link_present(rendered, :from_date,     "published after date",  "2040-01-01",      expected_filter_params.except(:from_date))
-    assert_remove_filter_link_present(rendered, :to_date,       "published before date", "2050-01-01",      expected_filter_params.except(:to_date))
+    assert_remove_filter_link_present(rendered, :keywords, "fishslice", "fishslice", expected_filter_params.except(:keywords))
+    assert_remove_filter_link_present(rendered, :organisations, organisation.name, organisation.slug, expected_filter_params.except(:organisations))
+    assert_remove_filter_link_present(rendered, :topics, topic_object.name, topic_object.base_path, expected_filter_params.except(:topics))
+    assert_remove_filter_link_present(rendered, :from_date, "published after date", "2040-01-01", expected_filter_params.except(:from_date))
+    assert_remove_filter_link_present(rendered, :to_date, "published before date", "2050-01-01", expected_filter_params.except(:to_date))
   end
 end

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -52,10 +52,6 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     assert_equal topics.map(&:name), [topic_1['title'], topic_2['title']]
   end
 
-  test "topics= handles nil" do
-    assert_equal [], build_class_instance(topics: nil).topics
-  end
-
   test "topic_ids returns topic ids" do
     topic = build(:taxon_hash)
     redis_cache_has_taxons([topic])

--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -1,68 +1,78 @@
 require 'test_helper'
 
 class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
-  def build(attrs = {})
+  include TaxonomyHelper
+
+  def build_class_instance(attrs = {})
     Frontend::StatisticsAnnouncementsFilter.new(attrs)
   end
 
   test "to_date= casts into Date, taking the latest possible date in its assumptions" do
-    assert_equal Date.new(2010, 1, 31), build(to_date: "Jan 2010").to_date
+    assert_equal Date.new(2010, 1, 31), build_class_instance(to_date: "Jan 2010").to_date
   end
 
   test "from_date= casts into Date, taking the earliest possible date in its assumptions" do
-    assert_equal Date.new(2010, 1, 1), build(from_date: "Jan 2010").from_date
+    assert_equal Date.new(2010, 1, 1), build_class_instance(from_date: "Jan 2010").from_date
   end
 
   test "to_date= and from_date= assumes english date format when ambiguous" do
-    assert_equal Date.new(2010, 6, 12), build(to_date: "12/6/2010").to_date
-    assert_equal Date.new(2010, 6, 12), build(from_date: "12/6/2010").from_date
+    assert_equal Date.new(2010, 6, 12), build_class_instance(to_date: "12/6/2010").to_date
+    assert_equal Date.new(2010, 6, 12), build_class_instance(from_date: "12/6/2010").from_date
   end
 
   test "#page= casts to integer" do
-    assert build(page: '2').page.is_a? Integer
+    assert build_class_instance(page: '2').page.is_a? Integer
   end
 
   test "page default to 1" do
-    assert_equal 1, build.page
+    assert_equal 1, build_class_instance.page
   end
 
   test "organisations= parses slugs into real organisations" do
     org_1, org_2 = 2.times.map { create(:organisation) }
-    assert_equal [org_1, org_2], build(organisations: [org_1.slug, org_2.slug]).organisations
+    assert_equal [org_1, org_2], build_class_instance(organisations: [org_1.slug, org_2.slug]).organisations
   end
 
   test "organisations= handles nil" do
-    assert_equal [], build(organisations: nil).organisations
+    assert_equal [], build_class_instance(organisations: nil).organisations
   end
 
   test "organisation_slugs returns slugs of organisations" do
     organisation = create(:organisation)
-    assert_equal [organisation.slug], build(organisations: [organisation.slug]).organisation_slugs
+    assert_equal [organisation.slug], build_class_instance(organisations: [organisation.slug]).organisation_slugs
   end
 
-  test "topics= parses slugs into real topics" do
-    topic_1, topic_2 = 2.times.map { create(:topic) }
-    assert_equal [topic_1, topic_2], build(topics: [topic_1.slug, topic_2.slug]).topics
+  test "topics= parses content_ids into real topics" do
+    topic_1, topic_2 = 2.times.map { build(:taxon_hash) }
+    redis_cache_has_taxons([topic_1, topic_2])
+
+    topics = build_class_instance(topics: [topic_1['content_id'], topic_2['content_id']]).topics
+
+    assert_equal([true, true], (topics.map { |topic| topic.is_a?(Taxonomy::Taxon) }))
+    assert_equal topics.map(&:name), [topic_1['title'], topic_2['title']]
   end
 
   test "topics= handles nil" do
-    assert_equal [], build(topics: nil).topics
+    assert_equal [], build_class_instance(topics: nil).topics
   end
 
-  test "policy_area_slugs returns slugs of topics" do
-    topic = create(:topic)
-    assert_equal [topic.slug], build(topics: [topic.slug]).policy_area_slugs
+  test "topic_ids returns topic ids" do
+    topic = build(:taxon_hash)
+    redis_cache_has_taxons([topic])
+
+    assert_equal [topic['content_id']], build_class_instance(topics: [topic['content_id']]).topic_ids
   end
 
   test "#valid_filter_params returns all attributes if all are present and valid excluding pagination parameters" do
     organisation = create :organisation
-    topic = create :topic
+    topic = build(:taxon_hash)
+    redis_cache_has_taxons([topic])
 
-    filter = build(keywords: "keyword",
+    filter = build_class_instance(keywords: "keyword",
                    from_date: "2020-01-01",
                    to_date: "2020-02-01",
                    organisations: [organisation.slug],
-                   topics: [topic.slug],
+                   topics: [topic['content_id']],
                    page: 2)
 
     assert_equal(
@@ -73,8 +83,8 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
         organisations: [
           organisation.slug,
         ],
-        policy_areas: [
-          topic.slug,
+        part_of_taxonomy_tree: [
+          topic['content_id'],
         ],
       },
       filter.valid_filter_params
@@ -82,18 +92,18 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
   end
 
   test "#valid_filter_params skips blank attributes" do
-    refute build(keywords: nil).valid_filter_params.key?(:keywords)
-    refute build(from_date: nil).valid_filter_params.key?(:from_date)
-    refute build(to_date: nil).valid_filter_params.key?(:to_date)
-    refute build(organisations: []).valid_filter_params.key?(:organisations)
-    refute build(topics: []).valid_filter_params.key?(:topics)
+    refute build_class_instance(keywords: nil).valid_filter_params.key?(:keywords)
+    refute build_class_instance(from_date: nil).valid_filter_params.key?(:from_date)
+    refute build_class_instance(to_date: nil).valid_filter_params.key?(:to_date)
+    refute build_class_instance(organisations: []).valid_filter_params.key?(:organisations)
+    refute build_class_instance(topics: []).valid_filter_params.key?(:topics)
   end
 
   test "#results should ask the provider for results, using #valid_filter_params + pagination params as search terms" do
     stub_provider = mock
     stub_provider.stubs(:search).with(keywords: "keyword", page: 2, per_page: 40).returns(:some_results)
 
-    filter = build(keywords: "keyword", page: 2)
+    filter = build_class_instance(keywords: "keyword", page: 2)
     filter.stubs(:provider).returns(stub_provider)
 
     assert_equal :some_results, filter.results
@@ -107,7 +117,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     stub_provider.stubs(:search).with(page: 1, per_page: 40).returns(normal_resultset)
     stub_provider.stubs(:search).with(page: 1, per_page: 40, statistics_announcement_state: 'cancelled', from_date: 1.month.ago.to_date, to_date: Time.zone.now.to_date).returns(cancelled_and_past_resultset)
 
-    filter = build
+    filter = build_class_instance
     filter.stubs(:provider).returns(stub_provider)
 
     resultset = filter.results
@@ -119,7 +129,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
   end
 
   test "#next_page_params returns valid_filter_params with the page number incremented by 1" do
-    filter = build(keywords: "keyword", page: 2)
+    filter = build_class_instance(keywords: "keyword", page: 2)
 
     stub_provider = mock
     stub_provider.stubs(:search).returns((1..50).to_a)
@@ -129,7 +139,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
   end
 
   test "#previous_page_params returns valid_filter_params with the page number incremented by 1" do
-    filter = build(keywords: "keyword", page: 2)
+    filter = build_class_instance(keywords: "keyword", page: 2)
 
     stub_provider = mock
     stub_provider.stubs(:search).returns((1..50).to_a)

--- a/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistics_announcement_presenter_test.rb
@@ -34,7 +34,6 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
 
     expected_links = {
       organisations: statistics_announcement.organisations.map(&:content_id),
-      policy_areas: statistics_announcement.topics.map(&:content_id),
     }
 
     presented_item = present(statistics_announcement)
@@ -81,7 +80,6 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
 
     expected_links = {
       organisations: statistics_announcement.organisations.map(&:content_id),
-      policy_areas: statistics_announcement.topics.map(&:content_id),
     }
 
     presented_item = present(statistics_announcement)
@@ -130,7 +128,6 @@ class PublishingApi::StatisticsAnnouncementPresenterTest < ActiveSupport::TestCa
 
     expected_links = {
       organisations: statistics_announcement.organisations.map(&:content_id),
-      policy_areas: statistics_announcement.topics.map(&:content_id),
     }
 
     presented_item = present(statistics_announcement)

--- a/test/unit/providers/frontend/statistics_announcement_provider_test.rb
+++ b/test/unit/providers/frontend/statistics_announcement_provider_test.rb
@@ -43,7 +43,6 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
 
   test "#search: release announcments are inflated from rummager hashes" do
     organisation = create(:organisation, name: 'Cabinet Office', slug: 'cabinet-office')
-    topic = create(:topic, name: 'Home affairs', slug: 'home-affairs')
 
     @mock_source.stubs(:advanced_search).returns('total' => 1, 'results' => [{
       "title" => "A title",
@@ -52,6 +51,7 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
       "release_timestamp" => Time.zone.now,
       "organisations" => ["cabinet-office"],
       "policy_areas" => ["home-affairs"],
+      "part_of_taxonomy_tree" => %w[home-affairs-id],
       "display_type" => "Statistics",
       "search_format_types" => %w[statistics_announcement],
       "format" => "statistics_announcement",
@@ -78,7 +78,6 @@ class Frontend::StatisticsAnnouncementProviderTest < ActiveSupport::TestCase
     assert_equal "Change is good", release_announcement.release_date_change_note
     assert_equal 1.year.ago,       release_announcement.previous_display_date
     assert_equal organisation,     release_announcement.organisations.first
-    assert_equal topic,            release_announcement.topics.first
     assert_equal "cancelled",      release_announcement.state
     assert_equal "Cancel reason",  release_announcement.cancellation_reason
     assert_equal 1.week.ago,       release_announcement.cancellation_date


### PR DESCRIPTION
As policy area's are soon to be retired, the policy area filter for
statistics annoucements has been removed and replaced with the topic
taxonomy alternative.

Also, the policy area link on each statistical announcement has been removed.

Trello:
https://trello.com/c/2lK4uXfx/234-replace-policy-areas-filter-with-topics-equivalent-on-this-page-https-wwwgovuk-government-statistics-announcements

## Before 
<img width="1094" alt="screen shot 2018-10-02 at 17 06 57" src="https://user-images.githubusercontent.com/24479188/46361489-acecd980-c665-11e8-9aad-047bcb90bc08.png">

## After 
<img width="1014" alt="screen shot 2018-10-02 at 17 06 25" src="https://user-images.githubusercontent.com/24479188/46361496-b24a2400-c665-11e8-895c-3784a98d0c2f.png">
