### PR TITLE
Patch links when updating drafts

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -16,8 +16,10 @@ module ServiceListeners
       when "force_publish", "publish", "unwithdraw"
         api.publish(edition)
       when "update_draft"
+        api.patch_links(edition)
         api.save_draft(edition)
       when "update_draft_translation"
+        api.patch_links(edition)
         api.save_draft_translation(edition, options.fetch(:locale))
       when "unpublish"
         api.unpublish_async(edition.unpublishing)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -53,9 +53,12 @@ module Whitehall
     def self.patch_links(model_instance)
       presenter = PublishingApiPresenters.presenter_for(model_instance)
 
+      links = presenter.links
+      return if links.empty?
+
       Services.publishing_api.patch_links(
         presenter.content_id,
-        links: presenter.links
+        links: links
       )
     end
 


### PR DESCRIPTION
Whitehall seems split between using ediiton links, and non-edition
links for different document types. Previously, a patch_links request
was made when publishing content, which is not the ideal time (for
reasons like draft preview inconsistencies).

So, patch the links of content when saving drafts, as this will make
changes like tagging to organisations take effect.