### PR TITLE
Separate out the edition links in the presenters

### DIFF
--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -26,11 +26,19 @@ module PublishingApi
           public_updated_at: public_updated_at,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
           schema_name: SCHEMA_NAME,
-          links: links,
+          links: edition_links,
         )
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       LinksPresenter
         .new(consultation)
         .extract(%i(organisations parent policy_areas related_policies topics))

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -27,11 +27,19 @@ module PublishingApi
           public_updated_at: public_updated_at,
           rendering_app: corporate_information_page.rendering_app,
           schema_name: SCHEMA_NAME,
-          links: links,
+          links: edition_links,
         )
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       links_presenter.extract(
         %i(
           organisations

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "document_collection",
-        links: links,
+        links: edition_links,
       )
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
@@ -30,6 +30,14 @@ module PublishingApi
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       links = LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics related_policies parent)
       )

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
           rendering_app: item.rendering_app,
           schema_name: "fatality_notice",
           details: details,
-          links: links,
+          links: edition_links,
         )
         content.merge!(PayloadBuilder::AccessLimitation.for(item))
         content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
@@ -32,6 +32,14 @@ module PublishingApi
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       LinksPresenter.new(item).extract(
         %i(organisations policy_areas)
       ).merge(

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -28,12 +28,20 @@ module PublishingApi
         public_updated_at: item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: schema_name,
-        links: links,
+        links: edition_links,
       )
       content.merge!(PayloadBuilder::Routes.for(base_path))
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       {
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
         organisations: parent.organisations.pluck(:content_id).uniq,

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -23,7 +23,7 @@ module PublishingApi
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "publication",
-        links: links,
+        links: edition_links,
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
       content.merge!(PayloadBuilder::AccessLimitation.for(item))
@@ -31,6 +31,14 @@ module PublishingApi
     end
 
     def links
+      # TODO: Previously, this presenter was sending all links to the
+      # Publishing API at both the document level, and edition
+      # level. This is probably redundant, and hopefully can be
+      # improved.
+      edition_links
+    end
+
+    def edition_links
       LinksPresenter.new(item).extract(
         %i[
           topics


### PR DESCRIPTION
For the Publishing API. Some presenters put the links in to the
edition, but these links will also be sent to the Publishing API using
a patch_links request.

So, to unmuddle this, rename links in the relevant presenters to
edition_links, and add a new links method which returns for now
returns the same value. Hopefully the two can then be tweased apart,
bit by bit, reducing the duplicate information being sent to the
Publishing API.