### PR TITLE
Avoid issues with saving localised content

### DIFF
--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -42,7 +42,11 @@ class EditionService
 private
 
   def notify!
-    notifier && notifier.publish(verb, edition, options)
+    # reload the edition to strip the LocalisedModel, as this can
+    # cause problems later with localisation.
+    #
+    # If we can get rid of LocalisedModel, this can be removed.
+    notifier && notifier.publish(verb, edition.reload, options)
   end
 
   def prepare_edition

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -13,7 +13,7 @@ module ServiceListeners
       handle_translations
 
       case event
-      when "force_publish", "publish", "unwithdraw"
+      when "force_publish", "publish"
         api.publish(edition)
       when "update_draft"
         api.patch_links(edition)


### PR DESCRIPTION
Previously, the LocalisedModel created in the controller was being
passed through to the Whitehall::PublishingApi class. The
LocalisedModel doesn't work the same as a normal model though, and it
breaks the way the PublishingApi class sends the translations to the
Publishing API.

Calling reload seems to avoid this broken behaviour. Unfortunately, I
don't know why LocalisedModel is used, so I'm unsure if this is the
best way of fixing this, but it seems to work.