### PR TITLE
Don't always send a value for first_published_at

### DIFF
--- a/app/presenters/publishing_api/payload_builder/first_public_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_public_at.rb
@@ -3,7 +3,7 @@ module PublishingApi
     class FirstPublicAt
       def self.for(item)
         if item.document.published?
-          { first_public_at: item.document.first_published_date }
+          { first_public_at: item.document.first_published_date || item.document.created_at }
         else
           {}
         end

--- a/app/presenters/publishing_api/payload_builder/first_public_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_public_at.rb
@@ -2,7 +2,11 @@ module PublishingApi
   module PayloadBuilder
     class FirstPublicAt
       def self.for(item)
-        { first_public_at: FirstPublishedAt.for(item)[:first_published_at] }
+        if item.document.published?
+          { first_public_at: item.document.first_published_date }
+        else
+          {}
+        end
       end
     end
   end

--- a/app/presenters/publishing_api/payload_builder/first_published_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_published_at.rb
@@ -3,7 +3,7 @@ module PublishingApi
     class FirstPublishedAt
       def self.for(item)
         if item.document.published?
-          { first_published_at: item.document.first_published_date }
+          { first_published_at: item.document.first_published_date || item.document.created_at }
         else
           {}
         end

--- a/app/presenters/publishing_api/payload_builder/first_published_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_published_at.rb
@@ -2,7 +2,11 @@ module PublishingApi
   module PayloadBuilder
     class FirstPublishedAt
       def self.for(item)
-        { first_published_at: item.first_published_at || item.document.created_at }
+        if item.document.published?
+          { first_published_at: item.document.first_published_date }
+        else
+          {}
+        end
       end
     end
   end

--- a/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
+++ b/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
@@ -1,0 +1,8 @@
+Document.where(
+  id: Edition.where(state: :scheduled).select(:document_id)
+).all.each do |document|
+  next unless document.published_edition.nil?
+
+  puts "Saving draft for #{document.id} (content_id: #{document.content_id})"
+  Whitehall::PublishingApi.save_draft(document.pre_publication_edition)
+end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -48,11 +48,9 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" }
       ],
       redirects: [],
-      first_published_at: detailed_guide.created_at,
       update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
-        first_public_at: detailed_guide.created_at,
         change_history: [],
         tags: {
           browse_pages: [],

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -74,36 +74,6 @@ class PublishingApi::DocumentCollectionPresenterWithPublicTimestampTest < Active
   end
 end
 
-class PublishingApi::DraftDocumentCollectionPresenter < ActiveSupport::TestCase
-  test "it presents the Document Collection's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::DocumentCollectionPresenter.new(
-      create(:draft_document_collection) do |document_collection|
-        document_collection.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
-class PublishingApi::DraftDocumentCollectionBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
-  test "it presents the Document Collection's first_published_at as first_public_at" do
-    presented_notice = PublishingApi::DocumentCollectionPresenter.new(
-      create(:published_document_collection) do |document_collection|
-        document_collection.stubs(:first_published_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::DocumentCollectionPresenterGroupTest < ActiveSupport::TestCase
   setup do
     document_collection = create(:document_collection, :with_groups)

--- a/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
@@ -4,9 +4,16 @@ module PublishingApi
   module PayloadBuilder
     class PayloadBuilderFirstPublicAtTest < ActiveSupport::TestCase
       def test_uses_first_published_at
-        first_published_at = Object.new
-        item = stub
-        FirstPublishedAt.stubs(:for).with(item).returns(first_published_at: first_published_at)
+        first_published_at = Date.new(2000, 1, 1)
+
+        document = build(:document)
+        item = build(
+          :published_edition,
+          document: document,
+          first_published_at: first_published_at
+        )
+        document.stubs(:published_edition).returns(item)
+        document.stubs(:reload_published_edition).returns(item)
 
         assert_equal(
           { first_public_at: first_published_at },

--- a/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
@@ -4,8 +4,16 @@ module PublishingApi
   module PayloadBuilder
     class PayloadBuilderFirstPublishedAtTest < ActiveSupport::TestCase
       def test_returns_first_published_at_if_present
-        first_published_at = Object.new
-        item = stub(first_published_at: first_published_at)
+        first_published_at = Date.new(2000, 1, 1)
+
+        document = build(:document)
+        item = build(
+          :published_edition,
+          document: document,
+          first_published_at: first_published_at
+        )
+        document.stubs(:published_edition).returns(item)
+        document.stubs(:reload_published_edition).returns(item)
 
         assert_equal(
           { first_published_at: first_published_at },
@@ -14,8 +22,16 @@ module PublishingApi
       end
 
       def test_returns_document_created_at_for_nil_first_published_at
-        created_at = Object.new
-        item = stub(first_published_at: nil, document: stub(created_at: created_at))
+        created_at = Date.new(2000, 1, 1)
+
+        document = build(:document, created_at: created_at)
+        item = build(
+          :published_edition,
+          document: document,
+          first_published_at: nil
+        )
+        document.stubs(:published_edition).returns(item)
+        document.stubs(:reload_published_edition).returns(item)
 
         assert_equal(
           { first_published_at: created_at },

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -74,36 +74,6 @@ class PublishingApi::StatisticalDataSetWithPublicTimestampTest < ActiveSupport::
   end
 end
 
-class PublishingApi::DraftStatisticalDataSetPresenter < ActiveSupport::TestCase
-  test "it presents the statistical data set's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::StatisticalDataSetPresenter.new(
-      create(:draft_statistical_data_set) do |statistical_data_set|
-        statistical_data_set.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
-class PublishingApi::StatisticalDataSetBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
-  test "it presents the Statistical Data Set's first_published_at as first_public_at" do
-    presented_notice = PublishingApi::StatisticalDataSetPresenter.new(
-      create(:published_statistical_data_set) do |statistical_data_set|
-        statistical_data_set.stubs(:first_published_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::PublishedStatisticalDataSetPresenterDetailsTest < ActiveSupport::TestCase
   setup do
     @expected_first_published_at = Time.new(2011, 2, 5)

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -73,36 +73,6 @@ class PublishingApi::WorldLocationNewsArticleWithPublicTimestampTest < ActiveSup
   end
 end
 
-class PublishingApi::DraftWorldLocationNewsArticlePresenter < ActiveSupport::TestCase
-  test "it presents the world location news article's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(
-      create(:draft_world_location_news_article) do |world_location_news_article|
-        world_location_news_article.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
-class PublishingApi::WorldLocationNewsArticleBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
-  test "it presents the World Location News Article's first_published_at as first_public_at" do
-    presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(
-      create(:published_world_location_news_article) do |world_location_news_article|
-        world_location_news_article.stubs(:first_published_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::WorldLocationNewsArticlePresenterDetailsTest < ActiveSupport::TestCase
   setup do
     @expected_first_published_at = Time.new(2011, 2, 5)


### PR DESCRIPTION
Only send a value if the document has actually been
published. Otherwise, the obvious problem occurs, and the document
appears to have been published when it was created, not when it was
first published!

The FirstPublicAt class has the same problem as it uses the
FirstPublishedAt class, so apply the same fix there also.