### PR TITLE
Fix first published at (attempt 2)

### DIFF
--- a/app/presenters/publishing_api/payload_builder/first_public_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_public_at.rb
@@ -2,7 +2,11 @@ module PublishingApi
   module PayloadBuilder
     class FirstPublicAt
       def self.for(item)
-        { first_public_at: FirstPublishedAt.for(item)[:first_published_at] }
+        first_published_at = item.first_published_at
+
+        return {} if first_published_at.nil?
+
+        { first_public_at: first_published_at }
       end
     end
   end

--- a/app/presenters/publishing_api/payload_builder/first_published_at.rb
+++ b/app/presenters/publishing_api/payload_builder/first_published_at.rb
@@ -2,7 +2,11 @@ module PublishingApi
   module PayloadBuilder
     class FirstPublishedAt
       def self.for(item)
-        { first_published_at: item.first_published_at || item.document.created_at }
+        first_published_at = item.first_published_at
+
+        return {} if first_published_at.nil?
+
+        { first_published_at: first_published_at }
       end
     end
   end

--- a/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
+++ b/db/data_migration/20181004172520_update_drafts_for_scheduled_content_to_resolve_first_published_at_issue.rb
@@ -1,0 +1,8 @@
+Document.where(
+  id: Edition.where(state: :scheduled).select(:document_id)
+).all.each do |document|
+  next unless document.published_edition.nil?
+
+  puts "Saving draft for #{document.id} (content_id: #{document.content_id})"
+  Whitehall::PublishingApi.save_draft(document.pre_publication_edition)
+end

--- a/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -48,11 +48,9 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" }
       ],
       redirects: [],
-      first_published_at: detailed_guide.created_at,
       update_type: "major",
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
-        first_public_at: detailed_guide.created_at,
         change_history: [],
         tags: {
           browse_pages: [],

--- a/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/document_collection_presenter_test.rb
@@ -74,21 +74,6 @@ class PublishingApi::DocumentCollectionPresenterWithPublicTimestampTest < Active
   end
 end
 
-class PublishingApi::DraftDocumentCollectionPresenter < ActiveSupport::TestCase
-  test "it presents the Document Collection's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::DocumentCollectionPresenter.new(
-      create(:draft_document_collection) do |document_collection|
-        document_collection.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::DraftDocumentCollectionBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
   test "it presents the Document Collection's first_published_at as first_public_at" do
     presented_notice = PublishingApi::DocumentCollectionPresenter.new(

--- a/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -93,21 +93,6 @@ class PublishingApi::FatalityNoticePresenterWithPublicTimestampTest < ActiveSupp
   end
 end
 
-class PublishingApi::DraftFatalityNoticePresenter < ActiveSupport::TestCase
-  test "it presents the Fatality Notice's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::FatalityNoticePresenter.new(
-      create(:draft_fatality_notice) do |fatality_notice|
-        fatality_notice.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::DraftFatalityBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
   test "it presents the Fatality Notice's first_public_at" do
     presented_notice = PublishingApi::FatalityNoticePresenter.new(
@@ -122,7 +107,6 @@ class PublishingApi::DraftFatalityBelongingToPublishedDocumentNoticePresenter < 
     )
   end
 end
-
 
 class PublishingApi::FatalityNoticePresenterDetailsTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_public_at_test.rb
@@ -5,8 +5,7 @@ module PublishingApi
     class PayloadBuilderFirstPublicAtTest < ActiveSupport::TestCase
       def test_uses_first_published_at
         first_published_at = Object.new
-        item = stub
-        FirstPublishedAt.stubs(:for).with(item).returns(first_published_at: first_published_at)
+        item = stub(first_published_at: first_published_at)
 
         assert_equal(
           { first_public_at: first_published_at },

--- a/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
@@ -12,16 +12,6 @@ module PublishingApi
           FirstPublishedAt.for(item)
         )
       end
-
-      def test_returns_document_created_at_for_nil_first_published_at
-        created_at = Object.new
-        item = stub(first_published_at: nil, document: stub(created_at: created_at))
-
-        assert_equal(
-          { first_published_at: created_at },
-          FirstPublishedAt.for(item)
-        )
-      end
     end
   end
 end

--- a/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -74,21 +74,6 @@ class PublishingApi::StatisticalDataSetWithPublicTimestampTest < ActiveSupport::
   end
 end
 
-class PublishingApi::DraftStatisticalDataSetPresenter < ActiveSupport::TestCase
-  test "it presents the statistical data set's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::StatisticalDataSetPresenter.new(
-      create(:draft_statistical_data_set) do |statistical_data_set|
-        statistical_data_set.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::StatisticalDataSetBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
   test "it presents the Statistical Data Set's first_published_at as first_public_at" do
     presented_notice = PublishingApi::StatisticalDataSetPresenter.new(

--- a/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/world_location_news_article_presenter_test.rb
@@ -73,21 +73,6 @@ class PublishingApi::WorldLocationNewsArticleWithPublicTimestampTest < ActiveSup
   end
 end
 
-class PublishingApi::DraftWorldLocationNewsArticlePresenter < ActiveSupport::TestCase
-  test "it presents the world location news article's parent document created_at as first_public_at" do
-    presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(
-      create(:draft_world_location_news_article) do |world_location_news_article|
-        world_location_news_article.document.stubs(:created_at).returns(Date.new(2015, 4, 10))
-      end
-    )
-
-    assert_equal(
-      Date.new(2015, 4, 10),
-      presented_notice.content[:details][:first_public_at]
-    )
-  end
-end
-
 class PublishingApi::WorldLocationNewsArticleBelongingToPublishedDocumentNoticePresenter < ActiveSupport::TestCase
   test "it presents the World Location News Article's first_published_at as first_public_at" do
     presented_notice = PublishingApi::WorldLocationNewsArticlePresenter.new(


### PR DESCRIPTION
Don't fallback to sending the document created_time as when the
content was first published. Otherwise, the obvious problem occurs,
and the document appears to have been published when it was created,
not when it was first published!

The FirstPublicAt class has the same problem as it uses the
FirstPublishedAt class, so apply the same fix there also.