### PR TITLE
Revert "Separate updating an edition from publishing"

### DIFF
--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -14,7 +14,6 @@ module PublishesToPublishingApi
 
   def publish_to_publishing_api
     run_callbacks :published do
-      Whitehall::PublishingApi.save_draft(self)
       Whitehall::PublishingApi.patch_links(self)
       Whitehall::PublishingApi.publish(self)
     end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -13,6 +13,17 @@ module Whitehall
     def self.publish(model_instance)
       assert_public_edition!(model_instance)
 
+      # Ideally this wouldn't happen, but aspects of Whitehall still
+      # depend on this behaviour, as the drafts sent to the Publishing
+      # API are not suitable for publishing.
+      #
+      # For example, the change notes only include changes from
+      # published editions in Whitehall, so the edition in Whitehall
+      # needs to be published, then the draft updated in the
+      # Publishing API updated to update the change notes (and
+      # possibly other things), and only then can it be published.
+      save_draft(model_instance)
+
       presenter = PublishingApiPresenters.presenter_for(model_instance)
 
       locales_for(model_instance).each do |locale|

--- a/test/integration/publishing_test.rb
+++ b/test/integration/publishing_test.rb
@@ -11,6 +11,7 @@ class PublishingTest < ActiveSupport::TestCase
 
   test "When an edition is published, it gets published with the Publishing API" do
     requests = [
+      stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 
@@ -25,11 +26,13 @@ class PublishingTest < ActiveSupport::TestCase
       @draft_edition.save!
 
       [
+        stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
         stub_publishing_api_publish(@presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
+      stub_publishing_api_put_content(@presenter.content_id, @presenter.content),
       stub_publishing_api_publish(@presenter.content_id, locale: 'en', update_type: nil)
     ]
 

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -53,11 +53,13 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
 
     # Main document
     content_id = @draft_edition.content_id
+    assert_requested(:put, %r|publishing-api.*content/#{content_id}|, headers: onward_headers)
     assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
 
     # HTML attachments
     @draft_edition.html_attachments.each do |html_attachment|
       attachment_content_id = html_attachment.content_id
+      assert_requested(:put, %r|publishing-api.*content/#{attachment_content_id}|, headers: onward_headers)
       assert_requested(:post, %r|publishing-api.*content/#{attachment_content_id}/publish|, headers: onward_headers)
     end
   end

--- a/test/support/publishing_api_test_helpers.rb
+++ b/test/support/publishing_api_test_helpers.rb
@@ -17,17 +17,11 @@ module PublishingApiTestHelpers
     end
   end
 
-  def expect_put_content(*editions, content_entries: {})
+  def expect_publishing(*editions, content_entries: {})
     editions.each do |edition|
-      Services.publishing_api.expects(:put_content).with(
-        edition.content_id,
-        has_entries({ publishing_app: 'whitehall' }.merge(content_entries))
-      )
-    end
-  end
-
-  def expect_publishing(*editions)
-    editions.each do |edition|
+      Services.publishing_api.expects(:put_content)
+        .with(edition.content_id,
+          has_entries({ publishing_app: 'whitehall' }.merge(content_entries)))
       Services.publishing_api.stubs(:patch_links)
         .with(edition.content_id, has_entries(links: anything))
       Services.publishing_api.expects(:publish)

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -118,7 +118,6 @@ class ContactTest < ActiveSupport::TestCase
       ServiceListeners::EditionDependenciesPopulator.new(news_article).populate!
       ServiceListeners::EditionDependenciesPopulator.new(corp_info_page).populate!
 
-      expect_put_content(contact)
       expect_publishing(contact)
       expect_republishing(news_article, corp_info_page)
 

--- a/test/unit/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/models/publishes_to_publishing_api_test.rb
@@ -70,8 +70,9 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
 
   test "defines and executes published callback when published" do
     Whitehall::PublishingApi.stubs(:publish)
-    Whitehall::PublishingApi.stubs(:patch_links)
     Whitehall::PublishingApi.stubs(:save_draft)
+    Whitehall::PublishingApi.stubs(:patch_links)
+
     test_object = TestObject.new
     class << test_object
       include PublishesToPublishingApi

--- a/test/unit/whitehall/publishing_api_test.rb
+++ b/test/unit/whitehall/publishing_api_test.rb
@@ -21,6 +21,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     edition = create(:published_publication)
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
+      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -34,6 +35,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     WebMock.reset! # because creating an organisation also pushes to Publishing API
     presenter = PublishingApiPresenters.presenter_for(organisation)
     requests = [
+      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -47,6 +49,7 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
 
     presenter = PublishingApiPresenters.presenter_for(edition)
     requests = [
+      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_publish(presenter.content_id, locale: presenter.content[:locale], update_type: nil)
     ]
 
@@ -65,11 +68,13 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
       WebMock.reset!
 
       [
+        stub_publishing_api_put_content(presenter.content_id, presenter.content),
         stub_publishing_api_publish(presenter.content_id, locale: 'fr', update_type: nil)
       ]
     end
 
     english_requests = [
+      stub_publishing_api_put_content(presenter.content_id, presenter.content),
       stub_publishing_api_publish(presenter.content_id, locale: 'en', update_type: nil)
     ]
 


### PR DESCRIPTION
What should have been a simple code cleanup has caused multiple
issues, including problems with scheduled publishing, timestamps and
change notes, simply due to Whitehall never being changed to send
drafts to the Publishing API suitable for publishing.

Some of these issues have been resolved, like the scheduled publishing
and timestamp issues, but at this point, for the change notes, the
relevant code doesn't even attempt to create something suitable, and
it doesn't look like a simple change, as with the way Whitehall
"republishes" content, if you were going to change it to include
drafts, this would have to be conditional on whether you plan to
immediately publish the content, or to leave it as an actual draft.

So, this commit returns to not publishing the draft in the Publishing
API, but instead sending through a new draft after the state changes
in Whitehall have taken place, which is then immediately
published. This isn't ideal, as obviously it defeats the purpose of
content preview if you're not publishing what you've previewed, but
this isn't the time to attempt to fix that.

This reverts commit 6ea0aca7e55bfd5a2451ca96928252de41007c6c.