### PR TITLE
Remove synchronised_with_asset_manager_at column

### DIFF
--- a/db/migrate/20181008152313_remove_synchronised_with_asset_manager_at_from_attachment_data.rb
+++ b/db/migrate/20181008152313_remove_synchronised_with_asset_manager_at_from_attachment_data.rb
@@ -1,0 +1,11 @@
+class RemoveSynchronisedWithAssetManagerAtFromAttachmentData < ActiveRecord::Migration[5.1]
+  def up
+    # this condition is because the PR which added the column was
+    # removed, so a freshly generated schema won't have it, causing
+    # the migration to fail.  however, the column does exist in the
+    # production database, so we want to remove it from there.
+    if column_exists? :attachment_data, :synchronised_with_asset_manager_at
+      remove_column :attachment_data, :synchronised_with_asset_manager_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180926102214) do
+ActiveRecord::Schema.define(version: 20181008152313) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"


### PR DESCRIPTION
The commit which added this logic was reverted (#4191), but the old
migration was never rolled back.  There's no need for this column to
exist, so just remove it.