### PR TITLE
Ensure current_release_date is up-to-date

### DIFF
--- a/app/models/statistics_announcement_date.rb
+++ b/app/models/statistics_announcement_date.rb
@@ -4,6 +4,8 @@ class StatisticsAnnouncementDate < ApplicationRecord
   belongs_to :statistics_announcement, touch: true
   belongs_to :creator, class_name: 'User'
 
+  after_save :update_statistics_announcement_current_release_date
+
   validates :release_date, presence: true
   validates :precision, presence: true, inclusion: { in: PRECISION.values }
   validate :confirmed_date_must_be_exact
@@ -20,6 +22,10 @@ class StatisticsAnnouncementDate < ApplicationRecord
   end
 
 private
+
+  def update_statistics_announcement_current_release_date
+    statistics_announcement.try(:reload_current_release_date)
+  end
 
   def confirmed_date_must_be_exact
     if confirmed? && precision != PRECISION[:exact]

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -116,7 +116,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   test '#most_recent_change_note returns the most recent change note' do
     announcement = create_announcement_with_changes
 
-    assert_equal '11 January 2012 9:30am', announcement.reload.display_date
+    assert_equal '18 January 2012 9:30am', announcement.reload.display_date
     assert announcement.confirmed?
     assert_equal 'Delayed because of census', announcement.last_change_note
   end
@@ -124,7 +124,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
   test '#previous_display_date returns the release date prior to the most recent change note' do
     announcement = create_announcement_with_changes
 
-    assert_equal '11 January 2012 9:30am', announcement.reload.display_date
+    assert_equal '18 January 2012 9:30am', announcement.reload.display_date
     assert_equal 'December 2011', announcement.previous_display_date
   end
 


### PR DESCRIPTION
Due to how associations work in ActiveRecord, I think there could be
issues with changing dates for StatisticsAnnouncements, as the
association on the model doesn't know that the data it has is now
invalid if the say a new StatisticsAnnouncementDate is created.

Therefore, to avoid this, reload the association after a
StatisticsAnnouncementDate is saved.