### PR TITLE
Simplify legacy association mapping

### DIFF
--- a/app/services/taxons_to_legacy_associations_tagging.rb
+++ b/app/services/taxons_to_legacy_associations_tagging.rb
@@ -3,7 +3,7 @@ class TaxonsToLegacyAssociationsTagging
     # Only perform the taxon based tagging for content with no
     # existing legacy associations, to avoid overriding human tagging
     # decisions
-    return false if any_legacy_associations_for_edition?(edition)
+    return false if tagged_to_specialist_sectors?(edition)
 
     legacy_associations_from_mappping = legacy_mapping_for_taxons(selected_taxons)
 
@@ -20,12 +20,7 @@ class TaxonsToLegacyAssociationsTagging
         legacy_association["content_id"]
       end
 
-      case document_type
-      when "policy"
-        edition.policy_content_ids = content_ids
-      when "policy_area"
-        edition.topics = Topic.where(content_id: content_ids)
-      when "topic"
+      if document_type == "topic"
         # This is inperfect, as the primary specialist sector tag is
         # being set in an arbitrary manor. But, this mapping function
         # is only a temporary thing while the specialist sectors still
@@ -51,20 +46,6 @@ private
     Taxonomy::Mapping
       .new
       .legacy_mapping_for_taxons(selected_taxons)
-  end
-
-  def any_legacy_associations_for_edition?(edition)
-    tagged_to_policies?(edition) ||
-      tagged_to_policy_areas?(edition) ||
-      tagged_to_specialist_sectors?(edition)
-  end
-
-  def tagged_to_policies?(edition)
-    defined?(edition.policy_content_ids) && edition.policy_content_ids.any?
-  end
-
-  def tagged_to_policy_areas?(edition)
-    defined?(edition.topic_ids) && edition.topic_ids.any?
   end
 
   def tagged_to_specialist_sectors?(edition)

--- a/lib/taxonomy/mapping.rb
+++ b/lib/taxonomy/mapping.rb
@@ -19,19 +19,12 @@ class Taxonomy::Mapping
       taxon.content_id == start_taxon_content_id
     end
 
-    document_types = %w(policy policy_area topic)
-    result = start_taxon.legacy_mapping.slice(*document_types)
+    result = start_taxon.legacy_mapping.slice('topic')
 
-    document_types.each do |document_type|
-      start_taxon.ancestors.each do |ancestor|
-        # Look up through the ancestors to find a mapping for each
-        # document_type, but stop once one is found
+    start_taxon.ancestors.each do |ancestor|
+      break if result['topic'].present?
 
-        result[document_type] = ancestor.legacy_mapping
-                                  .fetch(document_type, [])
-
-        break if result[document_type].present?
-      end
+      result['topic'] = ancestor.legacy_mapping.fetch('topic', [])
     end
 
     result

--- a/test/unit/services/taxons_to_legacy_associations_tagging_test.rb
+++ b/test/unit/services/taxons_to_legacy_associations_tagging_test.rb
@@ -1,60 +1,6 @@
 require 'test_helper'
 
 class TaxonsToLegacyAssociationsTaggingTest < ActiveSupport::TestCase
-  test "handles policies" do
-    policy = Policy.new(
-      "content_id" => SecureRandom.uuid,
-      "title" => "Test Policy",
-      "base_path" => "/government/policies/test-policy",
-      "internal_name" => "Test Policy"
-    )
-    taxon = taxon_mapped_to_policy(policy.content_id)
-
-    Taxonomy::TopicTaxonomy
-      .any_instance
-      .stubs(:all_taxons)
-      .returns([taxon])
-
-    edition = create(:publication)
-    edition.topics.delete_all
-
-    Services.publishing_api
-      .expects(:get_links)
-      .with(policy.content_id)
-      .raises(GdsApi::HTTPNotFound.new(404))
-
-    TaxonsToLegacyAssociationsTagging.new.call(
-      edition: edition,
-      user: create(:user),
-      selected_taxons: [taxon.content_id]
-    )
-
-    assert edition.policy_content_ids.count, 1
-    assert edition.policy_content_ids.first, policy.content_id
-  end
-
-  test "handles policy areas" do
-    policy_area = create(:topic)
-    taxon = taxon_mapped_to_policy_area(policy_area.content_id)
-
-    Taxonomy::TopicTaxonomy
-      .any_instance
-      .stubs(:all_taxons)
-      .returns([taxon])
-
-    edition = create(:publication)
-    edition.topics.delete_all
-
-    TaxonsToLegacyAssociationsTagging.new.call(
-      edition: edition,
-      user: create(:user),
-      selected_taxons: [taxon.content_id]
-    )
-
-    assert edition.topics.count, 1
-    assert edition.topics.first.content_id, policy_area.content_id
-  end
-
   test "handles specialist sectors" do
     specialist_sector_content_id = SecureRandom.uuid
     taxon = taxon_mapped_to_specialist_sector(
@@ -77,40 +23,6 @@ class TaxonsToLegacyAssociationsTaggingTest < ActiveSupport::TestCase
 
     assert edition.specialist_sectors.count, 1
     assert edition.specialist_sectors.first.topic_content_id, specialist_sector_content_id
-  end
-
-  def taxon_mapped_to_policy(policy_content_id)
-    Taxonomy::Taxon.new(
-      title: "Taxon mapped to policy",
-      base_path: "/mapped-to-policy",
-      content_id: "4415339f-d907-46e1-bc55-2e0c4b313787",
-      legacy_mapping: {
-        "policy" => [
-          {
-            "content_id" => policy_content_id,
-            "document_type" => "policy",
-            "title" => "Test Policy"
-          }
-        ]
-      }
-    )
-  end
-
-  def taxon_mapped_to_policy_area(policy_area_content_id)
-    Taxonomy::Taxon.new(
-      title: "Taxon mapped to policy area",
-      base_path: "/mapped-to-policy-area",
-      content_id: "24a01d2e-e4c4-4abf-bcdc-322289f135d8",
-      legacy_mapping: {
-        "policy_area" => [
-          {
-            "content_id" => policy_area_content_id,
-            "document_type" => "policy_area",
-            "title" => "Test Policy Area"
-          }
-        ]
-      }
-    )
   end
 
   def taxon_mapped_to_specialist_sector(specialist_sector_content_id)

--- a/test/unit/taxonomy/mapping_test.rb
+++ b/test/unit/taxonomy/mapping_test.rb
@@ -13,7 +13,7 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       test_taxon_with_direct_mapping.content_id
     )
 
-    assert_equal result.dig("policy_area", 0, "title"), "Test Policy Area"
+    assert_equal "Test Specialist Sector", result.dig("topic", 0, "title")
   end
 
   test "legacy_mapping_for_taxon with a indirect mapping" do
@@ -21,20 +21,17 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       test_taxon_with_indirect_mapping.content_id
     )
 
-    assert_equal result.dig("policy_area", 0, "title"), "Test Policy Area"
+    assert_equal "Test Specialist Sector", result.dig("topic", 0, "title")
   end
 
   test "legacy_mapping_for_taxons" do
     result = Taxonomy::Mapping.new.legacy_mapping_for_taxons(
-      [
-        test_taxon_with_direct_mapping.content_id,
-        test_taxon_with_multiple_legacy_taxons.content_id
-      ]
+      all_taxons.map(&:content_id)
     )
 
     assert_equal 2, result.length
     assert_same_elements(
-      ["Test Policy Area", "Test legacy policy"],
+      ["Test Specialist Sector", "Another Test Specialist Sector"],
       result.map { |x| x["title"] }
     )
   end
@@ -43,7 +40,7 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
     [
       test_taxon_with_direct_mapping,
       test_taxon_with_indirect_mapping,
-      test_taxon_with_multiple_legacy_taxons
+      another_test_taxon_with_direct_mapping
     ]
   end
 
@@ -53,10 +50,10 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       base_path: "/direct-mapping",
       content_id: "341b0937-8590-47d6-8fa6-3203e162ec93",
       legacy_mapping: {
-        "policy_area" => [
+        "topic" => [
           {
             "content_id" => "35baa314-9f31-4276-bad2-30bba3f40975",
-            "title" => "Test Policy Area"
+            "title" => "Test Specialist Sector"
           }
         ]
       }
@@ -76,22 +73,16 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
     taxon
   end
 
-  def test_taxon_with_multiple_legacy_taxons
+  def another_test_taxon_with_direct_mapping
     Taxonomy::Taxon.new(
-      title: "Multiple legacy",
-      base_path: "/multiple-legacy",
-      content_id: "bb5fbd37-0b75-4f90-8a24-b19d1d8b16f4",
+      title: "Direct mapping",
+      base_path: "/direct-mapping",
+      content_id: "59d39ef3-2d6d-4b38-8d8b-37c0d0390a29",
       legacy_mapping: {
-        "policy_area" => [
+        "topic" => [
           {
-            "content_id" => "35baa314-9f31-4276-bad2-30bba3f40975",
-            "title" => "Test Policy Area"
-          }
-        ],
-        "policy" => [
-          {
-            "content_id" => "40911228-459d-4568-8199-c2d921f5388f",
-            "title" => "Test legacy policy"
+            "content_id" => "e2aa4b5a-60d1-40c8-a1fd-ae94ee469efc",
+            "title" => "Another Test Specialist Sector"
           }
         ]
       }


### PR DESCRIPTION
Policy and Policy area pages are no more, so this only has to work for
Specialist Sectors, which still exist.