### PR TITLE
Change 'Related policy areas' subheading

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -31,7 +31,7 @@
                           locals: { organisations: @classification.organisations } %>
             </dd>
             <% if @related_classifications.any? %>
-              <dt>Related policy areas:</dt>
+              <dt>Related topics:</dt>
               <dd class="js-hide-other-links related-topics">
                 <%= @related_classifications.map { |rc| link_to(rc.name, rc) }.to_sentence.html_safe %>
               </dd>


### PR DESCRIPTION
Related story: https://trello.com/c/0LHLqLD7/20-change-policy-areas-title-to-topics-on-topical-events-pages.

This changes the "policy areas" sub heading to "topics" on topical events pages.