### PR TITLE
Remove Related Policy Areas from Topical Events pages.

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -8,7 +8,6 @@ class TopicalEventsController < ClassificationsController
     @consultations = fetch_associated(:published_consultations, PublicationesquePresenter)
     @announcements = fetch_associated(:published_announcements, AnnouncementPresenter)
     @detailed_guides = @classification.published_detailed_guides.includes(:translations, :document).limit(5)
-    @related_classifications = @classification.related_classifications
     @featurings = decorate_collection(@classification.classification_featurings.includes(:image, edition: :document).limit(5), ClassificationFeaturingPresenter)
 
     set_slimmer_organisations_header(@classification.organisations)

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -87,20 +87,6 @@
           </div>
         </section>
       <% end %>
-      <% if @related_classifications.any? %>
-        <section id="related-topics" class="document-block documents-<%= document_block_counter %>">
-          <h1 class="label">Related policy areas</h1>
-          <div class="content">
-            <ol class="document-list">
-              <% @related_classifications.each do |topic| %>
-                <%= content_tag_for :li, topic, class: 'document-row' do %>
-                  <h2><%= link_to topic.name, topic_path(topic) %></h2>
-                <% end %>
-              <% end %>
-            </ol>
-          </div>
-        </section>
-      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
Related Trello card: https://trello.com/c/0LHLqLD7/20-remove-policy-areas-list-from-topical-events-pages