### PR TITLE
Fix change_history issue with a couple of presenters

### DIFF
--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -91,7 +91,6 @@ module PublishingApi
       changes_with_public_timestamps =
         corporate_information_page
           .change_history
-          .as_json
           .select { |change| change[:public_timestamp].present? }
 
       { change_history: changes_with_public_timestamps.as_json }

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -36,7 +36,6 @@ module PublishingApi
       changes_with_public_timestamps =
         item
           .change_history
-          .as_json
           .select { |change| change[:public_timestamp].present? }
 
       details = {

--- a/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -356,6 +356,23 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
   end
 
+  class PublishedCorporateInformationPage < TestCase
+    setup do
+      self.corporate_information_page = create(
+        :published_corporate_information_page
+      )
+    end
+
+    test 'change history' do
+      assert_equal(
+        1,
+        presented_corporate_information_page
+          .content[:details][:change_history]
+          .length
+      )
+    end
+  end
+
   class CorporateInformationPageWithMinorChange < TestCase
     setup do
       self.corporate_information_page = create(:corporate_information_page,

--- a/test/unit/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/speech_presenter_test.rb
@@ -78,6 +78,18 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  describe "change_history" do
+    it "is generated for a published speech" do
+      assert_equal(
+        1,
+        PublishingApi::SpeechPresenter
+          .new(create(:published_speech))
+          .content[:details][:change_history]
+          .length
+      )
+    end
+  end
+
   describe "links" do
     let(:policy_content_id) { SecureRandom.uuid }
     let(:topical_event) { create(:topical_event) }


### PR DESCRIPTION
Previously, as_json was called twice, which meant that the select call
wasn't working properly. This fixes that, as well as adding some basic
test coverage for this code path.