### PR TITLE
Reslug weekly-national-flu-reports

### DIFF
--- a/db/data_migration/20181017084045_reslug_weekly_flu_reports.rb
+++ b/db/data_migration/20181017084045_reslug_weekly_flu_reports.rb
@@ -1,0 +1,9 @@
+# There are two different types of document at this slug hence the doc type criteria
+document = Document.find_by(slug: 'weekly-national-flu-reports', document_type: 'Publication')
+# remove the most recent edition from the search index
+edition = document.editions.published.last
+Whitehall::SearchIndex.delete(edition)
+
+# change the slug of the document and create a redirect from the original
+document.update_attributes!(slug: 'weekly-national-flu-reports-2017-to-2018-season')
+PublishingApiDocumentRepublishingWorker.new.perform(document.id)


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3402741

There's a Collection and a Publication at this slug, so the `reslug:document` rake task finds the collection which is not what we want. 