### PR TITLE
Don't override notify! in ScheduledEditionPublisher

### DIFF
--- a/app/services/scheduled_edition_publisher.rb
+++ b/app/services/scheduled_edition_publisher.rb
@@ -5,24 +5,6 @@ class ScheduledEditionPublisher < EditionPublisher
 
 private
 
-  def notify!
-    super
-  # We cannot afford for documents scheduled for publishing in production to
-  # fail so we catch and continue if there are problems in any of the
-  # registered listeners on scheduled publishing.
-  # Further work is required to make the notification bus more robust.
-  rescue StandardError => e
-    if Rails.env.production?
-      GovukError.notify(e,
-        extra: {
-          error_message: "Exception raised during scheduled publishing attempt: '#{e.message}'",
-          edition_id: edition.id
-        })
-    else
-      raise e
-    end
-  end
-
   def failure_reasons
     @failure_reasons ||= [].tap do |reasons|
       reasons << 'Only scheduled editions can be published with ScheduledEditionPublisher' unless scheduled_for_publication?


### PR DESCRIPTION
I believe the intention here was to suppress non-critical errors
relating to ScheduledPublishing. However, the way the publishing
actually happens currently, relies on a listener, specifically the one
for the Publishing API.

So, if the now-critical part of scheduled publishing fails, this
attempt to suppress non-critical errors will actually catch errors
relating to the critical parts of scheduled publishing. This has
knock-on effects, as the monitoring for scheduled publishing depends
on the Whitehall state, and supressing these exceptions means that the
state will still transition to published.

It's only since the Publishing API interaction for publishing moved
out of Sidekiq [1] that this became relevant, as before, the exception
would have occured in a disconnected Sidekiq job. Now, at least it
propagates up to here.

1: 5747885413bdf2d382f6edf4563a1c26c09bc688

Ideally, the Publishing API interaction would move out of the listener
to make the code clearer, and avoid conflating it with other actions,
but for now, by not supressing the exceptions, the code is a little
simpler, and the monitoring should detect scheduled publishing
failures.

Unfortunately, this applies to everything on the message bus, so we'll
have to watch out for spurious alerts based on non-critical failures.

---

This issue became apparent when this change 6ea0aca7e55bfd5a2451ca96928252de41007c6c was deployed, as it broke scheduled publishing for new content. The publish commands sent to the Publishing API failed, and the exception propagated up to the `rescue` block that has been removed in this Pull Request, and due to it, the monitoring for scheduled publishing didn't alert on these failures.