### PR TITLE
Delete Policy Areas

### DIFF
--- a/db/data_migration/20181018150601_delete_policy_areas.rb
+++ b/db/data_migration/20181018150601_delete_policy_areas.rb
@@ -1,0 +1,1 @@
+Topic.all.each(&:delete!)


### PR DESCRIPTION
Add a data migration to delete policy areas because they are no
longer in use.