### PR TITLE
Add rake task rummager:index:topical_event_editions

### DIFF
--- a/app/models/edition/topical_events.rb
+++ b/app/models/edition/topical_events.rb
@@ -22,12 +22,6 @@ module Edition::TopicalEvents
   end
 
   def search_index
-    # "Policy area" is the newer name for "topic"
-    # (https://www.gov.uk/government/topics)
-    # Rummager's policy areas also include "topical events", which we model
-    # separately in whitehall.
-    new_slugs = topical_events.map(&:slug)
-    existing_slugs = super.fetch("policy_areas", [])
-    super.merge("policy_areas" => new_slugs + existing_slugs)
+    super.merge("topical_events" => topical_events.pluck(:slug))
   end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -42,6 +42,10 @@ class TopicalEvent < Classification
             class_name: "Consultation",
             source: :consultation
 
+  has_many :editions,
+            -> { where("editions.state" => "published") },
+            through: :classification_memberships
+
   has_many :features, inverse_of: :topical_event, dependent: :destroy
 
   scope :active, -> { where("end_date > ?", Date.today) }

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -421,12 +421,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_not publication.search_index.include?("topics")
   end
 
-  test "rummager policy_areas include topical_events" do
+  test "rummager policy_areas include topics" do
     government = create(:current_government)
     publication = create(:published_policy_paper, :with_topical_events, title: "publication-title", political: true, first_published_at: government.start_date)
 
-    expected = publication.topics.map(&:name) + publication.topical_events.map(&:name)
+    expected = publication.topics.map(&:name)
     assert_equal expected.sort, publication.search_index["policy_areas"].sort
+    assert_not publication.search_index.include?("topics")
+  end
+
+  test "rummager topical_events include topical_events" do
+    government = create(:current_government)
+    publication = create(:published_policy_paper, :with_topical_events, title: "publication-title", political: true, first_published_at: government.start_date)
+
+    expected = publication.topical_events.map(&:name)
+    assert_equal expected.sort, publication.search_index["topical_events"].sort
     assert_not publication.search_index.include?("topics")
   end
 


### PR DESCRIPTION
This rake task will enable re-indexing of documents related to topical events.

This is useful if there is a change to topical events, and we need to re-index all related documents.

For the completion of https://github.com/alphagov/rummager/pull/1298 this rake task will need to be run on all environments.

The rake task intends to get all documents related to a topical event, and that belong in rummager (published editions), and then add these documents to the queue for re-indexing in rummager.

In addition, this commit adds topical_events to documents sent to rummager, in place of policy_areas, which are due for removal.