### PR TITLE
Revert "Don't override notify! in ScheduledEditionPublisher"

### DIFF
--- a/app/services/scheduled_edition_publisher.rb
+++ b/app/services/scheduled_edition_publisher.rb
@@ -5,6 +5,24 @@ class ScheduledEditionPublisher < EditionPublisher
 
 private
 
+  def notify!
+    super
+  # We cannot afford for documents scheduled for publishing in production to
+  # fail so we catch and continue if there are problems in any of the
+  # registered listeners on scheduled publishing.
+  # Further work is required to make the notification bus more robust.
+  rescue StandardError => e
+    if Rails.env.production?
+      GovukError.notify(e,
+        extra: {
+          error_message: "Exception raised during scheduled publishing attempt: '#{e.message}'",
+          edition_id: edition.id
+        })
+    else
+      raise e
+    end
+  end
+
   def failure_reasons
     @failure_reasons ||= [].tap do |reasons|
       reasons << 'Only scheduled editions can be published with ScheduledEditionPublisher' unless scheduled_for_publication?


### PR DESCRIPTION
Reverts alphagov/whitehall#4428

We're having issues with scheduled publishing at the moment, and this is the only related commit that got deployed recently. As an attempt at a quick fix, we're going to try and revert this and see if it helps.