### PR TITLE
Remove policy areas field from stats announcement

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -48,7 +48,7 @@ class StatisticsAnnouncement < ApplicationRecord
   validates :redirect_url, presence: { message: "must be provided when unpublishing an announcement" }, if: :unpublished?
   validates :redirect_url, uri: true, allow_blank: true
   validates :redirect_url, gov_uk_url: true, allow_blank: true
-  validates :title, :summary, :organisations, :topics, :creator, :current_release_date, presence: true
+  validates :title, :summary, :organisations, :creator, :current_release_date, presence: true
   validates :cancellation_reason, presence: { message: "must be provided when cancelling an announcement" }, if: :cancelled?
   validates :publication_type_id,
               inclusion: {

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -26,14 +26,6 @@
                   options_for_select(taggable_organisations_container, statistics_announcement.organisation_ids),
                   { }, multiple: true, class: 'chzn-select form-control' %>
   </div>
-  <div class="form-group stats-chosen-wrapper">
-    <%= form.label  :topic_ids, 'Policy Areas', required: true %>
-    <%= form.select :topic_ids,
-                  options_for_select(taggable_topics_container, statistics_announcement.topic_ids),
-                  { prompt: 'Select a topic' },
-                  multiple: true,
-                  class: 'chzn-select form-control' %>
-  </div>
   <% if statistics_announcement.new_record? %>
     <%= form.fields_for :current_release_date do |fields| %>
       <hr />

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -96,7 +96,6 @@ When(/^I announce an upcoming statistics publication called "(.*?)"$/) do |annou
   fill_in :statistics_announcement_summary, with: "Summary of publication"
   select_date 1.year.from_now.to_s, from: "Release date"
   select organisation.name, from: :statistics_announcement_organisation_ids
-  select topic.name, from: :statistics_announcement_topic_ids
 
   click_on 'Publish announcement'
 end

--- a/test/unit/statistics_announcement_test.rb
+++ b/test/unit/statistics_announcement_test.rb
@@ -49,11 +49,6 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal 'beard-statistics-2015', announcement.slug
   end
 
-  test 'must have at least one topic' do
-    announcement = build(:statistics_announcement, topics: [])
-    refute announcement.valid?
-  end
-
   test 'is search indexable' do
     announcement = create_announcement_with_changes
     expected_indexed_content = {


### PR DESCRIPTION
Removes the policy areas dropdown from statistics announcement page.

Policy areas were removed/deprecated by the taxonomy team. Keeping this field here (as required) is blocking publishers from publishing new statistics announcements (see image below).

<img width="445" alt="screen shot 2018-10-22 at 15 29 28" src="https://user-images.githubusercontent.com/29889908/47298309-58f36600-d60f-11e8-939e-cacfee5e9540.png">