### PR TITLE
Handle the Publishing API within the EditionService

### DIFF
--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -1,6 +1,7 @@
 class DraftEditionUpdater < EditionService
   def perform!
     if can_perform?
+      update_publishing_api!
       notify!
       true
     end

--- a/app/services/draft_translation_updater.rb
+++ b/app/services/draft_translation_updater.rb
@@ -1,6 +1,7 @@
 class DraftTranslationUpdater < EditionService
   def perform!
     if can_perform?
+      update_publishing_api!
       notify!
       true
     end

--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -13,6 +13,7 @@ class EditionService
       ActiveRecord::Base.transaction do
         prepare_edition
         fire_transition!
+        update_publishing_api!
       end
       notify!
       true
@@ -47,6 +48,12 @@ private
     #
     # If we can get rid of LocalisedModel, this can be removed.
     notifier && notifier.publish(verb, edition.reload, options)
+  end
+
+  def update_publishing_api!
+    ServiceListeners::PublishingApiPusher
+      .new(edition.reload)
+      .push(event: verb, options: options)
   end
 
   def prepare_edition

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -1,11 +1,4 @@
 Whitehall.edition_services.tap do |coordinator|
-  # publishing API
-  coordinator.subscribe do |event, edition, options|
-    ServiceListeners::PublishingApiPusher
-      .new(edition)
-      .push(event: event, options: options)
-  end
-
   coordinator.subscribe do |_event, edition, _options|
     ServiceListeners::AttachmentUpdater.call(attachable: edition)
   end

--- a/test/unit/services/draft_edition_updater_test.rb
+++ b/test/unit/services/draft_edition_updater_test.rb
@@ -5,6 +5,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
     edition = create(:draft_edition)
     edition.freeze
     updater = DraftEditionUpdater.new(edition)
+    updater.expects(:update_publishing_api!).once
     updater.expects(:notify!).once
 
     updater.perform!
@@ -14,6 +15,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
     edition = Edition.new
     updater = DraftEditionUpdater.new(edition)
     updater.expects(:notify!).never
+    updater.expects(:update_publishing_api!).never
 
     updater.perform!
   end
@@ -22,6 +24,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
     edition = create(:published_edition)
     updater = DraftEditionUpdater.new(edition)
     updater.expects(:notify!).never
+    updater.expects(:update_publishing_api!).never
 
     updater.perform!
   end

--- a/test/unit/services/draft_translation_updater_test.rb
+++ b/test/unit/services/draft_translation_updater_test.rb
@@ -5,6 +5,7 @@ class DraftTranslationUpdaterTest < ActiveSupport::TestCase
     edition = create(:draft_edition)
     edition.freeze
     updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:update_publishing_api!).once
     updater.expects(:notify!).once
 
     updater.perform!
@@ -13,6 +14,7 @@ class DraftTranslationUpdaterTest < ActiveSupport::TestCase
   test "cannot perform if edition is invalid" do
     edition = Edition.new
     updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:update_publishing_api!).never
     updater.expects(:notify!).never
 
     updater.perform!
@@ -21,6 +23,7 @@ class DraftTranslationUpdaterTest < ActiveSupport::TestCase
   test "cannot perform if edition is not draft" do
     edition = create(:published_edition)
     updater = DraftTranslationUpdater.new(edition)
+    updater.expects(:update_publishing_api!).never
     updater.expects(:notify!).never
 
     updater.perform!

--- a/test/unit/services/edition_unwithdrawer_test.rb
+++ b/test/unit/services/edition_unwithdrawer_test.rb
@@ -8,7 +8,7 @@ class EditionUnwithdrawerTest < ActiveSupport::TestCase
   end
 
   test "initialize raises an error unless the edition is withdrawn" do
-    @edition.update_attribute(:state, "published")
+    @edition = FactoryBot.create(:published_edition, state: 'published')
     unwithdraw
 
     assert_equal ["An edition that is published cannot be unwithdrawn"], @unwithdrawer.failure_reasons


### PR DESCRIPTION
Rather than processing the Publishing API change after the change has
been saved in Whitehall, process it during the transaction. This means
that there is less opportunities for Whitehall's state to diverge from
the Publishing API, as the state will only be transitioned in
Whitehall when the Publishing API update succeeds.