### PR TITLE
Add data migration to republish industrial emissions

### DIFF
--- a/db/data_migration/20181025112807_republish_industrial_emissions_collection.rb
+++ b/db/data_migration/20181025112807_republish_industrial_emissions_collection.rb
@@ -1,0 +1,4 @@
+document = Document.find_by(id: 231128)
+if document
+  PublishingApiDocumentRepublishingWorker.perform_async(231128)
+end


### PR DESCRIPTION
Adds data migration to republish industrial emissions in response to this ticket
https://govuk.zendesk.com/agent/tickets/3217699