### PR TITLE
Publish a high resolution version of lead images

### DIFF
--- a/app/presenters/lead_image_presenter_helper.rb
+++ b/app/presenters/lead_image_presenter_helper.rb
@@ -7,6 +7,14 @@ module LeadImagePresenterHelper
     end
   end
 
+  def high_resolution_lead_image_path
+    if image_data
+      image_data.file.url(:s960)
+    else
+      "placeholder.jpg"
+    end
+  end
+
   def lead_image_alt_text
     if images.first
       images.first.alt_text.squish

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -126,8 +126,17 @@ module PublishingApi
       end
 
       def call
+        image_url = ActionController::Base.helpers.image_url(
+          news_article.lead_image_path, host: Whitehall.public_asset_host
+        )
+
+        high_resolution_url = ActionController::Base.helpers.image_url(
+          news_article.high_resolution_lead_image_path, host: Whitehall.public_asset_host
+        )
+
         {
           image: {
+            high_resolution_url: high_resolution_url,
             url: image_url,
             caption: image_caption,
             alt_text: image_alt_text,
@@ -142,12 +151,6 @@ module PublishingApi
 
       def image_alt_text
         news_article.lead_image_alt_text.squish
-      end
-
-      def image_url
-        ActionController::Base.helpers.image_url(
-          news_article.lead_image_path, host: Whitehall.public_asset_host
-        )
       end
     end
   end

--- a/test/unit/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/news_article_presenter_test.rb
@@ -233,17 +233,18 @@ module PublishingApi::NewsArticlePresenterTest
         .returns(
           stub(
             lead_image_path: '/foo',
+            high_resolution_lead_image_path: '/foo-large',
             lead_image_alt_text: 'Bar',
             lead_image_caption: 'Baz',
           )
         )
 
-      expected_image_url = Whitehall.public_asset_host + '/foo'
       expected_image_caption = 'Baz'
       expected_image_alt_text = 'Bar'
 
       expected_image = {
-        url: expected_image_url,
+        high_resolution_url: Whitehall.public_asset_host + '/foo-large',
+        url: Whitehall.public_asset_host + '/foo',
         caption: expected_image_caption,
         alt_text: expected_image_alt_text,
       }


### PR DESCRIPTION
We currently only expose the image from the page to social media scrapers using the meta tags component. This image is often quite small, and unsuitable for services like Twitter.

This PR sends the 960px version of the image in the publishing-api payload (valid since https://github.com/alphagov/govuk-content-schemas/pull/827). This URL will be used in the meta tag via https://github.com/alphagov/govuk_publishing_components/pull/592.

https://trello.com/c/eqcMykln

