### PR TITLE
Change announcements finder rummager endpoint

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,7 +3,7 @@ class AnnouncementsController < DocumentsController
 
   def index
     expire_on_next_scheduled_publication(scheduled_announcements)
-    @filter = build_document_filter
+    @filter = build_document_filter("announcements")
     @filter.announcements_search
 
     respond_to do |format|

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -4,7 +4,7 @@ class AnnouncementsController < DocumentsController
   def index
     expire_on_next_scheduled_publication(scheduled_announcements)
     @filter = build_document_filter("announcements")
-    @filter.announcements_search
+    search_results = @filter.announcements_search
 
     respond_to do |format|
       format.html do
@@ -23,12 +23,9 @@ class AnnouncementsController < DocumentsController
         )
       end
       format.atom do
-        documents = Announcement.published_with_eager_loading(@filter.documents.map(&:id))
-        @announcements = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse,
-          AnnouncementPresenter,
-          view_context,
-        )
+        @announcements = search_results["results"].map do |result|
+          RummagerDocumentPresenter.new(result)
+        end
       end
     end
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,7 +9,12 @@ class DocumentsController < PublicFacingController
 
 private
 
-  def build_document_filter
+  def build_document_filter(filter_type = nil)
+    search_backend = if filter_type == "announcements"
+                       Whitehall::DocumentFilter::SearchRummager
+                     else
+                       Whitehall::DocumentFilter::AdvancedSearchRummager
+                     end
     search_backend.new(cleaned_document_filter_params)
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,12 +10,7 @@ class DocumentsController < PublicFacingController
 private
 
   def build_document_filter(filter_type = nil)
-    search_backend = if filter_type == "announcements"
-                       Whitehall::DocumentFilter::SearchRummager
-                     else
-                       Whitehall::DocumentFilter::AdvancedSearchRummager
-                     end
-    search_backend.new(cleaned_document_filter_params)
+    search_backend(filter_type).new(cleaned_document_filter_params)
   end
 
   def cleaned_document_filter_params

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -75,11 +75,12 @@ private
     set_slimmer_format_header(Whitehall.analytics_format(analytics_format))
   end
 
-  def search_backend
-    if Locale.current.english?
-      Whitehall.search_backend
+  def search_backend(filter_type)
+    return Whitehall::DocumentFilter::Mysql unless Locale.current.english?
+    if filter_type == "announcements"
+      Whitehall::DocumentFilter::SearchRummager
     else
-      Whitehall::DocumentFilter::Mysql
+      Whitehall::DocumentFilter::AdvancedSearchRummager
     end
   end
 

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -15,6 +15,8 @@ module PublicDocumentRoutesHelper
   end
 
   def document_url(edition, options = {}, _builder_options = {})
+    return edition.link if edition.is_a? RummagerDocumentPresenter
+
     if edition.non_english_edition?
       options[:locale] = edition.primary_locale
     elsif edition.translatable?

--- a/app/presenters/announcement_presenter.rb
+++ b/app/presenters/announcement_presenter.rb
@@ -17,7 +17,7 @@ class AnnouncementPresenter < Whitehall::Decorators::Decorator
   end
 
   def publication_collections
-    if model.respond_to?(:part_of_published_collection?) && model.part_of_published_collection?
+    if model.respond_to?(:published_document_collections) && model.published_document_collections.any?
       links = model.published_document_collections.map do |dc|
         context.link_to(dc.title, context.public_document_path(dc))
       end

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -1,0 +1,41 @@
+##
+## RummagerDocumentPresenter serves as a wrapper for documents returned in results
+## provided by Rummager/Search API, in order to present documents in Finders.
+##
+
+class RummagerDocumentPresenter
+  attr_reader :title, :link, :display_type, :summary, :content_id
+
+  def initialize(document_hash)
+    @document = document_hash
+    @link = @document.fetch('link', '')
+    @title = @document.fetch('title', '')
+    @display_type = @document.fetch('display_type', '')
+    @summary = @document.fetch('description', '')
+    @content_id = @document.fetch('content_id', '')
+  end
+
+  def publication_date
+    I18n.l @document.fetch('public_timestamp', '').to_date, format: :long_ordinal
+  end
+
+  def public_timestamp
+    @document.fetch('public_timestamp', '').to_time
+  end
+
+  def display_type_key
+    @document.fetch('display_type', '')
+  end
+
+  def id
+    # This matches the Atom FeedEntryPresenter in Collections:
+    # https://github.com/alphagov/collections/blob/master/app/presenters/feed_entry_presenter.rb#L9
+    "#{url}##{@document['public_timestamp'].to_date.rfc3339}"
+  end
+
+  private
+
+  def url
+    Plek.current.website_root + link
+  end
+end

--- a/app/services/fetch_from_cache_service.rb
+++ b/app/services/fetch_from_cache_service.rb
@@ -1,0 +1,26 @@
+class FetchFromCacheService
+  attr_reader :type, :slug
+
+  def initialize(type, slug)
+    @type = type
+    @slug = slug
+  end
+
+  def fetch
+    Rails.cache.fetch("#{type}-#{slug}", namespace: "results", expires_in: 30.minutes, race_condition_ttl: 1.second) do
+      case type
+      when :organisation
+        Organisation.includes(:translations).find_by(slug: slug)
+      when :topic
+        Classification.find_by(slug: slug)
+      when :document_collection
+        # Don't fall over if index refers a document which has had it's slug changed.
+        Document.find_by(slug: slug).try(:published_edition)
+      when :operational_field
+        OperationalField.find_by(slug: slug)
+      else
+        raise "Can't fetch '#{type}' -- unknown type"
+      end
+    end
+  end
+end

--- a/app/services/taxons_to_legacy_associations_tagging.rb
+++ b/app/services/taxons_to_legacy_associations_tagging.rb
@@ -3,7 +3,7 @@ class TaxonsToLegacyAssociationsTagging
     # Only perform the taxon based tagging for content with no
     # existing legacy associations, to avoid overriding human tagging
     # decisions
-    return false if any_legacy_associations_for_edition?(edition)
+    return false if tagged_to_specialist_sectors?(edition)
 
     legacy_associations_from_mappping = legacy_mapping_for_taxons(selected_taxons)
 
@@ -20,12 +20,7 @@ class TaxonsToLegacyAssociationsTagging
         legacy_association["content_id"]
       end
 
-      case document_type
-      when "policy"
-        edition.policy_content_ids = content_ids
-      when "policy_area"
-        edition.topics = Topic.where(content_id: content_ids)
-      when "topic"
+      if document_type == "topic"
         # This is inperfect, as the primary specialist sector tag is
         # being set in an arbitrary manor. But, this mapping function
         # is only a temporary thing while the specialist sectors still
@@ -51,20 +46,6 @@ private
     Taxonomy::Mapping
       .new
       .legacy_mapping_for_taxons(selected_taxons)
-  end
-
-  def any_legacy_associations_for_edition?(edition)
-    tagged_to_policies?(edition) ||
-      tagged_to_policy_areas?(edition) ||
-      tagged_to_specialist_sectors?(edition)
-  end
-
-  def tagged_to_policies?(edition)
-    defined?(edition.policy_content_ids) && edition.policy_content_ids.any?
-  end
-
-  def tagged_to_policy_areas?(edition)
-    defined?(edition.topic_ids) && edition.topic_ids.any?
   end
 
   def tagged_to_specialist_sectors?(edition)

--- a/app/views/classifications/_document_list_from_rummager.html.erb
+++ b/app/views/classifications/_document_list_from_rummager.html.erb
@@ -1,0 +1,34 @@
+<%
+   heading ||= type.to_s.humanize
+   filter_option = (heading == "Publications") ? "all" : heading.downcase
+%>
+<section id="<%= heading.downcase %>" class="document-block">
+  <h1 class="label"><%= heading %></h1>
+  <div class="content">
+    <%= render partial: "shared/list_description_for_rummager_list", locals: { heading: heading, editions: documents, documents_count: documents_count, type: type } %>
+    <p class="see-all">
+    <%-
+      see_more_url = public_send(
+        "#{type}_filter_path",
+        @classification,
+        publication_filter_option: filter_option
+      )
+    %>
+    <%=
+      link_to(
+        "See all #{heading.downcase}",
+        see_more_url,
+        data: {
+          track_category: 'navPolicyAreaLinkClicked',
+          track_action: "#{heading}",
+          track_label: see_more_url,
+          track_options: {
+            dimension28: documents_count.to_s,
+            dimension29: "See all #{heading.downcase}"
+          }
+        }
+      )
+    %>
+    </p>
+  </div>
+</section>

--- a/app/views/shared/_list_description_for_rummager_list.html.erb
+++ b/app/views/shared/_list_description_for_rummager_list.html.erb
@@ -1,0 +1,27 @@
+<ol class="document-list">
+  <% editions.each_with_index do |edition, edition_index| %>
+    <li class="document-row" id="<%= "#{type}_#{edition.content_id}" %>">
+      <h2>
+        <%=
+          link_to(
+            edition.title,
+            edition.link,
+            data: {
+              track_category: 'navPolicyAreaLinkClicked',
+              track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",
+              track_label: edition.link,
+              track_options: {
+                dimension28: documents_count.to_s,
+                dimension29: edition.title
+              }
+            }
+          )
+        %>
+      </h2>
+      <ul class="attributes">
+        <li class="publication-date"><%= edition.publication_date %></li>
+        <li class="document-type"><%= t_display_type(edition) %></li>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/shared/_recently_updated_documents_from_rummager.html.erb
+++ b/app/views/shared/_recently_updated_documents_from_rummager.html.erb
@@ -1,0 +1,13 @@
+<ol class="document-list">
+  <% recently_updated.each do |document| %>
+    <li class="document-row">
+      <h2><%= link_to document.title, public_document_path(document) %></h2>
+      <ul class="attributes">
+        <li class="published-date">
+          <%= document.publication_date %>
+        </li>
+        <li class="display-type"><%= t_display_type(document) %></li>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/shared/_recently_updated_from_rummager.html.erb
+++ b/app/views/shared/_recently_updated_from_rummager.html.erb
@@ -1,0 +1,21 @@
+<% extra_class ||= '' %>
+
+<section id="recently-updated" class="recently-updated <%= extra_class %>">
+  <div class="content">
+    <header>
+      <h1 class="label"><%= t('latest_feed.title') %></h1>
+    </header>
+    <% if recently_updated.any? %>
+      <%= render partial: "shared/recently_updated_documents_from_rummager",
+                locals: { recently_updated: recently_updated } %>
+    <% else %>
+      <p><%= t('latest_feed.no_updates') %></p>
+    <% end %>
+    <%= render 'shared/feeds', atom_url: atom_url %>
+    <% if local_assigns[:see_all_link] %>
+      <p class="see-all">
+        <%= link_to 'See all', see_all_link %>
+      </p>
+    <% end %>
+  </div>
+</section>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -58,8 +58,8 @@
           <%= render partial: 'classifications/classification_featuring',
                    collection: @featurings %>
         <% end %>
-        <%= render partial: 'shared/recently_updated',
-                   locals: { recently_updated: @recently_changed_documents,
+        <%= render partial: 'shared/recently_updated_from_rummager',
+                   locals: { recently_updated: @recently_changed_documents['results'],
                            atom_url: atom_feed_url_for(@classification),
                            extra_class: 'panel',
                            see_all_link: latest_path(topics: [@classification]) } %>
@@ -69,9 +69,9 @@
 
   <div class="documents-grid <%= topic_grid_size_class(@publications, @consultations, @announcements) %>">
     <div class="inner-block">
-      <%= render(partial: 'document_list', locals: { documents: @publications, type: :publications }) if @publications.any? %>
-      <%= render(partial: 'document_list', locals: { documents: @consultations, type: :consultations }) if @consultations.any? %>
-      <%= render(partial: 'document_list', locals: { documents: @announcements, type: :announcements }) if @announcements.any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @publications['results'], type: :publications, documents_count: @publications['total'] }) if @publications['results'].any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @consultations['results'], type: :consultations, documents_count: @consultations['total'] }) if @consultations['results'].any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @announcements['results'], type: :announcements, documents_count: @announcements['total'] }) if @announcements['results'].any? %>
 
       <% if @detailed_guides.any? %>
         <section id="detailed-guidance" class="document-block documents-<%= document_block_counter %>">

--- a/config/initializers/search_backend.rb
+++ b/config/initializers/search_backend.rb
@@ -1,5 +1,5 @@
 Whitehall.search_backend = if Rails.env.test?
                              Whitehall::DocumentFilter::Mysql
                            else
-                             Whitehall::DocumentFilter::Rummager
+                             Whitehall::DocumentFilter::AdvancedSearchRummager
                            end

--- a/features/email-signup-for-documents.feature
+++ b/features/email-signup-for-documents.feature
@@ -5,11 +5,13 @@ Feature: Email signup for documents
     And email alert api exists
     And a list of publications exists
 
+  @not-quite-as-fake-search
   Scenario: Signing up to unfiltered publications alerts
     When I visit the list of publications
     And I sign up for emails
     Then I should be signed up for the all publications mailing list
 
+  @not-quite-as-fake-search
   Scenario: Signing up to filtered publications alerts
     When I filter the publications list by "Correspondence"
     And I sign up for emails

--- a/features/fixtures/rummager_response.json
+++ b/features/fixtures/rummager_response.json
@@ -1,0 +1,36 @@
+{
+    "results": [
+        {
+            "link": "/foo/policy_paper",
+            "title": "Policy on Topicals",
+            "public_timestamp": "2016-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-A"
+        },
+        {
+            "link": "/foo/consultation",
+            "title": "Examination of Events",
+            "public_timestamp": "2017-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-B"
+        },
+        {
+            "link": "/foo/news_story",
+            "title": "PM attends summit on topical events",
+            "public_timestamp": "2018-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-C"
+        },
+        {
+            "link": "/foo/statistics",
+            "title": "Weekly topical event price",
+            "public_timestamp": "2018-10-17T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-D"
+        }
+    ]
+}

--- a/features/latest-documents.feature
+++ b/features/latest-documents.feature
@@ -7,7 +7,7 @@ Feature: List of most recently published documents
   Scenario: Latest documents on topical event page
     Given a topical event with published documents
     When I view that topical event page
-    Then I can see some of the latest documents
+    Then I can see some of the latest documents from rummager
     And I can follow a link to see all documents
 
   Scenario: List of all documents published about a topical event

--- a/features/step_definitions/latest_document_steps.rb
+++ b/features/step_definitions/latest_document_steps.rb
@@ -6,6 +6,14 @@ Then(/^I can see some of the latest documents$/) do
   end
 end
 
+Then(/^I can see some of the latest documents from rummager$/) do
+  within('#recently-updated') do
+    assert page.has_css?('header', text: 'Latest')
+    assert page.has_link?('Policy on Topicals')
+    assert page.has_link?('Examination of Events')
+  end
+end
+
 Then(/^I can follow a link to see all documents$/) do
   within('#recently-updated') do
     click_link 'See all'

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -30,6 +30,10 @@ module TopicalEventsHelper
     }
   end
 
+  def rummager_response
+    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
+  end
+
   def stub_topical_event_in_content_store(name)
     content_item = {
       format: "topical_event",

--- a/lib/taxonomy/mapping.rb
+++ b/lib/taxonomy/mapping.rb
@@ -19,19 +19,12 @@ class Taxonomy::Mapping
       taxon.content_id == start_taxon_content_id
     end
 
-    document_types = %w(policy policy_area topic)
-    result = start_taxon.legacy_mapping.slice(*document_types)
+    result = start_taxon.legacy_mapping.slice('topic')
 
-    document_types.each do |document_type|
-      start_taxon.ancestors.each do |ancestor|
-        # Look up through the ancestors to find a mapping for each
-        # document_type, but stop once one is found
+    start_taxon.ancestors.each do |ancestor|
+      break if result['topic'].present?
 
-        result[document_type] = ancestor.legacy_mapping
-                                  .fetch(document_type, [])
-
-        break if result[document_type].present?
-      end
+      result['topic'] = ancestor.legacy_mapping.fetch('topic', [])
     end
 
     result

--- a/lib/whitehall/announcement_filter_option.rb
+++ b/lib/whitehall/announcement_filter_option.rb
@@ -2,11 +2,11 @@ module Whitehall
   class AnnouncementFilterOption < FilterOption
     attr_accessor :speech_types, :news_article_types
 
-    PressRelease = create(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease])
-    NewsStory = create(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory])
-    FatalityNotice = create(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice])
-    Speech = create(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements)
-    Statement = create(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements)
-    GovernmentResponse = create(id: 6, label: "Government responses", search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse])
+    PressRelease = create(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease], document_type: "press_release")
+    NewsStory = create(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory], document_type: %w(news_article news_story))
+    FatalityNotice = create(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice], document_type: "fatality_notice")
+    Speech = create(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements, document_type: "speech")
+    Statement = create(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements, document_type: %w(written_statement oral_statement authored_article))
+    GovernmentResponse = create(id: 6, label: "Government responses", search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse], document_type: "government_response")
   end
 end

--- a/lib/whitehall/document_filter.rb
+++ b/lib/whitehall/document_filter.rb
@@ -1,5 +1,6 @@
 module Whitehall::DocumentFilter
   autoload :Mysql, 'whitehall/document_filter/mysql'
   autoload :FakeSearch, 'whitehall/document_filter/fake_search'
-  autoload :Rummager, 'whitehall/document_filter/rummager'
+  autoload :AdvancedSearchRummager, 'whitehall/document_filter/advanced_search_rummager'
+  autoload :SearchRummager, 'whitehall/document_filter/search_rummager'
 end

--- a/lib/whitehall/document_filter/advanced_search_result.rb
+++ b/lib/whitehall/document_filter/advanced_search_result.rb
@@ -1,0 +1,72 @@
+module Whitehall::DocumentFilter
+  class AdvancedSearchResult
+    ACCESSORS = %w{title description indexable_content attachments
+                   format display_type link id search_format_types
+                   relevant_to_local_government}.freeze
+    ACCESSORS.each do |attribute_name|
+      define_method attribute_name.to_sym do
+        @doc[attribute_name.to_s]
+      end
+    end
+
+    def initialize(doc)
+      @doc = doc
+    end
+
+    def type
+      format
+    end
+
+    def search_government_name
+      @doc['government_name']
+    end
+
+    def historic?
+      @doc['is_historic']
+    end
+
+    def public_timestamp
+      Time.zone.parse(@doc['public_timestamp'])
+    end
+
+    def part_of_published_collection?
+      published_document_collections.any?
+    end
+
+    def organisations
+      @doc.fetch('organisations', []).map { |slug| fetch_from_cache(:organisation, slug) }.compact
+    end
+
+    def topics
+      @doc.fetch('topics', []).map { |slug| fetch_from_cache(:topic, slug) }.compact
+    end
+
+    def published_document_collections
+      @doc.fetch('document_collections', []).map { |slug| fetch_from_cache(:document_collection, slug) }.compact
+    end
+
+    def operational_field
+      fetch_from_cache(:operational_field, @doc['operational_field'])
+    end
+
+  private
+
+    def fetch_from_cache(type, slug)
+      Rails.cache.fetch("#{type}-#{slug}", namespace: "results", expires_in: 30.minutes, race_condition_ttl: 1.second) do
+        case type
+        when :organisation
+          Organisation.includes(:translations).find_by(slug: slug)
+        when :topic
+          Classification.find_by(slug: slug)
+        when :document_collection
+          # Don't fall over if index refers a document which has had it's slug changed.
+          Document.find_by(slug: slug).try(:published_edition)
+        when :operational_field
+          OperationalField.find_by(slug: slug)
+        else
+          raise "Can't fetch '#{type}' -- unknown type"
+        end
+      end
+    end
+  end
+end

--- a/lib/whitehall/document_filter/advanced_search_result.rb
+++ b/lib/whitehall/document_filter/advanced_search_result.rb
@@ -52,21 +52,7 @@ module Whitehall::DocumentFilter
   private
 
     def fetch_from_cache(type, slug)
-      Rails.cache.fetch("#{type}-#{slug}", namespace: "results", expires_in: 30.minutes, race_condition_ttl: 1.second) do
-        case type
-        when :organisation
-          Organisation.includes(:translations).find_by(slug: slug)
-        when :topic
-          Classification.find_by(slug: slug)
-        when :document_collection
-          # Don't fall over if index refers a document which has had it's slug changed.
-          Document.find_by(slug: slug).try(:published_edition)
-        when :operational_field
-          OperationalField.find_by(slug: slug)
-        else
-          raise "Can't fetch '#{type}' -- unknown type"
-        end
-      end
+      FetchFromCacheService.new(type, slug).fetch
     end
   end
 end

--- a/lib/whitehall/document_filter/advanced_search_rummager.rb
+++ b/lib/whitehall/document_filter/advanced_search_rummager.rb
@@ -1,12 +1,7 @@
 require 'whitehall/document_filter/filterer'
 
 module Whitehall::DocumentFilter
-  class Rummager < Filterer
-    def announcements_search
-      filter_args = standard_filter_args.merge(filter_by_announcement_type)
-      @results = Whitehall.government_search_client.advanced_search(filter_args)
-    end
-
+  class AdvancedSearchRummager < Filterer
     def publications_search
       filter_args = standard_filter_args.merge(filter_by_publication_type)
                                         .merge(filter_by_official_document_status)
@@ -117,18 +112,6 @@ module Whitehall::DocumentFilter
       end
     end
 
-    def filter_by_announcement_type
-      announcement_types =
-        if selected_announcement_filter_option
-          selected_announcement_filter_option.search_format_types
-        elsif include_world_location_news
-          [Announcement.search_format_type]
-        else
-          non_world_announcement_types
-        end
-      { search_format_types: announcement_types }
-    end
-
     def filter_by_publication_type
       publication_types =
         if selected_publication_filter_option
@@ -141,21 +124,6 @@ module Whitehall::DocumentFilter
 
     def documents
       @documents ||= ResultSet.new(@results, @page, @per_page).paginated
-    end
-
-  private
-
-    def all_announcement_types
-      all_descendants = Announcement.concrete_descendant_search_format_types
-      descendants_without_news = all_descendants - [NewsArticle.search_format_type]
-      news_article_subtypes = NewsArticleType.search_format_types
-      descendants_without_news + news_article_subtypes
-    end
-
-    def non_world_announcement_types
-      types = all_announcement_types
-      types = types - NewsArticleType::WorldNewsStory.search_format_types
-      types - [WorldLocationNewsArticle.search_format_type]
     end
   end
 end

--- a/lib/whitehall/document_filter/advanced_search_rummager.rb
+++ b/lib/whitehall/document_filter/advanced_search_rummager.rb
@@ -123,7 +123,7 @@ module Whitehall::DocumentFilter
     end
 
     def documents
-      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+      @documents ||= ResultSet.new(@results, @page, @per_page, AdvancedSearchResult).paginated
     end
   end
 end

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -96,6 +96,10 @@ module Whitehall::DocumentFilter
       @include_world_location_news.to_s == '1'
     end
 
+    def all_announcement_filter_options
+      Whitehall::AnnouncementFilterOption.all
+    end
+
   private
 
     def find_by_slug(klass, slugs)

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -80,6 +80,11 @@ module Whitehall::DocumentFilter
       WorldLocation.where(slug: @world_locations)
     end
 
+    def selected_topical_events
+      topics = find_by_slug(Classification, @topics)
+      topics.select { |topic| topic.type == "TopicalEvent" }
+    end
+
     def selected_official_document_status
       @official_document_status
     end

--- a/lib/whitehall/document_filter/result_set.rb
+++ b/lib/whitehall/document_filter/result_set.rb
@@ -1,16 +1,15 @@
 module Whitehall::DocumentFilter
   class ResultSet
-    def initialize(results, page, per_page)
+    def initialize(results, page, per_page, result_type)
       @results = results
       @docs = results.respond_to?(:[]) ? results['results'] : []
       @page = page
       @per_page = per_page
+      @result_type = result_type
     end
 
     def merged_results
-      @docs.map do |doc|
-        Result.new(doc)
-      end
+      @docs.map { |doc| @result_type.new(doc) }
     end
 
     def paginated

--- a/lib/whitehall/document_filter/search_result.rb
+++ b/lib/whitehall/document_filter/search_result.rb
@@ -56,21 +56,7 @@ module Whitehall::DocumentFilter
   private
 
     def fetch_from_cache(type, slug)
-      Rails.cache.fetch("#{type}-#{slug}", namespace: "results", expires_in: 30.minutes, race_condition_ttl: 1.second) do
-        case type
-        when :organisation
-          Organisation.includes(:translations).find_by(slug: slug)
-        when :topic
-          Classification.find_by(slug: slug)
-        when :document_collection
-          # Don't fall over if index refers a document which has had it's slug changed.
-          Document.find_by(slug: slug).try(:published_edition)
-        when :operational_field
-          OperationalField.find_by(slug: slug)
-        else
-          raise "Can't fetch '#{type}' -- unknown type"
-        end
-      end
+      FetchFromCacheService.new(type, slug).fetch
     end
   end
 end

--- a/lib/whitehall/document_filter/search_result.rb
+++ b/lib/whitehall/document_filter/search_result.rb
@@ -1,7 +1,7 @@
 module Whitehall::DocumentFilter
   class SearchResult
     ACCESSORS = %w{title description indexable_content attachments
-                   format link content_id search_format_types
+                   format content_id search_format_types
                    relevant_to_local_government display_type id}.freeze
     ACCESSORS.each do |attribute_name|
       define_method attribute_name.to_sym do
@@ -47,6 +47,10 @@ module Whitehall::DocumentFilter
 
     def operational_field
       fetch_from_cache(:operational_field, @doc['operational_field'])
+    end
+
+    def link
+      @doc.fetch('link', [])
     end
 
   private

--- a/lib/whitehall/document_filter/search_result.rb
+++ b/lib/whitehall/document_filter/search_result.rb
@@ -1,8 +1,8 @@
 module Whitehall::DocumentFilter
-  class Result
+  class SearchResult
     ACCESSORS = %w{title description indexable_content attachments
-                   format display_type link id search_format_types
-                   relevant_to_local_government}.freeze
+                   format link content_id search_format_types
+                   relevant_to_local_government display_type id}.freeze
     ACCESSORS.each do |attribute_name|
       define_method attribute_name.to_sym do
         @doc[attribute_name.to_s]
@@ -26,7 +26,7 @@ module Whitehall::DocumentFilter
     end
 
     def public_timestamp
-      Time.zone.parse(@doc['public_timestamp'])
+      @doc['public_timestamp'].nil? ? Time.zone.now : Time.zone.parse(@doc['public_timestamp'])
     end
 
     def part_of_published_collection?
@@ -34,15 +34,15 @@ module Whitehall::DocumentFilter
     end
 
     def organisations
-      @doc.fetch('organisations', []).map { |slug| fetch_from_cache(:organisation, slug) }.compact
+      @doc.fetch('organisations', []).map { |organisation| fetch_from_cache(:organisation, organisation.fetch('slug', nil)) }.compact
     end
 
     def topics
-      @doc.fetch('topics', []).map { |slug| fetch_from_cache(:topic, slug) }.compact
+      @doc.fetch('topics', []).map { |topic| fetch_from_cache(:topic, topic.fetch('slug', nil)) }.compact
     end
 
     def published_document_collections
-      @doc.fetch('document_collections', []).map { |slug| fetch_from_cache(:document_collection, slug) }.compact
+      @doc.fetch('document_collections', []).map { |document_collection| fetch_from_cache(:document_collection, document_collection.fetch('slug', nil)) }.compact
     end
 
     def operational_field

--- a/lib/whitehall/document_filter/search_result.rb
+++ b/lib/whitehall/document_filter/search_result.rb
@@ -2,7 +2,7 @@ module Whitehall::DocumentFilter
   class SearchResult
     ACCESSORS = %w{title description indexable_content attachments
                    format content_id search_format_types
-                   relevant_to_local_government display_type id}.freeze
+                   relevant_to_local_government display_type id document_collections}.freeze
     ACCESSORS.each do |attribute_name|
       define_method attribute_name.to_sym do
         @doc[attribute_name.to_s]

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -25,6 +25,7 @@ module Whitehall::DocumentFilter
         .merge(filter_by_locations)
         .merge(filter_by_date)
         .merge(filter_by_taxon)
+        .merge(filter_by_topical_event)
         .merge(sort)
     end
 
@@ -65,6 +66,14 @@ module Whitehall::DocumentFilter
     def filter_by_locations
       if selected_locations.any?
         { filter_world_locations: selected_locations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_topical_event
+      if selected_topical_events.any?
+        { filter_topical_events: selected_topical_events.map(&:slug) }
       else
         {}
       end

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -13,7 +13,7 @@ module Whitehall::DocumentFilter
         count: @per_page.to_s,
         fields: %w[content_store_document_type government_name is_historic
                    public_timestamp organisations operational_field format
-                   content_id title description display_type id]
+                   content_id title description display_type link]
       }
     end
 

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -103,7 +103,7 @@ module Whitehall::DocumentFilter
     end
 
     def documents
-      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+      @documents ||= ResultSet.new(@results, @page, @per_page, SearchResult).paginated
     end
 
   private

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -93,13 +93,13 @@ module Whitehall::DocumentFilter
     def filter_by_announcement_type
       announcement_types =
         if selected_announcement_filter_option
-          selected_announcement_filter_option.search_format_types
+          selected_announcement_filter_option.document_type
         elsif include_world_location_news
-          [Announcement.search_format_type]
+          all_announcement_types
         else
           non_world_announcement_types
         end
-      { filter_search_format_types: announcement_types }
+      { filter_content_store_document_type: announcement_types }
     end
 
     def documents
@@ -109,16 +109,11 @@ module Whitehall::DocumentFilter
   private
 
     def all_announcement_types
-      all_descendants = Announcement.concrete_descendant_search_format_types
-      descendants_without_news = all_descendants - [NewsArticle.search_format_type]
-      news_article_subtypes = NewsArticleType.search_format_types
-      descendants_without_news + news_article_subtypes
+      %w(world_location_news_article world_news_story).concat(non_world_announcement_types)
     end
 
     def non_world_announcement_types
-      types = all_announcement_types
-      types = types - NewsArticleType::WorldNewsStory.search_format_types
-      types - [WorldLocationNewsArticle.search_format_type]
+      all_announcement_filter_options.map(&:document_type).flatten
     end
   end
 end

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -9,7 +9,7 @@ module Whitehall::DocumentFilter
 
     def default_filter_args
       @default = {
-        start: @page.to_s,
+        start: position_in_result_list.to_s,
         count: @per_page.to_s,
         fields: %w[content_store_document_type government_name is_historic
                    public_timestamp organisations operational_field format
@@ -123,6 +123,10 @@ module Whitehall::DocumentFilter
 
     def non_world_announcement_types
       all_announcement_filter_options.map(&:document_type).flatten
+    end
+
+    def position_in_result_list
+      (@page.to_i - 1) * @per_page.to_i
     end
   end
 end

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -1,0 +1,124 @@
+require 'whitehall/document_filter/filterer'
+
+module Whitehall::DocumentFilter
+  class SearchRummager < Filterer
+    def announcements_search
+      filter_args = standard_filter_args.merge(filter_by_announcement_type)
+      @results = Whitehall.search_client.search(filter_args)
+    end
+
+    def default_filter_args
+      @default = {
+        start: @page.to_s,
+        count: @per_page.to_s,
+        fields: %w[content_store_document_type government_name is_historic
+                   public_timestamp organisations operational_field format
+                   content_id title description display_type id]
+      }
+    end
+
+    def standard_filter_args
+      default_filter_args
+        .merge(filter_by_keywords)
+        .merge(filter_by_people)
+        .merge(filter_by_organisations)
+        .merge(filter_by_locations)
+        .merge(filter_by_date)
+        .merge(filter_by_taxon)
+        .merge(sort)
+    end
+
+    def filter_by_keywords
+      if @keywords.present?
+        { q: @keywords.to_s }
+      else
+        {}
+      end
+    end
+
+    def filter_by_people
+      if @people.present? && @people != %w[all]
+        { filter_people: @people }
+      else
+        {}
+      end
+    end
+
+    def filter_by_taxon
+      if selected_subtaxons.any? { |taxon| taxon != "all" }
+        { filter_part_of_taxonomy_tree: selected_subtaxons }
+      elsif selected_taxons.any?
+        { filter_part_of_taxonomy_tree: selected_taxons }
+      else
+        {}
+      end
+    end
+
+    def filter_by_organisations
+      if selected_organisations.any?
+        { filter_organisations: selected_organisations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_locations
+      if selected_locations.any?
+        { filter_world_locations: selected_locations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_date
+      dates_hash = {}
+      dates_hash[:from] = @from_date.to_s if @from_date.present?
+      dates_hash[:to] = @to_date.to_s if @to_date.present?
+
+      if dates_hash.empty?
+        {}
+      else
+        { filter_public_timestamp: dates_hash.map { |k, v| "#{k}:#{v}" }.join(',') }
+      end
+    end
+
+    def sort
+      if @keywords.blank?
+        { order: '-public_timestamp' }
+      else
+        {}
+      end
+    end
+
+    def filter_by_announcement_type
+      announcement_types =
+        if selected_announcement_filter_option
+          selected_announcement_filter_option.search_format_types
+        elsif include_world_location_news
+          [Announcement.search_format_type]
+        else
+          non_world_announcement_types
+        end
+      { filter_search_format_types: announcement_types }
+    end
+
+    def documents
+      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+    end
+
+  private
+
+    def all_announcement_types
+      all_descendants = Announcement.concrete_descendant_search_format_types
+      descendants_without_news = all_descendants - [NewsArticle.search_format_type]
+      news_article_subtypes = NewsArticleType.search_format_types
+      descendants_without_news + news_article_subtypes
+    end
+
+    def non_world_announcement_types
+      types = all_announcement_types
+      types = types - NewsArticleType::WorldNewsStory.search_format_types
+      types - [WorldLocationNewsArticle.search_format_type]
+    end
+  end
+end

--- a/lib/whitehall/filter_option.rb
+++ b/lib/whitehall/filter_option.rb
@@ -2,7 +2,7 @@ module Whitehall
   class FilterOption
     include ActiveRecordLikeInterface
 
-    attr_accessor :id, :label, :search_format_types, :group_key
+    attr_accessor :id, :label, :search_format_types, :group_key, :document_type
     attr_writer :edition_types, :slug
 
     def slug
@@ -21,6 +21,10 @@ module Whitehall
       all.detect do |at|
         format_types.any? { |t| at.search_format_types.include?(t) }
       end
+    end
+
+    def self.document_types
+      all.map(&:document_type)
     end
   end
 end

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -39,7 +39,7 @@ module Whitehall
         keywords = params.delete("q")
         order = { public_timestamp: "desc" }
         per_page = params.delete("count").to_i
-        page = params.delete("start").to_i
+        page = params.delete("start").to_i + 1
         params.delete("fields")
         params.delete("order")
         apply_filters(keywords, params, order, per_page, page, true)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -7,7 +7,10 @@ module Whitehall
       Whitehall.government_search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
-      Whitehall.search_backend = Whitehall::DocumentFilter::Rummager
+      Whitehall.search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
+        SearchIndex.government_search_index_path, store
+      )
+      Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
     end
 
     def self.start_faking_it_again!
@@ -21,8 +24,15 @@ module Whitehall
         @store = store
       end
 
-      def search(*_args)
-        raise "Not implemented"
+      def search(params)
+        params = params.stringify_keys
+        keywords = params.delete("q")
+        order = { public_timestamp: "desc" }
+        per_page = params.delete("count").to_i
+        page = params.delete("start").to_i
+        params.delete("fields")
+        params.delete("order")
+        apply_filters(keywords, params, order, per_page, page)
       end
 
       def autocomplete(*_args)
@@ -60,6 +70,7 @@ module Whitehall
             search_format_types
             world_locations
             document_collections
+            content_store_document_type
           },
           date: %w{public_timestamp},
           boolean: %w{
@@ -78,10 +89,10 @@ module Whitehall
 
       def apply_filters(keywords, params, order, per_page, page)
         results = @store.index(@index_name).values
-
         results = filter_by_keywords(keywords, results) unless keywords.blank?
 
         results = params.inject(results) do |new_results, (field_name, value)|
+          field_name = field_name.gsub(/filter_/, "")
           case field_type(field_name)
           when :date
             filter_by_date_field(field_name, value, new_results)
@@ -163,7 +174,14 @@ module Whitehall
       end
 
       def filter_by_simple_field(field, desired_field_values, document_hashes)
-        document_hashes.select { |document_hash| ([*desired_field_values] & document_hash.fetch(field, [])).any? }
+        document_hashes.select do |document_hash|
+          value = document_hash.fetch(field, [])
+          if value.is_a?(String)
+            Array(desired_field_values).include?(value)
+          else
+            (Array(desired_field_values) & value).any?
+          end
+        end
       end
 
       def filter_by_date_field(field, date_filter_hash, document_hashes)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -104,7 +104,7 @@ module Whitehall
             raise GdsApi::HTTPErrorResponse, "cannot filter by field '#{field_name}', its type is not known"
           end
         end
-
+        results = announcements_search ? format_organisations(results) : results
         if order && order.any?
           results = Ordering.new(order).sort(results)
         end
@@ -112,6 +112,18 @@ module Whitehall
           "total" => results.count,
           "results" => paginate(results, per_page, page)
         }
+      end
+
+      def format_organisations(results)
+        # Now we're querying the 'search' endpoint, results["organisations"]
+        # needs to return a hash
+        results.each do |result|
+          organisations = result.fetch("organisations", [])
+          if organisations.any? && organisations[0].is_a?(String)
+            result["organisations"] = organisations.map { |org| { "slug" => org } }
+          end
+        end
+        results
       end
 
       def paginate(results, per_page, page)
@@ -175,13 +187,21 @@ module Whitehall
 
       def filter_by_simple_field(field, desired_field_values, document_hashes)
         document_hashes.select do |document_hash|
-          value = document_hash.fetch(field, [])
+          if field == "organisations"
+            value = organisation_slugs(document_hash["organisations"])
+          else
+            value = document_hash.fetch(field, [])
+          end
           if value.is_a?(String)
             Array(desired_field_values).include?(value)
           else
             (Array(desired_field_values) & value).any?
           end
         end
+      end
+
+      def organisation_slugs(organisations)
+        organisations.map { |org| org["slug"] if org.fetch("slug") }
       end
 
       def filter_by_date_field(field, date_filter_hash, document_hashes)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -32,7 +32,7 @@ module Whitehall
         page = params.delete("start").to_i
         params.delete("fields")
         params.delete("order")
-        apply_filters(keywords, params, order, per_page, page)
+        apply_filters(keywords, params, order, per_page, page, true)
       end
 
       def autocomplete(*_args)
@@ -87,7 +87,7 @@ module Whitehall
         end
       end
 
-      def apply_filters(keywords, params, order, per_page, page)
+      def apply_filters(keywords, params, order, per_page, page, announcements_search = false)
         results = @store.index(@index_name).values
         results = filter_by_keywords(keywords, results) unless keywords.blank?
 
@@ -99,7 +99,7 @@ module Whitehall
           when :boolean
             filter_by_boolean_field(field_name, value, new_results)
           when :simple
-            filter_by_simple_field(field_name, value, new_results)
+            filter_by_simple_field(field_name, value, new_results, announcements_search)
           else
             raise GdsApi::HTTPErrorResponse, "cannot filter by field '#{field_name}', its type is not known"
           end
@@ -185,13 +185,15 @@ module Whitehall
         document_hashes.select { |document_hash| document_hash[field] == desired_boolean }
       end
 
-      def filter_by_simple_field(field, desired_field_values, document_hashes)
+      def filter_by_simple_field(field, desired_field_values, document_hashes, announcements_search = false)
         document_hashes.select do |document_hash|
-          if field == "organisations"
-            value = organisation_slugs(document_hash["organisations"])
-          else
-            value = document_hash.fetch(field, [])
-          end
+          value =
+            if field == "organisations" && announcements_search
+              organisation_slugs(document_hash.fetch("organisations", []))
+            else
+              document_hash.fetch(field, [])
+            end
+
           if value.is_a?(String)
             Array(desired_field_values).include?(value)
           else

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -2,19 +2,29 @@ require 'whitehall/document_filter/filterer'
 module Whitehall
   module NotQuiteAsFakeSearch
     def self.stop_faking_it_quite_so_much!
+      @search_indexer_class_store = SearchIndex.indexer_class.store
       store = Whitehall::NotQuiteAsFakeSearch::Store.new
       SearchIndex.indexer_class.store = store
+
+      @government_search_client = Whitehall.government_search_client
       Whitehall.government_search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_client = Whitehall.search_client
       Whitehall.search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_backend = Whitehall.search_backend
       Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
     end
 
     def self.start_faking_it_again!
-      SearchIndex.indexer_class.store = nil
+      SearchIndex.indexer_class.store = @search_indexer_class_store
+      Whitehall.government_search_client = @government_search_client
+      Whitehall.search_client = @search_client
+      Whitehall.search_backend = @search_backend
     end
 
     class GdsApiRummager

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -201,11 +201,10 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index only lists publications in the given locale" do
     english_publication = create(:published_publication)
     french_publication = create(:published_publication, translated_into: [:fr])
-
     get :index, params: { locale: 'fr' }
 
-    assert_select_object french_publication
-    refute_select_object english_publication
+    assert_select "#publication_#{french_publication.id}"
+    refute_select "#publication_#{english_publication.id}"
   end
 
   view_test '#index for non-english locales only allows filtering by world location' do

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -23,6 +23,7 @@ class StatisticsControllerTest < ActionController::TestCase
     content_store_has_item(@content_item['base_path'], @content_item)
 
     stub_taxonomy_with_all_taxons
+    @rummager = stub
   end
 
   view_test "#index only displays *published* statistics" do
@@ -115,11 +116,10 @@ class StatisticsControllerTest < ActionController::TestCase
   view_test "#index only lists statistics in the given locale" do
     english_publication = create(:published_statistics)
     french_publication = create(:published_statistics, translated_into: [:fr])
-
     get :index, params: { locale: 'fr' }
 
-    assert_select_object french_publication
-    refute_select_object english_publication
+    assert_select "#publication_#{french_publication.id}"
+    refute_select "#publication_#{english_publication.id}"
   end
 
   view_test '#index for non-english locales does not allow any filtering' do

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -13,9 +13,13 @@ class RoutingTest < ActionDispatch::IntegrationTest
   test "assets are served under the #{Whitehall.router_prefix} prefix" do
     content_store_has_item('/government/publications', {})
     stub_taxonomy_with_all_taxons
+    rummager = stub
 
-    get publications_path
-    assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
+    with_stubbed_rummager(rummager) do
+      rummager.expects(:advanced_search)
+      get publications_path
+      assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
+    end
   end
 
   test "visiting #{Whitehall.router_prefix} when not in frontend redirects to /" do

--- a/test/support/atom_test_helpers.rb
+++ b/test/support/atom_test_helpers.rb
@@ -13,7 +13,6 @@ module AtomTestHelpers
     assert_select 'feed > entry', count: documents.length do |entries|
       entries.zip(documents).each do |entry, document|
         assert_select entry, 'id', 1
-        assert_select entry, 'published', count: 1, text: document.first_public_at.iso8601
         assert_select entry, 'updated', count: 1, text: document.public_timestamp.iso8601
         assert_select(
           entry,
@@ -23,7 +22,7 @@ module AtomTestHelpers
         assert_select entry, 'title', count: 1, text: "#{document.display_type}: #{document.title}"
         assert_select entry, 'summary', count: 1, text: document.summary
         assert_select entry, 'category', count: 1, label: document.display_type, term: document.display_type
-        assert_select entry, 'content[type=?]', 'html', count: 1, text: /#{document.body}/
+        assert_select entry, 'content[type=?]', 'html', count: 1, text: /#{document.try(:body)}/
       end
     end
   end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -393,14 +393,18 @@ module DocumentControllerTestHelpers
 
     def should_return_json_suitable_for_the_document_filter(document_type)
       include DocumentFilterHelpers
-
+      announcement = %i(news_article speech).include?(document_type)
       view_test "index requested as JSON includes a count of #{document_type}" do
         rummager = stub
-        with_stubbed_rummager(rummager) do
-          rummager.expects(:search).returns('results' =>
-                                              [{ 'format' => document_type.to_s,
-                                                 'content_id' => 1 }])
-
+        with_stubbed_rummager(rummager, announcement) do
+          if announcement
+            rummager.expects(:search).returns('results' =>
+              [{ 'format' => document_type.to_s }])
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+              [{ 'format' => document_type.to_s,
+                 'public_timestamp' => Time.zone.now.to_s }])
+          end
           get :index, format: :json
 
           assert_equal 1, ActiveSupport::JSON.decode(response.body)["count"]
@@ -409,10 +413,13 @@ module DocumentControllerTestHelpers
 
       view_test "index requested as JSON includes the total pages of #{document_type}" do
         rummager = stub
-        with_stubbed_rummager(rummager) do
-          rummager.expects(:search).returns('results' =>
-                                              (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
-
+        with_stubbed_rummager(rummager, announcement) do
+          if announcement
+            rummager.expects(:search).returns('results' => (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+                                                (0..4).map { { 'format' => document_type.to_s, 'public_timestamp' => Time.zone.now.to_s } })
+          end
           with_number_of_documents_per_page(3) do
             get :index, format: :json
           end
@@ -424,8 +431,12 @@ module DocumentControllerTestHelpers
       view_test "index requested as JSON includes the current page of #{document_type}" do
         rummager = stub
         with_stubbed_rummager(rummager) do
-          doc = create(:"published_#{document_type}")
-          rummager.expects(:search).returns('results' => { 'format' => document_type.to_s, 'slug' => doc.slug })
+          if announcement
+            rummager.expects(:search).returns('results' => [{ 'format' => document_type.to_s, 'id' => 1 }])
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+              [{ 'format' => document_type.to_s, 'id' => 1, 'public_timestamp' => Time.zone.now.to_s }])
+          end
 
           get :index, format: :json
           assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -398,7 +398,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager) do
           rummager.expects(:search).returns('results' =>
-                                              [{ 'format' => "published_#{document_type}",
+                                              [{ 'format' => document_type.to_s,
                                                  'content_id' => 1 }])
 
           get :index, format: :json
@@ -411,7 +411,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager) do
           rummager.expects(:search).returns('results' =>
-                                              (0..4).map { |n| { 'format' => "published_#{document_type}", 'content_id' => n } })
+                                              (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
 
           with_number_of_documents_per_page(3) do
             get :index, format: :json
@@ -422,11 +422,14 @@ module DocumentControllerTestHelpers
       end
 
       view_test "index requested as JSON includes the current page of #{document_type}" do
-        create(:"published_#{document_type}")
+        rummager = stub
+        with_stubbed_rummager(rummager) do
+          doc = create(:"published_#{document_type}")
+          rummager.expects(:search).returns('results' => { 'format' => document_type.to_s, 'slug' => doc.slug })
 
-        get :index, format: :json
-
-        assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]
+          get :index, format: :json
+          assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,8 +65,11 @@ class ActiveSupport::TestCase
 
   def with_stubbed_rummager(stubbed_object, announcements = false)
     previous_client = Whitehall.search_client
+    previous_government_search_client = Whitehall.government_search_client
     previous_backend = Whitehall.search_backend
+
     Whitehall.search_client = stubbed_object
+    Whitehall.government_search_client = stubbed_object
     Whitehall.search_backend =
       if announcements
         Whitehall::DocumentFilter::SearchRummager
@@ -74,7 +77,9 @@ class ActiveSupport::TestCase
         Whitehall::DocumentFilter::AdvancedSearchRummager
       end
     yield
+
     Whitehall.search_client = previous_client
+    Whitehall.government_search_client = previous_government_search_client
     Whitehall.search_backend = previous_backend
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,6 +63,16 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
+  def with_stubbed_rummager(stubbed_object)
+    previous_client = Whitehall.search_client
+    previous_backend = Whitehall.search_backend
+    Whitehall.search_client = stubbed_object
+    Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
+    yield
+    Whitehall.search_client = previous_client
+    Whitehall.search_backend = previous_backend
+  end
+
   def acting_as(actor, &block)
     Edition::AuditTrail.acting_as(actor, &block)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,11 +63,16 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
-  def with_stubbed_rummager(stubbed_object)
+  def with_stubbed_rummager(stubbed_object, announcements = false)
     previous_client = Whitehall.search_client
     previous_backend = Whitehall.search_backend
     Whitehall.search_client = stubbed_object
-    Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
+    Whitehall.search_backend =
+      if announcements
+        Whitehall::DocumentFilter::SearchRummager
+      else
+        Whitehall::DocumentFilter::AdvancedSearchRummager
+      end
     yield
     Whitehall.search_client = previous_client
     Whitehall.search_backend = previous_backend

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class RummagerDocumentPresenterTest < ActiveSupport::TestCase
+  def rummager_result
+    {
+      "link" => "/government/news/quiddich-world-cup-2018",
+      "title" => "Quiddich World Cup 2018",
+      "description" => "The Quiddich World Cup 2018 will be...",
+      "public_timestamp" => "2018-10-25T10:18:32Z",
+      "display_type" => "News story"
+    }
+  end
+
+  def presenter
+    RummagerDocumentPresenter.new rummager_result
+  end
+
+  test "will provide access to document attributes required for Finders and Lists" do
+    assert_equal rummager_result['title'], presenter.title
+    assert_equal rummager_result['link'], presenter.link
+    assert_equal rummager_result['display_type'], presenter.display_type_key
+  end
+
+  test "will produce a humanized publication date required by Finders and Lists" do
+    assert_equal presenter.publication_date, '25 October 2018'
+  end
+end

--- a/test/unit/services/taxons_to_legacy_associations_tagging_test.rb
+++ b/test/unit/services/taxons_to_legacy_associations_tagging_test.rb
@@ -1,60 +1,6 @@
 require 'test_helper'
 
 class TaxonsToLegacyAssociationsTaggingTest < ActiveSupport::TestCase
-  test "handles policies" do
-    policy = Policy.new(
-      "content_id" => SecureRandom.uuid,
-      "title" => "Test Policy",
-      "base_path" => "/government/policies/test-policy",
-      "internal_name" => "Test Policy"
-    )
-    taxon = taxon_mapped_to_policy(policy.content_id)
-
-    Taxonomy::TopicTaxonomy
-      .any_instance
-      .stubs(:all_taxons)
-      .returns([taxon])
-
-    edition = create(:publication)
-    edition.topics.delete_all
-
-    Services.publishing_api
-      .expects(:get_links)
-      .with(policy.content_id)
-      .raises(GdsApi::HTTPNotFound.new(404))
-
-    TaxonsToLegacyAssociationsTagging.new.call(
-      edition: edition,
-      user: create(:user),
-      selected_taxons: [taxon.content_id]
-    )
-
-    assert edition.policy_content_ids.count, 1
-    assert edition.policy_content_ids.first, policy.content_id
-  end
-
-  test "handles policy areas" do
-    policy_area = create(:topic)
-    taxon = taxon_mapped_to_policy_area(policy_area.content_id)
-
-    Taxonomy::TopicTaxonomy
-      .any_instance
-      .stubs(:all_taxons)
-      .returns([taxon])
-
-    edition = create(:publication)
-    edition.topics.delete_all
-
-    TaxonsToLegacyAssociationsTagging.new.call(
-      edition: edition,
-      user: create(:user),
-      selected_taxons: [taxon.content_id]
-    )
-
-    assert edition.topics.count, 1
-    assert edition.topics.first.content_id, policy_area.content_id
-  end
-
   test "handles specialist sectors" do
     specialist_sector_content_id = SecureRandom.uuid
     taxon = taxon_mapped_to_specialist_sector(
@@ -77,40 +23,6 @@ class TaxonsToLegacyAssociationsTaggingTest < ActiveSupport::TestCase
 
     assert edition.specialist_sectors.count, 1
     assert edition.specialist_sectors.first.topic_content_id, specialist_sector_content_id
-  end
-
-  def taxon_mapped_to_policy(policy_content_id)
-    Taxonomy::Taxon.new(
-      title: "Taxon mapped to policy",
-      base_path: "/mapped-to-policy",
-      content_id: "4415339f-d907-46e1-bc55-2e0c4b313787",
-      legacy_mapping: {
-        "policy" => [
-          {
-            "content_id" => policy_content_id,
-            "document_type" => "policy",
-            "title" => "Test Policy"
-          }
-        ]
-      }
-    )
-  end
-
-  def taxon_mapped_to_policy_area(policy_area_content_id)
-    Taxonomy::Taxon.new(
-      title: "Taxon mapped to policy area",
-      base_path: "/mapped-to-policy-area",
-      content_id: "24a01d2e-e4c4-4abf-bcdc-322289f135d8",
-      legacy_mapping: {
-        "policy_area" => [
-          {
-            "content_id" => policy_area_content_id,
-            "document_type" => "policy_area",
-            "title" => "Test Policy Area"
-          }
-        ]
-      }
-    )
   end
 
   def taxon_mapped_to_specialist_sector(specialist_sector_content_id)

--- a/test/unit/taxonomy/mapping_test.rb
+++ b/test/unit/taxonomy/mapping_test.rb
@@ -13,7 +13,7 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       test_taxon_with_direct_mapping.content_id
     )
 
-    assert_equal result.dig("policy_area", 0, "title"), "Test Policy Area"
+    assert_equal "Test Specialist Sector", result.dig("topic", 0, "title")
   end
 
   test "legacy_mapping_for_taxon with a indirect mapping" do
@@ -21,20 +21,17 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       test_taxon_with_indirect_mapping.content_id
     )
 
-    assert_equal result.dig("policy_area", 0, "title"), "Test Policy Area"
+    assert_equal "Test Specialist Sector", result.dig("topic", 0, "title")
   end
 
   test "legacy_mapping_for_taxons" do
     result = Taxonomy::Mapping.new.legacy_mapping_for_taxons(
-      [
-        test_taxon_with_direct_mapping.content_id,
-        test_taxon_with_multiple_legacy_taxons.content_id
-      ]
+      all_taxons.map(&:content_id)
     )
 
     assert_equal 2, result.length
     assert_same_elements(
-      ["Test Policy Area", "Test legacy policy"],
+      ["Test Specialist Sector", "Another Test Specialist Sector"],
       result.map { |x| x["title"] }
     )
   end
@@ -43,7 +40,7 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
     [
       test_taxon_with_direct_mapping,
       test_taxon_with_indirect_mapping,
-      test_taxon_with_multiple_legacy_taxons
+      another_test_taxon_with_direct_mapping
     ]
   end
 
@@ -53,10 +50,10 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
       base_path: "/direct-mapping",
       content_id: "341b0937-8590-47d6-8fa6-3203e162ec93",
       legacy_mapping: {
-        "policy_area" => [
+        "topic" => [
           {
             "content_id" => "35baa314-9f31-4276-bad2-30bba3f40975",
-            "title" => "Test Policy Area"
+            "title" => "Test Specialist Sector"
           }
         ]
       }
@@ -76,22 +73,16 @@ class Taxonomy::MappingTest < ActiveSupport::TestCase
     taxon
   end
 
-  def test_taxon_with_multiple_legacy_taxons
+  def another_test_taxon_with_direct_mapping
     Taxonomy::Taxon.new(
-      title: "Multiple legacy",
-      base_path: "/multiple-legacy",
-      content_id: "bb5fbd37-0b75-4f90-8a24-b19d1d8b16f4",
+      title: "Direct mapping",
+      base_path: "/direct-mapping",
+      content_id: "59d39ef3-2d6d-4b38-8d8b-37c0d0390a29",
       legacy_mapping: {
-        "policy_area" => [
+        "topic" => [
           {
-            "content_id" => "35baa314-9f31-4276-bad2-30bba3f40975",
-            "title" => "Test Policy Area"
-          }
-        ],
-        "policy" => [
-          {
-            "content_id" => "40911228-459d-4568-8199-c2d921f5388f",
-            "title" => "Test legacy policy"
+            "content_id" => "e2aa4b5a-60d1-40c8-a1fd-ae94ee469efc",
+            "title" => "Another Test Specialist Sector"
           }
         ]
       }

--- a/test/unit/whitehall/document_filter/advanced_search_rummager_test.rb
+++ b/test/unit/whitehall/document_filter/advanced_search_rummager_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+module Whitehall::DocumentFilter
+  class AdvancedSearchRummagerTest < ActiveSupport::TestCase
+    setup do
+      Whitehall.government_search_client.stubs(:advanced_search).returns {}
+    end
+
+    def format_types(*classes)
+      classes.map(&:search_format_type)
+    end
+
+    def expect_search_by_format_types(format_types)
+      Whitehall
+        .government_search_client
+        .expects(:advanced_search)
+        .with(
+          has_entry(
+            search_format_types: format_types
+          )
+        )
+    end
+
+    def expect_search_by_taxonomy_tree(taxons)
+      Whitehall
+          .government_search_client
+          .expects(:advanced_search)
+          .with(
+            has_entry(
+              part_of_taxonomy_tree: taxons
+            )
+          )
+    end
+
+    def expect_search_by_people(people)
+      Whitehall
+        .government_search_client
+        .expects(:advanced_search)
+        .with(
+          has_entry(people: people)
+        )
+    end
+
+    test 'publications_search looks for Publications, Consultations, and StatisticalDataSets by default' do
+      rummager = AdvancedSearchRummager.new({})
+      expect_search_by_format_types(format_types(Consultation, Publication, StatisticalDataSet))
+      rummager.publications_search
+    end
+
+    test 'publications_search looks for a specific announcement sub type if we use the publication_type option' do
+      rummager = AdvancedSearchRummager.new(publication_type: 'policy-papers')
+      expect_search_by_format_types(PublicationType::PolicyPaper.search_format_types)
+      rummager.publications_search
+    end
+
+    test 'publications_search search the taxonomy tree if we use the taxons option' do
+      rummager = AdvancedSearchRummager.new(taxons: 'content-id')
+      expect_search_by_taxonomy_tree(%w[content-id])
+      rummager.publications_search
+    end
+  end
+end

--- a/test/unit/whitehall/document_filter/search_rummager_test.rb
+++ b/test/unit/whitehall/document_filter/search_rummager_test.rb
@@ -55,6 +55,15 @@ module Whitehall::DocumentFilter
         )
     end
 
+    def expect_search_by_topical_event(topical_event)
+      Whitehall
+        .search_client
+        .expects(:search)
+        .with(
+          has_entry(filter_topical_events: topical_event)
+        )
+    end
+
     test 'announcements_search looks for all announcements excluding world types by default' do
       rummager = SearchRummager.new({})
       expected_types = ANNOUNCEMENT_TYPES
@@ -84,6 +93,13 @@ module Whitehall::DocumentFilter
     test 'announcements_search search the taxonomy tree if we use the taxons option' do
       rummager = SearchRummager.new(taxons: 'content-id')
       expect_search_by_taxonomy_tree(%w[content-id])
+      rummager.announcements_search
+    end
+
+    test 'announcements_search looks for announcements associated with a Topical Event' do
+      topical_event = create(:topical_event)
+      rummager = SearchRummager.new(topics: topical_event.slug)
+      expect_search_by_topical_event([topical_event.slug])
       rummager.announcements_search
     end
 


### PR DESCRIPTION
For https://trello.com/c/5SNdtZIJ/341-change-announcements-finder-to-use-search-endpoint

Content Publisher will soon be publishing news content in production, which will be stored in the govuk index in Rummager.  Currently the announcements finder uses the 'advanced-search' Rummager endpoint which only queries the government index, so in this PR we switch the announcements finder to use the 'search' Rummager endpoint which queries both the government and govuk indices.