### PR TITLE
Return to running tests using the warn log level

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Whitehall::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.log_level = (ENV['LOG_LEVEL'].presence || :debug).to_sym
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
The LOG_LEVEL environment variable is being set in the Rakefile, but
since [1], the relevant line in the test environment file to use this
value hasn't existed. This commit restores that line.

1: 601b505d9663dd6f35a0f62f00625b75d6fff5b6