### PR TITLE
Inverse fake search global var changes

### DIFF
--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -2,19 +2,29 @@ require 'whitehall/document_filter/filterer'
 module Whitehall
   module NotQuiteAsFakeSearch
     def self.stop_faking_it_quite_so_much!
+      @search_indexer_class_store = SearchIndex.indexer_class.store
       store = Whitehall::NotQuiteAsFakeSearch::Store.new
       SearchIndex.indexer_class.store = store
+
+      @government_search_client = Whitehall.government_search_client
       Whitehall.government_search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_client = Whitehall.search_client
       Whitehall.search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_backend = Whitehall.search_backend
       Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
     end
 
     def self.start_faking_it_again!
-      SearchIndex.indexer_class.store = nil
+      SearchIndex.indexer_class.store = @search_indexer_class_store
+      Whitehall.government_search_client = @government_search_client
+      Whitehall.search_client = @search_client
+      Whitehall.search_backend = @search_backend
     end
 
     class GdsApiRummager


### PR DESCRIPTION
Before changing global attributes this sets them to ivars on the Module
and then when the inverse `start_faking_it_again!` method is called it
resets them to the stored variables.

This is intended to stop the calling of `stop_faking_it_quite_so_much!`
and `start_faking_it_again!` to affect subsequent tests by not resetting
the universe correctly.

This code is pretty vulnerable to being run in threads, but it already
was and I don't think this makes it any worse in that regard.