### PR TITLE
Use Rummager for related document lists on topical events

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -13,7 +13,7 @@ module FeedHelper
     builder.updated feed_updated_timestamp
 
     documents.each do |document|
-      builder.entry(document, id: document_id(document, builder), url: public_document_url(document), published: document.first_public_at, updated: document.public_timestamp) do |_entry|
+      builder.entry(document, id: document_id(document, builder), url: public_document_url(document), published: document.try(:first_public_at), updated: document.public_timestamp) do |_entry|
         document_as_feed_entry(document, builder)
       end
     end
@@ -26,7 +26,7 @@ module FeedHelper
     # spec.
     # The interpolation logic is straight out of:
     # http://api.rubyonrails.org/classes/ActionView/Helpers/AtomFeedHelper/AtomFeedBuilder.html#method-i-entry
-    id = record.document ? record.document.id : record.id
+    id = record.try(:document) ? record.document.id : record.id
     "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
   end
 
@@ -55,6 +55,7 @@ module FeedHelper
   end
 
   def entry_content(document)
+    return '' if document.is_a?(RummagerDocumentPresenter)
     change_note = document.most_recent_change_note
     change_note = "<p><em>Updated:</em> #{change_note}</p>" if change_note
     "#{change_note}#{govspeak_edition_to_html(document)}"

--- a/app/helpers/public_document_routes_helper.rb
+++ b/app/helpers/public_document_routes_helper.rb
@@ -15,6 +15,8 @@ module PublicDocumentRoutesHelper
   end
 
   def document_url(edition, options = {}, _builder_options = {})
+    return edition.url if edition.is_a?(RummagerDocumentPresenter)
+
     if edition.non_english_edition?
       options[:locale] = edition.primary_locale
     elsif edition.translatable?

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -1,0 +1,39 @@
+##
+## RummagerDocumentPresenter serves as a wrapper for documents returned in results
+## provided by Rummager/Search API, in order to present documents in Finders.
+##
+
+class RummagerDocumentPresenter
+  attr_reader :title, :link, :display_type, :summary, :content_id
+
+  def initialize(document_hash)
+    @document = document_hash
+    @link = @document.fetch('link', '')
+    @title = @document.fetch('title', '')
+    @display_type = @document.fetch('display_type', '')
+    @summary = @document.fetch('description', '')
+    @content_id = @document.fetch('content_id', '')
+  end
+
+  def publication_date
+    I18n.l @document.fetch('public_timestamp', '').to_date, format: :long_ordinal
+  end
+
+  def public_timestamp
+    @document.fetch('public_timestamp', '').to_time
+  end
+
+  def display_type_key
+    @document.fetch('display_type', '')
+  end
+
+  def id
+    # This matches the Atom FeedEntryPresenter in Collections:
+    # https://github.com/alphagov/collections/blob/master/app/presenters/feed_entry_presenter.rb#L9
+    "#{url}##{@document['public_timestamp'].to_date.rfc3339}"
+  end
+
+  def url
+    Plek.current.website_root + link
+  end
+end

--- a/app/views/classifications/_document_list_from_rummager.html.erb
+++ b/app/views/classifications/_document_list_from_rummager.html.erb
@@ -1,0 +1,34 @@
+<%
+   heading ||= type.to_s.humanize
+   filter_option = (heading == "Publications") ? "all" : heading.downcase
+%>
+<section id="<%= heading.downcase %>" class="document-block">
+  <h1 class="label"><%= heading %></h1>
+  <div class="content">
+    <%= render partial: "shared/list_description_for_rummager_list", locals: { heading: heading, editions: documents, documents_count: documents_count, type: type } %>
+    <p class="see-all">
+    <%-
+      see_more_url = public_send(
+        "#{type}_filter_path",
+        @classification,
+        publication_filter_option: filter_option
+      )
+    %>
+    <%=
+      link_to(
+        "See all #{heading.downcase}",
+        see_more_url,
+        data: {
+          track_category: 'navPolicyAreaLinkClicked',
+          track_action: "#{heading}",
+          track_label: see_more_url,
+          track_options: {
+            dimension28: documents_count.to_s,
+            dimension29: "See all #{heading.downcase}"
+          }
+        }
+      )
+    %>
+    </p>
+  </div>
+</section>

--- a/app/views/shared/_list_description_for_rummager_list.html.erb
+++ b/app/views/shared/_list_description_for_rummager_list.html.erb
@@ -1,0 +1,27 @@
+<ol class="document-list">
+  <% editions.each_with_index do |edition, edition_index| %>
+    <li class="document-row" id="<%= "#{type}_#{edition.content_id}" %>">
+      <h2>
+        <%=
+          link_to(
+            edition.title,
+            edition.link,
+            data: {
+              track_category: 'navPolicyAreaLinkClicked',
+              track_action: "#{local_assigns.has_key?(:heading) ? heading : "Unknown"}.#{edition_index + 1}",
+              track_label: edition.link,
+              track_options: {
+                dimension28: documents_count.to_s,
+                dimension29: edition.title
+              }
+            }
+          )
+        %>
+      </h2>
+      <ul class="attributes">
+        <li class="publication-date"><%= edition.publication_date %></li>
+        <li class="document-type"><%= t_display_type(edition) %></li>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/shared/_recently_updated.html.erb
+++ b/app/views/shared/_recently_updated.html.erb
@@ -6,7 +6,9 @@
       <h1 class="label"><%= t('latest_feed.title') %></h1>
     </header>
     <% if recently_updated.any? %>
-      <%= render partial: "shared/recently_updated_documents",
+      <%= render partial: defined?(documents_source) && documents_source == 'rummager' ?
+                "shared/recently_updated_documents_from_rummager" :
+                "shared/recently_updated_documents",
                 locals: { recently_updated: recently_updated } %>
     <% else %>
       <p><%= t('latest_feed.no_updates') %></p>

--- a/app/views/shared/_recently_updated_documents_from_rummager.html.erb
+++ b/app/views/shared/_recently_updated_documents_from_rummager.html.erb
@@ -1,0 +1,13 @@
+<ol class="document-list">
+  <% recently_updated.each do |document| %>
+    <li class="document-row">
+      <h2><%= link_to document.title, document.link %></h2>
+      <ul class="attributes">
+        <li class="published-date">
+          <%= document.publication_date %>
+        </li>
+        <li class="display-type"><%= t_display_type(document) %></li>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -62,16 +62,17 @@
                    locals: { recently_updated: @recently_changed_documents,
                            atom_url: atom_feed_url_for(@classification),
                            extra_class: 'panel',
-                           see_all_link: latest_path(topics: [@classification]) } %>
+                           see_all_link: latest_path(topics: [@classification]),
+                           documents_source: 'rummager' } %>
       </section>
     </div>
   </div>
 
   <div class="documents-grid <%= topic_grid_size_class(@publications, @consultations, @announcements) %>">
     <div class="inner-block">
-      <%= render(partial: 'document_list', locals: { documents: @publications, type: :publications }) if @publications.any? %>
-      <%= render(partial: 'document_list', locals: { documents: @consultations, type: :consultations }) if @consultations.any? %>
-      <%= render(partial: 'document_list', locals: { documents: @announcements, type: :announcements }) if @announcements.any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @publications['results'], type: :publications, documents_count: @publications['total'] }) if @publications['results'].any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @consultations['results'], type: :consultations, documents_count: @consultations['total'] }) if @consultations['results'].any? %>
+      <%= render(partial: 'document_list_from_rummager', locals: { documents: @announcements['results'], type: :announcements, documents_count: @announcements['total'] }) if @announcements['results'].any? %>
 
       <% if @detailed_guides.any? %>
         <section id="detailed-guidance" class="document-block documents-<%= document_block_counter %>">

--- a/features/fixtures/rummager_response.json
+++ b/features/fixtures/rummager_response.json
@@ -1,0 +1,36 @@
+{
+    "results": [
+        {
+            "link": "/foo/policy_paper",
+            "title": "Policy on Topicals",
+            "public_timestamp": "2016-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-A"
+        },
+        {
+            "link": "/foo/consultation",
+            "title": "Examination of Events",
+            "public_timestamp": "2017-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-B"
+        },
+        {
+            "link": "/foo/news_story",
+            "title": "PM attends summit on topical events",
+            "public_timestamp": "2018-10-07T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-C"
+        },
+        {
+            "link": "/foo/statistics",
+            "title": "Weekly topical event price",
+            "public_timestamp": "2018-10-17T22:18:32Z",
+            "display_type": "news_article",
+            "description": "Description of document...",
+            "content_id": "1234-D"
+        }
+    ]
+}

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -30,6 +30,10 @@ module TopicalEventsHelper
     }
   end
 
+  def rummager_response
+    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
+  end
+
   def stub_topical_event_in_content_store(name)
     content_item = {
       format: "topical_event",

--- a/test/support/atom_test_helpers.rb
+++ b/test/support/atom_test_helpers.rb
@@ -13,7 +13,6 @@ module AtomTestHelpers
     assert_select 'feed > entry', count: documents.length do |entries|
       entries.zip(documents).each do |entry, document|
         assert_select entry, 'id', 1
-        assert_select entry, 'published', count: 1, text: document.first_public_at.iso8601
         assert_select entry, 'updated', count: 1, text: document.public_timestamp.iso8601
         assert_select(
           entry,
@@ -23,7 +22,7 @@ module AtomTestHelpers
         assert_select entry, 'title', count: 1, text: "#{document.display_type}: #{document.title}"
         assert_select entry, 'summary', count: 1, text: document.summary
         assert_select entry, 'category', count: 1, label: document.display_type, term: document.display_type
-        assert_select entry, 'content[type=?]', 'html', count: 1, text: /#{document.body}/
+        assert_select entry, 'content[type=?]', 'html', count: 1, text: /#{document.try(:body)}/
       end
     end
   end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class RummagerDocumentPresenterTest < ActiveSupport::TestCase
+  def rummager_result
+    {
+      "link" => "/government/news/quiddich-world-cup-2018",
+      "title" => "Quiddich World Cup 2018",
+      "description" => "The Quiddich World Cup 2018 will be...",
+      "public_timestamp" => "2018-10-25T10:18:32Z",
+      "display_type" => "News story"
+    }
+  end
+
+  def presenter
+    RummagerDocumentPresenter.new rummager_result
+  end
+
+  test "will provide access to document attributes required for Finders and Lists" do
+    assert_equal rummager_result['title'], presenter.title
+    assert_equal rummager_result['link'], presenter.link
+    assert_equal rummager_result['display_type'], presenter.display_type_key
+  end
+
+  test "will produce a humanized publication date required by Finders and Lists" do
+    assert_equal presenter.publication_date, '25 October 2018'
+  end
+end


### PR DESCRIPTION
This change introduces RummagerDocumentPresenter, a wrapper for documents
returned by Rummager searches. It changes the source for related documents
on topical event pages from Whitehall to Rummager. For each related document
list on the topical event page, we make a rummager search query.

In addition it introduces additional views and test logic. This is necessary
because other pages will still have lists with documents sourced from Whitehall.

Hopefully RummagerDocumentPresenter will be extended and used more as we transition
away from Whitehall to using content store, publishing api and rummager to back
Finders and other kinds of list.

A side effect of this change is that the atom feed results for the topical events
will change. This may result in feed readers interpreting old documents as new,
since the IDs and other attributes will appear to have changed.

### Example

These are screenshots of a [topical event page](https://www.gov.uk/government/topical-events/western-balkans-summit-london-2018) after the changes.

End users shouldn't notice a difference after the changes have been deployed.

<img width="338" alt="screen shot 2018-10-31 at 12 03 07" src="https://user-images.githubusercontent.com/8124374/47786835-ea945f00-dd04-11e8-98ae-0acad3639cee.png">
<img width="1094" alt="screen shot 2018-10-31 at 12 00 57" src="https://user-images.githubusercontent.com/8124374/47786771-c173ce80-dd04-11e8-9d13-94a886ba6a61.png">

