### PR TITLE
Use topical_events rather than policy_areas for rummager queries

### DIFF
--- a/lib/whitehall/document_filter/rummager.rb
+++ b/lib/whitehall/document_filter/rummager.rb
@@ -24,7 +24,7 @@ module Whitehall::DocumentFilter
       default_filter_args
         .merge(filter_by_keywords)
         .merge(filter_by_people)
-        .merge(filter_by_topics)
+        .merge(filter_by_topical_events)
         .merge(filter_by_organisations)
         .merge(filter_by_locations)
         .merge(filter_by_date)
@@ -48,11 +48,11 @@ module Whitehall::DocumentFilter
       end
     end
 
-    # Note that "Topics" are called "Policy Areas" in Rummager. That's why we
-    # use `policy_areas` as the filter key here.
-    def filter_by_topics
+    # Note that though 'topic' terminology is used here, elsewhere in Whitehall, and
+    # in the UI, we are actually interested in topical events when querying rummager.
+    def filter_by_topical_events
       if selected_topics.any?
-        { policy_areas: selected_topics.map(&:slug) }
+        { topical_events: selected_topics.map(&:slug) }
       else
         {}
       end


### PR DESCRIPTION
`policy_areas` have been removed from rummager, so in order to get results related to topical events, we need to query topical_events rather than policy_areas.

Related Trello card: https://trello.com/c/t21ycTI6/125-topic-filters-not-working-on-whitehall-finders

Policy areas and topics are being deprecated. Previously, Topical Events were part of Policy Areas/Topics. The use of the topic terminology is not changed anywhere else. The param names are unchanged so links to e.g. topic=budget-2018 still work, though budget-2018 refers to a topical_event rather than a topic. 

A future PR is needed to migrate more of the topic/policy area stuff to topical events or to use the taxonomy.

### Before 

![screen shot 2018-11-02 at 11 27 32](https://user-images.githubusercontent.com/8124374/47913030-725ba400-de92-11e8-9a7c-adc3d8714f59.png)

### After

![screen shot 2018-11-02 at 11 27 20](https://user-images.githubusercontent.com/8124374/47913035-75ef2b00-de92-11e8-868f-6bb1b051c9ba.png)
