### PR TITLE
Short circuit has_links for editions that are the length of a novel

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -291,4 +291,23 @@ module Admin::EditionsHelper
   def show_similar_slugs_warning?(edition)
     !edition.document.published? && edition.document.similar_slug_exists?
   end
+
+  def edition_is_a_novel?(edition)
+    edition.body.split.size > 99999
+  end
+
+  def edition_has_links?(edition)
+    LinkCheckerApiService.has_links?(edition, convert_admin_links: false)
+  end
+
+  def show_link_check_report?(edition)
+    # There is an edition that is over 200000 words long.
+    # This causes timeouts when LinkCheckerApiService tries to extract links from the body.
+    # This is an exceptional case, but it stops publishers editing their editions.
+    # Short circuit the call to LinkCheckerApiService by testing for an edition being
+    # over 99999 words long. The number was chosen because Wikipedia suggests 100000 words is
+    # the lower length of a novel (https://en.wikipedia.org/wiki/Word_count#In_fiction).
+    # Returning true from the first half of the "or" means the second half doesn't get computed.
+    edition_is_a_novel?(edition) || edition_has_links?(edition)
+  end
 end

--- a/app/views/admin/editions/show.html.erb
+++ b/app/views/admin/editions/show.html.erb
@@ -69,7 +69,7 @@
       <% end %>
     <% end %>
 
-    <% if LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) %>
+    <% if show_link_check_report?(@edition) %>
       <%= render 'admin/link_check_reports/link_check_report', report: (@edition.link_check_reports.last || @edition.link_check_reports.build) %>
     <% end %>
 

--- a/test/unit/helpers/admin/editions_helper_test.rb
+++ b/test/unit/helpers/admin/editions_helper_test.rb
@@ -40,4 +40,14 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     refute_includes admin_author_filter_options(current_user), disabled_user
   end
+
+  def one_hundred_thousand_words
+    " There are ten words contained in this sentence there are" * 10000
+  end
+
+  test '#show_link_check_report does not execute LinkCheckerApiService#has_links? when the edition is novel length' do
+    edition = stub(body: one_hundred_thousand_words)
+    LinkCheckerApiService.expects(:has_links?).never
+    show_link_check_report?(edition)
+  end
 end


### PR DESCRIPTION
We have an edition that is over 200000 words long. That's longer than many novels.

This is causing timeouts when `LinkCheckerApiService#has_links?` tries to extract the links from the body of the edition. `LinkCheckerApiService#has_links?` is called indirectly from `editions/show.html.erb`. The results are used to decide whether or not to show the link checking sidebar (i.e. when no links are present in the edition's body, we don't bother to show the link check
sidebar).

This PR short circuits the logic for editions that are over 99999 words long and just displays the link check sidebar anyway. This does potentially introduce an inconsistency where a very long edition without links will show the link check sidebar regardless. However, this does also get around our timeout for now and will allow editors to actually get to their editions.

I've chosen 99999 words because [Wikipedia](https://en.wikipedia.org/wiki/Word_count#In_fiction) suggests a novel to be 100000 words.

[Trello](https://trello.com/c/KxLdqIhq/601-fix-whitehall-timeouts-for-novel-sized-editions)