### PR TITLE
Improve Contact presentation to Publishing API

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -14,6 +14,7 @@ module PublishingApi
     def content
       {
         title: title,
+        description: comments.presence,
         schema_name: schema_name,
         document_type: document_type,
         locale: locale,
@@ -58,10 +59,6 @@ module PublishingApi
 
     alias_method :document_type, :schema_name
 
-    def description
-      comments
-    end
-
     def locale
       I18n.locale.to_s
     end
@@ -71,10 +68,15 @@ module PublishingApi
     end
 
     def details
-      details = { description: description, contact_type: contact_type, title: title }
-      details[:contact_form_links] = [contact_form_links] if contact_form_url
-      details[:post_addresses] = [post_address] if postal_code
-      details[:email_addresses] = [email_address] if email
+      details = {
+        title: title,
+        description: comments.presence,
+        contact_type: contact_type,
+      }.compact
+
+      details[:contact_form_links] = [contact_form_links] if contact_form_url.present?
+      details[:post_addresses] = post_addresses
+      details[:email_addresses] = [email_address] if email.present?
       details[:phone_numbers] = phone_numbers if contact_numbers.any?
 
       details
@@ -82,23 +84,24 @@ module PublishingApi
 
     def contact_form_links
       {
-        title: title,
         link: contact_form_url,
-        description: ""
       }
     end
 
-    def post_address
+    def post_addresses
+      # These are the three required fields for the schema
+      return [] if !street_address.present? || !postal_code.present? || !country
+
       post_address = {
-        title: recipient || "",
-        street_address: street_address,
-        locality: locality || "",
-        region: region || "",
-        postal_code: postal_code,
-        world_location: country_name
+        title: recipient.presence,
+        street_address: street_address.presence,
+        locality: locality.presence,
+        region: region.presence,
+        postal_code: postal_code.presence,
+        world_location: country.try(:name),
       }
 
-      post_address
+      [post_address.compact]
     end
 
     def phone_numbers
@@ -112,13 +115,9 @@ module PublishingApi
 
     def email_address
       {
-        title: recipient || "",
+        title: recipient.presence,
         email: email,
-      }
-    end
-
-    def country_name
-      country.try(:name) || ""
+      }.compact
     end
 
     def updated_at

--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -98,7 +98,8 @@ module PublishingApi
         locality: locality.presence,
         region: region.presence,
         postal_code: postal_code.presence,
-        world_location: country.try(:name),
+        world_location: country&.name,
+        iso2_country_code: country&.iso2&.downcase,
       }
 
       [post_address.compact]

--- a/test/unit/presenters/publishing_api/contact_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/contact_presenter_test.rb
@@ -7,7 +7,8 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
 
     world_location = FactoryBot.build(:world_location,
                                        content_id: @world_location_content_id,
-                                       name: "United Kingdom")
+                                       name: "United Kingdom",
+                                       iso2: "GB")
 
     @contact = FactoryBot.build(:contact,
                                  title: "Government Digital Service",
@@ -54,6 +55,7 @@ class PublishingApi::ContactPresenterTest < ActiveSupport::TestCase
             street_address: "Aviation House, 125 Kingsway",
             postal_code: "WC2B 6NH",
             world_location: "United Kingdom",
+            iso2_country_code: "gb",
           }
         ],
         email_addresses: [


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

This is marked as DNM as it requires this https://github.com/alphagov/govuk-content-schemas/pull/830 to be deployed.

This resolves a lot of empty data problems with Contacts data in the Publishing API by removing null and empty string values. It also adds in the iso2_country_code field to help with rendering contacts in govspeak correctly: https://github.com/alphagov/govspeak/pull/130