### PR TITLE
Adds a data migration to remove superfluous classification memberships

### DIFF
--- a/db/data_migration/20181107123522_delete_classification_memberships_policy_areas.rb
+++ b/db/data_migration/20181107123522_delete_classification_memberships_policy_areas.rb
@@ -1,0 +1,4 @@
+ClassificationMembership.all.each_with_index do |membership, index|
+  membership.destroy if membership.classification.nil?
+  puts ClassificationMembership.count - index if (index % 10000).zero?
+end


### PR DESCRIPTION
When we deleted all policy areas, the associated classification
memberships were not deleted, causing some to become invalid.

This causes problems when trying to unwithdraw editions that used
to have policy areas associated with them

Zendesk: https://govuk.zendesk.com/agent/tickets/3437264