### PR TITLE
Change announcements finder rummager endpoint

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,7 +3,7 @@ class AnnouncementsController < DocumentsController
 
   def index
     expire_on_next_scheduled_publication(scheduled_announcements)
-    @filter = build_document_filter
+    @filter = build_document_filter("announcements")
     @filter.announcements_search
 
     respond_to do |format|

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -4,7 +4,7 @@ class AnnouncementsController < DocumentsController
   def index
     expire_on_next_scheduled_publication(scheduled_announcements)
     @filter = build_document_filter("announcements")
-    @filter.announcements_search
+    search_results = @filter.announcements_search
 
     respond_to do |format|
       format.html do
@@ -23,12 +23,9 @@ class AnnouncementsController < DocumentsController
         )
       end
       format.atom do
-        documents = Announcement.published_with_eager_loading(@filter.documents.map(&:id))
-        @announcements = Whitehall::Decorators::CollectionDecorator.new(
-          documents.sort_by(&:public_timestamp).reverse,
-          AnnouncementPresenter,
-          view_context,
-        )
+        @announcements = search_results["results"].map do |result|
+          RummagerDocumentPresenter.new(result)
+        end
       end
     end
   end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -5,6 +5,7 @@ class AnnouncementsController < DocumentsController
     expire_on_next_scheduled_publication(scheduled_announcements)
     @filter = build_document_filter("announcements")
     @filter.announcements_search
+    presenter = AnnouncementPresenter if params[:locale].present?
 
     respond_to do |format|
       format.html do
@@ -14,12 +15,12 @@ class AnnouncementsController < DocumentsController
           .to_hash
 
         @filter = AnnouncementFilterJsonPresenter.new(
-          @filter, view_context
+          @filter, view_context, presenter
         )
       end
       format.json do
         render json: AnnouncementFilterJsonPresenter.new(
-          @filter, view_context
+          @filter, view_context, presenter
         )
       end
       format.atom do

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -4,7 +4,7 @@ class AnnouncementsController < DocumentsController
   def index
     expire_on_next_scheduled_publication(scheduled_announcements)
     @filter = build_document_filter("announcements")
-    search_results = @filter.announcements_search
+    @filter.announcements_search
 
     respond_to do |format|
       format.html do
@@ -14,18 +14,16 @@ class AnnouncementsController < DocumentsController
           .to_hash
 
         @filter = AnnouncementFilterJsonPresenter.new(
-          @filter, view_context, AnnouncementPresenter
+          @filter, view_context
         )
       end
       format.json do
         render json: AnnouncementFilterJsonPresenter.new(
-          @filter, view_context, AnnouncementPresenter
+          @filter, view_context
         )
       end
       format.atom do
-        @announcements = search_results["results"].map do |result|
-          RummagerDocumentPresenter.new(result)
-        end
+        @announcements = @filter.documents
       end
     end
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,7 +9,12 @@ class DocumentsController < PublicFacingController
 
 private
 
-  def build_document_filter
+  def build_document_filter(filter_type = nil)
+    search_backend = if filter_type == "announcements"
+                       Whitehall::DocumentFilter::SearchRummager
+                     else
+                       Whitehall::DocumentFilter::AdvancedSearchRummager
+                     end
     search_backend.new(cleaned_document_filter_params)
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -10,12 +10,7 @@ class DocumentsController < PublicFacingController
 private
 
   def build_document_filter(filter_type = nil)
-    search_backend = if filter_type == "announcements"
-                       Whitehall::DocumentFilter::SearchRummager
-                     else
-                       Whitehall::DocumentFilter::AdvancedSearchRummager
-                     end
-    search_backend.new(cleaned_document_filter_params)
+    search_backend(filter_type).new(cleaned_document_filter_params)
   end
 
   def cleaned_document_filter_params

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -75,11 +75,12 @@ private
     set_slimmer_format_header(Whitehall.analytics_format(analytics_format))
   end
 
-  def search_backend
-    if Locale.current.english?
-      Whitehall.search_backend
+  def search_backend(filter_type)
+    return Whitehall::DocumentFilter::Mysql unless Locale.current.english?
+    if filter_type == "announcements"
+      Whitehall::DocumentFilter::SearchRummager
     else
-      Whitehall::DocumentFilter::Mysql
+      Whitehall::DocumentFilter::AdvancedSearchRummager
     end
   end
 

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -27,6 +27,8 @@ module FeedHelper
     # The interpolation logic is straight out of:
     # http://api.rubyonrails.org/classes/ActionView/Helpers/AtomFeedHelper/AtomFeedBuilder.html#method-i-entry
     id = record.try(:document) ? record.document.id : record.id
+    return id if record.is_a?(RummagerDocumentPresenter)
+
     "tag:#{host},#{schema_date(builder)}:#{record.class}/#{id}"
   end
 

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -49,7 +49,7 @@ module FeedHelper
     builder.title "#{feed_display_type_for(document)}: #{document.title}"
     builder.category label: document.display_type, term: document.display_type
     builder.summary entry_summary(document)
-    builder.content entry_content(document), type: 'html'
+    builder.content(entry_content(document), type: 'html') unless document.is_a?(RummagerDocumentPresenter)
   end
 
   def entry_summary(document)
@@ -57,7 +57,6 @@ module FeedHelper
   end
 
   def entry_content(document)
-    return '' if document.is_a?(RummagerDocumentPresenter)
     change_note = document.most_recent_change_note
     change_note = "<p><em>Updated:</em> #{change_note}</p>" if change_note
     "#{change_note}#{govspeak_edition_to_html(document)}"

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -77,6 +77,11 @@ class RummagerDocumentPresenter < ActionView::Base
     content_tag(:time, class: :public_timestamp, datetime: self.public_timestamp.iso8601) { self.publication_date }
   end
 
+  def topics
+    # Retuns nil as topics aren't rendered in the announcements finder.
+    # This method is needed because the shared mustache template expects it to be available.
+  end
+
 private
 
   def format_link(title, link)

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -57,6 +57,14 @@ class RummagerDocumentPresenter
     @document.fetch('is_historic', false)
   end
 
+  def organisations
+    orgs = @document.fetch('organisations', []).map do |organisation|
+      organisation.fetch('acronym', nil) || organisation.fetch('title', nil)
+    end
+    orgs.compact
+    orgs.to_sentence if orgs.any?
+  end
+
 private
 
   def collection_link(title, link)

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -3,8 +3,9 @@
 ## provided by Rummager/Search API, in order to present documents in Finders.
 ##
 
-class RummagerDocumentPresenter
+class RummagerDocumentPresenter < ActionView::Base
   include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::TagHelper
 
   attr_reader :title, :link, :display_type, :summary, :content_id
 
@@ -63,6 +64,12 @@ class RummagerDocumentPresenter
     end
     orgs.compact
     orgs.to_sentence if orgs.any?
+  end
+
+  # Returns a block of html:
+  # "<time class=\"public_timestamp\" datetime=\"2018-09-19T17:06:34+01:00\">19 September 2018</time>"
+  def display_date_microformat
+    content_tag(:time, class: :public_timestamp, datetime: self.public_timestamp.iso8601) { self.publication_date }
   end
 
 private

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -4,6 +4,8 @@
 ##
 
 class RummagerDocumentPresenter
+  include ActionView::Helpers::UrlHelper
+
   attr_reader :title, :link, :display_type, :summary, :content_id
 
   def initialize(document_hash)
@@ -35,5 +37,17 @@ class RummagerDocumentPresenter
 
   def url
     Plek.current.website_root + link
+  end
+
+  def publication_collections
+    links = @document.fetch('document_collections', []).map { |collection| collection_link(collection["title"], collection["link"]) }.compact
+
+    "Part of a collection: #{links.to_sentence}" if links.any?
+  end
+
+private
+
+  def collection_link(title, link)
+    link_to(title, Plek.current.website_root + link)
   end
 end

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -45,6 +45,18 @@ class RummagerDocumentPresenter
     "Part of a collection: #{links.to_sentence}" if links.any?
   end
 
+  def type
+    @document.fetch('format', '')
+  end
+
+  def government_name
+    @document.fetch('government_name', '')
+  end
+
+  def historic?
+    @document.fetch('is_historic', false)
+  end
+
 private
 
   def collection_link(title, link)

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -41,7 +41,7 @@ class RummagerDocumentPresenter < ActionView::Base
   end
 
   def publication_collections
-    links = @document.fetch('document_collections', []).map { |collection| collection_link(collection["title"], collection["link"]) }.compact
+    links = @document.fetch('document_collections', []).map { |collection| format_link(collection["title"], collection["link"]) }.compact
 
     "Part of a collection: #{links.to_sentence}" if links.any?
   end
@@ -66,6 +66,11 @@ class RummagerDocumentPresenter < ActionView::Base
     orgs.to_sentence if orgs.any?
   end
 
+  def field_of_operation
+    operational_field = @document.fetch('operational_field', '')
+    "Field of operation: #{operational_field_link(operational_field)}" if operational_field.present?
+  end
+
   # Returns a block of html:
   # "<time class=\"public_timestamp\" datetime=\"2018-09-19T17:06:34+01:00\">19 September 2018</time>"
   def display_date_microformat
@@ -74,7 +79,12 @@ class RummagerDocumentPresenter < ActionView::Base
 
 private
 
-  def collection_link(title, link)
+  def format_link(title, link)
     link_to(title, Plek.current.website_root + link)
+  end
+
+  def operational_field_link(operational_field)
+    path = "/government/fields-of-operation/#{operational_field}"
+    format_link(operational_field.titleize, path)
   end
 end

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -15,7 +15,7 @@ class RummagerDocumentPresenter < ActionView::Base
     @title = @document.fetch('title', '')
     @display_type = @document.fetch('display_type', '')
     @summary = @document.fetch('description', '')
-    @content_id = @document.fetch('content_id', '')
+    @content_id = @document.fetch('content_id', SecureRandom.uuid)
   end
 
   def publication_date
@@ -80,6 +80,23 @@ class RummagerDocumentPresenter < ActionView::Base
   def topics
     # Retuns nil as topics aren't rendered in the announcements finder.
     # This method is needed because the shared mustache template expects it to be available.
+  end
+
+  def as_hash
+    {
+      id: content_id,
+      type: type,
+      display_type: display_type,
+      title: title,
+      url: link,
+      organisations: organisations,
+      display_date_microformat: display_date_microformat,
+      public_timestamp: public_timestamp,
+      historic?: historic?,
+      government_name: government_name,
+      field_of_operation: field_of_operation,
+      publication_collections: publication_collections
+    }
   end
 
 private

--- a/config/initializers/search_backend.rb
+++ b/config/initializers/search_backend.rb
@@ -1,5 +1,5 @@
 Whitehall.search_backend = if Rails.env.test?
                              Whitehall::DocumentFilter::Mysql
                            else
-                             Whitehall::DocumentFilter::Rummager
+                             Whitehall::DocumentFilter::AdvancedSearchRummager
                            end

--- a/features/announcements.feature
+++ b/features/announcements.feature
@@ -8,5 +8,5 @@ Scenario: Viewing news articles and speeches together on the news and speeches p
   Given a published news article "Crackdown on tax avoidance" exists
   And a published speech "Minister announces crackdown on tax avoidance" exists
   When I visit the list of announcements
-  Then I should see the news article "Crackdown on tax avoidance"
-  And I should see the speech "Minister announces crackdown on tax avoidance"
+  Then I should see the news article "Crackdown on tax avoidance" in the list of announcements
+  And I should see the speech "Minister announces crackdown on tax avoidance" in the list of announcements

--- a/features/email-signup-for-documents.feature
+++ b/features/email-signup-for-documents.feature
@@ -5,11 +5,13 @@ Feature: Email signup for documents
     And email alert api exists
     And a list of publications exists
 
+  @not-quite-as-fake-search
   Scenario: Signing up to unfiltered publications alerts
     When I visit the list of publications
     And I sign up for emails
     Then I should be signed up for the all publications mailing list
 
+  @not-quite-as-fake-search
   Scenario: Signing up to filtered publications alerts
     When I filter the publications list by "Correspondence"
     And I sign up for emails

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -188,6 +188,10 @@ Then(/^I should not see (#{THE_DOCUMENT})$/) do |edition|
   assert has_no_css?(record_css_selector(edition))
 end
 
+Then(/^I should see (#{THE_DOCUMENT}) in the list of announcements$/) do |edition|
+  assert has_css?(search_result_css_selector(edition))
+end
+
 Then(/^I should see (#{THE_DOCUMENT}) in the list of draft documents$/) do |edition|
   visit admin_editions_path
   assert has_css?(record_css_selector(edition))

--- a/features/step_definitions/world_location_news_article_steps.rb
+++ b/features/step_definitions/world_location_news_article_steps.rb
@@ -79,7 +79,7 @@ When(/^I explicitly ask for world location news to be included$/) do
 end
 
 Then(/^I should be able to see the world location news article$/) do
-  assert page.has_css?(record_css_selector(@world_location_news))
+  assert page.has_css?(search_result_css_selector(@world_location_news))
 end
 
 Given(/^a draft right\-to\-left non\-English edition exists$/) do

--- a/lib/whitehall/announcement_filter_option.rb
+++ b/lib/whitehall/announcement_filter_option.rb
@@ -2,11 +2,11 @@ module Whitehall
   class AnnouncementFilterOption < FilterOption
     attr_accessor :speech_types, :news_article_types
 
-    PressRelease = create(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease])
-    NewsStory = create(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory])
-    FatalityNotice = create(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice])
-    Speech = create(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements)
-    Statement = create(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements)
-    GovernmentResponse = create(id: 6, label: "Government responses", search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse])
+    PressRelease = create(id: 1, label: "Press releases", search_format_types: NewsArticleType::PressRelease.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::PressRelease], document_type: "press_release")
+    NewsStory = create(id: 2, label: "News stories", search_format_types: NewsArticleType::NewsStory.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::NewsStory], document_type: %w(news_article news_story))
+    FatalityNotice = create(id: 3, label: "Fatality notices", search_format_types: [FatalityNotice.search_format_type], edition_types: %w[FatalityNotice], document_type: "fatality_notice")
+    Speech = create(id: 4, label: "Speeches", search_format_types: [SpeechType.non_statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.non_statements, document_type: "speech")
+    Statement = create(id: 5, label: "Statements", search_format_types: [SpeechType.statements.map(&:search_format_types)].flatten, edition_types: %w[Speech], speech_types: SpeechType.statements, document_type: %w(written_statement oral_statement authored_article))
+    GovernmentResponse = create(id: 6, label: "Government responses", search_format_types: NewsArticleType::GovernmentResponse.search_format_types, edition_types: %w[NewsArticle], news_article_types: [NewsArticleType::GovernmentResponse], document_type: "government_response")
   end
 end

--- a/lib/whitehall/document_filter.rb
+++ b/lib/whitehall/document_filter.rb
@@ -1,5 +1,6 @@
 module Whitehall::DocumentFilter
   autoload :Mysql, 'whitehall/document_filter/mysql'
   autoload :FakeSearch, 'whitehall/document_filter/fake_search'
-  autoload :Rummager, 'whitehall/document_filter/rummager'
+  autoload :AdvancedSearchRummager, 'whitehall/document_filter/advanced_search_rummager'
+  autoload :SearchRummager, 'whitehall/document_filter/search_rummager'
 end

--- a/lib/whitehall/document_filter/advanced_search_result.rb
+++ b/lib/whitehall/document_filter/advanced_search_result.rb
@@ -1,0 +1,72 @@
+module Whitehall::DocumentFilter
+  class AdvancedSearchResult
+    ACCESSORS = %w{title description indexable_content attachments
+                   format display_type link id search_format_types
+                   relevant_to_local_government}.freeze
+    ACCESSORS.each do |attribute_name|
+      define_method attribute_name.to_sym do
+        @doc[attribute_name.to_s]
+      end
+    end
+
+    def initialize(doc)
+      @doc = doc
+    end
+
+    def type
+      format
+    end
+
+    def search_government_name
+      @doc['government_name']
+    end
+
+    def historic?
+      @doc['is_historic']
+    end
+
+    def public_timestamp
+      Time.zone.parse(@doc['public_timestamp'])
+    end
+
+    def part_of_published_collection?
+      published_document_collections.any?
+    end
+
+    def organisations
+      @doc.fetch('organisations', []).map { |slug| fetch_from_cache(:organisation, slug) }.compact
+    end
+
+    def topics
+      @doc.fetch('topics', []).map { |slug| fetch_from_cache(:topic, slug) }.compact
+    end
+
+    def published_document_collections
+      @doc.fetch('document_collections', []).map { |slug| fetch_from_cache(:document_collection, slug) }.compact
+    end
+
+    def operational_field
+      fetch_from_cache(:operational_field, @doc['operational_field'])
+    end
+
+  private
+
+    def fetch_from_cache(type, slug)
+      Rails.cache.fetch("#{type}-#{slug}", namespace: "results", expires_in: 30.minutes, race_condition_ttl: 1.second) do
+        case type
+        when :organisation
+          Organisation.includes(:translations).find_by(slug: slug)
+        when :topic
+          Classification.find_by(slug: slug)
+        when :document_collection
+          # Don't fall over if index refers a document which has had it's slug changed.
+          Document.find_by(slug: slug).try(:published_edition)
+        when :operational_field
+          OperationalField.find_by(slug: slug)
+        else
+          raise "Can't fetch '#{type}' -- unknown type"
+        end
+      end
+    end
+  end
+end

--- a/lib/whitehall/document_filter/advanced_search_rummager.rb
+++ b/lib/whitehall/document_filter/advanced_search_rummager.rb
@@ -1,0 +1,129 @@
+require 'whitehall/document_filter/filterer'
+
+module Whitehall::DocumentFilter
+  class AdvancedSearchRummager < Filterer
+    def publications_search
+      filter_args = standard_filter_args.merge(filter_by_publication_type)
+                                        .merge(filter_by_official_document_status)
+      @results = Whitehall.government_search_client.advanced_search(filter_args)
+    end
+
+    def default_filter_args
+      @default = {
+        page: @page.to_s,
+        per_page: @per_page.to_s
+      }
+    end
+
+    def standard_filter_args
+      default_filter_args
+        .merge(filter_by_keywords)
+        .merge(filter_by_people)
+        .merge(filter_by_topical_events)
+        .merge(filter_by_organisations)
+        .merge(filter_by_locations)
+        .merge(filter_by_date)
+        .merge(filter_by_taxon)
+        .merge(sort)
+    end
+
+    def filter_by_keywords
+      if @keywords.present?
+        { keywords: @keywords.to_s }
+      else
+        {}
+      end
+    end
+
+    def filter_by_people
+      if @people.present? && @people != %w[all]
+        { people: @people }
+      else
+        {}
+      end
+    end
+
+    # Note that though 'topic' terminology is used here, elsewhere in Whitehall, and
+    # in the UI, we are actually interested in topical events when querying rummager.
+    def filter_by_topical_events
+      if selected_topics.any?
+        { topical_events: selected_topics.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_taxon
+      if selected_subtaxons.any? { |taxon| taxon != "all" }
+        { part_of_taxonomy_tree: selected_subtaxons }
+      elsif selected_taxons.any?
+        { part_of_taxonomy_tree: selected_taxons }
+      else
+        {}
+      end
+    end
+
+    def filter_by_organisations
+      if selected_organisations.any?
+        { organisations: selected_organisations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_locations
+      if selected_locations.any?
+        { world_locations: selected_locations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_official_document_status
+      case selected_official_document_status
+      when "command_and_act_papers"
+        { has_official_document: "1" }
+      when "command_papers_only"
+        { has_command_paper: "1" }
+      when "act_papers_only"
+        { has_act_paper: "1" }
+      else
+        {}
+      end
+    end
+
+    def filter_by_date
+      dates_hash = {}
+      dates_hash[:from] = @from_date.to_s if @from_date.present?
+      dates_hash[:to] = @to_date.to_s if @to_date.present?
+
+      if dates_hash.empty?
+        {}
+      else
+        { public_timestamp: dates_hash }
+      end
+    end
+
+    def sort
+      if @keywords.blank?
+        { order: { public_timestamp: "desc" } }
+      else
+        {}
+      end
+    end
+
+    def filter_by_publication_type
+      publication_types =
+        if selected_publication_filter_option
+          selected_publication_filter_option.search_format_types
+        else
+          Publicationesque.concrete_descendant_search_format_types
+        end
+      { search_format_types: publication_types }
+    end
+
+    def documents
+      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+    end
+  end
+end

--- a/lib/whitehall/document_filter/advanced_search_rummager.rb
+++ b/lib/whitehall/document_filter/advanced_search_rummager.rb
@@ -123,7 +123,7 @@ module Whitehall::DocumentFilter
     end
 
     def documents
-      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+      @documents ||= ResultSet.new(@results, @page, @per_page, AdvancedSearchResult).paginated
     end
   end
 end

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -96,6 +96,10 @@ module Whitehall::DocumentFilter
       @include_world_location_news.to_s == '1'
     end
 
+    def all_announcement_filter_options
+      Whitehall::AnnouncementFilterOption.all
+    end
+
   private
 
     def find_by_slug(klass, slugs)

--- a/lib/whitehall/document_filter/filterer.rb
+++ b/lib/whitehall/document_filter/filterer.rb
@@ -80,6 +80,11 @@ module Whitehall::DocumentFilter
       WorldLocation.where(slug: @world_locations)
     end
 
+    def selected_topical_events
+      topics = find_by_slug(Classification, @topics)
+      topics.select { |topic| topic.type == "TopicalEvent" }
+    end
+
     def selected_official_document_status
       @official_document_status
     end

--- a/lib/whitehall/document_filter/result_set.rb
+++ b/lib/whitehall/document_filter/result_set.rb
@@ -1,16 +1,15 @@
 module Whitehall::DocumentFilter
   class ResultSet
-    def initialize(results, page, per_page)
+    def initialize(results, page, per_page, result_type)
       @results = results
       @docs = results.respond_to?(:[]) ? results['results'] : []
       @page = page
       @per_page = per_page
+      @result_type = result_type
     end
 
     def merged_results
-      @docs.map do |doc|
-        Result.new(doc)
-      end
+      @docs.map { |doc| @result_type.new(doc) }
     end
 
     def paginated

--- a/lib/whitehall/document_filter/search_result.rb
+++ b/lib/whitehall/document_filter/search_result.rb
@@ -1,8 +1,8 @@
 module Whitehall::DocumentFilter
-  class Result
+  class SearchResult
     ACCESSORS = %w{title description indexable_content attachments
-                   format display_type link id search_format_types
-                   relevant_to_local_government}.freeze
+                   format link content_id search_format_types
+                   relevant_to_local_government display_type id}.freeze
     ACCESSORS.each do |attribute_name|
       define_method attribute_name.to_sym do
         @doc[attribute_name.to_s]
@@ -26,7 +26,7 @@ module Whitehall::DocumentFilter
     end
 
     def public_timestamp
-      Time.zone.parse(@doc['public_timestamp'])
+      @doc['public_timestamp'].nil? ? Time.zone.now : Time.zone.parse(@doc['public_timestamp'])
     end
 
     def part_of_published_collection?
@@ -34,15 +34,15 @@ module Whitehall::DocumentFilter
     end
 
     def organisations
-      @doc.fetch('organisations', []).map { |slug| fetch_from_cache(:organisation, slug) }.compact
+      @doc.fetch('organisations', []).map { |organisation| fetch_from_cache(:organisation, organisation.fetch('slug', nil)) }.compact
     end
 
     def topics
-      @doc.fetch('topics', []).map { |slug| fetch_from_cache(:topic, slug) }.compact
+      @doc.fetch('topics', []).map { |topic| fetch_from_cache(:topic, topic.fetch('slug', nil)) }.compact
     end
 
     def published_document_collections
-      @doc.fetch('document_collections', []).map { |slug| fetch_from_cache(:document_collection, slug) }.compact
+      @doc.fetch('document_collections', []).map { |document_collection| fetch_from_cache(:document_collection, document_collection.fetch('slug', nil)) }.compact
     end
 
     def operational_field

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -25,6 +25,7 @@ module Whitehall::DocumentFilter
         .merge(filter_by_locations)
         .merge(filter_by_date)
         .merge(filter_by_taxon)
+        .merge(filter_by_topical_event)
         .merge(sort)
     end
 
@@ -65,6 +66,14 @@ module Whitehall::DocumentFilter
     def filter_by_locations
       if selected_locations.any?
         { filter_world_locations: selected_locations.map(&:slug) }
+      else
+        {}
+      end
+    end
+
+    def filter_by_topical_event
+      if selected_topical_events.any?
+        { filter_topical_events: selected_topical_events.map(&:slug) }
       else
         {}
       end

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -13,7 +13,7 @@ module Whitehall::DocumentFilter
         count: @per_page.to_s,
         fields: %w[content_store_document_type government_name is_historic
                    public_timestamp organisations operational_field format
-                   content_id title description display_type id]
+                   content_id title description display_type link document_collections]
       }
     end
 

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -112,7 +112,7 @@ module Whitehall::DocumentFilter
     end
 
     def documents
-      @documents ||= ResultSet.new(@results, @page, @per_page, SearchResult).paginated
+      @documents ||= ResultSet.new(@results, @page, @per_page, RummagerDocumentPresenter).paginated
     end
 
   private

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -103,7 +103,7 @@ module Whitehall::DocumentFilter
     end
 
     def documents
-      @documents ||= ResultSet.new(@results, @page, @per_page).paginated
+      @documents ||= ResultSet.new(@results, @page, @per_page, SearchResult).paginated
     end
 
   private

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -93,13 +93,13 @@ module Whitehall::DocumentFilter
     def filter_by_announcement_type
       announcement_types =
         if selected_announcement_filter_option
-          selected_announcement_filter_option.search_format_types
+          selected_announcement_filter_option.document_type
         elsif include_world_location_news
-          [Announcement.search_format_type]
+          all_announcement_types
         else
           non_world_announcement_types
         end
-      { filter_search_format_types: announcement_types }
+      { filter_content_store_document_type: announcement_types }
     end
 
     def documents
@@ -109,16 +109,11 @@ module Whitehall::DocumentFilter
   private
 
     def all_announcement_types
-      all_descendants = Announcement.concrete_descendant_search_format_types
-      descendants_without_news = all_descendants - [NewsArticle.search_format_type]
-      news_article_subtypes = NewsArticleType.search_format_types
-      descendants_without_news + news_article_subtypes
+      %w(world_location_news_article world_news_story).concat(non_world_announcement_types)
     end
 
     def non_world_announcement_types
-      types = all_announcement_types
-      types = types - NewsArticleType::WorldNewsStory.search_format_types
-      types - [WorldLocationNewsArticle.search_format_type]
+      all_announcement_filter_options.map(&:document_type).flatten
     end
   end
 end

--- a/lib/whitehall/document_filter/search_rummager.rb
+++ b/lib/whitehall/document_filter/search_rummager.rb
@@ -9,7 +9,7 @@ module Whitehall::DocumentFilter
 
     def default_filter_args
       @default = {
-        start: @page.to_s,
+        start: position_in_result_list.to_s,
         count: @per_page.to_s,
         fields: %w[content_store_document_type government_name is_historic
                    public_timestamp organisations operational_field format
@@ -123,6 +123,10 @@ module Whitehall::DocumentFilter
 
     def non_world_announcement_types
       all_announcement_filter_options.map(&:document_type).flatten
+    end
+
+    def position_in_result_list
+      (@page.to_i - 1) * @per_page.to_i
     end
   end
 end

--- a/lib/whitehall/filter_option.rb
+++ b/lib/whitehall/filter_option.rb
@@ -2,7 +2,7 @@ module Whitehall
   class FilterOption
     include ActiveRecordLikeInterface
 
-    attr_accessor :id, :label, :search_format_types, :group_key
+    attr_accessor :id, :label, :search_format_types, :group_key, :document_type
     attr_writer :edition_types, :slug
 
     def slug
@@ -21,6 +21,10 @@ module Whitehall
       all.detect do |at|
         format_types.any? { |t| at.search_format_types.include?(t) }
       end
+    end
+
+    def self.document_types
+      all.map(&:document_type)
     end
   end
 end

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -39,7 +39,7 @@ module Whitehall
         keywords = params.delete("q")
         order = { public_timestamp: "desc" }
         per_page = params.delete("count").to_i
-        page = params.delete("start").to_i
+        page = params.delete("start").to_i + 1
         params.delete("fields")
         params.delete("order")
         apply_filters(keywords, params, order, per_page, page, true)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -7,7 +7,10 @@ module Whitehall
       Whitehall.government_search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
-      Whitehall.search_backend = Whitehall::DocumentFilter::Rummager
+      Whitehall.search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
+        SearchIndex.government_search_index_path, store
+      )
+      Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
     end
 
     def self.start_faking_it_again!
@@ -21,8 +24,15 @@ module Whitehall
         @store = store
       end
 
-      def search(*_args)
-        raise "Not implemented"
+      def search(params)
+        params = params.stringify_keys
+        keywords = params.delete("q")
+        order = { public_timestamp: "desc" }
+        per_page = params.delete("count").to_i
+        page = params.delete("start").to_i
+        params.delete("fields")
+        params.delete("order")
+        apply_filters(keywords, params, order, per_page, page)
       end
 
       def autocomplete(*_args)
@@ -60,6 +70,7 @@ module Whitehall
             search_format_types
             world_locations
             document_collections
+            content_store_document_type
           },
           date: %w{public_timestamp},
           boolean: %w{
@@ -78,10 +89,10 @@ module Whitehall
 
       def apply_filters(keywords, params, order, per_page, page)
         results = @store.index(@index_name).values
-
         results = filter_by_keywords(keywords, results) unless keywords.blank?
 
         results = params.inject(results) do |new_results, (field_name, value)|
+          field_name = field_name.gsub(/filter_/, "")
           case field_type(field_name)
           when :date
             filter_by_date_field(field_name, value, new_results)
@@ -163,7 +174,14 @@ module Whitehall
       end
 
       def filter_by_simple_field(field, desired_field_values, document_hashes)
-        document_hashes.select { |document_hash| ([*desired_field_values] & document_hash.fetch(field, [])).any? }
+        document_hashes.select do |document_hash|
+          value = document_hash.fetch(field, [])
+          if value.is_a?(String)
+            Array(desired_field_values).include?(value)
+          else
+            (Array(desired_field_values) & value).any?
+          end
+        end
       end
 
       def filter_by_date_field(field, date_filter_hash, document_hashes)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -104,7 +104,7 @@ module Whitehall
             raise GdsApi::HTTPErrorResponse, "cannot filter by field '#{field_name}', its type is not known"
           end
         end
-
+        results = announcements_search ? format_organisations(results) : results
         if order && order.any?
           results = Ordering.new(order).sort(results)
         end
@@ -112,6 +112,18 @@ module Whitehall
           "total" => results.count,
           "results" => paginate(results, per_page, page)
         }
+      end
+
+      def format_organisations(results)
+        # Now we're querying the 'search' endpoint, results["organisations"]
+        # needs to return a hash
+        results.each do |result|
+          organisations = result.fetch("organisations", [])
+          if organisations.any? && organisations[0].is_a?(String)
+            result["organisations"] = organisations.map { |org| { "slug" => org } }
+          end
+        end
+        results
       end
 
       def paginate(results, per_page, page)
@@ -175,13 +187,21 @@ module Whitehall
 
       def filter_by_simple_field(field, desired_field_values, document_hashes)
         document_hashes.select do |document_hash|
-          value = document_hash.fetch(field, [])
+          if field == "organisations"
+            value = organisation_slugs(document_hash["organisations"])
+          else
+            value = document_hash.fetch(field, [])
+          end
           if value.is_a?(String)
             Array(desired_field_values).include?(value)
           else
             (Array(desired_field_values) & value).any?
           end
         end
+      end
+
+      def organisation_slugs(organisations)
+        organisations.map { |org| org["slug"] if org.fetch("slug") }
       end
 
       def filter_by_date_field(field, date_filter_hash, document_hashes)

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -32,7 +32,7 @@ module Whitehall
         page = params.delete("start").to_i
         params.delete("fields")
         params.delete("order")
-        apply_filters(keywords, params, order, per_page, page)
+        apply_filters(keywords, params, order, per_page, page, true)
       end
 
       def autocomplete(*_args)
@@ -87,7 +87,7 @@ module Whitehall
         end
       end
 
-      def apply_filters(keywords, params, order, per_page, page)
+      def apply_filters(keywords, params, order, per_page, page, announcements_search = false)
         results = @store.index(@index_name).values
         results = filter_by_keywords(keywords, results) unless keywords.blank?
 
@@ -99,7 +99,7 @@ module Whitehall
           when :boolean
             filter_by_boolean_field(field_name, value, new_results)
           when :simple
-            filter_by_simple_field(field_name, value, new_results)
+            filter_by_simple_field(field_name, value, new_results, announcements_search)
           else
             raise GdsApi::HTTPErrorResponse, "cannot filter by field '#{field_name}', its type is not known"
           end
@@ -185,13 +185,15 @@ module Whitehall
         document_hashes.select { |document_hash| document_hash[field] == desired_boolean }
       end
 
-      def filter_by_simple_field(field, desired_field_values, document_hashes)
+      def filter_by_simple_field(field, desired_field_values, document_hashes, announcements_search = false)
         document_hashes.select do |document_hash|
-          if field == "organisations"
-            value = organisation_slugs(document_hash["organisations"])
-          else
-            value = document_hash.fetch(field, [])
-          end
+          value =
+            if field == "organisations" && announcements_search
+              organisation_slugs(document_hash.fetch("organisations", []))
+            else
+              document_hash.fetch(field, [])
+            end
+
           if value.is_a?(String)
             Array(desired_field_values).include?(value)
           else

--- a/lib/whitehall/not_quite_as_fake_search.rb
+++ b/lib/whitehall/not_quite_as_fake_search.rb
@@ -2,19 +2,29 @@ require 'whitehall/document_filter/filterer'
 module Whitehall
   module NotQuiteAsFakeSearch
     def self.stop_faking_it_quite_so_much!
+      @search_indexer_class_store = SearchIndex.indexer_class.store
       store = Whitehall::NotQuiteAsFakeSearch::Store.new
       SearchIndex.indexer_class.store = store
+
+      @government_search_client = Whitehall.government_search_client
       Whitehall.government_search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_client = Whitehall.search_client
       Whitehall.search_client = Whitehall::NotQuiteAsFakeSearch::GdsApiRummager.new(
         SearchIndex.government_search_index_path, store
       )
+
+      @search_backend = Whitehall.search_backend
       Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
     end
 
     def self.start_faking_it_again!
-      SearchIndex.indexer_class.store = nil
+      SearchIndex.indexer_class.store = @search_indexer_class_store
+      Whitehall.government_search_client = @government_search_client
+      Whitehall.search_client = @search_client
+      Whitehall.search_backend = @search_backend
     end
 
     class GdsApiRummager

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -107,12 +107,14 @@ class AnnouncementsControllerTest < ActionController::TestCase
                                           [{ 'format' => 'news_article',
                                              'id' => 'news_id',
                                              'organisations' =>
-                                               [{ 'slug' => first_org.slug },
-                                                { 'slug' => second_org.slug }] },
+                                               [{ 'acronym' => first_org.acronym },
+                                                { 'acronym' => second_org.acronym }],
+                                              'public_timestamp' => Time.zone.now.to_s },
                                            { 'format' => 'speech',
                                              'id' => 'speech_id',
                                              'organisations' =>
-                                               [{ 'slug' => second_org.slug }] }])
+                                               [{ 'acronym' => second_org.acronym }],
+                                             'public_timestamp' => Time.zone.now.to_s }])
 
       get :index
 

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -339,7 +339,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
       get :index, params: { departments: [org.to_param] }, format: :atom
 
       assert_select_atom_feed do
-        assert_select_atom_entries(processed_rummager_documents)
+        assert_select_atom_entries(processed_rummager_documents, false)
       end
     end
   end
@@ -357,7 +357,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
       get :index, params: { announcement_type_option: 'news-stories' }, format: :atom
 
       assert_select_atom_feed do
-        assert_select_atom_entries(processed_rummager_documents)
+        assert_select_atom_entries(processed_rummager_documents, false)
       end
     end
   end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -201,11 +201,10 @@ class PublicationsControllerTest < ActionController::TestCase
   view_test "#index only lists publications in the given locale" do
     english_publication = create(:published_publication)
     french_publication = create(:published_publication, translated_into: [:fr])
-
     get :index, params: { locale: 'fr' }
 
-    assert_select_object french_publication
-    refute_select_object english_publication
+    assert_select "#publication_#{french_publication.id}"
+    refute_select "#publication_#{english_publication.id}"
   end
 
   view_test '#index for non-english locales only allows filtering by world location' do

--- a/test/functional/statistics_controller_test.rb
+++ b/test/functional/statistics_controller_test.rb
@@ -23,6 +23,7 @@ class StatisticsControllerTest < ActionController::TestCase
     content_store_has_item(@content_item['base_path'], @content_item)
 
     stub_taxonomy_with_all_taxons
+    @rummager = stub
   end
 
   view_test "#index only displays *published* statistics" do
@@ -115,11 +116,10 @@ class StatisticsControllerTest < ActionController::TestCase
   view_test "#index only lists statistics in the given locale" do
     english_publication = create(:published_statistics)
     french_publication = create(:published_statistics, translated_into: [:fr])
-
     get :index, params: { locale: 'fr' }
 
-    assert_select_object french_publication
-    refute_select_object english_publication
+    assert_select "#publication_#{french_publication.id}"
+    refute_select "#publication_#{english_publication.id}"
   end
 
   view_test '#index for non-english locales does not allow any filtering' do

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -102,7 +102,7 @@ class TopicalEventsControllerTest < ActionController::TestCase
       assert_select 'feed > link[rel=?][type=?][href=?]', 'self', 'application/atom+xml', topical_event_url(topical_event, format: 'atom'), 1
       assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', topical_event_url(topical_event), 1
 
-      assert_select_atom_entries(processed_rummager_documents)
+      assert_select_atom_entries(processed_rummager_documents, false)
     end
   end
 

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -13,9 +13,13 @@ class RoutingTest < ActionDispatch::IntegrationTest
   test "assets are served under the #{Whitehall.router_prefix} prefix" do
     content_store_has_item('/government/publications', {})
     stub_taxonomy_with_all_taxons
+    rummager = stub
 
-    get publications_path
-    assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
+    with_stubbed_rummager(rummager) do
+      rummager.expects(:advanced_search)
+      get publications_path
+      assert_select "script[src=?]", "#{Whitehall.router_prefix}/assets/application.js"
+    end
   end
 
   test "visiting #{Whitehall.router_prefix} when not in frontend redirects to /" do

--- a/test/support/atom_test_helpers.rb
+++ b/test/support/atom_test_helpers.rb
@@ -9,7 +9,7 @@ module AtomTestHelpers
     assert_select 'head > link[rel=?][type=?][href=?]', 'alternate', 'application/atom+xml', url
   end
 
-  def assert_select_atom_entries(documents)
+  def assert_select_atom_entries(documents, renders_content = true)
     assert_select 'feed > entry', count: documents.length do |entries|
       entries.zip(documents).each do |entry, document|
         assert_select entry, 'id', 1
@@ -22,7 +22,7 @@ module AtomTestHelpers
         assert_select entry, 'title', count: 1, text: "#{document.display_type}: #{document.title}"
         assert_select entry, 'summary', count: 1, text: document.summary
         assert_select entry, 'category', count: 1, label: document.display_type, term: document.display_type
-        assert_select entry, 'content[type=?]', 'html', count: 1, text: /#{document.try(:body)}/
+        assert_select(entry, 'content[type=?]', 'html', count: 1, text: /#{document.try(:body)}/) if renders_content
       end
     end
   end

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -5,6 +5,10 @@ module CssSelectors
     '#' + dom_id(object, prefix)
   end
 
+  def search_result_css_selector(object)
+    '#' + object.type.underscore + "_" + object.content_id
+  end
+
   def record_id_from(element)
     element["id"].split("_").last
   end

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -399,7 +399,8 @@ module DocumentControllerTestHelpers
         with_stubbed_rummager(rummager, announcement) do
           if announcement
             rummager.expects(:search).returns('results' =>
-              [{ 'format' => document_type.to_s }])
+              [{ 'format' => document_type.to_s,
+                 'public_timestamp' => Time.zone.now.to_s }])
           else
             rummager.expects(:advanced_search).returns('results' =>
               [{ 'format' => document_type.to_s,
@@ -415,7 +416,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager, announcement) do
           if announcement
-            rummager.expects(:search).returns('results' => (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
+            rummager.expects(:search).returns('results' => (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n, 'public_timestamp' => Time.zone.now.to_s } })
           else
             rummager.expects(:advanced_search).returns('results' =>
                                                 (0..4).map { { 'format' => document_type.to_s, 'public_timestamp' => Time.zone.now.to_s } })
@@ -432,7 +433,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager) do
           if announcement
-            rummager.expects(:search).returns('results' => [{ 'format' => document_type.to_s, 'id' => 1 }])
+            rummager.expects(:search).returns('results' => [{ 'format' => document_type.to_s, 'id' => 1, 'public_timestamp' => Time.zone.now.to_s }])
           else
             rummager.expects(:advanced_search).returns('results' =>
               [{ 'format' => document_type.to_s, 'id' => 1, 'public_timestamp' => Time.zone.now.to_s }])

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -393,14 +393,18 @@ module DocumentControllerTestHelpers
 
     def should_return_json_suitable_for_the_document_filter(document_type)
       include DocumentFilterHelpers
-
+      announcement = %i(news_article speech).include?(document_type)
       view_test "index requested as JSON includes a count of #{document_type}" do
         rummager = stub
-        with_stubbed_rummager(rummager) do
-          rummager.expects(:search).returns('results' =>
-                                              [{ 'format' => document_type.to_s,
-                                                 'content_id' => 1 }])
-
+        with_stubbed_rummager(rummager, announcement) do
+          if announcement
+            rummager.expects(:search).returns('results' =>
+              [{ 'format' => document_type.to_s }])
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+              [{ 'format' => document_type.to_s,
+                 'public_timestamp' => Time.zone.now.to_s }])
+          end
           get :index, format: :json
 
           assert_equal 1, ActiveSupport::JSON.decode(response.body)["count"]
@@ -409,10 +413,13 @@ module DocumentControllerTestHelpers
 
       view_test "index requested as JSON includes the total pages of #{document_type}" do
         rummager = stub
-        with_stubbed_rummager(rummager) do
-          rummager.expects(:search).returns('results' =>
-                                              (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
-
+        with_stubbed_rummager(rummager, announcement) do
+          if announcement
+            rummager.expects(:search).returns('results' => (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+                                                (0..4).map { { 'format' => document_type.to_s, 'public_timestamp' => Time.zone.now.to_s } })
+          end
           with_number_of_documents_per_page(3) do
             get :index, format: :json
           end
@@ -424,8 +431,12 @@ module DocumentControllerTestHelpers
       view_test "index requested as JSON includes the current page of #{document_type}" do
         rummager = stub
         with_stubbed_rummager(rummager) do
-          doc = create(:"published_#{document_type}")
-          rummager.expects(:search).returns('results' => { 'format' => document_type.to_s, 'slug' => doc.slug })
+          if announcement
+            rummager.expects(:search).returns('results' => [{ 'format' => document_type.to_s, 'id' => 1 }])
+          else
+            rummager.expects(:advanced_search).returns('results' =>
+              [{ 'format' => document_type.to_s, 'id' => 1, 'public_timestamp' => Time.zone.now.to_s }])
+          end
 
           get :index, format: :json
           assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]

--- a/test/support/document_controller_test_helpers.rb
+++ b/test/support/document_controller_test_helpers.rb
@@ -398,7 +398,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager) do
           rummager.expects(:search).returns('results' =>
-                                              [{ 'format' => "published_#{document_type}",
+                                              [{ 'format' => document_type.to_s,
                                                  'content_id' => 1 }])
 
           get :index, format: :json
@@ -411,7 +411,7 @@ module DocumentControllerTestHelpers
         rummager = stub
         with_stubbed_rummager(rummager) do
           rummager.expects(:search).returns('results' =>
-                                              (0..4).map { |n| { 'format' => "published_#{document_type}", 'content_id' => n } })
+                                              (0..4).map { |n| { 'format' => document_type.to_s, 'content_id' => n } })
 
           with_number_of_documents_per_page(3) do
             get :index, format: :json
@@ -422,11 +422,14 @@ module DocumentControllerTestHelpers
       end
 
       view_test "index requested as JSON includes the current page of #{document_type}" do
-        create(:"published_#{document_type}")
+        rummager = stub
+        with_stubbed_rummager(rummager) do
+          doc = create(:"published_#{document_type}")
+          rummager.expects(:search).returns('results' => { 'format' => document_type.to_s, 'slug' => doc.slug })
 
-        get :index, format: :json
-
-        assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]
+          get :index, format: :json
+          assert_equal 1, ActiveSupport::JSON.decode(response.body)["current_page"]
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,8 +65,11 @@ class ActiveSupport::TestCase
 
   def with_stubbed_rummager(stubbed_object, announcements = false)
     previous_client = Whitehall.search_client
+    previous_government_search_client = Whitehall.government_search_client
     previous_backend = Whitehall.search_backend
+
     Whitehall.search_client = stubbed_object
+    Whitehall.government_search_client = stubbed_object
     Whitehall.search_backend =
       if announcements
         Whitehall::DocumentFilter::SearchRummager
@@ -74,7 +77,9 @@ class ActiveSupport::TestCase
         Whitehall::DocumentFilter::AdvancedSearchRummager
       end
     yield
+
     Whitehall.search_client = previous_client
+    Whitehall.government_search_client = previous_government_search_client
     Whitehall.search_backend = previous_backend
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,6 +63,16 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
+  def with_stubbed_rummager(stubbed_object)
+    previous_client = Whitehall.search_client
+    previous_backend = Whitehall.search_backend
+    Whitehall.search_client = stubbed_object
+    Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
+    yield
+    Whitehall.search_client = previous_client
+    Whitehall.search_backend = previous_backend
+  end
+
   def acting_as(actor, &block)
     Edition::AuditTrail.acting_as(actor, &block)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,11 +63,16 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
-  def with_stubbed_rummager(stubbed_object)
+  def with_stubbed_rummager(stubbed_object, announcements = false)
     previous_client = Whitehall.search_client
     previous_backend = Whitehall.search_backend
     Whitehall.search_client = stubbed_object
-    Whitehall.search_backend = Whitehall::DocumentFilter::AdvancedSearchRummager
+    Whitehall.search_backend =
+      if announcements
+        Whitehall::DocumentFilter::SearchRummager
+      else
+        Whitehall::DocumentFilter::AdvancedSearchRummager
+      end
     yield
     Whitehall.search_client = previous_client
     Whitehall.search_backend = previous_backend

--- a/test/unit/helpers/feed_helper_test.rb
+++ b/test/unit/helpers/feed_helper_test.rb
@@ -128,4 +128,21 @@ class FeedHelperTest < ActionView::TestCase
 
     assert_equal document_id(d, nil), "tag:#{host},2005:Publication/33"
   end
+
+  test 'document_id sets ID as link and updated date when record is from rummager' do
+    rummager_result = {
+      "link": "/foo/news_story",
+      "title": "PM attends summit on topical events",
+      "public_timestamp": "2018-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-C",
+      "content_store_document_type": "news_article"
+    }.with_indifferent_access
+
+    document = RummagerDocumentPresenter.new(rummager_result)
+
+    expected_date = rummager_result["public_timestamp"].to_date.rfc3339
+    assert_equal "#{Whitehall.public_root}/foo/news_story##{expected_date}", document_id(document, nil)
+  end
 end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -49,6 +49,10 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
     assert_equal presenter.publication_date, '25 October 2018'
   end
 
+  test "will produce an html block containing a time tag and the publication date" do
+    assert_equal presenter.display_date_microformat, '<time class="public_timestamp" datetime="2018-10-25T10:18:32+00:00">25 October 2018</time>'
+  end
+
   test "will returns associated document collections" do
     expected_result = "Part of a collection: <a href=\"https://www.test.gov.uk/government/collections/wizarding-sports\">" +
       "Wizarding sports</a> and <a href=\"https://www.test.gov.uk/government/collections/guidance-for-hosting-wizarding-competitions\">" +

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -8,6 +8,9 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
       "description" => "The Quiddich World Cup 2018 will be...",
       "public_timestamp" => "2018-10-25T10:18:32Z",
       "display_type" => "News story",
+      "format" => "news_article",
+      "government_name" => "2015 Ministry of Magic",
+      "is_historic" => true,
       "document_collections" => [
         {
           "title" => "Wizarding sports",
@@ -29,6 +32,9 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
     assert_equal rummager_result['title'], presenter.title
     assert_equal rummager_result['link'], presenter.link
     assert_equal rummager_result['display_type'], presenter.display_type_key
+    assert_equal rummager_result['format'], presenter.type
+    assert_equal rummager_result['government_name'], presenter.government_name
+    assert_equal rummager_result['is_historic'], presenter.historic?
   end
 
   test "will produce a humanized publication date required by Finders and Lists" do

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -7,7 +7,17 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
       "title" => "Quiddich World Cup 2018",
       "description" => "The Quiddich World Cup 2018 will be...",
       "public_timestamp" => "2018-10-25T10:18:32Z",
-      "display_type" => "News story"
+      "display_type" => "News story",
+      "document_collections" => [
+        {
+          "title" => "Wizarding sports",
+          "link" => "/government/collections/wizarding-sports"
+        },
+        {
+          "title" => "Guidance for hosting wizarding competitions",
+          "link" => "/government/collections/guidance-for-hosting-wizarding-competitions"
+        },
+      ],
     }
   end
 
@@ -23,5 +33,12 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
 
   test "will produce a humanized publication date required by Finders and Lists" do
     assert_equal presenter.publication_date, '25 October 2018'
+  end
+
+  test "will returns associated document collections" do
+    expected_result = "Part of a collection: <a href=\"https://www.test.gov.uk/government/collections/wizarding-sports\">" +
+      "Wizarding sports</a> and <a href=\"https://www.test.gov.uk/government/collections/guidance-for-hosting-wizarding-competitions\">" +
+      "Guidance for hosting wizarding competitions</a>"
+    assert_equal expected_result, presenter.publication_collections
   end
 end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -21,6 +21,14 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
           "link" => "/government/collections/guidance-for-hosting-wizarding-competitions"
         },
       ],
+      "organisations" => [
+        {
+          "acronym" => "DMGS",
+        },
+        {
+          "acronym" => "MOM",
+        }
+      ]
     }
   end
 
@@ -46,5 +54,22 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
       "Wizarding sports</a> and <a href=\"https://www.test.gov.uk/government/collections/guidance-for-hosting-wizarding-competitions\">" +
       "Guidance for hosting wizarding competitions</a>"
     assert_equal expected_result, presenter.publication_collections
+  end
+
+  test "will return acronyms for associated organisations" do
+    expected_result = "DMGS and MOM"
+    assert_equal expected_result, presenter.organisations
+  end
+
+  test "will return title for associated organisation if there is no acronym" do
+    search_result = {
+      "organisations" => [
+        {
+          "title" => "Department for Magical Games and Sports",
+        }
+      ]
+    }
+
+    assert_equal search_result["organisations"].first["title"], RummagerDocumentPresenter.new(search_result).organisations
   end
 end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -28,7 +28,8 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
         {
           "acronym" => "MOM",
         }
-      ]
+      ],
+      "operational_field" => "hogwarts"
     }
   end
 
@@ -75,5 +76,10 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
     }
 
     assert_equal search_result["organisations"].first["title"], RummagerDocumentPresenter.new(search_result).organisations
+  end
+
+  test "will return formatted operational field" do
+    expected_result = "Field of operation: <a href=\"https://www.test.gov.uk/government/fields-of-operation/hogwarts\">Hogwarts</a>"
+    assert_equal expected_result, presenter.field_of_operation
   end
 end

--- a/test/unit/whitehall/document_filter/advanced_search_rummager_test.rb
+++ b/test/unit/whitehall/document_filter/advanced_search_rummager_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+module Whitehall::DocumentFilter
+  class AdvancedSearchRummagerTest < ActiveSupport::TestCase
+    setup do
+      Whitehall.government_search_client.stubs(:advanced_search).returns {}
+    end
+
+    def format_types(*classes)
+      classes.map(&:search_format_type)
+    end
+
+    def expect_search_by_format_types(format_types)
+      Whitehall
+        .government_search_client
+        .expects(:advanced_search)
+        .with(
+          has_entry(
+            search_format_types: format_types
+          )
+        )
+    end
+
+    def expect_search_by_taxonomy_tree(taxons)
+      Whitehall
+        .government_search_client
+        .expects(:advanced_search)
+        .with(
+          has_entry(
+            part_of_taxonomy_tree: taxons
+          )
+        )
+    end
+
+    def expect_search_by_people(people)
+      Whitehall
+        .government_search_client
+        .expects(:advanced_search)
+        .with(
+          has_entry(people: people)
+        )
+    end
+
+    test 'publications_search looks for Publications, Consultations, and StatisticalDataSets by default' do
+      rummager = AdvancedSearchRummager.new({})
+      expect_search_by_format_types(format_types(Consultation, Publication, StatisticalDataSet))
+      rummager.publications_search
+    end
+
+    test 'publications_search looks for a specific announcement sub type if we use the publication_type option' do
+      rummager = AdvancedSearchRummager.new(publication_type: 'policy-papers')
+      expect_search_by_format_types(PublicationType::PolicyPaper.search_format_types)
+      rummager.publications_search
+    end
+
+    test 'publications_search search the taxonomy tree if we use the taxons option' do
+      rummager = AdvancedSearchRummager.new(taxons: 'content-id')
+      expect_search_by_taxonomy_tree(%w[content-id])
+      rummager.publications_search
+    end
+  end
+end

--- a/test/unit/whitehall/document_filter/search_rummager_test.rb
+++ b/test/unit/whitehall/document_filter/search_rummager_test.rb
@@ -55,6 +55,15 @@ module Whitehall::DocumentFilter
         )
     end
 
+    def expect_search_by_topical_event(topical_event)
+      Whitehall
+        .search_client
+        .expects(:search)
+        .with(
+          has_entry(filter_topical_events: topical_event)
+        )
+    end
+
     test 'announcements_search looks for all announcements excluding world types by default' do
       rummager = SearchRummager.new({})
       expected_types = ANNOUNCEMENT_TYPES
@@ -84,6 +93,13 @@ module Whitehall::DocumentFilter
     test 'announcements_search search the taxonomy tree if we use the taxons option' do
       rummager = SearchRummager.new(taxons: 'content-id')
       expect_search_by_taxonomy_tree(%w[content-id])
+      rummager.announcements_search
+    end
+
+    test 'announcements_search looks for announcements associated with a Topical Event' do
+      topical_event = create(:topical_event)
+      rummager = SearchRummager.new(topics: topical_event.slug)
+      expect_search_by_topical_event([topical_event.slug])
       rummager.announcements_search
     end
 


### PR DESCRIPTION
Supersedes PR #4449 
Trello: https://trello.com/c/5SNdtZIJ/341-change-announcements-finder-to-use-search-endpoint

Content Publisher will soon be publishing news content in production, which will be stored in the govuk index in Rummager. Currently the announcements finder uses the 'advanced-search' Rummager endpoint which only queries the government index, so in this PR we switch the announcements finder to use the 'search' Rummager endpoint which queries both the government and govuk indices.