### PR TITLE
Export contact lookup tables with news document

### DIFF
--- a/lib/export_news_document.rb
+++ b/lib/export_news_document.rb
@@ -27,7 +27,10 @@ class ExportNewsDocument
   end
 
   def call
-    document.as_json.merge("editions" => editions.as_json)
+    document.as_json.merge(
+      "editions" => editions.as_json,
+      "contacts" => contacts.as_json,
+    )
   end
 
 private
@@ -132,5 +135,14 @@ private
 
       data
     end
+  end
+
+  def contacts
+    bodies = document.editions.flat_map(&:translations).map(&:body)
+    contact_ids = bodies.flat_map do |body|
+      body.scan(/\[Contact:\s*(.*?)\s*\]/).flatten.map(&:to_i).reject(&:zero?)
+    end
+
+    Contact.where(id: contact_ids).pluck(:id, :content_id).to_h
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -149,7 +149,7 @@ namespace :export do
     puts result.to_json
   end
 
-  desc "Export news documents to JSON format export:news_documents e.g. ORGS=org-slug FROM=2018-07-01"
+  desc "Export news documents to JSON format e.g. export:news_documents ORGS=org-slug FROM=2018-07-01"
   task news_documents: :environment do
     org_slugs = ENV.fetch("ORGS", "").split(',')
 

--- a/test/unit/export_news_document_test.rb
+++ b/test/unit/export_news_document_test.rb
@@ -2,8 +2,9 @@ require "test_helper"
 
 class ExportNewsDocumentTest < ActiveSupport::TestCase
   test "returns a hash representation of a document" do
-    document = FactoryBot.build(:edition, :with_document).document
+    document = FactoryBot.create(:news_article, :with_document).document
     export = ExportNewsDocument.new(document).call
     assert_instance_of Hash, export
+    assert export["editions"].count == 1
   end
 end

--- a/test/unit/export_news_document_test.rb
+++ b/test/unit/export_news_document_test.rb
@@ -7,4 +7,13 @@ class ExportNewsDocumentTest < ActiveSupport::TestCase
     assert_instance_of Hash, export
     assert export["editions"].count == 1
   end
+
+  test "includes a mapping of contact ids to contact content_ids embedded" do
+    contact = FactoryBot.create(:contact, content_id: SecureRandom.uuid)
+    document = FactoryBot.create(:news_article,
+                                 :with_document,
+                                 body: "[Contact:#{contact.id}]").document
+    export = ExportNewsDocument.new(document).call
+    assert_equal export["contacts"], contact.id.to_s => contact.content_id
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

This PR has a couple of small fixes and is then focused on updating ExportNewsDocument to include a lookup table of Whitehall contact id to content_ids so that the bodies of documents can be updated with the appropriate content_id.

Pairs with this PR for content publisher: 