### PR TITLE
Ensure email subsciptions use taxon_tree instead of taxons

### DIFF
--- a/lib/url_to_subscriber_list_criteria.rb
+++ b/lib/url_to_subscriber_list_criteria.rb
@@ -28,10 +28,8 @@ class UrlToSubscriberListCriteria
                  { "links" => from_params.merge("roles" => [path_match[1]]) }
                elsif (path_match = @url.path.match(%r{^/government/organisations/(.*)\.atom$}))
                  { "links" => from_params.merge("organisations" => [path_match[1]]) }
-               elsif (path_match = @url.path.match(%r{^/government/topical-events/(.*)\.atom$}))
+               elsif (path_match = @url.path.match(%r{^/government/(?:topical-events|topics)/(.*)\.atom$}))
                  { "links" => from_params.merge("topical_events" => [path_match[1]]) }
-               elsif (path_match = @url.path.match(%r{^/government/topics/(.*)\.atom$}))
-                 { "links" => from_params.merge(topic_map([path_match[1]]) => [path_match[1]]) }
                elsif (path_match = @url.path.match(%r{^/world/(.*)\.atom$}))
                  { "links" => from_params.merge("world_locations" => [path_match[1]]) }
                elsif @url.path.match?(%r{/government/feed})
@@ -65,8 +63,7 @@ class UrlToSubscriberListCriteria
         result['organisations'] = result.delete('departments')
       end
       if result.key?('topics')
-        values = result.delete('topics')
-        result[topic_map(values)] = values
+        result['topical_events'] = result.delete('topics')
       end
       if result.key?('subtaxons')
         result['taxons'] = result.delete('subtaxons')
@@ -76,10 +73,6 @@ class UrlToSubscriberListCriteria
     end
   end
 
-  def topic_map(values)
-    @static_data.topical_event?(values) ? 'topical_events' : 'policy_areas'
-  end
-
   def lookup_content_id(key, slug)
     @static_data.content_id(key, slug)
   end
@@ -87,18 +80,13 @@ class UrlToSubscriberListCriteria
   module StaticData
     class UnknownStaticDataKey < StandardError; end
 
-    def self.topical_event?(values)
-      TopicalEvent.where(slug: values).any?
-    end
-
     def self.content_id(key, slug)
       lookup_map = {
         "world_locations" => WorldLocation,
         "organisations" => Organisation,
         "roles" => Role,
         "people" => Person,
-        "topical_events" => Classification,
-        "policy_areas" => Classification,
+        "topical_events" => Classification
       }
 
       lookup_class = lookup_map[key] || raise(UnknownStaticDataKey, key)

--- a/test/functional/email_signups_controller_test.rb
+++ b/test/functional/email_signups_controller_test.rb
@@ -22,14 +22,14 @@ class EmailSignupsControllerTest < ActionController::TestCase
   end
 
   test 'POST :create with a valid email signup redirects to the signup URL' do
-    topic = create(:topic)
+    topical_event = create(:topical_event)
 
     email_alert_api_has_subscriber_list(
-      "links" => { "policy_areas" => [topic.content_id] },
+      "links" => { "topical_events" => [topical_event.content_id] },
       "subscription_url" => "http://email_alert_api_signup_url",
     )
 
-    post :create, params: { email_signup: { feed: atom_feed_url_for(topic) } }
+    post :create, params: { email_signup: { feed: atom_feed_url_for(topical_event) } }
 
     assert_response :redirect
     assert_redirected_to 'http://email_alert_api_signup_url'

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -2,70 +2,78 @@ require 'test_helper'
 
 class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
   test "can convert department to organisation" do
+    static_data = stub("StaticData", topical_event?: false)
+    static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
-      stub("StaticData", topical_event?: false),
+      static_data,
     )
-    assert_equal converter.map_url_to_hash,
+    assert_equal converter.convert,
                  "links" => {
                    "organisations" => [
-                     "advisory-committee-on-clinical-excellence-awards",
+                     "123",
                    ],
                  }
   end
 
   test "can convert when topic is not a topical_event" do
+    static_data = stub("StaticData", topical_event?: false)
+    static_data.expects(:content_id).with('policy_areas', 'wildlife-and-animal-welfare').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?topics%5B%5D=wildlife-and-animal-welfare',
-      stub("StaticData", topical_event?: false),
+      static_data,
     )
-    assert_equal converter.map_url_to_hash,
+    assert_equal converter.convert,
                  "links" => {
                    "policy_areas" => [
-                     "wildlife-and-animal-welfare",
+                     "123",
                    ],
                  }
   end
 
   test "can convert when topic is a topical_event" do
+    static_data = stub("StaticData", topical_event?: true)
+    static_data.expects(:content_id).with('topical_events', 'spending-round-2013').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?topics%5B%5D=spending-round-2013',
-      stub("StaticData", topical_event?: true),
+      static_data,
     )
-    assert_equal converter.map_url_to_hash,
+    assert_equal converter.convert,
                  "links" => {
                    "topical_events" => [
-                     "spending-round-2013"
+                     "123"
                    ],
                  }
   end
 
   test "ignores trailing whitespace" do
+    static_data = stub("StaticData", topical_event?: false)
+    static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards  ',
-      stub("StaticData", topical_event?: false),
+      static_data,
     )
-    assert_equal converter.map_url_to_hash,
+    assert_equal converter.convert,
                  "links" => {
                    "organisations" => [
-                     "advisory-committee-on-clinical-excellence-awards",
+                     "123",
                    ],
                  }
   end
 
   test "can convert multiple options" do
+    static_data = stub("StaticData", topical_event?: false)
+    static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
+    static_data.expects(:content_id).with('policy_areas', 'employment').returns '456'
+
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards&topics%5B%5D=employment ',
-      stub("StaticData", topical_event?: false),
+      static_data,
     )
-    assert_equal converter.map_url_to_hash,
+    assert_equal converter.convert,
                  "links" => {
-                   "organisations" => [
-                     "advisory-committee-on-clinical-excellence-awards",
-                   ],
-                   "policy_areas" => %w[
-                     employment
-                   ],
+                   "organisations" => %w[123],
+                   "policy_areas" =>  %w[456]
                  }
   end
 
@@ -118,7 +126,7 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
         stub("StaticData"),
         )
 
-    assert_equal converter.convert, "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
+    assert_equal converter.convert, "links" => { "taxon_tree" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
                                       "email_document_supertype" => "publications"
   end
 
@@ -128,7 +136,7 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
         stub("StaticData"),
         )
 
-    assert_equal converter.convert,  "links" => { "taxons" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
+    assert_equal converter.convert,  "links" => { "taxon_tree" => ["a544d48b-1e9e-47fb-b427-7a987c658c14"] },
                                      "email_document_supertype" => "publications"
   end
 end

--- a/test/unit/url_to_subscriber_list_criteria_test.rb
+++ b/test/unit/url_to_subscriber_list_criteria_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
   test "can convert department to organisation" do
-    static_data = stub("StaticData", topical_event?: false)
+    static_data = stub("StaticData")
     static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards',
@@ -10,29 +10,12 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
     )
     assert_equal converter.convert,
                  "links" => {
-                   "organisations" => [
-                     "123",
-                   ],
-                 }
-  end
-
-  test "can convert when topic is not a topical_event" do
-    static_data = stub("StaticData", topical_event?: false)
-    static_data.expects(:content_id).with('policy_areas', 'wildlife-and-animal-welfare').returns '123'
-    converter = UrlToSubscriberListCriteria.new(
-      'https://www.gov.uk/government/feed?topics%5B%5D=wildlife-and-animal-welfare',
-      static_data,
-    )
-    assert_equal converter.convert,
-                 "links" => {
-                   "policy_areas" => [
-                     "123",
-                   ],
+                   "organisations" => %w[123]
                  }
   end
 
   test "can convert when topic is a topical_event" do
-    static_data = stub("StaticData", topical_event?: true)
+    static_data = stub("StaticData")
     static_data.expects(:content_id).with('topical_events', 'spending-round-2013').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?topics%5B%5D=spending-round-2013',
@@ -40,14 +23,12 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
     )
     assert_equal converter.convert,
                  "links" => {
-                   "topical_events" => [
-                     "123"
-                   ],
+                   "topical_events" => %w[123]
                  }
   end
 
   test "ignores trailing whitespace" do
-    static_data = stub("StaticData", topical_event?: false)
+    static_data = stub("StaticData")
     static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards  ',
@@ -55,16 +36,14 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
     )
     assert_equal converter.convert,
                  "links" => {
-                   "organisations" => [
-                     "123",
-                   ],
+                   "organisations" => %w[123]
                  }
   end
 
   test "can convert multiple options" do
-    static_data = stub("StaticData", topical_event?: false)
+    static_data = stub("StaticData")
     static_data.expects(:content_id).with('organisations', 'advisory-committee-on-clinical-excellence-awards').returns '123'
-    static_data.expects(:content_id).with('policy_areas', 'employment').returns '456'
+    static_data.expects(:content_id).with('topical_events', 'employment').returns '456'
 
     converter = UrlToSubscriberListCriteria.new(
       'https://www.gov.uk/government/feed?departments%5B%5D=advisory-committee-on-clinical-excellence-awards&topics%5B%5D=employment ',
@@ -73,7 +52,7 @@ class UrlToSubscriberListCriteriaTest < ActiveSupport::TestCase
     assert_equal converter.convert,
                  "links" => {
                    "organisations" => %w[123],
-                   "policy_areas" =>  %w[456]
+                   "topical_events" =>  %w[456]
                  }
   end
 


### PR DESCRIPTION
If using the 'taxons' key when creating email signups, subscribers
will only receive emails tagged to that particular taxon.

What we want instead is that subcribers receive emails tagged to
the specified taxon _and_ all its children

This change uses the 'taxon_tree' tag instead of the 'taxons'
tag so find/create subscriber lists, which will enable this.