### PR TITLE
Stop requiring postal_code for Contacts going to Publishing API

### DIFF
--- a/app/presenters/publishing_api/contact_presenter.rb
+++ b/app/presenters/publishing_api/contact_presenter.rb
@@ -89,8 +89,8 @@ module PublishingApi
     end
 
     def post_addresses
-      # These are the three required fields for the schema
-      return [] if !street_address.present? || !postal_code.present? || !country
+      # These are the required fields for the schema
+      return [] if !street_address.present? || !country
 
       post_address = {
         title: recipient.presence,


### PR DESCRIPTION
Turns out tons of the Whitehall contacts are lacking the postal_code
field (and instead may have it written in street address) and so are not
compliant with the schema. As there are a lot of these (448) the simple
approach seems to be to get rid of the postal_code requirement and also
remove it from schema requirements: https://github.com/alphagov/govuk-content-schemas/pull/835