### PR TITLE
Revert "Bump govuk_test from 0.2.1 to 0.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     carrierwave-i18n (0.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
+    chromedriver-helper (2.0.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     chronic (0.10.2)
@@ -232,10 +232,9 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    govuk_test (0.3.0)
+    govuk_test (0.2.1)
       capybara
       chromedriver-helper
-      ptools
       puma
       selenium-webdriver
     graphviz_transitions (0.1.2)
@@ -487,9 +486,9 @@ GEM
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.141.0)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2, >= 1.2.2)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     shared_mustache (1.0.1)
@@ -575,7 +574,7 @@ GEM
     websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
-    xpath (3.2.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
 
 PLATFORMS


### PR DESCRIPTION
Reverts alphagov/whitehall#4473

This seems to break CI as per: https://github.com/alphagov/content-publisher/pull/475

Since this was merged to master I get different builds failing due to: `unable to bind to locking port 9514 within 45 seconds (Selenium::WebDriver::Error::WebDriverError)`

According to @cbaines:

> I think this is actually due to chromedriver failing to start
> Yesterday I got as far as tracking down that government-frontend is installing an older version of the chromedriver gem, that generates a `chromedriver` binary that I think is what's being run here, but it doesn't work.
