### PR TITLE
Rescue from gds api client errors

### DIFF
--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -52,7 +52,7 @@ private
 
   def log_error_and_render_500(exception)
     logger.error "\n#{exception.class} (#{exception.message}):\n#{exception.backtrace.join("\n")}\n\n"
-    render plain: 'API Timed Out', status: :internal_server_error
+    render plain: 'API error', status: :internal_server_error
   end
 
   def set_locale(&block)

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -15,6 +15,10 @@ class PublicFacingController < ApplicationController
     log_error_and_render_500 exception
   end
 
+  rescue_from GdsApi::HTTPClientError do |exception|
+    log_error_and_render_400 exception
+  end
+
   # Allows additional request formats to be enabled.
   #
   # By default, PublicFacingController actions will only respond to HTML requests. To enable
@@ -40,6 +44,11 @@ class PublicFacingController < ApplicationController
   end
 
 private
+
+  def log_error_and_render_400(exception)
+    logger.error "\n#{exception.class} (#{exception.message}):\n#{exception.backtrace.join("\n")}\n\n"
+    render plain: 'Bad API request', status: :bad_request
+  end
 
   def log_error_and_render_500(exception)
     logger.error "\n#{exception.class} (#{exception.message}):\n#{exception.backtrace.join("\n")}\n\n"

--- a/test/functional/public_facing_controller_test.rb
+++ b/test/functional/public_facing_controller_test.rb
@@ -35,8 +35,8 @@ class PublicFacingControllerTest < ActionController::TestCase
       raise GdsApi::HTTPBadGateway.new('Bad Gateway')
     end
 
-    def api_not_found
-      raise GdsApi::HTTPNotFound.new('Not found')
+    def api_unprocessable_entity
+      raise GdsApi::HTTPUnprocessableEntity.new('Unprocessable entity')
     end
   end
 
@@ -158,6 +158,13 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
   end
 
+  test "public facing controllers catch GDS API client errors and renders a 400 response" do
+    with_routing_for_test_controller do
+      get :api_unprocessable_entity
+      assert_response :bad_request
+    end
+  end
+
   test "public facing controllers catch GDS API timeouts and error responses and renders a 500 response" do
     with_routing_for_test_controller do
       get :api_timeout
@@ -172,14 +179,6 @@ class PublicFacingControllerTest < ActionController::TestCase
     end
   end
 
-  test "public facing controllers do not catch client GDS API errors" do
-    with_routing_for_test_controller do
-      assert_raise GdsApi::HTTPErrorResponse do
-        get :api_not_found
-      end
-    end
-  end
-
   test "public facing controllers explicitly set X-FRAME-OPTIONS header" do
     with_routing_for_test_controller do
       get :test
@@ -190,7 +189,7 @@ class PublicFacingControllerTest < ActionController::TestCase
   def with_routing_for_test_controller
     with_routing do |map|
       map.draw do
-        %w(test json js_or_atom locale api_timeout api_bad_gateway api_not_found).each do |action|
+        %w(test json js_or_atom locale api_timeout api_bad_gateway api_unprocessable_entity).each do |action|
           get "/test/#{action}.{.:format}", to: "public_facing_controller_test/test##{action}"
         end
       end


### PR DESCRIPTION
Adds exception handling for GDS API client errors so that they are handled as a bad request not a server error.

An example where this can happen:

`GET /government/publications?publication_filter_option=consultations&page=10000000`

```
GdsApi::HTTPUnprocessableEntity
The maximum for `page` parameter is 500000.
```