### PR TITLE
Present content publisher documents in announcements finder

### DIFF
--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -7,13 +7,12 @@ class RummagerDocumentPresenter < ActionView::Base
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::TagHelper
 
-  attr_reader :title, :link, :display_type, :summary, :content_id
+  attr_reader :title, :link, :summary, :content_id
 
   def initialize(document_hash)
     @document = document_hash
     @link = @document.fetch('link', '')
     @title = @document.fetch('title', '')
-    @display_type = @document.fetch('display_type', '')
     @summary = @document.fetch('description', '')
     @content_id = @document.fetch('content_id', SecureRandom.uuid)
   end
@@ -29,6 +28,10 @@ class RummagerDocumentPresenter < ActionView::Base
   def display_type_key
     key = @document.fetch('display_type', nil) || @document.fetch('content_store_document_type', '')
     key.parameterize.underscore
+  end
+
+  def display_type
+    display_type_key.humanize
   end
 
   def id

--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -27,7 +27,8 @@ class RummagerDocumentPresenter < ActionView::Base
   end
 
   def display_type_key
-    @document.fetch('display_type', '')
+    key = @document.fetch('display_type', nil) || @document.fetch('content_store_document_type', '')
+    key.parameterize.underscore
   end
 
   def id

--- a/test/functional/announcements_controller_test.rb
+++ b/test/functional/announcements_controller_test.rb
@@ -63,7 +63,7 @@ class AnnouncementsControllerTest < ActionController::TestCase
         assert_select ".display-type", text: "Speech"
       end
       assert_select '#written_statement_written_statement_id' do
-        assert_select ".display-type", text: "Statement to Parliament"
+        assert_select ".display-type", text: "Statement to parliament"
       end
     end
   end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -90,4 +90,8 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
     search_result = { "content_store_document_type" => "news_story" }
     assert_equal "news_story", RummagerDocumentPresenter.new(search_result).display_type_key
   end
+
+  test "will return humanized display_type_key" do
+    assert_equal "News story", presenter.display_type
+  end
 end

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -40,7 +40,6 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
   test "will provide access to document attributes required for Finders and Lists" do
     assert_equal rummager_result['title'], presenter.title
     assert_equal rummager_result['link'], presenter.link
-    assert_equal rummager_result['display_type'], presenter.display_type_key
     assert_equal rummager_result['format'], presenter.type
     assert_equal rummager_result['government_name'], presenter.government_name
     assert_equal rummager_result['is_historic'], presenter.historic?
@@ -81,5 +80,14 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
   test "will return formatted operational field" do
     expected_result = "Field of operation: <a href=\"https://www.test.gov.uk/government/fields-of-operation/hogwarts\">Hogwarts</a>"
     assert_equal expected_result, presenter.field_of_operation
+  end
+
+  test "will return underscored display_type from Rummager if present" do
+    assert_equal "news_story", presenter.display_type_key
+  end
+
+  test "will return content_store_document_type if display_type is not present" do
+    search_result = { "content_store_document_type" => "news_story" }
+    assert_equal "news_story", RummagerDocumentPresenter.new(search_result).display_type_key
   end
 end


### PR DESCRIPTION
For https://trello.com/c/B638xumc/377-present-content-publisher-content-in-the-announcements-finder

This PR enables a document's type to appear:

- in the Announcements finder result
<img width="450" alt="screen shot 2018-11-15 at 11 35 16" src="https://user-images.githubusercontent.com/13434452/48556244-5a950e80-e8db-11e8-9ed6-82f9190d7e2a.png">

- in the title of the document in the Announcements atom feed
- in the category tag label in the Announcements atom feed

<img width="920" alt="screen shot 2018-11-15 at 11 34 47" src="https://user-images.githubusercontent.com/13434452/48556247-5ff25900-e8db-11e8-8829-d00f920dffc6.png">

Normally this value is derived from the `display_type` field in Rummager.  However `display_type` is not available in the govuk index, so when Rummager returns documents from that index we are unable to provide a value for it.  

We amend the `display_type_key` method, which is used by the Translation Helper, to fetch `content_store_document_type` instead in these cases. 

We also introduce a `display_type` method which is used in the Announcements finder to render the document's type.  This formats the value returned by `display_type_key` into a humanized form that's appropriate to be rendered.