### PR TITLE
Topical Events announcements filtered by content_store_document_type

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -6,7 +6,7 @@ class TopicalEventsController < ClassificationsController
     @content_item = Whitehall.content_store.content_item(@classification.base_path)
     @publications = fetch_related_documents(filter_format: 'publication')
     @consultations = fetch_related_documents(filter_format: 'consultation')
-    @announcements = fetch_related_documents(filter_format: 'news_article')
+    @announcements = fetch_related_documents(filter_content_store_document_type: announcement_document_types)
     @detailed_guides = @classification.published_detailed_guides.includes(:translations, :document).limit(5)
     @featurings = decorate_collection(@classification.classification_featurings.includes(:image, edition: :document).limit(5), ClassificationFeaturingPresenter)
 
@@ -40,7 +40,11 @@ private
       filter_topical_events: @classification.slug,
       count: 3,
       order: "-public_timestamp",
-      fields: %w[display_type title link public_timestamp format description content_id]
+      fields: %w[display_type title link public_timestamp format description content_id content_store_document_type]
     }
+  end
+
+  def announcement_document_types
+    Whitehall::AnnouncementFilterOption.all.map(&:document_type).flatten
   end
 end


### PR DESCRIPTION
For https://trello.com/c/ibulJkki/408-update-topical-events-page-announcements-to-query-rummager-by-content-store-document-type

This switches the rummager search for announcements on Topical Events pages to
filter by `content_store_document_type` instead of `format`. We do this for a
few reasons:

1) The announcements finder now filters by `content_store_document_type` as it
allows more precise control over the documents returned. For consistency we
should ensure that the 3 documents returned in the announcements section on
topical events pages match the top 3 documents that would appear on an
announcements finder filtered by a given topical event.

2) The current filtering only filters for `news_article`, but it's possible
that other announcement types could be tagged to a topical event.

3) `format` is expected to be deprecated in Rummager

We also ensure that `content_store_document_type` field is returned from
Rummager, as this will enable displaying the document's type in the
announcements section for Content Publisher documents.