### PR TITLE
Create SearchRummagerService

### DIFF
--- a/app/services/search_rummager_service.rb
+++ b/app/services/search_rummager_service.rb
@@ -1,0 +1,19 @@
+class SearchRummagerService
+  def fetch_related_documents(filter_params = {})
+    options = default_search_options.merge(filter_params)
+    search_response = Whitehall.search_client.search(options)
+    search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
+    search_response
+  end
+
+  private
+
+  def default_search_options
+    {
+      order: "-public_timestamp",
+      count: 1000,
+      fields: %w[display_type title link public_timestamp format content_store_document_type
+                 description content_id organisations document_collections]
+    }
+  end
+end

--- a/features/fixtures/rummager_response.json
+++ b/features/fixtures/rummager_response.json
@@ -1,36 +1,79 @@
 {
-    "results": [
+  "results": [
+    {
+      "link": "/foo/policy_paper",
+      "title": "Policy on Topicals",
+      "public_timestamp": "2016-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-A",
+      "organisations": [
         {
-            "link": "/foo/policy_paper",
-            "title": "Policy on Topicals",
-            "public_timestamp": "2016-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-A"
-        },
-        {
-            "link": "/foo/consultation",
-            "title": "Examination of Events",
-            "public_timestamp": "2017-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-B"
-        },
-        {
-            "link": "/foo/news_story",
-            "title": "PM attends summit on topical events",
-            "public_timestamp": "2018-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-C"
-        },
-        {
-            "link": "/foo/statistics",
-            "title": "Weekly topical event price",
-            "public_timestamp": "2018-10-17T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-D"
+          "acronym": "HMRC",
+          "title": "HM Revenue & Customs"
         }
-    ]
+      ],
+      "document_collections": [
+        {
+          "title": "Budget 2016: tax-related documents",
+          "link": "/government/collections/budget-2016-tax-related-documents"
+        },
+        {
+          "title": "Tax information and impact notes",
+          "link": "/government/collections/tax-information-and-impact-notes-tiins"
+        }
+      ]
+    },
+    {
+      "link": "/foo/consultation",
+      "title": "Examination of Events",
+      "public_timestamp": "2017-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-B",
+      "organisations": [
+        {
+          "acronym": "FCO",
+          "title": "Foreign and Commonwealth Office"
+        }
+      ]
+    },
+    {
+      "link": "/foo/news_story",
+      "title": "PM attends summit on topical events",
+      "public_timestamp": "2018-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-C",
+      "organisations": [
+        {
+          "title": "Number 10"
+        }
+      ],
+      "document_collections": [
+        {
+          "title": "PM Topical events",
+          "link": "/government/collections/pm-topical-events"
+        },
+        {
+          "title": "Tax information and impact notes",
+          "link": "/government/collections/tax-information-and-impact-notes-tiins"
+        }
+      ]
+    },
+    {
+      "link": "/foo/statistics",
+      "title": "Weekly topical event price",
+      "public_timestamp": "2018-10-17T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-D",
+      "organisations": [
+        {
+          "acronym": "DEP",
+          "title": "Some other Department"
+        }
+      ]
+    }
+  ]
 }

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -1,9 +1,11 @@
 require "test_helper"
 require 'gds_api/test_helpers/content_store'
+require_relative '../support/search_rummager_helper'
 
 class TopicalEventsControllerTest < ActionController::TestCase
   include FeedHelper
   include GdsApi::TestHelpers::ContentStore
+  include SearchRummagerHelper
 
   should_be_a_public_facing_controller
 
@@ -117,15 +119,5 @@ class TopicalEventsControllerTest < ActionController::TestCase
     content_store_has_item(topical_event.base_path, payload)
 
     topical_event
-  end
-
-  def rummager_response
-    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
-  end
-
-  def processed_rummager_documents
-    ActiveSupport::JSON.decode(rummager_response)['results'].map! { |res|
-      RummagerDocumentPresenter.new(res)
-    }
   end
 end

--- a/test/support/search_rummager_helper.rb
+++ b/test/support/search_rummager_helper.rb
@@ -1,0 +1,22 @@
+module SearchRummagerHelper
+  def rummager_response
+    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
+  end
+
+  def processed_rummager_documents
+    ActiveSupport::JSON.decode(rummager_response)['results'].map! { |res|
+      RummagerDocumentPresenter.new(res)
+    }
+  end
+
+  def attributes(documents_object)
+    documents_object.map do |document|
+      [
+        document.title,
+        document.link,
+        document.summary,
+        document.content_id,
+      ]
+    end
+  end
+end

--- a/test/unit/services/search_rummager_service_test.rb
+++ b/test/unit/services/search_rummager_service_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require "gds_api/test_helpers/rummager"
+require_relative "../../support/search_rummager_helper"
+
+class SearchRummagerServiceTest < ActiveSupport::TestCase
+  include SearchRummagerHelper
+
+  setup do
+    @topical_event = create(:topical_event, :active)
+  end
+
+  test 'returns empty results array if topical event has no documents' do
+    stub_any_rummager_search_to_return_no_results
+    assert_equal [], SearchRummagerService.new.fetch_related_documents(topical_param)['results']
+  end
+
+  test 'fetches documents related to a topical event' do
+    stub_any_rummager_search.to_return(body: rummager_response)
+
+    results = SearchRummagerService.new.fetch_related_documents(topical_param)['results']
+
+    assert_instance_of RummagerDocumentPresenter, results.first
+    assert_equal 4, results.count
+    assert_equal attributes(processed_rummager_documents),
+                 attributes(results)
+  end
+
+  def topical_param
+    { filter_topical_events: @topical_event.slug }
+  end
+end


### PR DESCRIPTION
The methods for searching rummager and returning the results have been
abstracted away from the topical_events controller so other pages can share
this functionality, e.g the latest documents page for topical_events and
world_locations.