### PR TITLE
Fix document collections bug

### DIFF
--- a/app/presenters/rummager_document_presenter.rb
+++ b/app/presenters/rummager_document_presenter.rb
@@ -106,6 +106,7 @@ class RummagerDocumentPresenter < ActionView::Base
 private
 
   def format_link(title, link)
+    return unless title.present? && link.present?
     link_to(title, Plek.current.website_root + link)
   end
 

--- a/test/unit/presenters/rummager_document_presenter_test.rb
+++ b/test/unit/presenters/rummager_document_presenter_test.rb
@@ -60,6 +60,11 @@ class RummagerDocumentPresenterTest < ActiveSupport::TestCase
     assert_equal expected_result, presenter.publication_collections
   end
 
+  test "will not return a document collection if title and link are not present" do
+    search_result = { "document_collections" => [{ "title" => "A title" }] }
+    assert_nil RummagerDocumentPresenter.new(search_result).publication_collections
+  end
+
   test "will return acronyms for associated organisations" do
     expected_result = "DMGS and MOM"
     assert_equal expected_result, presenter.organisations


### PR DESCRIPTION
On the announcements finder page some documents display a "Part of a
collection" link. In order to display this link a title and link must be
provided. This protects against cases where Rummager does not provide both a
link and title.