### PR TITLE
Use rummager for latest documents pages

### DIFF
--- a/app/controllers/latest_controller.rb
+++ b/app/controllers/latest_controller.rb
@@ -7,24 +7,22 @@ class LatestController < PublicFacingController
 
 private
 
+  helper_method :subject, :documents
+
   def subject
     case subject_param
     when 'departments'
       Organisation.with_translations(I18n.locale).find(subject_id)
-    when 'topics'
-      Classification.find(subject_id)
+    when 'topical_events'
+      TopicalEvent.find(subject_id)
     when 'world_locations'
       WorldLocation.with_translations(I18n.locale).find(subject_id)
     end
   end
-  helper_method :subject
 
   def documents
-    Whitehall::Decorators::CollectionDecorator.new(filter.documents,
-                                                   LatestDocumentPresenter,
-                                                   view_context)
+    filter.documents
   end
-  helper_method :documents
 
   def filter
     @filter = LatestDocumentsFilter.for_subject(subject, page_params)
@@ -45,7 +43,7 @@ private
   end
 
   def supported_subjects
-    %w(departments topics world_locations)
+    %w(departments topical_events world_locations)
   end
 
   def redirect_unless_subject

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -2,46 +2,34 @@ class TopicalEventsController < ClassificationsController
   enable_request_formats show: :atom
 
   def show
-    @classification = TopicalEvent.friendly.find(params[:id])
-    @content_item = Whitehall.content_store.content_item(@classification.base_path)
-    @publications = fetch_related_documents(filter_format: 'publication')
-    @consultations = fetch_related_documents(filter_format: 'consultation')
-    @announcements = fetch_related_documents(filter_content_store_document_type: announcement_document_types)
-    @detailed_guides = @classification.published_detailed_guides.includes(:translations, :document).limit(5)
-    @featurings = decorate_collection(@classification.classification_featurings.includes(:image, edition: :document).limit(5), ClassificationFeaturingPresenter)
+    @topical_event = TopicalEvent.friendly.find(params[:id])
+    @content_item = Whitehall.content_store.content_item(@topical_event.base_path)
+    @publications =  find_documents(filter_format: 'publication', count: 3)
+    @consultations = find_documents(filter_format: 'consultation', count: 3)
+    @announcements = find_documents(filter_content_store_document_type: announcement_document_types, count: 3)
+    @detailed_guides = @topical_event.published_detailed_guides.includes(:translations, :document).limit(5)
+    @featurings = decorate_collection(@topical_event.classification_featurings.includes(:image, edition: :document).limit(5), ClassificationFeaturingPresenter)
 
-    set_slimmer_organisations_header(@classification.organisations)
-    set_slimmer_page_owner_header(@classification.lead_organisations.first)
-    set_meta_description(@classification.description)
+    set_slimmer_organisations_header(@topical_event.organisations)
+    set_slimmer_page_owner_header(@topical_event.lead_organisations.first)
+    set_meta_description(@topical_event.description)
 
     set_expiry 5.minutes
     respond_to do |format|
       format.html do
-        @recently_changed_documents = fetch_related_documents(count: 3)['results']
+        @recently_changed_documents = find_documents(count: 3)['results']
       end
       format.atom do
-        @recently_changed_documents = fetch_related_documents(count: 10)['results']
+        @recently_changed_documents = find_documents(count: 10)['results']
       end
     end
   end
 
 private
 
-  def fetch_related_documents(additional_options = {})
-    options = default_search_options.merge(additional_options)
-    search_response = Whitehall.search_client.search(options)
-    search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
-
-    search_response
-  end
-
-  def default_search_options
-    {
-      filter_topical_events: @classification.slug,
-      count: 3,
-      order: "-public_timestamp",
-      fields: %w[display_type title link public_timestamp format description content_id content_store_document_type]
-    }
+  def find_documents(filter_params)
+    filter_params[:filter_topical_events] = @topical_event.slug
+    SearchRummagerService.new.fetch_related_documents(filter_params)
   end
 
   def announcement_document_types

--- a/app/services/search_rummager_service.rb
+++ b/app/services/search_rummager_service.rb
@@ -1,0 +1,19 @@
+class SearchRummagerService
+  def fetch_related_documents(filter_params = {})
+    options = default_search_options.merge(filter_params)
+    search_response = Whitehall.search_client.search(options)
+    search_response["results"].map! { |res| RummagerDocumentPresenter.new(res) }
+    search_response
+  end
+
+  private
+
+  def default_search_options
+    {
+      order: "-public_timestamp",
+      count: 1000,
+      fields: %w[display_type title link public_timestamp format content_store_document_type
+                 description content_id organisations document_collections]
+    }
+  end
+end

--- a/app/views/classifications/show.atom.builder
+++ b/app/views/classifications/show.atom.builder
@@ -1,8 +1,8 @@
-atom_feed language: 'en-GB', root_url: classification_url(@classification) do |feed|
-  feed.title [@classification.name, 'Activity on GOV.UK'].join(' - ')
+atom_feed language: 'en-GB', root_url: classification_url(@topical_event) do |feed|
+  feed.title [@topical_event.name, 'Activity on GOV.UK'].join(' - ')
   feed.author do |author|
     author.name 'HM Government'
   end
 
-  documents_as_feed_entries(@recently_changed_documents, feed, @classification.created_at)
+  documents_as_feed_entries(@recently_changed_documents, feed, @topical_event.created_at)
 end

--- a/app/views/latest/_rummager_documents.html.erb
+++ b/app/views/latest/_rummager_documents.html.erb
@@ -1,0 +1,21 @@
+<ol class="document-list">
+  <% documents.each do |document| %>
+    <li class="document-row">
+      <h3><%= link_to document.title, document.link %></h3>
+      <ul class="attributes">
+        <li class="date">
+          <%= document.publication_date %>
+        </li>
+        <li class="display-type"><%= document.display_type %></li>
+
+        <% if document.organisations.present? %>
+          <li class="organisations"><%= document.organisations.html_safe %></li>
+        <% end %>
+
+        <% if document.publication_collections.present? %>
+          <li class="document-collections"><%= document.publication_collections.html_safe %></li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/latest/index.html.erb
+++ b/app/views/latest/index.html.erb
@@ -13,29 +13,8 @@
 
 <div class="block results">
   <div class="inner-block">
-    <%= render 'shared/feeds', atom_url: atom_feed_url_for(subject) %>
-
-    <ol class="document-list">
-      <% documents.each do |document| %>
-        <li class="document-row">
-          <h3><%= link_to document.title, document_path(document) %></h3>
-          <ul class="attributes">
-            <li class="date">
-              <%= published_or_updated(document).titleize %>
-              <%= absolute_date(document.public_timestamp, class: 'published-at') %>
-            </li>
-            <li class="display-type"><%= document.display_type %></li>
-            <li class="organisations">
-              <%= document.display_organisations.html_safe %>
-            </li>
-            <% if document.document_collections.present? %>
-              <li class="document-collections"><%= document.document_collections %></li>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
-    </ol>
-
+    <%= render "shared/feeds", atom_url: atom_feed_url_for(subject) %>
+    <%= render "rummager_documents", documents: documents %>
     <%= paginate documents %>
   </div>
 </div>

--- a/app/views/shared/_document_list_from_rummager.html.erb
+++ b/app/views/shared/_document_list_from_rummager.html.erb
@@ -2,7 +2,7 @@
    heading ||= type.to_s.humanize
    filter_option = (heading == "Publications") ? "all" : heading.downcase
    world_location_news ||= "0"
-   filter_type = @classification || @world_location
+   filter_type = @classification || @world_location || @topical_event
 %>
 <section id="<%= heading.downcase.parameterize %>" class="document-block">
   <h1 class="label"><%= heading %></h1>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,29 +1,29 @@
-<% page_title @classification.name %>
+<% page_title @topical_event.name %>
 <% page_class "topical-events-show" %>
-<% atom_discovery_link_tag atom_feed_url_for(@classification), "Latest activity on #{@classification.name}" %>
+<% atom_discovery_link_tag atom_feed_url_for(@topical_event), "Latest activity on #{@topical_event.name}" %>
 
-<%= content_tag_for(:div, @classification, class: "classification #{@classification.class.name.underscore}") do %>
+<%= content_tag_for(:div, @topical_event, class: "classification #{@topical_event.class.name.underscore}") do %>
 
   <header class="block headings-block">
     <div class="inner-block floated-children">
       <%= render partial: 'shared/heading',
-                locals: { heading: "#{h(@classification.name)}#{' <span class="archived">(Archived)</span>' if @classification.archived?}".html_safe,
+                locals: { heading: "#{h(@topical_event.name)}#{' <span class="archived">(Archived)</span>' if @topical_event.archived?}".html_safe,
                           big: true, extra: true } %>
-      <% if @classification.logo_url.present? %>
+      <% if @topical_event.logo_url.present? %>
         <div class="heading-extra topical-event-logo">
           <div class="heading-inner">
-            <%= image_tag(@classification.logo_url(:s300), alt: @classification.logo_alt_text) if @classification.logo_url %>
+            <%= image_tag(@topical_event.logo_url(:s300), alt: @topical_event.logo_alt_text) if @topical_event.logo_url %>
           </div>
         </div>
       <% end %>
-      <% if @classification.organisations.any? %>
+      <% if @topical_event.organisations.any? %>
         <aside class="meta metadata-list">
           <div class="inner-heading">
             <dl>
-              <dt><%= t('document.headings.organisations', count: @classification.organisations.length) %>:</dt>
+              <dt><%= t('document.headings.organisations', count: @topical_event.organisations.length) %>:</dt>
               <dd>
                 <%= render  partial: 'organisations/organisations_name_list',
-                            locals: { organisations: @classification.organisations } %>
+                            locals: { organisations: @topical_event.organisations } %>
               </dd>
             </dl>
           </div>
@@ -36,15 +36,15 @@
     <div class="inner-block">
       <div class="page-description">
         <section class="description">
-          <%= govspeak_to_html @classification.description %>
-          <% if @classification.about_page.present? %>
+          <%= govspeak_to_html @topical_event.description %>
+          <% if @topical_event.about_page.present? %>
             <p class="read-more">
-              <%= link_to @classification.about_page.read_more_link_text, topical_event_about_pages_path(@classification) %>
+              <%= link_to @topical_event.about_page.read_more_link_text, topical_event_about_pages_path(@topical_event) %>
             </p>
           <% end %>
-          <% if @classification.social_media_accounts.any? %>
+          <% if @topical_event.social_media_accounts.any? %>
             <%= render partial: 'shared/social_media_accounts',
-                       locals: { socialable: @classification, followus: true } %>
+                       locals: { socialable: @topical_event, followus: true } %>
           <% end %>
         </section>
       </div>
@@ -60,7 +60,7 @@
         <% end %>
         <%= render partial: 'shared/recently_updated',
                    locals: { recently_updated: @recently_changed_documents,
-                           atom_url: atom_feed_url_for(@classification),
+                           atom_url: atom_feed_url_for(@topical_event),
                            extra_class: 'panel',
                            see_all_link: latest_path(topics: [@classification]),
                            documents_source: 'rummager' } %>
@@ -94,14 +94,14 @@
 
   <div class="block heading-block">
     <div class="inner-block">
-      <% if @classification.lead_organisations.any? %>
+      <% if @topical_event.lead_organisations.any? %>
         <section id="organisations" class="organisations">
           <div class="head-section">
             <h1 class="label">Who&rsquo;s involved</h1>
           </div>
           <div class="content">
             <ul>
-              <% @classification.lead_organisations.each do |organisation| %>
+              <% @topical_event.lead_organisations.each do |organisation| %>
                 <%= content_tag_for(:li, organisation, class: organisation_brand_colour_class(organisation)) do %>
                   <%= link_to organisation_path(organisation),
                         class: logo_classes(organisation: organisation, stacked: true) do %>
@@ -109,7 +109,7 @@
                   <% end %>
                 <% end %>
               <% end %>
-              <% if @classification.slug == 'first-world-war-centenary' %>
+              <% if @topical_event.slug == 'first-world-war-centenary' %>
                 <li class="non-govuk imperial-war-museums">
                   <a href="http://www.iwm.org.uk">Imperial War Museums</a>
                 </li>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -62,7 +62,7 @@
                    locals: { recently_updated: @recently_changed_documents,
                            atom_url: atom_feed_url_for(@topical_event),
                            extra_class: 'panel',
-                           see_all_link: latest_path(topics: [@classification]),
+                           see_all_link: latest_path(topical_events: [@topical_event]),
                            documents_source: 'rummager' } %>
       </section>
     </div>

--- a/features/fixtures/rummager_response.json
+++ b/features/fixtures/rummager_response.json
@@ -1,36 +1,79 @@
 {
-    "results": [
+  "results": [
+    {
+      "link": "/foo/policy_paper",
+      "title": "Policy on Topicals",
+      "public_timestamp": "2016-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-A",
+      "organisations": [
         {
-            "link": "/foo/policy_paper",
-            "title": "Policy on Topicals",
-            "public_timestamp": "2016-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-A"
-        },
-        {
-            "link": "/foo/consultation",
-            "title": "Examination of Events",
-            "public_timestamp": "2017-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-B"
-        },
-        {
-            "link": "/foo/news_story",
-            "title": "PM attends summit on topical events",
-            "public_timestamp": "2018-10-07T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-C"
-        },
-        {
-            "link": "/foo/statistics",
-            "title": "Weekly topical event price",
-            "public_timestamp": "2018-10-17T22:18:32Z",
-            "display_type": "news_article",
-            "description": "Description of document...",
-            "content_id": "1234-D"
+          "acronym": "HMRC",
+          "title": "HM Revenue & Customs"
         }
-    ]
+      ],
+      "document_collections": [
+        {
+          "title": "Budget 2016: tax-related documents",
+          "link": "/government/collections/budget-2016-tax-related-documents"
+        },
+        {
+          "title": "Tax information and impact notes",
+          "link": "/government/collections/tax-information-and-impact-notes-tiins"
+        }
+      ]
+    },
+    {
+      "link": "/foo/consultation",
+      "title": "Examination of Events",
+      "public_timestamp": "2017-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-B",
+      "organisations": [
+        {
+          "acronym": "FCO",
+          "title": "Foreign and Commonwealth Office"
+        }
+      ]
+    },
+    {
+      "link": "/foo/news_story",
+      "title": "PM attends summit on topical events",
+      "public_timestamp": "2018-10-07T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-C",
+      "organisations": [
+        {
+          "title": "Number 10"
+        }
+      ],
+      "document_collections": [
+        {
+          "title": "PM Topical events",
+          "link": "/government/collections/pm-topical-events"
+        },
+        {
+          "title": "Tax information and impact notes",
+          "link": "/government/collections/tax-information-and-impact-notes-tiins"
+        }
+      ]
+    },
+    {
+      "link": "/foo/statistics",
+      "title": "Weekly topical event prices",
+      "public_timestamp": "2018-10-17T22:18:32Z",
+      "display_type": "news_article",
+      "description": "Description of document...",
+      "content_id": "1234-D",
+      "organisations": [
+        {
+          "acronym": "DEP",
+          "title": "Some other Department"
+        }
+      ]
+    }
+  ]
 }

--- a/features/latest-documents.feature
+++ b/features/latest-documents.feature
@@ -2,7 +2,7 @@ Feature: List of most recently published documents
   So that I can …
   As a user
   I want to be able to see the most recently published content by an
-  organisation or about a topic, topical event or world location
+  organisation, topical event or world location
 
   Scenario: Latest documents on topical event page
     Given a topical event with published documents

--- a/features/step_definitions/latest_document_steps.rb
+++ b/features/step_definitions/latest_document_steps.rb
@@ -13,7 +13,7 @@ Then(/^I can follow a link to see all documents$/) do
 end
 
 When(/^I view the list of all documents for that topical event$/) do
-  visit latest_path(topics: [@topical_event])
+  visit latest_path(topical_events: [@topical_event])
 end
 
 Then(/^I see all documents for that topical event with the most recent first$/) do

--- a/features/step_definitions/latest_document_steps.rb
+++ b/features/step_definitions/latest_document_steps.rb
@@ -19,7 +19,7 @@ end
 Then(/^I see all documents for that topical event with the most recent first$/) do
   docs = sample_document_types_and_titles
 
-  within('.documents-index') do
+  within('.document-list') do
     assert_equal(page.body.scan('document-row').length, docs.length, "Can't see all the documents for the topical event")
     docs.each_value do |title|
       assert page.has_css?('.document-row', text: title)

--- a/test/functional/latest_controller_test.rb
+++ b/test/functional/latest_controller_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
+require "gds_api/test_helpers/rummager"
+require_relative "../support/search_rummager_helper"
 
 class LatestControllerTest < ActionController::TestCase
+  include SearchRummagerHelper
+
   should_be_a_public_facing_controller
 
   test 'GET :index should handle organisations' do
@@ -11,18 +15,10 @@ class LatestControllerTest < ActionController::TestCase
     assert_equal organisation, @controller.send(:subject)
   end
 
-  test 'GET :index should handle topics' do
-    topic = create(:topic)
-
-    get :index, params: { topics: [topic] }
-
-    assert_equal topic, @controller.send(:subject)
-  end
-
   test 'GET :index should handle topical events' do
     topical_event = create(:topical_event)
 
-    get :index, params: { topics: [topical_event] }
+    get :index, params: { topical_events: [topical_event] }
 
     assert_equal topical_event, @controller.send(:subject)
   end
@@ -42,30 +38,42 @@ class LatestControllerTest < ActionController::TestCase
     assert_redirected_to "/government/feed"
   end
 
+  test 'GET :index should expose rummager documents for the subject' do
+    topical_event = create(:topical_event)
+
+    stub_any_rummager_search.to_return(body: rummager_response)
+
+    get :index, params: { topical_events: [topical_event] }
+
+    assert_equal attributes(processed_rummager_documents),
+                 attributes(@controller.send(:documents))
+  end
+
+  test 'GET :index should accept pagination parameters with rummager documents' do
+    world_location = create(:world_location)
+
+    stub_any_rummager_search.to_return(body: rummager_response)
+
+    get :index, params: { world_locations: [world_location], page: 2 }
+
+    assert_equal [], @controller.send(:documents)
+  end
+
   test 'GET :index should expose documents for the subject' do
     organisation = create(:organisation)
 
-    policy_paper = create(:published_policy_paper,
-                          organisations: [organisation],
-                          first_published_at: 1.day.ago)
-    detailed_guide = create(:published_detailed_guide,
-                            organisations: [organisation],
-                            first_published_at: 2.days.ago)
+    stub_any_rummager_search.to_return(body: rummager_response)
 
     get :index, params: { departments: [organisation] }
 
-    assert_equal [policy_paper, detailed_guide], @controller.send(:documents)
+    assert_equal attributes(processed_rummager_documents),
+                 attributes(@controller.send(:documents))
   end
 
   test 'GET :index should accept pagination parameters' do
     organisation = create(:organisation)
 
-    create(:published_policy_paper, organisations: [organisation],
-           first_published_at: 1.day.ago)
-
-    create(:published_detailed_guide,
-           organisations: [organisation],
-           first_published_at: 2.days.ago)
+    stub_any_rummager_search.to_return(body: rummager_response)
 
     get :index, params: { departments: [organisation], page: 2 }
 

--- a/test/functional/topical_events_controller_test.rb
+++ b/test/functional/topical_events_controller_test.rb
@@ -1,9 +1,11 @@
 require "test_helper"
 require 'gds_api/test_helpers/content_store'
+require_relative '../support/search_rummager_helper'
 
 class TopicalEventsControllerTest < ActionController::TestCase
   include FeedHelper
   include GdsApi::TestHelpers::ContentStore
+  include SearchRummagerHelper
 
   should_be_a_public_facing_controller
 
@@ -117,15 +119,5 @@ class TopicalEventsControllerTest < ActionController::TestCase
     content_store_has_item(topical_event.base_path, payload)
 
     topical_event
-  end
-
-  def rummager_response
-    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
-  end
-
-  def processed_rummager_documents
-    ActiveSupport::JSON.decode(rummager_response)['results'].map! { |res|
-      RummagerDocumentPresenter.new(res)
-    }
   end
 end

--- a/test/functional/topics_controller_test.rb
+++ b/test/functional/topics_controller_test.rb
@@ -200,24 +200,6 @@ class TopicsControllerTest < ActionController::TestCase
     assert_select_autodiscovery_link atom_feed_url_for(topic)
   end
 
-  view_test 'GET :show for atom feed has the right elements' do
-    topic = create_topic_and_stub_content_store
-    publication = create(:published_publication, topics: [topic])
-
-    get :show, params: { id: topic }, format: :atom
-
-    assert_select_atom_feed do
-      assert_select 'feed > id', 1
-      assert_select 'feed > title', 1
-      assert_select 'feed > author, feed > entry > author'
-      assert_select 'feed > updated', 1
-      assert_select 'feed > link[rel=?][type=?][href=?]', 'self', 'application/atom+xml', topic_url(topic, format: 'atom'), 1
-      assert_select 'feed > link[rel=?][type=?][href=?]', 'alternate', 'text/html', topic_url(topic), 1
-
-      assert_select_atom_entries([publication])
-    end
-  end
-
   test 'GET :show has a 5 minute expiry time' do
     topic = create_topic_and_stub_content_store
     get :show, params: { id: topic }

--- a/test/support/search_rummager_helper.rb
+++ b/test/support/search_rummager_helper.rb
@@ -1,0 +1,35 @@
+module SearchRummagerHelper
+  def rummager_response
+    File.read(Rails.root.join('features/fixtures/rummager_response.json'))
+  end
+
+  def processed_rummager_documents
+    ActiveSupport::JSON.decode(rummager_response)['results'].map! { |res|
+      RummagerDocumentPresenter.new(res)
+    }
+  end
+
+  def search_rummager_service_stub(search_params)
+    results = {}
+    results['results'] = processed_rummager_documents
+
+    SearchRummagerService
+      .any_instance
+      .expects(:fetch_related_documents)
+      .with(search_params)
+      .returns(results)
+  end
+
+  def attributes(documents_object)
+    documents_object.map do |document|
+      [
+        document.title,
+        document.link,
+        document.summary,
+        document.content_id,
+        document.publication_collections,
+        document.publication_date
+      ]
+    end
+  end
+end

--- a/test/unit/services/search_rummager_service_test.rb
+++ b/test/unit/services/search_rummager_service_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require "gds_api/test_helpers/rummager"
+require_relative "../../support/search_rummager_helper"
+
+class SearchRummagerServiceTest < ActiveSupport::TestCase
+  include SearchRummagerHelper
+
+  setup do
+    @topical_event = create(:topical_event, :active)
+    @world_location = create(:world_location)
+  end
+
+  test 'returns empty results array if topical event has no documents' do
+    stub_any_rummager_search_to_return_no_results
+    assert_equal [], SearchRummagerService.new.fetch_related_documents(topical_params)['results']
+  end
+
+  test 'fetches documents related to a topical event' do
+    stub_any_rummager_search.to_return(body: rummager_response)
+    results = SearchRummagerService.new.fetch_related_documents(topical_params)['results']
+
+    assert_instance_of RummagerDocumentPresenter, results.first
+    assert_equal 4, results.count
+    assert_equal attributes(processed_rummager_documents),
+                 attributes(results)
+  end
+
+  test 'search receives correct params for a topical event' do
+    expected_search_params(topical_params)
+  end
+
+  test 'search receives correct params for a world_location' do
+    expected_search_params(world_params)
+  end
+
+  test 'setting count replaces the default count of 1000' do
+    expected_search_params(count: 3)
+  end
+
+  test 'search receives multiple additional params' do
+    expected_search_params(world_params.merge(filter_format: 'publication', count: 3))
+  end
+
+  def expected_search_params(params = {})
+    Whitehall
+      .search_client
+      .expects(:search)
+      .with(default_search_options.merge(params))
+      .returns('results' => [])
+
+    SearchRummagerService.new.fetch_related_documents(params)
+  end
+
+  def topical_params
+    {
+      filter_topical_events: @topical_event.slug,
+      reject_any_content_store_document_type: 'news_article'
+    }
+  end
+
+  def world_params
+    {
+      filter_world_locations: @world_location.slug,
+    }
+  end
+
+  def default_search_options
+    {
+      order: "-public_timestamp",
+      count: 1000,
+      fields: %w[display_type title link public_timestamp format content_store_document_type
+                 description content_id organisations document_collections]
+    }
+  end
+end


### PR DESCRIPTION
This change enables the latest documents page and atom feed to render results using rummager for topical events, world locations and organisations (latest orgs page has now been replaced by finder frontend pages although the Whitehall page is still accessible by url). 

We need to use Rummager results instead of Whitehall's local database as documents published by Content Publisher get indexed to the govuk index and would not be accessible from the database. 

As part of this work we investigated whether we needed to also retrieve translated documents from the Whitehall database in cases where the locale is not English (Rummager currently doesn't support locales). Our investigation concluded that there are no apparent cases where the locale is set to a foreign language; for example there don't seem to be any instances where a locale param is passed to the Latest Controller. A manual check on live GOV.UK also concluded that links from translated world location news pages (e.g. http://www.gov.uk/world/afghanistan/news.dr) to the latest finder also don't
pass any locale data, and so the results on the page are English only. Consequently we've decided to maintain this current behaviour and only provide English-language Rummager results.

Trello:
https://trello.com/c/aXQWMcmw/406-change-topical-events-latest-pages-to-use-rummager
https://trello.com/c/62hDsXHF/438-change-world-location-latest-pages-to-use-rummager