### PR TITLE
Filter out formats in organisations latest finder

### DIFF
--- a/app/models/latest_documents_filter.rb
+++ b/app/models/latest_documents_filter.rb
@@ -44,7 +44,7 @@ private
       super(
         {
           filter_organisations: subject.slug,
-          reject_any_format: 'corporate_information_page'
+          reject_any_format: %w[corporate_information_page organisation person]
         }
       )
     end

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -68,7 +68,7 @@ class OrganisationFilterTest < ActiveSupport::TestCase
 
     search_rummager_service_stub(
       filter_organisations: organisation.slug,
-      reject_any_format: 'corporate_information_page'
+      reject_any_format: %w[corporate_information_page organisation person]
     )
 
     assert_equal attributes(processed_rummager_documents), attributes(filter.documents)


### PR DESCRIPTION
We have found instances where People and Organisation pages are surfacing in the
latest finder for organisations, so we ensure these are filtered out in our
Rummager query.