### PR TITLE
Change reslug task to add edition to the search index

### DIFF
--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -50,9 +50,15 @@ namespace :reslug do
     # remove the most recent edition from the search index
     edition = document.editions.published.last
     Whitehall::SearchIndex.delete(edition)
+
     # change the slug of the document and create a redirect from the original
     document.update_attributes!(slug: args.new_slug)
+
+    # send edition to publishing api
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+
+    # add edition to search index
+    Whitehall::SearchIndex.add(edition)
   end
 
   desc "Change the slug of a PolicyGroup"


### PR DESCRIPTION
Previously, my thoughts were that sending the edition to the publishing
api would populate the govuk index via a message being enqued on the
rabbitmq que and rummager would pick the job up and index the document.

However, this did not happen when i last ran this rake task and i had to
republish the document for it to be indexed. This change manually adds
the edition to the index.