### PR TITLE
Reject additional formats in organisations latest finder

### DIFF
--- a/app/models/latest_documents_filter.rb
+++ b/app/models/latest_documents_filter.rb
@@ -44,7 +44,11 @@ private
       super(
         {
           filter_organisations: subject.slug,
-          reject_any_format: %w[corporate_information_page organisation person]
+          reject_any_format: %w[corporate_information_page
+                                minister
+                                organisation
+                                person
+                                statistics_announcement]
         }
       )
     end

--- a/test/unit/models/latest_documents_filter_test.rb
+++ b/test/unit/models/latest_documents_filter_test.rb
@@ -68,7 +68,7 @@ class OrganisationFilterTest < ActiveSupport::TestCase
 
     search_rummager_service_stub(
       filter_organisations: organisation.slug,
-      reject_any_format: %w[corporate_information_page organisation person]
+      reject_any_format: %w[corporate_information_page minister organisation person statistics_announcement]
     )
 
     assert_equal attributes(processed_rummager_documents), attributes(filter.documents)


### PR DESCRIPTION
We reject a couple more formats that don't have a public timestamp and
shouldn't appear in the organsiations latest finder.