### PR TITLE
Change world location atom feeds to use Rummager

### DIFF
--- a/app/controllers/world_locations_controller.rb
+++ b/app/controllers/world_locations_controller.rb
@@ -36,12 +36,24 @@ class WorldLocationsController < PublicFacingController
         redirect_to api_world_location_path(@world_location, format: :json)
       end
       format.atom do
-        @documents = EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
+        @documents = if Locale.current.english?
+                       fetch_documents
+                     else
+                       EditionCollectionPresenter.new(recently_updated_source.limit(10), view_context)
+                     end
       end
     end
   end
 
 private
+
+  def fetch_documents
+    filter_params = {
+      count: 10,
+      filter_world_locations: @world_location.slug
+    }
+    SearchRummagerService.new.fetch_related_documents(filter_params)["results"]
+  end
 
   def load_world_location
     @world_location = WorldLocation.with_translations(I18n.locale).find(params[:id])


### PR DESCRIPTION
This changes world location atom feeds (e.g. www.gov.uk/world/afghanistan.atom)
to retrieve results from Rummager instead of the local Whitehall database when
the locale is set to English, which matches the behaviour of world location
news atom feeds (e.g. https://www.gov.uk/world/afghanistan/news.atom). This allows
content published by Content Publisher to surface on these pages. Currently,
Content Publisher does not support translated content so we ensure that the
announcements section continues to retrieve documents from the Whitehall
database when the locale is not English.