### PR TITLE
Add offsite link types for Content Publisher documents

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,12 +1,26 @@
 class OffsiteLink < ApplicationRecord
   module LinkTypes
     def self.all
-      @all ||= %w(alert blog_post campaign careers manual nhs_content service)
+      @all ||= %w[
+        alert
+        blog_post
+        campaign
+        careers
+        manual
+        nhs_content
+        service
+        content_publisher_news_story
+        content_publisher_press_release
+      ]
     end
 
     def self.humanize(link_type)
       if link_type == 'nhs_content'
         'NHS content'
+      elsif link_type == 'content_publisher_news_story'
+        'News story (Content Publisher)'
+      elsif link_type == 'content_publisher_press_release'
+        'Press release (Content Publisher)'
       else
         link_type.humanize
       end
@@ -14,6 +28,16 @@ class OffsiteLink < ApplicationRecord
 
     def self.as_select_options
       all.map { |type| [humanize(type), type] }
+    end
+
+    def self.display_type(link_type)
+      if link_type == 'content_publisher_news_story'
+        'News story'
+      elsif link_type == 'content_publisher_press_release'
+        'Press release'
+      else
+        humanize(link_type)
+      end
     end
   end
 
@@ -40,6 +64,10 @@ class OffsiteLink < ApplicationRecord
 
   def humanized_link_type
     LinkTypes.humanize(link_type)
+  end
+
+  def display_type
+    LinkTypes.display_type(link_type)
   end
 
   def to_s

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -332,7 +332,7 @@ module PublishingApi
         },
         summary: Whitehall::GovspeakRenderer.new.govspeak_to_html(offsite_link.summary),
         public_updated_at: offsite_link.date,
-        document_type: offsite_link.humanized_link_type
+        document_type: offsite_link.display_type
       }
     end
 

--- a/app/views/admin/offsite_links/_form.html.erb
+++ b/app/views/admin/offsite_links/_form.html.erb
@@ -8,7 +8,7 @@
         <%= form.label :link_type, "Type", required: true %>
 
         <div class="form-group">
-          <%= form.select :link_type, OffsiteLink::LinkTypes.as_select_options, {}, {class: 'form-control input-md-2'} %>
+          <%= form.select :link_type, OffsiteLink::LinkTypes.as_select_options, {}, {class: 'form-control input-md-3'} %>
         </div>
 
         <div class="form-group">

--- a/test/unit/models/offsite_link_test.rb
+++ b/test/unit/models/offsite_link_test.rb
@@ -105,6 +105,16 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     assert offsite_link.valid?
   end
 
+  test 'should be valid if the type is content_publisher_news_story' do
+    offsite_link = build(:offsite_link, link_type: 'content_publisher_news_story')
+    assert offsite_link.valid?
+  end
+
+  test 'should be valid if the type is content_publisher_press_release' do
+    offsite_link = build(:offsite_link, link_type: 'content_publisher_press_release')
+    assert offsite_link.valid?
+  end
+
   test "#destroy also destroys 'featured offsite link' associations" do
     offsite_link = create(:offsite_link)
     feature = create(:feature, offsite_link: offsite_link)

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -255,4 +255,18 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
 
     assert_equal expected_hash, presented_item.content[:details][:default_news_image]
   end
+
+  test 'presents the display type of an offsite link' do
+    organisation = create(
+      :court,
+      name: 'An organisation with offsite links'
+    )
+    offsite_link = create(:offsite_link, link_type: "content_publisher_news_story")
+    feature = create(:feature, document: nil, offsite_link: offsite_link)
+    create(:feature_list, features: [feature], featurable: organisation)
+    presented_item = present(organisation)
+    document_type = presented_item.content.dig(:details, :ordered_featured_documents, 0, :document_type)
+
+    assert_equal document_type, offsite_link.display_type
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/TIvuahgZ/502-allow-publisher-to-feature-content-created-by-content-publisher-on-organisation-pages

This adds offsite link types for the two document types that Content Publisher
allows for publishing. This is intended as a short time fix (I know, I
know I wince writing those words) to allow featuring of Content
Publisher documents through Whitehall while the initial private beta is
in progress.

This adds the ability for the link type to be displayed in different
ways on the frontend and backend of Whitehall.

In Whitehall admin the choices for an offsite link now looks like: 

<img width="975" alt="screen shot 2018-11-27 at 18 49 49" src="https://user-images.githubusercontent.com/282717/49104203-4b1bab00-f275-11e8-98ad-bc666f32a52f.png">

And on the frontend we get the correct document type through like so:

<img width="358" alt="screen shot 2018-11-27 at 18 50 23" src="https://user-images.githubusercontent.com/282717/49104229-5a025d80-f275-11e8-8d12-711d6d146cdc.png">

But unfortunately, because of us using brackets in the naming, the list of featured documents looks like this:

<img width="1199" alt="screen shot 2018-11-27 at 18 51 06" src="https://user-images.githubusercontent.com/282717/49104260-71d9e180-f275-11e8-8cc7-c7923faa5911.png">

/cc @paola-roccuzzo

