### PR TITLE
Scope awaiting_response to published consultations

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -29,7 +29,7 @@ class Consultation < Publicationesque
   scope :opened_at_or_after, ->(time) { open.where('opening_at >= ?', time) }
   scope :upcoming, -> { where('opening_at > ?', Time.zone.now) }
   scope :responded, -> { joins(:outcome) }
-  scope :awaiting_response, -> { closed.where.not(id: responded.pluck(:id)) }
+  scope :awaiting_response, -> { published.closed.where.not(id: responded.pluck(:id)) }
 
   add_trait do
     def process_associations_after_save(edition)

--- a/test/unit/consultation_test.rb
+++ b/test/unit/consultation_test.rb
@@ -120,9 +120,10 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_same_elements [closed_with_outcome], Consultation.responded
   end
 
-  test ".awaiting_response includes closed consultations with no outcome" do
+  test ".awaiting_response includes published closed consultations with no outcome" do
     FactoryBot.create(:consultation_with_outcome)
     closed_without_outcome = FactoryBot.create(:closed_consultation)
+    FactoryBot.create(:closed_consultation, :superseded)
     FactoryBot.create(:open_consultation)
 
     assert_same_elements [closed_without_outcome], Consultation.awaiting_response

--- a/test/unit/models/consultation_reminder_test.rb
+++ b/test/unit/models/consultation_reminder_test.rb
@@ -159,6 +159,7 @@ class ConsultationReminderTest < ActiveSupport::TestCase
     author = FactoryBot.create(:author)
     consultation = FactoryBot.create(
       :consultation,
+      :published,
       opening_at: 10.months.ago,
       closing_at: Time.new(2018, 3, 6, 23, 45, 0),
     )
@@ -172,6 +173,6 @@ class ConsultationReminderTest < ActiveSupport::TestCase
 
   def create_consultation(closing_at:, responded: false)
     type = responded ? :consultation_with_outcome : :consultation
-    FactoryBot.create(type, opening_at: 10.months.ago, closing_at: closing_at)
+    FactoryBot.create(type, :published, opening_at: 10.months.ago, closing_at: closing_at)
   end
 end


### PR DESCRIPTION
https://trello.com/c/Be0yGatG/628-email-alerts-for-consultations-shouldnt-be-sent-early

Looking at [earlier zendesk analysis](https://govuk.zendesk.com/agent/tickets/2908362) (thanks @boffbowsh) the scope `awaiting_response` included non-published editions which may have led to emails being sent because a superseded edition had no response.
This alters the scope to consider only published editions.
