### PR TITLE
Add data migration to republish organisations

### DIFF
--- a/db/data_migration/20181203122824_republish_organisations_to_present_default_news_image.rb
+++ b/db/data_migration/20181203122824_republish_organisations_to_present_default_news_image.rb
@@ -1,0 +1,2 @@
+republisher = DataHygiene::PublishingApiRepublisher.new(Organisation.all)
+republisher.perform


### PR DESCRIPTION
This is so we can trigger link expansion in the Publishing API and propagate
`default_news_image` data in content items tagged to organisations.