### PR TITLE
Move CIP publishing API guard

### DIFF
--- a/app/services/edition_service.rb
+++ b/app/services/edition_service.rb
@@ -13,7 +13,7 @@ class EditionService
       ActiveRecord::Base.transaction do
         prepare_edition
         fire_transition!
-        update_publishing_api! unless is_whitehall_corp_info_page?
+        update_publishing_api!
       end
       notify!
       true
@@ -56,6 +56,8 @@ private
   end
 
   def update_publishing_api!
+    return if is_whitehall_corp_info_page?
+
     ServiceListeners::PublishingApiPusher
       .new(edition.reload)
       .push(event: verb, options: options)


### PR DESCRIPTION
This guard is a workaround to prevent errors when saving corporate information pages to the publishing API, however it was only in place for non-translated CIPs.

Translated CIPs were triggered using a subclass of `EditionService` which did not implement the guard.

Moving the guard into the `update_publishing_api!` method makes it less likely to be bypassed by subclasses and the like.

https://trello.com/c/Ic8amtN1/366-corporate-information-pages-clashing-with-its-own-translations
https://sentry.io/govuk/app-whitehall/issues/772912247/events/37335756049/?environment=production
https://sentry.io/govuk/app-whitehall/issues/750311158/?query=is:unresolved%20cairo