### PR TITLE
Check if latest page param is an array

### DIFF
--- a/app/controllers/latest_controller.rb
+++ b/app/controllers/latest_controller.rb
@@ -38,7 +38,7 @@ private
 
   def subject_param
     supported_subjects.find do |param_name|
-      params[param_name].present?
+      params[param_name].present? && params[param_name].is_a?(Array)
     end
   end
 


### PR DESCRIPTION
This guards against instances where a param is set to something other than an
array, which causes the application to throw a 500 error. In production this
has resulted in the static mirrors serving out-of-date and innacurate content
on latest pages.