### PR TITLE
Export Command Papers rake task

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -171,4 +171,34 @@ namespace :export do
       break # Can't do much about this, so just break
     end
   end
+
+  desc "Export command papers"
+  task command_papers: :environment do
+    puts 'Fetching command papers...'
+    path = "tmp/command-papers-#{Time.now.to_i}.csv"
+    puts "Generating CSV in #{path}..."
+
+    CSV.open(path, 'w') do |csv|
+      csv << [
+        'Title',
+        'Command Paper Number',
+        'URL'
+      ]
+
+      Attachment.where("command_paper_number <> ''").all.each do |file|
+        begin
+          url = file&.attachable.try(:search_link)
+
+          csv << [
+            file.title,
+            file.command_paper_number,
+            url ? "https://gov.uk#{url}" : file.url
+          ]
+        rescue StandardError => e
+          puts e
+          next
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/TKt5b6j4/167-a-csv-of-command-papers-for-the-house-of-commons-library

This produces a list of command papers with their associated CM ID, title and URL. The URL will ideally be the location of the file on GOV.UK, but will default to the static URL (e.g. direct link to the PDF) if the file is no longer attached to a GOV.UK document.

Title | Command Paper Number | URL
--- | --- | ---
Social Justice: transforming lives | Cm8314 | http://static.dev.gov.uk/government/uploads/system/uploads/attachment_data/file/2253/social-justice-transforming-lives.pdf
High speed rail: Investing in Britain's future - decisions and next steps | Cm 8247 | https://gov.uk/government/publications/high-speed-rail-investing-in-britains-future-decisions-and-next-steps
Post Legislative Assessment of the Concessionary Bus Travel Act 2007: Memorandum to the Transport Select Committee | Cm 8406 | https://gov.uk/government/publications/post-legislative-assessment-of-the-concessionary-bus-travel-act-2007-memorandum-to-the-transport-select-committee
