### PR TITLE
Don't set the number of unicorn workers

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -2,7 +2,6 @@ require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
 
 working_directory File.dirname(File.dirname(__FILE__))
-worker_processes Integer(ENV["UNICORN_WORKER_PROCESSES"] || 4)
 
 # Preload the entire app
 preload_app true


### PR DESCRIPTION
This is set in puppet to 8 (for a frontend box) or 4 (for a backend box):
https://github.com/alphagov/govuk-puppet/blob/725316a556c0ec3d429d94185314fb15044775cc/modules/govuk/manifests/apps/whitehall.pp#L162-L166