### PR TITLE
Republish organisation after creating a contact

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -16,12 +16,19 @@ class Contact < ApplicationRecord
 
   after_update :republish_dependent_editions
 
+  after_create :republish_organisation_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api
+
   include TranslatableModel
   translates :title, :comments, :recipient, :street_address, :locality,
              :region, :email, :contact_form_url
 
   extend HomePageList::ContentItem
   is_stored_on_home_page_lists
+
+  def republish_organisation_to_publishing_api
+    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
+  end
 
   def contactable_name
     if contactable.is_a? WorldwideOffice

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -124,4 +124,17 @@ class ContactTest < ActiveSupport::TestCase
       contact.update_attributes(title: "Changed contact title")
     end
   end
+
+  test "creating a new contact republishes the organisation" do
+    test_object = create(:organisation)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    create(:contact, contactable: test_object)
+  end
+
+  test "deleting a contact republishes the organisation" do
+    test_object = create(:organisation)
+    contact = create(:contact, contactable: test_object)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    contact.destroy
+  end
 end


### PR DESCRIPTION
The links between organisations and contacts are added when the organisation gets published. When creating new contacts, the organisation doesn't get republished so the links aren't created (even though the contact itself has made it to the content store).

I'm not sure why this has stopped working recently and how this sort of dependency in Whitehall is meant to work so I've based this code on 9ab682152226dfc635848ac6e0a413e2208f2678.

Tested on integration this solution seems to work.

[Trello Card](https://trello.com/c/Ullv8jH0/684-unable-to-create-or-edit-contacts-on-organisations)