### PR TITLE
Rename invisible_draft_taxons to invisible_taxons

### DIFF
--- a/app/views/admin/edition_tags/edit.html.erb
+++ b/app/views/admin/edition_tags/edit.html.erb
@@ -25,7 +25,7 @@
 
       </div>
 
-      <%= form.hidden_field "invisible_draft_taxons", value: @tag_form.invisible_taxons.join(",") %>
+      <%= form.hidden_field "invisible_taxons", value: @tag_form.invisible_taxons.join(",") %>
 
       <p>
         <%= link_to "Suggest a new topic",

--- a/test/functional/admin/edition_tags_controller_test.rb
+++ b/test/functional/admin/edition_tags_controller_test.rb
@@ -114,7 +114,7 @@ class Admin::EditionTagsControllerTest < ActionController::TestCase
 
     get :edit, params: { edition_id: @edition }
 
-    assert_select "input[name='taxonomy_tag_form[invisible_draft_taxons]'][value='invisible_draft_taxon_1_content_id,invisible_draft_taxon_2_content_id']"
+    assert_select "input[name='taxonomy_tag_form[invisible_taxons]'][value='invisible_draft_taxon_1_content_id,invisible_draft_taxon_2_content_id']"
   end
 
   def assert_tracking_attributes(element:, track_label:)

--- a/test/unit/models/taxonomy_tag_form_test.rb
+++ b/test/unit/models/taxonomy_tag_form_test.rb
@@ -40,7 +40,7 @@ class TaxonomyTagFormTest < ActiveSupport::TestCase
     assert_equal(form.previous_version, 1)
   end
 
-  test '#invisible_draft_taxons returns all invisible draft taxons tagged to the content item' do
+  test '#invisible_taxons returns all invisible draft taxons tagged to the content item' do
     content_id = "64aadc14-9bca-40d9-abb6-4f21f9792a05"
 
     publishing_api_has_links(


### PR DESCRIPTION
This was renamed elsewhere, but looks to have been missed in these places.