### PR TITLE
Add summary for organisations

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -28,7 +28,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        description: nil,
+        description: item.description_for_search,
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3536161

Previously we set the description to nil for all organisation, which
adversely affects the description metadata we use for search as it's
generated automatically by the engine. This set the description based on
the Govspeak-rendered summary of the organisation.