### PR TITLE
Present organisation description

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -28,7 +28,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        description: nil,
+        description: text_summary,
         details: details,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
@@ -75,7 +75,7 @@ module PublishingApi
     def details
       details = {
         acronym: acronym,
-        body: summary,
+        body: html_summary,
         brand: brand,
         logo: {
           formatted_title: formatted_title,
@@ -108,14 +108,20 @@ module PublishingApi
       item.acronym
     end
 
-    def summary
-      text = if item.court_or_hmcts_tribunal?
-               item.body
-             else
-               "#{item.summary}#{parent_child_relationships_text}"
-             end
+    def govspeak_summary
+      if item.court_or_hmcts_tribunal?
+        item.body
+      else
+        "#{item.summary}#{parent_child_relationships_text}"
+      end
+    end
 
-      Whitehall::GovspeakRenderer.new.govspeak_to_html(text)
+    def html_summary
+      Whitehall::GovspeakRenderer.new.govspeak_to_html(govspeak_summary)
+    end
+
+    def text_summary
+      Govspeak::Document.new(govspeak_summary).to_text
     end
 
     def parent_child_relationships_text

--- a/test/unit/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/presenters/publishing_api/organisation_presenter_test.rb
@@ -28,6 +28,11 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       important_board_members: 5,
       default_news_image: news_image,
     )
+    create(
+      :about_corporate_information_page,
+      organisation: organisation,
+      summary: "This org is a thing!"
+    )
     role = create(:role, organisations: [organisation])
     public_path = Whitehall.url_maker.organisation_path(organisation)
     public_atom_path = "#{public_path}.atom"
@@ -35,7 +40,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     expected_hash = {
       base_path: public_path,
       title: "Organisation of Things",
-      description: nil,
+      description: "This org is a thing! Organisation of Things works with the Department for Stuff .",
       schema_name: 'organisation',
       document_type: 'organisation',
       locale: 'en',
@@ -50,7 +55,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       update_type: "major",
       details: {
         acronym: nil,
-        body: govspeak_to_html("\nOrganisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>."),
+        body: govspeak_to_html("This org is a thing!\n\nOrganisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>."),
         brand: nil,
         logo: {
           formatted_title: "Organisation<br/>of<br/>Things",


### PR DESCRIPTION
The description is the same text as presented in `org["details"]["body"]`, but is just text, so is more appropriate for use in the description metatag and also the `GovernmentOrganization` schema.

(We're not currently populating the description meta tag on org pages, though we do provide a summary in the schema.org representation)