### PR TITLE
Fix republishing of dependent editions

### DIFF
--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -20,8 +20,6 @@ Whitehall.edition_services.tap do |coordinator|
   end
 
   coordinator.subscribe(/^(force_publish|publish|unwithdraw)$/) do |_event, edition, options|
-    # handling edition's dependency on other content
-    edition.republish_dependent_editions
     ServiceListeners::EditionDependenciesPopulator
       .new(edition)
       .populate!
@@ -29,6 +27,9 @@ Whitehall.edition_services.tap do |coordinator|
     ServiceListeners::AttachmentDependencyPopulator
       .new(edition)
       .populate!
+
+    # handling edition's dependency on other content
+    edition.republish_dependent_editions
 
     ServiceListeners::AnnouncementClearer
       .new(edition)


### PR DESCRIPTION
We need to populate the dependencies before we can republish them.
This regression was introduced with e9e8c575fecdf4b6af80b44853f94a24a1b71093

Reported with https://govuk.zendesk.com/agent/tickets/3483085