### PR TITLE
Add authentication to Rummager calls

### DIFF
--- a/lib/whitehall/rummageable.rb
+++ b/lib/whitehall/rummageable.rb
@@ -92,7 +92,7 @@ module Whitehall
         response = nil
         log_request(method, *args)
         call_time = Benchmark.realtime do
-          response = RestClient.send(method, *args, content_type: :json, accept: :json)
+          response = RestClient.send(method, *args, content_type: :json, accept: :json, authorization: "Bearer #{ENV['RUMMAGER_BEARER_TOKEN'] || 'example'}")
         end
         log_response(method, call_time, response, *args)
         response


### PR DESCRIPTION
This PR adds bearer token authentication to Rummager calls via the Rest client. Authentication was previously added to the Rummager GDS Api adapter, but Whitehall does not use this for all requests.