### PR TITLE
Fix minister reshuffle description

### DIFF
--- a/db/data_migration/20190116083807_add_space_to_minister_reshuffle_description.rb
+++ b/db/data_migration/20190116083807_add_space_to_minister_reshuffle_description.rb
@@ -1,0 +1,10 @@
+minister_reshuffle = SitewideSetting.new(
+  key: :minister_reshuffle_mode,
+  on: false,
+  description: "This setting enables you to turn on or off reshuffle mode. During a reshuffle, the ministers count on [how government works](http://www.gov.uk/government/how-government-works)
+  will be hidden, and the govspeak text that has been entered in the govspeak field for this setting will be displayed in a banner
+  on the [ministers](http://www.gov.uk/government/ministers) page",
+  govspeak: "Some ministerial roles and responsibilities are [changing at the moment](http://example.com) so the information here may change"
+)
+minister_reshuffle.save
+


### PR DESCRIPTION
Currently, the description reads:

"...During a reshuffle, the ministers count on thehow government works will be hidden..."

Remove "the" in front of "how" because it doesn't make sense. The added bonus of keeping spaces between words is also nice.