### PR TITLE
Add a data migration to unpublish old Policy Publisher content

### DIFF
--- a/db/data_migration/20190117142343_remove_policy_publisher_content.rb
+++ b/db/data_migration/20190117142343_remove_policy_publisher_content.rb
@@ -1,0 +1,13 @@
+puts 'Unpublishing /government/policies/school-and-college-funding-and-accountability/email-signup and redirecting to /email-signup/?topic=/education/school-and-academy-funding'
+Services.publishing_api.unpublish(
+  '377e1772-a6d5-454c-836f-f9c282457b0e',
+  type: 'redirect',
+  alternative_path: '/email-signup/?topic=/education/school-and-academy-funding'
+)
+
+puts 'Unpublishing /government/policies/all and redirecting to /'
+Services.publishing_api.unpublish(
+  'ccb6c301-2c64-4a59-88c9-0528d0ffd088',
+  type: 'redirect',
+  alternative_path: '/'
+)


### PR DESCRIPTION
This doesn't specifically relate to Whitehall, it's just an easy place
to put this code.

A single email signup page was left behind when Policy Publisher was
retired, so unpublish that and replace it with a redirect to the email
signup page for the replacement Topic in the Topic Taxonomy.

Policy Publisher also published a finder for policies, so unpublish
that, and replace it with a redirect to the homepage, as there isn't a
great alternative for that specific page.

https://trello.com/c/0jgKr3UT/105-policy-publisher-is-not-fully-retired