### PR TITLE
Add a Rake task for republishing content to the Publishing API

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -87,4 +87,10 @@ namespace :publishing_api do
 
     puts "Finished queuing items for Publishing API"
   end
+
+  desc "Republish a document to the Publishing API"
+  task :republish_document, [:slug] => :environment do |_, args|
+    document = Document.find_by!(slug: args[:slug])
+    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+  end
 end


### PR DESCRIPTION
Sometimes it's necessary to republish content to the Publishing API if it didn't succeed last time. At the moment the only way to do this is via the console so this task makes it easier for devs to complete the task.

[Trello Card](https://trello.com/c/6EIwWTyj/735-create-rake-task-for-representing-content-from-whitehall-to-publishing-api)