### PR TITLE
Support HTML Attachments with /government/admin/by-content-id/...

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,6 +1,12 @@
 class Admin::DocumentsController < Admin::BaseController
   def by_content_id
-    document = Document.find_by(content_id: params[:content_id])
+    document = (
+      Document.find_by(content_id: params[:content_id]) ||
+      # If the content_id doesn't match a document, it could be a HTML
+      # attachment
+      HtmlAttachment.find_by(content_id: params[:content_id])&.attachable
+    )
+
     url_maker = Whitehall::UrlMaker.new(host: Plek.find('whitehall'))
     if document
       redirect_to url_maker.admin_edition_path(document.latest_edition)

--- a/test/functional/admin/documents_controller_test.rb
+++ b/test/functional/admin/documents_controller_test.rb
@@ -15,6 +15,13 @@ class Admin::DocumentsControllerTest < ActionController::TestCase
     assert_redirected_to @url_maker.admin_edition_path(@document.latest_edition)
   end
 
+  view_test 'GET by-content-id supports HTML Attachments' do
+    attachment = create(:html_attachment)
+
+    get :by_content_id, params: { content_id: attachment.content_id }
+    assert_redirected_to @url_maker.admin_edition_path(attachment.attachable.latest_edition)
+  end
+
   view_test 'GET by-content-id redirects to a search if content_id is not found' do
     get :by_content_id, params: { content_id: @document.content_id + "wrong-id" }
     assert_redirected_to @url_maker.admin_editions_path


### PR DESCRIPTION
Previously, with the content id for a HTML Attachment, you'd end up on
the search page, as it's not a Document in Whitehall's internal model.

This change adds support for finding the relevant document for a HTML
Attachment, meaning that you now end up in a more helpful place.