### PR TITLE
Add a Rake Task to remove a change note

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'deprecated_columns', '~> 0.1.1'
 gem 'equivalent-xml', '~> 0.6.0', require: false
 gem 'faraday'
 gem 'friendly_id', '~> 5.2.4'
+gem "fuzzy_match", "~> 2.1"
 gem 'gds-sso', '~> 14.0'
 gem 'globalize', '~> 5'
 gem 'govuk_ab_testing', '~> 2.4x'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
     fugit (1.1.1)
       et-orbi (~> 1.1, >= 1.1.1)
       raabro (~> 1.1)
+    fuzzy_match (2.1.0)
     gds-api-adapters (57.1.0)
       addressable
       link_header
@@ -598,6 +599,7 @@ DEPENDENCIES
   factory_bot
   faraday
   friendly_id (~> 5.2.4)
+  fuzzy_match (~> 2.1)
   gds-api-adapters
   gds-sso (~> 14.0)
   globalize (~> 5)

--- a/lib/data_hygiene/change_note_not_found.rb
+++ b/lib/data_hygiene/change_note_not_found.rb
@@ -1,0 +1,3 @@
+module DataHygiene
+  class ChangeNoteNotFound < StandardError; end
+end

--- a/lib/data_hygiene/change_note_remover.rb
+++ b/lib/data_hygiene/change_note_remover.rb
@@ -1,0 +1,53 @@
+module DataHygiene
+  class ChangeNoteRemover
+    def initialize(content_id, locale, change_note_search, dry_run:)
+      @content_id = content_id
+      @locale = locale
+      @change_note_search = change_note_search
+      @dry_run = dry_run
+    end
+
+    def call
+      raise DataHygiene::ChangeNoteNotFound.new unless edition
+      return edition if dry_run
+
+      destroy_edition_change_note
+      represent_downstream
+
+      edition
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :content_id, :locale, :change_note_search, :dry_run
+
+    def document
+      @document ||= Document.find_by(content_id: content_id)
+    end
+
+    def find_edition_with_change_note
+      fuzzy_match = FuzzyMatch.new(document.editions, read: :change_note)
+      fuzzy_match.find(change_note_search, must_match_at_least_one_word: true)
+    end
+
+    def edition
+      @edition ||= find_edition_with_change_note
+    end
+
+    def destroy_edition_change_note
+      edition[:minor_change] = true
+      edition.change_note = nil
+      edition.save!(validate: false)
+    end
+
+    def represent_downstream
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -6,3 +6,30 @@ namespace :db do
     warn o.summarize_by_type
   end
 end
+
+namespace :data_hygiene do
+  desc "Remove a change note from a document and represent to the content store."
+  namespace :remove_change_note do
+    def call_change_note_remover(content_id, locale, query, dry_run:)
+      edition = DataHygiene::ChangeNoteRemover.call(
+        content_id, locale, query, dry_run: dry_run
+      )
+
+      if dry_run
+        puts "Would have removed: #{edition.change_note.inspect}"
+      else
+        puts "Updated change history: #{edition.document.change_history.inspect}"
+      end
+    rescue DataHygiene::ChangeNoteNotFound
+      puts "Could not find a change note."
+    end
+
+    task :dry, %i[content_id locale query] => :environment do |_, args|
+      call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: true)
+    end
+
+    task :real, %i[content_id locale query] => :environment do |_, args|
+      call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: false)
+    end
+  end
+end

--- a/test/unit/tasks/data_hygiene/change_note_remover_test.rb
+++ b/test/unit/tasks/data_hygiene/change_note_remover_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class ChangeNoteRemoverTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:document)            { create(:document) }
+  let!(:superseded_edition) { create(:superseded_edition, document: document, change_note: "First change note.") }
+  let!(:live_edition)       { create(:published_edition, document: document, change_note: "Second change note.") }
+
+  let(:query) { nil }
+
+  let(:deleted_edition) do
+    call_change_note_remover
+  end
+
+  def call_change_note_remover
+    DataHygiene::ChangeNoteRemover.call(document.content_id, 'en', query, dry_run: dry_run)
+  end
+
+  context "during a dry run" do
+    let(:dry_run) { true }
+
+    context "the query matches a change note" do
+      let(:query) { "second" }
+
+      it "doesn't delete the change note" do
+        call_change_note_remover
+        assert_not_nil(superseded_edition.reload.change_note)
+        assert_not_nil(live_edition.reload.change_note)
+      end
+
+      it "returns the change note" do
+        assert_equal(live_edition, deleted_edition)
+      end
+    end
+  end
+
+  context "during a real run" do
+    let(:dry_run) { false }
+
+    context "the query doesn't match a change note" do
+      let(:query) { "nonexistent" }
+
+      it "raises an exception" do
+        assert_raises DataHygiene::ChangeNoteNotFound do
+          call_change_note_remover
+        end
+      end
+    end
+
+    context "the query matches a change note" do
+      let(:query) { "second" }
+
+      it "deletes the change note" do
+        call_change_note_remover
+        assert_not_nil(superseded_edition.reload.change_note)
+        assert_nil(live_edition.reload.change_note)
+      end
+
+      it "removes change_history from the edition" do
+        call_change_note_remover
+        assert_equal(
+          document.change_history.changes,
+          [DocumentHistory::Change.new(nil, superseded_edition.change_note)]
+        )
+      end
+
+      it "represents to the content store" do
+        PublishingApiDocumentRepublishingWorker
+          .any_instance
+          .expects(:perform)
+          .with(document.id)
+
+        call_change_note_remover
+      end
+
+      it "returns the edition" do
+        assert_equal(deleted_edition, live_edition)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a Rake task to allow developers to quickly remove a change note from a document.

It provides two interfaces to allow a dry run first, returning the change note that would be deleted. A real run will then update the document's edition to a minor version and the change note text to nil.

```
data_hygiene:remove_change_note:dry[content_id,locale,query]
data_hygiene:remove_change_note:real[content_id,locale,query]
```

Co-authored-by: Thomas Leese <thomas.leese@digital.cabinet-office.gov.uk>
[Trello](https://trello.com/c/eE4pp5Zm/721-rake-task-for-removing-changenotes-in-whitehall)
[Related PR in publishing-API](https://github.com/alphagov/publishing-api/pull/1426)