### PR TITLE
Add consultation start and end dates to search

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -156,6 +156,8 @@ class Consultation < Publicationesque
 
   def search_index
     super.merge(
+      end_date: closing_at,
+      start_date: opening_at,
       has_official_document: has_official_document? || (outcome.present? && outcome.has_official_document?),
       has_command_paper: has_command_paper? || (outcome.present? && outcome.has_command_paper?),
       has_act_paper: has_act_paper? || (outcome.present? && outcome.has_act_paper?)


### PR DESCRIPTION
This will enable us to reduce the number of requests to content store that taxonomy (topic) pages make by up to 5 per page request.  Given that content store connections seem a little flaky at the moment, this seems like something we should try to do more of.

We're reusing the date field in rummager that is used for topical content.