### PR TITLE
Find gsi-family domain references in contacts

### DIFF
--- a/lib/tasks/find_gsi_domain_references.rake
+++ b/lib/tasks/find_gsi_domain_references.rake
@@ -1,0 +1,42 @@
+require 'csv'
+
+namespace :report do
+  desc "Find all references to GSI/GSE/GCSX/GSX domains"
+  task find_gsi_domain_references: :environment do
+    CSV_HEADERS = ["Title", "URL", "Publishing application", "Publishing organisation", "Format", "Domain", "Content ID"].freeze
+
+    CSV.open("#{Rails.root}/tmp/gsi_domain_contact_items.csv", 'wb') do |csv|
+      csv << CSV_HEADERS
+
+      domains = %w(gsi gse gcsx gsx)
+
+      domains.each do |domain|
+        puts "Searching for #{domain}.gov.uk..."
+
+        contacts = Contact.eager_load(:translations).where('contact_translations.email like ?', "%#{domain}.gov.uk%")
+        number_of_contacts = 0
+
+        contacts.each do |contact|
+          next unless contact.contactable.try(:govuk_status) == 'live'
+
+          number_of_contacts += 1
+
+          csv << [
+            contact.title,
+            "https://www.gov.uk/government/organisations/#{contact.contactable.slug}",
+            'whitehall',
+            contact.contactable.name,
+            'contact',
+            domain,
+            contact.content_id
+          ]
+        end
+
+        puts "Found #{number_of_contacts} contacts containing #{domain}.gov.uk"
+      end
+    end
+
+    puts 'Finished searching'
+    puts "CSV file at #{Rails.root}/tmp/gsi_domain_contact_items.csv"
+  end
+end


### PR DESCRIPTION
The government is migrating away from GSI domains by March 2019.

This script searches for all references to gsi-family domains (gsi/gse/gcsx/gsx) in contacts and outputs them to a CSV file.

This output can be used to automatically or manually change the references for the relevant contacts.

Built on top of work by @deborahchua

Trello: https://trello.com/c/jfpoEh55/698-next-steps-on-changing-gsigovuk-domains-to-non-gsigovuk-in-static-and-dynamic-content-on-govuk

Sample console output:

```
vagrant@development:/var/govuk/whitehall$ bundle exec rake report:find_gsi_domain_references
Searching for gsi.gov.uk...
Found 208 contacts containing gsi.gov.uk
Searching for gse.gov.uk...
Found 0 contacts containing gse.gov.uk
Searching for gcsx.gov.uk...
Found 0 contacts containing gcsx.gov.uk
Searching for gsx.gov.uk...
Found 0 contacts containing gsx.gov.uk
Finished searching
CSV file at /var/govuk/whitehall/tmp/gsi_domain_contact_items.csv
```