### PR TITLE
Prepare whitehall to directly serve API paths

### DIFF
--- a/app/controllers/api/governments_controller.rb
+++ b/app/controllers/api/governments_controller.rb
@@ -1,5 +1,8 @@
 class Api::GovernmentsController < PublicFacingController
+  skip_before_action :set_cache_control_headers
   skip_before_action :restrict_request_formats
+  before_action :set_api_cache_control_headers
+  before_action :set_api_access_control_allow_origin_headers
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,5 +1,8 @@
 class Api::OrganisationsController < PublicFacingController
+  skip_before_action :set_cache_control_headers
   skip_before_action :restrict_request_formats
+  before_action :set_api_cache_control_headers
+  before_action :set_api_access_control_allow_origin_headers
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/world_locations_controller.rb
+++ b/app/controllers/api/world_locations_controller.rb
@@ -1,5 +1,8 @@
 class Api::WorldLocationsController < PublicFacingController
+  skip_before_action :set_cache_control_headers
   skip_before_action :restrict_request_formats
+  before_action :set_api_cache_control_headers
+  before_action :set_api_access_control_allow_origin_headers
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/api/worldwide_organisations_controller.rb
+++ b/app/controllers/api/worldwide_organisations_controller.rb
@@ -1,5 +1,8 @@
 class Api::WorldwideOrganisationsController < PublicFacingController
+  skip_before_action :set_cache_control_headers
   skip_before_action :restrict_request_formats
+  before_action :set_api_cache_control_headers
+  before_action :set_api_access_control_allow_origin_headers
   respond_to :json
 
   self.responder = Api::Responder

--- a/app/controllers/public_facing_controller.rb
+++ b/app/controllers/public_facing_controller.rb
@@ -63,6 +63,14 @@ private
     expires_in Whitehall.default_cache_max_age, public: true
   end
 
+  def set_api_cache_control_headers
+    expires_in Whitehall.default_api_cache_max_age, public: true
+  end
+
+  def set_api_access_control_allow_origin_headers
+    response.headers['Access-Control-Allow-Origin'] = '*'
+  end
+
   def restrict_request_formats
     unless can_handle_format?(request.format)
       render status: :not_acceptable, plain: "Request format #{request.format} not handled."

--- a/config/initializers/cache_max_age.rb
+++ b/config/initializers/cache_max_age.rb
@@ -1,3 +1,4 @@
 Whitehall.default_cache_max_age = 15.minutes
+Whitehall.default_api_cache_max_age = 30.minutes
 Whitehall.uploads_cache_max_age = 4.hours
 Whitehall.document_collections_cache_max_age = 5.minutes

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -28,6 +28,24 @@ namespace :publishing_api do
         title: "Courts and tribunals",
         description: "The prefix route under which pages for courts and tribunals are published.",
       },
+      {
+        base_path: "/api/governments",
+        content_id: "2d5bafcc-2c45-4a84-8fbc-525b75dd6d19",
+        title: "Governments API",
+        description: "API exposing all governments on GOV.UK.",
+      },
+      {
+        base_path: "/api/world-locations",
+        content_id: "2a63b605-77be-4af5-932d-224a054dd5a5",
+        title: "World Locations API",
+        description: "API exposing all world locations on GOV.UK.",
+      },
+      {
+        base_path: "/api/worldwide-organisations",
+        content_id: "736f8a5a-ce6f-4a6f-b0cb-954442aa23c1",
+        title: "Worldwide Organisations API",
+        description: "API exposing all worldwide organisations on GOV.UK.",
+      },
     ].each do |route|
       publisher.publish(
         {

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -9,6 +9,7 @@ module Whitehall
 
   mattr_accessor :content_store
   mattr_accessor :default_cache_max_age
+  mattr_accessor :default_api_cache_max_age
   mattr_accessor :document_collections_cache_max_age
   mattr_accessor :government_search_client
   mattr_accessor :link_checker_api_client

--- a/test/functional/api/governments_controller_test.rb
+++ b/test/functional/api/governments_controller_test.rb
@@ -4,6 +4,30 @@ class Api::GovernmentsControllerTest < ActionController::TestCase
   disable_database_queries
   should_be_a_public_facing_controller
 
+  test "sets cache expiry to 30 minutes" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    Government.stubs(:order).returns([])
+    Api::GovernmentPresenter.stubs(:paginate).with(Government.order(start_date: :desc), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert_cache_control("max-age=#{Whitehall.default_api_cache_max_age}")
+  end
+
+  test "sets Access-Control-Allow-Origin to *" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    Government.stubs(:order).returns([])
+    Api::GovernmentPresenter.stubs(:paginate).with(Government.order(start_date: :desc), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert response.headers['Access-Control-Allow-Origin'] == '*'
+  end
+
   view_test "index paginates governments" do
     presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
     presenter.stubs(:as_json).returns(paged: :representation)

--- a/test/functional/api/organisations_controller_test.rb
+++ b/test/functional/api/organisations_controller_test.rb
@@ -6,6 +6,36 @@ class Api::OrganisationsControllerTest < ActionController::TestCase
   disable_database_queries
   should_be_a_public_facing_controller
 
+  test "sets cache expiry to 30 minutes" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    orgs_includes = stub
+    orgs_includes.stubs(:order).returns([])
+    Organisation.stubs(:includes).returns(orgs_includes)
+
+    Api::OrganisationPresenter.stubs(:paginate).with(Organisation.includes(:parent_organisations, :child_organisations, :translations).order(:id), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert_cache_control("max-age=#{Whitehall.default_api_cache_max_age}")
+  end
+
+  test "sets Access-Control-Allow-Origin to *" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+
+    orgs_includes = stub
+    orgs_includes.stubs(:order).returns([])
+    Organisation.stubs(:includes).returns(orgs_includes)
+
+    Api::OrganisationPresenter.stubs(:paginate).with(Organisation.includes(:parent_organisations, :child_organisations, :translations).order(:id), anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert response.headers['Access-Control-Allow-Origin'] == '*'
+  end
+
   view_test "show responds with JSON representation of found organisation" do
     organisation = stub_record(:organisation, slug: 'meh')
     organisation.stubs(:to_param).returns('meh')

--- a/test/functional/api/world_locations_controller_test.rb
+++ b/test/functional/api/world_locations_controller_test.rb
@@ -4,6 +4,26 @@ class Api::WorldLocationsControllerTest < ActionController::TestCase
   disable_database_queries
   should_be_a_public_facing_controller
 
+  test "sets cache expiry to 30 minutes" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert_cache_control("max-age=#{Whitehall.default_api_cache_max_age}")
+  end
+
+  test "sets Access-Control-Allow-Origin to *" do
+    presenter = Api::PagePresenter.new(Kaminari.paginate_array([]).page(1).per(1), controller.view_context)
+    presenter.stubs(:as_json).returns(paged: :representation)
+    Api::WorldLocationPresenter.stubs(:paginate).with(WorldLocation.ordered_by_name, anything).returns(presenter)
+
+    get :index, format: 'json'
+
+    assert response.headers['Access-Control-Allow-Origin'] == '*'
+  end
+
   view_test "show responds with JSON representation of found world location" do
     world_location = stub_record(:world_location, slug: 'meh')
     world_location.stubs(:to_param).returns('meh')


### PR DESCRIPTION
This PR makes changes in whitehall to directly route `/api` endpoints that are currently routed using publicapi.

Trello: https://trello.com/c/C2DS0GbF/46-some-routing-info-is-in-nginx-config