### PR TITLE
Improve placement of cancel on prepare to close government

### DIFF
--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -14,9 +14,10 @@
 <div class="form-actions">
   <%= form_tag close_admin_government_path(@government) do %>
     <button type="submit" class="btn btn-danger btn-lg">Yes, close this government</button>
-  <% end %>
 
-  <span class="or_cancel">
-    <%= link_to "No! Don’t do that! Noooo!", edit_admin_government_path(@government) %>
-  </span>
+    <span class="or_cancel">
+      or
+      <%= link_to "No! Don’t do that! Noooo!", edit_admin_government_path(@government) %>
+    </span>
+  <% end %>
 </div>


### PR DESCRIPTION
The placement of the cancel option on prepare to close government view
is very close to the "Yes, close this government" button. This could
easily lead to misclicks.

Update the form and move the cancel option adjacent to the "Yes" button. 
This also makes it consistent with the way Whitehall normally lays out its 
confirm and cancel actions on views.

## Old:
![screen shot 2019-01-31 at 16 05 46](https://user-images.githubusercontent.com/647311/52126012-1259d280-2626-11e9-9d8e-f901f940f9a2.png)

## New:
<img width="462" alt="screen shot 2019-02-01 at 13 19 30" src="https://user-images.githubusercontent.com/647311/52126023-184fb380-2626-11e9-96fc-01c46b73a0c1.png">