### PR TITLE
Fixed typo

### DIFF
--- a/app/views/histories/lancaster_house.html.erb
+++ b/app/views/histories/lancaster_house.html.erb
@@ -56,7 +56,7 @@
     <%= image_tag 'history/buildings/lancaster-house-long-gallery.jpg', alt:'Lancaster House long gallery' %>
     <p>The long gallery can hold up to 200 people seated theatre-style or 150 for a seated dinner. Alternatively, it can accommodate a conference table for up to 60, with a further 120 people seated beside and behind the table. The long gallery provides a dramatic backdrop for big events; it is perfect for opening or closing ceremonies and receptions for up to 350 people.</p>
     <p>More than 35 metres in length, the long gallery dominates the whole of the east side of the house. With 18 windows and a large ornate skylight, the room is filled with natural light.</p>
-    <p>Winston Churchill gave a coronation banquet for the newly crowned Queen Elisabeth II here in June 1953. More recently, the long gallery has been used for a number of top-level international summits, wedding receptions, fashion shows and filming.</p>
+    <p>Winston Churchill gave a coronation banquet for the newly crowned Queen Elizabeth II here in June 1953. More recently, the long gallery has been used for a number of top-level international summits, wedding receptions, fashion shows and filming.</p>
     <p>The ceiling, painted by the Italian artist Guercino, shows Saint Chrysogonus borne to heaven by angels. The chimney piece below features ormolu decorations from France and a shelf supported by gilded allegorical figures of Architecture and Painting.</p>
     <p>An anteroom at the end of the gallery contains Zelotti’s Cupid receiving an apple from the Graces. The tall, heavy doors are decorated with the Sutherland monogram.</p>
 


### PR DESCRIPTION
https://trello.com/c/X6ph8oGt/2035-typo-lancaster-house

Changed Queen Elisabeth II to Queen Elizabeth II