### PR TITLE
Change Menu link from Announcements to News and communications

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -8,7 +8,7 @@
       <li class="clear-child"><%= main_navigation_link_to "Publications", publications_path %></li>
       <li><%= main_navigation_link_to "Consultations", publications_filter_path(publication_filter_option: 'consultations') %></li>
       <li><%= main_navigation_link_to "Statistics", statistics_path %></li>
-      <li><%= main_navigation_link_to "Announcements", announcements_path %></li>
+      <li><a href="/news-and-communications">News and communications</a></li>
     </ul>
   </nav>
   <main id="content" role="main" class="whitehall-content">

--- a/features/step_definitions/announcement_steps.rb
+++ b/features/step_definitions/announcement_steps.rb
@@ -6,6 +6,5 @@ end
 
 When(/^I visit the list of announcements$/) do
   stub_content_item_from_content_store_for(announcements_path)
-  visit homepage
-  click_link "Announcements"
+  visit announcements_path
 end

--- a/features/step_definitions/fatalities_steps.rb
+++ b/features/step_definitions/fatalities_steps.rb
@@ -12,8 +12,7 @@ end
 
 Then(/^the fatality notice is shown on the Announcements page$/) do
   stub_content_item_from_content_store_for(announcements_path)
-  visit homepage
-  click_link "Announcements"
+  visit announcements_path
   assert page.has_content?(FatalityNotice.last.title)
 end
 


### PR DESCRIPTION
https://trello.com/c/CvwsYUuD/341-replace-announcements-link-in-header-footer-and-on-homepage

This switches the link from `/government/announcements` to `/news-and-communications` in the sitewide menu.

This is a new finder replacing an old finder. View the new finder: https://www.gov.uk/news-and-communications.