### PR TITLE
Replace announcements lists with news and comms lists on world location news pages

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -13,11 +13,7 @@ class WorldLocationNewsController < PublicFacingController
         publications = Publication.published.in_world_location(@world_location)
         @non_statistics_publications = latest_presenters(publications.not_statistics, translated: true, count: 2)
         @statistics_publications = latest_presenters(publications.statistics, translated: true, count: 2)
-        @announcements = if Locale.current.english?
-                           fetch_documents(count: 2, filter_content_store_document_type: announcement_document_types)
-                         else
-                           latest_presenters(Announcement.published.in_world_location(@world_location), translated: true, count: 2)
-                         end
+        @news_and_communications = fetch_news_and_communications
         @feature_list = FeatureListPresenter.new(@world_location.feature_list_for_locale(I18n.locale), view_context).limit_to(5)
       end
       format.json do
@@ -44,8 +40,7 @@ private
     SearchRummagerService.new.fetch_related_documents(filter_params)["results"]
   end
 
-  def announcement_document_types
-    non_world_announcement_types = Whitehall::AnnouncementFilterOption.all.map(&:document_type).flatten
-    %w(world_location_news_article world_news_story).concat(non_world_announcement_types)
+  def fetch_news_and_communications
+    fetch_documents(count: 2, filter_content_purpose_supergroup: 'news_and_communications')
   end
 end

--- a/app/helpers/filter_routes_helper.rb
+++ b/app/helpers/filter_routes_helper.rb
@@ -3,6 +3,10 @@ module FilterRoutesHelper
     announcements_path(path_arguments(objects))
   end
 
+  def news_and_communications_filter_path(*objects)
+    "/news-and-communications?#{path_arguments(objects).to_query}"
+  end
+
   def publications_filter_path(*objects)
     publications_path(path_arguments(objects))
   end

--- a/app/helpers/filter_routes_helper.rb
+++ b/app/helpers/filter_routes_helper.rb
@@ -3,10 +3,6 @@ module FilterRoutesHelper
     announcements_path(path_arguments(objects))
   end
 
-  def news_and_communications_filter_path(*objects)
-    "/news-and-communications?#{path_arguments(objects).to_query}"
-  end
-
   def publications_filter_path(*objects)
     publications_path(path_arguments(objects))
   end

--- a/app/views/world_location_news/index.html.erb
+++ b/app/views/world_location_news/index.html.erb
@@ -50,17 +50,17 @@
     </div>
   </div>
 
-  <% if (@non_statistics_publications + @announcements + @statistics_publications).any? %>
+  <% if (@non_statistics_publications + @news_and_communications + @statistics_publications).any? %>
     <div class="block documents-grid">
       <div class="inner-block">
         <h1 class="block-title"><%= t('world_location.headings.documents') %></h1>
-        <% if @announcements.any? %>
+        <% if @news_and_communications.any? %>
           <div class="content">
             <%= render partial: "shared/document_list_from_rummager", locals: {
-              documents: @announcements,
-              type: :announcements,
-              documents_count: @announcements.count,
-              heading: t('world_location.headings.announcements'),
+              documents: @news_and_communications,
+              type: :news_and_communications,
+              documents_count: @news_and_communications.count,
+              heading: t('world_location.headings.news_and_communications'),
               world_location_news: "1",
             } %>
           </div>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -403,6 +403,7 @@ ar:
       country: البلد
       documents: وثائق
       mission: مهمتنا
+      news_and_communications:
       organisations: مؤسسات
       publications: مطبوعاتنا
       quick_links: وصلات سريعة

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -425,6 +425,7 @@ az:
       country: Ölkə
       documents: Sənədlər
       mission: Bizim missiyamız
+      news_and_communications:
       organisations: Təşkilatlar
       publications: Bizim nəşrlər
       quick_links: Linklər

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -301,6 +301,7 @@ be:
       country: Краіна
       documents: Дакументы
       mission: Наша місія
+      news_and_communications:
       organisations: Арганізацыі
       publications: Нашы публікацыі
       quick_links: Хуткія спасылкі

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -201,6 +201,7 @@ bg:
       country: Държава
       documents: Документи
       mission: Нашата мисия
+      news_and_communications:
       organisations: Организации
       publications: Нашите публикации
       quick_links: Бързи връзки

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -199,6 +199,7 @@ bn:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -250,6 +250,7 @@ cs:
       country: Země
       documents: Dokumenty
       mission: Naše poslání
+      news_and_communications:
       organisations: Organizace
       publications: Naše publikace
       quick_links: Odkazy

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -403,6 +403,7 @@ cy:
       country: Gwlad
       documents: Dogfennau
       mission: Ein cenhadaeth
+      news_and_communications:
       organisations: Sefydliadau
       publications: Ein cyhoeddiadau
       quick_links: Dolenni cyflym

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -199,6 +199,7 @@ de:
       country: Land
       documents: Dokumente
       mission: Unser Auftrag
+      news_and_communications:
       organisations: Organisationen
       publications: Unsere Veröffentlichungen
       quick_links: Quicklinks

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -199,6 +199,7 @@ dr:
       country: کشور
       documents: اسناد
       mission: ماموریت ما
+      news_and_communications:
       organisations: سازمان ها
       publications: نشریات ما
       quick_links: لینک های عاجل

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -199,6 +199,7 @@ el:
       country: Χώρα
       documents: Έγγραφα
       mission: Η αποστολή μας
+      news_and_communications:
       organisations: Οργανισμοί
       publications: Οι εκδόσεις μας
       quick_links: Σύντομοι σύνδεσμοι

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,7 @@ en:
       country: Country
       documents: Documents
       mission: Our mission
+      news_and_communications: News and communications
       organisations: Organisations
       publications: Our publications
       quick_links: Quick links

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -199,6 +199,7 @@ es-419:
       country: País
       documents: Documentos
       mission: Nuestra misión
+      news_and_communications:
       organisations: Organizaciones
       publications: Nuestras publicaciones
       quick_links: Vínculos rápidos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -199,6 +199,7 @@ es:
       country: País
       documents: Documentos
       mission: Nuestra Misión
+      news_and_communications:
       organisations: Organizaciones
       publications: Publicaciones
       quick_links: Enlaces directos

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -199,6 +199,7 @@ et:
       country: Riik
       documents: Dokumendid
       mission: Meie missioon
+      news_and_communications:
       organisations: Organisatsioonid
       publications: Meie publikatsioonid
       quick_links: Otselingid

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -428,6 +428,7 @@ fa:
       country: کشور
       documents: مدارک
       mission: هدف ما
+      news_and_communications:
       organisations: سازمان ها
       publications: انتشارات ما
       quick_links: دسترسی سریع

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -199,6 +199,7 @@ fr:
       country: Pays
       documents: Documents
       mission: Notre mission
+      news_and_communications:
       organisations: Organisations
       publications: Nos publications
       quick_links: Liens directs

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -199,6 +199,7 @@ he:
       country: מדינה
       documents: מסמכים
       mission: החזון שלנו
+      news_and_communications:
       organisations: ארגונים
       publications: הפרסומים שלנו
       quick_links: קישורים מהירים

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -199,6 +199,7 @@ hi:
       country: देश
       documents: दस्तावेज़
       mission: हमारा लक्ष्य
+      news_and_communications:
       organisations: संगठन
       publications: हमारे प्रकाशन
       quick_links: क्विक लिंक्स

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,139 +1,13 @@
 hu:
-  activerecord:
-    attributes:
-      attachment:
-        hoc_paper_number:
-        isbn:
-        unnumbered_hoc_paper:
-      attachment_data:
-        file:
-      corporate_information_page/corporate_information_page_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        order_url:
-        price:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
-      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
-        file:
-      edition:
-        nation_inapplicabilities:
-      policy_group/policy_group_attachments/attachment/attachment_data:
-        file:
-      response/consultation_response_attachments/attachment:
-        command_paper_number:
-        hoc_paper_number:
-        isbn:
-        order_url:
-        price:
-        title:
-        unique_reference:
-        unnumbered_hoc_paper:
-      response/consultation_response_attachments/attachment/attachment_data:
-        file:
-    nested_attachment_data_field_names:
-      file:
-    nested_attachment_field_names:
-      command_paper_number:
-      hoc_paper_number:
-      isbn:
-      order_url:
-      price:
-      title:
-      unique_reference:
-      unnumbered_hoc_paper:
-  announcements:
-    heading: Közlemények
-    view_all:
-  attachment:
-    accessibility:
-      full_help_html: 'Ha ezt a dokumentumot más formátumban szeretné igényelni (braille,
-        audio stb.), kérjük, írjon a %{email} címre. Levelében adja meg címét, telefonszámát
-        és az igényelt dokumentum címét: ("%{title}")%{references}.'
-      heading: Ez a fájl valószínűleg nem megfelelő hozzáférést segítő alkalmások
-        számára.
-      request_a_different_format: Más formátum igénylése.
-    headings:
-      order_a_copy: Másolat kérése
-      order_a_copy_full: A publikáció másolatának megrendelése
-      published: Közzététel időpontja
-      reference: Ref
-      unnumbered_command_paper:
-      unnumbered_hoc_paper:
-    opendocument:
-      help_html:
-    see_more:
-  broken_links:
-    broken:
-      subheading:
-    caution:
-      subheading:
-    title:
-  change_notes:
-    page_history:
-    published_at:
-    see_all_updates:
-    updated_at:
-  contact:
-    contact_form: Kapcsolati űrlap
-    email: E-mail
-  corporate_information_page:
-    type:
-      link_text:
-        welsh_language_scheme:
-      title:
-        about:
-        about_our_services:
-        access_and_opening:
-        complaints_procedure:
-        equality_and_diversity:
-        media_enquiries:
-        membership:
-        our_energy_use:
-        our_governance:
-        personal_information_charter: Személyes információk kezelése
-        petitions_and_campaigns:
-        procurement:
-        publication_scheme: Az információk publikálására vonatkozó eljárási rend
-        recruitment:
-        research:
-        social_media_use: Social media
-        staff_update:
-        statistics:
-        terms_of_reference:
-        welsh_language_scheme: Welsh language scheme
-  date:
-    formats:
-      default: "%Y %B %d"
-      long_ordinal: "%Y %B %e"
   document:
-    contents:
-    footer_meta:
-      full_page_history:
-      page_history:
-      published:
-      updated:
     headings:
-      applies_to_nations: 'A következő nemzetekre vonatkozik:'
       attachments:
         one: Dokumentum
         other: Dokumentumok
+      applies_to_nations: 'A következő nemzetekre vonatkozik:'
       from:
       location:
       part_of:
-    published: közzététel dátuma
-    read: 'Olvassa el a következő cikket: %{title}'
-    speech:
-      author_title:
-        minister: Miniszter
-        speaker: Szerző
-      delivered_on: 'Elhangzott:'
-      delivery_title:
-        minister: Miniszter
-        speaker: Beszélő
-      written_on: 'A beszéd megírásának időpontja:'
     type:
       announcement:
         one: Bejelentés
@@ -273,8 +147,173 @@ hu:
       written_statement:
         one: Írásbeli parlamenti nyilatkozat
         other: Írásbeli parlamenti nyilatkozatok
+    contents:
+    footer_meta:
+      full_page_history:
+      page_history:
+      published:
+      updated:
+    published: közzététel dátuma
+    read: 'Olvassa el a következő cikket: %{title}'
+    speech:
+      author_title:
+        minister: Miniszter
+        speaker: Szerző
+      delivered_on: 'Elhangzott:'
+      delivery_title:
+        minister: Miniszter
+        speaker: Beszélő
+      written_on: 'A beszéd megírásának időpontja:'
     updated: 'Utolsó frissítés:'
     view: Tekintse meg a következő dokumentumot '%{title}'
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:
+  world_location:
+    type:
+      international_delegation:
+        one: Nemzetközi delegáció
+        other: Nemzetközi delegációk
+      world_location:
+        one: Ország
+        other: Országok
+    headings:
+      announcements: Híreink
+      country: Ország
+      documents: Dokumentumok
+      mission: Küldetésünk
+      news_and_communications:
+      organisations: Szervezetek
+      publications: Kiadványaink
+      quick_links: Gyorslinkek
+      related_policies: Kapcsolódó szakpolitikák
+      statistics: Statisztikák
+  activerecord:
+    attributes:
+      attachment:
+        hoc_paper_number:
+        isbn:
+        unnumbered_hoc_paper:
+      attachment_data:
+        file:
+      corporate_information_page/corporate_information_page_attachments/attachment:
+        command_paper_number:
+        hoc_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+        unnumbered_hoc_paper:
+      corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
+        file:
+      edition:
+        nation_inapplicabilities:
+      policy_group/policy_group_attachments/attachment/attachment_data:
+        file:
+      response/consultation_response_attachments/attachment:
+        command_paper_number:
+        hoc_paper_number:
+        isbn:
+        order_url:
+        price:
+        title:
+        unique_reference:
+        unnumbered_hoc_paper:
+      response/consultation_response_attachments/attachment/attachment_data:
+        file:
+    nested_attachment_data_field_names:
+      file:
+    nested_attachment_field_names:
+      command_paper_number:
+      hoc_paper_number:
+      isbn:
+      order_url:
+      price:
+      title:
+      unique_reference:
+      unnumbered_hoc_paper:
+  announcements:
+    heading: Közlemények
+    view_all:
+  attachment:
+    accessibility:
+      full_help_html: 'Ha ezt a dokumentumot más formátumban szeretné igényelni (braille,
+        audio stb.), kérjük, írjon a %{email} címre. Levelében adja meg címét, telefonszámát
+        és az igényelt dokumentum címét: ("%{title}")%{references}.'
+      heading: Ez a fájl valószínűleg nem megfelelő hozzáférést segítő alkalmások
+        számára.
+      request_a_different_format: Más formátum igénylése.
+    headings:
+      order_a_copy: Másolat kérése
+      order_a_copy_full: A publikáció másolatának megrendelése
+      published: Közzététel időpontja
+      reference: Ref
+      unnumbered_command_paper:
+      unnumbered_hoc_paper:
+    opendocument:
+      help_html:
+    see_more:
+  broken_links:
+    broken:
+      subheading:
+    caution:
+      subheading:
+    title:
+  change_notes:
+    page_history:
+    published_at:
+    see_all_updates:
+    updated_at:
+  contact:
+    contact_form: Kapcsolati űrlap
+    email: E-mail
+  corporate_information_page:
+    type:
+      link_text:
+        welsh_language_scheme:
+      title:
+        about:
+        about_our_services:
+        access_and_opening:
+        complaints_procedure:
+        equality_and_diversity:
+        media_enquiries:
+        membership:
+        our_energy_use:
+        our_governance:
+        personal_information_charter: Személyes információk kezelése
+        petitions_and_campaigns:
+        procurement:
+        publication_scheme: Az információk publikálására vonatkozó eljárási rend
+        recruitment:
+        research:
+        social_media_use: Social media
+        staff_update:
+        statistics:
+        terms_of_reference:
+        welsh_language_scheme: Welsh language scheme
+  date:
+    formats:
+      default: "%Y %B %d"
+      long_ordinal: "%Y %B %e"
   document_filters:
     description: A szűrők segítséget nyújtanak az érdeklődésének megfelelő eredmények
       keresésében
@@ -343,14 +382,6 @@ hu:
       step1_html:
       step2_html:
       step3_html:
-  people:
-    biography:
-    heading:
-      one:
-      other:
-    previous_roles:
-    previous_roles_in_government:
-    read_more:
   policies:
     heading: Szakpolitikák
     view_all:
@@ -359,18 +390,6 @@ hu:
     headings:
       detail: Részletek
   read_more: Tovább...
-  roles:
-    heading:
-      one:
-      other:
-    headings:
-      current_holder:
-      previous_holders:
-      responsibilities:
-    ministerial:
-    policies_responsible_with_person:
-    previous_holders:
-    read_more:
   see_all:
     announcement: " bejelentések - mindegyik megtekintése"
     authored_article: " publicisztikák - mindegyik megtekintése"
@@ -423,24 +442,6 @@ hu:
   time:
     formats:
       long_ordinal: "%Y %B %e %H:%M"
-  world_location:
-    headings:
-      announcements: Híreink
-      country: Ország
-      documents: Dokumentumok
-      mission: Küldetésünk
-      organisations: Szervezetek
-      publications: Kiadványaink
-      quick_links: Gyorslinkek
-      related_policies: Kapcsolódó szakpolitikák
-      statistics: Statisztikák
-    type:
-      international_delegation:
-        one: Nemzetközi delegáció
-        other: Nemzetközi delegációk
-      world_location:
-        one: Ország
-        other: Országok
   worldwide_organisation:
     corporate_information:
       about_our_services_html:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -199,6 +199,7 @@ hy:
       country: Երկիր
       documents: Փաստաթղթեր
       mission: Մեր գործունեությունը
+      news_and_communications:
       organisations: Կազմակերպություններ
       publications: Մեր հրատարակությունները
       quick_links: Հղումներ

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -428,6 +428,7 @@ id:
       country: Negara
       documents: Dokumen-dokumen
       mission: Misi kami
+      news_and_communications:
       organisations: Organisasi-organisasi
       publications: Publikasi-publikasi kami
       quick_links: Tautan cepat

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -199,6 +199,7 @@ it:
       country: Paese
       documents: Documenti
       mission: La nostra missione
+      news_and_communications:
       organisations: Organizzazioni
       publications: Le nostre pubblicazioni
       quick_links: Link veloci

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -426,6 +426,7 @@ ja:
       country: 国名
       documents: お知らせ
       mission: 役割
+      news_and_communications:
       organisations: 組織
       publications: 出版物
       quick_links: Quick links

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -425,6 +425,7 @@ ka:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -426,6 +426,7 @@ ko:
       country: 국가
       documents: 자료
       mission: 대사관 안내
+      news_and_communications:
       organisations: 조직 안내
       publications: 출판물
       quick_links: 퀵 링크

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -250,6 +250,7 @@ lt:
       country: Šalis
       documents: Dokumentai
       mission: Mūsų misija
+      news_and_communications:
       organisations: Organizacijos
       publications: Mūsų publikacijos
       quick_links: Greitos nuorodos

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -199,6 +199,7 @@ lv:
       country: Valsts
       documents: Dokumenti
       mission: Misija
+      news_and_communications:
       organisations: Organizācijas
       publications: Publikācijas
       quick_links: Ātrās saites

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -425,6 +425,7 @@ ms:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -301,6 +301,7 @@ pl:
       country: Kraj
       documents: Dokumenty
       mission: Nasza misja
+      news_and_communications:
       organisations: Organizacje
       publications: Nasze publikacje
       quick_links: Szybkie linki

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -199,6 +199,7 @@ ps:
       country: هیواد
       documents: سندونه
       mission: زموږ ماموریت
+      news_and_communications:
       organisations: دفترونه
       publications: زموږ نشریات
       quick_links: چټکی اړیکی

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -199,6 +199,7 @@ pt:
       country: País
       documents: Documentos
       mission: Nossa missão
+      news_and_communications:
       organisations: Organizações
       publications: Nossas publicações
       quick_links: Links

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -250,6 +250,7 @@ ro:
       country: Țară
       documents: Documente
       mission: Obiectiv
+      news_and_communications:
       organisations: Organizații
       publications: Documente
       quick_links: 'Link-uri rapide '

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -301,6 +301,7 @@ ru:
       country: Страна
       documents: Документы
       mission: Наша цель
+      news_and_communications:
       organisations: Организации
       publications: Наши публикации
       quick_links: Быстрые ссылки

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -199,6 +199,7 @@ si:
       country: රට
       documents: ලේඛන
       mission: අපේ මෙහෙවර ප්‍රකාශය
+      news_and_communications:
       organisations: සංවිධාන
       publications: අපේ ප්‍රකාශන
       quick_links: ක්ෂණික සන්ධිය

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -250,6 +250,7 @@ sk:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -199,6 +199,7 @@ so:
       country: Dal
       documents: Dokumentiyo
       mission: Hawsheenna
+      news_and_communications:
       organisations: Ururro
       publications: Daabacaadaheenna
       quick_links: Waddooyin xiriir degdeg ah

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -199,6 +199,7 @@ sq:
       country: Vendi
       documents: Dokumenta
       mission: Misioni yne
+      news_and_communications:
       organisations: Organizatat
       publications: Publikimet tona
       quick_links: Lidhje te shpejta

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -301,6 +301,7 @@ sr:
       country: Država
       documents: Dokumenti
       mission: Naša misija
+      news_and_communications:
       organisations: Organizacije
       publications: Naše publikacije
       quick_links: Linkovi

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -199,6 +199,7 @@ sw:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -199,6 +199,7 @@ ta:
       country: நாடு
       documents: ஆவணங்கள்
       mission: எங்களது இலட்சியம்
+      news_and_communications:
       organisations: ஸ்தாபனங்கள்
       publications: எங்களது வெளியீடுகள்
       quick_links: விரைவான இணைப்புகள்

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -426,6 +426,7 @@ th:
       country: ประเทศ
       documents: เอกสาร
       mission: ภาระกิจของเรา
+      news_and_communications:
       organisations: องค์กร
       publications: สิ่งพิมพ์ของเรา
       quick_links: ลิงค์ด่วน

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -199,6 +199,7 @@ tk:
       country:
       documents:
       mission:
+      news_and_communications:
       organisations:
       publications:
       quick_links:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -427,6 +427,7 @@ tr:
       country: Ülke
       documents: Belgeler
       mission: Misyonumuz
+      news_and_communications:
       organisations: Organizasyon
       publications: Yayınlarımız
       quick_links: Kısa Yollar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -301,6 +301,7 @@ uk:
       country: Країна
       documents: Документи
       mission: Наша місія
+      news_and_communications:
       organisations: Організації
       publications: Наші публікації
       quick_links: Короткі посилання

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -199,6 +199,7 @@ ur:
       country: ملک
       documents: دستاویزات
       mission: ہمارا مشن
+      news_and_communications:
       organisations: ادارے
       publications: ہماری مطبوعات
       quick_links: فوری لنکس

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -199,6 +199,7 @@ uz:
       country: Mamlakat
       documents: Hujjatlar
       mission: Bizning vazifalar
+      news_and_communications:
       organisations: Tashkilotlar
       publications: Bizning nashrlar
       quick_links: Tez bog'lanish linklari

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -429,6 +429,7 @@ vi:
       country: Đất nước
       documents: Tài liệu
       mission: Nhiệm vụ của chúng tôi
+      news_and_communications:
       organisations: Các tổ chức
       publications: Tài liệu truyền thông của chúng tôi
       quick_links: Links nhanh

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -425,6 +425,7 @@ zh-hk:
       country: 國家
       documents: 文件
       mission: 我們的使命
+      news_and_communications:
       organisations: 組織
       publications: 我們的出版物
       quick_links: 快速連結

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -425,6 +425,7 @@ zh-tw:
       country: 國家
       documents: 文件
       mission: 我們的使命
+      news_and_communications:
       organisations: 組織
       publications: 我們的出版物
       quick_links: 快速連結

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -425,6 +425,7 @@ zh:
       country: 国家
       documents: 文件
       mission: 我们的任务
+      news_and_communications:
       organisations: 机构
       publications: 我们的报告
       quick_links: 快速链接

--- a/test/functional/world_location_news_controller_test.rb
+++ b/test/functional/world_location_news_controller_test.rb
@@ -28,11 +28,6 @@ class WorldLocationNewsControllerTest < ActionController::TestCase
     )
   end
 
-  # def announcement_document_types
-  #   non_world_announcement_types = Whitehall::AnnouncementFilterOption.all.map(&:document_type).flatten
-  #   %w(world_location_news_article world_news_story).concat(non_world_announcement_types)
-  # end
-
   setup do
     @world_location = create(:world_location,
                              title: "UK and India",

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -105,8 +105,15 @@ class RoutingTest < ActionDispatch::IntegrationTest
 
   test "routing to world location news" do
     create(:world_location, slug: "france", translated_into: [:fr])
+    rummager = stub
 
-    get "/world/france/news.fr"
-    assert_response :success
+    with_stubbed_rummager(rummager, true) do
+      rummager.expects(:search).returns('results' =>
+                                         [{ 'format' => 'news_article', 'content_id' => 'news_id', 'public_timestamp' => Time.zone.now.to_s },
+                                          { 'format' => 'speech', 'content_id' => 'speech_id', 'public_timestamp' => Time.zone.now.to_s }])
+
+      get "/world/france/news.fr"
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/u6doZAVR/373-replace-announcements-lists-with-news-and-comms-lists-on-world-location-news-pages

We have created a new finder within finder-frontend called [news and communications](https://www.gov.uk/news-and-communications).

This change ensures that the information under news and communications on the `/world/:slug/news` pages matches the content of the news and comms finder (they both filter results based on content_purpose_supergroup: news_and_communications).

The link to the announcements finder has also been replaced.

The goal is to deprecate the announcements finder and replace it with the news and communications finder; replacing the links is required before we can do this.

Before: https://www.gov.uk/world/jamaica/news

![screen shot 2019-02-18 at 11 51 18](https://user-images.githubusercontent.com/8124374/52949731-0a639780-3375-11e9-9cd4-c3e375be650c.png)

After:

![screen shot 2019-02-18 at 11 51 13](https://user-images.githubusercontent.com/8124374/52949728-08013d80-3375-11e9-9e6a-d92feaa7fcac.png)
