### PR TITLE
Bring back test for first published at

### DIFF
--- a/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
+++ b/test/unit/presenters/publishing_api/payload_builder/first_published_at_test.rb
@@ -12,6 +12,13 @@ module PublishingApi
           FirstPublishedAt.for(item)
         )
       end
+
+      def test_returns_nil_created_at_for_nil_first_published_at
+        created_at = Object.new
+        item = stub(first_published_at: nil, document: stub(created_at: created_at))
+
+        assert_empty(FirstPublishedAt.for(item))
+      end
     end
   end
 end


### PR DESCRIPTION
This test was removed as part of some changes  #4413 but
we want to ensure that the created at of the document
is not sent to the Publishing API.