### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,12 +1,12 @@
 require 'gds_api/rummager'
 
 Whitehall.government_search_client = GdsApi::Rummager.new(
-  Plek.find('rummager') + Whitehall::SearchIndex.government_search_index_path,
+  Plek.find('search') + Whitehall::SearchIndex.government_search_index_path,
   bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
 )
 
 Whitehall.search_client = GdsApi::Rummager.new(
-  Plek.find('rummager'),
+  Plek.find('search'),
   bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
 )
 
@@ -15,7 +15,7 @@ def statistics_announcement_search_client
     DevelopmentModeStubs::FakeRummagerApiForStatisticsAnnouncements
   else
     GdsApi::Rummager.new(
-      Plek.find('rummager') + Whitehall::SearchIndex.government_search_index_path,
+      Plek.find('search') + Whitehall::SearchIndex.government_search_index_path,
       bearer_token: ENV['RUMMAGER_BEARER_TOKEN'] || 'example'
     )
   end

--- a/lib/whitehall/search_index.rb
+++ b/lib/whitehall/search_index.rb
@@ -42,7 +42,7 @@ module Whitehall
     end
 
     def self.rummager_host
-      Plek.find('rummager')
+      Plek.find('search')
     end
   end
 

--- a/test/unit/whitehall/not_quite_as_fake_search_test.rb
+++ b/test/unit/whitehall/not_quite_as_fake_search_test.rb
@@ -7,7 +7,7 @@ module Whitehall
       setup do
         @store = Store.new
         SearchIndex.indexer_class.store = @store
-        @index = SearchIndex.indexer_class.new('http://rummager.test', 'government')
+        @index = SearchIndex.indexer_class.new('http://search.test', 'government')
       end
 
       teardown do


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)