### PR TITLE
Fix a bug where specialist sectors wouldn't stick

### DIFF
--- a/app/services/taxons_to_legacy_associations_tagging.rb
+++ b/app/services/taxons_to_legacy_associations_tagging.rb
@@ -49,6 +49,6 @@ private
   end
 
   def tagged_to_specialist_sectors?(edition)
-    defined?(edition.specialist_sectors) && edition.specialist_sectors.any?
+    edition.respond_to?(:specialist_sectors) && edition.specialist_sectors.any?
   end
 end


### PR DESCRIPTION
Because this code was using `defined?` to check for the presence of the `specialist_sectors` method on the edition, and the edition is wrapped in a `LocalisedModel` which technically doesn't have that method defined, the code was replacing existing specialist sectors with recommended ones.

Using `respond_to?` provides the correct behaviour since it accounts for `method_missing` in `LocalisedModel` and therefore uses duck typing to figure out whether it's safe to call `specialist_sectors` on the object.

https://trello.com/c/9OARj5Uf/813-topics-not-making-it-to-the-publishing-api-from-whitehall