### PR TITLE
Shortcut access to content_store_document_type

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -659,7 +659,7 @@ class Edition < ApplicationRecord
   end
 
   def content_store_document_type
-    PublishingApiPresenters.presenter_for(self).content.fetch(:document_type)
+    PublishingApiPresenters.presenter_for(self).document_type
   end
 
   def has_legacy_tags?

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "case_study",
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "case_study",
@@ -39,6 +39,10 @@ module PublishingApi
           worldwide_organisations
         ]
       )
+    end
+
+    def document_type
+      "case_study"
     end
 
   private

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -23,7 +23,7 @@ module PublishingApi
         .merge(
           description: corporate_information_page.summary,
           details: details,
-          document_type: display_type_key,
+          document_type: document_type,
           public_updated_at: public_updated_at,
           rendering_app: corporate_information_page.rendering_app,
           schema_name: SCHEMA_NAME,
@@ -46,6 +46,10 @@ module PublishingApi
           parent
         )
       ).merge(CorporateInformationPages.for(corporate_information_page))
+    end
+
+    def document_type
+      display_type_key
     end
 
   private

--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         .merge(
           description: item.summary,
           details: details,
-          document_type: "detailed_guide",
+          document_type: document_type,
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: item.rendering_app,
           schema_name: "detailed_guide",
@@ -44,6 +44,10 @@ module PublishingApi
         related_guides: item.related_detailed_guide_content_ids,
         related_mainstream_content: related_mainstream_content_ids
       )
+    end
+
+    def document_type
+      "detailed_guide"
     end
 
   private

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "document_collection",
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "document_collection",
@@ -43,6 +43,10 @@ module PublishingApi
       )
       links[:documents] = item.documents.pluck(:content_id).uniq
       links.merge!(PayloadBuilder::TopicalEvents.for(item))
+    end
+
+    def document_type
+      "document_collection"
     end
 
   private

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
         content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
         content.merge!(
           description: item.summary,
-          document_type: "fatality_notice",
+          document_type: document_type,
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: item.rendering_app,
           schema_name: "fatality_notice",
@@ -51,6 +51,10 @@ module PublishingApi
       ).merge(
         PayloadBuilder::Roles.for(item)
       )
+    end
+
+    def document_type
+      "fatality_notice"
     end
 
   private

--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: PayloadBuilder::TagDetails.for(item),
-        document_type: item.display_type_key,
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "placeholder_#{item.class.name.underscore}",
@@ -34,6 +34,10 @@ module PublishingApi
         :topics,
         :parent, # please use the breadcrumb component when migrating document_type to government-frontend
       ])
+    end
+
+    def document_type
+      item.display_type_key
     end
   end
 end

--- a/app/presenters/publishing_api/news_article_presenter.rb
+++ b/app/presenters/publishing_api/news_article_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
         .merge(
           description: news_article.summary,
           details: details,
-          document_type: display_type_key,
+          document_type: document_type,
           public_updated_at: public_updated_at,
           rendering_app: news_article.rendering_app,
           schema_name: SCHEMA_NAME,
@@ -49,6 +49,10 @@ module PublishingApi
         .merge(PayloadBuilder::TopicalEvents.for(news_article))
         .merge(PayloadBuilder::Roles.for(news_article))
         .merge(PayloadBuilder::People.for(news_article, :people))
+    end
+
+    def document_type
+      display_type_key
     end
 
   private

--- a/app/presenters/publishing_api/publication_presenter.rb
+++ b/app/presenters/publishing_api/publication_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: item.display_type_key,
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "publication",
@@ -58,6 +58,10 @@ module PublishingApi
       ).merge(
         PayloadBuilder::People.for(item, :people)
       )
+    end
+
+    def document_type
+      item.display_type_key
     end
 
   private

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -65,8 +65,6 @@ module PublishingApi
       links.merge!(PayloadBuilder::People.for(item, :people))
     end
 
-  private
-
     def document_type
       if SpeechType.non_statements.include?(item.speech_type)
         "speech"
@@ -74,6 +72,8 @@ module PublishingApi
         item.speech_type.key
       end
     end
+
+  private
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)

--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "statistical_data_set",
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "statistical_data_set",
@@ -32,6 +32,10 @@ module PublishingApi
       LinksPresenter.new(item).extract(
         %i(organisations policy_areas topics parent)
       )
+    end
+
+    def document_type
+      "statistical_data_set"
     end
 
   private

--- a/app/presenters/publishing_api/world_location_news_article_presenter.rb
+++ b/app/presenters/publishing_api/world_location_news_article_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
       content.merge!(
         description: item.summary,
         details: details,
-        document_type: "world_location_news_article",
+        document_type: document_type,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: item.rendering_app,
         schema_name: "world_location_news_article",
@@ -32,6 +32,10 @@ module PublishingApi
       LinksPresenter.new(item).extract(
         %i(worldwide_organisations parent policy_areas topics world_locations)
       )
+    end
+
+    def document_type
+      "world_location_news_article"
     end
 
   private

--- a/app/presenters/publishing_api_presenters.rb
+++ b/app/presenters/publishing_api_presenters.rb
@@ -61,10 +61,10 @@ module PublishingApiPresenters
         else
           PublishingApi::CorporateInformationPagePresenter
         end
-      when ::DocumentCollection
-        PublishingApi::DocumentCollectionPresenter
       when ::DetailedGuide
         PublishingApi::DetailedGuidePresenter
+      when ::DocumentCollection
+        PublishingApi::DocumentCollectionPresenter
       when ::FatalityNotice
         PublishingApi::FatalityNoticePresenter
       when ::NewsArticle


### PR DESCRIPTION
Fleshing out the full content of a publishing API presenter is a hugely expensive operation, so let's skip straight to the end result which is a method called on this object anyway.

This represents at least a 50% reduction in loading time for the tag edit form, more so if the database is heavily loaded at the time.

https://trello.com/c/GQJ2AEsS/827-make-the-edit-tags-publishing-step-more-resilient