### PR TITLE
Add rake task to report the number of draft...

### DIFF
--- a/lib/reports/draft_publications_report.rb
+++ b/lib/reports/draft_publications_report.rb
@@ -35,7 +35,7 @@ module Reports
     attr_reader :start_date, :end_date
 
     def parse_date(date)
-      Time.parse(date)
+      Time.zone.parse(date)
     end
 
     def get_draft_publications(date_range)

--- a/lib/reports/draft_publications_report.rb
+++ b/lib/reports/draft_publications_report.rb
@@ -1,0 +1,51 @@
+module Reports
+  class DraftPublicationsReport
+    def initialize(start_date, end_date)
+      @start_date = parse_date(start_date)
+      @end_date = parse_date(end_date)
+    end
+
+    def report
+      date_range = @start_date...@end_date
+      draft_publications = get_draft_publications(date_range)
+      organisations = Organisation.order(slug: :asc)
+
+      path = "#{Rails.root}/tmp/number_of_draft_publications_by_organisation_#{@start_date}_to_#{@end_date}.csv"
+      csv_headers = ["Lead publishing organisation", "Number of draft publications"]
+
+      CSV.open(path, "wb", headers: csv_headers, write_headers: true) do |csv|
+        puts "Searching for draft publications between #{start_date} and #{end_date}"
+
+        organisations.find_each do |organisation|
+          publications = draft_publications
+            .where(edition_organisations: { lead: 1, organisation_id: organisation.id })
+
+          csv << [
+            organisation,
+            publications.count
+          ]
+          puts "#{organisation.slug}: #{publications.count}"
+        end
+        puts "Report available at #{path}"
+      end
+    end
+
+    private
+
+    attr_reader :start_date, :end_date
+
+    def parse_date(date)
+      Time.parse(date)
+    end
+
+    def get_draft_publications(date_range)
+      Edition.include(Edition::Organisations)
+
+      Edition.latest_edition
+        .joins(:edition_organisations)
+        .where(state: "draft")
+        .where(type: "publication")
+        .where(updated_at: date_range)
+    end
+  end
+end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -80,6 +80,46 @@ namespace :reporting do
     end
   end
 
+  desc "A CSV report of the number of publications in draft state by organisation between the dates specified [Month Day Year 00:00:00]"
+  task :number_of_draft_publications_by_organisation_by_date_range, %i[start_date end_date] => :environment do |_t, args|
+    if args[:start_date].present? && args[:end_date].present?
+      start_date = Time.parse(args[:start_date])
+      end_date = Time.parse(args[:end_date])
+    end
+
+    date_range = start_date...end_date
+
+    path = "#{Rails.root}/tmp/number_of_draft_publications_by_organisation_between_#{start_date}_to_#{end_date}.csv"
+
+    CSV_HEADERS = ["Lead publishing organisation", "Number of draft publications"].freeze
+
+    CSV.open(path, "wb", headers: CSV_HEADERS, write_headers: true) do |csv|
+      Edition.include(Edition::Organisations)
+
+      puts "Searching for draft publications between #{start_date} and #{end_date}"
+
+      draft_publications = Edition.latest_edition
+      .joins(:edition_organisations)
+      .where(state: "draft")
+      .where(type: "publication")
+      .where(updated_at: date_range)
+
+      organisations = Organisation.order(slug: :asc)
+
+      organisations.find_each do |organisation|
+        publications = draft_publications.where(edition_organisations: { lead: 1, organisation_id: organisation.id })
+
+        csv << [
+          organisation,
+          publications.count
+        ]
+        puts "#{organisation.slug}: #{publications.count}"
+      end
+
+      puts "Report available at #{path}"
+    end
+  end
+
   desc "A CSV report of all documents published by the given organisation"
   task organisation_documents: :environment do
     options = opts_from_environment(:organisation_slug)

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -82,11 +82,10 @@ namespace :reporting do
 
   desc "A CSV report of the number of publications in draft state by organisation between the dates specified [Month Day Year 00:00:00]"
   task :number_of_draft_publications_by_organisation_by_date_range, %i[start_date end_date] => :environment do |_t, args|
-    if args[:start_date].present? && args[:end_date].present?
-      start_date = Time.parse(args[:start_date])
-      end_date = Time.parse(args[:end_date])
-    end
+    raise "Missing start_date or end_date" unless args[:start_date].present? && args[:end_date].present?
 
+    start_date = Time.parse(args[:start_date])
+    end_date = Time.parse(args[:end_date])
     date_range = start_date...end_date
 
     path = "#{Rails.root}/tmp/number_of_draft_publications_by_organisation_between_#{start_date}_to_#{end_date}.csv"


### PR DESCRIPTION
...publications by organisation within a given date range.

This rake task will generate a report to CSV as well as output in
the console.
Running this task weekly will mean we can monitor and see if there
is an increase in draft publications.

Trello card: https://trello.com/c/rLXkQ9Nj/835-find-out-how-many-drafts-exist-in-the-system-at-a-given-time