### PR TITLE
Optimise parts used in force publishing

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -90,7 +90,10 @@ class Document < ApplicationRecord
   end
 
   def published?
-    reload_published_edition.present?
+    Edition.exists?(
+      state: Edition::PUBLICLY_VISIBLE_STATES,
+      document_id: id,
+    )
   end
 
   def first_published_date

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -332,7 +332,7 @@ class Edition < ApplicationRecord
   end
 
   def creator
-    edition_authors.first && edition_authors.first.user
+    edition_authors.first&.user
   end
 
   def creator=(user)

--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -42,7 +42,7 @@ module Edition::Publishing
     elsif draft? && new_record?
       false
     else
-      other_editions.published.any?
+      other_editions.published.exists?
     end
   end
 

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -41,12 +41,18 @@ private
     delete_unpublishing!
   end
 
+  def previous_editions
+    Edition
+      .unscoped
+      .where(document_id: edition.document_id)
+      .where.not(id: edition.id)
+      .published
+  end
+
   def supersede_previous_editions!
-    edition.document.editions.published.each do |e|
-      if e != edition
-        e.supersede
-        e.save(validate: false)
-      end
+    previous_editions.each do |edition|
+      edition.supersede
+      edition.save(validate: false)
     end
   end
 

--- a/db/migrate/20190312101215_add_index_to_edition_updated_at.rb
+++ b/db/migrate/20190312101215_add_index_to_edition_updated_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToEditionUpdatedAt < ActiveRecord::Migration[5.1]
+  def change
+    add_index :editions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181023071345) do
+ActiveRecord::Schema.define(version: 20190312101215) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -421,6 +421,7 @@ ActiveRecord::Schema.define(version: 20181023071345) do
     t.index ["state", "type"], name: "index_editions_on_state_and_type"
     t.index ["state"], name: "index_editions_on_state"
     t.index ["type"], name: "index_editions_on_type"
+    t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
   create_table "editorial_remarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
This optimises a few of the operations done in Whitehall, specifically aiming at improving the performance of force publishing.

See commits for individual details on optimisations.

Adding the index to `updated_at` in integration took less than 2 seconds, however it looks like MySQL allows adding of indexes without blocking the table: https://dev.mysql.com/doc/refman/5.6/en/innodb-online-ddl-operations.html

```
10:25:44 *** [err :: ip-10-1-4-230.eu-west-1.compute.internal] == 20190312101215 AddIndexToEditionUpdatedAt: migrating =======================
10:25:44 *** [err :: ip-10-1-4-230.eu-west-1.compute.internal] -- add_index(:editions, :updated_at)
10:25:46 *** [err :: ip-10-1-4-230.eu-west-1.compute.internal] -> 1.8123s
10:25:46 *** [err :: ip-10-1-4-230.eu-west-1.compute.internal] == 20190312101215 AddIndexToEditionUpdatedAt: migrated (1.8124s) ==============
```

[Trello Card](https://trello.com/c/H3MnHlyx/833-make-the-force-publish-step-more-resilient)