### PR TITLE
Speed up document search

### DIFF
--- a/app/controllers/admin/document_searches_controller.rb
+++ b/app/controllers/admin/document_searches_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DocumentSearchesController < Admin::BaseController
   def show
-    @editions = Filterer.new(params).editions
+    @editions = Filterer.new(params).editions.pluck(:id, :document_id, :title)
   end
 
   class Filterer

--- a/app/views/admin/document_searches/show.json.jbuilder
+++ b/app/views/admin/document_searches/show.json.jbuilder
@@ -1,10 +1,8 @@
 json.results_any? @editions.any?
 json.set! :results do
-  json.array! @editions do |edition|
-    json.extract!     edition, :id, :document_id, :title, :display_type
-    json.type         edition.type.underscore
-    json.url          admin_edition_path(edition)
-    json.public_time  public_time_for_edition(edition)
-    json.organisation edition.organisations.map { |o| organisation_display_name(o) }.to_sentence.html_safe
+  json.array! @editions do |id, document_id, title|
+    json.id id
+    json.document_id document_id
+    json.title title
   end
 end

--- a/test/functional/admin/document_searches_controller_test.rb
+++ b/test/functional/admin/document_searches_controller_test.rb
@@ -22,8 +22,6 @@ class Admin::DocumentSearchesControllerTest < ActionController::TestCase
     assert_equal publication.id, publication_json['id']
     assert_equal publication.document_id, publication_json['document_id']
     assert_equal publication.title, publication_json['title']
-    assert_equal 'publication', publication_json['type']
-    assert_equal publication.display_type, publication_json['display_type']
   end
 
   view_test 'GET #show can filter by edition type and subtype' do
@@ -40,7 +38,5 @@ class Admin::DocumentSearchesControllerTest < ActionController::TestCase
     assert_equal guidance.id, publication_json['id']
     assert_equal guidance.document_id, publication_json['document_id']
     assert_equal guidance.title, publication_json['title']
-    assert_equal 'publication', publication_json['type']
-    assert_equal guidance.display_type, publication_json['display_type']
   end
 end


### PR DESCRIPTION
This change avoids loading any extraneous data when searching for documents.  It's possible that this extra data was in use (or intended to be in use) but only the IDs and title are now used.

This results in an 85% reduction in search times.

I attempted to speed up other aspects of these pages but progress was too slow going; eager loading in this part of the code is quite difficult due mostly to the need to find the latest edition.  WIP here: https://github.com/alphagov/whitehall/compare/master...faster-collections-wip

https://trello.com/c/LXNyOmjO/832-make-documents-collections-publishing-more-resilient