### PR TITLE
Make it possible to redirect static pages

### DIFF
--- a/lib/publish_static_pages.rb
+++ b/lib/publish_static_pages.rb
@@ -92,14 +92,6 @@ class PublishStaticPages
         locales: Locale.non_english.map(&:code),
       },
       {
-        content_id: "88936763-df8a-441f-8b96-9ea0dc0758a1",
-        title: "Government announcements",
-        document_type: "finder",
-        description: "Find news articles, speeches and statements from government organisations",
-        base_path: "/government/announcements",
-        locales: Locale.non_english.map(&:code),
-      },
-      {
         content_id: "324e4708-2285-40a0-b3aa-cb13af14ec5f",
         title: "Ministers",
         document_type: "finder",

--- a/lib/redirect_static_pages.rb
+++ b/lib/redirect_static_pages.rb
@@ -1,0 +1,24 @@
+# This enables us to redirect static pages published by PublishStaticPages
+# to specified URLs.
+
+class RedirectStaticPages
+  def redirect
+    pages.each do |page|
+      PublishingApiRedirectWorker.new.perform(page[:content_id], page[:target_path], "en")
+    rescue GdsApi::HTTPNotFound => e
+      # we can't unpublish something that doesn't exist
+      puts e
+      nil
+    end
+  end
+
+  def pages
+    [
+      {
+        base_path: "/government/announcements",
+        content_id: "88936763-df8a-441f-8b96-9ea0dc0758a1",
+        target_path: "/redirect/announcements",
+      },
+    ]
+  end
+end

--- a/lib/tasks/redirect_static_pages.rake
+++ b/lib/tasks/redirect_static_pages.rake
@@ -1,0 +1,6 @@
+desc "Redirect static pages in publishing api, remove from rummager. This is called manually when needed."
+task redirect_static_pages: [:environment] do
+  puts "redirecting static pages..."
+  RedirectStaticPages.new.redirect
+  puts "FINISHED"
+end

--- a/test/unit/redirect_static_pages_test.rb
+++ b/test/unit/redirect_static_pages_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "govuk-content-schema-test-helpers"
+
+class RedirectStaticPagesTest < ActiveSupport::TestCase
+  test 'sends static pages to rummager and publishing api' do
+    expect_redirection(RedirectStaticPages.new.pages)
+    RedirectStaticPages.new.redirect
+  end
+
+  def expect_redirection(pages)
+    pages.each do |page|
+      PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        page[:content_id],
+        page[:target_path],
+        "en",
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Xbz5SvfD/350-allow-publishing-of-whitehall-finders-routes-to-finder-frontend

This will enable us to run a rake task to remove pages
published via PublishStaticPages such as
/government/announcements.

The new rake task redirect_static_pages will replace
specific static pages with redirects to new URLs and
will remove them from the search index.

The logic of RedirectStaticPages is a reverse of
PublishStaticPages, so if you read both that should
help explain the intent of the new class.