### PR TITLE
Revert "Add an index on editions updated_at field"

### DIFF
--- a/db/migrate/20190312101215_add_index_to_edition_updated_at.rb
+++ b/db/migrate/20190312101215_add_index_to_edition_updated_at.rb
@@ -1,5 +1,0 @@
-class AddIndexToEditionUpdatedAt < ActiveRecord::Migration[5.1]
-  def change
-    add_index :editions, :updated_at
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190312101215) do
+ActiveRecord::Schema.define(version: 20181023071345) do
 
   create_table "about_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "topical_event_id"
@@ -421,7 +421,6 @@ ActiveRecord::Schema.define(version: 20190312101215) do
     t.index ["state", "type"], name: "index_editions_on_state_and_type"
     t.index ["state"], name: "index_editions_on_state"
     t.index ["type"], name: "index_editions_on_type"
-    t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
   create_table "editorial_remarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
This reverts commit 03277d83892733ecdcbc4a0d3def2698f7b6941b.

We run MySQL 5.5 in production which doesn't support online migrations for indexes. Although it only took 2 seconds in staging, I'm not confident about deploying this change in hours in production, but I would like to get my other optimisations out and don't want to block deploys.

```
thomasleese@staging-whitehall-mysql-master-1:~$ mysql -V
mysql  Ver 14.14 Distrib 5.5.62, for debian-linux-gnu (x86_64) using readline 6.3
```

[Trello Card](https://trello.com/c/H3MnHlyx/833-make-the-force-publish-step-more-resilient)