### PR TITLE
Mock Redis client to fix test

### DIFF
--- a/test/unit/models/frontend/statistics_announcement_filter_test.rb
+++ b/test/unit/models/frontend/statistics_announcement_filter_test.rb
@@ -92,6 +92,7 @@ class Frontend::StatisticsAnnouncementsFilterTest < ActiveSupport::TestCase
     refute build_class_instance(from_date: nil).valid_filter_params.key?(:from_date)
     refute build_class_instance(to_date: nil).valid_filter_params.key?(:to_date)
     refute build_class_instance(organisations: []).valid_filter_params.key?(:organisations)
+    redis_cache_has_taxons([])
     refute build_class_instance(topics: []).valid_filter_params.key?(:topics)
   end
 


### PR DESCRIPTION
Running `"#valid_filter_params skips blank attributes"`
(`test/unit/models/frontend/statistics_announcement_filter_test.rb:90`)
on its own fails at the point where we test topics (taxons)
```
refute build_class_instance(topics: []).valid_filter_params.key?(:topics)
```

This is because we are using the real Redis client, and this returns
`nil` when getting the `TAXONS_CACHE_KEY` in
`lib/taxonomy/redis_cache_adapter.rb:12`
```
cached_data = @redis_client.get(TAXONS_CACHE_KEY)
```

This results in the PublishingApi returning a `RestClient::Response` with
an empty string when getting expanded links in
`lib/taxonomy/publishing_api_adapter.rb:33`
```
publishing_api_with_huge_timeout.get_expanded_links(content_id, with_drafts: false)
```

Finally, when we call `to_h` on that, we get a `JSON::ParserError`
(`unexpected token at ''`).

Mocking the Redis client to have an empty array as taxons in its cash,
instead of a `nil` value, solves this issue.

Co-Authored-By: Deborah Chua <deborah.chua@digital.cabinet-office.gov.uk>