### PR TITLE
 Zip document list CSV export 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'redis-namespace'
 gem 'responders', '~> 2.4'
 gem 'rinku', require: 'rails_rinku'
 gem 'ruby-progressbar', require: false
+gem 'rubyzip', '~> 1.2'
 gem 'sass', '~> 3.7'
 gem 'sassc-rails', '~> 2.1'
 gem 'shared_mustache', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,6 +655,7 @@ DEPENDENCIES
   rinku
   ruby-prof
   ruby-progressbar
+  rubyzip (~> 1.2)
   sass (~> 3.7)
   sassc-rails (~> 2.1)
   shared_mustache (~> 1.0.0)
@@ -678,4 +679,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -1,3 +1,5 @@
+require 'zip'
+
 class Notifications < ActionMailer::Base
   include ActionView::RecordIdentifier
   include ActionView::Helpers::TextHelper
@@ -57,7 +59,14 @@ class Notifications < ActionMailer::Base
   end
 
   def document_list(csv, recipient_address, filter_title)
-    attachments['document_list.csv'] = csv
+    stream = Zip::OutputStream.write_buffer do |zip|
+      zip.put_next_entry("document_list.csv")
+      zip.write(csv)
+    end
+
+    stream.rewind
+
+    attachments["document_list.zip"] = stream.sysread
 
     mail from: no_reply_email_address, to: recipient_address, subject: "#{filter_title} from GOV.UK"
   end

--- a/app/workers/document_list_export_worker.rb
+++ b/app/workers/document_list_export_worker.rb
@@ -21,8 +21,9 @@ private
   end
 
   def generate_csv(filter, csv_file)
-    csv = CSV.new(csv_file)
-    csv << DocumentListExportPresenter.header_row
+    headers = DocumentListExportPresenter.header_row
+    csv = CSV.new(csv_file, headers: headers, write_headers: true)
+
     filter.each_edition_for_csv do |edition|
       presenter = DocumentListExportPresenter.new(edition)
       csv << presenter.row

--- a/test/functional/notifications_document_list_test.rb
+++ b/test/functional/notifications_document_list_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class NotificationsDocumentListTest < ActionMailer::TestCase
+  enable_url_helpers
+
+  setup do
+    @csv = "column1,column2\ncolumn3,column4"
+    @address = "test@example.com"
+    @filter_title = "Test"
+    @mail = Notifications.document_list(@csv, @address, @filter_title)
+  end
+
+  test "email should be sent to the correct address" do
+    assert_equal @mail.to, [@address]
+  end
+
+  test "email subject should include filter title" do
+    assert_equal @mail.subject, "Test from GOV.UK"
+  end
+
+  test "email attachment should include zipped CSV file" do
+    attachment = @mail.attachments["document_list.zip"]
+
+    Zip::InputStream.open(StringIO.new(attachment.body.to_s)) do |zip|
+      entry = zip.get_next_entry
+      assert_equal entry.name, "document_list.csv"
+      assert_equal zip.read, @csv
+    end
+  end
+end

--- a/test/functional/notifications_fact_check_request_response_test.rb
+++ b/test/functional/notifications_fact_check_request_response_test.rb
@@ -126,7 +126,7 @@ class NotificationsFactCheckResponseTest < ActionMailer::TestCase
     file = file_fixture('sample.csv').read
     receiver = 'test@gov.co.uk'
     mail = Notifications.document_list(file, receiver, "Everyone's documents")
-    assert_equal 'document_list.csv', mail.attachments.first.filename
+    assert_equal 'document_list.zip', mail.attachments.first.filename
     assert_match %r{list of documents}, mail.parts.first.body.to_s
   end
 


### PR DESCRIPTION
The document export fails if a user tries to include many documents from an organisation. By zipping up the CSV file, it's much smaller and so the emails should send successfully.

[Trello Card](https://trello.com/c/ZtF7mzsA/859-exporting-large-document-lists-from-whitehall-to-email-fails-takes-a-long-time)