### PR TITLE
Change link in header to new policy papers and consultations finder

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -6,7 +6,7 @@
       <li><%= main_navigation_link_to 'How government works', how_government_works_path %></li>
       <li><%= main_navigation_link_to "Get involved", get_involved_path %></li>
       <li class="clear-child"><%= main_navigation_link_to "Publications", publications_path %></li>
-      <li><%= main_navigation_link_to "Consultations", publications_filter_path(publication_filter_option: 'consultations') %></li>
+      <li><a href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">Consultations</a></li>
       <li><%= main_navigation_link_to "Statistics", statistics_path %></li>
       <li><a href="/news-and-communications">News and communications</a></li>
     </ul>


### PR DESCRIPTION
Changes link in header to new policy papers and consultations finder
Uses appropriate parameters to only show closed and open
consultations

Trello: https://trello.com/c/dkz8ZIol/511-change-whitehall-header-link-to-consultations-finder-s