### PR TITLE
Fix transparency link

### DIFF
--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -526,7 +526,7 @@ module PublishingApi
 
     def transparency_and_freedom_of_information_href(item)
       params = { organisations: [item.slug] }
-      "/transparency-and-freedom-of-information-releases?#{params.to_query}"
+      "/search/transparency-and-freedom-of-information-releases?#{params.to_query}"
     end
   end
 end


### PR DESCRIPTION
This finder has now moved.  It redirects, but it's best to keep the path short.