### PR TITLE
Remove Rails 4 cache_if method

### DIFF
--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -244,17 +244,6 @@ module Admin::TaggableContentHelper
     @taggable_worldwide_organisations_cache_digest ||= calculate_digest(WorldwideOrganisation.order(:id), 'worldwide-organisations')
   end
 
-  # Note: Taken from Rails 4
-  def cache_if(condition, name = {}, options = nil, &block)
-    if condition
-      cache(name, options, &block)
-    else
-      yield
-    end
-
-    nil
-  end
-
 private
 
   def calculate_digest(scope, digest_name)


### PR DESCRIPTION
This method had been patched in from Rails 4 in 2014, when Whitehall was on Rails 3.2.18
https://github.com/alphagov/whitehall/pull/1712

As we are now on Rails 5, we can do away with this and use the new, and updated,
native method

https://api.rubyonrails.org/v5.1/classes/ActionView/Helpers/CacheHelper.html#method-i-cache_if