### PR TITLE
Improve loading attachments for publication

### DIFF
--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -9,7 +9,7 @@
 
 <%= form_tag [:order, :admin, typecast_for_attachable_routing(attachable), Attachment], method: :put do %>
   <ol class="existing-attachments list-unstyled">
-    <% attachable.attachments.each do |attachment| %>
+    <% attachable.attachments.includes(:attachment_data).each do |attachment| %>
       <%= content_tag_for(:li, attachment.becomes(Attachment), class: "well") do %>
         <strong><%= attachment.title %></strong>
         <span class="file">

--- a/app/views/admin/editions/_show_attachments.html.erb
+++ b/app/views/admin/editions/_show_attachments.html.erb
@@ -6,7 +6,7 @@
     <th></th>
   </tr>
 </thead>
-<% @edition.attachments.each do |attachment| %>
+<% @edition.attachments.includes(:attachment_data).each do |attachment| %>
   <tr>
     <td>
       <%= attachment.title %>


### PR DESCRIPTION
As part of our load testing improvements, we want to make the
publication overview page more resilient.

There are three types of `Attachments`: `FileAttachment`, `HtmlAttachment`,
and `ExternalAttachment`. They all share the same view when loaded
into the publication overview and currently call the attachments of an
`edition` within the view. Each `attachment` requires it's `attachment_data`,
so including it here should optimise this query.

Co-authored-by: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>

Trello card: https://trello.com/c/uHiHYiru/855-make-the-visit-publication-overview-step-more-resilient