### PR TITLE
[DO NOT MERGE] Change header link to statistics finder

### DIFF
--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -7,8 +7,8 @@
       <li><%= main_navigation_link_to "Get involved", get_involved_path %></li>
       <li class="clear-child"><%= main_navigation_link_to "Publications", publications_path %></li>
       <li><a href="<%= CGI::escapeHTML('/search/policy-papers-and-consultations?content_store_document_type[]=open_consultations&content_store_document_type[]=closed_consultations') %>">Consultations</a></li>
-      <li><%= main_navigation_link_to "Statistics", statistics_path %></li>
-      <li><a href="/news-and-communications">News and communications</a></li>
+      <li><%= main_navigation_link_to "Statistics", "/search/statistics" %></li>
+      <li><a href="/search/news-and-communications">News and communications</a></li>
     </ul>
   </nav>
   <main id="content" role="main" class="whitehall-content">


### PR DESCRIPTION
Update the whitehall header so the statistics link points to the new statistics finder.

Also update the link to the news and comms finder (thanks @sihugh)

Trello card: https://trello.com/c/CAtBdn4k/510-change-whitehall-header-link-to-stats-finder-s
