### PR TITLE
Improve loading edit attachments page for publication

### DIFF
--- a/app/views/admin/editions/_edit_attachments.html.erb
+++ b/app/views/admin/editions/_edit_attachments.html.erb
@@ -9,7 +9,7 @@
       <th></th>
     </tr>
   </thead>
-  <% @edition.attachments.each do |attachment| %>
+  <% @edition.attachments.includes(:attachment_data).each do |attachment| %>
     <tr>
       <td id='<%= "js-attachment-#{attachment.id}" %>' class="control-group">
         <%= fields_for 'attachments[]', attachment, builder: ActionView::Helpers::FormBuilder do |f| %>


### PR DESCRIPTION
Following https://github.com/alphagov/whitehall/pull/4686
The Edit Attachments page for a publication requests that each `attachment` requires it's `attachment_data`. Including this here should help optimise the query.

[Trello](https://trello.com/c/8vxsdXsq/857-make-the-add-html-attachment-step-more-resilient)